### PR TITLE
Do not let trl's entropy metric fail a run that has no logits

### DIFF
--- a/tests/test_trl_entropy_metric.py
+++ b/tests/test_trl_entropy_metric.py
@@ -1,0 +1,196 @@
+"""trl logs a token-entropy metric from logits Unsloth deliberately does not have.
+
+`SFTTrainer.compute_loss` does this, with no way to turn it off short of
+`use_liger_kernel`:
+
+    if not self.args.use_liger_kernel:
+        with torch.no_grad():
+            per_token_entropy = entropy_from_logits(outputs.logits)
+
+Unsloth's entire point there is that a [batch, seq, vocab] float32 tensor -- the
+largest allocation in an SFT step -- is never materialised, and `EMPTY_LOGITS`
+stands in for it. So a diagnostic metric became a hard training failure, in two
+different shapes, both observed live in the sweep:
+
+    Qwen3_(32B)_A100   NotImplementedError: Unsloth: Logits are empty from
+                       2024.11 onwards ... set UNSLOTH_RETURN_LOGITS=1
+    Spark_TTS_(0_5B)   TypeError: iteration over a 0-d tensor
+                       (trl/trainer/utils.py, per_token_entropies.extend)
+
+on Colab AND on Kaggle, on notebooks that trained fine before trl added the
+metric. The advice in the first cannot be taken: UNSLOTH_RETURN_LOGITS=1 buys
+the metric back by giving up the memory saving the user came to Unsloth for.
+
+The detection is on the OBJECT, not the exception text, and that matters.
+`EmptyLogits.__getattr__` returns the `raise_logits_error` FUNCTION for every
+attribute, so what actually blows up depends on which attribute the installed
+trl touches first -- `.split(...)` raises NotImplementedError, while
+`logits.shape[:-1]` subscripts a function object and raises TypeError. A first
+draft of this patch keyed on the two messages and would have fixed one trl
+version while missing the other.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+# ---- the real sentinel, reproduced (unsloth_zoo must not import unsloth) ----
+
+def _raise_logits_error(*a, **k):
+    raise NotImplementedError("Unsloth: Logits are empty from 2024.11 onwards.")
+
+
+def _return_none(*a, **k):
+    return None
+
+
+class EmptyLogits:
+    """Byte-for-byte the shape of unsloth/models/_utils.py's EmptyLogits."""
+
+    def raise_getattr_error(self, attr):
+        return _return_none if attr == "to" else _raise_logits_error
+
+    __getitem__ = _raise_logits_error
+    __getattr__ = raise_getattr_error
+
+
+@pytest.fixture(scope="module")
+def patched():
+    trl_utils = pytest.importorskip("trl.trainer.utils")
+    import trl.trainer.sft_trainer as sft
+    from unsloth_zoo.temporary_patches.misc import patch_trl_entropy_from_logits
+
+    original = trl_utils.entropy_from_logits
+    # Importing unsloth_zoo applies TEMPORARY_PATCHES, so by the time this
+    # fixture runs the name may already be the wrapper. functools.wraps records
+    # the real one on __wrapped__; without this the "unpatched control" test
+    # would call the wrapper and conclude the bug had never existed.
+    while getattr(original, "_unsloth_patched", False) and \
+            getattr(original, "__wrapped__", None) is not None:
+        original = original.__wrapped__
+    patch_trl_entropy_from_logits()
+    yield trl_utils, sft, original
+    trl_utils.entropy_from_logits = original
+    sft.entropy_from_logits = original
+
+
+# ---- it degrades instead of failing --------------------------------------
+
+def test_the_unsloth_sentinel_no_longer_raises(patched):
+    trl_utils, _, _ = patched
+    assert float(trl_utils.entropy_from_logits(EmptyLogits())) == 0.0
+
+
+def test_the_unpatched_call_really_does_raise(patched):
+    """Without this the test above could be passing against a bug that no
+    longer exists."""
+    _, _, original = patched
+    with pytest.raises(Exception):
+        original(EmptyLogits())
+
+
+@pytest.mark.parametrize("logits", [None, torch.randn(0, 7), torch.randn(5)])
+def test_other_unusable_logits_degrade_too(patched, logits):
+    trl_utils, _, _ = patched
+    assert float(trl_utils.entropy_from_logits(logits)) == 0.0
+
+
+def test_the_result_broadcasts_the_way_the_caller_uses_it(patched):
+    """The caller does `sum(entropy * attention_mask) / sum(mask)` in one
+    branch and `mean(entropy)` in the other. A shape that raises in either is
+    no better than the original failure."""
+    trl_utils, _, _ = patched
+    e = trl_utils.entropy_from_logits(EmptyLogits())
+    mask = torch.ones(2, 5)
+    assert float(torch.sum(e * mask) / mask.sum()) == 0.0
+    assert float(torch.mean(e)) == 0.0
+
+
+# ---- and does not quietly break the metric for everyone else -------------
+
+def test_real_logits_are_untouched(patched):
+    """The patch must be invisible when logits do exist -- otherwise it turns
+    a working metric into a zero for every non-Unsloth user of trl."""
+    trl_utils, _, original = patched
+    logits = torch.randn(2, 5, 11)
+    assert torch.allclose(trl_utils.entropy_from_logits(logits), original(logits))
+
+
+def test_a_genuine_error_still_raises(patched):
+    """A bug inside entropy_from_logits must not be swallowed on every step."""
+    trl_utils, _, _ = patched
+    with pytest.raises(Exception):
+        trl_utils.entropy_from_logits("not logits at all")
+
+
+# ---- where it is installed ------------------------------------------------
+
+def test_it_patches_the_module_the_caller_actually_reads(patched):
+    """sft_trainer.py does `from ..trainer.utils import entropy_from_logits`,
+    which binds the name at import time. Patching only trl.trainer.utils would
+    be a no-op for the one caller that matters."""
+    trl_utils, sft, _ = patched
+    assert getattr(trl_utils.entropy_from_logits, "_unsloth_patched", False)
+    assert getattr(sft.entropy_from_logits, "_unsloth_patched", False)
+
+
+def test_applying_it_twice_does_not_stack(patched):
+    from unsloth_zoo.temporary_patches.misc import patch_trl_entropy_from_logits
+    trl_utils, _, _ = patched
+    once = trl_utils.entropy_from_logits
+    patch_trl_entropy_from_logits()
+    assert trl_utils.entropy_from_logits is once
+
+
+def test_it_is_registered(patched):
+    from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
+    assert any(getattr(f, "__name__", "") == "patch_trl_entropy_from_logits"
+               for f in TEMPORARY_PATCHES)
+
+
+# ---- the source ----------------------------------------------------------
+
+def _src():
+    return (ROOT / "unsloth_zoo" / "temporary_patches" / "misc.py").read_text(encoding="utf-8")
+
+
+def test_detection_is_on_the_object_not_the_message():
+    """The point of the rewrite. If someone reintroduces a message match as
+    the primary discriminator, it will pass on one trl and fail on another."""
+    src = _src()
+    i = src.index("def patch_trl_entropy_from_logits")
+    body = src[i:src.index('TEMPORARY_PATCHES.append(patch_trl_entropy_from_logits)', i)]
+    assert 'type(logits).__name__ == "EmptyLogits"' in body
+    assert body.index("def _unusable") < body.index("except TypeError")
+
+
+def test_the_backstop_stays_narrow():
+    src = _src()
+    i = src.index("def patch_trl_entropy_from_logits")
+    body = src[i:src.index('TEMPORARY_PATCHES.append(patch_trl_entropy_from_logits)', i)]
+    assert '"iteration over a 0-d tensor" not in str(e)' in body
+    assert "raise" in body
+
+
+def test_the_logger_is_imported():
+    """The warning is not inside a bare `except Exception: pass`, so a missing
+    `logger` would be a NameError on the first step rather than a silent no-op."""
+    import unsloth_zoo.temporary_patches.misc as misc
+    assert hasattr(misc, "logger")
+    assert hasattr(misc, "functools")
+
+
+def test_the_warning_says_how_to_get_the_real_number():
+    src = _src()
+    i = src.index("def patch_trl_entropy_from_logits")
+    assert "UNSLOTH_RETURN_LOGITS=1" in src[i:src.index('TEMPORARY_PATCHES.append(patch_trl_entropy_from_logits)', i)]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_trl_entropy_metric.py
+++ b/tests/test_trl_entropy_metric.py
@@ -112,6 +112,43 @@ def test_the_result_broadcasts_the_way_the_caller_uses_it(patched):
     assert float(torch.mean(e)) == 0.0
 
 
+# ---- and survives the gather trl does next -------------------------------
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "no accelerator to land on")
+def test_the_fallback_lands_on_the_accelerate_device(patched, monkeypatch):
+    """trl passes this straight to `accelerator.gather_for_metrics`, whose
+    distributed path allocates on PartialState().device and calls NCCL, which
+    rejects a CPU tensor with "Tensors must be CUDA and dense". The masked
+    branch is rescued by multiplying with a device-resident mask, but the
+    padding-free branch (trl's default packing_strategy is "bfd", so plain
+    packing=True reaches it) is a bare mean(), so a CPU scalar would swap one
+    multi-GPU crash for another."""
+    trl_utils, _, _ = patched
+    state = pytest.importorskip("accelerate.state")
+    monkeypatch.setitem(state.PartialState._shared_state, "device", torch.device("cuda", 0))
+    e = trl_utils.entropy_from_logits(EmptyLogits())
+    assert e.device.type == "cuda"
+    assert torch.mean(e).device.type == "cuda"
+    mask = torch.ones(2, 5, device = "cuda")
+    assert (torch.sum(e * mask) / mask.sum()).device.type == "cuda"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "no accelerator to land on")
+def test_the_fallback_follows_the_logits_device(patched):
+    trl_utils, _, _ = patched
+    empty = torch.empty(0, 7, device = "cuda")
+    assert trl_utils.entropy_from_logits(empty).device == empty.device
+
+
+def test_the_fallback_stays_on_cpu_for_a_cpu_run(patched, monkeypatch):
+    """A CPU-only run must not be handed a device it never allocates on, so the
+    device is read off accelerate rather than guessed from torch.cuda."""
+    trl_utils, _, _ = patched
+    state = pytest.importorskip("accelerate.state")
+    monkeypatch.setitem(state.PartialState._shared_state, "device", torch.device("cpu"))
+    assert trl_utils.entropy_from_logits(EmptyLogits()).device.type == "cpu"
+
+
 # ---- and does not quietly break the metric for everyone else -------------
 
 def test_real_logits_are_untouched(patched):

