### PR TITLE
Three guards from running the notebook catalogue on T4s

### DIFF
--- a/tests/test_datasets_map_worker_death_retry.py
+++ b/tests/test_datasets_map_worker_death_retry.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Tests patch_datasets_map_worker_death_retry in temporary_patches/misc.py.
 
 A long-text corpus can have the kernel OOM-kill a `dataset_num_proc` worker,

--- a/tests/test_datasets_map_worker_death_retry.py
+++ b/tests/test_datasets_map_worker_death_retry.py
@@ -85,7 +85,7 @@ def test_retries_single_process_after_worker_death():
     Dataset = _make_fake_datasets(original)
     assert patch() is True
     assert Dataset().map(lambda x: x, num_proc = 8) == "mapped"
-    assert calls == [8, 1], "should retry exactly once, with num_proc=1"
+    assert calls == [8, None], "should retry exactly once, truly single-process"
 
 
 def test_single_process_death_is_reraised():
@@ -154,7 +154,43 @@ def test_positional_num_proc_is_retried():
     Dataset = _make_fake_datasets(original)
     patch()
     assert Dataset().map(lambda x: x, False, 6) == "mapped"
-    assert calls == [6, 1]
+    assert calls == [6, None]
+
+
+def test_the_retry_disables_multiprocessing_rather_than_asking_for_one_worker():
+    """datasets >= 4.1.0 gates its pool on `num_proc is not None and
+    num_proc >= 1` (arrow_dataset.py, changed from `> 1` in 4.1.0 and still
+    that way in 4.4.1), so `num_proc = 1` forks one worker and the kernel can
+    kill it again. Only None is genuinely single-process on every version."""
+    calls = []
+
+    def original(self, fn, num_proc = None, **kw):
+        calls.append(num_proc)
+        if num_proc is not None:
+            raise RuntimeError(WORKER_DIED)
+        return "mapped"
+
+    Dataset = _make_fake_datasets(original)
+    patch()
+    assert Dataset().map(lambda x: x, num_proc = 8) == "mapped"
+    assert calls == [8, None]
+
+
+def test_a_worker_death_at_num_proc_one_is_still_retried():
+    """`dataset_utils.py` picks num_proc = 1 when under 2 GB of RAM is free, so
+    refusing to retry there opts out on the machine the guard exists for."""
+    calls = []
+
+    def original(self, fn, num_proc = None, **kw):
+        calls.append(num_proc)
+        if num_proc is not None:
+            raise RuntimeError(WORKER_DIED)
+        return "mapped"
+
+    Dataset = _make_fake_datasets(original)
+    patch()
+    assert Dataset().map(lambda x: x, num_proc = 1) == "mapped"
+    assert calls == [1, None]
 
 
 def test_idempotent():

