### PR TITLE
fix(mlx): qualify audio training over a version range, and run the MLX suites in CI

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -341,3 +341,73 @@ jobs:
             tests/test_transformers_moe_structure_drift.py \
             tests/test_moe_merge_e2e_cpu.py \
             tests/test_merge_e2e_hub_unreachable.py
+
+  # The MLX VLM/shape/batching suites on Linux CPU MLX. mlx publishes manylinux
+  # CPU wheels and mlx-lm/mlx-vlm are py3-none-any, so these run here for no
+  # macOS minutes; mlx-ci.yml runs the same three files against real Metal.
+  #
+  # They were executed by NO job before this: `pytest tests/ --collect-only`
+  # proves only that they import, and it is continue-on-error besides. That is
+  # how the audio family gate reached main with a failing test of its own --
+  # the gate admitted one exact mlx-vlm string while pyproject allows every
+  # later release, so the feature was unreachable on a normal install and
+  # nothing said so.
+  mlx-cpu-tests:
+    name: MLX suites (Linux CPU MLX)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install CPU torch + zoo + CPU MLX
+        # --no-deps unsloth satisfies the find_spec("unsloth") guard at
+        # unsloth_zoo/__init__.py. mlx[cpu] is the Linux runtime; mlx-lm and
+        # mlx-vlm are pure-Python wheels that resolve on any platform.
+        run: |
+          python -m pip install --upgrade pip
+          pip install --index-url https://download.pytorch.org/whl/cpu \
+            "torch>=2.4.0,<2.11.0"
+          pip install -e .[core]
+          pip install "mlx[cpu]>=0.22.0" "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4"
+          pip install --no-deps "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
+          pip install pytest==9.0.3
+
+      - name: Assert the real MLX runtime is what got installed
+        # All three files importorskip mlx.core, and a module that skips wholesale
+        # still exits 0 -- so without this the job could report green having run
+        # nothing. tests/mlx_simulation/ is the torch-backed shim these suites
+        # must not be measured against.
+        run: |
+          python - <<'PY'
+          import mlx.core as mx
+          origin = str(getattr(mx, "__file__", "") or "")
+          assert "mlx_simulation" not in origin, f"shim, not real mlx: {origin}"
+          assert int(mx.array([1, 2, 3]).sum()) == 6, "mlx cannot add"
+          print("real mlx at", origin)
+          PY
+          python -c "import mlx_vlm, mlx_lm; print('mlx-vlm', mlx_vlm.__version__)"
+
+      # One pytest process per file: tests/mlx_simulation/ replaces
+      # sys.modules["mlx.core"] process-wide, so a sibling suite that installs
+      # the shim would silently disarm whichever file ran after it.
+      - name: tests/test_mlx_shape_guard.py
+        run: python -m pytest tests/test_mlx_shape_guard.py -v -rs
+
+      - name: tests/test_mlx_vlm_label_masks.py
+        # Audio collation, label masking and the family/version gate.
+        run: python -m pytest tests/test_mlx_vlm_label_masks.py -v -rs
+
+      - name: tests/test_mlx_batching_and_decay.py
+        run: python -m pytest tests/test_mlx_batching_and_decay.py -v -rs

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -350,6 +350,10 @@ jobs:
   # import, and is continue-on-error besides. That is how the audio family gate
   # reached main admitting one exact mlx-vlm string while pyproject allows every
   # later release, leaving the feature unreachable on a normal install.
+  #
+  # Kept separate from mlx-cpu-numerics rather than folded into it: these suites
+  # need mlx-lm and mlx-vlm, which that job deliberately does not install, and
+  # resolving them there could move transformers under an established gate.
   mlx-cpu-tests:
     name: MLX suites (Linux CPU MLX)
     runs-on: ubuntu-latest
@@ -371,13 +375,14 @@ jobs:
 
       - name: Install CPU torch + zoo + CPU MLX
         # --no-deps unsloth satisfies the find_spec("unsloth") guard in
-        # unsloth_zoo/__init__.py; mlx[cpu] is the Linux runtime.
+        # unsloth_zoo/__init__.py; mlx-cpu is the Linux runtime, spelled as
+        # mlx-cpu-numerics spells it.
         run: |
           python -m pip install --upgrade pip
           pip install --index-url https://download.pytorch.org/whl/cpu \
             "torch>=2.4.0,<2.11.0"
           pip install -e .[core]
-          pip install "mlx[cpu]>=0.22.0" "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4"
+          pip install "mlx>=0.22.0" mlx-cpu "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4"
           pip install --no-deps "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
           pip install pytest==9.0.3
 

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -351,9 +351,8 @@ jobs:
   # reached main admitting one exact mlx-vlm string while pyproject allows every
   # later release, leaving the feature unreachable on a normal install.
   #
-  # Kept separate from mlx-cpu-numerics rather than folded into it: these suites
-  # need mlx-lm and mlx-vlm, which that job deliberately does not install, and
-  # resolving them there could move transformers under an established gate.
+  # Separate from mlx-cpu-numerics: these need mlx-lm and mlx-vlm, which that job
+  # deliberately omits, and resolving them there could move transformers.
   mlx-cpu-tests:
     name: MLX suites (Linux CPU MLX)
     runs-on: ubuntu-latest
@@ -378,14 +377,11 @@ jobs:
         # unsloth_zoo/__init__.py; mlx-cpu is the Linux runtime, spelled as
         # mlx-cpu-numerics spells it.
         #
-        # The MLX packages resolve in the SAME pip call as .[core], not a
-        # second one. Split, pip solves them independently: mlx-vlm 0.6.9
-        # requires transformers>=5.14, so it upgrades transformers past the
-        # <=5.5.0 this project pins, warns, and leaves the job gating an
-        # environment the package forbids. Measured: transformers 5.5.0 ->
-        # 5.14.1 with mlx-vlm 0.6.9. Resolved together, pip has to honour the
-        # cap and lands on the newest mlx-vlm that fits -- which is the 0.6.4
-        # ceiling the audio gate records, so this job also proves it.
+        # The MLX packages must resolve in the SAME pip call as .[core]. Split,
+        # pip solves them independently and mlx-vlm 0.6.9 (transformers>=5.14)
+        # drags transformers past the <=5.5.0 this project pins: measured
+        # 5.5.0 -> 5.14.1. Together, pip honours the cap and lands on the newest
+        # mlx-vlm that fits, which is the 0.6.4 ceiling the audio gate records.
         run: |
           python -m pip install --upgrade pip
           pip install --index-url https://download.pytorch.org/whl/cpu \
@@ -398,8 +394,7 @@ jobs:
       - name: Assert the real MLX runtime is what got installed
         # All three files importorskip mlx.core, and a module that skips
         # wholesale still exits 0, so without this the job could go green having
-        # run nothing. tests/mlx_simulation/ is the torch-backed shim these
-        # suites must not be measured against.
+        # run nothing. tests/mlx_simulation/ is the torch-backed shim.
         run: |
           python - <<'PY'
           import mlx.core as mx
