### PR TITLE
Report the real cause when a GGUF export or merge fails

### DIFF
--- a/tests/test_bin_only_base_diagnosis.py
+++ b/tests/test_bin_only_base_diagnosis.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """A base that exists but ships no safetensors must not be called missing.
 
 `check_hf_model_exists` returns True only when the listing contains a

--- a/tests/test_bin_only_base_diagnosis.py
+++ b/tests/test_bin_only_base_diagnosis.py
@@ -1,0 +1,120 @@
+"""A base that exists but ships no safetensors must not be called missing.
+
+`check_hf_model_exists` returns True only when the listing contains a
+`.safetensors` file, so a public `.bin`-only repo such as `unsloth/bge-m3`
+answers False exactly like a repo that is not there, and the caller blames
+the name. Diagnosis only: which repos resolve is unchanged.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import unsloth_zoo.saving_utils as su  # noqa: E402
+
+
+class _FakeFS:
+    """Stands in for HfFileSystem: one listing, or an exception."""
+    payload = None
+
+    def __init__(self, token = None):
+        pass
+
+    def ls(self, name, detail = True):
+        if isinstance(self.__class__.payload, Exception):
+            raise self.__class__.payload
+        return [{"name": f"{name}/{n}"} for n in self.__class__.payload]
+
+
+@pytest.fixture
+def fs(monkeypatch):
+    def _set(payload):
+        _FakeFS.payload = payload
+        monkeypatch.setattr(su, "HfFileSystem", _FakeFS)
+    return _set
+
+
+def test_bin_only_repo_is_named(fs):
+    fs(["config.json", "pytorch_model.bin", "tokenizer.json"])
+    assert su._hub_repo_weights_without_safetensors("org/m") == ["pytorch_model.bin"]
+
+
+def test_pt_and_bin_are_both_reported(fs):
+    # bge-m3's actual layout.
+    fs(["config.json", "colbert_linear.pt", "pytorch_model.bin", "sparse_linear.pt"])
+    assert sorted(su._hub_repo_weights_without_safetensors("org/m")) == [
+        "colbert_linear.pt", "pytorch_model.bin", "sparse_linear.pt"]
+
+
+def test_safetensors_repo_says_nothing(fs):
+    # This one resolves normally, so there is no second diagnosis to offer.
+    fs(["config.json", "model.safetensors"])
+    assert su._hub_repo_weights_without_safetensors("org/m") is None
+
+
+def test_sharded_safetensors_say_nothing(fs):
+    fs(["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"])
+    assert su._hub_repo_weights_without_safetensors("org/m") is None
+
+
+def test_repo_with_no_weights_at_all_says_nothing(fs):
+    # Nothing useful to add; the original "could not be read" message stands.
+    fs(["README.md", "config.json"])
+    assert su._hub_repo_weights_without_safetensors("org/m") is None
+
+
+def test_unreachable_hub_says_nothing(fs):
+    # Absent, gated and unreachable are already described by the caller, and a
+    # guess here would override a more accurate message.
+    fs(ConnectionError("boom"))
+    assert su._hub_repo_weights_without_safetensors("org/m") is None
+
+
+def test_local_directory_is_not_probed(fs):
+    fs(["pytorch_model.bin"])
+    assert su._hub_repo_weights_without_safetensors("./outputs/mymodel") is None
+
+
+def test_openvino_subdirectory_bins_do_not_count(fs):
+    # all-MiniLM-L6-v2 ships openvino/*.bin beside a root model.safetensors.
+    fs(["model.safetensors", "openvino/openvino_model.bin"])
+    assert su._hub_repo_weights_without_safetensors("org/m") is None
+
+
+def test_caller_raises_the_specific_message():
+    """The bin-only branch must reach the user, not just exist.
+
+    Assert on the RENDERED message: the literal is split across implicit
+    concatenation, so no phrase a user would read is contiguous in the source.
+    """
+    import ast, re
+    src = Path(su.__file__).read_text(encoding = "utf-8")
+    i = src.index("_bin_only = _hub_repo_weights_without_safetensors")
+    j = src.index("could not be read locally or on Hugging Face")
+    assert i < j, "the bin-only check must run before the generic message"
+
+    # Render every f-string in the module, then find the one this branch raises.
+    rendered = [
+        re.sub(r"\s+", " ", "".join(v.value for v in n.values
+                                    if isinstance(v, ast.Constant)))
+        for n in ast.walk(ast.parse(src)) if isinstance(n, ast.JoinedStr)
+    ]
+    msg = [m for m in rendered if "ships no safetensors weights" in m]
+    assert msg, "the bin-only message is not raised anywhere"
+    assert "Nothing was written to" in msg[0]
+    assert "Convert the base to safetensors" in msg[0]
+
+
+@pytest.mark.skipif("--live" not in sys.argv, reason = "needs network")
+def test_live_bge_m3():
+    got = su._hub_repo_weights_without_safetensors("unsloth/bge-m3")
+    assert got and "pytorch_model.bin" in got
+    assert su._hub_repo_weights_without_safetensors(
+        "sentence-transformers/all-MiniLM-L6-v2") is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_bin_only_base_diagnosis.py
+++ b/tests/test_bin_only_base_diagnosis.py
@@ -16,10 +16,9 @@
 
 """A base that exists but ships no safetensors must not be called missing.
 
-`check_hf_model_exists` returns True only when the listing contains a
-`.safetensors` file, so a public `.bin`-only repo such as `unsloth/bge-m3`
-answers False exactly like a repo that is not there, and the caller blames
-the name. Diagnosis only: which repos resolve is unchanged.
+`check_hf_model_exists` only returns True when the listing holds a
+`.safetensors`, so a `.bin`-only repo like `unsloth/bge-m3` looks absent and
+the caller blames the name. Diagnosis only: which repos resolve is unchanged.
 """
 
 import os
@@ -67,7 +66,6 @@ def test_pt_and_bin_are_both_reported(fs):
 
 
 def test_safetensors_repo_says_nothing(fs):
-    # This one resolves normally, so there is no second diagnosis to offer.
     fs(["config.json", "model.safetensors"])
     assert su._hub_repo_weights_without_safetensors("org/m") is None
 
@@ -84,8 +82,7 @@ def test_repo_with_no_weights_at_all_says_nothing(fs):
 
 
 def test_unreachable_hub_says_nothing(fs):
-    # Absent, gated and unreachable are already described by the caller, and a
-    # guess here would override a more accurate message.
+    # Already described by the caller; a guess would override a better message.
     fs(ConnectionError("boom"))
     assert su._hub_repo_weights_without_safetensors("org/m") is None
 
@@ -104,8 +101,8 @@ def test_openvino_subdirectory_bins_do_not_count(fs):
 def test_caller_raises_the_specific_message():
     """The bin-only branch must reach the user, not just exist.
 
-    Assert on the RENDERED message: the literal is split across implicit
-    concatenation, so no phrase a user would read is contiguous in the source.
+    Asserts on the rendered message: implicit concatenation means no phrase a
+    user would read is contiguous in the source.
     """
     import ast, re
     src = Path(su.__file__).read_text(encoding = "utf-8")
@@ -125,9 +122,7 @@ def test_caller_raises_the_specific_message():
     assert "Convert the base to safetensors" in msg[0]
 
 
