### PR TITLE
MLX: keep the token cap off the audio feature extractor

### DIFF
--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2262,6 +2262,12 @@ class _FakeGemmaAudioProcessor(_ConversationalPromptCompletionProcessor):
                              for _ in range(v.count("<audio>"))), []) + [11]
                 for v in text]
         width = max(len(r) for r in rows)
+        # A batch carrying audio gets the token cap scoped under `text_kwargs`,
+        # because a flat one reaches some processors' audio extractors and is
+        # read there as a sample budget. Honour it from either place, as a real
+        # processor does.
+        if max_length is None:
+            max_length = (_kwargs.get("text_kwargs") or {}).get("max_length")
         cut = max_length if self.truncates else width
         pad = lambda r, v: r + [v] * (width - len(r))
         out = {
@@ -4655,3 +4661,84 @@ def test_the_repeated_audio_placeholder_is_never_a_target(monkeypatch):
     ignored = _get_vlm_ignore_token_ids(processor=processor) or []
     for token_id in soft:
         assert token_id in ignored, token_id
+
+
+class _TruncationDivertingAudioProcessor:
+    """A processor that hands its flat keywords to its audio extractor.
+
+    Gemma 3n does this: `max_length` is a token budget, but it reaches the
+    feature extractor, which reads the same number as a sample budget. A
+    one-second 16 kHz clip under `max_length=512` comes back as zero mel
+    frames while `input_ids` is untouched.
+
+    Scoped under `text_kwargs`, the budget stays on the text and the audio
+    survives. This fixture reproduces exactly that asymmetry.
+    """
+
+    tokenizer = _FakeTokenizer()
+    image_processor = object()
+    feature_extractor = object()
+    chat_template = "{{ messages }}"
+
+    def __init__(self):
+        self.saw_flat_max_length = None
+
+    def __call__(self, text, audio=None, **kwargs):
+        flat_cap = kwargs.get("max_length")
+        scoped = kwargs.get("text_kwargs") or {}
+        self.saw_flat_max_length = flat_cap
+        cap = flat_cap if flat_cap is not None else scoped.get("max_length")
+
+        rows = [[101, 10, 11, 0] for _ in text]
+        masks = [[1, 1, 1, 0] for _ in text]
+        clips = len(audio) if audio is not None else 0
+        # The diversion: a flat cap truncates the waveform, a scoped one does
+        # not. 512 samples frame to nothing, which is the (n, 0, 128) the real
+        # processor returns.
+        frames = 0 if flat_cap is not None else 97
+        out = {
+            "input_ids": np.array(rows, dtype=np.int32),
+            "attention_mask": np.array(masks, dtype=np.int32),
+        }
+        if clips:
+            out["input_features"] = np.zeros((clips, frames, 128), np.float32)
+            out["input_features_mask"] = np.ones((clips, frames), np.int32)
+        assert cap is not None, "the cap must reach the processor somehow"
+        return out
+
+
+def test_a_text_cap_does_not_reach_the_audio_extractor():
+    """`max_length` is a token budget and must not be read as a sample budget.
+
+    Passed flat, a processor that owns an audio feature extractor may forward
+    it there, and every clip longer than `max_seq_length` samples -- which is
+    every clip, at any realistic cap -- loses its audio. The row still has its
+    placeholders, so what is left is placeholders with nothing behind them.
+    """
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    processor = _TruncationDivertingAudioProcessor()
+    inputs = mlx_utils._processor_vlm_inputs(
+        processor, ["<|audio|>"], [[]], 512,
+        all_audio=[[np.zeros(16000, np.float32)]],
+    )
+
+    assert processor.saw_flat_max_length is None, (
+        "the text cap was passed flat, where an audio extractor can read it"
+    )
+    assert inputs["input_features"].shape[1] > 0, (
+        "the clip was truncated to the token budget and framed to nothing"
+    )
+
+
+def test_a_text_only_batch_still_gets_the_cap_flat():
+    """The scoping is for batches carrying audio, and only those.
+
+    A processor with no audio to divert the keyword into should see the same
+    call it always did, so this cannot change collation for text or images.
+    """
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    processor = _TruncationDivertingAudioProcessor()
+    mlx_utils._processor_vlm_inputs(processor, ["hello"], [[]], 512)
+    assert processor.saw_flat_max_length == 512

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2262,12 +2262,6 @@ class _FakeGemmaAudioProcessor(_ConversationalPromptCompletionProcessor):
                              for _ in range(v.count("<audio>"))), []) + [11]
                 for v in text]
         width = max(len(r) for r in rows)
