### PR TITLE
Pin that a fresh cloud VM never starts in high-performance mode

### DIFF
--- a/tests/test_hf_xet_applies_automatically.py
+++ b/tests/test_hf_xet_applies_automatically.py
@@ -144,10 +144,15 @@ def test_a_fresh_vm_with_an_empty_xet_log_dir_does_not_import_into_high_performa
         }))
     """, {"HF_XET_CACHE": str(xet_cache), "HF_HOME": str(tmp_path / "hf")})
 
-    assert result["hp"] not in ("1", "true", "yes", "on"), (
+    # Judge the flag with the parser the tuning code uses: it strips and lowercases, so a raw
+    # membership test would let "True" or " on " through while the process is in fact sized for
+    # high performance -- the regression back, in a different spelling.
+    from unsloth_zoo.hf_xet_tuning import _is_true
+
+    assert not _is_true(result["hp"]), (
         f"import put this process into high-performance mode ({result['hp']!r}); xet-core then "
         "applies its 64GB preset AFTER reading the environment and discards every cap below"
     )
-    assert result["hp_alias"] not in ("1", "true", "yes", "on")
+    assert not _is_true(result["hp_alias"])
     # The caps only mean anything while the preset is off, so assert they arrived at all.
     assert result["limit"] and int(result["limit"]) <= 64_000_000_000

--- a/tests/test_hf_xet_applies_automatically.py
+++ b/tests/test_hf_xet_applies_automatically.py
@@ -120,3 +120,34 @@ def test_a_user_who_asked_for_high_performance_still_has_it_after_import(tmp_pat
 
     for key in _CAPS_VOIDED_BY_HIGH_PERFORMANCE:
         assert key not in result, key
+
+
+@pytest.mark.timeout(1200)
+def test_a_fresh_vm_with_an_empty_xet_log_dir_does_not_import_into_high_performance(tmp_path):
+    """The 2026.6.7 regression lived in ``__init__``, not in the tuning function, so it can only be
+    caught by importing. That release read hf_xet's logs for a prior 429 and, finding none, set
+    ``HF_XET_HIGH_PERFORMANCE=1`` -- which on a VM created seconds ago is every single time. Colab
+    standard then OOM-killed a 29.5GB download at 11.32GB RSS against 13.61GB of RAM.
+
+    An empty log directory is the exact state under test, so create one and point the cache at it
+    rather than relying on whatever this machine happens to have.
+    """
+    xet_cache = tmp_path / "xet"
+    (xet_cache / "logs").mkdir(parents = True)   # exists, and holds no 429 -- the fresh-VM case
+    result = _run(tmp_path, """
+        import json, os
+        import unsloth_zoo  # noqa: F401  -- the import IS the thing under test
+        print(json.dumps({
+            "hp": os.environ.get("HF_XET_HIGH_PERFORMANCE"),
+            "hp_alias": os.environ.get("HF_XET_HP"),
+            "limit": os.environ.get("HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"),
+        }))
+    """, {"HF_XET_CACHE": str(xet_cache), "HF_HOME": str(tmp_path / "hf")})
+
+    assert result["hp"] not in ("1", "true", "yes", "on"), (
+        f"import put this process into high-performance mode ({result['hp']!r}); xet-core then "
+        "applies its 64GB preset AFTER reading the environment and discards every cap below"
+    )
+    assert result["hp_alias"] not in ("1", "true", "yes", "on")
+    # The caps only mean anything while the preset is off, so assert they arrived at all.
+    assert result["limit"] and int(result["limit"]) <= 64_000_000_000

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -731,3 +731,80 @@ def test_a_throttle_asked_for_by_a_logged_429_survives_the_resize(monkeypatch, t
     # Still overridable, for a caller that knows the throttle has lifted.
     assert int(tuning.resize_for_cache_dir(dict(fake_env), roomy / "hub", throttled = False)[key]) \
         > throttled_streams
+
+
+# A fresh cloud VM: nothing in the environment, and no Xet logs to have learned from. Colab and
+# Kaggle look like this on EVERY run, which is what made the old heuristic fail there forever.
+CLOUD_VMS = [
+    # name,                RAM GB, cpus, free disk GB
+    ("Colab standard",       13.6,    2,   78),
+    ("Colab high-RAM",       51.0,    8,  225),
+    ("Kaggle T4 x2",         33.7,    4, 1100),
+    ("Kaggle CPU",           30.0,    4,   20),
+    ("SageMaker Studio Lab", 16.0,    4,   15),
+    ("Paperspace free",      30.0,    8,   50),
+]
+
+# xet-core's high-performance preset (xet_runtime/src/config/xet_config.rs: with_high_performance
+# is applied AFTER the environment, so it VOIDS whatever we set).
+_HIGH_PERFORMANCE_CEILING = 64 * GB
+
+
+@pytest.mark.parametrize("name, ram_gb, cpus, disk_gb", CLOUD_VMS,
+                         ids = [d[0] for d in CLOUD_VMS])
+def test_a_fresh_cloud_vm_is_never_put_into_high_performance_mode(
+        name, ram_gb, cpus, disk_gb, monkeypatch):
+    """The 2026.6.7 regression, pinned: high-performance mode was enabled whenever the local Xet
+    logs held no prior 429. A fresh VM's logs are ALWAYS empty, so every Colab and Kaggle session
+    started with xet-core's 64GB ceiling; a 29.5GB download was OOM-killed on Colab at 11.32GB RSS
+    against 13.61GB of RAM. The flag is what matters rather than our own numbers, because
+    with_high_performance() is applied after the environment and discards them."""
+    for var in (*tuning.XET_HIGH_PERFORMANCE_VARS, "UNSLOTH_XET_FORCE_CAPS"):
+        monkeypatch.delenv(var, raising = False)
+    env: dict = {}
+    tuning.apply_xet_env(env, profile = _profile(ram_gb, cpus, disk_gb))
+
+    for var in tuning.XET_HIGH_PERFORMANCE_VARS:
+        assert not tuning._is_true(env.get(var)), (
+            f"{name}: {var}={env.get(var)!r} hands this VM a "
+            f"{_HIGH_PERFORMANCE_CEILING // GB}GB ceiling on {ram_gb}GB of RAM"
+        )
+
+
+@pytest.mark.parametrize("name, ram_gb, cpus, disk_gb", CLOUD_VMS,
+                         ids = [d[0] for d in CLOUD_VMS])
+def test_a_fresh_cloud_vm_keeps_its_buffers_inside_its_own_ram(
+        name, ram_gb, cpus, disk_gb, monkeypatch):
+    """The consequence the flag test cannot see on its own: whatever route the sizing takes, what
+    hf_xet can hold at once has to stay a modest share of the machine. A quarter is the line --
+    measured peak RSS on Colab was 1.3GB of 13.6GB (10%) once sized, against 11.3GB (83%) before."""
+    for var in (*tuning.XET_HIGH_PERFORMANCE_VARS, "UNSLOTH_XET_FORCE_CAPS"):
+        monkeypatch.delenv(var, raising = False)
+    env: dict = {}
+    tuning.apply_xet_env(env, profile = _profile(ram_gb, cpus, disk_gb))
+
+    in_flight = (int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"])
+                 + int(env["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"])
+                 * int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE"]))
+    budget = ram_gb * GB / 4
+    assert in_flight <= budget, (
+        f"{name}: {in_flight / GB:.2f}GB in flight on a {ram_gb}GB VM "
+        f"({100 * in_flight / (ram_gb * GB):.0f}% of RAM, limit 25%)"
+    )
+
+
+def test_an_empty_xet_log_directory_is_not_read_as_permission_to_go_fast():
+    """The exact inversion that shipped: "no 429 in the logs" was treated as "this machine can take
+    high performance", when on a VM created seconds ago it only means nothing has been tried yet.
+    Absence of evidence has to resolve to the conservative branch."""
+    quiet: dict = {}
+    tuning.apply_xet_env(quiet, profile = _profile(13.6, 2, 78))
+    throttled: dict = {}
+    tuning.apply_xet_env(throttled, profile = _profile(13.6, 2, 78), throttled = True)
+
+    for env, label in ((quiet, "no 429s logged"), (throttled, "a 429 was logged")):
+        for var in tuning.XET_HIGH_PERFORMANCE_VARS:
+            assert not tuning._is_true(env.get(var)), f"{label}: {var} enabled"
+    # A logged 429 may fetch less hard, but a quiet log never fetches HARDER than one.
+    assert (int(throttled["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"])
+            <= int(quiet["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]))


### PR DESCRIPTION
Tests only. Pins the regression that made Colab and Kaggle downloads fail, so it cannot come back quietly.

## What shipped in 2026.6.7

`unsloth_zoo/__init__.py` decided high-performance mode from the local Xet logs:

```python
os.environ.setdefault(
    "HF_XET_HIGH_PERFORMANCE",
    has_429_exact_full_read(xet_cache / "logs") if xet_cache is not None else "1",
)
os.environ.setdefault("HF_XET_NUM_CONCURRENT_RANGE_GETS", "64")
```

`has_429_exact_full_read` returns `"0"` only when a *previous* 429 is already sitting in those logs. A VM created seconds ago has none, so it returned `"1"` and every fresh Colab or Kaggle session started in high-performance mode with 64 concurrent range GETs. That is xet-core's preset with a 64 GB buffer ceiling, and because `with_high_performance()` is applied *after* the environment is read (`xet_runtime/src/config/xet_config.rs`), it voids whatever caps we set alongside it.

The heuristic could only ever help on a second run, after the machine had already been rate limited. Cloud VMs are always on their first run.

## What it did, measured

Colab standard, 2 vCPU / 13.61 GB RAM, downloading `unsloth/Qwen3-14B` (29.5 GB, 6 shards):

| zoo | outcome | peak RSS |
| --- | --- | --- |
| 2026.6.7 | **OOM-killed** (`exit -9`) | 11.32 GB |
| bare hf_xet, no zoo | completed | 5.43 GB |
| current | completed | 1.37 GB |

Same download on Kaggle (4 vCPU / 33.7 GB) survived at 21.74 GB RSS, which is why this never showed up there: the box was big enough to absorb it.

## The tests

- `test_a_fresh_cloud_vm_is_never_put_into_high_performance_mode` over six named VMs (Colab standard and high-RAM, Kaggle T4 x2 and CPU, SageMaker Studio Lab, Paperspace). It asserts on the flag rather than on our numbers, because our numbers are exactly what the preset discards.
- `test_a_fresh_cloud_vm_keeps_its_buffers_inside_its_own_ram`: in-flight bytes stay under a quarter of RAM whatever route the sizing takes. Measured peak on Colab is 10% once sized, against 83% before.
- `test_an_empty_xet_log_directory_is_not_read_as_permission_to_go_fast`: pins the inversion itself, and that a logged 429 never fetches harder than a quiet log.

## Negative control

Reintroducing the old behaviour (`setdefault("HF_XET_HIGH_PERFORMANCE", "1")` on empty logs) fails 7 of the 13 cases, naming each affected VM:

```
FAILED ...test_a_fresh_cloud_vm_is_never_put_into_high_performance_mode[Colab standard]
FAILED ...test_a_fresh_cloud_vm_is_never_put_into_high_performance_mode[Kaggle T4 x2]
FAILED ...test_an_empty_xet_log_directory_is_not_read_as_permission_to_go_fast
...
7 failed, 6 passed
```

Full suite on this branch: 3380 passed, 187 skipped.

## Deliberately not claimed

Throughput. Colab's network measured a 22% relative standard deviation with a 2.34x spread across 18 identical baseline runs, which is several times any difference between configurations, so no speed number here would survive scrutiny. Peak RSS is unaffected by network conditions and is reproduced in every run.
