### PR TITLE
Make the package importable on the Python floor pyproject declares

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -120,6 +120,12 @@ jobs:
         # CPU-pure and monkeypatch every Hub entry point, so they cost under two
         # seconds. Left out of a gate they would have been collected but never
         # run: `pytest tests/ --collect-only` above proves only that they import.
+        #
+        # test_python39_compatibility pins the package to the floor pyproject
+        # declares. No job here runs that floor -- the matrix above starts at 3.10 --
+        # so a 3.10-only `match` and a module-level `str | Path` both reached main and
+        # made the package un-importable on 3.9. It reads the floor from pyproject, so
+        # raising requires-python relaxes it rather than making it lie.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
@@ -139,6 +145,7 @@ jobs:
             tests/test_find_common_token_ids_no_match.py \
             tests/test_vllm_direct_lora_loading.py \
             tests/test_sft_prepare_dataset_double_bos.py \
+            tests/test_python39_compatibility.py \
             -v
 
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -42,9 +42,8 @@ jobs:
       - run: pip install 'ruff==0.15.12' 'pyyaml>=6'
 
       - name: Python AST/syntax check (every committed .py must compile)
-        # continue-on-error during CI bootstrap: pyproject.toml declares
-        # `requires-python = ">=3.9,<3.15"` but temporary_patches/gpt_oss.py
-        # uses a 3.10+ `match` statement. Tracked as a separate cleanup PR.
+        # This runs on 3.12, so it cannot see syntax that is merely newer than the
+        # declared floor. tests/test_python39_compatibility.py is what pins that.
         continue-on-error: true
         run: |
           python -m compileall -q -j 0 unsloth_zoo tests scripts
@@ -52,7 +51,8 @@ jobs:
       - name: Python ruff check (narrow gate)
         # E9 / F63 / F7 / F82: syntax errors, broken comparisons, undefined names.
         # continue-on-error during CI bootstrap: first run on main surfaced 13