@@ -409,9 +404,8 @@ jobs:
           print("real mlx at", origin)
           PY
           python -c "import mlx_vlm, mlx_lm; print('mlx-vlm', mlx_vlm.__version__)"
-          # The joint resolution above must have honoured the transformers cap.
-          # If it did not, this job is gating an unsupported environment and the
-          # audio gate's recorded ceiling means nothing here.
+          # If the joint resolution missed the transformers cap, this job is
+          # gating an environment the package forbids.
           python - <<'PY'
           from importlib.metadata import version
           from packaging.version import Version
@@ -424,8 +418,7 @@ jobs:
           PY
 
       # One pytest process per file: tests/mlx_simulation/ replaces
-      # sys.modules["mlx.core"] process-wide, silently disarming any file that
-      # runs after a suite that installs the shim.
+      # sys.modules["mlx.core"] process-wide, disarming whatever runs after it.
       - name: tests/test_mlx_shape_guard.py
         run: python -m pytest tests/test_mlx_shape_guard.py -v -rs
 

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -342,16 +342,14 @@ jobs:
             tests/test_moe_merge_e2e_cpu.py \
             tests/test_merge_e2e_hub_unreachable.py
 
-  # The MLX VLM/shape/batching suites on Linux CPU MLX. mlx publishes manylinux
-  # CPU wheels and mlx-lm/mlx-vlm are py3-none-any, so these run here for no
-  # macOS minutes; mlx-ci.yml runs the same three files against real Metal.
+  # The MLX VLM/shape/batching suites on Linux CPU MLX: mlx ships manylinux CPU
+  # wheels and mlx-lm/mlx-vlm are py3-none-any, so these cost no macOS minutes.
+  # mlx-ci.yml runs the same three files against real Metal.
   #
-  # They were executed by NO job before this: `pytest tests/ --collect-only`
-  # proves only that they import, and it is continue-on-error besides. That is
-  # how the audio family gate reached main with a failing test of its own --
-  # the gate admitted one exact mlx-vlm string while pyproject allows every
-  # later release, so the feature was unreachable on a normal install and
-  # nothing said so.
+  # No job ran them before: `pytest tests/ --collect-only` proves only that they
+  # import, and is continue-on-error besides. That is how the audio family gate
+  # reached main admitting one exact mlx-vlm string while pyproject allows every
+  # later release, leaving the feature unreachable on a normal install.
   mlx-cpu-tests:
     name: MLX suites (Linux CPU MLX)
     runs-on: ubuntu-latest
@@ -372,9 +370,8 @@ jobs:
           cache: 'pip'
 
       - name: Install CPU torch + zoo + CPU MLX
-        # --no-deps unsloth satisfies the find_spec("unsloth") guard at
-        # unsloth_zoo/__init__.py. mlx[cpu] is the Linux runtime; mlx-lm and
-        # mlx-vlm are pure-Python wheels that resolve on any platform.
+        # --no-deps unsloth satisfies the find_spec("unsloth") guard in
+        # unsloth_zoo/__init__.py; mlx[cpu] is the Linux runtime.
         run: |
           python -m pip install --upgrade pip
           pip install --index-url https://download.pytorch.org/whl/cpu \
@@ -385,10 +382,10 @@ jobs:
           pip install pytest==9.0.3
 
       - name: Assert the real MLX runtime is what got installed
-        # All three files importorskip mlx.core, and a module that skips wholesale
-        # still exits 0 -- so without this the job could report green having run
-        # nothing. tests/mlx_simulation/ is the torch-backed shim these suites
-        # must not be measured against.
+        # All three files importorskip mlx.core, and a module that skips
+        # wholesale still exits 0, so without this the job could go green having
+        # run nothing. tests/mlx_simulation/ is the torch-backed shim these
+        # suites must not be measured against.
         run: |
           python - <<'PY'
           import mlx.core as mx
@@ -400,8 +397,8 @@ jobs:
           python -c "import mlx_vlm, mlx_lm; print('mlx-vlm', mlx_vlm.__version__)"
 
       # One pytest process per file: tests/mlx_simulation/ replaces
-      # sys.modules["mlx.core"] process-wide, so a sibling suite that installs
-      # the shim would silently disarm whichever file ran after it.
+      # sys.modules["mlx.core"] process-wide, silently disarming any file that
+      # runs after a suite that installs the shim.
       - name: tests/test_mlx_shape_guard.py
         run: python -m pytest tests/test_mlx_shape_guard.py -v -rs
 

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -377,12 +377,21 @@ jobs:
         # --no-deps unsloth satisfies the find_spec("unsloth") guard in
         # unsloth_zoo/__init__.py; mlx-cpu is the Linux runtime, spelled as
         # mlx-cpu-numerics spells it.
+        #
+        # The MLX packages resolve in the SAME pip call as .[core], not a
+        # second one. Split, pip solves them independently: mlx-vlm 0.6.9
+        # requires transformers>=5.14, so it upgrades transformers past the
+        # <=5.5.0 this project pins, warns, and leaves the job gating an
+        # environment the package forbids. Measured: transformers 5.5.0 ->
+        # 5.14.1 with mlx-vlm 0.6.9. Resolved together, pip has to honour the
+        # cap and lands on the newest mlx-vlm that fits -- which is the 0.6.4
+        # ceiling the audio gate records, so this job also proves it.
         run: |
           python -m pip install --upgrade pip
           pip install --index-url https://download.pytorch.org/whl/cpu \
             "torch>=2.4.0,<2.11.0"
-          pip install -e .[core]
-          pip install "mlx>=0.22.0" mlx-cpu "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4"
+          pip install -e .[core] \
+            "mlx>=0.22.0" mlx-cpu "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4"
           pip install --no-deps "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
           pip install pytest==9.0.3
 
@@ -400,6 +409,19 @@ jobs:
           print("real mlx at", origin)
           PY
           python -c "import mlx_vlm, mlx_lm; print('mlx-vlm', mlx_vlm.__version__)"
+          # The joint resolution above must have honoured the transformers cap.
+          # If it did not, this job is gating an unsupported environment and the
+          # audio gate's recorded ceiling means nothing here.
+          python - <<'PY'
+          from importlib.metadata import version
+          from packaging.version import Version
+          transformers = Version(version("transformers"))
+          assert transformers <= Version("5.5.0"), (
+              f"transformers {transformers} exceeds the cap this package pins; "
+              "the MLX packages were resolved without it"
+          )
+          print("transformers", transformers, "within the pinned cap")
+          PY
 
       # One pytest process per file: tests/mlx_simulation/ replaces
       # sys.modules["mlx.core"] process-wide, silently disarming any file that

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -133,4 +133,13 @@ jobs:
         run: python -m pytest tests/test_mlx_vlm_label_masks.py -v -rs
 
       - name: tests/test_mlx_batching_and_decay.py