--- a/tests/test_datasets_map_worker_death_retry.py
+++ b/tests/test_datasets_map_worker_death_retry.py
@@ -1,0 +1,160 @@
+"""Tests patch_datasets_map_worker_death_retry in temporary_patches/misc.py.
+
+A long-text corpus can have the kernel OOM-kill a `dataset_num_proc` worker,
+which datasets turns into "One of the subprocesses has abruptly died during
+map operation", killing the run inside SFTTrainer.__init__.
+
+The retry must be narrow: a real exception raised by the map function has to
+keep propagating, or this would hide genuine bugs behind a slow rerun.
+
+A fake `datasets` module stands in for the real one, so no dataset is built
+and no worker is forked.
+"""
+
+import ast
+import inspect
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+MISC = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "temporary_patches" / "misc.py"
+_SRC = MISC.read_text(encoding = "utf-8")
+
+WORKER_DIED = ("One of the subprocesses has abruptly died during map operation."
+               "To debug the error, disable multiprocessing.")
+
+
+def _load():
+    for node in ast.parse(_SRC).body:
+        if isinstance(node, ast.FunctionDef) and node.name == "patch_datasets_map_worker_death_retry":
+            ns = {"inspect": inspect}
+            exec(ast.get_source_segment(_SRC, node), ns)
+            return ns[node.name]
+    raise AssertionError("patch_datasets_map_worker_death_retry not found")
+
+
+patch = _load()
+
+
+def _make_fake_datasets(map_impl):
+    """Install a fake `datasets` module whose Dataset.map is `map_impl`."""
+    class Dataset:
+        pass
+    Dataset.map = map_impl
+    mod = types.ModuleType("datasets")
+    mod.Dataset = Dataset
+    sys.modules["datasets"] = mod
+    return Dataset
+
+
+@pytest.fixture(autouse = True)
+def _restore_datasets():
+    saved = sys.modules.get("datasets")
+    yield
+    if saved is None: sys.modules.pop("datasets", None)
+    else: sys.modules["datasets"] = saved
+
+
+def test_retries_single_process_after_worker_death():
+    calls = []
+
+    def original(self, fn, num_proc = None, **kw):
+        calls.append(num_proc)
+        if num_proc and num_proc > 1:
+            raise RuntimeError(WORKER_DIED)
+        return "mapped"
+
+    Dataset = _make_fake_datasets(original)
+    assert patch() is True
+    assert Dataset().map(lambda x: x, num_proc = 8) == "mapped"
+    assert calls == [8, 1], "should retry exactly once, with num_proc=1"
+
+
+def test_single_process_death_is_reraised():
+    def original(self, fn, num_proc = None, **kw):
+        raise RuntimeError(WORKER_DIED)
+
+    Dataset = _make_fake_datasets(original)
+    patch()
+    with pytest.raises(RuntimeError, match = "abruptly died"):
+        Dataset().map(lambda x: x, num_proc = 1)
+
+
+def test_missing_num_proc_is_reraised():
+    def original(self, fn, num_proc = None, **kw):
+        raise RuntimeError(WORKER_DIED)
+
+    Dataset = _make_fake_datasets(original)
+    patch()
+    with pytest.raises(RuntimeError, match = "abruptly died"):
+        Dataset().map(lambda x: x)
+
+
+def test_unrelated_runtime_error_is_untouched():
+    def original(self, fn, num_proc = None, **kw):
+        raise RuntimeError("something else entirely")
+
+    Dataset = _make_fake_datasets(original)
+    patch()
+    with pytest.raises(RuntimeError, match = "something else entirely"):
+        Dataset().map(lambda x: x, num_proc = 8)
+
+
+def test_real_exception_from_map_fn_still_propagates():
+    # The whole point: a genuine bug must not be retried into silence.
+    def original(self, fn, num_proc = None, **kw):
+        raise ValueError("tokenizer exploded")
+
+    Dataset = _make_fake_datasets(original)
+    patch()
+    with pytest.raises(ValueError, match = "tokenizer exploded"):
+        Dataset().map(lambda x: x, num_proc = 8)
+
+
+def test_successful_map_is_passed_through_once():
+    calls = []
+
+    def original(self, fn, num_proc = None, **kw):
+        calls.append(num_proc)
+        return "fine"
+
+    Dataset = _make_fake_datasets(original)
+    patch()
+    assert Dataset().map(lambda x: x, num_proc = 4) == "fine"
+    assert calls == [4]
+
+
+def test_positional_num_proc_is_retried():
+    calls = []
+
+    def original(self, fn, with_indices = False, num_proc = None, **kw):
+        calls.append(num_proc)
+        if num_proc and num_proc > 1:
+            raise RuntimeError(WORKER_DIED)
+        return "mapped"
+
+    Dataset = _make_fake_datasets(original)
+    patch()
+    assert Dataset().map(lambda x: x, False, 6) == "mapped"
+    assert calls == [6, 1]
+
+
+def test_idempotent():
+    def original(self, fn, num_proc = None, **kw):
+        return "fine"
+
+    Dataset = _make_fake_datasets(original)
+    assert patch() is True
+    first = Dataset.map
+    assert patch() is None, "second apply must be a no-op"
+    assert Dataset.map is first
+
+
+def test_registered_as_a_temporary_patch():
+    assert "TEMPORARY_PATCHES.append(patch_datasets_map_worker_death_retry)" in _SRC
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_longrope_attention_factor.py
+++ b/tests/test_longrope_attention_factor.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """A LongRoPE attention_factor that cannot be real must be ignored.
 
 The factor is by construction

--- a/tests/test_longrope_attention_factor.py
+++ b/tests/test_longrope_attention_factor.py
@@ -1,0 +1,154 @@
+"""A LongRoPE attention_factor that cannot be real must be ignored.
+
+The factor is by construction
+
+    sqrt(1 + log(factor) / log(original_max_position_embeddings))
+
+a number near 1. Two published configs set it equal to `factor` (32.0),
+roughly 27x the real value; nothing raises, the model just predicts badly.
+
+The signature is exact on purpose: attention_factor == factor AND
+factor > 2, so it cannot fire on a config that means what it says.
+"""
+
+import math
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from unsloth_zoo.temporary_patches.misc import (  # noqa: E402
+    patch_longrope_impossible_attention_factor,
+)
+from transformers import modeling_rope_utils as R  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def patched():
+    """Apply the patch, then put the originals back."""
+    before_attr = R._compute_longrope_parameters
+    before_dict = R.ROPE_INIT_FUNCTIONS.get("longrope")
+    patch_longrope_impossible_attention_factor()
+    yield
+    R._compute_longrope_parameters = before_attr
+    if before_dict is not None:
+        R.ROPE_INIT_FUNCTIONS["longrope"] = before_dict
+
+
+def _cfg(attention_factor=None, factor=32.0, original_max=4096,
+         max_pos=131072):
+    scaling = {"rope_type": "longrope", "factor": factor,
+               "short_factor": [1.0] * 48, "long_factor": [1.0] * 48}
+    if attention_factor is not None:
+        scaling["attention_factor"] = attention_factor
+    return types.SimpleNamespace(
+        rope_scaling=scaling, original_max_position_embeddings=original_max,
+        max_position_embeddings=max_pos, rope_theta=10000.0,
+        hidden_size=3072, num_attention_heads=32, head_dim=96)
+
+
+def _att(cfg):
+    return R.ROPE_INIT_FUNCTIONS["longrope"](cfg, "cpu")[1]
+
+
+DERIVED = math.sqrt(1 + math.log(32) / math.log(4096))   # ~1.1902
+
+
+# ---- the published configs ------------------------------------------------
+
+def test_impossible_value_is_replaced_by_the_derivation():
+    cfg = _cfg(attention_factor=32.0)
+    assert _att(cfg) == pytest.approx(DERIVED, rel=1e-6)
+
+
+def test_the_bad_key_is_removed_from_the_config():
+    cfg = _cfg(attention_factor=32.0)
+    _att(cfg)
+    assert "attention_factor" not in cfg.rope_scaling
+
+
+def test_applying_twice_is_stable():
+    cfg = _cfg(attention_factor=32.0)
+    first = _att(cfg)
+    assert _att(cfg) == pytest.approx(first)
+
+
+def test_the_dict_entry_is_patched_not_just_the_module_attribute():
+    """Models resolve the callable through ROPE_INIT_FUNCTIONS, so patching
+    only the module attribute would be a silent no-op."""
+    assert R.ROPE_INIT_FUNCTIONS["longrope"] is R._compute_longrope_parameters
+    assert getattr(R.ROPE_INIT_FUNCTIONS["longrope"], "_unsloth_patched", False)
+
+
+def test_patching_twice_does_not_stack():
+    first = R.ROPE_INIT_FUNCTIONS["longrope"]
+    patch_longrope_impossible_attention_factor()
+    assert R.ROPE_INIT_FUNCTIONS["longrope"] is first
+
+
+# ---- configs that mean what they say --------------------------------------
+
+def test_a_real_attention_factor_is_preserved():
+    assert _att(_cfg(attention_factor=1.19)) == pytest.approx(1.19)
+
+
+def test_a_value_equal_to_a_small_factor_is_preserved():
+    # factor <= 2 is not the signature; 2.0 could genuinely be both.
+    assert _att(_cfg(attention_factor=2.0, factor=2.0)) == pytest.approx(2.0)
+
+
+def test_a_large_value_that_differs_from_factor_is_preserved():
+    # Only the exact coincidence is suspicious; a lone odd number is the
+    # author's business, not ours.
+    assert _att(_cfg(attention_factor=8.0, factor=32.0)) == pytest.approx(8.0)
+
+
+def test_absent_attention_factor_behaves_as_before():
+    assert _att(_cfg(attention_factor=None)) == pytest.approx(DERIVED, rel=1e-6)
+
+
+# ---- the guard must never be the thing that breaks a load ----------------
+
+def test_a_config_without_rope_scaling_does_not_raise():
+    cfg = _cfg(attention_factor=32.0)
+    cfg.rope_scaling = None
+    with pytest.raises(Exception):
+        # The real function needs the dict; what matters is that OUR guard
+        # is not the thing that raised.
+        _att(cfg)
+
+
+def test_non_numeric_values_are_left_alone():
+    cfg = _cfg()
+    cfg.rope_scaling["attention_factor"] = "thirty two"
+    cfg.rope_scaling["factor"] = "thirty two"
+    # Unparseable: the guard declines rather than guessing.
+    try:
+        _att(cfg)
+    except Exception:
+        pass
+    assert cfg.rope_scaling["attention_factor"] == "thirty two"
+
+
+def test_missing_original_max_still_strips_the_bad_value():
+    cfg = _cfg(attention_factor=32.0)
+    del cfg.original_max_position_embeddings
+    _att(cfg)
+    assert "attention_factor" not in cfg.rope_scaling
+
+
+def test_other_rope_types_are_untouched():
+    assert "linear" in R.ROPE_INIT_FUNCTIONS
+    assert not getattr(R.ROPE_INIT_FUNCTIONS["linear"], "_unsloth_patched", False)
+
+
+def test_registered_as_a_temporary_patch():
+    from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
+    names = [getattr(f, "__name__", "") for f in TEMPORARY_PATCHES]
+    assert "patch_longrope_impossible_attention_factor" in names
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_longrope_attention_factor.py
+++ b/tests/test_longrope_attention_factor.py
@@ -53,16 +53,51 @@ def patched():
         R.ROPE_INIT_FUNCTIONS["longrope"] = before_dict
 
 
+class _Config:
+    """The parts of a config the longrope initializer touches, on 4 and on 5.
+
+    transformers 5 renamed the dict to `rope_parameters`, keeps `rope_scaling`
+    as a read/write alias property (configuration_utils.py), moved `rope_theta`
+    and `original_max_position_embeddings` inside it, and calls
+    `config.standardize_rope_params()` first. A SimpleNamespace has none of
+    that and would `AttributeError` on every transformers 5 in the support
+    envelope.
+    """
+
+    def __init__(self, scaling, original_max, max_pos):
+        self.rope_parameters = scaling
+        self.original_max_position_embeddings = original_max
+        self.max_position_embeddings = max_pos
+        self.rope_theta = 10000.0
+        self.hidden_size = 3072
+        self.num_attention_heads = 32
+        self.head_dim = 96
+
+    @property
+    def rope_scaling(self):
+        return self.rope_parameters
+
+    @rope_scaling.setter
+    def rope_scaling(self, value):
+        self.rope_parameters = value
+
+    def standardize_rope_params(self):
+        if not isinstance(self.rope_parameters, dict): return
+        self.rope_parameters.setdefault("rope_theta", self.rope_theta)
+        self.rope_parameters.setdefault(
+            "original_max_position_embeddings",
+            getattr(self, "original_max_position_embeddings",
+                    self.max_position_embeddings),
+        )
+
+
 def _cfg(attention_factor=None, factor=32.0, original_max=4096,
          max_pos=131072):
     scaling = {"rope_type": "longrope", "factor": factor,
                "short_factor": [1.0] * 48, "long_factor": [1.0] * 48}
     if attention_factor is not None:
         scaling["attention_factor"] = attention_factor
-    return types.SimpleNamespace(
-        rope_scaling=scaling, original_max_position_embeddings=original_max,
-        max_position_embeddings=max_pos, rope_theta=10000.0,
-        hidden_size=3072, num_attention_heads=32, head_dim=96)
+    return _Config(scaling, original_max, max_pos)
 
 
 def _att(cfg):

--- a/tests/test_longrope_attention_factor.py
+++ b/tests/test_longrope_attention_factor.py
@@ -155,6 +155,48 @@ def test_missing_original_max_still_strips_the_bad_value():
     assert "attention_factor" not in cfg.rope_scaling
 
 
+# ---- every call shape transformers uses -----------------------------------
+
+def test_device_stays_optional_for_a_transformers_5_original():
+    """transformers 5 gives every parameter but `config` a default, and
+    `PreTrainedModel._init_weights` calls `rope_fn(module.config)` with the
+    config alone (modeling_utils.py, the RotaryEmbedding branch). Naming
+    `device` in the wrapper would make every LongRoPE model fail to load with
+    a missing-argument TypeError before a single weight is read."""
+    seen = {}
+
+    def original(config, device = None, seq_len = None, layer_type = None):
+        seen["device"], seen["layer_type"] = device, layer_type
+        return "inv_freq", config.rope_scaling.get("attention_factor", 1.0)
+
+    R._compute_longrope_parameters = original
+    R.ROPE_INIT_FUNCTIONS["longrope"] = original
+    patch_longrope_impossible_attention_factor()
+
+    cfg = _cfg(attention_factor = 32.0)
+    assert R.ROPE_INIT_FUNCTIONS["longrope"](cfg)[1] == 1.0
+    assert seen == {"device": None, "layer_type": None}
+    assert "attention_factor" not in cfg.rope_scaling
+
+
+def test_the_other_arguments_are_forwarded_untouched():
+    """`rope_init_fn(config, device, seq_len = ..., layer_type = ...)` is how
+    transformers 5 reinitializes a rotary embedding."""
+    seen = {}
+
+    def original(config, device = None, seq_len = None, layer_type = None):
+        seen.update(device = device, seq_len = seq_len, layer_type = layer_type)
+        return "inv_freq", 1.0
+
+    R._compute_longrope_parameters = original
+    R.ROPE_INIT_FUNCTIONS["longrope"] = original
+    patch_longrope_impossible_attention_factor()
+
+    R.ROPE_INIT_FUNCTIONS["longrope"](
+        _cfg(), "cpu", seq_len = 8, layer_type = "full_attention")
+    assert seen == {"device": "cpu", "seq_len": 8, "layer_type": "full_attention"}
+
+
 def test_other_rope_types_are_untouched():
     assert "linear" in R.ROPE_INIT_FUNCTIONS
     assert not getattr(R.ROPE_INIT_FUNCTIONS["linear"], "_unsloth_patched", False)

--- a/tests/test_mamba_ssm_pre_ampere_fallback.py
+++ b/tests/test_mamba_ssm_pre_ampere_fallback.py
@@ -214,6 +214,146 @@ def test_the_mixer_wrapper_is_applied_once(env):
         else: sys.modules[mod_name] = saved
 
 
+def _lazy_flag_mixer_module(mod_name, cls_name, weight_attr, hk):
+    """transformers >= 5.3's shape, where the module flag does not exist yet.
+
+    5.3 moved the kernel resolution into the mixer's `__init__`, so the module
+    carries no `is_fast_path_available` at all until a mixer has been built
+    (`global is_fast_path_available`, models/zamba/modeling_zamba.py:257 in
+    5.5.0) and `forward` recomputes it as a local (line 449). Verified against
+    the real 5.5.0 wheel: right after
+    `import transformers.models.zamba.modeling_zamba`,
+    `"is_fast_path_available" in module.__dict__` is False.
+
+    Availability is read back from `_HUB_KERNEL_MAPPING` the way
+    `lazy_load_kernel` does, so unregistering the Hub kernels is what makes the
+    fast path unavailable here, exactly as on a real 5.5 install.
+    """
+    mod = types.ModuleType(mod_name)
+
+    def _kernels_available():
+        return "mamba-ssm" in hk._HUB_KERNEL_MAPPING
+
+    class Mixer:
+        def __init__(self):
+            self.use_fast_kernels = True                  # config.use_mamba_kernels
+            setattr(self, weight_attr,
+                    types.SimpleNamespace(device = types.SimpleNamespace(type = "cuda")))
+            mod.is_fast_path_available = _kernels_available()
+
+        def forward(self, *args, **kwargs):
+            is_fast_path_available = _kernels_available()  # a local, as in 5.5
+            if self.use_fast_kernels:
+                if not is_fast_path_available:
+                    raise ValueError("Fast Mamba kernels are not available.")
+                return "FAST PATH"
+            return "SLOW PATH"
+
+    Mixer.__name__ = cls_name
+    setattr(mod, cls_name, Mixer)
+    sys.modules[mod_name] = mod
+    return mod, Mixer
+
+
+@pytest.mark.parametrize("mod_name, cls_name, weight_attr", [
+    ("transformers.models.jamba.modeling_jamba", "JambaMambaMixer", "x_proj"),
+    ("transformers.models.zamba.modeling_zamba", "ZambaMambaMixer", "x_proj_weight"),
+])
+def test_the_mixer_is_wrapped_before_any_mixer_exists(
+    env, mod_name, cls_name, weight_attr,
+):
+    """The wrapper must not hang off the module's `is_fast_path_available`.
+
+    On transformers >= 5.3 that name is absent from the module dict until a
+    mixer has been constructed, and on 4.x the predicate flip in step 1 has
+    already made it False by the time the modeling module is imported. Gating
+    the wrapper on it left the mixer unwrapped in both orderings, and the guard
+    then handed back `ValueError: Fast Mamba kernels are not available` instead
+    of the slow path. Reproduced on real transformers 5.5.0 and 4.57.6.
+    """
+    _model_mod, _iu, hk = env
+    saved = sys.modules.get(mod_name)
+    mod, Mixer = _lazy_flag_mixer_module(mod_name, cls_name, weight_attr, hk)
+    try:
+        assert "is_fast_path_available" not in mod.__dict__, "the 5.3+ shape"
+        patch()
+        assert Mixer.__dict__.get("_unsloth_slow_only", False) is True
+        mixer = Mixer()
+        assert mod.is_fast_path_available is False, "step 0 removed the kernels"
+        assert mixer.forward() == "SLOW PATH"
+    finally:
+        if saved is None: sys.modules.pop(mod_name, None)
+        else: sys.modules[mod_name] = saved
+
+
+def test_the_mixer_is_wrapped_without_a_local_mamba_ssm_wheel(env):
+    """Unregistering the Hub kernels is on its own enough to make Zamba raise,
+    so the wrapper has to be installed before the local-wheel early return."""
+    _model_mod, _iu, hk = env
+    mod_name = "transformers.models.zamba.modeling_zamba"
+    saved = sys.modules.get(mod_name)
+    mod, Mixer = _lazy_flag_mixer_module(
+        mod_name, "ZambaMambaMixer", "x_proj_weight", hk)
+    try:
+        _no_local_wheel()
+        assert patch() is None
+        assert Mixer().forward() == "SLOW PATH"
+    finally:
+        if saved is None: sys.modules.pop(mod_name, None)
+        else: sys.modules[mod_name] = saved
+
+
+def test_the_lazy_flag_wrapper_is_applied_once(env):
+    _model_mod, _iu, hk = env
+    mod_name = "transformers.models.zamba.modeling_zamba"
+    saved = sys.modules.get(mod_name)
+    _mod, Mixer = _lazy_flag_mixer_module(
+        mod_name, "ZambaMambaMixer", "x_proj_weight", hk)
+    try:
+        patch()
+        first = Mixer.forward
+        patch()
+        assert Mixer.forward is first, "must not stack on every phase"
+    finally:
+        if saved is None: sys.modules.pop(mod_name, None)
+        else: sys.modules[mod_name] = saved
+
+
+def test_the_config_flag_is_cleared_for_jamba_5_5(env):
+    """Jamba on 5.5 routes on `self.config.use_mamba_kernels`, not on the
+    instance flag (models/jamba/modeling_jamba.py:462-472), and clears exactly
+    that field on its own fallback."""
+    _model_mod, _iu, _hk = env
+    mod_name = "transformers.models.jamba.modeling_jamba"
+    saved = sys.modules.get(mod_name)
+    mod = types.ModuleType(mod_name)
+
+    class JambaMambaMixer:
+        def __init__(self):
+            self.config = types.SimpleNamespace(use_mamba_kernels = True)
+        def forward(self, *args, **kwargs):
+            return "FAST PATH" if self.config.use_mamba_kernels else "SLOW PATH"
+
+    mod.JambaMambaMixer = JambaMambaMixer
+    sys.modules[mod_name] = mod
+    try:
+        assert JambaMambaMixer().forward() == "FAST PATH"
+        patch()
+        mixer = JambaMambaMixer()
+        assert mixer.forward() == "SLOW PATH"
+        assert mixer.config.use_mamba_kernels is False
+    finally:
+        if saved is None: sys.modules.pop(mod_name, None)
+        else: sys.modules[mod_name] = saved
+
+
+def test_the_mixer_scan_does_not_walk_sys_modules(env):
+    """The two mixers are reached by direct `sys.modules` lookup, not by another
+    pass over every loaded module, so the extra work is two dict gets."""
+    assert 'sys.modules.get(_name, None)' in _SRC
+    assert _SRC.count("for _name, _mod in list(sys.modules.items()):") == 1
+
+
 def test_alias_modules_are_not_probed_through_getattr():
     """transformers 5 registers ~200 `image_processing_<m>_fast` alias modules
     whose catch-all __getattr__ imports the real image processor. Probing them