-        # latent findings (rl_replacements.py L1128 F821, gpt_oss match-on-3.9).
+        # latent findings (rl_replacements.py L1128 F821). The gpt_oss match-on-3.9
+        # one is fixed; the rest still need clearing before this can gate.
         continue-on-error: true
         run: |
           ruff check --select E9,F63,F7,F82 unsloth_zoo tests scripts

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -1,0 +1,149 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The package must be importable on the Python floor ``pyproject.toml`` declares.
+
+It was not. ``requires-python`` said ``>=3.9`` while ``__init__.py`` annotated
+``log_dir: str | Path`` at module level, so ``import unsloth_zoo`` died with
+``TypeError: unsupported operand type(s) for |`` before reaching anything else, and
+``temporary_patches/gpt_oss.py`` used a ``match`` statement that 3.9 cannot even parse.
+Nothing caught it: no CI job runs the floor, and the whole matrix starts at 3.10.
+
+The floor is read from ``pyproject.toml`` rather than hardcoded, so raising
+``requires-python`` relaxes these checks instead of turning them into a false alarm.
+
+Two exclusions, both asserted below rather than trusted:
+``_vendored/fla`` is skipped entirely under 3.10 by ``fla_vendor.py``, and the lazy
+``mlx`` modules cannot run on the floor because ``mlx`` itself requires 3.10+.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "unsloth_zoo"
+
+# Imported eagerly by unsloth_zoo/__init__.py, so they must hold on the floor even
+# though the rest of mlx/ is lazy.
+MLX_IMPORT_TIME = {"__init__.py", "runtime.py"}
+
+
+def declared_floor():
+    """The ``>=X.Y`` in requires-python, as a tuple for ast.parse(feature_version=)."""
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r"^requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.M)
+    assert match, "no requires-python in pyproject.toml"
+    floor = re.search(r">=\s*(\d+)\.(\d+)", match.group(1))
+    assert floor, f"no >= lower bound in requires-python = {match.group(1)!r}"
+    return int(floor.group(1)), int(floor.group(2))
+
+
+def in_scope(path):
+    """Files that must work on the floor, with the two exclusions applied."""
+    rel = path.relative_to(PACKAGE_ROOT).parts
+    if rel[0] == "_vendored":
+        return False
+    if rel[0] == "mlx" and path.name not in MLX_IMPORT_TIME:
+        return False
+    return True
+
+
+def scoped_files():
+    files = sorted(p for p in PACKAGE_ROOT.rglob("*.py")
+                   if "__pycache__" not in p.parts and in_scope(p))
+    assert len(files) > 50, f"only found {len(files)} files, the glob is wrong"
+    return files
+
+
+def annotations_of(node):
+    """Annotation expressions that this node evaluates at def/exec time."""
+    if isinstance(node, ast.AnnAssign):
+        return [node.annotation] if node.annotation else []
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return []
+    args = node.args
+    out = [a.annotation for a in
+           [*args.args, *args.kwonlyargs, *args.posonlyargs, args.vararg, args.kwarg]
+           if a is not None and a.annotation is not None]
+    if node.returns:
+        out.append(node.returns)
+    return out
+
+
+def has_future_annotations(tree):
+    return any(isinstance(n, ast.ImportFrom) and n.module == "__future__"
+               and any(alias.name == "annotations" for alias in n.names)
+               for n in tree.body)
+
+
+def test_every_module_parses_on_the_declared_floor():
+    floor = declared_floor()
+    broken = []
+    for path in scoped_files():
+        try:
+            ast.parse(path.read_text(encoding="utf-8"), filename=str(path),
+                      feature_version=floor)
+        except SyntaxError as error:
+            broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
+    assert not broken, (
+        "syntax newer than the declared floor "
+        f"{floor[0]}.{floor[1]}; either rewrite it or raise requires-python:\n  "
+        + "\n  ".join(broken)
+    )
+
+
+def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
+    """`X | Y` is a TypeError below 3.10 unless the module defers annotations."""
+    if declared_floor() >= (3, 10):
+        pytest.skip("floor is 3.10+, PEP 604 evaluates fine")
+    offenders = []
+    for path in scoped_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if has_future_annotations(tree):
+            continue
+        for node in ast.walk(tree):
+            for annotation in annotations_of(node):
+                for inner in ast.walk(annotation):
+                    if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
+                        offenders.append(
+                            f"{path.relative_to(REPO_ROOT)}:{inner.lineno}: "
+                            f"{ast.unparse(inner)}"
+                        )
+    assert not offenders, (
+        "PEP 604 unions evaluated at def time; add `from __future__ import "
+        "annotations` to these modules:\n  " + "\n  ".join(sorted(set(offenders)))
+    )
+
+
+def test_vendored_fla_stays_gated_below_310():
+    """The exclusion above is only sound while this guard skips the injection."""
+    source = (PACKAGE_ROOT / "temporary_patches" / "fla_vendor.py").read_text(encoding="utf-8")
+    assert re.search(r"sys\.version_info\s*<\s*\(\s*3\s*,\s*10\s*\)", source), (
+        "the <3.10 guard in fla_vendor.py is gone, so the vendored kernels can now be "
+        "injected on the floor - either restore it or bring _vendored/fla into scope here"
+    )
+
+
+def test_mlx_modules_reachable_at_import_are_in_scope():
+    """mlx/ is excluded as lazy, but these two are imported by unsloth_zoo/__init__.py."""
+    for name in sorted(MLX_IMPORT_TIME):
+        path = PACKAGE_ROOT / "mlx" / name
+        assert path.exists(), f"{path} vanished; update MLX_IMPORT_TIME"
+        assert in_scope(path), f"{name} must stay in scope, it is imported eagerly"

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -310,6 +310,23 @@ def test_vendored_fla_stays_gated_below_310():
         "on the floor - restore the guard or bring _vendored/fla into in_scope()"
     )
 
+    # The guard only matters if the injection path actually consults it.
+    injectors = [n for n in ast.walk(tree)
+                 if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                 and any(isinstance(c, ast.Call)
+                         and getattr(c.func, "id", None) == "_inject_vendored_fla"
+                         for c in ast.walk(n))]
+    assert injectors, "nothing calls _inject_vendored_fla; re-point this test"
+    for caller in injectors:
+        consults = any(isinstance(c, ast.Call)
+                       and getattr(c.func, "id", None) == "_torch_triton_cuda_supported"
+                       for c in ast.walk(caller))
+        assert consults, (
+            f"{caller.name} injects the vendored FLA kernels without consulting "
+            "_torch_triton_cuda_supported, so the <3.10 guard no longer gates injection "
+            "and excluding _vendored/fla from this gate is unsound"
+        )
+
 
 def strict_patch_calls(tree):
     """``patch_function(...)`` calls that keep the default ``match_level="strict"``."""

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -41,14 +41,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_ROOT = REPO_ROOT / "unsloth_zoo"
 
 # Imported eagerly by unsloth_zoo/__init__.py, so they must hold on the floor even