-        run: python -m pytest tests/test_mlx_batching_and_decay.py -v -rs
+        # test_compiler_review_guards_are_present is deselected here, not
+        # skipped in the file: it asserts on the source text of
+        # unsloth_zoo.compiler and needs neither MLX nor Metal, so the Linux
+        # job covers it. Importing that module on this runner pulls torch's
+        # flop_counter, which raises "isinstance() arg 2 must be a type" while
+        # registering flex-attention formulas against a triton that is not
+        # installable on macOS arm64. A torch problem, not one of this repo's.
+        run: |
+          python -m pytest tests/test_mlx_batching_and_decay.py -v -rs \
+            --deselect tests/test_mlx_batching_and_decay.py::test_compiler_review_guards_are_present

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -120,3 +120,17 @@ jobs:
         # 8-bit first-moment numerics on Metal: the affine quantizer rounds
         # differently per backend, so the mlx-cpu job is not a substitute.
         run: python -m pytest tests/test_mlx_quantized_optimizer_state.py -v -rs
+
+      # The three VLM/shape/batching suites. consolidated-tests-ci.yml runs
+      # these on Linux CPU MLX too; here they meet real Metal and the mlx-vlm
+      # version an Apple Silicon user actually resolves, which is what the
+      # audio family gate is keyed on.
+      - name: tests/test_mlx_shape_guard.py
+        run: python -m pytest tests/test_mlx_shape_guard.py -v -rs
+
+      - name: tests/test_mlx_vlm_label_masks.py
+        # Audio collation, label masking and the family/version gate.
+        run: python -m pytest tests/test_mlx_vlm_label_masks.py -v -rs
+
+      - name: tests/test_mlx_batching_and_decay.py
+        run: python -m pytest tests/test_mlx_batching_and_decay.py -v -rs

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -123,8 +123,7 @@ jobs:
 
       # The three VLM/shape/batching suites, also run on Linux CPU MLX by
       # consolidated-tests-ci.yml. Here they meet real Metal and the mlx-vlm
-      # version an Apple Silicon user resolves, which is what the audio family
-      # gate is keyed on.
+      # version an Apple Silicon user resolves, which the audio gate is keyed on.
       - name: tests/test_mlx_shape_guard.py
         run: python -m pytest tests/test_mlx_shape_guard.py -v -rs
 
@@ -133,13 +132,12 @@ jobs:
         run: python -m pytest tests/test_mlx_vlm_label_masks.py -v -rs
 
       - name: tests/test_mlx_batching_and_decay.py
-        # test_compiler_review_guards_are_present is deselected here, not
-        # skipped in the file: it asserts on the source text of
-        # unsloth_zoo.compiler and needs neither MLX nor Metal, so the Linux
-        # job covers it. Importing that module on this runner pulls torch's
-        # flop_counter, which raises "isinstance() arg 2 must be a type" while
+        # test_compiler_review_guards_are_present is deselected here, not skipped
+        # in the file: it only asserts on unsloth_zoo.compiler source text, so
+        # the Linux job covers it. Importing that module here pulls torch's
+        # flop_counter, which raises "isinstance() arg 2 must be a type"
         # registering flex-attention formulas against a triton that is not
-        # installable on macOS arm64. A torch problem, not one of this repo's.
+        # installable on macOS arm64. A torch problem, not this repo's.
         run: |
           python -m pytest tests/test_mlx_batching_and_decay.py -v -rs \
             --deselect tests/test_mlx_batching_and_decay.py::test_compiler_review_guards_are_present

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -121,10 +121,10 @@ jobs:
         # differently per backend, so the mlx-cpu job is not a substitute.
         run: python -m pytest tests/test_mlx_quantized_optimizer_state.py -v -rs
 
-      # The three VLM/shape/batching suites. consolidated-tests-ci.yml runs
-      # these on Linux CPU MLX too; here they meet real Metal and the mlx-vlm
-      # version an Apple Silicon user actually resolves, which is what the
-      # audio family gate is keyed on.
+      # The three VLM/shape/batching suites, also run on Linux CPU MLX by
+      # consolidated-tests-ci.yml. Here they meet real Metal and the mlx-vlm
+      # version an Apple Silicon user resolves, which is what the audio family
+      # gate is keyed on.
       - name: tests/test_mlx_shape_guard.py
         run: python -m pytest tests/test_mlx_shape_guard.py -v -rs
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2295,8 +2295,9 @@ def _qualify(monkeypatch, processor=None, version=None):
     from unsloth_zoo.mlx import utils as mlx_utils
     family = mlx_utils._audio_family_from_processor(
         processor or _FakeGemmaAudioProcessor())