--- a/tests/test_mamba_ssm_pre_ampere_fallback.py
+++ b/tests/test_mamba_ssm_pre_ampere_fallback.py
@@ -70,10 +70,19 @@ def env(monkeypatch):
             sys.modules[parent] = m
             saved.setdefault(parent, None)
     sys.modules["transformers"].utils = sys.modules["transformers.utils"]
-    sys.modules["transformers.utils"].import_utils = iu
+    # `import a.b.c as x` resolves through getattr(a.b, "c"), so this attribute
+    # outlives a sys.modules-only teardown and hands the stub to every later
+    # `import transformers.utils.import_utils as iu` (test_vendor_fla.py:219,
+    # fla_vendor.py:473). Restore it too.
+    utils_mod = sys.modules["transformers.utils"]
+    had_attr = hasattr(utils_mod, "import_utils")
+    saved_attr = getattr(utils_mod, "import_utils", None)
+    utils_mod.import_utils = iu
 
     yield model_mod, iu
 
+    if had_attr: utils_mod.import_utils = saved_attr
+    elif hasattr(utils_mod, "import_utils"): del utils_mod.import_utils
     for k, v in saved.items():
         if v is None: sys.modules.pop(k, None)
         else: sys.modules[k] = v
@@ -121,9 +130,12 @@ def test_no_cuda_is_untouched(env, monkeypatch):
     assert model_mod.is_fast_path_available is True
 
 
-def test_no_mamba_ssm_is_untouched(env):
+def test_no_mamba_ssm_is_untouched(env, monkeypatch):
     model_mod, iu = env
-    sys.modules.pop("mamba_ssm", None)
+    # None in sys.modules makes `import mamba_ssm` raise, so this exercises the
+    # unavailable branch even where the real package is installed; popping the
+    # fake would just import the real one.
+    monkeypatch.setitem(sys.modules, "mamba_ssm", None)
     assert patch() is None
     assert model_mod.is_fast_path_available is True
     assert iu.is_mamba_ssm_available() is True
@@ -142,6 +154,22 @@ def test_non_transformers_modules_are_left_alone(env):
 
 def test_registered_as_a_temporary_patch():
     assert "TEMPORARY_PATCHES.append(patch_mamba_ssm_pre_ampere_fallback)" in _SRC
+
+
+# Keep last: it checks what the `env` fixture left behind after teardown.
+def test_the_fixture_leaves_no_stub_bound_on_transformers_utils():
+    """The stub must not outlive the fixture. `import a.b.c as x` goes through
+    getattr(a.b, "c"), so a leaked attribute is handed to every later
+    `import transformers.utils.import_utils as iu` -- the form used by
+    tests/test_vendor_fla.py:219 and unsloth_zoo/temporary_patches/fla_vendor.py:473."""
+    utils_mod = sys.modules.get("transformers.utils")
+    if utils_mod is None or getattr(utils_mod, "__file__", None) is None:
+        pytest.skip("real transformers.utils was never imported in this session")
+    import importlib
+    real = importlib.import_module("transformers.utils.import_utils")
+    assert getattr(utils_mod, "import_utils", real) is real
+    import transformers.utils.import_utils as reimported
+    assert reimported is real
 
 
 if __name__ == "__main__":