-# though the rest of mlx/ is lazy.
-MLX_IMPORT_TIME = {"__init__.py", "runtime.py"}
+# though the rest of mlx/ is lazy. Package-relative, since mlx/cce/__init__.py shares
+# a file name with mlx/__init__.py but is lazy like the rest of the subpackage.
+MLX_IMPORT_TIME = {"mlx/__init__.py", "mlx/runtime.py"}
 
 
 def declared_floor():
     """The ``>=X.Y`` in requires-python, as a tuple for ast.parse(feature_version=)."""
     text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    match = re.search(r"^requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.M)
+    match = re.search(r"^requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.MULTILINE)
     assert match, "no requires-python in pyproject.toml"
     floor = re.search(r">=\s*(\d+)\.(\d+)", match.group(1))
     assert floor, f"no >= lower bound in requires-python = {match.group(1)!r}"
@@ -57,10 +58,10 @@ def declared_floor():
 
 def in_scope(path):
     """Files that must work on the floor, with the two exclusions applied."""
-    rel = path.relative_to(PACKAGE_ROOT).parts
-    if rel[0] == "_vendored":
+    rel = path.relative_to(PACKAGE_ROOT)
+    if rel.parts[0] == "_vendored":
         return False
-    if rel[0] == "mlx" and path.name not in MLX_IMPORT_TIME:
+    if rel.parts[0] == "mlx" and rel.as_posix() not in MLX_IMPORT_TIME:
         return False
     return True
 
@@ -72,18 +73,71 @@ def scoped_files():
     return files
 
 
-def annotations_of(node):
-    """Annotation expressions that this node evaluates at def/exec time."""
-    if isinstance(node, ast.AnnAssign):
-        return [node.annotation] if node.annotation else []
-    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        return []
+def signature_annotations(node):
+    """Parameter and return annotations, evaluated when the ``def`` executes."""
     args = node.args
     out = [a.annotation for a in
            [*args.args, *args.kwonlyargs, *args.posonlyargs, args.vararg, args.kwarg]
            if a is not None and a.annotation is not None]
     if node.returns:
         out.append(node.returns)
+    return out
+
+
+def evaluated_annotations(tree):
+    """Annotations Python evaluates, so the future import is what defers them.
+
+    Variable annotations are evaluated at module and class scope only; inside a
+    function body they are never evaluated, so flagging those is a false positive.
+    Signature annotations are evaluated wherever their ``def`` is.
+    """
+    out = []
+
+    def walk(node, in_function):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.AnnAssign) and child.annotation and not in_function:
+                out.append(child.annotation)
+            elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                out.extend(signature_annotations(child))
+            nested = isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda))
+            walk(child, in_function or nested)
+
+    walk(tree, False)
+    return out
+
+
+def looks_like_a_type(node):
+    """Conservative: enough for ``str | Path``, not enough for ``re.A | re.M``.
+
+    Flag constants are ALL_CAPS by convention, so requiring a non-caps name keeps
+    bitwise arithmetic (``re.DOTALL | re.MULTILINE``, ``os.W_OK | os.X_OK``) out.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value is None
+    if isinstance(node, ast.Subscript):
+        return looks_like_a_type(node.value)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return looks_like_a_type(node.left) and looks_like_a_type(node.right)
+    name = getattr(node, "id", None) or getattr(node, "attr", None)
+    return bool(name) and not name.isupper()
+
+
+def evaluated_values(tree):
+    """Assigned values at module and class scope, which run on import.
+
+    Type aliases are the case that matters: ``PathLike = str | Path`` raises below
+    3.10 and, unlike an annotation, the future import does not defer it.
+    """
+    out = []
+
+    def walk(node):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.Assign, ast.AnnAssign)) and child.value is not None:
+                out.append(child.value)
+            if isinstance(child, ast.ClassDef):
+                walk(child)
+
+    walk(tree)
     return out
 
 
@@ -110,40 +164,79 @@ def test_every_module_parses_on_the_declared_floor():
 
 
 def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
-    """`X | Y` is a TypeError below 3.10 unless the module defers annotations."""
+    """``X | Y`` is a TypeError below 3.10 unless the module defers it."""
     if declared_floor() >= (3, 10):
         pytest.skip("floor is 3.10+, PEP 604 evaluates fine")
     offenders = []
     for path in scoped_files():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        if has_future_annotations(tree):
-            continue
-        for node in ast.walk(tree):
-            for annotation in annotations_of(node):
-                for inner in ast.walk(annotation):
-                    if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
-                        offenders.append(
-                            f"{path.relative_to(REPO_ROOT)}:{inner.lineno}: "
-                            f"{ast.unparse(inner)}"
-                        )
+        where = path.relative_to(REPO_ROOT)
+        # The future import defers annotations only; an assigned value still runs.
+        deferred = has_future_annotations(tree)
+        for expression in ([] if deferred else evaluated_annotations(tree)):
+            for inner in ast.walk(expression):
+                if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
+                    offenders.append(
+                        f"{where}:{inner.lineno}: {ast.unparse(inner)} (annotation)")
+        for expression in evaluated_values(tree):
+            for inner in ast.walk(expression):
+                if (isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr)
+                        and looks_like_a_type(inner)):
+                    offenders.append(
+                        f"{where}:{inner.lineno}: {ast.unparse(inner)} (type alias)")
     assert not offenders, (
-        "PEP 604 unions evaluated at def time; add `from __future__ import "
-        "annotations` to these modules:\n  " + "\n  ".join(sorted(set(offenders)))
+        "PEP 604 unions evaluated below 3.10. Annotations are deferred by `from "
+        "__future__ import annotations`; type aliases need typing.Union, which that "
+        "import does NOT defer:\n  " + "\n  ".join(sorted(set(offenders)))
     )
 
 
+def _is_floor_version_check(node):
+    """``sys.version_info < (3, 10)``, as an expression."""
+    if not (isinstance(node, ast.Compare) and len(node.ops) == 1
+            and isinstance(node.ops[0], ast.Lt)):
+        return False
+    left = node.left
+    if not (isinstance(left, ast.Attribute) and left.attr == "version_info"):
+        return False
+    right = node.comparators[0]
+    return (isinstance(right, ast.Tuple) and len(right.elts) == 2
+            and [getattr(e, "value", None) for e in right.elts] == [3, 10])
+
+
 def test_vendored_fla_stays_gated_below_310():
-    """The exclusion above is only sound while this guard skips the injection."""
-    source = (PACKAGE_ROOT / "temporary_patches" / "fla_vendor.py").read_text(encoding="utf-8")
-    assert re.search(r"sys\.version_info\s*<\s*\(\s*3\s*,\s*10\s*\)", source), (
-        "the <3.10 guard in fla_vendor.py is gone, so the vendored kernels can now be "
-        "injected on the floor - either restore it or bring _vendored/fla into scope here"
+    """Excluding _vendored/fla is sound only while this guard bails out on the floor.
+
+    Asserted structurally, not by grepping: a commented-out or dead-code check would
+    satisfy a text search while the injection went ahead anyway.
+    """
+    path = PACKAGE_ROOT / "temporary_patches" / "fla_vendor.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    guard = next((n for n in ast.walk(tree)
+                  if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                  and n.name == "_torch_triton_cuda_supported"), None)
+    assert guard is not None, (
+        "_torch_triton_cuda_supported is gone from fla_vendor.py; this test pins the "
+        "guard that lets _vendored/fla stay out of scope, so re-point it or drop that "
+        "exclusion in in_scope()"
+    )
+    bails_out = any(
+        _is_floor_version_check(node.test)
+        and any(isinstance(inner, ast.Return)
+                and getattr(inner.value, "value", None) is False
+                for inner in ast.walk(node))
+        for node in ast.walk(guard) if isinstance(node, ast.If)
+    )
+    assert bails_out, (
+        "no `if sys.version_info < (3, 10): return False` controls "
+        "_torch_triton_cuda_supported, so the vendored FLA kernels can now be injected "
+        "on the floor - restore the guard or bring _vendored/fla into in_scope()"
     )
 
 
 def test_mlx_modules_reachable_at_import_are_in_scope():
     """mlx/ is excluded as lazy, but these two are imported by unsloth_zoo/__init__.py."""
-    for name in sorted(MLX_IMPORT_TIME):
-        path = PACKAGE_ROOT / "mlx" / name
+    for relative in sorted(MLX_IMPORT_TIME):
+        path = PACKAGE_ROOT / relative
         assert path.exists(), f"{path} vanished; update MLX_IMPORT_TIME"
-        assert in_scope(path), f"{name} must stay in scope, it is imported eagerly"
+        assert in_scope(path), f"{relative} must stay in scope, it is imported eagerly"

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -193,11 +193,33 @@ def evaluated_values(tree):
                 out.extend(child.decorator_list)
             if isinstance(child, (ast.Assign, ast.AnnAssign)) and child.value is not None:
                 out.append(child.value)
+            if isinstance(child, ast.Expr):
+                out.append(child.value)   # a bare call runs on import too
             if isinstance(child, scoped):
                 walk(child)
 
     walk(tree)
     return out
+
+
+def union_nodes(expression):
+    """``BinOp(BitOr)`` nodes in an annotation, skipping ``Literal[...]`` contents.
+
+    ``Literal[re.I | re.M]`` is flag arithmetic over values, evaluates fine on 3.9,
+    and must not be read as a union.
+    """
+    if isinstance(expression, ast.Subscript):
+        base = expression.value
+        name = getattr(base, "id", None) or getattr(base, "attr", None)
+        if name == "Literal":
+            return union_nodes(base)
+        return union_nodes(base) + union_nodes(expression.slice)
+    found = []
+    if isinstance(expression, ast.BinOp) and isinstance(expression.op, ast.BitOr):
+        found.append(expression)
+    for child in ast.iter_child_nodes(expression):
+        found.extend(union_nodes(child))
+    return found
 
 
 def has_future_annotations(tree):
@@ -251,14 +273,12 @@ def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
         # The future import defers annotations only; an assigned value still runs.
         deferred = has_future_annotations(tree)
         for expression in ([] if deferred else evaluated_annotations(tree)):
-            for inner in ast.walk(expression):
-                if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr):
-                    offenders.append(
-                        f"{where}:{inner.lineno}: {ast.unparse(inner)} (annotation)")
+            for inner in union_nodes(expression):
+                offenders.append(
+                    f"{where}:{inner.lineno}: {ast.unparse(inner)} (annotation)")
         for expression in evaluated_values(tree):
-            for inner in ast.walk(expression):
-                if (isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr)
-                        and looks_like_a_type_alias(inner, known_typing_names)):
+            for inner in union_nodes(expression):
+                if looks_like_a_type_alias(inner, known_typing_names):
                     offenders.append(
                         f"{where}:{inner.lineno}: {ast.unparse(inner)} (type alias)")
     assert not offenders, (

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -170,18 +170,30 @@ def looks_like_a_type_alias(node, known_typing_names):
 
 
 def evaluated_values(tree):
-    """Assigned values at module and class scope, which run on import.
+    """Expressions that run at import, at module or class scope.
 
     Type aliases are the case that matters: ``PathLike = str | Path`` raises below
-    3.10 and, unlike an annotation, the future import does not defer it.
+    3.10 and, unlike an annotation, the future import does not defer it. Decorator
+    expressions and parameter defaults are evaluated the same way, so they belong
+    here too. Control flow is descended into (a branch that runs, runs) but function
+    bodies are not, since those only execute when called.
     """
     out = []