--- a/tests/test_trl_entropy_metric.py
+++ b/tests/test_trl_entropy_metric.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """trl logs a token-entropy metric from logits Unsloth deliberately does not have.
 
 `SFTTrainer.compute_loss` does this, with no way to turn it off short of

--- a/tests/test_trl_entropy_metric.py
+++ b/tests/test_trl_entropy_metric.py
@@ -76,6 +76,20 @@ class EmptyLogits:
     __getattr__ = raise_getattr_error
 
 
+@pytest.fixture(autouse = True)
+def _pin_the_accelerate_device(monkeypatch):
+    """`accelerate.PartialState` is a process-global borg. Anything earlier in
+    the session that builds an Accelerator (many tests here do) leaves
+    `_shared_state["device"] = cuda`, and the fallback below then allocates its
+    scalar there, where it meets the CPU tensors in these tests and raises
+    "Expected all tensors to be on the same device". Pinned so the result of
+    this module does not depend on what ran before it in the same process; the
+    two device tests set their own value on top of it.
+    """
+    state = pytest.importorskip("accelerate.state")
+    monkeypatch.setitem(state.PartialState._shared_state, "device", torch.device("cpu"))
+
+
 @pytest.fixture(scope="module")
 def patched():
     trl_utils = pytest.importorskip("trl.trainer.utils")

--- a/tests/test_trl_entropy_metric.py
+++ b/tests/test_trl_entropy_metric.py
@@ -82,7 +82,12 @@ def patched():
     import trl.trainer.sft_trainer as sft
     from unsloth_zoo.temporary_patches.misc import patch_trl_entropy_from_logits
 
-    original = trl_utils.entropy_from_logits
+    # entropy_from_logits landed in trl 0.20.0 and pyproject allows >= 0.18.2,
+    # so an allowed build can lack it. Production no-ops there, so skip rather
+    # than error out of the fixture.
+    original = getattr(trl_utils, "entropy_from_logits", None)
+    if original is None:
+        pytest.skip("this trl predates entropy_from_logits (added in 0.20.0)")
     # Importing unsloth_zoo applies TEMPORARY_PATCHES, so by the time this
     # fixture runs the name may already be the wrapper. functools.wraps records
     # the real one on __wrapped__; without this the "unpatched control" test

--- a/tests/test_trl_entropy_metric.py
+++ b/tests/test_trl_entropy_metric.py
@@ -169,6 +169,27 @@ def test_the_fallback_lands_on_the_accelerate_device(patched, monkeypatch):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "no accelerator to land on")
+def test_a_cpu_sentinel_tensor_does_not_drag_the_scalar_to_cpu(patched, monkeypatch):
+    """The fused-loss path returns a MODULE-LEVEL `EMPTY_LOGITS = torch.empty(0)`
+    (unsloth_zoo/fused_losses/forward_adapter.py), built at import time and so
+    always on cpu regardless of the run's device. Following the tensor's own
+    device there would hand NCCL a CPU scalar on exactly the distributed run
+    this fallback exists for, and the padding-free branch is a bare mean() with
+    no device-resident mask to rescue it."""
+    trl_utils, _, _ = patched
+    state = pytest.importorskip("accelerate.state")
+    monkeypatch.setitem(state.PartialState._shared_state, "device", torch.device("cuda", 0))
+    assert trl_utils.entropy_from_logits(torch.empty(0)).device.type == "cuda"
+
+
+def test_a_cpu_sentinel_tensor_stays_on_cpu_for_a_cpu_run(patched, monkeypatch):
+    trl_utils, _, _ = patched
+    state = pytest.importorskip("accelerate.state")
+    monkeypatch.setitem(state.PartialState._shared_state, "device", torch.device("cpu"))
+    assert trl_utils.entropy_from_logits(torch.empty(0)).device.type == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "no accelerator to land on")
 def test_the_fallback_follows_the_logits_device(patched):
     trl_utils, _, _ = patched
     empty = torch.empty(0, 7, device = "cuda")

--- a/tests/test_trl_sft_logits_metrics.py
+++ b/tests/test_trl_sft_logits_metrics.py
@@ -473,8 +473,10 @@ def test_a_trainer_that_asked_for_outputs_still_gets_them():
     self.aux_loss_enabled = True
     result, outputs = _sft_call_without_logits_metrics(
         original, self, (self.model, _inputs(), True), {})
-    assert result is pair
-    assert outputs is None, "the caller asked, so nothing was forced or unwrapped"
+    assert result is pair, "the caller asked, so the tuple is handed back intact"
+    # Still harvested for the replay: an eval step arrives already asking, and
+    # those are the batches that would otherwise lose the metric.
+    assert outputs is pair[1]
 
 
 # ---- an output object with no logits at all is somebody else's bug ---------
@@ -659,6 +661,73 @@ def test_a_positional_return_outputs_is_replaced_not_duplicated(sft, sentinel):
     finally:
         Trainer.compute_loss = original
     assert self._metrics["train"]["aux_loss"] == [0.25, 0.25]
+
+
+# ---- eval and predict, where the caller already asked for outputs ---------
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_aux_loss_survives_an_eval_step_too(sft, sentinel):
+    """`Trainer.prediction_step` calls compute_loss(..., return_outputs=True),
+    so `force` is False and the outputs side channel would be empty for exactly
+    the batches that still want the metric."""
+    from transformers import Trainer
+    Out = collections.namedtuple("Out", "loss logits aux_loss")
+
+    def fake(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        loss = torch.tensor(1.0)
+        out = Out(loss, sentinel(), torch.tensor(0.25))
+        return (loss, out) if return_outputs else loss
+
+    original = Trainer.compute_loss
+    Trainer.compute_loss = fake
+    try:
+        self = _trainer(sft)
+        self.aux_loss_enabled = True
+        for _ in range(3):
+            got = sft.SFTTrainer.compute_loss(
+                self, self.model, _inputs(), return_outputs = True,
+                num_items_in_batch = None)
+            assert isinstance(got, tuple) and len(got) == 2, got
+    finally:
+        Trainer.compute_loss = original
+    assert self._metrics["train"]["aux_loss"] == [0.25, 0.25, 0.25]
+
+
+# ---- a retry that also fails must not latch the trainer -------------------
+
+def test_a_failing_retry_does_not_latch_the_fast_path():
+    """If the logits are wanted by something other than the metric block
+    (trl's loss_type='dft', a custom loss), the retry raises too. Latching
+    before it would keep this trainer in the no-logits path for the rest of the
+    process, including a rerun with UNSLOTH_RETURN_LOGITS=1 set.
+
+    Driven through the wrapper directly: the detector reads a frame local
+    named `outputs`, and going via the installed trl would only ever raise
+    from the metric block, which the retry skips by construction.
+    """
+    from unsloth_zoo.temporary_patches.misc import _sft_wrap_compute_loss
+    Out = collections.namedtuple("Out", "loss logits")
+    calls = []
+
+    def original(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        calls.append(self.args.use_liger_kernel)
+        outputs = Out(torch.tensor(1.0), EmptyLogits())  # noqa: F841 - read off the frame
+        raise RuntimeError("this loss needs the logits itself")
+
+    self = _trainer()
+    with pytest.raises(RuntimeError, match = "needs the logits"):
+        _sft_wrap_compute_loss(original)(self, self.model, _inputs(),
+                                         num_items_in_batch = None)
+    assert calls == [False, True], calls
+    assert not getattr(self, "_unsloth_logits_are_empty", False)
+
+
+def test_a_succeeding_retry_still_latches(sft):
+    """The other half: the fast path exists so step 2 onwards costs one attempt,
+    not two."""
+    self, calls = _run_steps(sft, EmptyLogits(), steps = 3)
+    assert getattr(self, "_unsloth_logits_are_empty", False)
+    assert calls == 4, calls
 
 
 if __name__ == "__main__":

--- a/tests/test_trl_sft_logits_metrics.py
+++ b/tests/test_trl_sft_logits_metrics.py
@@ -1,0 +1,383 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""trl's SFTTrainer touches outputs.logits TWICE, and rebinding entropy_from_logits
+only covers the first. On trl 1.x the second one runs FIRST, so the rebind is inert.
+
+    trl 0.22.2  sft_trainer.py:1080  shift_logits = outputs.logits[..., :-1, :]
+    trl 0.24.0  sft_trainer.py:1146  shift_logits = outputs.logits[..., :-1, :]
+    trl 0.25.1  sft_trainer.py:1151  shift_logits = outputs.logits[..., :-1, :]
+    trl 1.9.2   sft_trainer.py:1769  shift_logits = outputs.logits[..., :-1, :]
+
+Two shapes are exercised here. The installed trl's REAL compute_loss (no stubbing
+of trl) against both real sentinels, and a stand-in for trl 1.x -- whose liger
+branch runs BEFORE the forward and injects forward kwargs, so "pretend liger is
+on" is only safe there if those kwargs are kept out of the model call.
+"""
+import collections
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+LOGITS_ERROR_STRING = "Unsloth: Logits are empty from 2024.11 onwards."
+
+
+def _raise(*a, **k): raise NotImplementedError(LOGITS_ERROR_STRING)
+def _none(*a, **k): return None
+
+
+class EmptyLogits:
+    """The compiler.py sentinel. The fused-loss path returns torch.empty(0)
+    instead, so both are parametrised wherever the sentinel is the input."""
+
+    def raise_getattr_error(self, attr): return _none if attr == "to" else _raise
+    __getitem__ = _raise
+    __getattr__ = raise_getattr_error
+    def __repr__(self): return LOGITS_ERROR_STRING
+    def __eq__(self, other): return type(other).__name__ == "EmptyLogits"
+    __hash__ = object.__hash__
+
+
+SENTINELS = [pytest.param(EmptyLogits, id = "EmptyLogits"),
+             pytest.param(lambda: torch.empty(0), id = "empty-tensor")]
+
+
+class _Acc:
+    def gather_for_metrics(self, t): return t if torch.is_tensor(t) else torch.tensor(t)
+
+
+class _Args:
+    use_liger_kernel = False
+    loss_type = "nll"
+    average_tokens_across_devices = False
+    prediction_loss_only = False
+
+
+class _Model:
+    training = True
+    active_adapter = "default"
+    peft_config = {}
+
+
+@pytest.fixture(autouse = True)
+def _pin_the_accelerate_device(monkeypatch):
+    """`accelerate.PartialState` is a process-global borg. Anything earlier in
+    the session that builds an Accelerator (many tests here do) leaves
+    `_shared_state["device"] = cuda`, and the entropy fallback then allocates
+    its scalar there, where it meets the CPU tensors below and raises "Expected
+    all tensors to be on the same device". Pinned so the result of this module
+    does not depend on what ran before it in the same process.
+    """
+    state = pytest.importorskip("accelerate.state")
+    monkeypatch.setitem(state.PartialState._shared_state, "device", torch.device("cpu"))
+
+
+@pytest.fixture(scope = "module")
+def sft():
+    pytest.importorskip("trl")
+    sftmod = pytest.importorskip("trl.trainer.sft_trainer")
+    if not hasattr(sftmod, "SFTTrainer"):
+        pytest.skip("this trl has no SFTTrainer")
+    from unsloth_zoo.temporary_patches.misc import (
+        patch_trl_entropy_from_logits, patch_trl_sft_logits_metrics,
+    )
+    patch_trl_entropy_from_logits()
+    patch_trl_sft_logits_metrics()
+    return sftmod
+
+
+def _trainer(sftmod = None):
+    self = object.__new__(sftmod.SFTTrainer) if sftmod is not None else \
+        type("FakeTrainer", (), {})()
+    self.args = _Args()
+    self.model = _Model()
+    self.accelerator = _Acc()
+    self.num_virtual_tokens = 0
+    self.compute_metrics = None
+    self.preprocess_logits_for_metrics = None
+    self._metrics = {"train": collections.defaultdict(list),
+                     "eval": collections.defaultdict(list)}
+    self._total_train_tokens = 0
+    self.aux_loss_enabled = False
+    self.compute_loss_func = None
+    return self
+
+
+def _inputs(B = 2, L = 6, V = 11):
+    return {
+        "input_ids": torch.randint(0, V, (B, L)),
+        "attention_mask": torch.ones(B, L, dtype = torch.long),
+        "labels": torch.randint(0, V, (B, L)),
+    }
+
+
+def _run_steps(sftmod, logits, steps = 3, pop_labels = False):
+    """Drive trl's real compute_loss with a Trainer.compute_loss that returns
+    `logits`, and report the metrics it accumulated."""
+    from transformers import Trainer
+    Out = collections.namedtuple("Out", "loss logits")
+    loss = torch.tensor(1.0)
+    calls = [0]
+
+    def fake(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        calls[0] += 1
+        # transformers pops labels out of the inputs whenever `compute_loss_func`
+        # or label smoothing is set, so a retry that reuses the same mapping
+        # would run a forward with no labels and no loss.
+        if pop_labels: inputs.pop("labels")
+        assert "labels" in inputs or pop_labels
+        out = Out(loss, logits)
+        return (loss, out) if return_outputs else loss
+
+    original = Trainer.compute_loss
+    Trainer.compute_loss = fake
+    try:
+        self = _trainer(sftmod)
+        inputs = _inputs()
+        for _ in range(steps):
+            sftmod.SFTTrainer.compute_loss(self, self.model, dict(inputs),
+                                           num_items_in_batch = None)
+        return self, calls[0]
+    finally:
+        Trainer.compute_loss = original
+
+
+# ---- against the installed trl -------------------------------------------
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_a_run_with_no_logits_completes(sft, sentinel):
+    """The whole point. Before this patch the step aborted -- at the entropy
+    line on trl <= 0.25 and at the accuracy line on trl 1.x."""
+    self, _ = _run_steps(sft, sentinel())
+    assert self._metrics["train"]["num_tokens"] == [36.0]
+
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_the_token_counter_is_not_double_counted_by_the_retry(sft, sentinel):
+    """The failing call already advanced _total_train_tokens; a naive retry
+    would count the first step twice."""
+    self, _ = _run_steps(sft, sentinel(), steps = 3)
+    assert self._total_train_tokens == 36
+
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_only_the_first_step_pays_for_the_detection(sft, sentinel):
+    _, calls = _run_steps(sft, sentinel(), steps = 3)
+    assert calls == 4, calls
+
+
+def test_the_retry_still_has_the_labels_the_first_attempt_popped(sft):
+    """transformers `Trainer.compute_loss` pops `labels` out of the inputs when
+    a custom loss function or label smoothing is in play. Replaying the same
+    mapping into the retry would hand the model a batch with no labels."""
+    self, _ = _run_steps(sft, EmptyLogits(), steps = 2, pop_labels = True)
+    assert self._metrics["train"]["num_tokens"] == [24.0]
+
+
+def test_real_logits_keep_their_metrics(sft):
+    """A non-Unsloth trl user must not lose entropy or mean_token_accuracy."""
+    self, calls = _run_steps(sft, torch.randn(2, 6, 11), steps = 3)
+    assert calls == 3
+    assert len(self._metrics["train"]["mean_token_accuracy"]) == 3
+    assert len(self._metrics["train"]["entropy"]) == 3
+    assert all(e != 0.0 for e in self._metrics["train"]["entropy"])
+
+
+def test_real_logits_do_not_touch_use_liger_kernel(sft):
+    self, _ = _run_steps(sft, torch.randn(2, 6, 11))
+    assert self.args.use_liger_kernel is False
+    assert not getattr(self, "_unsloth_logits_are_empty", False)
+
+
+def test_use_liger_kernel_is_restored(sft):
+    self, _ = _run_steps(sft, EmptyLogits())
+    assert self.args.use_liger_kernel is False
+
+
+def test_a_real_error_is_not_swallowed(sft):
+    from transformers import Trainer
+    original = Trainer.compute_loss
+
+    def boom(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        raise TypeError("something else entirely")
+
+    Trainer.compute_loss = boom
+    try:
+        with pytest.raises(TypeError, match = "something else entirely"):
+            sft.SFTTrainer.compute_loss(_trainer(sft), _Model(), _inputs(),
+                                        num_items_in_batch = None)
+    finally:
+        Trainer.compute_loss = original
+
+
+def test_a_failure_with_real_logits_is_not_swallowed(sft):
+    """The discriminator is the logits trl was holding, not the exception. A
+    genuine bug in the metric block, with real logits, must still raise."""
+    from transformers import Trainer
+    Out = collections.namedtuple("Out", "loss logits")
+    original = Trainer.compute_loss
+
+    def bad_shape(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        out = Out(torch.tensor(1.0), torch.randn(2, 6, 11))
+        return (torch.tensor(1.0), out) if return_outputs else torch.tensor(1.0)
+
+    Trainer.compute_loss = bad_shape
+    try:
+        inputs = _inputs()
+        inputs["labels"] = torch.randint(0, 11, (2, 99))  # will not line up
+        with pytest.raises(Exception):
+            sft.SFTTrainer.compute_loss(_trainer(sft), _Model(), inputs,
+                                        num_items_in_batch = None)
+    finally:
+        Trainer.compute_loss = original
+
+
+def test_applying_it_twice_does_not_stack(sft):
+    from unsloth_zoo.temporary_patches.misc import patch_trl_sft_logits_metrics
+    once = sft.SFTTrainer.compute_loss
+    patch_trl_sft_logits_metrics()
+    assert sft.SFTTrainer.compute_loss is once
+
+
+def test_it_is_registered(sft):
+    from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
+    assert any(getattr(f, "__name__", "") == "patch_trl_sft_logits_metrics"
+               for f in TEMPORARY_PATCHES)
+
+
+# ---- against a stand-in for trl 1.x --------------------------------------
+#
+# trl 1.x is not the version installed here, and its compute_loss differs in the
+# one way that decides whether the off switch is usable at all: the liger branch
+# runs BEFORE the forward and writes liger-only kwargs into the batch.
+
+FORWARD_KWARGS_SEEN = []
+
+
+def _trl_1x_compute_loss(self, model, inputs, return_outputs = False,
+                         num_items_in_batch = None):
+    """trl 1.9.2 sft_trainer.py:1700-1832, trimmed to the parts that matter."""
+    from transformers import Trainer
+    mode = "train" if self.model.training else "eval"
+    prediction_loss_only = inputs.pop("_prediction_loss_only", None)
+    labels = inputs["labels"]
+    inputs["use_cache"] = False
+    if self.args.use_liger_kernel:
+        inputs["skip_logits"] = (
+            self.model.training or self.args.prediction_loss_only
+            or (self.compute_metrics is None
+                and self.preprocess_logits_for_metrics is None
+                and prediction_loss_only is not False)
+        )
+        inputs["return_token_accuracy"] = True
+        inputs["use_token_scaling"] = self.args.loss_type == "dft"
+    (loss, outputs) = Trainer.compute_loss(
+        self, model, inputs, return_outputs = True,
+        num_items_in_batch = num_items_in_batch,
+    )
+    if not self.args.use_liger_kernel:
+        with torch.no_grad():
+            shift_logits = outputs.logits[..., :-1, :]
+            shift_labels = labels[..., 1:]
+            mask = shift_labels != -100
+            predictions = shift_logits.argmax(dim = -1)
+            correct = ((predictions == shift_labels) & mask).sum()
+            total = mask.sum()
+        self._metrics[mode]["entropy"].append(0.0)
+        self._metrics[mode]["mean_token_accuracy"].append((correct / total).item())
+    if mode == "train":
+        self._total_train_tokens += inputs["attention_mask"].sum().item()
+    self._metrics[mode]["num_tokens"] = [self._total_train_tokens]
+    if self.args.use_liger_kernel:
+        if getattr(outputs, "token_accuracy", None) is not None:
+            self._metrics[mode]["mean_token_accuracy"].append(outputs.token_accuracy)
+        else:
+            warnings.warn(
+                "liger-kernel did not return token_accuracy when requested. The "
+                "mean_token_accuracy metric will not be logged. This is "
+                "unexpected; please report it to the liger-kernel repository.",
+                stacklevel = 2,
+            )
+    return (loss, outputs) if return_outputs else loss
+
+
+def _run_1x(logits, steps = 2):
+    from transformers import Trainer
+    from unsloth_zoo.temporary_patches.misc import _sft_wrap_compute_loss
+    Out = collections.namedtuple("Out", "loss logits")
+    FORWARD_KWARGS_SEEN.clear()
+
+    def fake(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        FORWARD_KWARGS_SEEN.append(sorted(inputs.keys()))
+        loss = torch.tensor(1.0)
+        out = Out(loss, logits)
+        return (loss, out) if return_outputs else loss
+
+    wrapped = _sft_wrap_compute_loss(_trl_1x_compute_loss)
+    original = Trainer.compute_loss
+    Trainer.compute_loss = fake
+    try:
+        self = _trainer()
+        for _ in range(steps):
+            wrapped(self, self.model, _inputs(), num_items_in_batch = None)
+        return self
+    finally:
+        Trainer.compute_loss = original
+
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_the_1x_shape_completes_too(sentinel):
+    self = _run_1x(sentinel())
+    assert self._total_train_tokens == 24
+    assert self._metrics["train"]["mean_token_accuracy"] == []
+
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_liger_only_kwargs_never_reach_the_forward(sentinel):
+    """`skip_logits` / `return_token_accuracy` / `use_token_scaling` are for a
+    liger-patched forward. The model here is an Unsloth one, and it would be
+    handed them on the retry and on every step after it."""
+    _run_1x(sentinel())
+    assert FORWARD_KWARGS_SEEN, "the forward was never called"
+    for seen in FORWARD_KWARGS_SEEN:
+        assert "skip_logits" not in seen, seen
+        assert "return_token_accuracy" not in seen, seen
+        assert "use_token_scaling" not in seen, seen
+
+
+def test_the_1x_liger_kernel_bug_report_is_not_shown(recwarn):
+    """With the flag forced on, trl 1.x asks the user to report a bug to
+    liger-kernel for not returning token_accuracy. There is no liger here."""
+    warnings.simplefilter("always")
+    _run_1x(EmptyLogits())
+    assert not [w for w in recwarn if "liger-kernel" in str(w.message)]
+
+
+def test_the_1x_shape_keeps_real_metrics():
+    self = _run_1x(torch.randn(2, 6, 11))
+    assert len(self._metrics["train"]["mean_token_accuracy"]) == 2
+    for seen in FORWARD_KWARGS_SEEN:
+        assert "skip_logits" not in seen
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_trl_sft_logits_metrics.py
+++ b/tests/test_trl_sft_logits_metrics.py
@@ -379,5 +379,187 @@ def test_the_1x_shape_keeps_real_metrics():
         assert "skip_logits" not in seen
 
 
+# ---- aux_loss is not logits-derived and must survive the skip --------------
+
+def _run_with_aux(sftmod, logits, steps = 3, aux = torch.tensor(0.25),
+                  trainer_logs_aux = False):
+    """As `_run_steps`, but the outputs carry `aux_loss` and the trainer is a
+    MoE one (`output_router_logits = True` -> `aux_loss_enabled`).
+
+    `trainer_logs_aux` stands in for trl 1.x, which moved this metric OUT of
+    the `use_liger_kernel` branch (1.9.2 sft_trainer.py:1826 "applies to both
+    Liger and non-Liger") and therefore logs it itself.
+    """
+    from transformers import Trainer
+    Out = collections.namedtuple("Out", "loss logits aux_loss")
+    loss = torch.tensor(1.0)
+
+    def fake(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        if trainer_logs_aux:
+            self._metrics["train"]["aux_loss"].append(float(aux))
+        out = Out(loss, logits, aux)
+        return (loss, out) if return_outputs else loss
+
+    original = Trainer.compute_loss
+    Trainer.compute_loss = fake
+    try:
+        self = _trainer(sftmod)
+        self.aux_loss_enabled = True
+        inputs = _inputs()
+        for _ in range(steps):
+            sftmod.SFTTrainer.compute_loss(self, self.model, dict(inputs),
+                                           num_items_in_batch = None)
+        return self
+    finally:
+        Trainer.compute_loss = original
+
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_aux_loss_survives_the_skipped_metric_block(sft, sentinel):
+    """On trl 0.23.0-0.25.x this metric sits INSIDE the block being skipped, so
+    without a replay a MoE run silently stops logging it."""
+    self = _run_with_aux(sft, sentinel(), steps = 3)
+    assert self._metrics["train"]["aux_loss"] == [0.25, 0.25, 0.25]
+
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_aux_loss_is_not_logged_twice(sft, sentinel):
+    """trl 1.x logs it outside the branch, so replaying would double-count.
+    Gated on the count rather than on a version number."""
+    self = _run_with_aux(sft, sentinel(), steps = 3, trainer_logs_aux = True)
+    assert self._metrics["train"]["aux_loss"] == [0.25, 0.25, 0.25]
+
+
+def test_aux_loss_is_left_alone_when_the_run_is_not_moe(sft):
+    """`aux_loss_enabled` is False for every dense model, and nothing should
+    appear for them."""
+    self, _ = _run_steps(sft, EmptyLogits(), steps = 2)
+    assert self._metrics["train"]["aux_loss"] == []
+
+
+def test_the_ordinary_call_shape_is_unchanged_for_a_dense_run():
+    """`return_outputs` is forced only when there is an aux_loss to rescue.
+
+    Asked of the wrapper's own call into trl, not of trl's call into
+    transformers: trl passes `return_outputs = True` inward on every version,
+    since that is how it reaches `outputs.logits` at all.
+    """
+    from unsloth_zoo.temporary_patches.misc import _sft_call_without_logits_metrics
+    seen = []
+
+    def original(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        seen.append(return_outputs)
+        return torch.tensor(1.0)
+
+    self = _trainer()
+    for aux_enabled, expected in ((False, False), (True, True)):
+        seen.clear()
+        self.aux_loss_enabled = aux_enabled
+        _sft_call_without_logits_metrics(
+            original, self, (self.model, _inputs()), {"num_items_in_batch": None})
+        assert seen == [expected], (aux_enabled, seen)
+
+
+def test_a_trainer_that_asked_for_outputs_still_gets_them():
+    """Forcing the flag must not change what the caller receives."""
+    from unsloth_zoo.temporary_patches.misc import _sft_call_without_logits_metrics
+    Out = collections.namedtuple("Out", "loss logits aux_loss")
+    pair = (torch.tensor(1.0), Out(torch.tensor(1.0), EmptyLogits(), torch.tensor(0.5)))
+
+    def original(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        return pair if return_outputs else pair[0]
+
+    self = _trainer()
+    self.aux_loss_enabled = True
+    result, outputs = _sft_call_without_logits_metrics(
+        original, self, (self.model, _inputs(), True), {})
+    assert result is pair
+    assert outputs is None, "the caller asked, so nothing was forced or unwrapped"
+
+
+# ---- an output object with no logits at all is somebody else's bug ---------
+
+def test_a_missing_logits_attribute_still_raises(sft):
+    """`getattr(outputs, "logits", None)` would call an absent attribute
+    unusable and retry with the metrics off, turning a broken output contract
+    into silent training."""
+    from transformers import Trainer
+    Out = collections.namedtuple("Out", "loss")
+
+    def fake(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        loss = torch.tensor(1.0)
+        out = Out(loss)
+        return (loss, out) if return_outputs else loss
+
+    original = Trainer.compute_loss
+    Trainer.compute_loss = fake
+    try:
+        self = _trainer(sft)
+        with pytest.raises(AttributeError):
+            sft.SFTTrainer.compute_loss(self, self.model, _inputs(),
+                                        num_items_in_batch = None)
+        assert not getattr(self, "_unsloth_logits_are_empty", False)
+    finally:
+        Trainer.compute_loss = original
+
+
+def test_an_explicit_none_logits_is_still_the_sentinel(sft):
+    """The distinction is absent-vs-present, not None-vs-not: a model that
+    really sets `logits = None` must still be handled."""
+    self, _ = _run_steps(sft, None, steps = 2)
+    assert self._metrics["train"]["mean_token_accuracy"] == []
+
+
+# ---- the two warnings must not contradict each other ----------------------
+
+def test_the_entropy_warning_is_not_shown_when_both_are_omitted(sft, caplog):
+    """The entropy patch promises "Entropy will be reported as 0.0". When the
+    accuracy read then fails, the wrapper reports that BOTH are omitted, so the
+    first message is wrong and the user sees two contradictory ones on step 1."""
+    import logging
+    from unsloth_zoo.temporary_patches.misc import logger as misc_logger
+    import trl.trainer.utils as trl_utils
+    flag = getattr(trl_utils.entropy_from_logits, "_unsloth_warned", None)
+    if flag is None:
+        pytest.skip("entropy patch is not installed in this environment")
+    was = flag[0]
+    flag[0] = False
+    try:
+        with caplog.at_level(logging.WARNING, logger = misc_logger.name):
+            _run_steps(sft, EmptyLogits(), steps = 2)
+        text = caplog.text
+    finally:
+        flag[0] = was
+    assert "Both will be omitted" in text
+    assert "Entropy will be reported as 0.0" not in text
+
+
+def test_a_real_failure_leaves_the_entropy_flag_alone(sft):
+    """The mute is for the probing call only; an unrelated error must restore
+    it rather than swallow the next legitimate entropy warning."""
+    from transformers import Trainer
+    import trl.trainer.utils as trl_utils
+    flag = getattr(trl_utils.entropy_from_logits, "_unsloth_warned", None)
+    if flag is None:
+        pytest.skip("entropy patch is not installed in this environment")
+
+    def fake(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        raise RuntimeError("something else entirely")
+
+    original = Trainer.compute_loss
+    Trainer.compute_loss = fake
+    was = flag[0]
+    flag[0] = False
+    try:
+        self = _trainer(sft)
+        with pytest.raises(RuntimeError, match = "something else"):
+            sft.SFTTrainer.compute_loss(self, self.model, _inputs(),
+                                        num_items_in_batch = None)
+        assert flag[0] is False
+    finally:
+        Trainer.compute_loss = original
+        flag[0] = was
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_trl_sft_logits_metrics.py
+++ b/tests/test_trl_sft_logits_metrics.py
@@ -561,5 +561,105 @@ def test_a_real_failure_leaves_the_entropy_flag_alone(sft):
         flag[0] = was
 
 
+# ---- nothing may leave an empty metric list behind ------------------------
+
+def _log_would_divide_by_zero(self):
+    """Names of metrics trl's own `log` would choke on.
+
+    `SFTTrainer.log` averages every key it finds with `sum(val) / len(val)`
+    (0.25.1 sft_trainer.py:1194), so an empty list is a ZeroDivisionError at
+    the first logging step, not a missing metric.
+    """
+    return sorted(n for n, v in self._metrics["train"].items() if len(v) == 0)
+
+
+def test_a_dense_run_does_not_invent_an_aux_loss_key(sft):
+    """`_metrics[mode]` is a defaultdict(list), so reading the key would create
+    it, on every step, for models that will never have an aux_loss."""
+    self, _ = _run_steps(sft, EmptyLogits(), steps = 3)
+    assert "aux_loss" not in self._metrics["train"]
+    assert _log_would_divide_by_zero(self) == []
+
+
+def test_a_healthy_run_does_not_invent_one_either(sft):
+    """The count is taken before the probe, so real-logits steps pass through
+    it too and a dense trainer would be poisoned without ever failing."""
+    self, _ = _run_steps(sft, torch.randn(2, 6, 11), steps = 2)
+    assert "aux_loss" not in self._metrics["train"]
+    assert _log_would_divide_by_zero(self) == []
+
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_the_rollback_removes_keys_the_probe_invented(sft, sentinel):
+    """The failed probe can get as far as appending entropy before the accuracy
+    read fails. Truncating that list to [] leaves the key behind."""
+    self, _ = _run_steps(sft, sentinel(), steps = 2)
+    assert _log_would_divide_by_zero(self) == []
+
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_trl_can_actually_log_after_the_retry(sft, sentinel):
+    """The end of the story, through trl's real `log` rather than a stand-in."""
+    self, _ = _run_steps(sft, sentinel(), steps = 2)
+    logs = {}
+    import transformers
+    original = transformers.Trainer.log
+    transformers.Trainer.log = lambda self, d, start_time = None: logs.update(d)
+    try:
+        sft.SFTTrainer.log(self, {"loss": 1.0})
+    finally:
+        transformers.Trainer.log = original
+    assert logs["loss"] == 1.0
+
+
+def test_a_metric_the_probe_only_extended_is_truncated_not_dropped(sft):
+    """A key that already existed keeps its earlier values; only the probe's
+    own additions go."""
+    self = _trainer(sft)
+    self._metrics["train"]["mean_token_accuracy"].extend([0.5, 0.75])
+    from transformers import Trainer
+    Out = collections.namedtuple("Out", "loss logits")
+
+    def fake(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        loss = torch.tensor(1.0)
+        out = Out(loss, EmptyLogits())
+        return (loss, out) if return_outputs else loss
+
+    original = Trainer.compute_loss
+    Trainer.compute_loss = fake
+    try:
+        sft.SFTTrainer.compute_loss(self, self.model, _inputs(),
+                                    num_items_in_batch = None)
+    finally:
+        Trainer.compute_loss = original
+    assert self._metrics["train"]["mean_token_accuracy"] == [0.5, 0.75]
+
+
+# ---- the public positional call shape -------------------------------------
+
+@pytest.mark.parametrize("sentinel", SENTINELS)
+def test_a_positional_return_outputs_is_replaced_not_duplicated(sft, sentinel):
+    """`compute_loss(model, inputs, False, ...)` is a legal public call. Adding
+    the keyword beside the positional would raise "got multiple values"."""
+    from transformers import Trainer
+    Out = collections.namedtuple("Out", "loss logits aux_loss")
+
+    def fake(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        loss = torch.tensor(1.0)
+        out = Out(loss, sentinel(), torch.tensor(0.25))
+        return (loss, out) if return_outputs else loss
+
+    original = Trainer.compute_loss
+    Trainer.compute_loss = fake
+    try:
+        self = _trainer(sft)
+        self.aux_loss_enabled = True
+        for _ in range(2):
+            sft.SFTTrainer.compute_loss(self, self.model, _inputs(), False, None)
+    finally:
+        Trainer.compute_loss = original
+    assert self._metrics["train"]["aux_loss"] == [0.25, 0.25]
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 import inspect
 import importlib
+import warnings
 from collections.abc import Mapping
 from typing import Any, List, Optional, Tuple, Union, Dict, Set, Callable
 import functools
@@ -1801,3 +1802,214 @@ def patch_trl_entropy_from_logits():
             _mod.entropy_from_logits = entropy_from_logits
 pass
 TEMPORARY_PATCHES.append(patch_trl_entropy_from_logits)
+
+
+# trl >= 1.0 injects these into the forward kwargs when `use_liger_kernel` is
+# on, because its liger path expects a liger-patched forward to consume them
+# (trl 1.9.2 sft_trainer.py:1718-1735). An Unsloth model is not liger-patched,
+# so they must not ride along when the flag is forced on below.
+_SFT_LIGER_ONLY_FORWARD_KWARGS = frozenset((
+    "skip_logits",
+    "return_token_accuracy",
+    "use_token_scaling",
+))
+_SFT_SHIELDED_INPUT_TYPES = {}
+
+
+def _sft_shielded_inputs(inputs, contents):
+    """A copy of `contents` that silently drops the liger-only forward kwargs.
+
+    The injection happens inside `compute_loss`, on the mapping the caller
+    handed in, so the mapping is the only interception point available. Built
+    from the caller's own mapping type so a `BatchEncoding` stays one, and
+    cached per type so the class is created once rather than per step.
+    """
+    if not isinstance(inputs, Mapping):
+        return contents
+    cls = type(inputs)
+    shielded = _SFT_SHIELDED_INPUT_TYPES.get(cls, None)
+    if shielded is None:
+        def __setitem__(self, key, value, _cls = cls):
+            if key in _SFT_LIGER_ONLY_FORWARD_KWARGS: return
+            _cls.__setitem__(self, key, value)
+        try:
+            shielded = type("Unsloth" + cls.__name__, (cls,), {"__setitem__" : __setitem__})
+        except Exception:
+            return contents
+        _SFT_SHIELDED_INPUT_TYPES[cls] = shielded
+    try:
+        return shielded(contents)
+    except Exception:
+        return contents
+pass
+
+
+def _sft_logits_are_unusable(logits):
+    """Same predicate `patch_trl_entropy_from_logits` applies to its argument.
+
+    Kept separate rather than shared because that one is closed over the
+    entropy patch and matched by name: unsloth_zoo must not import unsloth, so
+    the sentinel is recognised by class name, and the fused-loss path returns a
+    real 0-element tensor (`fused_losses/forward_adapter.py: EMPTY_LOGITS =
+    torch.empty(0)`) instead.
+    """
+    if logits is None: return True
+    if type(logits).__name__ == "EmptyLogits": return True
+    if isinstance(logits, torch.Tensor) and (logits.numel() == 0 or logits.dim() < 2):
+        return True
+    return False
+pass
+
+
+def _sft_raised_on_empty_logits(exception):
+    """Decided on the object trl was holding, not on the exception message.
+
+    Which exception comes out depends on which sentinel the model returned and
+    which attribute the installed trl reaches for first:
+
+        EmptyLogits().shape[:-1]      TypeError    ('function' not subscriptable)
+        EmptyLogits()[..., :-1, :]    NotImplementedError
+        torch.empty(0)[..., :-1, :]   IndexError   (too many indices)
+        torch.empty(0).argmax(-1)     RuntimeError
+
+    so a message match fixes one build and misses the next. The failing frame
+    still holds trl's `outputs`, so the question can be asked of the logits
+    themselves: if they are real, this is somebody's genuine bug and it must
+    keep propagating.
+
+    Matched on the local rather than on the frame's name, because the raise can
+    land in a helper trl called and because the enclosing method has been
+    renamed before. The stack starts inside SFTTrainer.compute_loss either way.
+    """
+    tb = getattr(exception, "__traceback__", None)
+    while tb is not None:
+        frame = tb.tb_frame
+        if "outputs" in frame.f_locals:
+            try:
+                logits = getattr(frame.f_locals["outputs"], "logits", None)
+                unusable = _sft_logits_are_unusable(logits)
+            except Exception:
+                unusable = False
+            if unusable: return True
+        tb = tb.tb_next
+    return False
+pass
+
+
+def _sft_inputs_slot(args, kwargs):
+    """Where `inputs` sits in a `compute_loss(self, model, inputs, ...)` call."""
+    if len(args) > 1: return 1, args[1]
+    if "inputs" in kwargs: return "inputs", kwargs["inputs"]
+    return None, None
+pass
+
+
+def _sft_call_without_logits_metrics(original, self, args, kwargs, contents = None):
+    """Run trl's own `compute_loss` with its logits-derived metrics turned off.
+
+    Every version in the supported range gates that section on
+    `self.args.use_liger_kernel` ("liger doesn't return logits"), which is
+    exactly the "there are no logits" condition, so the flag is trl's own off
+    switch for it. Only forced when the user had it off; a real liger run is
+    left alone. `contents` replays the mapping as it was BEFORE a failed first
+    attempt, which may have popped `labels` out of it (transformers
+    `Trainer.compute_loss` does exactly that when `compute_loss_func` or label
+    smoothing is set).
+    """
+    targs = getattr(self, "args", None)
+    previous = getattr(targs, "use_liger_kernel", None)
+    if previous is None or previous:
+        return original(self, *args, **kwargs)
+    slot, inputs = _sft_inputs_slot(args, kwargs)
+    if slot is not None:
+        shielded = _sft_shielded_inputs(inputs, inputs if contents is None else contents)
+        if slot == "inputs":
+            kwargs = dict(kwargs)
+            kwargs["inputs"] = shielded
+        else:
+            args = args[:slot] + (shielded,) + args[slot + 1:]
+    targs.use_liger_kernel = True
+    try:
+        with warnings.catch_warnings():
+            # trl >= 1.0 tells the user to file a liger-kernel bug when the
+            # flag is on and the outputs carry no token_accuracy
+            # (sft_trainer.py:1821). There is no liger here, so that report
+            # would be sent to the wrong project.
+            warnings.filterwarnings("ignore", message = ".*token_accuracy.*")
+            return original(self, *args, **kwargs)
+    finally:
+        targs.use_liger_kernel = previous
+pass
+
+
+def _sft_wrap_compute_loss(original):
+    """The wrapper installed below; separated so it can be driven against a
+    stand-in for a trl version that is not the one installed."""
+
+    @functools.wraps(original)
+    def compute_loss(self, *args, **kwargs):
+        # Per trainer, not per process: two SFTTrainers can live in one process
+        # and only one of them may be running an Unsloth model.
+        if getattr(self, "_unsloth_logits_are_empty", False):
+            return _sft_call_without_logits_metrics(original, self, args, kwargs)
+        # A failed attempt leaves state behind: it advanced the token counter,
+        # appended the metrics it got as far as, and let transformers pop
+        # `labels` out of the inputs. All three are replayed to the retry as
+        # they were, so nothing is counted twice and nothing is missing.
+        counter = getattr(self, "_total_train_tokens", None)
+        metrics = getattr(self, "_metrics", None)
+        lengths = {k : {n : len(v) for n, v in d.items()} for k, d in metrics.items()} \
+            if isinstance(metrics, dict) else None
+        _, inputs = _sft_inputs_slot(args, kwargs)
+        contents = dict(inputs) if isinstance(inputs, Mapping) else None
+        try:
+            return original(self, *args, **kwargs)
+        except Exception as e:
+            if not _sft_raised_on_empty_logits(e): raise
+            self._unsloth_logits_are_empty = True
+            if counter is not None:
+                self._total_train_tokens = counter
+            if lengths is not None:
+                for k, d in metrics.items():
+                    for n, v in list(d.items()):
+                        del v[lengths.get(k, {}).get(n, 0):]
+            logger.warning(
+                "Unsloth: your trl version logs entropy and mean_token_accuracy "
+                "from the full logits, which Unsloth does not materialise (that "
+                "is where the memory saving comes from). Both will be omitted. "
+                "Set UNSLOTH_RETURN_LOGITS=1 before training if you need them "
+                "and can afford the memory."
+            )
+            return _sft_call_without_logits_metrics(original, self, args, kwargs, contents)
+    compute_loss._unsloth_patched = True
+    return compute_loss
+pass
+
+
+def patch_trl_sft_logits_metrics():
+    """The entropy rebind above is not enough: trl's SFTTrainer.compute_loss
+    touches `outputs.logits` a second time, inline, for mean_token_accuracy.
+
+        trl 0.22.2  sft_trainer.py:1080  shift_logits = outputs.logits[..., :-1, :]
+        trl 0.24.0  sft_trainer.py:1146  shift_logits = outputs.logits[..., :-1, :]
+        trl 0.25.1  sft_trainer.py:1151  shift_logits = outputs.logits[..., :-1, :]
+        trl 1.9.2   sft_trainer.py:1769  shift_logits = outputs.logits[..., :-1, :]
+
+    On trl 1.x that line runs BEFORE entropy_from_logits, so rebinding the
+    helper cannot help there at all. There is no helper to rebind for the
+    accuracy block, so the whole logits-derived metric section is skipped
+    instead -- and only after a run has actually proved its logits are empty,
+    so a non-Unsloth trl user keeps the real metrics and pays nothing but one
+    `try`.
+    """
+    try:
+        import trl.trainer.sft_trainer as _sft
+    except Exception:
+        return
+    trainer = getattr(_sft, "SFTTrainer", None)
+    original = getattr(trainer, "compute_loss", None)
+    if original is None or getattr(original, "_unsloth_patched", False):
+        return
+    trainer.compute_loss = _sft_wrap_compute_loss(original)
+pass
+TEMPORARY_PATCHES.append(patch_trl_sft_logits_metrics)

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1760,8 +1760,15 @@ def patch_trl_entropy_from_logits():
         multi-GPU run would swap one crash for another. Asked of accelerate
         rather than guessed, and only once it is already initialised, so a
         single-process run keeps the CPU scalar accelerate leaves alone.
+
+        A tensor's own device is only trusted when it is NOT cpu. The
+        fused-loss path returns a module-level `EMPTY_LOGITS = torch.empty(0)`
+        (fused_losses/forward_adapter.py), built at import time and therefore
+        always on cpu no matter which device the run is on, so following it
+        would hand NCCL a CPU scalar on exactly the distributed run this
+        function exists for.
         """
-        if isinstance(logits, torch.Tensor):
+        if isinstance(logits, torch.Tensor) and logits.device.type != "cpu":
             return logits.device
         try:
             from accelerate.state import PartialState
@@ -1769,7 +1776,7 @@ def patch_trl_entropy_from_logits():
                 return PartialState().device
         except Exception:
             pass
-        return None
+        return logits.device if isinstance(logits, torch.Tensor) else None
 
     # 0-d so it broadcasts against attention_mask in both of the caller's
     # branches: sum(0 * mask)/sum(mask) and mean(0) are both 0.0, neither raises.
@@ -1793,6 +1800,11 @@ def patch_trl_entropy_from_logits():
             return _no_entropy(logits)
 
     entropy_from_logits._unsloth_patched = True
+    # Exposed so the SFT wrapper can mute this for its probing call. That call
+    # may be about to fail on the SECOND logits read, in which case the
+    # wrapper reports that both metrics are omitted and this message, which
+    # promises entropy as 0.0, would contradict it on the very first step.
+    entropy_from_logits._unsloth_warned = _warned
     for _mod_name in ("trl.trainer.utils", "trl.trainer.sft_trainer"):
         try:
             _mod = importlib.import_module(_mod_name)
@@ -1881,18 +1893,40 @@ def _sft_raised_on_empty_logits(exception):
     land in a helper trl called and because the enclosing method has been
     renamed before. The stack starts inside SFTTrainer.compute_loss either way.
     """
+    return _sft_empty_logits_outputs(exception) is not None
+pass
+
+
+_SFT_NO_LOGITS = object()
+
+
+def _sft_empty_logits_outputs(exception):
+    """The `outputs` object trl was holding, if its logits were the sentinel.
+
+    Returned rather than just a bool so the caller can replay `aux_loss` off
+    it: that metric is not logits-derived, but it lives inside the same
+    `if not self.args.use_liger_kernel` block, so skipping the block to avoid
+    the logits would silently drop it for MoE runs.
+    """
     tb = getattr(exception, "__traceback__", None)
     while tb is not None:
         frame = tb.tb_frame
         if "outputs" in frame.f_locals:
+            outputs = frame.f_locals["outputs"]
             try:
-                logits = getattr(frame.f_locals["outputs"], "logits", None)
-                unusable = _sft_logits_are_unusable(logits)
+                # A default of None would be indistinguishable from a model
+                # that really does set `logits = None`, and _..._are_unusable
+                # calls that unusable. An output object with no `logits` at all
+                # is somebody's broken contract, not our sentinel, and must
+                # keep raising.
+                logits = getattr(outputs, "logits", _SFT_NO_LOGITS)
+                unusable = (logits is not _SFT_NO_LOGITS
+                            and _sft_logits_are_unusable(logits))
             except Exception:
                 unusable = False
-            if unusable: return True
+            if unusable: return outputs
         tb = tb.tb_next
-    return False
+    return None
 pass
 
 
@@ -1901,6 +1935,62 @@ def _sft_inputs_slot(args, kwargs):
     if len(args) > 1: return 1, args[1]
     if "inputs" in kwargs: return "inputs", kwargs["inputs"]
     return None, None
+pass
+
+
+def _sft_mute_entropy_warning():
+    """Silence the entropy patch for one probing call; returns a restore token."""
+    try:
+        import trl.trainer.utils as _u
+        flag = getattr(getattr(_u, "entropy_from_logits", None), "_unsloth_warned", None)
+        if flag is None: return None
+        was, flag[0] = flag[0], True
+        return (flag, was)
+    except Exception:
+        return None
+pass
+
+
+def _sft_aux_loss_count(self):
+    """How many aux_loss values trl has logged for the current mode."""
+    metrics = getattr(self, "_metrics", None)
+    if not isinstance(metrics, dict): return None
+    mode = "train" if getattr(getattr(self, "model", None), "training", True) else "eval"
+    bucket = metrics.get(mode)
+    if bucket is None: return None
+    try:
+        return len(bucket["aux_loss"])
+    except Exception:
+        return None
+pass
+
+
+def _sft_replay_aux_loss(self, outputs, before):
+    """Log the aux_loss the skipped block would have logged.
+
+    aux_loss is not logits-derived, but on trl 0.23.0 through 0.25.x it sits
+    INSIDE the same `if not self.args.use_liger_kernel` block as the accuracy
+    metric, so turning that flag on to dodge the logits drops it too, silently,
+    for exactly the MoE runs (`output_router_logits = True`) that want it.
+
+    Gated on the count rather than on a version, because trl 1.x moved this out
+    to `# applies to both Liger and non-Liger` (1.9.2 sft_trainer.py:1826) and
+    logs it regardless, where appending again would double-count. 0.22.2 has no
+    aux_loss in this trainer at all.
+    """
+    if outputs is None or before is None: return
+    if not getattr(self, "aux_loss_enabled", False): return
+    if (_sft_aux_loss_count(self) or 0) > before: return
+    aux = getattr(outputs, "aux_loss", None)
+    if aux is None: return
+    try:
+        metrics = self._metrics["train" if self.model.training else "eval"]
+        metrics["aux_loss"].append(
+            self.accelerator.gather_for_metrics(aux).mean().item()
+        )
+    except Exception:
+        # A lost diagnostic must never take down the step that produced it.
+        pass
 pass
 
 
@@ -1919,7 +2009,14 @@ def _sft_call_without_logits_metrics(original, self, args, kwargs, contents = No
     targs = getattr(self, "args", None)
     previous = getattr(targs, "use_liger_kernel", None)
     if previous is None or previous:
-        return original(self, *args, **kwargs)
+        return original(self, *args, **kwargs), None
+    # Ask for the outputs only when there is an aux_loss to rescue off them, so
+    # the ordinary path keeps trl's exact call shape.
+    asked = args[2] if len(args) > 2 else kwargs.get("return_outputs", False)
+    force = bool(getattr(self, "aux_loss_enabled", False)) and not asked
+    if force:
+        kwargs = dict(kwargs)
+        kwargs["return_outputs"] = True
     slot, inputs = _sft_inputs_slot(args, kwargs)
     if slot is not None:
         shielded = _sft_shielded_inputs(inputs, inputs if contents is None else contents)
@@ -1936,9 +2033,12 @@ def _sft_call_without_logits_metrics(original, self, args, kwargs, contents = No
             # (sft_trainer.py:1821). There is no liger here, so that report
             # would be sent to the wrong project.
             warnings.filterwarnings("ignore", message = ".*token_accuracy.*")
-            return original(self, *args, **kwargs)
+            result = original(self, *args, **kwargs)
     finally:
         targs.use_liger_kernel = previous
+    if force and isinstance(result, tuple) and len(result) == 2:
+        return result[0], result[1]
+    return result, None
 pass
 
 
@@ -1951,7 +2051,11 @@ def _sft_wrap_compute_loss(original):
         # Per trainer, not per process: two SFTTrainers can live in one process
         # and only one of them may be running an Unsloth model.
         if getattr(self, "_unsloth_logits_are_empty", False):
-            return _sft_call_without_logits_metrics(original, self, args, kwargs)
+            before = _sft_aux_loss_count(self)
+            result, outputs = _sft_call_without_logits_metrics(
+                original, self, args, kwargs)
+            _sft_replay_aux_loss(self, outputs, before)
+            return result
         # A failed attempt leaves state behind: it advanced the token counter,
         # appended the metrics it got as far as, and let transformers pop
         # `labels` out of the inputs. All three are replayed to the retry as
@@ -1962,10 +2066,18 @@ def _sft_wrap_compute_loss(original):
             if isinstance(metrics, dict) else None
         _, inputs = _sft_inputs_slot(args, kwargs)
         contents = dict(inputs) if isinstance(inputs, Mapping) else None
+        aux_before = _sft_aux_loss_count(self)
+        # This first call is a probe. If it fails on the second logits read the
+        # warning below replaces the entropy patch's, which promises a 0.0 that
+        # is not going to be reported after all.
+        muted = _sft_mute_entropy_warning()
         try:
-            return original(self, *args, **kwargs)
+            result = original(self, *args, **kwargs)
         except Exception as e:
-            if not _sft_raised_on_empty_logits(e): raise
+            outputs = _sft_empty_logits_outputs(e)
+            if outputs is None:
+                if muted is not None: muted[0][0] = muted[1]
+                raise
             self._unsloth_logits_are_empty = True
             if counter is not None:
                 self._total_train_tokens = counter
@@ -1980,7 +2092,16 @@ def _sft_wrap_compute_loss(original):
                 "Set UNSLOTH_RETURN_LOGITS=1 before training if you need them "
                 "and can afford the memory."
             )
-            return _sft_call_without_logits_metrics(original, self, args, kwargs, contents)
+            retried, retry_outputs = _sft_call_without_logits_metrics(
+                original, self, args, kwargs, contents)
+            _sft_replay_aux_loss(
+                self, outputs if retry_outputs is None else retry_outputs, aux_before)
+            return retried
+        else:
+            # No failure, so the entropy message (if it wanted to fire) was
+            # accurate after all: let the next step emit it.
+            if muted is not None: muted[0][0] = muted[1]
+            return result
     compute_loss._unsloth_patched = True
     return compute_loss
 pass

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -20,6 +20,15 @@ import inspect
 import importlib
 from collections.abc import Mapping
 from typing import Any, List, Optional, Tuple, Union, Dict, Set, Callable
+import functools
+# Guarded because tests load this file by path rather than as
+# `unsloth_zoo.temporary_patches.misc`, where a two-level relative import
+# raises "attempted relative import beyond top-level package".
+try:
+    from ..log import logger
+except (ImportError, ValueError):
+    import logging
+    logger = logging.getLogger("unsloth_zoo.log")
 from .common import TEMPORARY_PATCHES, torch_compile, _torch_compile
 from .utils import (
     patch_function,
@@ -1669,3 +1678,104 @@ def patch_deepseek_v2_moe_alias():
         m.DeepseekV2MoE = m.DeepseekV2Moe
 pass
 TEMPORARY_PATCHES.append(patch_deepseek_v2_moe_alias)
+
+
+def patch_trl_entropy_from_logits():
+    """trl logs a token-entropy metric from logits Unsloth does not materialise.
+
+    `SFTTrainer.compute_loss` does, with no flag to turn it off other than
+    `use_liger_kernel`:
+
+        if not self.args.use_liger_kernel:
+            with torch.no_grad():
+                per_token_entropy = entropy_from_logits(outputs.logits)
+
+    A [batch, seq, vocab] float32 tensor is the largest allocation in an SFT
+    step and Unsloth never materialises it, so a diagnostic metric became a
+    hard training failure, in two shapes, both seen live:
+
+      Qwen3_(32B)_A100   NotImplementedError: Unsloth: Logits are empty from
+                         2024.11 onwards ... set UNSLOTH_RETURN_LOGITS=1
+      Spark_TTS_(0_5B)   TypeError: iteration over a 0-d tensor
+                         (trl/trainer/utils.py, per_token_entropies.extend)
+
+    The advice in the first cannot be taken: UNSLOTH_RETURN_LOGITS=1 buys the
+    metric back by giving up the memory saving the user came for. So the metric
+    degrades instead, reporting 0.0 and saying once why, since silently logging
+    a zero would look like a real measurement.
+
+    Patched on `trl.trainer.sft_trainer` as well as `trl.trainer.utils`, which
+    binds the name at import, so patching only the source module would be a
+    no-op for the one caller that matters.
+    """
+    try:
+        import torch
+        import trl.trainer.utils as _utils
+    except Exception:
+        return
+
+    original = getattr(_utils, "entropy_from_logits", None)
+    if original is None or getattr(original, "_unsloth_patched", False):
+        return
+
+    _warned = [False]
+
+    def _unusable(logits):
+        """Checked on the object, not the exception text. `EmptyLogits.__getattr__`
+        hands back the `raise_logits_error` function for every attribute, so what
+        blows up depends on which attribute this trl touches first: `.split(...)`
+        raises NotImplementedError, `logits.shape[:-1]` subscripts a function and
+        raises TypeError. Keying on either message fixes one trl and misses the
+        other. Matched by name because unsloth_zoo must not import unsloth.
+        """
+        if logits is None:
+            return True
+        if type(logits).__name__ == "EmptyLogits":
+            return True
+        if isinstance(logits, torch.Tensor) and (logits.numel() == 0 or logits.dim() < 2):
+            return True
+        return False
+
+    def _warn_once():
+        if _warned[0]:
+            return
+        _warned[0] = True
+        logger.warning(
+            "Unsloth: your trl version logs a token-entropy metric computed "
+            "from the full logits, which Unsloth does not materialise (that is "
+            "where the memory saving comes from). Entropy will be reported as "
+            "0.0. Set UNSLOTH_RETURN_LOGITS=1 before training if you need the "
+            "real value and can afford the memory."
+        )
+
+    # 0-d so it broadcasts against attention_mask in both of the caller's
+    # branches: sum(0 * mask)/sum(mask) and mean(0) are both 0.0, neither raises.
+    def _no_entropy():
+        return torch.zeros((), dtype = torch.float32)
+
+    @functools.wraps(original)
+    def entropy_from_logits(logits, *args, **kwargs):
+        if _unusable(logits):
+            _warn_once()
+            return _no_entropy()
+        try:
+            return original(logits, *args, **kwargs)
+        except TypeError as e:
+            # Backstop for a shape the check above did not anticipate. Narrow:
+            # anything else from inside entropy_from_logits is a real bug and
+            # must still raise, or this hides it on every single step.
+            if "iteration over a 0-d tensor" not in str(e):
+                raise
+            _warn_once()
+            return _no_entropy()
+
+    entropy_from_logits._unsloth_patched = True
+    for _mod_name in ("trl.trainer.utils", "trl.trainer.sft_trainer"):
+        try:
+            _mod = importlib.import_module(_mod_name)
+        except Exception:
+            continue
+        if getattr(_mod, "entropy_from_logits", None) is original:
+            _mod.entropy_from_logits = entropy_from_logits
+pass
+TEMPORARY_PATCHES.append(patch_trl_entropy_from_logits)

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1748,16 +1748,38 @@ def patch_trl_entropy_from_logits():
             "real value and can afford the memory."
         )
 
+    def _metric_device(logits):
+        """Device trl will gather this scalar on.
+
+        trl hands the result straight to `accelerator.gather_for_metrics`, whose
+        distributed path allocates on `PartialState().device` and calls NCCL,
+        which rejects a CPU tensor ("Tensors must be CUDA and dense"). The
+        masked branch is rescued by multiplying with a device-resident
+        attention_mask, but the padding-free branch is a bare mean(), so a
+        multi-GPU run would swap one crash for another. Asked of accelerate
+        rather than guessed, and only once it is already initialised, so a
+        single-process run keeps the CPU scalar accelerate leaves alone.
+        """
+        if isinstance(logits, torch.Tensor):
+            return logits.device
+        try:
+            from accelerate.state import PartialState
+            if PartialState._shared_state:
+                return PartialState().device
+        except Exception:
+            pass
+        return None
+
     # 0-d so it broadcasts against attention_mask in both of the caller's
     # branches: sum(0 * mask)/sum(mask) and mean(0) are both 0.0, neither raises.
-    def _no_entropy():
-        return torch.zeros((), dtype = torch.float32)
+    def _no_entropy(logits = None):
+        return torch.zeros((), dtype = torch.float32, device = _metric_device(logits))
 
     @functools.wraps(original)
     def entropy_from_logits(logits, *args, **kwargs):
         if _unusable(logits):
             _warn_once()
-            return _no_entropy()
+            return _no_entropy(logits)
         try:
             return original(logits, *args, **kwargs)
         except TypeError as e:
@@ -1767,7 +1789,7 @@ def patch_trl_entropy_from_logits():
             if "iteration over a 0-d tensor" not in str(e):
                 raise
             _warn_once()
-            return _no_entropy()
+            return _no_entropy(logits)
 
     entropy_from_logits._unsloth_patched = True
     for _mod_name in ("trl.trainer.utils", "trl.trainer.sft_trainer"):

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1952,14 +1952,21 @@ pass
 
 
 def _sft_aux_loss_count(self):
-    """How many aux_loss values trl has logged for the current mode."""
+    """How many aux_loss values trl has logged for the current mode.
+
+    `.get`, never `[...]`: `_metrics[mode]` is a `defaultdict(list)`, so a
+    subscript CREATES the key, and this runs on every step including dense
+    ones that will never have an aux_loss. trl's `SFTTrainer.log` averages
+    every key it finds with `sum(val) / len(val)` (sft_trainer.py:1194), so
+    one empty list left behind is a ZeroDivisionError at the first log.
+    """
     metrics = getattr(self, "_metrics", None)
     if not isinstance(metrics, dict): return None
     mode = "train" if getattr(getattr(self, "model", None), "training", True) else "eval"
     bucket = metrics.get(mode)
     if bucket is None: return None
     try:
-        return len(bucket["aux_loss"])
+        return len(bucket.get("aux_loss") or ())
     except Exception:
         return None
 pass
@@ -2015,8 +2022,14 @@ def _sft_call_without_logits_metrics(original, self, args, kwargs, contents = No
     asked = args[2] if len(args) > 2 else kwargs.get("return_outputs", False)
     force = bool(getattr(self, "aux_loss_enabled", False)) and not asked
     if force:
-        kwargs = dict(kwargs)
-        kwargs["return_outputs"] = True
+        # Replace the positional slot rather than adding a keyword beside it:
+        # `compute_loss(model, inputs, False, ...)` is a legal public call, and
+        # doing both would raise "got multiple values for argument".
+        if len(args) > 2:
+            args = args[:2] + (True,) + args[3:]
+        else:
+            kwargs = dict(kwargs)
+            kwargs["return_outputs"] = True
     slot, inputs = _sft_inputs_slot(args, kwargs)
     if slot is not None:
         shielded = _sft_shielded_inputs(inputs, inputs if contents is None else contents)
@@ -2083,8 +2096,14 @@ def _sft_wrap_compute_loss(original):
                 self._total_train_tokens = counter
             if lengths is not None:
                 for k, d in metrics.items():
+                    seen = lengths.get(k, {})
                     for n, v in list(d.items()):
-                        del v[lengths.get(k, {}).get(n, 0):]
+                        # Delete a key the probe invented rather than emptying
+                        # it. trl's log averages every key with
+                        # sum(val) / len(val), so an emptied list left in place
+                        # is a ZeroDivisionError at the first logging step.
+                        if n in seen: del v[seen[n]:]
+                        else: del d[n]
             logger.warning(
                 "Unsloth: your trl version logs entropy and mean_token_accuracy "
                 "from the full logits, which Unsloth does not materialise (that "

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -2049,9 +2049,15 @@ def _sft_call_without_logits_metrics(original, self, args, kwargs, contents = No
             result = original(self, *args, **kwargs)
     finally:
         targs.use_liger_kernel = previous
-    if force and isinstance(result, tuple) and len(result) == 2:
-        return result[0], result[1]
-    return result, None
+    # Take the outputs whenever they are there, not only when we asked. An
+    # eval or predict step arrives with return_outputs already True
+    # (Trainer.prediction_step), so `force` is False and the side channel would
+    # otherwise be empty for exactly the batches that still want aux_loss.
+    _outputs = result[1] if isinstance(result, tuple) and len(result) == 2 else None
+    if force and _outputs is not None:
+        # We asked for these, the caller did not: hand back only the loss.
+        result = result[0]
+    return result, _outputs
 pass
 
 
@@ -2091,7 +2097,6 @@ def _sft_wrap_compute_loss(original):
             if outputs is None:
                 if muted is not None: muted[0][0] = muted[1]
                 raise
-            self._unsloth_logits_are_empty = True
             if counter is not None:
                 self._total_train_tokens = counter
             if lengths is not None:
@@ -2113,6 +2118,12 @@ def _sft_wrap_compute_loss(original):
             )
             retried, retry_outputs = _sft_call_without_logits_metrics(
                 original, self, args, kwargs, contents)
+            # Latched only now. If the retry raises too, the logits were wanted
+            # by something other than the metric block (trl's loss_type='dft',
+            # a custom loss), and latching would keep this trainer in the
+            # no-logits path for the rest of the process -- including a rerun
+            # with UNSLOTH_RETURN_LOGITS=1, which would then never re-probe.
+            self._unsloth_logits_are_empty = True
             _sft_replay_aux_loss(
                 self, outputs if retry_outputs is None else retry_outputs, aux_before)
             return retried


### PR DESCRIPTION
### The failure

`SFTTrainer.compute_loss` logs a token-entropy metric, with no switch to turn it off short of `use_liger_kernel`:

```python
if not self.args.use_liger_kernel:
    with torch.no_grad():
        per_token_entropy = entropy_from_logits(outputs.logits)
```

A `[batch, seq, vocab]` float32 tensor is the largest allocation in an SFT step, and not materialising it is the whole point of what Unsloth does there. So a diagnostic metric became a hard training failure, in two different shapes, both observed live on Colab and on Kaggle:

```
Qwen3_(32B)_A100   NotImplementedError: Unsloth: Logits are empty from
                   2024.11 onwards ... set UNSLOTH_RETURN_LOGITS=1
Spark_TTS_(0_5B)   TypeError: iteration over a 0-d tensor
                   (trl/trainer/utils.py, per_token_entropies.extend)
```

Both on notebooks that trained fine before trl added the metric. The advice in the first cannot usefully be taken: `UNSLOTH_RETURN_LOGITS=1` buys the metric back by giving up the memory saving the user came here for.

### The fix

The metric degrades instead of the run failing. It reports 0.0 and says once why, because silently logging a zero would look like a real measurement.

Detection is on the **object**, not the exception text, and that distinction is load-bearing. `EmptyLogits.__getattr__` returns the `raise_logits_error` *function* for every attribute, so what blows up depends entirely on which attribute the installed trl touches first: `.split(...)` raises `NotImplementedError`, while `logits.shape[:-1]` subscripts a function object and raises `TypeError`. A first draft of this patch keyed on the two messages and would have fixed one trl version while missing the other. A narrow message backstop remains for the 0-d case; anything else from inside `entropy_from_logits` is a real bug and still raises.

Patched on `trl.trainer.sft_trainer` as well as `trl.trainer.utils`, because `sft_trainer` binds the name at import, so patching only the source module would be a no-op for the one caller that matters.

The returned value is 0-d so it broadcasts in both of the caller's branches: `sum(0 * mask) / sum(mask)` and `mean(0)` are both 0.0 and neither raises.

### Tests

15 tests, all passing, including:

- a control that the **unpatched** call really does raise, so the fix is not passing against a bug that no longer exists
- that real logits are byte-identical to the unpatched result, so the metric is not quietly zeroed for everyone else
- that a genuine error inside `entropy_from_logits` still raises
- that the patch is installed on the module the caller actually reads, and does not stack when applied twice