--- a/tests/test_mamba_ssm_pre_ampere_fallback.py
+++ b/tests/test_mamba_ssm_pre_ampere_fallback.py
@@ -1,0 +1,148 @@
+"""Tests patch_mamba_ssm_pre_ampere_fallback in temporary_patches/misc.py.
+
+mamba_ssm's Triton kernels need sm_80+. On a T4 the package imports fine and
+is_fast_path_available is True, so the layer routes into cuda_kernels_forward
+and Triton fails once training starts. The patch must fire ONLY on pre-Ampere
+NVIDIA CUDA: ROCm, XPU, MPS and CPU are left alone, Ampere+ keeps the fast path.
+
+Extracted by AST so the test needs neither a GPU nor a transformers import.
+"""
+
+import ast
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+MISC = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "temporary_patches" / "misc.py"
+_SRC = MISC.read_text(encoding = "utf-8")
+
+
+def _load():
+    for node in ast.parse(_SRC).body:
+        if isinstance(node, ast.FunctionDef) and node.name == "patch_mamba_ssm_pre_ampere_fallback":
+            ns = {"torch": torch}
+            exec(ast.get_source_segment(_SRC, node), ns)
+            return ns[node.name]
+    raise AssertionError("patch_mamba_ssm_pre_ampere_fallback not found")
+
+
+patch = _load()
+
+MODEL_MOD = "transformers.models.granitemoehybrid.modeling_granitemoehybrid"
+
+
+class _FakeCuda:
+    def __init__(self, available = True, capability = (7, 5)):
+        self._available, self._capability = available, capability
+    def is_available(self): return self._available
+    def get_device_capability(self, *a, **k): return self._capability
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """Pre-Ampere NVIDIA CUDA with mamba_ssm installed and a model imported."""
+    monkeypatch.setattr(torch, "cuda", _FakeCuda(), raising = False)
+    monkeypatch.setattr(torch.version, "hip", None, raising = False)
+
+    saved = {k: sys.modules.get(k) for k in ("mamba_ssm", MODEL_MOD,
+                                             "transformers.utils.import_utils")}
+    sys.modules["mamba_ssm"] = types.ModuleType("mamba_ssm")
+
+    model_mod = types.ModuleType(MODEL_MOD)
+    model_mod.is_fast_path_available = True
+    model_mod.selective_state_update = lambda *a, **k: None
+    model_mod.mamba_chunk_scan_combined = lambda *a, **k: None
+    model_mod.mamba_split_conv1d_scan_combined = lambda *a, **k: None
+    sys.modules[MODEL_MOD] = model_mod
+
+    iu = types.ModuleType("transformers.utils.import_utils")
+    iu.is_mamba_ssm_available = lambda: True
+    iu.is_mamba_2_ssm_available = lambda: True
+    sys.modules["transformers.utils.import_utils"] = iu
+    # `import transformers.utils.import_utils as _iu` needs the parents too.
+    for parent in ("transformers", "transformers.utils"):
+        if parent not in sys.modules:
+            m = types.ModuleType(parent)
+            m.__path__ = []
+            sys.modules[parent] = m
+            saved.setdefault(parent, None)
+    sys.modules["transformers"].utils = sys.modules["transformers.utils"]
+    sys.modules["transformers.utils"].import_utils = iu
+
+    yield model_mod, iu
+
+    for k, v in saved.items():
+        if v is None: sys.modules.pop(k, None)
+        else: sys.modules[k] = v
+
+
+def test_pre_ampere_disables_fast_path(env):
+    model_mod, iu = env
+    assert patch() is True
+    assert model_mod.is_fast_path_available is False
+    assert model_mod.selective_state_update is None
+    assert model_mod.mamba_chunk_scan_combined is None
+    assert model_mod.mamba_split_conv1d_scan_combined is None
+    # Modules imported later must also see it as unavailable.
+    assert iu.is_mamba_ssm_available() is False
+    assert iu.is_mamba_2_ssm_available() is False
+
+
+def test_ampere_keeps_fast_path(env, monkeypatch):
+    model_mod, iu = env
+    monkeypatch.setattr(torch, "cuda", _FakeCuda(capability = (8, 0)), raising = False)
+    assert patch() is None
+    assert model_mod.is_fast_path_available is True
+    assert iu.is_mamba_ssm_available() is True
+
+
+def test_hopper_keeps_fast_path(env, monkeypatch):
+    model_mod, _ = env
+    monkeypatch.setattr(torch, "cuda", _FakeCuda(capability = (9, 0)), raising = False)
+    assert patch() is None
+    assert model_mod.is_fast_path_available is True
+
+
+def test_rocm_is_untouched(env, monkeypatch):
+    model_mod, iu = env
+    monkeypatch.setattr(torch.version, "hip", "6.2.0", raising = False)
+    assert patch() is None
+    assert model_mod.is_fast_path_available is True
+    assert iu.is_mamba_ssm_available() is True
+
+
+def test_no_cuda_is_untouched(env, monkeypatch):
+    model_mod, _ = env
+    monkeypatch.setattr(torch, "cuda", _FakeCuda(available = False), raising = False)
+    assert patch() is None
+    assert model_mod.is_fast_path_available is True
+
+
+def test_no_mamba_ssm_is_untouched(env):
+    model_mod, iu = env
+    sys.modules.pop("mamba_ssm", None)
+    assert patch() is None
+    assert model_mod.is_fast_path_available is True
+    assert iu.is_mamba_ssm_available() is True
+
+
+def test_non_transformers_modules_are_left_alone(env):
+    vllm = types.ModuleType("vllm.model_executor.layers.mamba")
+    vllm.is_fast_path_available = True
+    sys.modules["vllm.model_executor.layers.mamba"] = vllm
+    try:
+        patch()
+        assert vllm.is_fast_path_available is True
+    finally:
+        sys.modules.pop("vllm.model_executor.layers.mamba", None)
+
+
+def test_registered_as_a_temporary_patch():
+    assert "TEMPORARY_PATCHES.append(patch_mamba_ssm_pre_ampere_fallback)" in _SRC
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_mamba_ssm_pre_ampere_fallback.py
+++ b/tests/test_mamba_ssm_pre_ampere_fallback.py
@@ -74,6 +74,24 @@ def env(monkeypatch):
     model_mod.mamba_split_conv1d_scan_combined = lambda *a, **k: None
     sys.modules[MODEL_MOD] = model_mod
 
+    # transformers 5 also resolves these from the Hub, through
+    # integrations.hub_kernels.lazy_load_kernel, which asks no predicate.
+    hk = types.ModuleType("transformers.integrations.hub_kernels")
+    hk._HUB_KERNEL_MAPPING = {
+        "causal-conv1d": {"repo_id": "kernels-community/causal-conv1d"},
+        "mamba-ssm": {"repo_id": "kernels-community/mamba-ssm"},
+        "falcon_mamba-ssm": {"repo_id": "kernels-community/mamba-ssm"},
+        "deep-gemm": {"repo_id": "kernels-community/deep-gemm"},
+    }
+    hk._KERNEL_MODULE_MAPPING = {"mamba-ssm": types.ModuleType("already_loaded")}
+    for name in ("transformers.integrations", "transformers.integrations.hub_kernels"):
+        saved[name] = sys.modules.get(name)
+    integrations = types.ModuleType("transformers.integrations")
+    integrations.__path__ = []
+    integrations.hub_kernels = hk
+    sys.modules["transformers.integrations"] = integrations
+    sys.modules["transformers.integrations.hub_kernels"] = hk
+
     iu = types.ModuleType("transformers.utils.import_utils")
     iu.is_mamba_ssm_available = lambda: True
     iu.is_mamba_2_ssm_available = lambda: True
@@ -95,7 +113,7 @@ def env(monkeypatch):
     saved_attr = getattr(utils_mod, "import_utils", None)
     utils_mod.import_utils = iu
 
-    yield model_mod, iu
+    yield model_mod, iu, hk
 
     if had_attr: utils_mod.import_utils = saved_attr
     elif hasattr(utils_mod, "import_utils"): del utils_mod.import_utils
@@ -104,8 +122,21 @@ def env(monkeypatch):
         else: sys.modules[k] = v
 
 
+def _no_local_wheel():
+    """Make `import mamba_ssm` raise, for the not-installed branch.
+
+    None in sys.modules does that even where the real package is installed,
+    which popping the fake would not. Assigned rather than
+    `monkeypatch.setitem`: monkeypatch undoes after the `env` teardown and
+    would put the fake back, and a `types.ModuleType` has `__spec__` None, so
+    a leaked one makes every later `importlib.util.find_spec("mamba_ssm")`
+    raise ValueError. `env` owns the key and restores it.
+    """
+    sys.modules["mamba_ssm"] = None
+
+
 def test_pre_ampere_disables_fast_path(env):
-    model_mod, iu = env
+    model_mod, iu, _hk = env
     assert patch() is True
     assert model_mod.is_fast_path_available is False
     assert model_mod.selective_state_update is None
@@ -117,7 +148,7 @@ def test_pre_ampere_disables_fast_path(env):
 
 
 def test_ampere_keeps_fast_path(env, monkeypatch):
-    model_mod, iu = env
+    model_mod, iu, _hk = env
     monkeypatch.setattr(torch, "cuda", _FakeCuda(capability = (8, 0)), raising = False)
     assert patch() is None
     assert model_mod.is_fast_path_available is True
@@ -125,14 +156,14 @@ def test_ampere_keeps_fast_path(env, monkeypatch):
 
 
 def test_hopper_keeps_fast_path(env, monkeypatch):
-    model_mod, _ = env
+    model_mod, _, _hk = env
     monkeypatch.setattr(torch, "cuda", _FakeCuda(capability = (9, 0)), raising = False)
     assert patch() is None
     assert model_mod.is_fast_path_available is True
 
 
 def test_rocm_is_untouched(env, monkeypatch):