+    scoped = (ast.If, ast.Try, ast.With, ast.AsyncWith, ast.For, ast.AsyncFor,
+              ast.While, ast.ExceptHandler, ast.ClassDef)
 
     def walk(node):
         for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                out.extend(child.decorator_list)
+                out.extend(d for d in child.args.defaults if d is not None)
+                out.extend(d for d in child.args.kw_defaults if d is not None)
+                continue  # the body only runs when called
+            if isinstance(child, ast.ClassDef):
+                out.extend(child.decorator_list)
             if isinstance(child, (ast.Assign, ast.AnnAssign)) and child.value is not None:
                 out.append(child.value)
-            if isinstance(child, ast.ClassDef):
+            if isinstance(child, scoped):
                 walk(child)
 
     walk(tree)
@@ -208,6 +220,23 @@ def test_every_module_parses_on_the_declared_floor():
         f"{floor[0]}.{floor[1]}; either rewrite it or raise requires-python:\n  "
         + "\n  ".join(broken)
     )
+
+
+def test_every_module_compiles():
+    """``ast.parse`` accepts things ``compile`` rejects, and only compile runs on import.
+
+    A misplaced ``from __future__ import annotations`` is the case that bites here: it
+    parses, it makes ``has_future_annotations`` suppress the union check, and it still
+    raises SyntaxError on import.
+    """
+    broken = []
+    for path in scoped_files():
+        try:
+            compile(path.read_text(encoding="utf-8"), str(path), "exec",
+                    dont_inherit=True)
+        except SyntaxError as error:
+            broken.append(f"{path.relative_to(REPO_ROOT)}:{error.lineno}: {error.msg}")
+    assert not broken, "these modules do not compile:\n  " + "\n  ".join(broken)
 
 
 def test_no_pep604_unions_are_evaluated_on_the_declared_floor():