-        # A batch carrying audio gets the token cap scoped under `text_kwargs`,
-        # because a flat one reaches some processors' audio extractors and is
-        # read there as a sample budget. Honour it from either place, as a real
-        # processor does.
-        if max_length is None:
-            max_length = (_kwargs.get("text_kwargs") or {}).get("max_length")
         cut = max_length if self.truncates else width
         pad = lambda r, v: r + [v] * (width - len(r))
         out = {
@@ -4664,15 +4658,18 @@ def test_the_repeated_audio_placeholder_is_never_a_target(monkeypatch):
 
 
 class _TruncationDivertingAudioProcessor:
-    """A processor that hands its flat keywords to its audio extractor.
+    """A processor that fans its flat keywords out to its audio extractor.
 
-    Gemma 3n does this: `max_length` is a token budget, but it reaches the
-    feature extractor, which reads the same number as a sample budget. A
-    one-second 16 kHz clip under `max_length=512` comes back as zero mel
-    frames while `input_ids` is untouched.
+    This is what transformers' `_merge_kwargs` does: a flat keyword reaches
+    every modality that declares it, and `AudioKwargs` declares `max_length`
+    and `truncation`. Gemma 3n shows the result -- a one-second clip under
+    `max_length=512` comes back as zero mel frames, the waveform cut to 512
+    samples, while `input_ids` is untouched.
 
-    Scoped under `text_kwargs`, the budget stays on the text and the audio
-    survives. This fixture reproduces exactly that asymmetry.
+    An empty `audio_kwargs` is what stops it: a modality present in kwargs
+    stops reading flat keywords. This fixture reproduces exactly that rule,
+    including the part that matters most -- the text side must keep reading
+    its flat keywords, or padding and `add_special_tokens` go with it.
     """
 
     tokenizer = _FakeTokenizer()
@@ -4681,39 +4678,40 @@ class _TruncationDivertingAudioProcessor:
     chat_template = "{{ messages }}"
 
     def __init__(self):
-        self.saw_flat_max_length = None
+        self.text_saw = {}
 
     def __call__(self, text, audio=None, **kwargs):
-        flat_cap = kwargs.get("max_length")
-        scoped = kwargs.get("text_kwargs") or {}
-        self.saw_flat_max_length = flat_cap
-        cap = flat_cap if flat_cap is not None else scoped.get("max_length")
+        # The `_merge_kwargs` rule, both ways round.
+        audio_reads_flat = "audio_kwargs" not in kwargs
+        text_reads_flat = "text_kwargs" not in kwargs
+        self.text_saw = {
+            "max_length": kwargs.get("max_length") if text_reads_flat else None,
+            "padding": kwargs.get("padding") if text_reads_flat else None,
+        }
+        cap = kwargs.get("max_length")
 
         rows = [[101, 10, 11, 0] for _ in text]
-        masks = [[1, 1, 1, 0] for _ in text]
-        clips = len(audio) if audio is not None else 0
-        # The diversion: a flat cap truncates the waveform, a scoped one does
-        # not. 512 samples frame to nothing, which is the (n, 0, 128) the real
-        # processor returns.
-        frames = 0 if flat_cap is not None else 97
         out = {
             "input_ids": np.array(rows, dtype=np.int32),
-            "attention_mask": np.array(masks, dtype=np.int32),
+            "attention_mask": np.array(
+                [[1, 1, 1, 0] for _ in text], dtype=np.int32),
         }
+        clips = len(audio) if audio is not None else 0
         if clips:
+            # The waveform is cut to the cap when the audio side reads it.
+            frames = 0 if (audio_reads_flat and cap is not None) else 97
             out["input_features"] = np.zeros((clips, frames, 128), np.float32)
             out["input_features_mask"] = np.ones((clips, frames), np.int32)
-        assert cap is not None, "the cap must reach the processor somehow"
         return out
 
 
 def test_a_text_cap_does_not_reach_the_audio_extractor():
     """`max_length` is a token budget and must not be read as a sample budget.
 
-    Passed flat, a processor that owns an audio feature extractor may forward
-    it there, and every clip longer than `max_seq_length` samples -- which is
-    every clip, at any realistic cap -- loses its audio. The row still has its
-    placeholders, so what is left is placeholders with nothing behind them.
+    Left flat, it fans out to every modality that declares it, and
+    `AudioKwargs` declares it. Every clip longer than `max_seq_length` samples
+    -- which is every clip, at any realistic cap -- then loses its audio while
+    the row keeps its placeholders, leaving placeholders with nothing behind.
     """
     from unsloth_zoo.mlx import utils as mlx_utils
 
@@ -4723,22 +4721,37 @@ def test_a_text_cap_does_not_reach_the_audio_extractor():
         all_audio=[[np.zeros(16000, np.float32)]],
     )
 
-    assert processor.saw_flat_max_length is None, (
-        "the text cap was passed flat, where an audio extractor can read it"
-    )
     assert inputs["input_features"].shape[1] > 0, (
         "the clip was truncated to the token budget and framed to nothing"
     )
 
 
-def test_a_text_only_batch_still_gets_the_cap_flat():
-    """The scoping is for batches carrying audio, and only those.
+def test_shielding_the_audio_side_leaves_the_text_side_flat():
+    """The shield goes on the audio modality, never the text one.
 
-    A processor with no audio to divert the keyword into should see the same
-    call it always did, so this cannot change collation for text or images.
+    Putting `text_kwargs` in instead would stop the text modality reading its
+    flat keywords, taking `padding`, `add_special_tokens` and `return_tensors`
+    with the cap -- ragged output and a doubled BOS. So the text side must
+    still see both the cap and its padding flag.
+    """
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    processor = _TruncationDivertingAudioProcessor()
+    mlx_utils._processor_vlm_inputs(
+        processor, ["<|audio|>"], [[]], 512,
+        all_audio=[[np.zeros(16000, np.float32)]],
+    )
+    assert processor.text_saw == {"max_length": 512, "padding": True}
+
+
+def test_a_text_only_batch_is_collated_exactly_as_before():
+    """The shield is for batches carrying audio, and only those.
+
+    A processor with no audio to fan the keyword into should see the call it
+    always did, so this cannot change collation for text or images.
     """
     from unsloth_zoo.mlx import utils as mlx_utils
 
     processor = _TruncationDivertingAudioProcessor()
     mlx_utils._processor_vlm_inputs(processor, ["hello"], [[]], 512)
-    assert processor.saw_flat_max_length == 512
+    assert processor.text_saw == {"max_length": 512, "padding": True}

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -7243,32 +7243,34 @@ def _processor_vlm_inputs(
         # caller's processor stays as mlx-vlm made it.
         processor = _audio_repaired_processor(processor)
     if truncation:
-        text_truncation = {"truncation": True}
+        base_kwargs["truncation"] = True
         if max_seq_length is not None:
-            text_truncation["max_length"] = max_seq_length
-        if audio is None:
-            base_kwargs.update(text_truncation)
-        else:
-            # `max_length` is a token budget, but a processor that owns an audio
-            # feature extractor may hand its flat keywords straight to it, and
-            # the extractor reads the same number as a *sample* budget. Gemma 3n
-            # does: a one-second 16 kHz clip under `max_length=512` comes back
-            # as `input_features` of shape (1, 0, 128) -- the waveform cut to
-            # 512 samples, which is 0.032s and frames to nothing -- while
-            # `input_ids` is untouched. Every clip longer than `max_seq_length`
-            # samples loses its audio that way, which is every clip.
+            base_kwargs["max_length"] = max_seq_length
+        if audio is not None:
+            # `max_length` is a token budget, but transformers' `_merge_kwargs`
+            # fans a flat keyword out to *every* modality that declares it, and
+            # `AudioKwargs` declares both `max_length` and `truncation`. So the
+            # token cap reaches the audio feature extractor, which reads the
+            # same number as a *sample* budget. Gemma 3n shows it plainly: a
+            # one-second 16 kHz clip under `max_length=512` comes back as
+            # `input_features` of shape (1, 0, 128) -- the waveform cut to 512
+            # samples, 0.032s, which frames to nothing -- while `input_ids` is
+            # untouched. Every clip longer than `max_seq_length` samples loses
+            # its audio that way, which at any realistic cap is every clip.
             #
-            # Scoping it under `text_kwargs` puts the budget where it was meant
-            # to go. Text still truncates at the cap; the audio survives.
+            # An empty `audio_kwargs` shields the audio modality alone: a
+            # modality that appears in kwargs stops reading flat keywords, so
+            # the extractor no longer sees the cap while the text path keeps
+            # every flat keyword it has always had.
             #
-            # A processor whose signature cannot take `text_kwargs` gets the
-            # flat pair it has always had: it is no worse off than before, and
-            # a processor narrow enough to name its keywords one by one is not
-            # the kind that quietly forwards them to a feature extractor.
-            scoped = _drop_unsupported_processor_kwargs(
-                processor, {"text_kwargs": text_truncation},
-            )
-            base_kwargs.update(scoped or text_truncation)
+            # Scoping the *text* side instead would take the same switch the
+            # other way and silently drop `padding`, `add_special_tokens` and
+            # `return_tensors` for the text modality, which returns ragged
+            # lists and a doubled BOS. The shield has to go on the side that
+            # should not be reading these keywords.
+            base_kwargs.update(_drop_unsupported_processor_kwargs(
+                processor, {"audio_kwargs": {}},
+            ))
     if padding_side is not None:
         base_kwargs["padding_side"] = padding_side
     images = _format_vlm_images_for_processor(all_images, processor=processor)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -7243,9 +7243,32 @@ def _processor_vlm_inputs(
         # caller's processor stays as mlx-vlm made it.
         processor = _audio_repaired_processor(processor)
     if truncation:
-        base_kwargs["truncation"] = True
+        text_truncation = {"truncation": True}
         if max_seq_length is not None:
-            base_kwargs["max_length"] = max_seq_length
+            text_truncation["max_length"] = max_seq_length
+        if audio is None:
+            base_kwargs.update(text_truncation)
+        else:
+            # `max_length` is a token budget, but a processor that owns an audio
+            # feature extractor may hand its flat keywords straight to it, and
+            # the extractor reads the same number as a *sample* budget. Gemma 3n
+            # does: a one-second 16 kHz clip under `max_length=512` comes back
+            # as `input_features` of shape (1, 0, 128) -- the waveform cut to
+            # 512 samples, which is 0.032s and frames to nothing -- while
+            # `input_ids` is untouched. Every clip longer than `max_seq_length`
+            # samples loses its audio that way, which is every clip.
+            #
+            # Scoping it under `text_kwargs` puts the budget where it was meant
+            # to go. Text still truncates at the cap; the audio survives.
+            #
+            # A processor whose signature cannot take `text_kwargs` gets the
+            # flat pair it has always had: it is no worse off than before, and
+            # a processor narrow enough to name its keywords one by one is not
+            # the kind that quietly forwards them to a feature extractor.
+            scoped = _drop_unsupported_processor_kwargs(
+                processor, {"text_kwargs": text_truncation},
+            )
+            base_kwargs.update(scoped or text_truncation)
     if padding_side is not None:
         base_kwargs["padding_side"] = padding_side
     images = _format_vlm_images_for_processor(all_images, processor=processor)


### PR DESCRIPTION
`max_length` is a token budget, but `_processor_vlm_inputs` passes it flat alongside `truncation`. A processor that owns an audio feature extractor may hand its flat keywords straight to it, and the extractor reads the same number as a **sample** budget.

Gemma 3n does exactly this. Against the real `Gemma3nProcessor`, a one-second 16 kHz clip:

| call | `input_features` | `input_ids` |
|---|---|---|
| no truncation | `(1, 97, 128)` | `(1, 206)` |
| `truncation=True` only | `(1, 97, 128)` | `(1, 206)` |
| **`max_length=512` (what collation sends)** | **`(1, 0, 128)`** | `(1, 206)` |
| `text_kwargs={"truncation": True, "max_length": 512}` | `(1, 97, 128)` | `(1, 206)` |

512 samples is 0.032 seconds, which frames to nothing. `input_ids` is untouched, so the row keeps every audio placeholder and loses everything behind them. Any clip longer than `max_seq_length` samples hits this, which at any realistic cap is every clip: 0.128s at 2048.

So gemma3n audio training could not have worked through collation. It does at least fail loudly rather than silently -- `_assert_audio_features_present` refuses the batch, which is precisely what it is there for -- but the family is qualified and shipping, so what a user gets today is a hard error where they expected training.

## The fix

Scope the pair under `text_kwargs` when the batch carries audio. Text still truncates at the cap; the audio survives.

Verified against the real `Gemma3nProcessor` at `max_seq_length` 512, 2048 and 8192: 97 mel frames every time, with text truncation unchanged. Confirmed end to end through `_collate_vlm_batch` -> `_finalize_vlm_batch`.

## Scope

- Text-only and image-only batches keep the flat pair, so collation is unchanged for them. There is a test asserting that specifically.
- A processor whose signature cannot take `text_kwargs` also keeps the flat pair. It is no worse off than before, and a processor narrow enough to name its keywords one by one is not the kind that forwards them to an extractor.
- The width assertion in `_assert_audio_runs_intact` already covers a processor that ignores the truncation it was given, so a silently unapplied cap still cannot reach training.

Reverting the scoping fails the new test. Full suites: 303 passed across `test_mlx_vlm_label_masks.py`, `test_mlx_shape_guard.py` and `test_mlx_batching_and_decay.py`.

Found while probing gemma3n as a control for #983.