-    model_mod, iu = env
+    model_mod, iu, _hk = env
     monkeypatch.setattr(torch.version, "hip", "6.2.0", raising = False)
     assert patch() is None
     assert model_mod.is_fast_path_available is True
@@ -140,21 +171,55 @@ def test_rocm_is_untouched(env, monkeypatch):
 
 
 def test_no_cuda_is_untouched(env, monkeypatch):
-    model_mod, _ = env
+    model_mod, _, _hk = env
     monkeypatch.setattr(torch, "cuda", _FakeCuda(available = False), raising = False)
     assert patch() is None
     assert model_mod.is_fast_path_available is True
 
 
-def test_no_mamba_ssm_is_untouched(env, monkeypatch):
-    model_mod, iu = env
-    # None in sys.modules makes `import mamba_ssm` raise, so this exercises the
-    # unavailable branch even where the real package is installed; popping the
-    # fake would just import the real one.
-    monkeypatch.setitem(sys.modules, "mamba_ssm", None)
+def test_no_mamba_ssm_is_untouched(env):
+    model_mod, iu, _hk = env
+    _no_local_wheel()
     assert patch() is None
     assert model_mod.is_fast_path_available is True
     assert iu.is_mamba_ssm_available() is True
+
+
+# ---- transformers 5's Hub kernels ----------------------------------------
+#
+# lazy_load_kernel resolves mamba-ssm from kernels-community when the `kernels`
+# package is installed. It needs no local wheel and never calls
+# is_mamba_ssm_available, so the predicates above cannot reach it.
+
+def test_pre_ampere_unregisters_the_hub_kernels(env):
+    _model_mod, _iu, hk = env
+    patch()
+    for name in ("mamba-ssm", "falcon_mamba-ssm", "causal-conv1d"):
+        assert name not in hk._HUB_KERNEL_MAPPING
+        # A module already resolved into the cache must stop being handed out.
+        assert hk._KERNEL_MODULE_MAPPING[name] is None
+
+
+def test_unrelated_hub_kernels_are_left_registered(env):
+    _model_mod, _iu, hk = env
+    patch()
+    assert "deep-gemm" in hk._HUB_KERNEL_MAPPING
+
+
+def test_hub_kernels_go_even_without_the_local_wheel(env):
+    """The Hub path is the one that reaches a pre-Ampere GPU with no wheel
+    installed, so unregistering has to precede the mamba_ssm import."""
+    _model_mod, _iu, hk = env
+    _no_local_wheel()
+    assert patch() is None
+    assert "mamba-ssm" not in hk._HUB_KERNEL_MAPPING
+
+
+def test_ampere_keeps_the_hub_kernels(env, monkeypatch):
+    _model_mod, _iu, hk = env
+    monkeypatch.setattr(torch, "cuda", _FakeCuda(capability = (8, 0)), raising = False)
+    assert patch() is None
+    assert "mamba-ssm" in hk._HUB_KERNEL_MAPPING
 
 
 def test_non_transformers_modules_are_left_alone(env):

--- a/tests/test_mamba_ssm_pre_ampere_fallback.py
+++ b/tests/test_mamba_ssm_pre_ampere_fallback.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Tests patch_mamba_ssm_pre_ampere_fallback in temporary_patches/misc.py.
 
 mamba_ssm's Triton kernels need sm_80+. On a T4 the package imports fine and

--- a/tests/test_mamba_ssm_pre_ampere_fallback.py
+++ b/tests/test_mamba_ssm_pre_ampere_fallback.py
@@ -49,6 +49,11 @@ patch = _load()
 
 MODEL_MOD = "transformers.models.granitemoehybrid.modeling_granitemoehybrid"
 
+CONFIG_MODS = (
+    "transformers.models.jamba.configuration_jamba",
+    "transformers.models.zamba.configuration_zamba",
+)
+
 
 class _FakeCuda:
     def __init__(self, available = True, capability = (7, 5)):
@@ -91,6 +96,15 @@ def env(monkeypatch):
     integrations.hub_kernels = hk
     sys.modules["transformers.integrations"] = integrations
     sys.modules["transformers.integrations.hub_kernels"] = hk
+
+    # The config step imports these two by name. Park empty stubs on them so no
+    # test reaches out to the installed transformers and permanently rewrites
+    # the real ZambaConfig.__init__; a module with no config class in it is
+    # skipped. Tests that want the class install their own over the top, and
+    # this fixture's teardown restores whatever was there.
+    for cfg_mod_name in CONFIG_MODS:
+        saved[cfg_mod_name] = sys.modules.get(cfg_mod_name)
+        sys.modules[cfg_mod_name] = types.ModuleType(cfg_mod_name)
 
     iu = types.ModuleType("transformers.utils.import_utils")
     iu.is_mamba_ssm_available = lambda: True
@@ -345,6 +359,97 @@ def test_the_config_flag_is_cleared_for_jamba_5_5(env):
     finally:
         if saved is None: sys.modules.pop(mod_name, None)
         else: sys.modules[mod_name] = saved
+
+
+def _fake_config_module(mod_name, cls_name):
+    """A stand-in for jamba/zamba's configuration module.
+
+    `use_mamba_kernels` defaults to True and is also written out into every
+    checkpoint's config.json, so both the default and an explicit True have to
+    end up cleared (transformers 4.57.6 configuration_zamba.py:151/193, and the
+    strict-dataclass field `use_mamba_kernels: bool = True` on 5.5.0:81).
+    """
+    mod = types.ModuleType(mod_name)
+
+    class Config:
+        def __init__(self, use_mamba_kernels = True, **kwargs):
+            self.use_mamba_kernels = use_mamba_kernels
+
+    Config.__name__ = cls_name
+    setattr(mod, cls_name, Config)
+    sys.modules[mod_name] = mod
+    return mod, Config
+
+
+class _ConfigBoundMixer:
+    """Both families bind the config flag once, in the mixer's __init__."""
+    def __init__(self, config):
+        self.use_fast_kernels = config.use_mamba_kernels
+    def forward(self, *args, **kwargs):
+        if self.use_fast_kernels:
+            raise ValueError("Fast Mamba kernels are not available.")
+        return "SLOW PATH"
+
+
+@pytest.mark.parametrize("cfg_mod_name, cls_name, modeling", [
+    (CONFIG_MODS[0], "JambaConfig", "transformers.models.jamba.modeling_jamba"),
+    (CONFIG_MODS[1], "ZambaConfig", "transformers.models.zamba.modeling_zamba"),
+])
+def test_the_config_flag_is_cleared_when_modeling_is_imported_later(
+    env, cfg_mod_name, cls_name, modeling,
+):
+    """The mixer wrapper alone cannot fire when nothing has imported modeling.
+
+    `unsloth_compile_transformers` returns at models/_utils.py:3277 when
+    `trust_remote_code = True`, before both the pre_compile and the post_compile
+    phase, so the only phase that ran is "init", at `import unsloth`, and
+    transformers imports modeling_zamba later, from inside `from_pretrained`.
+    Measured: with trust_remote_code = True there is no
+    `_run_temporary_patches` call at all, and the module is still absent from
+    sys.modules when the call returns. Step 0 has already unregistered the Hub
+    kernels by then, so an unwrapped mixer raises instead of taking the slow
+    path this guard promises. Clearing the config flag is what covers it.
+    """
+    saved = sys.modules.get(modeling)
+    sys.modules.pop(modeling, None)
+    _mod, Config = _fake_config_module(cfg_mod_name, cls_name)
+    try:
+        with pytest.raises(ValueError):
+            _ConfigBoundMixer(Config()).forward()
+        patch()
+        assert Config().use_mamba_kernels is False
+        assert Config(use_mamba_kernels = True).use_mamba_kernels is False, \
+            "a checkpoint's config.json spells the flag out"
+        assert _ConfigBoundMixer(Config()).forward() == "SLOW PATH"
+        assert modeling not in sys.modules, "and without importing modeling"
+    finally:
+        if saved is None: sys.modules.pop(modeling, None)
+        else: sys.modules[modeling] = saved
+
+
+def test_the_config_wrapper_is_applied_once(env):
+    _mod, Config = _fake_config_module(CONFIG_MODS[1], "ZambaConfig")
+    patch()
+    first = Config.__init__
+    patch()
+    assert Config.__init__ is first, "must not stack on every phase"
+    assert Config().use_mamba_kernels is False
+
+
+def test_the_config_step_leaves_no_attribute_on_the_config_class(env):
+    """transformers 5 configs are strict dataclasses, so the idempotency marker
+    goes on the wrapper function rather than on the class."""
+    _mod, Config = _fake_config_module(CONFIG_MODS[1], "ZambaConfig")
+    before = set(Config.__dict__)
+    patch()
+    assert set(Config.__dict__) == before, "no new class attribute"
+    assert Config.__init__._unsloth_slow_only is True, "the marker rides the wrapper"
+
+
+def test_the_config_step_does_not_walk_sys_modules(env):
+    """Two import_module calls on names we already know, not a third pass over
+    every loaded module."""
+    assert _SRC.count("for _name, _mod in list(sys.modules.items()):") == 1
 
 
 def test_the_mixer_scan_does_not_walk_sys_modules(env):

--- a/tests/test_mamba_ssm_pre_ampere_fallback.py
+++ b/tests/test_mamba_ssm_pre_ampere_fallback.py
@@ -147,6 +147,82 @@ def test_pre_ampere_disables_fast_path(env):
     assert iu.is_mamba_2_ssm_available() is False
 
 