--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -89,7 +89,8 @@ def evaluated_annotations(tree):
 
     Variable annotations are evaluated at module and class scope only; inside a
     function body they are never evaluated, so flagging those is a false positive.
-    Signature annotations are evaluated wherever their ``def`` is.
+    A class body nested in a function is still class scope, so it goes back to
+    being evaluated. Signature annotations are evaluated wherever their ``def`` is.
     """
     out = []
 
@@ -99,27 +100,73 @@ def evaluated_annotations(tree):
                 out.append(child.annotation)
             elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 out.extend(signature_annotations(child))
-            nested = isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda))
-            walk(child, in_function or nested)
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                walk(child, True)
+            elif isinstance(child, ast.ClassDef):
+                walk(child, False)
+            else:
+                walk(child, in_function)
 
     walk(tree, False)
     return out
 
 
-def looks_like_a_type(node):
-    """Conservative: enough for ``str | Path``, not enough for ``re.A | re.M``.
+# A `|` between these is a union, not arithmetic: builtin types, `None`, and whatever
+# the module pulled in from typing.
+TYPE_ANCHORS = frozenset({
+    "str", "int", "float", "bool", "bytes", "bytearray", "complex", "object", "type",
+    "list", "dict", "tuple", "set", "frozenset",
+})
+TYPING_MODULES = frozenset({"typing", "typing_extensions", "collections.abc"})
 