-# An env var, not a pytest flag: `--live` was never registered through
-# pytest_addoption, so `pytest --live` exits with "unrecognized arguments"
-# before collection and this test could never actually be run.
+# An env var, not `--live`: an unregistered pytest flag aborts collection.
 @pytest.mark.skipif(
     os.environ.get("UNSLOTH_LIVE_TESTS", "0") != "1",
     reason = "needs network; set UNSLOTH_LIVE_TESTS=1",

--- a/tests/test_bin_only_base_diagnosis.py
+++ b/tests/test_bin_only_base_diagnosis.py
@@ -22,6 +22,7 @@ answers False exactly like a repo that is not there, and the caller blames
 the name. Diagnosis only: which repos resolve is unchanged.
 """
 
+import os
 import sys
 import types
 from pathlib import Path
@@ -124,7 +125,13 @@ def test_caller_raises_the_specific_message():
     assert "Convert the base to safetensors" in msg[0]
 
 
-@pytest.mark.skipif("--live" not in sys.argv, reason = "needs network")
+# An env var, not a pytest flag: `--live` was never registered through
+# pytest_addoption, so `pytest --live` exits with "unrecognized arguments"
+# before collection and this test could never actually be run.
+@pytest.mark.skipif(
+    os.environ.get("UNSLOTH_LIVE_TESTS", "0") != "1",
+    reason = "needs network; set UNSLOTH_LIVE_TESTS=1",
+)
 def test_live_bge_m3():
     got = su._hub_repo_weights_without_safetensors("unsloth/bge-m3")
     assert got and "pytorch_model.bin" in got

--- a/tests/test_gguf_bitsandbytes_guard.py
+++ b/tests/test_gguf_bitsandbytes_guard.py
@@ -97,6 +97,9 @@ def test_guard_is_wired_into_convert_to_gguf():
 
 def test_error_message_is_actionable():
     assert "load_in_4bit = False" in _SRC
+    # An 8bit checkpoint carries the same quant_method and hits the same guard,
+    # so the remediation has to name its flag too.
+    assert "load_in_8bit = False" in _SRC
     assert "merged_16bit" in _SRC
 
 

--- a/tests/test_gguf_bitsandbytes_guard.py
+++ b/tests/test_gguf_bitsandbytes_guard.py
@@ -1,0 +1,88 @@
+"""Tests the bitsandbytes guard in llama_cpp.convert_to_gguf.
+
+llama.cpp has no bitsandbytes dequantizer, and only raises
+`NotImplementedError: Quant method is not yet supported: 'bitsandbytes'` after
+reading the entire model, so the guard has to fire before the subprocess.
+
+The detector searches nested dicts because VLMs keep their quantization_config
+under a sub-config, the same reason _remove_quantization_config recurses.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+LLAMA_CPP = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "llama_cpp.py"
+_SRC = LLAMA_CPP.read_text(encoding = "utf-8")
+
+
+def _load():
+    for node in ast.parse(_SRC).body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_find_bitsandbytes_quantization":
+            ns = {}
+            exec(ast.get_source_segment(_SRC, node), ns)
+            return ns[node.name]
+    raise AssertionError("_find_bitsandbytes_quantization not found")
+
+
+find = _load()
+
+
+def test_top_level_bitsandbytes_is_found():
+    cfg = {"quantization_config": {"quant_method": "bitsandbytes",
+                                   "load_in_4bit": True}}
+    assert find(cfg) == "config.json"
+
+
+def test_nested_text_config_is_found():
+    # VLMs keep it under a sub-config.
+    cfg = {"text_config": {"quantization_config": {"quant_method": "bitsandbytes"}}}
+    assert find(cfg) == "config.json['text_config']"
+
+
+def test_deeply_nested_is_found():
+    cfg = {"a": {"b": {"quantization_config": {"quant_method": "bitsandbytes"}}}}
+    assert find(cfg) == "config.json['a']['b']"
+
+
+def test_legacy_config_without_quant_method():
+    # Older checkpoints only carry the bnb flags.
+    assert find({"quantization_config": {"load_in_4bit": True}}) == "config.json"
+    assert find({"quantization_config": {"load_in_8bit": True}}) == "config.json"
+
+
+def test_clean_16bit_config_passes():
+    assert find({"model_type": "llama", "num_hidden_layers": 32}) is None
+
+
+def test_other_quant_methods_are_not_flagged():
+    # fp8 and gptq have their own handling; only bitsandbytes is refused here.
+    for method in ("fp8", "gptq", "awq", "compressed-tensors", "mxfp4"):
+        assert find({"quantization_config": {"quant_method": method}}) is None, method
+
+
+def test_non_dict_inputs_are_safe():
+    assert find(None) is None
+    assert find([1, 2, 3]) is None
+    assert find({"quantization_config": "not-a-dict"}) is None
+    assert find({"text_config": None}) is None
+
+
+def test_guard_is_wired_into_convert_to_gguf():
+    body = _SRC[_SRC.index("def convert_to_gguf("):]
+    assert "_find_bitsandbytes_quantization(config_file)" in body
+    # The whole point is failing fast, so the guard has to come before the
+    # converter subprocess rather than after a multi-GB read.
+    guard = body.index("_find_bitsandbytes_quantization(config_file)")
+    launch = body.index("subprocess.run")
+    assert guard < launch
+
+
+def test_error_message_is_actionable():
+    assert "load_in_4bit = False" in _SRC
+    assert "merged_16bit" in _SRC
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_gguf_bitsandbytes_guard.py
+++ b/tests/test_gguf_bitsandbytes_guard.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Tests the bitsandbytes guard in llama_cpp.convert_to_gguf.
 
 llama.cpp has no bitsandbytes dequantizer, and only raises

--- a/tests/test_gguf_bitsandbytes_guard.py
+++ b/tests/test_gguf_bitsandbytes_guard.py
@@ -16,12 +16,9 @@
 
 """Tests the bitsandbytes guard in llama_cpp.convert_to_gguf.
 
-llama.cpp has no bitsandbytes dequantizer, and only raises
-`NotImplementedError: Quant method is not yet supported: 'bitsandbytes'` after
-reading the entire model, so the guard has to fire before the subprocess.
-
-The detector searches nested dicts because VLMs keep their quantization_config
-under a sub-config, the same reason _remove_quantization_config recurses.
+llama.cpp has no bitsandbytes dequantizer and only refuses after reading the
+entire model, so the guard has to fire before the subprocess. The detector
+recurses because VLMs keep quantization_config under a sub-config.
 """
 
 import ast
@@ -88,8 +85,7 @@ def test_non_dict_inputs_are_safe():
 def test_guard_is_wired_into_convert_to_gguf():
     body = _SRC[_SRC.index("def convert_to_gguf("):]
     assert "_find_bitsandbytes_quantization(config_file)" in body
-    # The whole point is failing fast, so the guard has to come before the
-    # converter subprocess rather than after a multi-GB read.
+    # Failing fast: the guard must precede the converter subprocess.
     guard = body.index("_find_bitsandbytes_quantization(config_file)")
     launch = body.index("subprocess.run")
     assert guard < launch
@@ -97,8 +93,7 @@ def test_guard_is_wired_into_convert_to_gguf():
 
 def test_error_message_is_actionable():
     assert "load_in_4bit = False" in _SRC
-    # An 8bit checkpoint carries the same quant_method and hits the same guard,
-    # so the remediation has to name its flag too.
+    # 8bit hits the same guard, so the remediation must name its flag too.
     assert "load_in_8bit = False" in _SRC
     assert "merged_16bit" in _SRC
 

--- a/tests/test_gguf_oom_temp_file_retry.py
+++ b/tests/test_gguf_oom_temp_file_retry.py
@@ -1,0 +1,156 @@
+"""An OOM-killed GGUF conversion can usually just be retried onto disk.
+
+The converter holds tensors in host RAM. A large model on a free Colab or
+Kaggle VM is taken by the kernel OOM-killer, and subprocess reports only
+
+    Command '[...]' died with <Signals.SIGKILL: 9>
+
+`Gemma3N_(4B)-Audio` dies exactly here, measured: it trains, infers and merges
+cleanly (15.7GB written, 155GB disk free, freed before the conversion) and the
+converter is then killed, on the high-RAM T4 as well as the plain one.
+
+llama.cpp already has the answer. `--use-temp-file` is documented as "helpful
+when running out of memory, process killed". The catch is that it refuses to
+run alongside splitting:
+
+    Error: Cannot use temp file when splitting
+
+and `--split-max-size` is always passed, so the flag has to arrive with the
+split options removed or the retry swaps one hard failure for another.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from unsloth_zoo.llama_cpp import (  # noqa: E402
+    _converter_was_oom_killed,
+    _retry_with_temp_file,
+)
+
+
+# ---- recognising the kill --------------------------------------------------
+
+def test_sigkill_from_the_message():
+    assert _converter_was_oom_killed(
+        RuntimeError("Command '[...]' died with <Signals.SIGKILL: 9>."))
+
+
+@pytest.mark.parametrize("code", [-9, 137])
+def test_sigkill_from_the_returncode(code):
+    class _Called(Exception):
+        returncode = code
+
+    assert _converter_was_oom_killed(_Called())
+
+
+def test_an_ordinary_failure_is_not_a_kill():
+    """A converter that fails for its own reasons must not be run twice."""
+    assert not _converter_was_oom_killed(
+        RuntimeError("NotImplementedError: Unknown tensor audio_tower.x"))
+
+
+def test_a_nonzero_exit_is_not_a_kill():
+    class _Called(Exception):
+        returncode = 1
+
+    assert not _converter_was_oom_killed(_Called())
+
+
+# ---- building the retry ----------------------------------------------------
+
+BASE = ["/usr/bin/python3", "/root/.unsloth/llama.cpp/unsloth_convert_hf_to_gguf.py",
+        "--outfile", "model.F16.gguf", "--outtype", "f16",
+        "--split-max-size", "50G", "/tmp/model_dir"]
+
+
+def test_the_split_option_is_removed():
+    """This is the whole point. llama.cpp exits 1 on the combination, so a
+    retry that kept --split-max-size would fail differently and look like a
+    new bug."""
+    out = _retry_with_temp_file(BASE)
+    assert "--split-max-size" not in out
+    assert "50G" not in out
+
+
+def test_split_max_tensors_is_removed_too():
+    cmd = BASE[:-3] + ["--split-max-tensors", "128", "/tmp/model_dir"]
+    out = _retry_with_temp_file(cmd)
+    assert "--split-max-tensors" not in out and "128" not in out
+
+
+def test_a_valueless_split_flag_does_not_eat_the_next_option():
+    """Defensive: skipping "the token after" would drop an unrelated flag if a
+    split option ever arrives without a value."""
+    cmd = ["/usr/bin/python3", "conv.py", "--split-max-size", "--outtype", "f16",
+           "/tmp/model_dir"]
+    out = _retry_with_temp_file(cmd)
+    assert "--outtype" in out and "f16" in out
+    assert "--split-max-size" not in out
+
+
+def test_the_flag_is_added():
+    assert "--use-temp-file" in _retry_with_temp_file(BASE)
+
+
+def test_the_model_path_stays_last():
+    """It is positional; anything after it is parsed as another positional."""
+    assert _retry_with_temp_file(BASE)[-1] == "/tmp/model_dir"
+
+
+def test_everything_else_survives():
+    out = _retry_with_temp_file(BASE)
+    for token in ("--outfile", "model.F16.gguf", "--outtype", "f16"):
+        assert token in out
+
+
+def test_it_refuses_to_retry_twice():
+    """Without this the loop would re-issue the same command forever on a
+    machine that is simply too small."""
+    once = _retry_with_temp_file(BASE)
+    assert _retry_with_temp_file(once) is None
+
+
+def test_the_result_is_a_new_list():
+    out = _retry_with_temp_file(BASE)
+    assert out is not BASE
+    assert "--split-max-size" in BASE, "the caller's command must not be mutated"
+
+
+# ---- how the run loop uses it ----------------------------------------------
+
+def _loop_src():
+    src = (ROOT / "unsloth_zoo" / "llama_cpp.py").read_text(encoding="utf-8")
+    i = src.index("attempted_temp_file = False")
+    return src[i:src.index("if not required:", i)]
+
+
+def test_the_retry_is_gated_on_a_kill():
+    assert "_converter_was_oom_killed(e)" in _loop_src()
+
+
+def test_the_retry_happens_at_most_once():
+    body = _loop_src()
+    assert "not attempted_temp_file" in body
+    assert "attempted_temp_file = True" in body
+
+
+def test_it_says_what_it_is_doing():
+    """A silent retry that then succeeds hides a real capacity problem, and one
+    that then fails looks like a single inexplicable failure."""
+    body = _loop_src()
+    assert "--use-temp-file" in body and "host RAM" in body
+
+
+def test_the_dependency_repair_retry_is_independent():
+    """Two retries share one loop; one must not consume the other's chance."""
+    body = _loop_src()
+    assert body.index("attempted_repair") < body.index("attempted_temp_file = True")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_gguf_oom_temp_file_retry.py
+++ b/tests/test_gguf_oom_temp_file_retry.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """An OOM-killed GGUF conversion can usually just be retried onto disk.
 
 The converter holds tensors in host RAM. A large model on a free Colab or

--- a/tests/test_gguf_oom_temp_file_retry.py
+++ b/tests/test_gguf_oom_temp_file_retry.py
@@ -29,6 +29,8 @@ sys.path.insert(0, str(ROOT))
 
 from unsloth_zoo.llama_cpp import (  # noqa: E402
     _converter_was_oom_killed,
+    _gguf_output_paths,
+    _remove_gguf_outputs,
     _retry_with_temp_file,
 )
 
@@ -150,6 +152,69 @@ def test_the_dependency_repair_retry_is_independent():
     """Two retries share one loop; one must not consume the other's chance."""
     body = _loop_src()
     assert body.index("attempted_repair") < body.index("attempted_temp_file = True")
+
+
+# ---- clearing what the killed run left behind ------------------------------
+
+def _touch(directory, name, data = b"GGUF"):
+    path = directory / name
+    path.write_bytes(data)
+    return path
+
+
+def test_the_shards_of_a_killed_split_run_are_removed(tmp_path):
+    """GGUFWriter.open_output_file opens every shard with "wb" before a single
+    tensor byte, so a SIGKILL always leaves them. The retry then drops
+    --split-max-size and writes the unsharded name instead, and callers upload
+    every save_directory/*.gguf, so the stubs would ship beside the real file."""
+    out = str(tmp_path / "model.BF16.gguf")
+    shards = [_touch(tmp_path, f"model.BF16-{i:05d}-of-00003.gguf") for i in (1, 2, 3)]
+    _remove_gguf_outputs(out)
+    assert not any(s.exists() for s in shards)
+
+
+def test_a_partial_output_file_is_removed(tmp_path):
+    out = _touch(tmp_path, "model.BF16-mmproj.gguf")
+    _remove_gguf_outputs(str(out))
+    assert not out.exists()
+
+
+def test_unrelated_ggufs_are_left_alone(tmp_path):
+    """Only this run's own name and its shards, never a sibling export."""
+    keep = [_touch(tmp_path, "model.BF16.gguf"),
+            _touch(tmp_path, "other.BF16-00001-of-00002.gguf"),
+            _touch(tmp_path, "model.Q4_K_M.gguf")]
+    _remove_gguf_outputs(str(tmp_path / "model.BF16-mmproj.gguf"))
+    assert all(k.exists() for k in keep)
+
+
+def test_removing_a_missing_output_is_not_an_error(tmp_path):
+    _remove_gguf_outputs(str(tmp_path / "nothing" / "model.gguf"))
+
+
+def test_the_paths_include_the_file_and_its_shards(tmp_path):
+    _touch(tmp_path, "model.BF16-00001-of-00002.gguf")
+    _touch(tmp_path, "model.BF16-00002-of-00002.gguf")
+    got = [Path(p).name for p in _gguf_output_paths(str(tmp_path / "model.BF16.gguf"))]
+    assert got == ["model.BF16.gguf",
+                   "model.BF16-00001-of-00002.gguf",
+                   "model.BF16-00002-of-00002.gguf"]
+
+
+def test_the_retry_clears_the_old_output_first():
+    body = _loop_src()
+    assert body.index("_remove_gguf_outputs(output_file)") < body.index("command = retry")
+
+
+def test_a_failed_projector_is_removed_and_stops_claiming_vlm():
+    """The converter truncates its --outfile at header time, so "a failed
+    optional run wrote no file" was never true: the partial projector, or a good
+    one from an earlier export, sits there and gets uploaded as valid."""
+    src = (ROOT / "unsloth_zoo" / "llama_cpp.py").read_text(encoding="utf-8")
+    i = src.index("if not required:")
+    body = src[i:src.index("if optional_failed:", i)]
+    assert "_remove_gguf_outputs(output_file)" in body
+    assert "is_vlm = False" in body
 
 
 if __name__ == "__main__":

--- a/tests/test_gguf_oom_temp_file_retry.py
+++ b/tests/test_gguf_oom_temp_file_retry.py
@@ -16,23 +16,14 @@
 
 """An OOM-killed GGUF conversion can usually just be retried onto disk.
 
-The converter holds tensors in host RAM. A large model on a free Colab or
-Kaggle VM is taken by the kernel OOM-killer, and subprocess reports only
+The converter holds tensors in host RAM, so a large model on a free Colab or
+Kaggle VM is OOM-killed and subprocess reports only SIGKILL. Measured on
+`Gemma3N_(4B)-Audio`, which trains, infers and merges cleanly with 155GB disk
+free, then dies here.
 
-    Command '[...]' died with <Signals.SIGKILL: 9>
-
-`Gemma3N_(4B)-Audio` dies exactly here, measured: it trains, infers and merges
-cleanly (15.7GB written, 155GB disk free, freed before the conversion) and the
-converter is then killed, on the high-RAM T4 as well as the plain one.
-
-llama.cpp already has the answer. `--use-temp-file` is documented as "helpful
-when running out of memory, process killed". The catch is that it refuses to
-run alongside splitting:
-
-    Error: Cannot use temp file when splitting
-
-and `--split-max-size` is always passed, so the flag has to arrive with the
-split options removed or the retry swaps one hard failure for another.
+llama.cpp's `--use-temp-file` is the documented fix, but it refuses to run
+alongside splitting ("Cannot use temp file when splitting") and
+`--split-max-size` is always passed, so the retry must drop the split options.
 """
 
 import sys
@@ -87,9 +78,8 @@ BASE = ["/usr/bin/python3", "/root/.unsloth/llama.cpp/unsloth_convert_hf_to_gguf
 
 
 def test_the_split_option_is_removed():
-    """This is the whole point. llama.cpp exits 1 on the combination, so a
-    retry that kept --split-max-size would fail differently and look like a
-    new bug."""
+    """llama.cpp exits 1 on the combination, so keeping --split-max-size would
+    only swap one failure for another."""
     out = _retry_with_temp_file(BASE)
     assert "--split-max-size" not in out
     assert "50G" not in out
@@ -102,8 +92,7 @@ def test_split_max_tensors_is_removed_too():
 
 
 def test_a_valueless_split_flag_does_not_eat_the_next_option():
-    """Defensive: skipping "the token after" would drop an unrelated flag if a
-    split option ever arrives without a value."""
+    """Defensive: skipping "the token after" would drop an unrelated flag."""
     cmd = ["/usr/bin/python3", "conv.py", "--split-max-size", "--outtype", "f16",
            "/tmp/model_dir"]
     out = _retry_with_temp_file(cmd)
@@ -127,8 +116,7 @@ def test_everything_else_survives():
 
 
 def test_it_refuses_to_retry_twice():
-    """Without this the loop would re-issue the same command forever on a
-    machine that is simply too small."""
+    """Otherwise the loop re-issues the same command forever on a small machine."""
     once = _retry_with_temp_file(BASE)
     assert _retry_with_temp_file(once) is None
 
@@ -158,8 +146,7 @@ def test_the_retry_happens_at_most_once():
 
 
 def test_it_says_what_it_is_doing():
-    """A silent retry that then succeeds hides a real capacity problem, and one
-    that then fails looks like a single inexplicable failure."""
+    """A silent retry hides a real capacity problem."""
     body = _loop_src()
     assert "--use-temp-file" in body and "host RAM" in body
 
@@ -179,10 +166,8 @@ def _touch(directory, name, data = b"GGUF"):
 
 
 def test_the_shards_of_a_killed_split_run_are_removed(tmp_path):
-    """GGUFWriter.open_output_file opens every shard with "wb" before a single
-    tensor byte, so a SIGKILL always leaves them. The retry then drops
-    --split-max-size and writes the unsharded name instead, and callers upload
-    every save_directory/*.gguf, so the stubs would ship beside the real file."""
+    """The writer opens every shard with "wb" before any tensor byte, so a
+    SIGKILL leaves stubs that would ship beside the retry's unsharded file."""
     out = str(tmp_path / "model.BF16.gguf")
     shards = [_touch(tmp_path, f"model.BF16-{i:05d}-of-00003.gguf") for i in (1, 2, 3)]
     _remove_gguf_outputs(out)
@@ -205,12 +190,8 @@ def test_unrelated_ggufs_are_left_alone(tmp_path):
 
 
 def test_a_neighbour_whose_name_ends_with_ours_is_left_alone(tmp_path):
-    """The shard pattern is matched against the whole filename.
-
-    These paths are os.remove'd, so an unanchored match would take somebody
-    else's export: "old-model.BF16-00001-of-00002" ends with the shard name
-    that cleaning "model.BF16" looks for.
-    """
+    """Matched against the whole filename: these are os.remove'd, so an
+    unanchored match would take "old-model.BF16-00001-of-00002" too."""
     keep = [_touch(tmp_path, "old-model.BF16-00001-of-00002.gguf"),
             _touch(tmp_path, "my-model.BF16-00002-of-00002.gguf")]
     mine = _touch(tmp_path, "model.BF16-00001-of-00002.gguf")
@@ -238,9 +219,8 @@ def test_the_retry_clears_the_old_output_first():
 
 
 def test_a_failed_projector_is_removed_and_stops_claiming_vlm():
-    """The converter truncates its --outfile at header time, so "a failed
-    optional run wrote no file" was never true: the partial projector, or a good
-    one from an earlier export, sits there and gets uploaded as valid."""
+    """The converter truncates its --outfile at header time, so the failed run
+    leaves a partial projector that would be uploaded as valid."""
     src = (ROOT / "unsloth_zoo" / "llama_cpp.py").read_text(encoding="utf-8")
     i = src.index("if not required:")
     body = src[i:src.index("if optional_failed:", i)]

--- a/tests/test_gguf_oom_temp_file_retry.py
+++ b/tests/test_gguf_oom_temp_file_retry.py
@@ -204,6 +204,21 @@ def test_unrelated_ggufs_are_left_alone(tmp_path):
     assert all(k.exists() for k in keep)
 
 
+def test_a_neighbour_whose_name_ends_with_ours_is_left_alone(tmp_path):
+    """The shard pattern is matched against the whole filename.
+
+    These paths are os.remove'd, so an unanchored match would take somebody
+    else's export: "old-model.BF16-00001-of-00002" ends with the shard name
+    that cleaning "model.BF16" looks for.
+    """
+    keep = [_touch(tmp_path, "old-model.BF16-00001-of-00002.gguf"),
+            _touch(tmp_path, "my-model.BF16-00002-of-00002.gguf")]
+    mine = _touch(tmp_path, "model.BF16-00001-of-00002.gguf")
+    _remove_gguf_outputs(str(tmp_path / "model.BF16.gguf"))
+    assert all(k.exists() for k in keep)
+    assert not mine.exists()
+
+
 def test_removing_a_missing_output_is_not_an_error(tmp_path):
     _remove_gguf_outputs(str(tmp_path / "nothing" / "model.gguf"))
 

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2346,6 +2346,48 @@ def _find_bitsandbytes_quantization(config, _path = "config.json"):
     return None
 
 
+def _converter_was_oom_killed(exc):
+    """Did the kernel kill the converter, rather than it failing on its own?
+
+    The converter holds tensors in host RAM, so a large model on a small VM is
+    OOM-killed and subprocess reports only SIGKILL, naming no resource.
+    """
+    if getattr(exc, "returncode", None) in (-9, 137):
+        return True
+    return "sigkill" in f"{exc}".lower()
+
+
+def _retry_with_temp_file(command):
+    """The same command spooling tensors to disk instead of holding them in RAM.
+
+    `--use-temp-file` is llama.cpp's own answer to this ("helpful when running
+    out of memory, process killed"), but it refuses to run alongside splitting:
+
+        Error: Cannot use temp file when splitting
+
+    and `--split-max-size` is always passed, so the flag has to arrive with
+    splitting disabled. Returns None when the command already has it, so the
+    retry cannot loop.
+    """
+    if "--use-temp-file" in command:
+        return None
+    out = []
+    drop_value = False
+    for token in command:
+        if drop_value:
+            drop_value = False
+            # Only its value. A flag here means the previous one had none, and
+            # eating it would silently drop an unrelated option.
+            if not str(token).startswith("--"):
+                continue
+        if token in ("--split-max-size", "--split-max-tensors"):
+            drop_value = True
+            continue
+        out.append(token)
+    # The trailing model path must stay last.
+    return out[:-1] + ["--use-temp-file"] + out[-1:]
+
+
 def convert_to_gguf(
     model_name,
     input_folder,
@@ -2564,6 +2606,7 @@ def convert_to_gguf(
         # Run the converter; self-heal and retry once if the env (not the model)
         # is broken. No cost on the happy path.
         attempted_repair = False
+        attempted_temp_file = False
         repair_note = ""
         optional_failed = False
         while True:
@@ -2597,6 +2640,23 @@ def convert_to_gguf(
                         repair_note = f"\n--- dependency reinstall failed ---\n{(repair.stdout or '').strip()}"
                     except Exception as repair_error:
                         repair_note = f"\n--- dependency reinstall failed ---\n{repair_error}"
+
+                # OOM-killed: retry once spooling to disk. Disk is the one
+                # resource these machines have (155GB free on the Colab VM
+                # where Gemma3N_(4B)-Audio dies), and this is what the flag is
+                # for. Only for a kill, so a converter that failed on its own
+                # is not quietly run twice.
+                if not attempted_temp_file and _converter_was_oom_killed(e):
+                    retry = _retry_with_temp_file(command)
+                    if retry is not None:
+                        attempted_temp_file = True
+                        print(
+                            "Unsloth: The GGUF converter ran out of host RAM "
+                            "and was killed. Retrying with --use-temp-file, "
+                            "which spools tensors to disk instead."
+                        )
+                        command = retry
+                        continue
 
                 if print_output and getattr(e, 'stdout', None):
                     print(e.stdout)

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2321,10 +2321,7 @@ def _has_mtp_weight_tensors(input_folder, num_layers):
 def _find_bitsandbytes_quantization(config, _path = "config.json"):
     """Where a bitsandbytes `quantization_config` sits, or None.
 
-    Searched recursively because VLMs keep theirs under a sub-config
-    (`text_config`, `vision_config`), which is the same reason
-    `_remove_quantization_config` in saving_utils walks nested dicts rather
-    than only the top level.
+    Recursive: VLMs keep theirs under a sub-config like `text_config`.
     """
     if not isinstance(config, dict):
         return None
@@ -2347,11 +2344,7 @@ def _find_bitsandbytes_quantization(config, _path = "config.json"):
 
 
 def _converter_was_oom_killed(exc):
-    """Did the kernel kill the converter, rather than it failing on its own?
-
-    The converter holds tensors in host RAM, so a large model on a small VM is
-    OOM-killed and subprocess reports only SIGKILL, naming no resource.
-    """
+    """Was the converter OOM-killed (SIGKILL), rather than failing on its own?"""
     if getattr(exc, "returncode", None) in (-9, 137):
         return True
     return "sigkill" in f"{exc}".lower()
@@ -2360,14 +2353,9 @@ def _converter_was_oom_killed(exc):
 def _retry_with_temp_file(command):
     """The same command spooling tensors to disk instead of holding them in RAM.
 
-    `--use-temp-file` is llama.cpp's own answer to this ("helpful when running
-    out of memory, process killed"), but it refuses to run alongside splitting:
-
-        Error: Cannot use temp file when splitting
-
-    and `--split-max-size` is always passed, so the flag has to arrive with
-    splitting disabled. Returns None when the command already has it, so the
-    retry cannot loop.
+    llama.cpp refuses `--use-temp-file` alongside splitting ("Cannot use temp
+    file when splitting"), so the split options are dropped. None when the
+    command already has the flag, so the retry cannot loop.
     """
     if "--use-temp-file" in command:
         return None
@@ -2376,8 +2364,7 @@ def _retry_with_temp_file(command):
     for token in command:
         if drop_value:
             drop_value = False
-            # Only its value. A flag here means the previous one had none, and
-            # eating it would silently drop an unrelated option.
+            # Only its value: a flag here means the previous one had none.
             if not str(token).startswith("--"):
                 continue
         if token in ("--split-max-size", "--split-max-tensors"):
@@ -2397,9 +2384,8 @@ def _gguf_output_paths(output_file):
     parent_dir = os.path.dirname(output_file) or '.'
     paths = [output_file]
     try:
-        # fullmatch, not search: these paths get os.remove'd, and an unanchored
-        # match would delete a neighbour whose name merely ends with ours
-        # (cleaning "model.BF16" would take "old-model.BF16-00001-of-00002").
+        # fullmatch, not search: these get os.remove'd, and an unanchored match
+        # would take a neighbour like "old-model.BF16-00001-of-00002".
         paths += sorted(os.path.join(parent_dir, f) for f in os.listdir(parent_dir)
                         if shard_pattern.fullmatch(f))
     except OSError:
@@ -2410,11 +2396,9 @@ def _gguf_output_paths(output_file):
 def _remove_gguf_outputs(output_file):
     """Delete what a failed or abandoned conversion left at `output_file`.
 
-    GGUFWriter.open_output_file opens every shard with "wb" before a single
-    tensor byte is written, and neither the converter nor the writer cleans up
-    on failure, so a nonzero exit or a SIGKILL always leaves truncated files
-    behind. Callers enumerate save_directory.glob("*.gguf") and upload every
-    match, so a leftover is reported and published as a valid artifact.
+    The writer opens every shard with "wb" before any tensor byte and cleans up
+    nothing on failure, and callers upload every save_directory/*.gguf, so a
+    truncated leftover gets published as a valid artifact.
     """
     for path in _gguf_output_paths(output_file):
         try:
@@ -2457,13 +2441,9 @@ def convert_to_gguf(
 
     _bnb_where = _find_bitsandbytes_quantization(config_file)
     if _bnb_where is not None:
-        # llama.cpp has no bitsandbytes dequantizer, and its converter only
-        # raises `NotImplementedError: Quant method is not yet supported:
-        # 'bitsandbytes'` after reading the whole model, so fail here instead
-        # of after a multi-GB download and a long conversion.
-        # Names both flags: the guard fires on 8bit checkpoints too (they carry
-        # the same quant_method), and naming only the 4bit one would send an
-        # 8bit user back to an identical failure.
+        # llama.cpp has no bitsandbytes dequantizer and only refuses after
+        # reading the whole model, so fail here instead of after a multi-GB
+        # download. Both flags are named: 8bit checkpoints hit this too.
         raise RuntimeError(
             f"Unsloth: `{input_folder}` still holds bitsandbytes quantized "
             f"weights (`quantization_config` at {_bnb_where}), and llama.cpp "
@@ -2575,8 +2555,7 @@ def convert_to_gguf(
             "--mmproj"         : "",
             "--split-max-size" : max_shard_size,
         }
-        # Optional: the text GGUF above is already written, so a projector
-        # failure must not discard it (see the run loop's non-fatal handler).
+        # Optional: a projector failure must not discard the text GGUF above.
         runs_to_do.append((mmproj_args, mmproj_output, "vision projector", False))
 
     else:
@@ -2680,11 +2659,9 @@ def convert_to_gguf(
                     except Exception as repair_error:
                         repair_note = f"\n--- dependency reinstall failed ---\n{repair_error}"
 
-                # OOM-killed: retry once spooling to disk. Disk is the one
-                # resource these machines have (155GB free on the Colab VM
-                # where Gemma3N_(4B)-Audio dies), and this is what the flag is
-                # for. Only for a kill, so a converter that failed on its own
-                # is not quietly run twice.
+                # OOM-killed: retry once spooling to disk, the one resource
+                # these machines have. Only for a kill, so a converter that
+                # failed on its own is not quietly run twice.
                 if not attempted_temp_file and _converter_was_oom_killed(e):
                     retry = _retry_with_temp_file(command)
                     if retry is not None:
@@ -2694,10 +2671,9 @@ def convert_to_gguf(
                             "and was killed. Retrying with --use-temp-file, "
                             "which spools tensors to disk instead."
                         )
-                        # The retry drops --split-max-size, so it writes
-                        # model.gguf while the killed split run already created
-                        # every model-00001-of-0000N.gguf. Left in place they
-                        # sit beside the good file and get uploaded with it.
+                        # The retry drops --split-max-size, so the killed
+                        # run's shards would linger beside the good file and
+                        # be uploaded with it.
                         _remove_gguf_outputs(output_file)
                         command = retry
                         continue
@@ -2715,10 +2691,8 @@ def convert_to_gguf(
                     text = text.strip()
                     if text: details += f"\n--- converter {label} ---\n{text}"
                 if not required:
-                    # Degrade like the existing "Converting as text-only model"
-                    # path, which only covers architectures missing from
-                    # supported_vision_archs. This covers the ones that ARE
-                    # listed but whose projector conversion still fails.
+                    # Degrade like the "Converting as text-only model" path,
+                    # but for listed archs whose projector conversion fails.
                     reason = ""
                     for line in reversed((details or "").splitlines()):
                         line = line.strip()
@@ -2726,11 +2700,8 @@ def convert_to_gguf(
                             reason = line
                             break
                     # The converter truncates its --outfile at header time,
-                    # before any tensor, so the failed run either left a partial
-                    # projector here or destroyed a good one from an earlier
-                    # export. Callers upload every save_directory/*.gguf, so
-                    # leaving it publishes a broken projector as if it were
-                    # valid, paired with the new text model.
+                    # so the failed run leaves a partial projector that callers
+                    # would upload as if it were valid.
                     _remove_gguf_outputs(output_file)
                     is_vlm = False
                     optional_failed = True
@@ -2743,8 +2714,7 @@ def convert_to_gguf(
                     break
                 raise RuntimeError(f"Unsloth: Failed to convert {description} to GGUF with command `{cmd}`: {e}{details}{repair_note}")
 
-        # The failed optional run's partial output was just removed, so
-        # validating it would raise "output file not created" for nothing.
+        # Its partial output was just removed, so validation would fail for nothing.
         if optional_failed:
             continue
 

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2388,6 +2388,38 @@ def _retry_with_temp_file(command):
     return out[:-1] + ["--use-temp-file"] + out[-1:]
 
 
+def _gguf_output_paths(output_file):
+    """`output_file` plus any shards llama.cpp names after it."""
+    basename_without_gguf = os.path.splitext(output_file)[0]
+    shard_pattern = re.compile(
+        re.escape(os.path.basename(basename_without_gguf)) + r'-(\d{5})-of-(\d{5})\.gguf$'
+    )
+    parent_dir = os.path.dirname(output_file) or '.'
+    paths = [output_file]
+    try:
+        paths += sorted(os.path.join(parent_dir, f) for f in os.listdir(parent_dir)
+                        if shard_pattern.search(f))
+    except OSError:
+        pass
+    return paths
+
+
+def _remove_gguf_outputs(output_file):
+    """Delete what a failed or abandoned conversion left at `output_file`.
+
+    GGUFWriter.open_output_file opens every shard with "wb" before a single
+    tensor byte is written, and neither the converter nor the writer cleans up
+    on failure, so a nonzero exit or a SIGKILL always leaves truncated files
+    behind. Callers enumerate save_directory.glob("*.gguf") and upload every
+    match, so a leftover is reported and published as a valid artifact.
+    """
+    for path in _gguf_output_paths(output_file):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
 def convert_to_gguf(
     model_name,
     input_folder,
@@ -2655,6 +2687,11 @@ def convert_to_gguf(
                             "and was killed. Retrying with --use-temp-file, "
                             "which spools tensors to disk instead."
                         )
+                        # The retry drops --split-max-size, so it writes
+                        # model.gguf while the killed split run already created
+                        # every model-00001-of-0000N.gguf. Left in place they
+                        # sit beside the good file and get uploaded with it.
+                        _remove_gguf_outputs(output_file)
                         command = retry
                         continue
 
@@ -2681,6 +2718,14 @@ def convert_to_gguf(
                         if line and ("Error" in line or "Exception" in line):
                             reason = line
                             break
+                    # The converter truncates its --outfile at header time,
+                    # before any tensor, so the failed run either left a partial
+                    # projector here or destroyed a good one from an earlier
+                    # export. Callers upload every save_directory/*.gguf, so
+                    # leaving it publishes a broken projector as if it were
+                    # valid, paired with the new text model.
+                    _remove_gguf_outputs(output_file)
+                    is_vlm = False
                     optional_failed = True
                     print(
                         f"Unsloth: Could not convert the {description} to GGUF "
@@ -2691,8 +2736,8 @@ def convert_to_gguf(
                     break
                 raise RuntimeError(f"Unsloth: Failed to convert {description} to GGUF with command `{cmd}`: {e}{details}{repair_note}")
 
-        # A failed optional run wrote no file, so validating it would raise
-        # "output file not created" and defeat the point.
+        # The failed optional run's partial output was just removed, so
+        # validating it would raise "output file not created" for nothing.
         if optional_failed:
             continue
 

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2392,13 +2392,16 @@ def _gguf_output_paths(output_file):
     """`output_file` plus any shards llama.cpp names after it."""
     basename_without_gguf = os.path.splitext(output_file)[0]
     shard_pattern = re.compile(
-        re.escape(os.path.basename(basename_without_gguf)) + r'-(\d{5})-of-(\d{5})\.gguf$'
+        re.escape(os.path.basename(basename_without_gguf)) + r'-(\d{5})-of-(\d{5})\.gguf'
     )
     parent_dir = os.path.dirname(output_file) or '.'
     paths = [output_file]
     try:
+        # fullmatch, not search: these paths get os.remove'd, and an unanchored
+        # match would delete a neighbour whose name merely ends with ours
+        # (cleaning "model.BF16" would take "old-model.BF16-00001-of-00002").
         paths += sorted(os.path.join(parent_dir, f) for f in os.listdir(parent_dir)
-                        if shard_pattern.search(f))
+                        if shard_pattern.fullmatch(f))
     except OSError:
         pass
     return paths
@@ -2458,15 +2461,19 @@ def convert_to_gguf(
         # raises `NotImplementedError: Quant method is not yet supported:
         # 'bitsandbytes'` after reading the whole model, so fail here instead
         # of after a multi-GB download and a long conversion.
+        # Names both flags: the guard fires on 8bit checkpoints too (they carry
+        # the same quant_method), and naming only the 4bit one would send an
+        # 8bit user back to an identical failure.
         raise RuntimeError(
-            f"Unsloth: `{input_folder}` still holds bitsandbytes 4bit weights "
-            f"(`quantization_config` at {_bnb_where}), and llama.cpp cannot "
-            f"convert those to GGUF.\n"
+            f"Unsloth: `{input_folder}` still holds bitsandbytes quantized "
+            f"weights (`quantization_config` at {_bnb_where}), and llama.cpp "
+            f"cannot convert those to GGUF.\n"
             f"GGUF export needs dequantized 16bit weights. Either load the "
-            f"model with `load_in_4bit = False` before saving, or merge a LoRA "
-            f"adapter with `save_method = \"merged_16bit\"`, which downloads "
-            f"the original 16bit weights. Saving a 4bit model that has no "
-            f"adapter does not dequantize it."
+            f"model with `load_in_4bit = False` and `load_in_8bit = False` "
+            f"before saving, or merge a LoRA adapter with "
+            f"`save_method = \"merged_16bit\"`, which downloads the original "
+            f"16bit weights. Saving a quantized model that has no adapter does "
+            f"not dequantize it."
         )
 
     # The converter sizes block_count from the config, so keep `mtp_num_hidden_layers`

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2318,6 +2318,34 @@ def _has_mtp_weight_tensors(input_folder, num_layers):
     return False
 
 
+def _find_bitsandbytes_quantization(config, _path = "config.json"):
+    """Where a bitsandbytes `quantization_config` sits, or None.
+
+    Searched recursively because VLMs keep theirs under a sub-config
+    (`text_config`, `vision_config`), which is the same reason
+    `_remove_quantization_config` in saving_utils walks nested dicts rather
+    than only the top level.
+    """
+    if not isinstance(config, dict):
+        return None
+    quant = config.get("quantization_config")
+    if isinstance(quant, dict):
+        method = quant.get("quant_method")
+        # Older checkpoints omit quant_method and only carry the bnb flags.
+        if method == "bitsandbytes" or (
+            method is None
+            and ("load_in_4bit" in quant or "load_in_8bit" in quant)
+        ):
+            return _path
+    for key, value in config.items():
+        if key == "quantization_config" or not isinstance(value, dict):
+            continue
+        found = _find_bitsandbytes_quantization(value, f"{_path}[{key!r}]")
+        if found is not None:
+            return found
+    return None
+
+
 def convert_to_gguf(
     model_name,
     input_folder,
@@ -2349,6 +2377,23 @@ def convert_to_gguf(
     # Load config.json
     with open(config_path, "r", encoding = "utf-8") as f:
         config_file = json.load(f)
+
+    _bnb_where = _find_bitsandbytes_quantization(config_file)
+    if _bnb_where is not None:
+        # llama.cpp has no bitsandbytes dequantizer, and its converter only
+        # raises `NotImplementedError: Quant method is not yet supported:
+        # 'bitsandbytes'` after reading the whole model, so fail here instead
+        # of after a multi-GB download and a long conversion.
+        raise RuntimeError(
+            f"Unsloth: `{input_folder}` still holds bitsandbytes 4bit weights "
+            f"(`quantization_config` at {_bnb_where}), and llama.cpp cannot "
+            f"convert those to GGUF.\n"
+            f"GGUF export needs dequantized 16bit weights. Either load the "
+            f"model with `load_in_4bit = False` before saving, or merge a LoRA "
+            f"adapter with `save_method = \"merged_16bit\"`, which downloads "
+            f"the original 16bit weights. Saving a 4bit model that has no "
+            f"adapter does not dequantize it."
+        )
 
     # The converter sizes block_count from the config, so keep `mtp_num_hidden_layers`
     # only when the weights still carry the MTP layer (else it crashes on the extra
@@ -2440,7 +2485,7 @@ def convert_to_gguf(
                 "--outtype"        : quantization_type,
                 "--split-max-size" : max_shard_size,
             }
-        runs_to_do.append((text_args, text_output, "text model"))
+        runs_to_do.append((text_args, text_output, "text model", True))
 
         # Vision projector conversion
         mmproj_args = {
@@ -2449,7 +2494,9 @@ def convert_to_gguf(
             "--mmproj"         : "",
             "--split-max-size" : max_shard_size,
         }
-        runs_to_do.append((mmproj_args, mmproj_output, "vision projector"))
+        # Optional: the text GGUF above is already written, so a projector
+        # failure must not discard it (see the run loop's non-fatal handler).
+        runs_to_do.append((mmproj_args, mmproj_output, "vision projector", False))
 
     else:
         if is_gpt_oss:
@@ -2475,7 +2522,7 @@ def convert_to_gguf(
                 "--outtype"        : quantization_type,
                 "--split-max-size" : max_shard_size,
             }
-        runs_to_do.append((args, final_output, "model"))
+        runs_to_do.append((args, final_output, "model", True))
 
     # A bare --outfile lands in the process CWD. On Windows that CWD is often not writable
     # (app launched from a protected dir), so the final write failed with PermissionError
@@ -2493,7 +2540,7 @@ def convert_to_gguf(
     _cwd_writable = _dir_is_writable(os.getcwd())
 
     # Execute conversions
-    for args, output_file, description in runs_to_do:
+    for args, output_file, description, required in runs_to_do:
         # Redirect only a bare filename under an unwritable CWD. Absolute paths and
         # relative paths with a directory are the caller's choice; input_folder is probed
         # too since it may be a read-only model source.
@@ -2518,6 +2565,7 @@ def convert_to_gguf(
         # is broken. No cost on the happy path.
         attempted_repair = False
         repair_note = ""
+        optional_failed = False
         while True:
             try:
                 # encoding/errors pinned so non-UTF8 output never crashes decoding.
@@ -2562,7 +2610,31 @@ def convert_to_gguf(
                     text = stream if isinstance(stream, str) else stream.decode("utf-8", errors="replace")
                     text = text.strip()
                     if text: details += f"\n--- converter {label} ---\n{text}"
+                if not required:
+                    # Degrade like the existing "Converting as text-only model"
+                    # path, which only covers architectures missing from
+                    # supported_vision_archs. This covers the ones that ARE
+                    # listed but whose projector conversion still fails.
+                    reason = ""
+                    for line in reversed((details or "").splitlines()):
+                        line = line.strip()
+                        if line and ("Error" in line or "Exception" in line):
+                            reason = line
+                            break
+                    optional_failed = True
+                    print(
+                        f"Unsloth: Could not convert the {description} to GGUF "
+                        f"({reason or e}). The text model was converted "
+                        f"successfully and is usable; only multimodal "
+                        f"(image/audio) input is unavailable in this GGUF."
+                    )
+                    break
                 raise RuntimeError(f"Unsloth: Failed to convert {description} to GGUF with command `{cmd}`: {e}{details}{repair_note}")
+
+        # A failed optional run wrote no file, so validating it would raise
+        # "output file not created" and defeat the point.
+        if optional_failed:
+            continue
 
         # Simple validation using native Python - check for main file or sharded files
         if os.path.exists(output_file):

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2938,6 +2938,17 @@ def merge_and_overwrite_lora(
                 f"`{save_directory}`. Use `save_method=\"forced_merged_4bit\"` instead."
             )
         if final_model_name is None:
+            # A repo that exists but ships no safetensors also lands here, and
+            # "the name is wrong" would be actively misleading for it.
+            _bin_only = _hub_repo_weights_without_safetensors(model_name, token)
+            if _bin_only is not None:
+                raise RuntimeError(
+                    f"Unsloth: Model {model_name} exists on Hugging Face but ships no "
+                    f"safetensors weights (found {', '.join(sorted(_bin_only)[:4])}), and "
+                    f"the {save_method} merge reads safetensors only. Nothing was written "
+                    f"to `{save_directory}`. Convert the base to safetensors, or point at "
+                    f"a sibling repo that already publishes them."
+                )
             # Never return None: `save_pretrained_merged` would look like it succeeded
             # while creating no output directory, signalled only by a UserWarning.
             raise RuntimeError(
@@ -4742,6 +4753,30 @@ def check_hf_model_exists(model_name, token=None):
     except Exception as e:
         raise _hub_unreachable_error(model_name, e) from e
 pass
+
+def _hub_repo_weights_without_safetensors(model_name, token = None):
+    """Weight files in a repo that exists but ships no safetensors, else None.
+
+    `check_hf_model_exists` answers False both for a repo that is not there and
+    for one that is there in a format the merge cannot read, so callers blame
+    the name for repos like `unsloth/bge-m3`, which is public and ships only
+    `pytorch_model.bin`.
+
+    Diagnosis only: which repos resolve is unchanged, and anything unanswerable
+    returns None so the caller's original message stands.
+    """
+    if not _is_hub_repo_id(model_name): return None
+    try:
+        file_list = HfFileSystem(token = token).ls(model_name, detail = True)
+    except Exception:
+        # Absent, gated, or unreachable: all already described by the caller.
+        return None
+    names = [os.path.basename(x["name"]) for x in file_list]
+    if any(n.endswith(".safetensors") for n in names): return None
+    weights = [n for n in names
+               if n.endswith((".bin", ".pt", ".pth", ".h5", ".msgpack", ".gguf"))]
+    return weights or None
+
 
 def check_local_model_exists(model_path):
     """

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2938,8 +2938,7 @@ def merge_and_overwrite_lora(
                 f"`{save_directory}`. Use `save_method=\"forced_merged_4bit\"` instead."
             )
         if final_model_name is None:
-            # A repo that exists but ships no safetensors also lands here, and
-            # "the name is wrong" would be actively misleading for it.
+            # A repo that exists but ships no safetensors also lands here.
             _bin_only = _hub_repo_weights_without_safetensors(model_name, token)
             if _bin_only is not None:
                 raise RuntimeError(
@@ -4757,13 +4756,10 @@ pass
 def _hub_repo_weights_without_safetensors(model_name, token = None):
     """Weight files in a repo that exists but ships no safetensors, else None.
 
-    `check_hf_model_exists` answers False both for a repo that is not there and
-    for one that is there in a format the merge cannot read, so callers blame
-    the name for repos like `unsloth/bge-m3`, which is public and ships only
-    `pytorch_model.bin`.
-
-    Diagnosis only: which repos resolve is unchanged, and anything unanswerable
-    returns None so the caller's original message stands.
+    `check_hf_model_exists` answers False both for a missing repo and for one
+    in a format the merge cannot read, like `unsloth/bge-m3`, so callers blame
+    the name. Diagnosis only: None whenever unanswerable, so the caller's
+    original message stands.
     """
     if not _is_hub_repo_id(model_name): return None
     try:


### PR DESCRIPTION
Three export failures that each reported something other than what went wrong.

### A vision projector failure threw away a working text GGUF

`convert_to_gguf` queues two runs for a vision model, the text model and the `mmproj` projector. Both were treated as required, so a projector failure raised and discarded the text GGUF that had already been written and was perfectly usable.

The run list now carries a `required` flag. An optional run that fails prints what it could not do and continues, degrading the same way the existing "Converting as text-only model" path already does for architectures missing from `supported_vision_archs`. This covers the ones that *are* listed but whose projector conversion still fails. The validation step is skipped for a failed optional run, since it wrote no file and would otherwise raise "output file not created" and defeat the point.

### bitsandbytes weights reached llama.cpp before being refused

llama.cpp has no bitsandbytes dequantizer, and its converter only raises

```
NotImplementedError: Quant method is not yet supported: 'bitsandbytes'
```

*after* reading the whole model. On Kaggle that is a multi-GB download and a long conversion before the refusal.

The config is now checked up front. The search is recursive because VLMs keep `quantization_config` under a sub-config (`text_config`, `vision_config`), which is the same reason `_remove_quantization_config` in `saving_utils` walks nested dicts. Older checkpoints that omit `quant_method` and carry only the bnb flags are matched too.

The message says which config the flag sits in and what to do: load with `load_in_4bit = False` before saving, or merge with `save_method = "merged_16bit"`, which downloads the original 16bit weights. It also says the thing that is easy to get wrong, that saving a 4bit model with no adapter does not dequantize it.

### A bin-only base was reported as a wrong model name

`check_hf_model_exists` answers `False` both for a repo that is not there and for one that is there in a format the merge cannot read, so the caller blamed the name. `unsloth/bge-m3` is public and ships only `pytorch_model.bin`, and the user was told their model name was wrong.

`_hub_repo_weights_without_safetensors` distinguishes the two and names the files it actually found. Diagnosis only: which repos resolve is unchanged, and anything unanswerable returns `None` so the caller's original message stands.

### Tests

**342 passed, 1 skipped, 0 failed.** That is the two new files plus every existing suite touching `llama_cpp` / GGUF conversion / `saving_utils`: the converter patcher, MTP reconcile, self-heal, bundle converter, loader, prebuilt, Q2_K_L quantize, LoRA remap count, quant-aware merge, hub-unreachable merge and local 4bit offline resolution. The single skip is `test_live_bge_m3`, gated behind `--live` because it hits the network.

Nothing downloads a model or builds llama.cpp. The new tests write nothing to disk: the bin-only one fakes `HfFileSystem`, the guard one extracts the function from source via AST.