-    monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES", {family: frozenset(
-        {version or mlx_utils._installed_mlx_vlm_version()})})
+    pinned = version or mlx_utils._installed_mlx_vlm_version()
+    monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES",
+                        {family: mlx_utils._AudioVersions(pinned, pinned)})
 
 
 @pytest.mark.parametrize("gate,message", [
@@ -2692,23 +2693,105 @@ def test_audio_merge_compacts_valid_features_per_row():
 
 
 def test_qualified_families_carry_their_probed_requirements():
+    """The table itself: which families, over which mlx-vlm releases.
+
+    Bounded at both ends, so an unreleased version is refused rather than
+    assumed good. Gemma 4 stays at the version its probes ran on: its processor
+    changed in 0.5.0, upstream reports it failing to load from 0.6.4
+    (Blaizzy/mlx-vlm#1526), and 0.6.3 split off a separate `gemma4_unified`.
+    """
     from unsloth_zoo.mlx import utils as mlx_utils
 
-    gate = mlx_utils._AUDIO_QUALIFIED_FAMILIES
-    # Exact versions: a stray one would enable code no probe ran against.
-    assert gate == {
-        "gemma3n": frozenset({"0.4.4"}),
-        "gemma4": frozenset({"0.4.4"}),
-        "phi4mm": frozenset({"0.4.4"}),
-        "minicpmo": frozenset({"0.4.4"}),
+    versions = mlx_utils._AudioVersions
+    assert mlx_utils._AUDIO_QUALIFIED_FAMILIES == {
+        "gemma3n": versions("0.4.4", "0.6.4"),
+        "gemma4": versions("0.4.4", "0.4.4"),
+        "phi4mm": versions("0.4.4", "0.6.4"),
+        "minicpmo": versions("0.4.4", "0.6.4"),
     }
-    # Gemma 4 was probed only on a newer transformers; this env pins an older.
-    gemma4_like = type("Proc", (), {})
-    gemma4_like.__module__ = "mlx_vlm.models.gemma4.processing_gemma4"
-    assert mlx_utils._audio_family_from_processor(gemma4_like()) == "gemma4"
-    with pytest.raises(NotImplementedError, match="transformers"):
-        mlx_utils._check_audio_family_gate(gemma4_like())
+
+
+@pytest.mark.parametrize("installed,admitted", [
+    ("0.4.3", False),        # below the probed floor
+    ("0.4.4", True),         # the version the probes ran on
+    ("0.4.4.post1", True),   # a packaging-only re-release of that same code
+    ("0.5.0", True),
+    ("0.6.4", True),         # the ceiling: 0.6.5+ needs transformers>=5.14,
+    ("0.6.5", False),        # which this package caps at 5.5.0
+    ("0.6.9", False),
+    ("", False),             # version unreadable: not evidence of anything
+    ("not-a-version", False),
+])
+def test_the_gate_admits_exactly_its_qualified_window(installed, admitted):
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    window = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma3n"]
+    assert window.admits(installed) is admitted, installed
+
+
+def test_a_family_pinned_to_one_version_still_takes_its_post_release():
+    """Gemma 4's window is a single version, and `0.4.4.post1` is that version
+    repackaged. Refusing it was part of what made the feature unreachable."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    gemma4 = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"]
+    assert gemma4.admits("0.4.4") is True
+    assert gemma4.admits("0.4.4.post1") is True
+    # But not the release after it, which is a different processor.
+    assert gemma4.admits("0.4.5") is False
+    assert gemma4.admits("0.5.0") is False
+
+
+def test_the_renamed_gemma4_family_is_refused_by_the_name_it_now_loads_under():
+    """mlx-vlm 0.6.3 added `gemma4_unified` beside `gemma4`, so a gemma 4
+    checkpoint can present under a family key this gate never qualified.
+    Refusing it as simply unrecognised tells the user nothing they can act on;
+    the refusal names the entry they are actually looking for."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    unified = type("Gemma4UnifiedProcessor", (), {})
+    unified.__module__ = "mlx_vlm.models.gemma4_unified.processing_gemma4_unified"
+    assert mlx_utils._audio_family_from_processor(unified()) == "gemma4_unified"
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        mlx_utils._check_audio_family_gate(unified())
+    message = str(excinfo.value)
+    assert "gemma4_unified" in message and "'gemma4'" in message
+    assert "0.4.4" in message, "the version to pin is not named"
+
+
+def test_the_transformers_floor_reads_a_release_candidate_as_its_release(
+        monkeypatch):
+    """`int(x) for x in version.split(".")` raised on any version that is not
+    plain digits, and the handler reported that as a version it could not
+    determine -- so transformers 5.5rc1 was refused, with a reason that named
+    the wrong problem."""
+    import sys
+    import types
+
+    from unsloth_zoo.mlx import utils as mlx_utils
+
     mlx_utils._check_audio_transformers_floor("gemma3n")  # no floor recorded
+
+    def _pin(spelling):
+        fake = types.ModuleType("transformers")
+        fake.__version__ = spelling
+        monkeypatch.setitem(sys.modules, "transformers", fake)
+
+    for spelling in ("5.5.0", "5.5rc1", "v5.5.0", "5.5.0.dev0", "5.6.0"):
+        _pin(spelling)
+        mlx_utils._check_audio_transformers_floor("gemma4")  # must not raise
+
+    # Genuinely older releases are still refused, and say so.
+    for spelling in ("4.57.6", "5.4.0"):
+        _pin(spelling)
+        with pytest.raises(NotImplementedError, match="was verified on"):
+            mlx_utils._check_audio_transformers_floor("gemma4")
+
+    # An unreadable version is still refused, and now only that case says so.
+    _pin("not-a-version")
+    with pytest.raises(NotImplementedError, match="could not be determined"):
+        mlx_utils._check_audio_transformers_floor("gemma4")
 
 
 class _Gemma4Extractor:
@@ -2924,9 +3007,10 @@ def test_the_corrected_count_rides_a_copy_and_only_for_its_family(monkeypatch):
     from unsloth_zoo.mlx import utils as mlx_utils
 
     monkeypatch.setattr(mlx_utils, "_AUDIO_MIN_TRANSFORMERS", {})
+    _here = mlx_utils._installed_mlx_vlm_version()
     monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES", {
-        "gemma4": frozenset({mlx_utils._installed_mlx_vlm_version()}),
-        "fakegemmaaudio": frozenset({mlx_utils._installed_mlx_vlm_version()}),
+        "gemma4": mlx_utils._AudioVersions(_here, _here),
+        "fakegemmaaudio": mlx_utils._AudioVersions(_here, _here),
     })
     processor = Gemma4Processor(_Gemma4Extractor(True))
     assert mlx_utils._check_audio_family_gate(processor) == "gemma4"

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2718,12 +2718,12 @@ def test_qualified_families_carry_their_probed_requirements():
     ("0.6.4", True),         # ceiling: 0.6.5+ needs transformers>=5.14,
     ("0.6.5", False),        # which this package caps at 5.5.0
     ("0.6.9", False),
-    ("0.5.0rc1", False),     # prerelease inside the window: never qualified
+    ("0.5.0rc1", False),     # prereleases inside the window: never qualified
     ("0.4.5.dev0", False),
-    ("0.4.4.post1", False),  # nor a post-release or a local build of one
+    ("0.4.4.post1", False),  # nor post-releases or local builds
     ("0.6.4.post1", False),
     ("0.4.4+local", False),
-    ("", False),             # unreadable version: not evidence of anything
+    ("", False),             # unreadable: not evidence of anything
     ("not-a-version", False),
 ])
 def test_the_gate_admits_exactly_its_qualified_window(installed, admitted):

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2713,13 +2713,13 @@ def test_qualified_families_carry_their_probed_requirements():
 
 @pytest.mark.parametrize("installed,admitted", [
     ("0.4.3", False),        # below the probed floor
-    ("0.4.4", True),         # the version the probes ran on
-    ("0.4.4.post1", True),   # a packaging-only re-release of that same code
+    ("0.4.4", True),         # the probed version
+    ("0.4.4.post1", True),   # same code, repackaged
     ("0.5.0", True),
-    ("0.6.4", True),         # the ceiling: 0.6.5+ needs transformers>=5.14,
+    ("0.6.4", True),         # ceiling: 0.6.5+ needs transformers>=5.14,
     ("0.6.5", False),        # which this package caps at 5.5.0
     ("0.6.9", False),
-    ("", False),             # version unreadable: not evidence of anything
+    ("", False),             # unreadable version: not evidence of anything
     ("not-a-version", False),
 ])
 def test_the_gate_admits_exactly_its_qualified_window(installed, admitted):
@@ -2769,7 +2769,7 @@ def test_a_family_pinned_to_one_version_still_takes_its_post_release():
     gemma4 = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"]
     assert gemma4.admits("0.4.4") is True
     assert gemma4.admits("0.4.4.post1") is True
-    # But not the release after it, which is a different processor.
+    # But not the next release, which is a different processor.
     assert gemma4.admits("0.4.5") is False
     assert gemma4.admits("0.5.0") is False
 
