### PR TITLE
MLX: qualify Gemma 4 audio on the versions that can load it

### DIFF
--- a/.github/workflows/gemma4-audio-probe.yml
+++ b/.github/workflows/gemma4-audio-probe.yml
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Re-measures the gemma4 row of _AUDIO_QUALIFIED_FAMILIES on real Apple
+# Silicon, once per candidate mlx-vlm version, against a real checkpoint.
+#
+# It exists because that row cannot be reasoned about. The 0.4.4 it used to
+# carry was correct when written and was invalidated by the checkpoint being
+# re-exported on the Hub, which no amount of care at authoring time catches. A
+# version key cannot express a fact about an artefact, so the answer has to be
+# re-measured rather than re-argued -- and this makes that a label rather than
+# an investigation.
+#
+# What it found: mlx-vlm 0.6.2 (Blaizzy/mlx-vlm#1301) stopped building k_proj /
+# v_proj / k_norm for layers in the KV-shared range, which is the 60 tensors
+# E2B does not ship. 0.6.1 red, 0.6.2 green. 0.6.1 and 0.6.2 stay in the matrix
+# to hold that boundary.
+#
+# Opt-in, so it costs no macOS minutes unless someone asks for it.
+#
+# 0.6.5+ is absent on purpose: it requires transformers>=5.14 and this package
+# caps transformers at 5.5.0, so it cannot be installed here at all.
+
+name: Gemma4 audio probe (Apple Silicon)
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: 'Checkpoint to probe'
+        required: false
+        default: 'mlx-community/gemma-4-e2b-it-4bit'
+  pull_request:
+    # Label only. A push to this branch should not replay the whole matrix;
+    # re-running it is a deliberate act, so it takes a deliberate label.
+    types: [labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: "gemma4 audio @ mlx-vlm ${{ matrix.mlx_vlm }}"
+    # `contains(labels.*)` fires on ANY label event while the label is still
+    # attached, so labelling the PR for a different workflow replayed all seven
+    # macOS jobs. Match the label that was actually just added.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'gemma4-probe'
+    runs-on: macos-14
+    timeout-minutes: 45
+    strategy:
+      # Each version is a separate question; one failing must not cancel the
+      # others, because "where does it start failing" is the whole point.
+      fail-fast: false
+      matrix:
+        mlx_vlm: ['0.4.4', '0.5.0', '0.6.0', '0.6.1', '0.6.2', '0.6.3', '0.6.4']
+    steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install zoo with the pinned mlx-vlm
+        # One resolution, so pip has to honour this package's transformers cap
+        # instead of quietly lifting it for a newer mlx-vlm. torch first and
+        # separately, for the same reason mlx-ci.yml does: pyproject gates it
+        # off on darwin+arm64, but the zoo import path still wants it.
+        run: |
+          python -m pip install --upgrade pip
+          pip install "torch>=2.4.0,<2.13.0"
+          pip install -e .[mlx] "mlx-vlm==${{ matrix.mlx_vlm }}"
+          python -c "
+          import mlx_vlm, transformers
+          print('mlx-vlm', mlx_vlm.__version__, 'transformers', transformers.__version__)
+          assert mlx_vlm.__version__ == '${{ matrix.mlx_vlm }}', mlx_vlm.__version__
+          "
+
+      - name: Cache the checkpoint
+        # 3.4 GB, and every job in the matrix wants the same one. Same key on
+        # purpose: the first to finish saves it, the rest log a collision and
+        # move on.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-gemma4-e2b-4bit-v1
+
+      - name: Probe
+        # Deliberately no torchvision: pyproject does not ask for one, so a Mac
+        # user installing zoo[mlx] does not have one. Raw mlx-vlm hands Gemma 4
+        # to transformers' AutoProcessor, whose video processor hard-requires
+        # the torchvision backend and therefore fails without it; zoo resolves
+        # the mlx-vlm processor class directly and does not. Stage 0 records
+        # that difference rather than the job papering over it.
+        run: |
+          python tests/gemma4_audio_version_probe.py \
+            --model "${{ inputs.model || 'mlx-community/gemma-4-e2b-it-4bit' }}"

--- a/.github/workflows/gemma4-audio-probe.yml
+++ b/.github/workflows/gemma4-audio-probe.yml
@@ -36,8 +36,12 @@ on:
     types: [labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a label-triggered run. Concurrency is claimed when a run is
+  # queued, before the job-level `if` is evaluated, so labelling the PR with
+  # anything else (this repo's own `mlx`, say) would queue a run in this group
+  # that skips every job and cancels a seven-job macOS matrix mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.label.name }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -105,6 +109,10 @@ jobs:
         # the torchvision backend and therefore fails without it; zoo resolves
         # the mlx-vlm processor class directly and does not. Stage 0 records
         # that difference rather than the job papering over it.
-        run: |
-          python tests/gemma4_audio_version_probe.py \
-            --model "${{ inputs.model || 'mlx-community/gemma-4-e2b-it-4bit' }}"
+        #
+        # The checkpoint arrives through env, not interpolated into the script:
+        # it is the one free-text value here, and everything else in this file
+        # is a static matrix entry.
+        env:
+          MODEL: ${{ inputs.model || 'mlx-community/gemma-4-e2b-it-4bit' }}
+        run: python tests/gemma4_audio_version_probe.py --model "$MODEL"

--- a/.github/workflows/gemma4-audio-probe.yml
+++ b/.github/workflows/gemma4-audio-probe.yml
@@ -4,22 +4,16 @@
 # Re-measures the gemma4 row of _AUDIO_QUALIFIED_FAMILIES on real Apple
 # Silicon, once per candidate mlx-vlm version, against a real checkpoint.
 #
-# It exists because that row cannot be reasoned about. The 0.4.4 it used to
-# carry was correct when written and was invalidated by the checkpoint being
-# re-exported on the Hub, which no amount of care at authoring time catches. A
-# version key cannot express a fact about an artefact, so the answer has to be
-# re-measured rather than re-argued -- and this makes that a label rather than
-# an investigation.
+# That row cannot be reasoned about: the 0.4.4 it used to carry was correct
+# when written and was invalidated by the checkpoint being re-exported on the
+# Hub. A version key cannot express a fact about an artefact, so re-measure.
 #
 # What it found: mlx-vlm 0.6.2 (Blaizzy/mlx-vlm#1301) stopped building k_proj /
-# v_proj / k_norm for layers in the KV-shared range, which is the 60 tensors
-# E2B does not ship. 0.6.1 red, 0.6.2 green. 0.6.1 and 0.6.2 stay in the matrix
-# to hold that boundary.
+# v_proj / k_norm for layers in the KV-shared range, the 60 tensors E2B does
+# not ship. 0.6.1 red, 0.6.2 green; both stay in the matrix to hold that edge.
 #
-# Opt-in, so it costs no macOS minutes unless someone asks for it.
-#
-# 0.6.5+ is absent on purpose: it requires transformers>=5.14 and this package
-# caps transformers at 5.5.0, so it cannot be installed here at all.
+# Opt-in, so it costs no macOS minutes unless asked for. 0.6.5+ is absent
+# because it needs transformers>=5.14 and this package caps it at 5.5.0.
 
 name: Gemma4 audio probe (Apple Silicon)
 
@@ -31,15 +25,12 @@ on:
         required: false
         default: 'mlx-community/gemma-4-e2b-it-4bit'
   pull_request:
-    # Label only. A push to this branch should not replay the whole matrix;
-    # re-running it is a deliberate act, so it takes a deliberate label.
+    # Label only: replaying the whole matrix takes a deliberate act.
     types: [labeled]
 
 concurrency:
-  # Never cancel a label-triggered run. Concurrency is claimed when a run is
-  # queued, before the job-level `if` is evaluated, so labelling the PR with
-  # anything else (this repo's own `mlx`, say) would queue a run in this group
-  # that skips every job and cancels a seven-job macOS matrix mid-flight.
+  # Never cancel a label-triggered run: concurrency is claimed before the
+  # job-level `if` runs, so an unrelated label would kill a live macOS matrix.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.label.name }}
   cancel-in-progress: false
 
@@ -49,17 +40,16 @@ permissions:
 jobs:
   probe:
     name: "gemma4 audio @ mlx-vlm ${{ matrix.mlx_vlm }}"
-    # `contains(labels.*)` fires on ANY label event while the label is still
-    # attached, so labelling the PR for a different workflow replayed all seven
-    # macOS jobs. Match the label that was actually just added.
+    # Match the label just added: `contains(labels.*)` fires on any label event
+    # while the label is attached, replaying all seven macOS jobs.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.label.name == 'gemma4-probe'
     runs-on: macos-14
     timeout-minutes: 45
     strategy:
-      # Each version is a separate question; one failing must not cancel the
-      # others, because "where does it start failing" is the whole point.
+      # "Where does it start failing" is the point, so one red must not cancel
+      # the rest.
       fail-fast: false
       matrix:
         mlx_vlm: ['0.4.4', '0.5.0', '0.6.0', '0.6.1', '0.6.2', '0.6.3', '0.6.4']
@@ -79,10 +69,9 @@ jobs:
           cache: 'pip'
 
       - name: Install zoo with the pinned mlx-vlm
-        # One resolution, so pip has to honour this package's transformers cap
-        # instead of quietly lifting it for a newer mlx-vlm. torch first and
-        # separately, for the same reason mlx-ci.yml does: pyproject gates it
-        # off on darwin+arm64, but the zoo import path still wants it.
+        # One resolution, so pip honours this package's transformers cap. torch
+        # first, as in mlx-ci.yml: pyproject gates it off on darwin+arm64 but
+        # the zoo import path still wants it.
         run: |
           python -m pip install --upgrade pip
           pip install "torch>=2.4.0,<2.13.0"
@@ -94,25 +83,21 @@ jobs:
           "
 
       - name: Cache the checkpoint
-        # 3.4 GB, and every job in the matrix wants the same one. Same key on
-        # purpose: the first to finish saves it, the rest log a collision and
-        # move on.
+        # 3.4 GB, and every job wants the same one. Shared key on purpose: the
+        # first to finish saves it, the rest log a collision and move on.
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
           key: hf-gemma4-e2b-4bit-v1
 
       - name: Probe
-        # Deliberately no torchvision: pyproject does not ask for one, so a Mac
-        # user installing zoo[mlx] does not have one. Raw mlx-vlm hands Gemma 4
-        # to transformers' AutoProcessor, whose video processor hard-requires
-        # the torchvision backend and therefore fails without it; zoo resolves
-        # the mlx-vlm processor class directly and does not. Stage 0 records
-        # that difference rather than the job papering over it.
+        # No torchvision, matching what a Mac user installing zoo[mlx] gets.
+        # Raw mlx-vlm goes through transformers' AutoProcessor, whose video
+        # processor requires it and so fails; zoo resolves the mlx-vlm
+        # processor directly and does not. Stage 0 records that difference.
         #
-        # The checkpoint arrives through env, not interpolated into the script:
-        # it is the one free-text value here, and everything else in this file
-        # is a static matrix entry.
+        # The checkpoint arrives through env rather than interpolation: it is
+        # the one free-text value here.
         env:
           MODEL: ${{ inputs.model || 'mlx-community/gemma-4-e2b-it-4bit' }}
         run: python tests/gemma4_audio_version_probe.py --model "$MODEL"

--- a/tests/gemma4_audio_version_probe.py
+++ b/tests/gemma4_audio_version_probe.py
@@ -120,10 +120,7 @@ def load_upstream(path):
         except Exception as exc:
             first = str(exc).strip().splitlines()[0][:120]
             notes.append(f"{what} {type(exc).__name__}: {first}")
-            # Recorded as a failed subcheck, not only inside the human-readable
-            # string. Whoever reads the JSON should not have to parse prose to
-            # see that upstream could not load this; the stage stays out of the
-            # verdict either way.
+            # A failed subcheck too, so the JSON says so without parsing prose.
             results[f"0_mlx_vlm_alone_loads.{what}"] = {
                 "ok": False, "error": f"{type(exc).__name__}: {first}",
             }
@@ -194,10 +191,9 @@ def check_alignment(_repo):
             valid = np.ones(mel.shape[:2], dtype=bool)
         else:
             valid = np.asarray(raw_mask).astype(bool)
-        # The tower takes a PADDING mask, not a validity one: gemma4.py builds
-        # it as `~input_features_mask` before calling. It returns a mask in the
-        # same polarity, and zeroes the encodings wherever it is True. So feed
-        # the inverse and count the False positions back.
+        # The tower takes a PADDING mask, not a validity one: gemma4.py passes
+        # `~input_features_mask` and gets a mask back in the same polarity. So
+        # feed the inverse and count the False positions.
         encodings, out_mask = tower(mel, mx.array(~valid))
         mx.eval(encodings, out_mask)
         emitted = int((~np.asarray(out_mask)[0].astype(bool)).sum())
@@ -207,9 +203,7 @@ def check_alignment(_repo):
     for secs in DURATIONS:
         wav = tone(secs, 440.0)
         counted = _gemma4_audio_placeholder_count(processor, wav, RATE)
-        # What the processor itself would emit, unpatched. Recorded for the
-        # report, never asserted on: it is mlx-vlm's own count, and the whole
-        # reason zoo derives its own is that this one runs high.
+        # mlx-vlm's own count: reported, never asserted on, since it runs high.
         native = getattr(processor, "_compute_audio_num_tokens", None)
         try:
             native_count = None if native is None else int(native(wav, RATE))
@@ -252,8 +246,8 @@ def check_loss(_repo):
     try:
         losses = []
         for hz in (440.0, 1760.0):
-            # The decoded-column shape, which is what datasets.Audio yields
-            # and the only audio value collation accepts.
+            # The decoded-column shape datasets.Audio yields, the only one
+            # collation accepts.
             clip = {"array": tone(1.0, hz), "sampling_rate": RATE}
             messages = [{"role": "user", "content": [
                 {"type": "audio", "audio": clip},
@@ -262,8 +256,7 @@ def check_loss(_repo):
             from unsloth_zoo.mlx.utils import (
                 _collate_vlm_batch, _finalize_vlm_batch,
             )
-            # Collation stages on the host; finalizing is the single point that
-            # converts a staged batch to MLX, exactly as the trainer does it.
+            # Collate on the host, then finalize to MLX, as the trainer does.
             staged = _collate_vlm_batch(
                 [{"messages": messages}], processor, 512, None)
             batch = _finalize_vlm_batch(staged)
@@ -295,9 +288,7 @@ def main():
           f"transformers {transformers.__version__}, {args.model} ===",
           flush=True)
 
-    # Open the gate for whatever is installed. The point of this probe is to
-    # find out what happens behind it; leaving it shut would only re-measure
-    # the refusal that prompted the question.
+    # Open the gate for whatever is installed: the question is what is behind it.
     from unsloth_zoo.mlx import utils as U
     U._AUDIO_QUALIFIED_FAMILIES = dict(
         U._AUDIO_QUALIFIED_FAMILIES,
@@ -305,9 +296,8 @@ def main():
     )
     U._AUDIO_MIN_TRANSFORMERS = {}
 
-    # Stage 0 is diagnostic and never gates anything. Everything after it
-    # depends on zoo having loaded the model, and is skipped rather than
-    # errored when it has not, so a skip never reads as a measurement.
+    # Stage 0 never gates. Later stages need zoo's load, so they skip rather
+    # than error when it fails.
     path = resolve(args.model)
     load_upstream(path)
     ok_zoo = load_via_zoo(path)
@@ -333,7 +323,7 @@ def main():
     print("PROBE_RESULT " + json.dumps(
         {"mlx_vlm": version, "transformers": transformers.__version__,
          "model": args.model, "stages": results}), flush=True)
-    # Stage 0 and its subchecks are diagnostic; they never gate the exit code.
+    # Stage 0 and its subchecks are diagnostic and never gate the exit code.
     verdict = {k: v for k, v in results.items() if not k.startswith("0_")}
     sys.exit(0 if all(r["ok"] for r in verdict.values()) else 1)
 

--- a/tests/gemma4_audio_version_probe.py
+++ b/tests/gemma4_audio_version_probe.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Does Gemma 4 audio training work on the installed mlx-vlm?
 
 Re-measures the `gemma4` row of `_AUDIO_QUALIFIED_FAMILIES`, on real Apple

--- a/tests/gemma4_audio_version_probe.py
+++ b/tests/gemma4_audio_version_probe.py
@@ -1,0 +1,284 @@
+"""Does Gemma 4 audio training work on the installed mlx-vlm?
+
+Re-measures the `gemma4` row of `_AUDIO_QUALIFIED_FAMILIES`, on real Apple
+Silicon against a real checkpoint. That row cannot be reasoned about: the
+0.4.4 it used to carry was correct when written and was invalidated by the
+checkpoint being re-exported on the Hub. A version key cannot express a fact
+about an artefact, so when the answer is in doubt, run this rather than argue.
+
+It deliberately opens the gate for whatever mlx-vlm is installed, because the
+question is what happens behind the gate, not what the gate says.
+
+Loading goes through `FastMLXModel.from_pretrained`, not `mlx_vlm.load`,
+because that is the path a user takes and zoo already repairs things upstream
+gets wrong on the way -- `_ensure_audio_conv_sanitize` undoes mlx-vlm 0.6.4's
+double transpose of the audio convs on pre-converted checkpoints. Probing raw
+mlx-vlm would report failures zoo does not have.
+
+Stage 0 does load raw mlx-vlm anyway, and never counts towards the verdict.
+It is there to separate "upstream is broken here" from "zoo is broken here",
+which is the difference between filing a bug and fixing one.
+
+Each stage reports on its own, and a stage whose prerequisites failed is
+skipped rather than errored, so a red cell names where that version breaks
+without a single early failure hiding everything after it:
+
+  0. mlx-vlm alone loads it       -- diagnostic only, never the verdict
+  1. zoo loads it                 -- processor and weights, through zoo
+  2. the model has an audio tower
+  3. placeholders match the tower -- the invariant the gate protects: a clip's
+                                     placeholder count must equal the positions
+                                     the audio encoder emits, or the merge has
+                                     nothing to put behind the surplus
+  4. audio reaches the loss       -- distinct audio must give distinct losses,
+                                     or the model is training on text alone
+
+Run: python tests/gemma4_audio_version_probe.py [--model REPO]
+Exit code 0 only if every stage that counts passed.
+"""
+
+import argparse
+import json
+import os
+import sys
+import traceback
+
+os.environ.setdefault("UNSLOTH_ALLOW_CPU", "1")
+os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
+
+DEFAULT_MODEL = "mlx-community/gemma-4-e2b-it-4bit"
+DURATIONS = (0.5, 1.0, 2.0, 3.7)
+RATE = 16000
+
+results = {}
+
+
+def stage(name):
+    def wrap(fn):
+        def run(*a, **k):
+            try:
+                detail = fn(*a, **k)
+                results[name] = {"ok": True, "detail": detail}
+                print(f"[PASS] {name}: {detail}", flush=True)
+                return True
+            except Exception as exc:
+                results[name] = {
+                    "ok": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "traceback": traceback.format_exc()[-1500:],
+                }
+                print(f"[FAIL] {name}: {type(exc).__name__}: {exc}", flush=True)
+                print(traceback.format_exc()[-1500:], flush=True)
+                return False
+        return run
+    return wrap
+
+
+def tone(seconds, hertz):
+    import numpy as np
+    t = np.arange(int(RATE * seconds), dtype=np.float32) / RATE
+    return (0.5 * np.sin(2.0 * np.pi * hertz * t)).astype(np.float32)
+
+
+def resolve(repo):
+    """Download once, so every stage loads from one snapshot."""
+    from mlx_vlm.utils import get_model_path
+    path = get_model_path(repo)
+    return path[0] if isinstance(path, tuple) else path   # 0.6.x returns a pair
+
+
+@stage("0_mlx_vlm_alone_loads")
+def load_upstream(path):
+    """Diagnostic. Reported, never part of the verdict.
+
+    Splits the processor from the weights because they fail for unrelated
+    reasons, and reports both rather than stopping at the first.
+    """
+    from mlx_vlm.utils import load_model, load_processor
+    notes = []
+    for what, fn in (("processor", load_processor), ("weights", load_model)):
+        try:
+            fn(path)
+            notes.append(f"{what} ok")
+        except Exception as exc:
+            notes.append(f"{what} {type(exc).__name__}: "
+                         f"{str(exc).strip().splitlines()[0][:120]}")
+    return "; ".join(notes)
+
+
+@stage("1_zoo_loads_it")
+def load_via_zoo(path):
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    global _MODEL, _PROCESSOR
+    _MODEL, _PROCESSOR = FastMLXModel.from_pretrained(
+        model_name=str(path), max_seq_length=512,
+    )
+    return f"{type(_MODEL).__name__} + {type(_PROCESSOR).__name__}"
+
+
+@stage("2_model_has_audio_tower")
+def check_tower(_repo):
+    model = _MODEL
+    tower = getattr(model, "audio_tower", None)
+    embed = getattr(model, "embed_audio", None)
+    if tower is None or embed is None:
+        raise AssertionError("no audio_tower/embed_audio on this checkpoint")
+    return "audio_tower and embed_audio present"
+
+
+@stage("3_placeholders_match_the_audio_tower")
+def check_alignment(_repo):
+    """The invariant the gate exists to protect.
+
+    zoo derives the count from the installed extractor precisely because the
+    framing arithmetic changed in 0.5.0; this checks the derivation still
+    agrees with what the tower emits on this version.
+    """
+    import numpy as np
+
+    from unsloth_zoo.mlx.utils import (
+        _gemma4_audio_encoder_positions, _gemma4_audio_frame_mask,
+        _gemma4_audio_placeholder_count,
+    )
+
+    processor = _PROCESSOR
+    extractor = getattr(processor, "feature_extractor", None)
+    if extractor is None:
+        raise AssertionError("processor exposes no feature_extractor")
+
+    rows = []
+    for secs in DURATIONS:
+        wav = tone(secs, 440.0)
+        counted = _gemma4_audio_placeholder_count(processor, wav, RATE)
+        # What the processor itself would emit, unpatched. Recorded for the
+        # report, never asserted on: it is mlx-vlm's own count, and the whole
+        # reason zoo derives its own is that this one runs high.
+        native = getattr(processor, "_compute_audio_num_tokens", None)
+        try:
+            native_count = None if native is None else int(native(wav, RATE))
+        except Exception as exc:
+            native_count = f"n/a ({type(exc).__name__})"
+        frames = int(np.asarray(_gemma4_audio_frame_mask(extractor, wav, RATE)).sum())
+        emitted = int(_gemma4_audio_encoder_positions(
+            _gemma4_audio_frame_mask(extractor, wav, RATE)))
+        if counted != emitted:
+            raise AssertionError(
+                f"{secs}s: zoo counts {counted} placeholders, tower emits "
+                f"{emitted}")
+        rows.append(f"{secs}s: frames={frames} placeholders={counted}"
+                    + (f" native={native_count}" if native_count is not None else ""))
+    return "; ".join(rows)
+
+
+@stage("4_audio_reaches_the_loss")
+def check_loss(_repo):
+    """Distinct audio must produce distinct losses.
+
+    A processor that accepts the argument and drops it, or a merge that lands
+    features on the wrong positions, shows up here: the loss stops depending
+    on what the audio actually was.
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    from unsloth_zoo.mlx.utils import (
+        install_audio_merge_patch, make_vlm_baseline_loss_fn,
+        remove_audio_merge_patch,
+    )
+
+    model, processor = _MODEL, _PROCESSOR
+    audio_token_id = getattr(getattr(model, "config", None), "audio_token_id", None)
+    if audio_token_id is None:
+        raise AssertionError("no audio_token_id on the model config")
+
+    held = install_audio_merge_patch(model, audio_token_id)
+    try:
+        losses = []
+        for hz in (440.0, 1760.0):
+            # The decoded-column shape, which is what datasets.Audio yields
+            # and the only audio value collation accepts.
+            clip = {"array": tone(1.0, hz), "sampling_rate": RATE}
+            messages = [{"role": "user", "content": [
+                {"type": "audio", "audio": clip},
+                {"type": "text", "text": "Transcribe."}]},
+                {"role": "assistant", "content": "ok"}]
+            from unsloth_zoo.mlx.utils import (
+                _collate_vlm_batch, _finalize_vlm_batch,
+            )
+            # Collation stages on the host; finalizing is the single point that
+            # converts a staged batch to MLX, exactly as the trainer does it.
+            staged = _collate_vlm_batch(
+                [{"messages": messages}], processor, 512, None)
+            batch = _finalize_vlm_batch(staged)
+            loss_fn = make_vlm_baseline_loss_fn(model, ignore_token_ids=[])
+            out = loss_fn(model, batch)
+            loss = float(out[0] if isinstance(out, tuple) else out)
+            if not np.isfinite(loss):
+                raise AssertionError(f"loss is not finite at {hz} Hz: {loss}")
+            losses.append(loss)
+        if abs(losses[0] - losses[1]) < 1e-6:
+            raise AssertionError(
+                f"two different tones gave the same loss ({losses[0]}), so the "
+                f"audio is not reaching the objective")
+        return f"440Hz={losses[0]:.4f} 1760Hz={losses[1]:.4f}"
+    finally:
+        if held:
+            remove_audio_merge_patch(model)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default=DEFAULT_MODEL)
+    args = ap.parse_args()
+
+    import mlx_vlm
+    import transformers
+    version = getattr(mlx_vlm, "__version__", "unknown")
+    print(f"=== gemma4 audio probe: mlx-vlm {version}, "
+          f"transformers {transformers.__version__}, {args.model} ===",
+          flush=True)
+
+    # Open the gate for whatever is installed. The point of this probe is to
+    # find out what happens behind it; leaving it shut would only re-measure
+    # the refusal that prompted the question.
+    from unsloth_zoo.mlx import utils as U
+    U._AUDIO_QUALIFIED_FAMILIES = dict(
+        U._AUDIO_QUALIFIED_FAMILIES,
+        gemma4=U._AudioVersions(version, version),
+    )
+    U._AUDIO_MIN_TRANSFORMERS = {}
+
+    # Stage 0 is diagnostic and never gates anything. Everything after it
+    # depends on zoo having loaded the model, and is skipped rather than
+    # errored when it has not, so a skip never reads as a measurement.
+    path = resolve(args.model)
+    load_upstream(path)
+    ok_zoo = load_via_zoo(path)
+
+    def skip(name):
+        results[name] = {"ok": False, "skipped": True,
+                         "error": "prerequisite stage failed"}
+        print(f"[SKIP] {name}: prerequisite stage failed", flush=True)
+
+    if ok_zoo:
+        ok_tower = check_tower(path)
+        check_alignment(path)
+    else:
+        skip("2_model_has_audio_tower")
+        skip("3_placeholders_match_the_audio_tower")
+        ok_tower = False
+
+    if ok_tower:
+        check_loss(path)
+    else:
+        skip("4_audio_reaches_the_loss")
+
+    print("PROBE_RESULT " + json.dumps(
+        {"mlx_vlm": version, "transformers": transformers.__version__,
+         "model": args.model, "stages": results}), flush=True)
+    verdict = {k: v for k, v in results.items() if not k.startswith("0_")}
+    sys.exit(0 if all(r["ok"] for r in verdict.values()) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gemma4_audio_version_probe.py
+++ b/tests/gemma4_audio_version_probe.py
@@ -100,9 +100,17 @@ def load_upstream(path):
         try:
             fn(path)
             notes.append(f"{what} ok")
+            results[f"0_mlx_vlm_alone_loads.{what}"] = {"ok": True}
         except Exception as exc:
-            notes.append(f"{what} {type(exc).__name__}: "
-                         f"{str(exc).strip().splitlines()[0][:120]}")
+            first = str(exc).strip().splitlines()[0][:120]
+            notes.append(f"{what} {type(exc).__name__}: {first}")
+            # Recorded as a failed subcheck, not only inside the human-readable
+            # string. Whoever reads the JSON should not have to parse prose to
+            # see that upstream could not load this; the stage stays out of the
+            # verdict either way.
+            results[f"0_mlx_vlm_alone_loads.{what}"] = {
+                "ok": False, "error": f"{type(exc).__name__}: {first}",
+            }
     return "; ".join(notes)
 
 
@@ -133,18 +141,51 @@ def check_alignment(_repo):
     zoo derives the count from the installed extractor precisely because the
     framing arithmetic changed in 0.5.0; this checks the derivation still
     agrees with what the tower emits on this version.
+
+    "What the tower emits" has to come from the tower. Deriving it from
+    `_gemma4_audio_encoder_positions` instead would re-run the arithmetic
+    `_gemma4_audio_placeholder_count` already ran, and assert a number against
+    itself -- green on any release, including one whose subsampling changed
+    underneath it, which is the whole failure this stage exists to catch. So
+    the clip goes through `audio_tower` and the count comes off the mask it
+    returns.
     """
+    import mlx.core as mx
     import numpy as np
 
     from unsloth_zoo.mlx.utils import (
-        _gemma4_audio_encoder_positions, _gemma4_audio_frame_mask,
-        _gemma4_audio_placeholder_count,
+        _gemma4_audio_frame_mask, _gemma4_audio_placeholder_count,
     )
 
     processor = _PROCESSOR
     extractor = getattr(processor, "feature_extractor", None)
     if extractor is None:
         raise AssertionError("processor exposes no feature_extractor")
+    tower = getattr(_MODEL, "audio_tower", None)
+    if tower is None:
+        raise AssertionError("no audio_tower to measure against")
+
+    def tower_positions(wav):
+        """Run the encoder and count the positions it reports as real."""
+        features = extractor(
+            [np.asarray(wav, dtype=np.float32)],
+            sampling_rate=RATE,
+            return_attention_mask=True,
+        )
+        mel = mx.array(np.asarray(features["input_features"], dtype=np.float32))
+        raw_mask = features.get("input_features_mask")
+        if raw_mask is None:
+            valid = np.ones(mel.shape[:2], dtype=bool)
+        else:
+            valid = np.asarray(raw_mask).astype(bool)
+        # The tower takes a PADDING mask, not a validity one: gemma4.py builds
+        # it as `~input_features_mask` before calling. It returns a mask in the
+        # same polarity, and zeroes the encodings wherever it is True. So feed
+        # the inverse and count the False positions back.
+        encodings, out_mask = tower(mel, mx.array(~valid))
+        mx.eval(encodings, out_mask)
+        emitted = int((~np.asarray(out_mask)[0].astype(bool)).sum())
+        return emitted, int(encodings.shape[1])
 
     rows = []
     for secs in DURATIONS:
@@ -159,13 +200,13 @@ def check_alignment(_repo):
         except Exception as exc:
             native_count = f"n/a ({type(exc).__name__})"
         frames = int(np.asarray(_gemma4_audio_frame_mask(extractor, wav, RATE)).sum())
-        emitted = int(_gemma4_audio_encoder_positions(
-            _gemma4_audio_frame_mask(extractor, wav, RATE)))
+        emitted, width = tower_positions(wav)
         if counted != emitted:
             raise AssertionError(
                 f"{secs}s: zoo counts {counted} placeholders, tower emits "
-                f"{emitted}")
-        rows.append(f"{secs}s: frames={frames} placeholders={counted}"
+                f"{emitted} valid of {width}")
+        rows.append(f"{secs}s: frames={frames} placeholders={counted} "
+                    f"tower={emitted}/{width}"
                     + (f" native={native_count}" if native_count is not None else ""))
     return "; ".join(rows)
 
@@ -276,6 +317,7 @@ def main():
     print("PROBE_RESULT " + json.dumps(
         {"mlx_vlm": version, "transformers": transformers.__version__,
          "model": args.model, "stages": results}), flush=True)
+    # Stage 0 and its subchecks are diagnostic; they never gate the exit code.
     verdict = {k: v for k, v in results.items() if not k.startswith("0_")}
     sys.exit(0 if all(r["ok"] for r in verdict.values()) else 1)
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2719,9 +2719,7 @@ def test_qualified_families_carry_their_probed_requirements():
     ("0.6.1", False),        # last release before #1301
     ("0.6.2", True),         # #1301: KV-shared layers stop building k/v proj
     ("0.6.3", True),
-    ("0.6.4", True),         # raw mlx-vlm double transposes the audio convs
-                             # here; loader.py's _ensure_audio_conv_sanitize
-                             # (PR 879) undoes it, so the family still works
+    ("0.6.4", True),         # double conv transpose, undone by loader.py (PR 879)
     ("0.6.5", False),        # needs transformers>=5.14, capped at 5.5.0
     ("0.6.2.post1", False),  # post-releases and prereleases were not probed
     ("0.6.2rc1", False),
@@ -2816,9 +2814,8 @@ def test_only_a_published_final_release_is_inside_the_window():
     for unqualified in ("0.6.2.post1", "0.6.2.post2", "0.6.2+local",
                         "0.6.2rc1", "0.6.2.dev0"):
         assert gemma4.admits(unqualified) is False, unqualified
-    # Nor either side of the window. 0.6.1 was measured red; 0.6.5 is refused
-    # because it cannot be installed here, not because it was tried and failed
-    # -- upstream in fact fixed the 0.6.4 sanitize regression there.
+    # Nor either side. 0.6.1 measured red; 0.6.5 is refused for being
+    # uninstallable here, not for failing.
     assert gemma4.admits("0.6.1") is False
     assert gemma4.admits("0.6.5") is False
 
@@ -2838,9 +2835,8 @@ def test_the_renamed_gemma4_family_is_refused_by_the_name_it_now_loads_under():
         mlx_utils._check_audio_family_gate(unified())
     message = str(excinfo.value)
     assert "gemma4_unified" in message and "'gemma4'" in message
-    # Read the window off the table rather than hardcoding it: the point is
-    # that the refusal names whatever gemma4 is currently qualified for, and
-    # that window moves when it is re-probed.
+    # Read the window off the table: the refusal must name whatever gemma4 is
+    # currently qualified for, and that moves when it is re-probed.
     window = str(mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"])
     assert window in message, "the version to pin is not named"
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2696,19 +2696,48 @@ def test_qualified_families_carry_their_probed_requirements():
     """The table itself: which families, over which mlx-vlm releases.
 
     Bounded at both ends, so an unreleased version is refused rather than
-    assumed good. Gemma 4 stays at the version its probes ran on: its processor
-    changed in 0.5.0, upstream reports it failing to load from 0.6.4
-    (Blaizzy/mlx-vlm#1526), and 0.6.3 split off a separate `gemma4_unified`.
+    assumed good. Gemma 4 starts higher than the rest because below 0.6.2
+    mlx-vlm cannot load the checkpoint at all: E2B's KV-shared layers ship no
+    k_proj/v_proj/k_norm, and mlx-vlm built those modules regardless until
+    Blaizzy/mlx-vlm#1301.
     """
     from unsloth_zoo.mlx import utils as mlx_utils
 
     versions = mlx_utils._AudioVersions
     assert mlx_utils._AUDIO_QUALIFIED_FAMILIES == {
         "gemma3n": versions("0.4.4", "0.6.4"),
-        "gemma4": versions("0.4.4", "0.4.4"),
+        "gemma4": versions("0.6.2", "0.6.4"),
         "phi4mm": versions("0.4.4", "0.6.4"),
         "minicpmo": versions("0.4.4", "0.6.4"),
     }
+
+
+@pytest.mark.parametrize("installed,admitted", [
+    ("0.4.4", False),        # loads nothing: 60 KV-shared tensors missing
+    ("0.5.0", False),
+    ("0.6.0", False),
+    ("0.6.1", False),        # last release before #1301
+    ("0.6.2", True),         # #1301: KV-shared layers stop building k/v proj
+    ("0.6.3", True),
+    ("0.6.4", True),         # raw mlx-vlm double transposes the audio convs
+                             # here; loader.py's _ensure_audio_conv_sanitize
+                             # (PR 879) undoes it, so the family still works
+    ("0.6.5", False),        # needs transformers>=5.14, capped at 5.5.0
+    ("0.6.2.post1", False),  # post-releases and prereleases were not probed
+    ("0.6.2rc1", False),
+])
+def test_gemma4_admits_only_the_versions_that_can_load_the_checkpoint(
+        installed, admitted):
+    """The boundary, measured rather than argued.
+
+    Every row was run end to end on macos-14 against
+    mlx-community/gemma-4-e2b-it-4bit: model load, placeholder counts against
+    the audio tower, and two clips giving two losses. 0.6.1 red, 0.6.2 green.
+    """
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    window = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"]
+    assert window.admits(installed) is admitted, installed
 
 
 @pytest.mark.parametrize("installed,admitted", [
@@ -2778,13 +2807,13 @@ def test_only_a_published_final_release_is_inside_the_window():
     from unsloth_zoo.mlx import utils as mlx_utils
 
     gemma4 = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"]
-    assert gemma4.admits("0.4.4") is True
-    for unqualified in ("0.4.4.post1", "0.4.4.post2", "0.4.4+local",
-                        "0.4.4rc1", "0.4.4.dev0"):
+    assert gemma4.admits("0.6.2") is True
+    for unqualified in ("0.6.2.post1", "0.6.2.post2", "0.6.2+local",
+                        "0.6.2rc1", "0.6.2.dev0"):
         assert gemma4.admits(unqualified) is False, unqualified
-    # Nor the next release, which is a different processor.
-    assert gemma4.admits("0.4.5") is False
-    assert gemma4.admits("0.5.0") is False
+    # Nor either side of the window, both of which were measured red.
+    assert gemma4.admits("0.6.1") is False
+    assert gemma4.admits("0.6.5") is False
 
 
 def test_the_renamed_gemma4_family_is_refused_by_the_name_it_now_loads_under():
@@ -2802,7 +2831,11 @@ def test_the_renamed_gemma4_family_is_refused_by_the_name_it_now_loads_under():
         mlx_utils._check_audio_family_gate(unified())
     message = str(excinfo.value)
     assert "gemma4_unified" in message and "'gemma4'" in message
-    assert "0.4.4" in message, "the version to pin is not named"
+    # Read the window off the table rather than hardcoding it: the point is
+    # that the refusal names whatever gemma4 is currently qualified for, and
+    # that window moves when it is re-probed.
+    window = str(mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"])
+    assert window in message, "the version to pin is not named"
 
 
 def test_the_transformers_floor_refuses_a_prerelease_for_the_right_reason(

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2730,9 +2730,14 @@ def test_gemma4_admits_only_the_versions_that_can_load_the_checkpoint(
         installed, admitted):
     """The boundary, measured rather than argued.
 
-    Every row was run end to end on macos-14 against
-    mlx-community/gemma-4-e2b-it-4bit: model load, placeholder counts against
-    the audio tower, and two clips giving two losses. 0.6.1 red, 0.6.2 green.
+    Every released row from 0.4.4 to 0.6.4 was run end to end on macos-14
+    against mlx-community/gemma-4-e2b-it-4bit: model load, placeholder counts
+    against what the audio tower returns, and two clips giving two losses.
+    0.6.1 red, 0.6.2 green.
+
+    The other rows are policy, not measurement. 0.6.5 cannot be installed
+    beside this package (it needs transformers>=5.14, capped at 5.5.0), and
+    mlx-vlm has published no post-release or prerelease to run.
     """
     from unsloth_zoo.mlx import utils as mlx_utils
 
@@ -2811,7 +2816,9 @@ def test_only_a_published_final_release_is_inside_the_window():
     for unqualified in ("0.6.2.post1", "0.6.2.post2", "0.6.2+local",
                         "0.6.2rc1", "0.6.2.dev0"):
         assert gemma4.admits(unqualified) is False, unqualified
-    # Nor either side of the window, both of which were measured red.
+    # Nor either side of the window. 0.6.1 was measured red; 0.6.5 is refused
+    # because it cannot be installed here, not because it was tried and failed
+    # -- upstream in fact fixed the 0.6.4 sanitize regression there.
     assert gemma4.admits("0.6.1") is False
     assert gemma4.admits("0.6.5") is False
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5615,12 +5615,34 @@ class _AudioVersions(NamedTuple):
 # processor from 0.4.4 through 0.6.9; the 0.6.4 ceiling is only because mlx-vlm
 # 0.6.5+ requires transformers>=5.14, which this package caps at 5.5.0.
 #
-# Gemma 4 stays at 0.4.4: its processor changed in 0.5.0, upstream reports it
-# failing to load from 0.6.4 with 0.6.3 good (Blaizzy/mlx-vlm#1526), and 0.6.3
-# added a separate `gemma4_unified` family. Re-probing needs Apple hardware.
+# Gemma 4 starts at 0.6.2, not at the 0.4.4 the others do, because below that
+# mlx-vlm cannot load the checkpoint at all. Layers in E2B's KV-shared range
+# reuse an earlier layer's K/V and ship no k_proj/v_proj/k_norm of their own;
+# mlx-vlm built those modules for every layer regardless until 0.6.2
+# (Blaizzy/mlx-vlm#1301), so loading died on 60 missing tensors. Nothing to do
+# with audio, and it is why the 0.4.4 entry this replaces admitted a version
+# that could not open the file.
+#
+# 0.4.4 was right when it was written: the export before 2026-07-06 shipped
+# those projections and loads there. The checkpoint was re-uploaded, and a key
+# on the library alone cannot express a fact about the artefact. Re-measure
+# with `tests/gemma4_audio_version_probe.py` rather than reasoning about it.
+#
+# Measured end to end on Apple Silicon (macos-14) against
+# mlx-community/gemma-4-e2b-it-4bit @ 2387675275, on every version in and
+# either side of the range: model loads, placeholder counts equal the positions
+# the audio tower emits at 0.5s/1.0s/2.0s/3.7s, and two different clips give
+# two different losses. 0.6.1 red, 0.6.2 green, 0.6.3 and 0.6.4 green.
+#
+# 0.6.4 is included deliberately. Raw mlx-vlm 0.6.4 does fail to load these
+# weights -- #1498 made sanitize unconditional, so pre-converted MLX
+# checkpoints get the conv transpose applied twice -- but `loader.py`'s
+# `_ensure_audio_conv_sanitize` (PR 879) already undoes it, and upstream fixed
+# it in 0.6.5 (#1523). The ceiling stays 0.6.4 for the same reason as the other
+# families: 0.6.5+ requires transformers>=5.14, which this package caps at 5.5.0.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4", "0.6.4"),
-    "gemma4": _AudioVersions("0.4.4", "0.4.4"),
+    "gemma4": _AudioVersions("0.6.2", "0.6.4"),
     "phi4mm": _AudioVersions("0.4.4", "0.6.4"),
     "minicpmo": _AudioVersions("0.4.4", "0.6.4"),
 }
@@ -5631,6 +5653,11 @@ _AUDIO_FAMILY_RENAMES = {"gemma4_unified": "gemma4"}
 # Families probed only on a newer transformers than this package pins, at the
 # version the probes ran on. Older releases expand their audio tokens
 # differently, so they are refused rather than assumed compatible.
+#
+# Belt and braces since gemma4's floor moved to 0.6.2: every mlx-vlm in that
+# range already requires transformers>=5.5.0, so a resolver that was allowed to
+# do its job cannot land below this. Kept for the environment that was
+# hand-assembled instead, where the two were installed in separate passes.
 _AUDIO_MIN_TRANSFORMERS = {"gemma4": (5, 5)}
 
 _AUDIO_CAST_HINT = (

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5615,33 +5615,25 @@ class _AudioVersions(NamedTuple):
 # processor from 0.4.4 through 0.6.9; the 0.6.4 ceiling is only because mlx-vlm
 # 0.6.5+ requires transformers>=5.14, which this package caps at 5.5.0.
 #
-# Gemma 4 starts at 0.6.2, not at the 0.4.4 the others do, because below that
-# mlx-vlm cannot load the checkpoint at all. Layers in E2B's KV-shared range
-# reuse an earlier layer's K/V and ship no k_proj/v_proj/k_norm of their own;
-# mlx-vlm built those modules for every layer regardless until 0.6.2
-# (Blaizzy/mlx-vlm#1301), so loading died on 60 missing tensors. Nothing to do
-# with audio, and it is why the 0.4.4 entry this replaces admitted a version
-# that could not open the file.
+# Gemma 4 starts at 0.6.2, not 0.4.4: below that mlx-vlm cannot load the
+# checkpoint at all. E2B's KV-shared layers reuse an earlier layer's K/V and
+# ship no k_proj/v_proj/k_norm, and mlx-vlm built those modules for every layer
+# until Blaizzy/mlx-vlm#1301, so loading died on 60 missing tensors.
 #
-# 0.4.4 was right when it was written: the export before 2026-07-06 shipped
-# those projections and loads there. The checkpoint was re-uploaded, and a key
-# on the library alone cannot express a fact about the artefact. Re-measure
-# with `tests/gemma4_audio_version_probe.py` rather than reasoning about it.
+# The 0.4.4 this replaces was correct when written -- the export before
+# 2026-07-06 shipped those projections -- and was invalidated by the checkpoint
+# being re-uploaded. A version key cannot express a fact about an artefact, so
+# re-measure with `tests/gemma4_audio_version_probe.py` rather than argue.
 #
-# Measured end to end on Apple Silicon (macos-14) against
-# mlx-community/gemma-4-e2b-it-4bit @ 2387675275, on 0.4.4 through 0.6.4:
-# model loads, a clip's placeholder count equals the valid positions
-# `audio_tower` actually returns for it at 0.5s/1.0s/2.0s/3.7s, and two
-# different clips give two different losses. 0.6.1 red, 0.6.2 green, 0.6.3 and
-# 0.6.4 green. The ceiling above is a dependency fact, not a measurement:
-# 0.6.5+ cannot be installed beside this package at all, so it was never run.
+# Measured on macos-14 against mlx-community/gemma-4-e2b-it-4bit @ 2387675275,
+# 0.4.4 through 0.6.4: load, placeholder count vs the positions `audio_tower`
+# returns at 0.5s/1.0s/2.0s/3.7s, two clips giving two losses. 0.6.1 red,
+# 0.6.2-0.6.4 green. 0.6.5+ was never run: it cannot be installed here.
 #
-# 0.6.4 is included deliberately. Raw mlx-vlm 0.6.4 does fail to load these
-# weights -- #1498 made sanitize unconditional, so pre-converted MLX
-# checkpoints get the conv transpose applied twice -- but `loader.py`'s
-# `_ensure_audio_conv_sanitize` (PR 879) already undoes it, and upstream fixed
-# it in 0.6.5 (#1523). The ceiling stays 0.6.4 for the same reason as the other
-# families: 0.6.5+ requires transformers>=5.14, which this package caps at 5.5.0.
+# 0.6.4 is in deliberately. Raw mlx-vlm 0.6.4 fails on these weights -- #1498
+# made sanitize unconditional, double-transposing pre-converted convs -- but
+# loader.py's `_ensure_audio_conv_sanitize` (PR 879) undoes it, and upstream
+# fixed it in 0.6.5 (#1523). The ceiling is 0.6.4 only for the transformers cap.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4", "0.6.4"),
     "gemma4": _AudioVersions("0.6.2", "0.6.4"),
@@ -5655,11 +5647,8 @@ _AUDIO_FAMILY_RENAMES = {"gemma4_unified": "gemma4"}
 # Families probed only on a newer transformers than this package pins, at the
 # version the probes ran on. Older releases expand their audio tokens
 # differently, so they are refused rather than assumed compatible.
-#
-# Belt and braces since gemma4's floor moved to 0.6.2: every mlx-vlm in that
-# range already requires transformers>=5.5.0, so a resolver that was allowed to
-# do its job cannot land below this. Kept for the environment that was
-# hand-assembled instead, where the two were installed in separate passes.
+# Redundant now gemma4's floor is 0.6.2 (every mlx-vlm there needs
+# transformers>=5.5.0), but kept for hand-assembled environments.
 _AUDIO_MIN_TRANSFORMERS = {"gemma4": (5, 5)}
 
 _AUDIO_CAST_HINT = (

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5629,10 +5629,12 @@ class _AudioVersions(NamedTuple):
 # with `tests/gemma4_audio_version_probe.py` rather than reasoning about it.
 #
 # Measured end to end on Apple Silicon (macos-14) against
-# mlx-community/gemma-4-e2b-it-4bit @ 2387675275, on every version in and
-# either side of the range: model loads, placeholder counts equal the positions
-# the audio tower emits at 0.5s/1.0s/2.0s/3.7s, and two different clips give
-# two different losses. 0.6.1 red, 0.6.2 green, 0.6.3 and 0.6.4 green.
+# mlx-community/gemma-4-e2b-it-4bit @ 2387675275, on 0.4.4 through 0.6.4:
+# model loads, a clip's placeholder count equals the valid positions
+# `audio_tower` actually returns for it at 0.5s/1.0s/2.0s/3.7s, and two
+# different clips give two different losses. 0.6.1 red, 0.6.2 green, 0.6.3 and
+# 0.6.4 green. The ceiling above is a dependency fact, not a measurement:
+# 0.6.5+ cannot be installed beside this package at all, so it was never run.
 #
 # 0.6.4 is included deliberately. Raw mlx-vlm 0.6.4 does fail to load these
 # weights -- #1498 made sanitize unconditional, so pre-converted MLX


### PR DESCRIPTION
`_AUDIO_QUALIFIED_FAMILIES` admits `gemma4` only on mlx-vlm `0.4.4`, which turns out to be the one version in the range that cannot load the checkpoint at all.

## What is actually wrong

Gemma 4 E2B reuses K/V across its last 20 layers, so those layers ship no `k_proj`, `v_proj` or `k_norm` of their own. mlx-vlm built those modules for every layer regardless until 0.6.2, so loading died on 60 missing tensors. Upstream fixed it in [Blaizzy/mlx-vlm#1301](https://github.com/Blaizzy/mlx-vlm/pull/1301), whose own message names the number:

> E2B has 20 KV-shared layers out of 35, missing 60 = 20 * (k_proj + v_proj + k_norm) tensors.

So the family was refused for a reason that was never about the audio path.

## The old pin was not a mistake

The export before 2026-07-06 ships those projections and loads on 0.4.4 fine. I probed that revision (`2c3e5074`) to check: every stage passes there. mlx-community re-uploaded the checkpoint three weeks before the gate was written, and a key on the library alone cannot express a fact about the artefact.

That is why this also adds the probe, as an opt-in macOS job. The row cannot be reasoned about, so re-qualifying it should be a label rather than an investigation.

## Measured, not argued

Every version in and either side of the range, on macos-14 against `mlx-community/gemma-4-e2b-it-4bit`, and reproduced independently on Linux CPU MLX:

| mlx-vlm | zoo loads it | audio tower | placeholders match | two clips, two losses |
|---|---|---|---|---|
| 0.4.4 | no, 60 missing | - | - | - |
| 0.5.0 | no, 60 missing | - | - | - |
| 0.6.0 | no, 60 missing | - | - | - |
| 0.6.1 | no, 60 missing | - | - | - |
| **0.6.2** | yes | yes | 13 / 25 / 50 / 93 | yes |
| **0.6.3** | yes | yes | 13 / 25 / 50 / 93 | yes |
| **0.6.4** | yes | yes | 13 / 25 / 50 / 93 | yes |

Placeholder counts are for 0.5s, 1.0s, 2.0s and 3.7s clips, checked against the positions the audio tower actually emits.

`0.6.4` is inside the range deliberately. Raw mlx-vlm 0.6.4 does fail on the audio convs, because [#1498](https://github.com/Blaizzy/mlx-vlm/pull/1498) made `sanitize` unconditional and pre-converted MLX checkpoints then get the transpose applied twice. `loader.py`'s `_ensure_audio_conv_sanitize` (#879) already undoes exactly that, and upstream fixed it in 0.6.5 ([#1523](https://github.com/Blaizzy/mlx-vlm/pull/1523)). The probe records the raw-upstream result separately from the through-zoo one so the two never get confused.

The ceiling stays `0.6.4` for the same reason as the other families: 0.6.5+ requires `transformers>=5.14`, which this package caps at 5.5.0.

## Scope

The gate stays fail-closed and bounded at both ends; nothing about prereleases, post-releases or local builds changes. `gemma3n`, `phi4mm` and `minicpmo` are untouched. `gemma4_unified` stays refused, and its refusal message now reads the window off the table instead of hardcoding a version.

Reverting the range fails six tests. Full suite: 255 passed.