-    Flag constants are ALL_CAPS by convention, so requiring a non-caps name keeps
-    bitwise arithmetic (``re.DOTALL | re.MULTILINE``, ``os.W_OK | os.X_OK``) out.
+
+def typing_names(tree):
+    """Names this module bound with ``from typing import X`` and friends."""
+    return {alias.asname or alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module in TYPING_MODULES
+            for alias in node.names}
+
+
+def union_operands(node):
+    """Operands of an ``A | B | C`` chain, or None if any part is not name-shaped.
+
+    ``str``, ``os.PathLike``, ``List[int]``, ``None`` and a ``"ForwardRef"`` string
+    are name-shaped; a call, a set/dict/list display or a number is not.
     """
-    if isinstance(node, ast.Constant):
-        return node.value is None
-    if isinstance(node, ast.Subscript):
-        return looks_like_a_type(node.value)
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return looks_like_a_type(node.left) and looks_like_a_type(node.right)
-    name = getattr(node, "id", None) or getattr(node, "attr", None)
-    return bool(name) and not name.isupper()
+        left, right = union_operands(node.left), union_operands(node.right)
+        return None if left is None or right is None else left + right
+    if isinstance(node, ast.Subscript):
+        return union_operands(node.value)
+    if isinstance(node, (ast.Name, ast.Attribute)):
+        return [node]
+    if isinstance(node, ast.Constant) and (node.value is None
+                                           or isinstance(node.value, str)):
+        return [node]
+    return None
+
+
+def looks_like_a_type_alias(node, known_typing_names):
+    """``PathLike = str | Path`` yes; ``defaults | extra`` and ``re.A | re.M`` no.
+
+    Every operand must be name-shaped and at least one must be a recognisable type.
+    Without that anchor a ``|`` between plain names is far more likely to be a dict
+    merge (PEP 584, valid on 3.9), a set union or flag arithmetic, and failing the
+    gate on those would block code that runs perfectly well on the floor.
+    """
+    operands = union_operands(node)
+    if not operands:
+        return False
+    for operand in operands:
+        if isinstance(operand, ast.Constant):
+            if operand.value is None:
+                return True
+            continue  # a bare string is a forward reference, never an anchor alone
+        name = operand.id if isinstance(operand, ast.Name) else operand.attr
+        if name in TYPE_ANCHORS or name in known_typing_names:
+            return True
+    return False
 
 
 def evaluated_values(tree):
@@ -171,6 +218,7 @@ def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
     for path in scoped_files():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         where = path.relative_to(REPO_ROOT)
+        known_typing_names = typing_names(tree)
         # The future import defers annotations only; an assigned value still runs.
         deferred = has_future_annotations(tree)
         for expression in ([] if deferred else evaluated_annotations(tree)):
@@ -181,7 +229,7 @@ def test_no_pep604_unions_are_evaluated_on_the_declared_floor():
         for expression in evaluated_values(tree):
             for inner in ast.walk(expression):
                 if (isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr)