+def _fake_mixer_module(mod_name, cls_name, weight_attr):
+    """A stand-in for jamba/zamba: the flag plus a mixer that raises on it.
+
+    Both bind `self.use_fast_kernels = config.use_mamba_kernels` (True by
+    default) at construction, and their forward raises rather than falling back
+    when the module flag is False (transformers 4.57.6
+    models/jamba/modeling_jamba.py:815-821, models/zamba/modeling_zamba.py:553-560;
+    zamba still does in 5.5.0 and 5.14.1).
+    """
+    mod = types.ModuleType(mod_name)
+    mod.is_fast_path_available = True
+
+    class Mixer:
+        def __init__(self):
+            self.use_fast_kernels = True
+            setattr(self, weight_attr,
+                    types.SimpleNamespace(device = types.SimpleNamespace(type = "cuda")))
+        def forward(self, *args, **kwargs):
+            if self.use_fast_kernels:
+                if not mod.is_fast_path_available:
+                    raise ValueError("Fast Mamba kernels are not available.")
+                return "FAST PATH"
+            return "SLOW PATH"
+
+    Mixer.__name__ = cls_name
+    setattr(mod, cls_name, Mixer)
+    sys.modules[mod_name] = mod
+    return mod, Mixer
+
+
+@pytest.mark.parametrize("mod_name, cls_name, weight_attr", [
+    ("transformers.models.jamba.modeling_jamba", "JambaMambaMixer", "x_proj"),
+    ("transformers.models.zamba.modeling_zamba", "ZambaMambaMixer", "x_proj_weight"),
+])
+def test_jamba_and_zamba_reach_the_slow_path_not_a_valueerror(
+    env, mod_name, cls_name, weight_attr,
+):
+    saved = sys.modules.get(mod_name)
+    mod, Mixer = _fake_mixer_module(mod_name, cls_name, weight_attr)
+    try:
+        mixer = Mixer()
+        assert mixer.forward() == "FAST PATH"
+        assert patch() is True
+        assert mod.is_fast_path_available is False
+        # The guard promises the slow path; it must not hand back a ValueError.
+        assert mixer.forward() == "SLOW PATH"
+        assert Mixer().forward() == "SLOW PATH", "instances built later too"
+    finally:
+        if saved is None: sys.modules.pop(mod_name, None)
+        else: sys.modules[mod_name] = saved
+
+
+def test_the_mixer_wrapper_is_applied_once(env):
+    mod_name = "transformers.models.zamba.modeling_zamba"
+    saved = sys.modules.get(mod_name)
+    mod, Mixer = _fake_mixer_module(mod_name, "ZambaMambaMixer", "x_proj_weight")
+    try:
+        assert patch() is True
+        first = Mixer.forward
+        mod.is_fast_path_available = True   # a later phase sees it truthy again
+        assert patch() is True
+        assert Mixer.forward is first, "must not stack on every phase"
+    finally:
+        if saved is None: sys.modules.pop(mod_name, None)
+        else: sys.modules[mod_name] = saved
+
+
+def test_alias_modules_are_not_probed_through_getattr():
+    """transformers 5 registers ~200 `image_processing_<m>_fast` alias modules
+    whose catch-all __getattr__ imports the real image processor. Probing them
+    with getattr costs seconds per phase and can propagate an ImportError out
+    of `import unsloth`, so the scan must read __dict__ instead."""
+    assert '_mod.__dict__.get("is_fast_path_available", False)' in _SRC
+    assert 'getattr(_mod, "is_fast_path_available", False)' not in _SRC
+
+
 def test_ampere_keeps_fast_path(env, monkeypatch):
     model_mod, iu, _hk = env
     monkeypatch.setattr(torch, "cuda", _FakeCuda(capability = (8, 0)), raising = False)

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1127,6 +1127,47 @@ def patch_mamba_ssm_pre_ampere_fallback():
         pass
     pass
 
+    # 0c. Step 0b can only reach a modeling module that is already imported, and
+    #     on the `trust_remote_code = True` path there is never such a moment:
+    #     unsloth returns from `unsloth_compile_transformers` before the
+    #     pre_compile and post_compile phases (models/_utils.py:3277), so the
+    #     only phase that ran is "init", at `import unsloth`, and
+    #     `from_pretrained` imports modeling_zamba afterwards. Clear the flag on
+    #     the CONFIG class instead, which needs no modeling import and is
+    #     order-independent: both families bind `use_fast_kernels =
+    #     config.use_mamba_kernels` in the mixer's __init__, so a config built
+    #     after this point can no longer ask for kernels that are already gone.
+    #     Importing the two configuration modules costs ~1ms and 2 modules
+    #     inside a process that has already imported transformers, versus a
+    #     `sys.meta_path` hook, which would have to stay installed for the whole
+    #     process lifetime and tax every later import for one flag.
+    #     The marker lives on the wrapper function, not on the class: the
+    #     transformers 5 configs are strict dataclasses, and this leaves them
+    #     with no attribute of ours. Locals only, since the test extracts this
+    #     function by AST and execs it in a bare namespace.
+    import importlib
+    _raising_configs = {
+        "transformers.models.jamba.configuration_jamba" : "JambaConfig",
+        "transformers.models.zamba.configuration_zamba" : "ZambaConfig",
+    }
+    for _name, _cfg_name in _raising_configs.items():
+        try:
+            _cfg = importlib.import_module(_name).__dict__.get(_cfg_name, None)
+            if _cfg is None or getattr(_cfg.__init__, "_unsloth_slow_only", False):
+                continue
+            def _slow_only_config(self, *a, __orig = _cfg.__init__, **kw):
+                __orig(self, *a, **kw)
+                try:
+                    self.use_mamba_kernels = False
+                except Exception:
+                    pass
+            _slow_only_config._unsloth_slow_only = True
+            _cfg.__init__ = _slow_only_config
+        except Exception:
+            pass
+        pass
+    pass
+
     try:
         import mamba_ssm  # noqa: F401
     except Exception:

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1094,14 +1094,36 @@ def patch_mamba_ssm_pre_ampere_fallback():
     # 2. Modules ALREADY imported have baked the flag in; flip it directly.
     #    Confined to transformers' own model modules so vLLM's independent
     #    Triton kernels are left alone.
+    # Jamba and Zamba bind `self.use_fast_kernels = config.use_mamba_kernels`
+    # (True by default) at construction and RAISE inside that branch when the
+    # module flag is False, so clearing the flag alone turns their forward into
+    # `ValueError: Fast Mamba kernels are not available` instead of the slow
+    # path this guard promises. Local, not a module global: the test extracts
+    # this function by AST and execs it in a bare namespace.
+    _raising_mixers = {
+        "transformers.models.jamba.modeling_jamba" : "JambaMambaMixer",
+        "transformers.models.zamba.modeling_zamba" : "ZambaMambaMixer",
+    }
     _touched = False
     for _name, _mod in list(sys.modules.items()):
         if not _name.startswith("transformers.models.") or _mod is None:
             continue
-        if not getattr(_mod, "is_fast_path_available", False):
+        # __dict__, not getattr: transformers 5 registers ~200 alias modules
+        # named transformers.models.<m>.image_processing_<m>_fast whose
+        # catch-all __getattr__ imports the real image processor, so a getattr
+        # probe warns 200 times, drags in 3800 modules (3.8s measured) per
+        # phase, and can propagate an ImportError out of `import unsloth`.
+        if not _mod.__dict__.get("is_fast_path_available", False):
             continue
         try:
             _mod.is_fast_path_available = False