@@ -2814,13 +2814,13 @@ def test_the_transformers_floor_reads_a_release_candidate_as_its_release(
         _pin(spelling)
         mlx_utils._check_audio_transformers_floor("gemma4")  # must not raise
 
-    # Genuinely older releases are still refused, and say so.
+    # Genuinely older releases are still refused.
     for spelling in ("4.57.6", "5.4.0"):
         _pin(spelling)
         with pytest.raises(NotImplementedError, match="was verified on"):
             mlx_utils._check_audio_transformers_floor("gemma4")
 
-    # An unreadable version is still refused, and now only that case says so.
+    # Only an unreadable version reports that reason now.
     _pin("not-a-version")
     with pytest.raises(NotImplementedError, match="could not be determined"):
         mlx_utils._check_audio_transformers_floor("gemma4")

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2714,11 +2714,15 @@ def test_qualified_families_carry_their_probed_requirements():
 @pytest.mark.parametrize("installed,admitted", [
     ("0.4.3", False),        # below the probed floor
     ("0.4.4", True),         # the probed version
-    ("0.4.4.post1", True),   # same code, repackaged
     ("0.5.0", True),
     ("0.6.4", True),         # ceiling: 0.6.5+ needs transformers>=5.14,
     ("0.6.5", False),        # which this package caps at 5.5.0
     ("0.6.9", False),
+    ("0.5.0rc1", False),     # prerelease inside the window: never qualified
+    ("0.4.5.dev0", False),
+    ("0.4.4.post1", False),  # nor a post-release or a local build of one
+    ("0.6.4.post1", False),
+    ("0.4.4+local", False),
     ("", False),             # unreadable version: not evidence of anything
     ("not-a-version", False),
 ])
@@ -2732,8 +2736,9 @@ def test_the_gate_admits_exactly_its_qualified_window(installed, admitted):
 @pytest.mark.parametrize("installed,allowed", [
     ("0.4.3", False),
     ("0.4.4", True),
-    ("0.4.4.post1", True),
+    ("0.4.4.post1", False),
     ("0.5.0", True),
+    ("0.5.0rc1", False),
     ("0.6.4", True),
     ("0.6.5", False),
     ("0.6.9", False),
@@ -2761,15 +2766,23 @@ def test_the_gate_itself_honours_the_range_not_just_the_range_object(
             mlx_utils._check_audio_family_gate(gemma3n_like())
 
 
-def test_a_family_pinned_to_one_version_still_takes_its_post_release():
-    """Gemma 4's window is a single version, and `0.4.4.post1` is that version
-    repackaged. Refusing it was part of what made the feature unreachable."""
+def test_only_a_published_final_release_is_inside_the_window():
+    """The qualification covers published final releases and nothing else.
+
+    A post-release is conventionally the same code repackaged, but nothing
+    enforces that, and a local build carries whatever its builder put there.
+    mlx-vlm has published no prerelease, post-release or local build across 73
+    releases, so admitting them would widen a fail-closed gate for a case that
+    has never happened.
+    """
     from unsloth_zoo.mlx import utils as mlx_utils
 
     gemma4 = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"]
     assert gemma4.admits("0.4.4") is True
-    assert gemma4.admits("0.4.4.post1") is True
-    # But not the next release, which is a different processor.
+    for unqualified in ("0.4.4.post1", "0.4.4.post2", "0.4.4+local",
+                        "0.4.4rc1", "0.4.4.dev0"):
+        assert gemma4.admits(unqualified) is False, unqualified
+    # Nor the next release, which is a different processor.
     assert gemma4.admits("0.4.5") is False
     assert gemma4.admits("0.5.0") is False
 
@@ -2792,12 +2805,18 @@ def test_the_renamed_gemma4_family_is_refused_by_the_name_it_now_loads_under():
     assert "0.4.4" in message, "the version to pin is not named"
 
 
-def test_the_transformers_floor_reads_a_release_candidate_as_its_release(
+def test_the_transformers_floor_refuses_a_prerelease_for_the_right_reason(
         monkeypatch):
     """`int(x) for x in version.split(".")` raised on any version that is not
-    plain digits, and the handler reported that as a version it could not
-    determine -- so transformers 5.5rc1 was refused, with a reason that named
-    the wrong problem."""
+    plain digits, and the catch-all handler reported that as a version it could
+    not determine. So `5.5rc1` was refused with a reason naming the wrong
+    problem, and `v5.5.0` -- a real 5.5 -- was refused outright.
+
+    A prerelease is still refused, because PEP 440 sorts it below the release
+    and the floor exists precisely because older transformers expand audio
+    tokens differently. What changes is that it is refused as the older version
+    it is, rather than as an unreadable one.
+    """
     import sys
     import types
 
@@ -2810,12 +2829,12 @@ def test_the_transformers_floor_reads_a_release_candidate_as_its_release(
         fake.__version__ = spelling
         monkeypatch.setitem(sys.modules, "transformers", fake)
 
-    for spelling in ("5.5.0", "5.5rc1", "v5.5.0", "5.5.0.dev0", "5.6.0"):
+    for spelling in ("5.5.0", "v5.5.0", "5.6.0", "5.5.1"):
         _pin(spelling)
         mlx_utils._check_audio_transformers_floor("gemma4")  # must not raise
 
-    # Genuinely older releases are still refused.
-    for spelling in ("4.57.6", "5.4.0"):
+    # Older releases, and prereleases of the floor, are refused as such.
+    for spelling in ("4.57.6", "5.4.0", "5.5rc1", "5.5.0.dev0"):
         _pin(spelling)
         with pytest.raises(NotImplementedError, match="was verified on"):
             mlx_utils._check_audio_transformers_floor("gemma4")

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2729,6 +2729,38 @@ def test_the_gate_admits_exactly_its_qualified_window(installed, admitted):
     assert window.admits(installed) is admitted, installed
 
 
+@pytest.mark.parametrize("installed,allowed", [
+    ("0.4.3", False),
+    ("0.4.4", True),
+    ("0.4.4.post1", True),
+    ("0.5.0", True),
+    ("0.6.4", True),
+    ("0.6.5", False),
+    ("0.6.9", False),
+])
+def test_the_gate_itself_honours_the_range_not_just_the_range_object(
+        monkeypatch, installed, allowed):
+    """Drives `_check_audio_family_gate`, not `_AudioVersions.admits`.
+
+    Asserting the range object alone would pass just as happily with the gate
+    still comparing strings, which is the whole defect. Whether an audio row
+    trains or is refused is decided here.
+    """
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    monkeypatch.setattr(mlx_utils, "_AUDIO_MIN_TRANSFORMERS", {})
+    monkeypatch.setattr(mlx_utils, "_installed_mlx_vlm_version",
+                        lambda: installed)
+    gemma3n_like = type("Proc", (), {})
+    gemma3n_like.__module__ = "mlx_vlm.models.gemma3n.processing_gemma3n"
+
+    if allowed:
+        assert mlx_utils._check_audio_family_gate(gemma3n_like()) == "gemma3n"
+    else:
+        with pytest.raises(NotImplementedError, match="only been verified"):
+            mlx_utils._check_audio_family_gate(gemma3n_like())
+
+
 def test_a_family_pinned_to_one_version_still_takes_its_post_release():
     """Gemma 4's window is a single version, and `0.4.4.post1` is that version
     repackaged. Refusing it was part of what made the feature unreachable."""

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -55,6 +55,8 @@ from functools import lru_cache, partial, wraps
 from pathlib import Path
 from typing import NamedTuple
 
+from packaging.version import Version as _Version
+
 
 from .cce import _get_runtime_cce
 from .cce.runtime_cce import _normalize_label_smoothing
@@ -5575,15 +5577,63 @@ _AUDIO_SOFT_TOKEN_STRINGS = (
     "<|endoftext11|>",
 )
 
-# Families and the exact mlx-vlm versions their audio path was validated on.
-# Anything else is refused: merge contracts differ per family and mlx-vlm has
-# changed audio preprocessing within its supported span.
-_AUDIO_QUALIFIED_FAMILIES: "dict[str, frozenset]" = {
-    "gemma3n": frozenset({"0.4.4"}),
-    "gemma4": frozenset({"0.4.4"}),
-    "phi4mm": frozenset({"0.4.4"}),
-    "minicpmo": frozenset({"0.4.4"}),
+class _AudioVersions(NamedTuple):
+    """The mlx-vlm releases a family's audio path is qualified for.
+
+    Bounded at both ends on purpose. An unreleased version is refused rather
+    than assumed good, which is the property the whole gate exists for: a wrong
+    "yes" here trains against misaligned features and fails silently, where a
+    wrong "no" only asks someone to pin.
+    """
+
+    minimum: str
+    maximum: str
+
+    def admits(self, installed):
+        if not installed:
+            return False
+        try:
+            found = _Version(installed)
+            ceiling = _Version(self.maximum)
+            if found < _Version(self.minimum):
+                return False
+            # A post-release carries the same code as the release it follows,
+            # so `0.4.4.post1` is inside a range ending at `0.4.4` even though
+            # it sorts above it.
+            return found <= ceiling or found.base_version == ceiling.base_version
+        except Exception:
+            # An unparseable version is not evidence of anything.
+            return False
+
+    def __str__(self):
+        if self.minimum == self.maximum:
+            return self.minimum
+        return f"{self.minimum} to {self.maximum}"
+
+
+# Families and the mlx-vlm releases their audio path is qualified for.
+#
+# The probes ran on 0.4.4. Three of these families ship a processor that is
+# byte-identical from 0.4.4 through 0.6.9, so the probed code is the code that
+# runs and the range is widened to every release that can be installed beside
+# this package -- mlx-vlm 0.6.5+ requires transformers>=5.14, which pyproject
+# caps at 5.5.0, so 0.6.4 is the real ceiling.
+#
+# Gemma 4 is deliberately left at the probed version. Its processor changed in
+# 0.5.0, upstream reports it failing to load at all from 0.6.4
+# (Blaizzy/mlx-vlm#1526, with 0.6.3 good), and 0.6.3 added a separate
+# `gemma4_unified` family. Re-probing it needs a real checkpoint on Apple
+# hardware; until then, refusing is the honest answer.
+_AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
+    "gemma3n": _AudioVersions("0.4.4", "0.6.4"),
+    "gemma4": _AudioVersions("0.4.4", "0.4.4"),
+    "phi4mm": _AudioVersions("0.4.4", "0.6.4"),
+    "minicpmo": _AudioVersions("0.4.4", "0.6.4"),
 }
+
+# Renames upstream gave a family this gate qualified under another name, so the
+# refusal can say which entry the user is actually looking at.
+_AUDIO_FAMILY_RENAMES = {"gemma4_unified": "gemma4"}
 
 # Families probed only on a newer transformers than this package pins, at the
 # version the probes ran on. Older releases expand their audio tokens
@@ -5641,7 +5691,11 @@ def _check_audio_transformers_floor(family):
         import transformers
 
         version = transformers.__version__
-        parts = tuple(int(x) for x in version.split(".")[:2])
+        # PEP 440 rather than int(split(".")): a release candidate ("5.5rc1")
+        # or a v-prefixed tag would otherwise raise here and be reported as a
+        # version that could not be determined, which is both a refusal of a
+        # perfectly good release and a misleading reason for it.
+        parts = _Version(version).release[:2]
     except Exception:
         raise NotImplementedError(
             f"Unsloth MLX: audio training for '{family}' requires transformers "
@@ -5851,9 +5905,22 @@ def _check_audio_family_gate(processor):
     family = _audio_family_from_processor(processor)
     probed = _AUDIO_QUALIFIED_FAMILIES.get(family)
     installed = _installed_mlx_vlm_version()
-    if probed and installed in probed:
+    if probed and probed.admits(installed):
         _check_audio_transformers_floor(family)
         return family
+    renamed = _AUDIO_FAMILY_RENAMES.get(family)
+    if renamed and renamed in _AUDIO_QUALIFIED_FAMILIES:
+        # Upstream renamed a qualified family; the entry under the old name
+        # says nothing about the new one, so say that rather than reporting an
+        # unrecognised family the user cannot act on.
+        raise NotImplementedError(
+            f"Unsloth MLX: audio training is not supported for '{family}'. "
+            f"mlx-vlm {installed or 'unknown'} loads this checkpoint as "
+            f"'{family}', which is a different implementation from the "
+            f"'{renamed}' this package qualified on mlx-vlm "
+            f"{_AUDIO_QUALIFIED_FAMILIES[renamed]}. Pin that version to train "
+            f"on audio with this model."
+        )
     if not _AUDIO_QUALIFIED_FAMILIES:
         raise NotImplementedError(
             f"Unsloth MLX: audio inputs were found in this dataset, but audio "
@@ -5862,13 +5929,13 @@ def _check_audio_family_gate(processor):
             f"image parts of this dataset."
         )
     supported = ", ".join(
-        f"{name} (mlx-vlm {', '.join(sorted(versions))})"
+        f"{name} (mlx-vlm {versions})"
         for name, versions in sorted(_AUDIO_QUALIFIED_FAMILIES.items())
     )
     if probed:
         raise NotImplementedError(
             f"Unsloth MLX: audio training for '{family}' has only been verified "
-            f"on mlx-vlm {', '.join(sorted(probed))}, but mlx-vlm "
+            f"on mlx-vlm {probed}, but mlx-vlm "
             f"{installed or 'unknown'} is installed. Pin a verified version to "
             f"train on audio. Verified: {supported}."
         )

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5594,14 +5594,17 @@ class _AudioVersions(NamedTuple):
             return False
         try:
             found = _Version(installed)
-            ceiling = _Version(self.maximum)
-            if found < _Version(self.minimum):
+            # Only published final releases were qualified. mlx-vlm has
+            # published no prerelease, post-release or local build in 73
+            # releases, so none of these is a version anyone was probed
+            # against, and each can carry code the probes never saw -- a local
+            # build most of all.
+            if found.is_prerelease or found.is_postrelease or found.local:
                 return False
-            # A post-release is the same code repackaged, so `0.4.4.post1` is
-            # inside a range ending at `0.4.4` though it sorts above it.
-            return found <= ceiling or found.base_version == ceiling.base_version
+            return _Version(self.minimum) <= found <= _Version(self.maximum)
         except Exception:
-            # An unparseable version is not evidence of anything.
+            # Neither an unparseable installed version nor an unparseable bound
+            # is evidence of anything. Refusing beats raising out of collation.
             return False
 
     def __str__(self):
@@ -5689,14 +5692,16 @@ def _check_audio_transformers_floor(family):
         version = transformers.__version__
         # PEP 440, not int(split(".")): "5.5rc1" or a v-prefixed tag would
         # raise and be refused as a version that could not be determined.
-        parts = _Version(version).release[:2]
+        # Compared whole rather than by `.release`, which would read 5.5rc1 as
+        # 5.5 and admit a prerelease of the floor -- PEP 440 sorts it below.
+        found = _Version(version)
     except Exception:
         raise NotImplementedError(
             f"Unsloth MLX: audio training for '{family}' requires transformers "
             f"{floor[0]}.{floor[1]} or newer, and the installed version could "
             f"not be determined."
         ) from None
-    if parts < floor:
+    if found < _Version(f"{floor[0]}.{floor[1]}"):
         raise NotImplementedError(
             f"Unsloth MLX: audio training for '{family}' was verified on "
             f"transformers {floor[0]}.{floor[1]}, but {version} is installed; "

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5597,9 +5597,8 @@ class _AudioVersions(NamedTuple):
             ceiling = _Version(self.maximum)
             if found < _Version(self.minimum):
                 return False
-            # A post-release carries the same code as the release it follows,
-            # so `0.4.4.post1` is inside a range ending at `0.4.4` even though
-            # it sorts above it.
+            # A post-release is the same code repackaged, so `0.4.4.post1` is
+            # inside a range ending at `0.4.4` though it sorts above it.
             return found <= ceiling or found.base_version == ceiling.base_version
         except Exception:
             # An unparseable version is not evidence of anything.
@@ -5613,17 +5612,15 @@ class _AudioVersions(NamedTuple):
 
 # Families and the mlx-vlm releases their audio path is qualified for.
 #
-# The probes ran on 0.4.4. Three of these families ship a processor that is
-# byte-identical from 0.4.4 through 0.6.9, so the probed code is the code that
-# runs and the range is widened to every release that can be installed beside
-# this package -- mlx-vlm 0.6.5+ requires transformers>=5.14, which pyproject
-# caps at 5.5.0, so 0.6.4 is the real ceiling.
+# The probes ran on 0.4.4. gemma3n, phi4mm and minicpmo ship a processor that
+# is byte-identical from 0.4.4 through 0.6.9, so the probed code is the code
+# that runs; the ceiling is 0.6.4 only because mlx-vlm 0.6.5+ requires
+# transformers>=5.14, which this package caps at 5.5.0.
 #
-# Gemma 4 is deliberately left at the probed version. Its processor changed in
-# 0.5.0, upstream reports it failing to load at all from 0.6.4
-# (Blaizzy/mlx-vlm#1526, with 0.6.3 good), and 0.6.3 added a separate
-# `gemma4_unified` family. Re-probing it needs a real checkpoint on Apple
-# hardware; until then, refusing is the honest answer.
+# Gemma 4 stays at the probed version: its processor changed in 0.5.0, upstream
+# reports it failing to load from 0.6.4 with 0.6.3 good (Blaizzy/mlx-vlm#1526),
+# and 0.6.3 added a separate `gemma4_unified` family. Re-probing needs a real
+# checkpoint on Apple hardware.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4", "0.6.4"),
     "gemma4": _AudioVersions("0.4.4", "0.4.4"),
@@ -5631,8 +5628,7 @@ _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "minicpmo": _AudioVersions("0.4.4", "0.6.4"),
 }
 
-# Renames upstream gave a family this gate qualified under another name, so the
-# refusal can say which entry the user is actually looking at.
+# Names upstream renamed, so a refusal can point at the qualified entry.
 _AUDIO_FAMILY_RENAMES = {"gemma4_unified": "gemma4"}
 
 # Families probed only on a newer transformers than this package pins, at the
@@ -5691,10 +5687,8 @@ def _check_audio_transformers_floor(family):
         import transformers
 
         version = transformers.__version__
-        # PEP 440 rather than int(split(".")): a release candidate ("5.5rc1")
-        # or a v-prefixed tag would otherwise raise here and be reported as a
-        # version that could not be determined, which is both a refusal of a
-        # perfectly good release and a misleading reason for it.
+        # PEP 440, not int(split(".")): "5.5rc1" or a v-prefixed tag would
+        # raise and be refused as a version that could not be determined.
         parts = _Version(version).release[:2]
     except Exception:
         raise NotImplementedError(
@@ -5910,9 +5904,8 @@ def _check_audio_family_gate(processor):
         return family
     renamed = _AUDIO_FAMILY_RENAMES.get(family)
     if renamed and renamed in _AUDIO_QUALIFIED_FAMILIES:
-        # Upstream renamed a qualified family; the entry under the old name
-        # says nothing about the new one, so say that rather than reporting an
-        # unrecognised family the user cannot act on.
+        # The entry under the old name says nothing about the renamed
+        # implementation, so say that instead of "unrecognised family".
         raise NotImplementedError(
             f"Unsloth MLX: audio training is not supported for '{family}'. "
             f"mlx-vlm {installed or 'unknown'} loads this checkpoint as "

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5594,17 +5594,13 @@ class _AudioVersions(NamedTuple):
             return False
         try:
             found = _Version(installed)
-            # Only published final releases were qualified. mlx-vlm has
-            # published no prerelease, post-release or local build in 73
-            # releases, so none of these is a version anyone was probed
-            # against, and each can carry code the probes never saw -- a local
-            # build most of all.
+            # Only published final releases were probed, and mlx-vlm has shipped
+            # no prerelease, post-release or local build in 73 releases.
             if found.is_prerelease or found.is_postrelease or found.local:
                 return False
             return _Version(self.minimum) <= found <= _Version(self.maximum)
         except Exception:
-            # Neither an unparseable installed version nor an unparseable bound
-            # is evidence of anything. Refusing beats raising out of collation.
+            # An unparseable version is not evidence; refusing beats raising.
             return False
 
     def __str__(self):
@@ -5615,15 +5611,13 @@ class _AudioVersions(NamedTuple):
 
 # Families and the mlx-vlm releases their audio path is qualified for.
 #
-# The probes ran on 0.4.4. gemma3n, phi4mm and minicpmo ship a processor that
-# is byte-identical from 0.4.4 through 0.6.9, so the probed code is the code
-# that runs; the ceiling is 0.6.4 only because mlx-vlm 0.6.5+ requires
-# transformers>=5.14, which this package caps at 5.5.0.
+# Probes ran on 0.4.4. gemma3n, phi4mm and minicpmo ship a byte-identical
+# processor from 0.4.4 through 0.6.9; the 0.6.4 ceiling is only because mlx-vlm
+# 0.6.5+ requires transformers>=5.14, which this package caps at 5.5.0.
 #
-# Gemma 4 stays at the probed version: its processor changed in 0.5.0, upstream
-# reports it failing to load from 0.6.4 with 0.6.3 good (Blaizzy/mlx-vlm#1526),
-# and 0.6.3 added a separate `gemma4_unified` family. Re-probing needs a real
-# checkpoint on Apple hardware.
+# Gemma 4 stays at 0.4.4: its processor changed in 0.5.0, upstream reports it
+# failing to load from 0.6.4 with 0.6.3 good (Blaizzy/mlx-vlm#1526), and 0.6.3
+# added a separate `gemma4_unified` family. Re-probing needs Apple hardware.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4", "0.6.4"),
     "gemma4": _AudioVersions("0.4.4", "0.4.4"),
@@ -5690,10 +5684,9 @@ def _check_audio_transformers_floor(family):
         import transformers
 
         version = transformers.__version__
-        # PEP 440, not int(split(".")): "5.5rc1" or a v-prefixed tag would
-        # raise and be refused as a version that could not be determined.
-        # Compared whole rather than by `.release`, which would read 5.5rc1 as
-        # 5.5 and admit a prerelease of the floor -- PEP 440 sorts it below.
+        # PEP 440, not int(split(".")), which raised on "5.5rc1" or a v-prefixed
+        # tag. Compared whole, not by `.release`: that reads 5.5rc1 as 5.5, and
+        # PEP 440 sorts the prerelease below 5.5.0.
         found = _Version(version)
     except Exception:
         raise NotImplementedError(
@@ -5909,8 +5902,7 @@ def _check_audio_family_gate(processor):
         return family
     renamed = _AUDIO_FAMILY_RENAMES.get(family)
     if renamed and renamed in _AUDIO_QUALIFIED_FAMILIES:
-        # The entry under the old name says nothing about the renamed
-        # implementation, so say that instead of "unrecognised family".
+        # The old name's entry says nothing about the renamed implementation.
         raise NotImplementedError(
             f"Unsloth MLX: audio training is not supported for '{family}'. "
             f"mlx-vlm {installed or 'unknown'} loads this checkpoint as "


### PR DESCRIPTION
Two defects that shipped with #966. The second is why the first reached main.

## The audio gate refuses every installable mlx-vlm

`_AUDIO_QUALIFIED_FAMILIES` admitted a family only when the installed mlx-vlm matched the string `"0.4.4"`. `pyproject.toml` declares `mlx-vlm>=0.4.4`, Studio installs unpinned and actively upgrades an old mlx-vlm, and PyPI now serves 0.6.9. So on a normal install every audio row raised `NotImplementedError` and the feature was unreachable.

This is not hypothetical: `tests/test_mlx_vlm_label_masks.py::test_qualified_families_carry_their_probed_requirements` **fails on main today**.

The gate stays fail-closed. A wrong "yes" here trains against misaligned audio features and fails silently; a wrong "no" only asks someone to pin. So each family now carries a range bounded at **both** ends, and an unreleased version is still refused rather than assumed good.

| family | qualified for | why |
|---|---|---|
| gemma3n | 0.4.4 to 0.6.4 | processor byte-identical 0.4.4 through 0.6.9 |
| phi4mm | 0.4.4 to 0.6.4 | same |
| minicpmo | 0.4.4 to 0.6.4 | same |
| **gemma4** | **0.4.4 only** | processor changed in 0.5.0; see below |

The three widened families ship a processor that is **byte-identical** to the code the probes ran against, from 0.4.4 through 0.6.9, so the probed code is the code that runs. The 0.6.4 ceiling is a dependency fact rather than a guess: mlx-vlm 0.6.5+ requires `transformers>=5.14`, which this package caps at `5.5.0`, so 0.6.5 and later cannot be installed beside it at all.

**Gemma 4 is deliberately not widened.** Its processor changed in 0.5.0, upstream reports it failing to load from 0.6.4 with 0.6.3 good ([Blaizzy/mlx-vlm#1526](https://github.com/Blaizzy/mlx-vlm/issues/1526)), and 0.6.3 added a separate `gemma4_unified` family that a gemma 4 checkpoint can now present as. Re-qualifying it needs a real checkpoint on Apple hardware. `gemma4_unified` is refused by name, pointing at the entry and version to pin rather than reporting something unrecognised.

Also fixes the transformers floor, which parsed with `int()` over the first two dot-components inside a catch-all handler, so `5.5rc1` and `v5.5.0` raised there and were refused as versions that *could not be determined*. Parsed per PEP 440 now, so only a genuinely unreadable version gets that message.

## Nothing was running these tests

`test_mlx_vlm_label_masks.py`, `test_mlx_shape_guard.py` and `test_mlx_batching_and_decay.py` appear in no `run:` line in `.github/workflows/`. `pytest tests/ --collect-only` proves only that they import, and it is `continue-on-error` besides. 227 test functions were carried without ever executing.

Added on `ubuntu-latest` with `mlx[cpu]` (mlx publishes manylinux CPU wheels and mlx-lm/mlx-vlm are `py3-none-any`, so this costs no macOS minutes) and on the existing `macos-14` job, where they meet real Metal and the mlx-vlm version an Apple Silicon user actually resolves.

One pytest process per file, as `mlx-ci.yml` already does, because `tests/mlx_simulation/` replaces `sys.modules["mlx.core"]` process-wide.

The Linux job asserts the real runtime before running anything. All three files `importorskip` `mlx.core`, and a module that skips wholesale still exits 0, so without that assertion the job would report green having run nothing. Measured with mlx absent: two of the three report `1 skipped` and exit 0.

## Verification

Gate behaviour driven across the version axis, per family:

```
family                 0.4.3       0.4.4 0.4.4.post1    0.5.0rc1       0.5.0       0.6.4     0.6.4+x       0.6.5
gemma3n               refuse       ALLOW      refuse      refuse       ALLOW       ALLOW      refuse      refuse
phi4mm                refuse       ALLOW      refuse      refuse       ALLOW       ALLOW      refuse      refuse
minicpmo              refuse       ALLOW      refuse      refuse       ALLOW       ALLOW      refuse      refuse
gemma4                refuse       ALLOW      refuse      refuse      refuse      refuse      refuse      refuse
gemma4_unified        refuse      refuse      refuse      refuse      refuse      refuse      refuse      refuse
```

Only published final releases are inside a window: prereleases, post-releases and local builds are
refused. mlx-vlm has published none of the three across 73 releases, so admitting them would widen a
fail-closed gate for a case that has never happened. That does mean `0.4.4.post1` is refused, which
narrows the original report slightly, and is deliberate.

The Linux job resolves the MLX packages in the same pip call as `.[core]`, so pip must honour the
`transformers<=5.5.0` cap. On a clean runner it independently lands on the ceiling this PR records:

```
real mlx at .../mlx/core.cpython-312-x86_64-linux-gnu.so
mlx-vlm 0.6.4
transformers 5.5.0 within the pinned cap
```

- Suites at this head, real CPU MLX: **301 passed, 0 failed** (213 + 32 + 56). The single failure on main is gone.
- With mlx absent: 25 passed, 7 skipped, nothing failing.
- Every fix mutation-checked by reverting it and requiring the new test to fail. The first version of the range test did **not** catch reverting the gate to string equality, because it asserted `_AudioVersions.admits` rather than the gate; it now parametrizes `_check_audio_family_gate` itself, and 3 cases fail on that revert.