-                        and looks_like_a_type(inner)):
+                        and looks_like_a_type_alias(inner, known_typing_names)):
                     offenders.append(
                         f"{where}:{inner.lineno}: {ast.unparse(inner)} (type alias)")
     assert not offenders, (
@@ -231,6 +279,44 @@ def test_vendored_fla_stays_gated_below_310():
         "no `if sys.version_info < (3, 10): return False` controls "
         "_torch_triton_cuda_supported, so the vendored FLA kernels can now be injected "
         "on the floor - restore the guard or bring _vendored/fla into in_scope()"
+    )
+
+
+def strict_patch_calls(tree):
+    """``patch_function(...)`` calls that keep the default ``match_level="strict"``."""
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+        if name != "patch_function":
+            continue
+        if not any(kw.arg == "match_level" for kw in node.keywords):
+            out.append(node)
+    return out
+
+
+def test_modules_with_strict_patches_do_not_defer_annotations():
+    """Deferring annotations is not a safe way to reach the floor in a patching module.
+
+    ``can_safely_patch`` compares ``inspect.signature(...).annotation`` objects directly,
+    with no ``get_type_hints``, so under the default strict match level a stringified
+    annotation never equals the live upstream one. ``patch_function`` then declines the
+    patch and only logs it, which is silent in normal use. Reach the floor with
+    ``typing.Optional`` / ``typing.Union`` in these modules instead.
+    """
+    offenders = []
+    for path in scoped_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if not has_future_annotations(tree):
+            continue
+        for call in strict_patch_calls(tree):
+            offenders.append(f"{path.relative_to(REPO_ROOT)}:{call.lineno}")
+    assert not offenders, (
+        "`from __future__ import annotations` in a module that calls patch_function at "
+        "the default strict match level; the patch will be silently skipped. Use "
+        "typing.Optional / typing.Union for the annotations instead:\n  "
+        + "\n  ".join(sorted(set(offenders)))
     )
 
 

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -14,6 +14,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+# Keeps PEP 604 annotations (`str | Path`) from being evaluated at def time, which
+# is a TypeError on the 3.9 floor pyproject declares.
+from __future__ import annotations
+
 __version__ = "2026.8.2"
 
 import os

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2917,10 +2917,11 @@ def encode_conversations_with_harmony(
 
     assert reasoning_effort in ("low", "medium", "high")
 
-    match reasoning_effort:
-        case "low":     harmony_reasoning = ReasoningEffort.LOW
-        case "medium":  harmony_reasoning = ReasoningEffort.MEDIUM
-        case "high":    harmony_reasoning = ReasoningEffort.HIGH
+    # No else: an unmatched value must leave harmony_reasoning unbound exactly as
+    # `match` did, which is what happens under -O when the assert above is stripped.
+    if   reasoning_effort == "low":    harmony_reasoning = ReasoningEffort.LOW
+    elif reasoning_effort == "medium": harmony_reasoning = ReasoningEffort.MEDIUM
+    elif reasoning_effort == "high":   harmony_reasoning = ReasoningEffort.HIGH
 
     convos = []
 

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -22,10 +22,6 @@ and quantize those parameters and route the experts forward through the
 standard backend after on-the-fly dequantization.
 """
 
-# patched_convert below annotates with PEP 604 unions, which evaluate when the patch
-# is applied and raise on Python 3.9.
-from __future__ import annotations
-
 from typing import Optional, List, Union
 
 import torch
@@ -275,8 +271,12 @@ def patch_bnb4bit_quantize_convert():
     def patched_convert(
         self,
         input_dict: dict[str, Union[list[torch.Tensor], torch.Tensor]],
-        full_layer_name: str | None = None,
-        model: torch.nn.Module | None = None,
+        # typing.Optional, not `str | None`: PEP 604 evaluates at def time and raises
+        # on the 3.9 floor, and deferring it with `from __future__ import annotations`
+        # would stringify every annotation in this module, which patch_function's
+        # default strict signature match compares against the live upstream ones.
+        full_layer_name: Optional[str] = None,
+        model: Optional[torch.nn.Module] = None,
         **kwargs,
     ) -> dict[str, torch.Tensor]:
         value = list(input_dict.values())[0]

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -22,6 +22,10 @@ and quantize those parameters and route the experts forward through the
 standard backend after on-the-fly dequantization.
 """
 
+# patched_convert below annotates with PEP 604 unions, which evaluate when the patch
+# is applied and raise on Python 3.9.
+from __future__ import annotations
+
 from typing import Optional, List, Union
 
 import torch

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -28,6 +28,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# PEP 604 annotations below would evaluate at def time and raise on Python 3.9.
+from __future__ import annotations
+
 __all__ = [
     "process_vision_info",
     "UnslothVisionDataCollator",


### PR DESCRIPTION
## The problem

`pyproject.toml` declares `requires-python = ">=3.9,<3.15"`, but the package cannot be imported on 3.9 at all. On a real CPython 3.9.25:

```
File "unsloth_zoo/__init__.py", line 92, in <module>
    def has_429_exact_full_read(log_dir: str | Path) -> bool:
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

That annotation is module level and ungated, so it kills every configuration before anything else runs. Behind it, `temporary_patches/gpt_oss.py:2920` uses a `match` statement that 3.9 cannot even parse, reached eagerly through `__init__.py`'s import of `encode_conversations_with_harmony`.

This is already tracked as deferred work. `lint-ci.yml` says so verbatim:

> `continue-on-error` during CI bootstrap: pyproject.toml declares `requires-python = ">=3.9,<3.15"` but `temporary_patches/gpt_oss.py` uses a 3.10+ `match` statement. **Tracked as a separate cleanup PR.**

This is that PR. The intent to support 3.9 is not in question elsewhere in the tree: `fla_vendor.py:176` skips the vendored kernels below 3.10 *specifically* because they use runtime PEP 604 annotations, `tests/test_vendor_fla.py` has a `test_python_39_skips_injection`, and `tests/test_mlx_generate.py:103` carries the comment "no PEP 604 union: the package supports 3.9". The code simply drifted, and nothing caught it because the CI matrix starts at 3.10.

## The fix

Scope was established by parsing every module at `ast.parse(feature_version=(3,9))` and tracing import-time reachability from `__init__.py` (49 of 140 modules are eager).

| Site | Why it fires |
|---|---|
| `unsloth_zoo/__init__.py` | module level, ungated - the first failure |
| `temporary_patches/gpt_oss.py` | `match` statement, imported eagerly |
| `temporary_patches/moe_utils_bnb4bit.py` | annotations evaluate when the patch sweep runs |
| `unsloth_zoo/vision_utils.py` | fires as soon as `unsloth` imports it |

- **`gpt_oss.py`** - `match` becomes an `if`/`elif` chain with **no `else`**, so an unmatched value still leaves `harmony_reasoning` unbound exactly as `match` did. That distinction matters under `-O`, where the `assert reasoning_effort in (...)` above it is stripped.
- **The other three** - `from __future__ import annotations`, the idiom already used in 20 modules here (`hf_cache.py:25`, `fused_losses/ast_rewriter.py:30`, ...). One line each, no annotation text touched. Safe because the package calls `get_type_hints` nowhere and defines no pydantic models, so nothing reads annotations back at runtime.

## Deliberately not touched

- **`_vendored/fla/**` (158 union sites, two `zip(strict=)` calls)** - already skipped below 3.10 by `fla_vendor.py:176`, and it is a vendored upstream snapshot.
- **`mlx/**` (42 union sites)** - `mlx` and `mlx-vlm` themselves declare `requires-python = ">=3.10"`, so this code cannot run on 3.9. The two eagerly-imported modules, `mlx/__init__.py` and `mlx/runtime.py`, are in scope and clean.

Both exclusions are asserted by the new test rather than left as folklore.

## The regression gate

`tests/test_python39_compatibility.py` is CPU-pure, needs no torch and no network, and reads the floor **from `pyproject.toml`** instead of hardcoding it - so raising `requires-python` relaxes the checks rather than turning them into a false alarm. Four assertions:

1. every in-scope module parses at the declared floor;
2. no in-scope module evaluates a PEP 604 union unless it defers annotations;
3. the `<3.10` guard in `fla_vendor.py` still exists (removing it invalidates exclusion 1);
4. `mlx/__init__.py` and `mlx/runtime.py` stay in scope (they are imported eagerly).

Added to the `pytest behavioral gates (HARD GATE)` list. The stale `lint-ci.yml` comments deferring this work are updated; I did **not** flip `continue-on-error` on the ruff step, since that comment records 13 latent findings including an unrelated `rl_replacements.py` F821 that this PR does not address.

## Verification

- **Non-vacuity first.** On unfixed `main`, 3.9 import fails at `__init__.py:92` and the syntax sweep reports exactly 1 failure. Both confirmed before the fix was written.
- **Real 3.9.25 end to end.** `import unsloth_zoo` succeeds; `gpt_oss`, `moe_utils_bnb4bit` and `vision_utils` all import; the `str | Path` annotation is evaluated during import (it is called at `:122` and `del`d at `:123`).
- **Mutation-tested.** Restoring the `match` statement, dropping the `__init__.py` future import, and removing the `fla_vendor` guard each make the new test fail, with a message naming the fix.
- **No regression on supported versions.** The behavioral gate list goes 761 -> 765 passed, 2 skipped: exactly the 4 new tests, nothing else moved.
- The `if`/`elif` rewrite was checked against all three arms plus an unmatched value.

## Known follow-up, not fixed here

A 3.9 **install** still fails to resolve, because `peft>=0.18.0` requires Python 3.10+. Every other declared dependency has a version satisfying both its pin and 3.9 (`torch` 2.8.0, `transformers` 4.57.6, `datasets` 4.3.0, `trl` 0.24.0, ...); `peft` is the only blocker. Relaxing that pin for 3.9 is a dependency decision rather than a source fix, so it is left out of this PR deliberately. Verification above used `peft 0.17.1`.

Worth noting separately: 3.9 reached end of life in October 2025, and `trl` already emits a deprecation warning about dropping it. If the preference is to raise `requires-python` to `>=3.10` instead, this PR's test would follow that automatically - but the source fixes here are worth keeping either way, since they also remove a `match` statement that `ruff` currently flags.