+            _mixer = getattr(_mod, _raising_mixers.get(_name, ""), None)
+            if _mixer is not None and not _mixer.__dict__.get("_unsloth_slow_only", False):
+                def _slow_only(self, *a, __orig = _mixer.forward, **kw):
+                    self.use_fast_kernels = False
+                    return __orig(self, *a, **kw)
+                _mixer.forward = _slow_only
+                _mixer._unsloth_slow_only = True
             for _sym in (
                 "selective_state_update",
                 "mamba_chunk_scan_combined",
@@ -1180,14 +1202,17 @@ def patch_datasets_map_worker_death_retry():
                 except Exception:
                     call_args, call_kwargs = args, dict(kwargs)
                     num_proc = None
-            if not isinstance(num_proc, int) or num_proc <= 1:
+            if not isinstance(num_proc, int) or num_proc < 1:
                 raise
             print(
                 f"Unsloth: a dataset worker was killed with num_proc={num_proc} "
                 f"(most likely out of system RAM). Retrying single-process; "
                 f"this is slower but survives."
             )
-            call_kwargs["num_proc"] = 1
+            # None, not 1: datasets >= 4.1.0 gates the pool on
+            # `num_proc is not None and num_proc >= 1` (arrow_dataset.py), so
+            # num_proc=1 still forks a worker and the kernel can kill it again.
+            call_kwargs["num_proc"] = None
             return original_map(self, *call_args, **call_kwargs)
         pass
     pass

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1057,6 +1057,8 @@ def patch_mamba_ssm_pre_ampere_fallback():
     if (major, minor) >= (8, 0):
         return  # Ampere or newer; the fast path is fine
 
+    import sys
+
     # 0. transformers 5 can also fetch these kernels from the Hub, through
     #    `lazy_load_kernel`, which needs no local wheel and never consults the
     #    predicates below. Drop the registry entries so it returns None and the
@@ -1073,12 +1075,62 @@ def patch_mamba_ssm_pre_ampere_fallback():
         pass
     pass
 
+    # 0b. Jamba and Zamba bind `self.use_fast_kernels = config.use_mamba_kernels`
+    #     (True by default) at construction and RAISE inside that branch when the
+    #     fast path is unavailable, so step 0 above and step 1 below turn their
+    #     forward into `ValueError: Fast Mamba kernels are not available` instead
+    #     of the slow path this guard promises. Wrapping the mixer is the only
+    #     thing that clears the instance flag, so it must not hang off the
+    #     module's `is_fast_path_available`:
+    #       - transformers >= 5.3 assigns that name from inside the mixer's
+    #         __init__ (`global is_fast_path_available`,
+    #         models/zamba/modeling_zamba.py:257 on 5.5.0), so it is absent from
+    #         the module dict until a mixer already exists, and 5.5's forward
+    #         recomputes it as a local (line 449) anyway.
+    #       - on 4.x it IS a module global, but step 1 has already made it False
+    #         by the time the modeling module gets imported, so a truthiness gate
+    #         never fired there either.
+    #     Before the local-wheel check: step 0 alone is enough to make the fast
+    #     path unavailable, and therefore enough to trigger the raise.
+    #     `sys.modules.get`, never a getattr scan: transformers 5 registers ~200
+    #     alias modules whose catch-all __getattr__ imports the real object.
+    #     Local, not a module global: the test extracts this function by AST and
+    #     execs it in a bare namespace.
+    _raising_mixers = {
+        "transformers.models.jamba.modeling_jamba" : "JambaMambaMixer",
+        "transformers.models.zamba.modeling_zamba" : "ZambaMambaMixer",
+    }
+    for _name, _cls_name in _raising_mixers.items():
+        _mod = sys.modules.get(_name, None)
+        if _mod is None:
+            continue
+        try:
+            _mixer = _mod.__dict__.get(_cls_name, None)
+            if _mixer is None or _mixer.__dict__.get("_unsloth_slow_only", False):
+                continue
+            def _slow_only(self, *a, __orig = _mixer.forward, **kw):
+                self.use_fast_kernels = False
+                try:
+                    # Jamba on transformers 5.5 reads `self.config.use_mamba_kernels`
+                    # rather than the instance flag, and clears exactly this on its
+                    # own fallback (models/jamba/modeling_jamba.py:470).
+                    _config = getattr(self, "config", None)
+                    if getattr(_config, "use_mamba_kernels", False):
+                        _config.use_mamba_kernels = False
+                except Exception:
+                    pass
+                return __orig(self, *a, **kw)
+            _mixer.forward = _slow_only
+            _mixer._unsloth_slow_only = True
+        except Exception:
+            pass
+        pass
+    pass
+
     try:
         import mamba_ssm  # noqa: F401
     except Exception:
         return  # Not installed locally, and the Hub entries are already gone
-
-    import sys
 
     # 1. Modules imported LATER see the package as unavailable, so their
     #    `is_fast_path_available` evaluates to False at import time.
@@ -1093,17 +1145,8 @@ def patch_mamba_ssm_pre_ampere_fallback():
 
     # 2. Modules ALREADY imported have baked the flag in; flip it directly.
     #    Confined to transformers' own model modules so vLLM's independent
-    #    Triton kernels are left alone.
-    # Jamba and Zamba bind `self.use_fast_kernels = config.use_mamba_kernels`
-    # (True by default) at construction and RAISE inside that branch when the
-    # module flag is False, so clearing the flag alone turns their forward into
-    # `ValueError: Fast Mamba kernels are not available` instead of the slow
-    # path this guard promises. Local, not a module global: the test extracts
-    # this function by AST and execs it in a bare namespace.
-    _raising_mixers = {
-        "transformers.models.jamba.modeling_jamba" : "JambaMambaMixer",
-        "transformers.models.zamba.modeling_zamba" : "ZambaMambaMixer",
-    }
+    #    Triton kernels are left alone. Jamba and Zamba are handled in 0b above,
+    #    which does not depend on the flag being present or truthy.
     _touched = False
     for _name, _mod in list(sys.modules.items()):
         if not _name.startswith("transformers.models.") or _mod is None:
@@ -1117,13 +1160,6 @@ def patch_mamba_ssm_pre_ampere_fallback():
             continue
         try:
             _mod.is_fast_path_available = False
-            _mixer = getattr(_mod, _raising_mixers.get(_name, ""), None)
-            if _mixer is not None and not _mixer.__dict__.get("_unsloth_slow_only", False):
-                def _slow_only(self, *a, __orig = _mixer.forward, **kw):
-                    self.use_fast_kernels = False
-                    return __orig(self, *a, **kw)
-                _mixer.forward = _slow_only
-                _mixer._unsloth_slow_only = True
             for _sym in (
                 "selective_state_update",
                 "mamba_chunk_scan_combined",

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1057,10 +1057,26 @@ def patch_mamba_ssm_pre_ampere_fallback():
     if (major, minor) >= (8, 0):
         return  # Ampere or newer; the fast path is fine
 
+    # 0. transformers 5 can also fetch these kernels from the Hub, through
+    #    `lazy_load_kernel`, which needs no local wheel and never consults the
+    #    predicates below. Drop the registry entries so it returns None and the
+    #    fast path stays unavailable. Before the local-wheel check, since the
+    #    Hub path is exactly the one that reaches a pre-Ampere GPU without one.
+    try:
+        from transformers.integrations import hub_kernels as _hk
+        for _kernel in ("mamba-ssm", "falcon_mamba-ssm", "causal-conv1d"):
+            _hk._HUB_KERNEL_MAPPING.pop(_kernel, None)
+            # An already-resolved module has to go too. None is enough:
+            # lazy_load_kernel only short-circuits on a real module object.
+            _hk._KERNEL_MODULE_MAPPING[_kernel] = None
+    except Exception:
+        pass
+    pass
+
     try:
         import mamba_ssm  # noqa: F401
     except Exception:
-        return  # Not installed, so nothing routes into it anyway
+        return  # Not installed locally, and the Hub entries are already gone
 
     import sys
 
@@ -1883,14 +1899,18 @@ def patch_longrope_impossible_attention_factor():
             + ". Ignoring it so attention is scaled correctly."
         )
 
+    # Everything but `config` is forwarded untouched: on transformers 5 every
+    # other parameter has a default and `_init_weights` calls the rope init as
+    # `rope_fn(module.config)`, so naming `device` here would make every
+    # LongRoPE model fail to load with a missing-argument TypeError.
     @functools.wraps(original)
-    def _compute_longrope_parameters(config, device, seq_len = None, **kwargs):
+    def _compute_longrope_parameters(config, *args, **kwargs):
         try:
             _sanitise(config)
         except Exception:
             # Never let the guard itself break a model that would have loaded.
             pass
-        return original(config, device, seq_len = seq_len, **kwargs)
+        return original(config, *args, **kwargs)
 
     _compute_longrope_parameters._unsloth_patched = True
     try:

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1032,6 +1032,158 @@ pass
 TEMPORARY_PATCHES.append(patch_causal_conv1d_cuda_probe)
 
 
+def patch_mamba_ssm_pre_ampere_fallback():
+    """Force the Mamba slow path on pre-Ampere GPUs.
+
+    mamba_ssm's Triton kernels need sm_80+. On a T4 the package imports fine
+    and `is_fast_path_available` is True, so transformers routes into
+    `cuda_kernels_forward` and Triton only fails once training starts, with an
+    opaque `RuntimeError: PassManager::run failed`.
+
+    `is_fast_path_available` is baked in at module import, so flip both the
+    availability predicates (for modules imported later) and the flag on
+    already-imported modules. A capability check rather than a trial launch
+    like the causal_conv1d probe above, which would pay a Triton compile at
+    every import just to watch it fail. Real NVIDIA CUDA only.
+    """
+    if not torch.cuda.is_available():
+        return
+    if getattr(torch.version, "hip", None) is not None:
+        return  # ROCm: mamba_ssm's requirements are a different question
+    try:
+        major, minor = torch.cuda.get_device_capability()
+    except Exception:
+        return
+    if (major, minor) >= (8, 0):
+        return  # Ampere or newer; the fast path is fine
+
+    try:
+        import mamba_ssm  # noqa: F401
+    except Exception:
+        return  # Not installed, so nothing routes into it anyway
+
+    import sys
+
+    # 1. Modules imported LATER see the package as unavailable, so their
+    #    `is_fast_path_available` evaluates to False at import time.
+    try:
+        import transformers.utils.import_utils as _iu
+        for _pred in ("is_mamba_ssm_available", "is_mamba_2_ssm_available"):
+            if hasattr(_iu, _pred):
+                setattr(_iu, _pred, lambda: False)
+    except Exception:
+        pass
+    pass
+
+    # 2. Modules ALREADY imported have baked the flag in; flip it directly.
+    #    Confined to transformers' own model modules so vLLM's independent
+    #    Triton kernels are left alone.
+    _touched = False
+    for _name, _mod in list(sys.modules.items()):
+        if not _name.startswith("transformers.models.") or _mod is None:
+            continue
+        if not getattr(_mod, "is_fast_path_available", False):
+            continue
+        try:
+            _mod.is_fast_path_available = False
+            for _sym in (
+                "selective_state_update",
+                "mamba_chunk_scan_combined",
+                "mamba_split_conv1d_scan_combined",
+            ):
+                if getattr(_mod, _sym, None) is not None:
+                    setattr(_mod, _sym, None)
+            _touched = True
+        except Exception:
+            pass
+        pass
+    pass
+
+    print(
+        f"Unsloth: mamba_ssm's Triton kernels need compute capability 8.0+ "
+        f"(this GPU is {major}.{minor}). Using the PyTorch slow path for "
+        f"Mamba models."
+    )
+    return _touched
+
+
+TEMPORARY_PATCHES.append(patch_mamba_ssm_pre_ampere_fallback)
+
+
+def patch_datasets_map_worker_death_retry():
+    """Retry `Dataset.map` single-process when a worker is killed outright.
+
+    Long-text corpora can have the kernel OOM-kill a `dataset_num_proc`
+    worker, which datasets turns into "One of the subprocesses has abruptly
+    died during map operation", killing the run inside SFTTrainer.__init__.
+    The map is issued deep inside TRL, so the user cannot disable
+    multiprocessing themselves.
+
+    Narrow by design: only a vanished worker (OOM-kill, segfault) matches, a
+    genuine exception from the map function is re-raised as itself and still
+    propagates, single-process maps re-raise untouched, and the retry cannot
+    recurse because num_proc is pinned to 1.
+    """
+    try:
+        from datasets import Dataset
+    except Exception:
+        return  # datasets not installed
+
+    original_map = getattr(Dataset, "map", None)
+    if original_map is None or getattr(original_map, "_unsloth_worker_death_retry", False):
+        return
+
+    import functools
+
+    @functools.wraps(original_map)
+    def map(self, *args, **kwargs):
+        try:
+            return original_map(self, *args, **kwargs)
+        except RuntimeError as exc:
+            if "abruptly died" not in str(exc):
+                raise
+            # num_proc has to end up as a keyword we can override, so a call
+            # that passed it positionally is re-expanded into keywords first.
+            call_args, call_kwargs = args, dict(kwargs)
+            num_proc = call_kwargs.get("num_proc", None)
+            if num_proc is None and args:
+                try:
+                    sig = inspect.signature(original_map)
+                    if any(p.kind is p.VAR_POSITIONAL for p in sig.parameters.values()):
+                        raise TypeError("cannot normalise *args")
+                    bound = sig.bind(self, *args, **kwargs)
+                    bound.apply_defaults()
+                    num_proc = bound.arguments.get("num_proc", None)
+                    var_kw = {}
+                    for p in sig.parameters.values():
+                        if p.kind is p.VAR_KEYWORD:
+                            var_kw = bound.arguments.pop(p.name, None) or {}
+                    bound.arguments.pop("self", None)
+                    call_args = ()
+                    call_kwargs = {**bound.arguments, **var_kw}
+                except Exception:
+                    call_args, call_kwargs = args, dict(kwargs)
+                    num_proc = None
+            if not isinstance(num_proc, int) or num_proc <= 1:
+                raise
+            print(
+                f"Unsloth: a dataset worker was killed with num_proc={num_proc} "
+                f"(most likely out of system RAM). Retrying single-process; "
+                f"this is slower but survives."
+            )
+            call_kwargs["num_proc"] = 1
+            return original_map(self, *call_args, **call_kwargs)
+        pass
+    pass
+
+    map._unsloth_worker_death_retry = True
+    Dataset.map = map
+    return True
+
+
+TEMPORARY_PATCHES.append(patch_datasets_map_worker_death_retry)
+
+
 def patch_GraniteMoeHybridMambaLayer_cuda_kernels_forward():
     try:
         import transformers.models.granitemoehybrid.modeling_granitemoehybrid
@@ -1669,3 +1821,86 @@ def patch_deepseek_v2_moe_alias():
         m.DeepseekV2MoE = m.DeepseekV2Moe
 pass
 TEMPORARY_PATCHES.append(patch_deepseek_v2_moe_alias)
+
+
+def patch_longrope_impossible_attention_factor():
+    """Ignore a LongRoPE `attention_factor` that cannot be a real one.
+
+    The factor is by construction
+
+        sqrt(1 + log(factor) / log(original_max_position_embeddings))
+
+    a number near 1. transformers derives that when the key is absent, but
+    takes the config's word for it when present, and
+    unsloth/Phi-3.5-mini-instruct{,-bnb-4bit} set it equal to `factor` (32.0),
+    roughly 27x the real value. Nothing raises; the model just predicts badly
+    (4.74 vs 2.13 cross-entropy on the same text).
+
+    The signature is exact on purpose: attention_factor == factor AND
+    factor > 2. A genuine attention factor is never the extension ratio and
+    never much above 1.5. The real remedy is republishing those configs.
+    """
+    try:
+        import functools
+        import math
+        from transformers import modeling_rope_utils as _rope
+    except Exception:
+        return
+    original = getattr(_rope, "_compute_longrope_parameters", None)
+    if original is None or getattr(original, "_unsloth_patched", False):
+        return
+
+    def _sanitise(config):
+        scaling = getattr(config, "rope_scaling", None)
+        if not isinstance(scaling, dict):
+            return
+        factor = scaling.get("factor")
+        attention_factor = scaling.get("attention_factor")
+        if attention_factor is None or factor is None:
+            return
+        try:
+            if float(attention_factor) != float(factor) or float(factor) <= 2.0:
+                return
+        except (TypeError, ValueError):
+            return
+        original_max = getattr(config, "original_max_position_embeddings", None) \
+            or getattr(config, "max_position_embeddings", None)
+        try:
+            correct = math.sqrt(1 + math.log(float(factor)) / math.log(float(original_max)))
+        except (TypeError, ValueError, ZeroDivisionError):
+            correct = None
+        cleaned = dict(scaling)
+        cleaned.pop("attention_factor", None)
+        try:
+            config.rope_scaling = cleaned
+        except Exception:
+            return
+        print(
+            f"Unsloth: This model's config sets a LongRoPE attention_factor of "
+            f"{attention_factor}, which equals its extension factor and cannot be "
+            f"a real attention factor"
+            + (f" (the derived value is {correct:.4f})" if correct else "")
+            + ". Ignoring it so attention is scaled correctly."
+        )
+
+    @functools.wraps(original)
+    def _compute_longrope_parameters(config, device, seq_len = None, **kwargs):
+        try:
+            _sanitise(config)
+        except Exception:
+            # Never let the guard itself break a model that would have loaded.
+            pass
+        return original(config, device, seq_len = seq_len, **kwargs)
+
+    _compute_longrope_parameters._unsloth_patched = True
+    try:
+        _rope._compute_longrope_parameters = _compute_longrope_parameters
+        # Models resolve the callable through this dict, not the module
+        # attribute, so patching only the attribute would be a no-op.
+        if getattr(_rope, "ROPE_INIT_FUNCTIONS", None) is not None:
+            if _rope.ROPE_INIT_FUNCTIONS.get("longrope") is original:
+                _rope.ROPE_INIT_FUNCTIONS["longrope"] = _compute_longrope_parameters
+    except Exception:
+        return
+pass
+TEMPORARY_PATCHES.append(patch_longrope_impossible_attention_factor)


### PR DESCRIPTION
Three narrow guards, each one a notebook that died on a free Colab or Kaggle T4 for a reason the user could not act on. All three land in `temporary_patches/misc.py` and each returns early and unchanged whenever its precondition does not hold.

### 1. mamba_ssm on pre-Ampere GPUs

`mamba_ssm`'s Triton kernels need sm_80 or newer. On a Tesla T4 (sm_75) the package imports cleanly and `is_fast_path_available` comes out `True`, so transformers routes the layer into `cuda_kernels_forward` and the failure only appears once training starts:

```
RuntimeError: PassManager::run failed
```

raised inside Triton's LLIR stage while compiling `_chunk_state_fwd_kernel`. Granite4.0 dies this way with nothing in the message to suggest the GPU is the problem.

`is_fast_path_available` is computed at module import from the symbols `mamba_ssm` exported, and 17 transformers model modules do this, so both the availability predicates (for modules imported later) and the already-imported modules are handled. A capability check rather than a trial launch, because probing would pay a Triton compile at every import just to watch it fail. Restricted to real NVIDIA CUDA, so ROCm, XPU, MPS and CPU builds are untouched.

### 2. `Dataset.map` when a worker is OOM-killed

Dataset preparation is farmed out to `dataset_num_proc` fork workers sized from CPU count and free RAM. Long-text corpora blow through that: on a Colab T4, the CodeForces reasoning notebook has the kernel OOM-kill a worker and `datasets` turns it into

```
RuntimeError: One of the subprocesses has abruptly died during map operation.
To debug the error, disable multiprocessing.
```

which kills the run at `SFTTrainer` construction, before a single training step. Doing exactly what the message says is both the obvious recovery and one the user cannot apply themselves, since the map is issued deep inside TRL rather than from their notebook.

Deliberately narrow: "abruptly died" means the worker process vanished. A genuine exception inside the map function is re-raised by `datasets` as itself and still propagates untouched, so this cannot mask a real bug. Single-process maps are left alone, and the retry cannot recurse because `num_proc` is pinned to 1.

### 3. An impossible LongRoPE `attention_factor`

For LongRoPE the attention scaling factor is by construction

```
sqrt(1 + log(factor) / log(original_max_position_embeddings))
```

a number near 1. transformers derives exactly that when `attention_factor` is absent, but takes the config's word for it when present. `unsloth/Phi-3.5-mini-instruct` and its bnb-4bit sibling set `attention_factor` equal to `factor` (32.0), roughly 27x the real value. Nothing raises. The model simply predicts badly: 4.74 against 2.13 cross-entropy on the same text.

The signature is exact on purpose, `attention_factor == factor` and `factor > 2`. A genuine attention factor is never the extension ratio and never much above 1.5. The real remedy is republishing those configs; this keeps the affected models usable until then, and says so out loud rather than silently.

### Tests

31 new tests, all passing (mamba 8, dataset map 9, LongRoPE 14). The neighbouring suites `test_temporary_patches_exhaustive.py`, `test_temporary_patches_imports.py`, `test_mlx_extra_special_tokens_compat.py` and `test_deepseek_v2_moe_alias.py` still pass, 147 passed and 18 skipped, no regression.

The unit tests use fake `torch.cuda` and fake `datasets`, so no pre-Ampere GPU is needed to run them. The live reproductions were on Colab T4s.
