### PR TITLE
Keep a compiled forward alive when Dynamo gives up on it

### DIFF
--- a/tests/test_disabled_hook_graph_break.py
+++ b/tests/test_disabled_hook_graph_break.py
@@ -1,0 +1,209 @@
+"""Two Unsloth fixes collide; the run should not die of it.
+
+One wraps the gradient-checkpointing `requires_grad` hooks in
+`torch.compiler.disable`, because Dynamo cannot trace
+`Tensor.requires_grad_()`. The other compiles a forward with
+`fullgraph = True`. The disabled hook is then invoked from inside that
+fullgraph region and Dynamo refuses:
+
+    Unsupported: Skip calling `torch.compiler.disable()`d function
+
+Neither fix is wrong on its own and a user can do nothing about the
+combination, so it should cost speed rather than the run.
+
+The hazard guarded against here is over-catching. The fallback takes exactly
+this one extra case, matched on the disable signature, and most of the tests
+below are about the graph breaks that must STILL raise.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from unsloth_zoo.temporary_patches import utils as U  # noqa: E402
+
+DISABLE_MSG = (
+    "Skip calling `torch.compiler.disable()`d function\n"
+    "  Explanation: Skip calling function "
+    "`<function requires_grad_for_gradient_checkpointing.<locals>."
+    "requires_grad_pre_hook at 0x7f00>` since it was wrapped with "
+    "`torch.compiler.disable` (reason: None)\n"
+    "  Hint: Remove the `torch.compiler.disable` call"
+)
+
+
+# ---- the matcher ----------------------------------------------------------
+
+def test_it_recognises_our_own_disabled_hook():
+    assert U._is_our_own_disabled_hook(RuntimeError(DISABLE_MSG))
+
+
+def test_an_ordinary_graph_break_is_not_matched():
+    """The whole point. These must keep raising."""
+    for text in (
+        "Unsupported: call_function BuiltinVariable(print)",
+        "Unsupported Tensor.requires_grad_() call",
+        "Dynamo failed to trace a data-dependent branch",
+        "graph break in user code",
+    ):
+        assert not U._is_our_own_disabled_hook(RuntimeError(text)), text
+
+
+def test_a_mention_of_disable_alone_is_not_enough():
+    """Both halves of the signature are required, so a message that merely
+    talks about torch.compiler.disable does not qualify."""
+    assert not U._is_our_own_disabled_hook(
+        RuntimeError("consider using torch.compiler.disable here"))
+
+
+def test_an_unstringifiable_exception_does_not_crash():
+    class Bad(Exception):
+        def __str__(self):
+            raise ValueError("nope")
+    assert U._is_our_own_disabled_hook(Bad()) is False
+
+
+# ---- the fallback ---------------------------------------------------------
+
+def _wrap(compiled, eager=None):
+    eager = eager or (lambda *a, **k: "eager")
+    return U._fall_back_to_eager_on_recompile_limit(compiled, eager, "TestMod")
+
+
+def _unsupported(msg):
+    import torch._dynamo.exc as exc
+    cls = getattr(exc, "Unsupported", None)
+    if cls is None:
+        pytest.skip("this torch has no torch._dynamo.exc.Unsupported")
+    try:
+        return cls(msg)
+    except Exception:
+        pytest.skip("Unsupported cannot be constructed on this torch")
+
+
+def test_our_disabled_hook_falls_back_to_eager():
+    def compiled(*a, **k):
+        raise _unsupported(DISABLE_MSG)
+    assert _wrap(compiled)() == "eager"
+
+
+def test_the_fallback_latches():
+    """Do not reverse this. Per-call retry was tried and does not keep a
+    checkpoint pack and its own recompute in the same mode: they run under
+    different guards, so the compiler can flip either way. Latching leaves
+    exactly one inconsistent step, which unsloth catches and retries via
+    `force_eager_fallback`, instead of an unbounded number.
+    """
+    calls = {"n": 0}
+
+    def compiled(*a, **k):
+        calls["n"] += 1
+        raise _unsupported(DISABLE_MSG)
+
+    w = _wrap(compiled)
+    w(); w(); w()
+    assert calls["n"] == 1, "the compiler must not be re-entered after the latch"
+
+
+def test_every_later_call_takes_the_same_path():
+    """The property the checkpoint depends on, in the form that survived: once
+    the switch has happened, it is total. A build that sends some calls eager
+    and some compiled is the configuration that aborts the backward."""
+    outcomes = iter(["ok", "fail", "ok", "ok"])
+    seen = []
+
+    def compiled(*a, **k):
+        which = next(outcomes)
+        seen.append(which)
+        if which == "fail":
+            raise _unsupported(DISABLE_MSG)
+        return "compiled"
+
+    w = _wrap(compiled)
+    assert w() == "compiled"
+    assert w() == "eager"   # the call that exhausted the cache
+    assert w() == "eager"   # latched: no second attempt at the compiler
+    assert w() == "eager"
+    assert seen == ["ok", "fail"]
+
+
+def test_it_warns_once_and_not_per_call(caplog):
+    """The condition repeats every call; the log must not."""
+    import logging
+
+    def compiled(*a, **k):
+        raise _unsupported(DISABLE_MSG)
+
+    w = _wrap(compiled)
+    with caplog.at_level(logging.WARNING):
+        w(); w(); w(); w()
+    warnings = [r for r in caplog.records if "eagerly" in r.getMessage()]
+    assert len(warnings) == 1, [r.getMessage() for r in warnings]
+
+
+def test_a_real_graph_break_still_raises():
+    """The property the narrow match exists to protect."""
+    def compiled(*a, **k):
+        raise _unsupported("Unsupported: call_function on a data-dependent value")
+    with pytest.raises(Exception) as ei:
+        _wrap(compiled)()
+    assert "data-dependent" in str(ei.value)
+
+
+def test_an_unrelated_exception_still_raises():
+    def compiled(*a, **k):
+        raise ValueError("something else entirely")
+    with pytest.raises(ValueError):
+        _wrap(compiled)()
+
+
+def test_a_successful_compile_is_untouched():
+    assert _wrap(lambda *a, **k: "compiled")() == "compiled"
+
+
+def test_arguments_reach_the_eager_function():
+    def compiled(*a, **k):
+        raise _unsupported(DISABLE_MSG)
+    w = _wrap(compiled, eager=lambda x, y=0: x + y)
+    assert w(3, y=4) == 7
+
+
+# ---- what must be preserved ----------------------------------------------
+
+def test_the_recompile_limit_fallback_still_works():
+    errs = U._recompile_limit_errors()
+    if not errs:
+        pytest.skip("no recompile-limit exceptions on this torch")
+
+    def compiled(*a, **k):
+        raise errs[0]("recompile_limit reached with fullgraph=True")
+    assert _wrap(compiled)() == "eager"
+
+
+def test_the_compiled_callable_stays_reachable():
+    """Anything that unwraps the wrapper must still find it."""
+    def compiled(*a, **k):
+        return "compiled"
+    compiled.get_compiler_config = lambda: {}
+    w = _wrap(compiled)
+    assert w._unsloth_compiled_func is compiled
+    assert hasattr(w, "get_compiler_config")
+
+
+def test_it_degrades_to_the_compiled_function_when_torch_offers_neither():
+    """On a torch with no such exceptions at all, wrapping buys nothing and
+    must not add a layer."""
+    import unittest.mock as mock
+    with mock.patch.object(U, "_recompile_limit_errors", lambda: ()), \
+         mock.patch.object(U, "_disabled_hook_graph_break_error", lambda: ()):
+        sentinel = object()
+        assert U._fall_back_to_eager_on_recompile_limit(
+            sentinel, lambda: None, "x") is sentinel
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_disabled_hook_graph_break.py
+++ b/tests/test_disabled_hook_graph_break.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Two Unsloth fixes collide; the run should not die of it.
 
 One wraps the gradient-checkpointing `requires_grad` hooks in

--- a/tests/test_disabled_hook_graph_break.py
+++ b/tests/test_disabled_hook_graph_break.py
@@ -58,6 +58,37 @@ def test_it_recognises_our_own_disabled_hook():
     assert U._is_our_own_disabled_hook(RuntimeError(DISABLE_MSG))
 
 
+_HOOK = ("<function requires_grad_for_gradient_checkpointing.<locals>."
+         "requires_grad_pre_hook at 0x7f00>")
+
+# Dynamo's refusal to trace a disabled callable, once per wording inside the
+# torch>=2.4,<2.13 pyproject declares. 2.4 to 2.6 emit the `_dynamo.disable`
+# text from `variables/functions.py` (2.4.0 L604, 2.5.1 L655, 2.6.0 L620); 2.7
+# replaced it with the structured `unimplemented_v2` block (2.7.0 L1173) and 2.8
+# added the trailing reason. Missing a wording means the run dies on that torch
+# instead of slowing down, which is exactly what this fallback exists to stop.
+_OLD_WORDING = f"call torch._dynamo.disable() wrapped function {_HOOK}"
+_NEW_WORDING = (
+    "Skip calling `torch.compiler.disable()`d function\n"
+    f"  Explanation: Skip calling function `{_HOOK}` since it was wrapped "
+    "with `torch.compiler.disable`\n"
+    "  Hint: Remove the `torch.compiler.disable` call\n"
+    f"\n  Developer debug context: {_HOOK}\n"
+)
+
+
+@pytest.mark.parametrize("versions,message", [
+    ("2.4 / 2.5 / 2.6", _OLD_WORDING),
+    ("2.7", _NEW_WORDING),
+    ("2.8+", DISABLE_MSG),
+])
+def test_every_supported_torch_wording_is_recognised(versions, message):
+    assert U._is_our_own_disabled_hook(RuntimeError(message)), versions
+    def compiled(*a, **k):
+        raise _unsupported(message)
+    assert _wrap(compiled)() == "eager", versions
+
+
 def test_an_ordinary_graph_break_is_not_matched():
     """The whole point. These must keep raising."""
     for text in (
@@ -74,6 +105,10 @@ def test_a_mention_of_disable_alone_is_not_enough():
     talks about torch.compiler.disable does not qualify."""
     assert not U._is_our_own_disabled_hook(
         RuntimeError("consider using torch.compiler.disable here"))
+    # Same for the pre-2.7 wording: the whole literal is required, not the
+    # decorator's name, so advice to apply it is not a disabled-hook break.
+    assert not U._is_our_own_disabled_hook(
+        RuntimeError("try torch._dynamo.disable() on this function"))
 
 
 def test_an_unstringifiable_exception_does_not_crash():

--- a/tests/test_eager_fallback_latch.py
+++ b/tests/test_eager_fallback_latch.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """The eager fallback must latch, and it must be announceable.
 
 `fullgraph = True` turns Dynamo's recompilation-cache exhaustion into a raise

--- a/tests/test_eager_fallback_latch.py
+++ b/tests/test_eager_fallback_latch.py
@@ -243,5 +243,23 @@ def test_state_reports_each_label():
     assert U.eager_fallback_state() == {"A.f": True, "B.f": False}
 
 
+def test_the_recovery_hook_is_importable_from_the_package():
+    """unsloth calls this from its activation-checkpoint retry path, through
+    the `unsloth_zoo.temporary_patches` facade rather than the submodule."""
+    from unsloth_zoo.temporary_patches import (
+        eager_fallback_state,
+        force_eager_fallback,
+    )
+    assert force_eager_fallback is U.force_eager_fallback
+    assert eager_fallback_state is U.eager_fallback_state
+
+
+def test_the_recovery_hook_is_declared_public():
+    """`from ... import *` honours __all__, so a name missing from it is not
+    public however it is re-exported."""
+    assert "force_eager_fallback" in U.__all__
+    assert "eager_fallback_state" in U.__all__
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_eager_fallback_latch.py
+++ b/tests/test_eager_fallback_latch.py
@@ -1,0 +1,231 @@
+"""The eager fallback must latch, and it must be announceable.
+
+`fullgraph = True` turns Dynamo's recompilation-cache exhaustion into a raise
+instead of a fallback, so a performance problem becomes a hard training
+failure. `_fall_back_to_eager_on_recompile_limit` catches that and runs the
+eager original instead.
+
+The subtlety is non-reentrant activation checkpointing: it recomputes each
+packed forward during backward and asserts the two saved the same
+intermediates, so a mode change between them aborts the backward. Latching
+makes every call after the first failure eager, leaving one mixed step, which
+`force_eager_fallback()` lets unsloth close. A non-latching wrapper does not
+fix this -- see the note on `test_the_fallback_latches` in
+test_recompile_limit_fallback.py before changing it back.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from unsloth_zoo.temporary_patches import utils as U  # noqa: E402
+
+
+class Boom(Exception):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry(monkeypatch):
+    """Each test gets its own wrapper registry.
+
+    Without this the registry is module-global and tests see each other's
+    wrappers, so `force_eager_fallback()`'s count depends on execution order.
+    """
+    monkeypatch.setattr(U, "_EAGER_FALLBACK_WRAPPERS", [])
+    monkeypatch.setattr(U, "_recompile_limit_errors", lambda: (Boom,))
+    monkeypatch.setattr(U, "_disabled_hook_graph_break_error", lambda: ())
+
+
+def _pair(fail_after=0):
+    """A compiled func that raises from call `fail_after` on, and its eager twin."""
+    calls = {"compiled": 0, "eager": 0}
+
+    def compiled(x):
+        calls["compiled"] += 1
+        if calls["compiled"] > fail_after:
+            raise Boom("recompile_limit reached with fullgraph=True")
+        return ("compiled", x)
+
+    def eager(x):
+        calls["eager"] += 1
+        return ("eager", x)
+
+    return compiled, eager, calls
+
+
+# ---- the latch -----------------------------------------------------------
+
+def test_a_healthy_compiled_function_is_never_wrapped_out_of_the_way():
+    compiled, eager, calls = _pair(fail_after=100)
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "M.forward")
+    assert [w(i)[0] for i in range(5)] == ["compiled"] * 5
+    assert calls["eager"] == 0
+
+
+def test_it_falls_back_on_cache_exhaustion():
+    compiled, eager, calls = _pair(fail_after=0)
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "M.forward")
+    assert w(1) == ("eager", 1)
+
+
+def test_the_fallback_latches():
+    """The whole point. After the first failure the compiler is not consulted
+    again, so every later pack and recompute agree."""
+    compiled, eager, calls = _pair(fail_after=2)
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "M.forward")
+    modes = [w(i)[0] for i in range(6)]
+    assert modes == ["compiled", "compiled", "eager", "eager", "eager", "eager"]
+    # 3 attempts: two that worked and the one that raised. Never again.
+    assert calls["compiled"] == 3
+
+
+def test_the_warning_is_logged_once(monkeypatch):
+    seen = []
+    monkeypatch.setattr(U.logger, "warning", lambda m: seen.append(m))
+    compiled, eager, _ = _pair(fail_after=0)
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "M.forward")
+    for _ in range(4):
+        w(1)
+    assert len(seen) == 1
+    assert "M.forward" in seen[0]
+
+
+def test_an_unrelated_exception_still_propagates():
+    def compiled(x):
+        raise ValueError("a real bug")
+
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, lambda x: x, "M.f")
+    with pytest.raises(ValueError):
+        w(1)
+
+
+def test_no_wrapper_at_all_when_torch_has_no_such_errors(monkeypatch):
+    """On a torch with neither exception there is nothing to catch, and the
+    compiled callable must be returned untouched rather than wrapped."""
+    monkeypatch.setattr(U, "_recompile_limit_errors", lambda: ())
+    compiled, eager, _ = _pair()
+    assert U._fall_back_to_eager_on_recompile_limit(
+        compiled, eager, "M.f") is compiled
+
+
+def test_the_compiled_callable_stays_reachable():
+    compiled, eager, _ = _pair()
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "M.f")
+    assert w._unsloth_compiled_func is compiled
+    assert w.__wrapped__ is eager
+
+
+# ---- the graph-break arm is unchanged ------------------------------------
+
+def test_our_own_disabled_hook_falls_back_and_latches(monkeypatch):
+    class GraphBreak(Exception):
+        pass
+
+    monkeypatch.setattr(U, "_disabled_hook_graph_break_error",
+                        lambda: (GraphBreak,))
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        raise GraphBreak("Skip calling `torch.compiler.disable()`d function")
+
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, lambda x: "eager",
+                                                 "M.f")
+    assert [w(1) for _ in range(3)] == ["eager"] * 3
+    assert calls["n"] == 1, "latched, so the compiler is consulted once"
+
+
+def test_someone_elses_graph_break_still_raises(monkeypatch):
+    class GraphBreak(Exception):
+        pass
+
+    monkeypatch.setattr(U, "_disabled_hook_graph_break_error",
+                        lambda: (GraphBreak,))
+
+    def compiled(x):
+        raise GraphBreak("Unsupported: some genuinely unsupported construct")
+
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, lambda x: "eager",
+                                                 "M.f")
+    with pytest.raises(GraphBreak):
+        w(1)
+
+
+# ---- force_eager_fallback ------------------------------------------------
+
+def test_force_does_nothing_when_nothing_ever_fell_back():
+    """The honest default. A caller getting 0 back knows the activation
+    checkpoint assertion it caught was not caused by a mode flip, and must
+    re-raise rather than retry."""
+    compiled, eager, _ = _pair(fail_after=100)
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "M.f")
+    w(1)
+    assert U.force_eager_fallback() == 0
+    assert w(1)[0] == "compiled", "must not switch a healthy function"
+
+
+def test_force_switches_the_others_once_one_has_fallen_back():
+    a_c, a_e, a_calls = _pair(fail_after=0)     # this one exhausts its cache
+    b_c, b_e, b_calls = _pair(fail_after=100)   # this one is still fine
+    a = U._fall_back_to_eager_on_recompile_limit(a_c, a_e, "A.f")
+    b = U._fall_back_to_eager_on_recompile_limit(b_c, b_e, "B.f")
+    a(1)
+    assert U.force_eager_fallback() == 2
+    assert b(1)[0] == "eager"
+    assert b_calls["compiled"] == 0
+
+
+def test_force_counts_wrappers_not_changes():
+    """Deliberate: by the time unsloth calls this, the wrapper that caused the
+    trouble has already latched itself, so "how many changed" can be 0 in
+    exactly the case that matters and would read as "nothing happened"."""
+    compiled, eager, _ = _pair(fail_after=0)
+    # Bound, not called inline: the registry holds wrappers weakly, so an
+    # unbound one is collected before force_eager_fallback() can see it.
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "A.f")
+    w(1)
+    assert U.force_eager_fallback() == 1
+
+
+def test_force_ignores_the_guard_when_asked():
+    compiled, eager, _ = _pair(fail_after=100)
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "M.f")
+    assert U.force_eager_fallback(only_if_already_triggered=False) == 1
+    assert w(1)[0] == "eager"
+
+
+def test_force_is_idempotent():
+    compiled, eager, _ = _pair(fail_after=0)
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "A.f")
+    w(1)
+    assert U.force_eager_fallback() == U.force_eager_fallback() == 1
+
+
+def test_the_registry_does_not_keep_dead_wrappers_alive():
+    """Weak, so a model that was patched and thrown away is not reported as a
+    live compiled forward and cannot inflate the count."""
+    import gc
+    compiled, eager, _ = _pair()
+    w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "gone.f")
+    assert "gone.f" in U.eager_fallback_state()
+    del w
+    gc.collect()
+    assert "gone.f" not in U.eager_fallback_state()
+
+
+def test_state_reports_each_label():
+    a_c, a_e, _ = _pair(fail_after=0)
+    b_c, b_e, _ = _pair(fail_after=100)
+    a = U._fall_back_to_eager_on_recompile_limit(a_c, a_e, "A.f")
+    b = U._fall_back_to_eager_on_recompile_limit(b_c, b_e, "B.f")
+    a(1)
+    b(1)
+    assert U.eager_fallback_state() == {"A.f": True, "B.f": False}
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_recompile_limit_fallback.py
+++ b/tests/test_recompile_limit_fallback.py
@@ -324,3 +324,56 @@ def test_end_to_end_through_patch_function():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+# ---- the one case where falling back is the wrong answer ------------------
+
+def test_the_hard_failure_flag_is_respected():
+    """torch raises FailOnRecompileLimitHit from two branches with the same
+    class: fullgraph=True, where falling back is exactly right, and
+    `fail_on_recompile_limit_hit`, where the user asked for the run to stop.
+    The exception cannot tell them apart, so the flag has to be read."""
+    import torch._dynamo.config as config
+
+    c, e, calls = _pair(_LIMIT_ERROR("recompile_limit reached"))
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    previous = config.fail_on_recompile_limit_hit
+    config.fail_on_recompile_limit_hit = True
+    try:
+        with pytest.raises(_LIMIT_ERROR):
+            w(3)
+    finally:
+        config.fail_on_recompile_limit_hit = previous
+    # Nothing latched either, or a later call would silently go eager.
+    assert calls == {"c": 1, "e": 0}
+
+
+def test_the_flag_being_off_keeps_the_fallback():
+    import torch._dynamo.config as config
+
+    previous = config.fail_on_recompile_limit_hit
+    config.fail_on_recompile_limit_hit = False
+    try:
+        c, e, calls = _pair(_LIMIT_ERROR("recompile_limit reached"))
+        w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+        assert w(3) == 6
+    finally:
+        config.fail_on_recompile_limit_hit = previous
+    assert calls == {"c": 1, "e": 1}
+
+
+def test_a_torch_without_the_flag_still_falls_back():
+    """2.6 spells it fail_on_cache_limit_hit, and some builds have neither."""
+    from unsloth_zoo.temporary_patches.utils import _wants_hard_recompile_failure
+    import torch._dynamo.config as config
+
+    saved = {n: getattr(config, n) for n in
+             ("fail_on_recompile_limit_hit", "fail_on_cache_limit_hit")
+             if hasattr(config, n)}
+    for n in saved:
+        setattr(config, n, False)
+    try:
+        assert _wants_hard_recompile_failure() is False
+    finally:
+        for n, v in saved.items():
+            setattr(config, n, v)

--- a/tests/test_recompile_limit_fallback.py
+++ b/tests/test_recompile_limit_fallback.py
@@ -1,0 +1,239 @@
+"""Exhausting the recompile cache must slow a run down, not end it.
+
+`patch_function(..., fullgraph = True)` compiles with fullgraph, and Dynamo
+raises on cache exhaustion under fullgraph instead of falling back:
+
+    FailOnRecompileLimitHit: recompile_limit reached with fullgraph=True
+
+Running out of compilation cache is a performance problem, and turning it into
+a hard training failure is strictly worse than being slow.
+
+The fallback is narrow on purpose. A genuine graph break under fullgraph
+still raises, because that is a correctness signal about the patch itself.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from unsloth_zoo.temporary_patches.utils import (  # noqa: E402
+    _fall_back_to_eager_on_recompile_limit,
+    _recompile_limit_errors,
+)
+
+from torch._dynamo.exc import FailOnRecompileLimitHit  # noqa: E402
+
+
+def _pair(compiled_raises = None, calls = None):
+    calls = calls if calls is not None else {"c": 0, "e": 0}
+
+    def compiled(x):
+        calls["c"] += 1
+        if compiled_raises is not None:
+            raise compiled_raises
+        return x * 2
+
+    def eager(x):
+        """Eager docstring."""
+        calls["e"] += 1
+        return x * 2
+
+    return compiled, eager, calls
+
+
+# ---- the failure that must stop being fatal -------------------------------
+
+def test_recompile_limit_falls_back_instead_of_raising():
+    c, e, calls = _pair(FailOnRecompileLimitHit("recompile_limit reached"))
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    assert w(3) == 6
+    assert calls == {"c": 1, "e": 1}
+
+
+def test_the_fallback_latches():
+    """Do not reverse this assertion. It has been settled twice, on live
+    hardware rather than by argument.
+
+    Retrying the compiler per call was tried, so that each activation
+    checkpoint pack and its own recompute would agree on a mode. It does not
+    work: the pack and the recompute run under different guards -- grad mode
+    differs, and the recompute happens inside backward -- so the compiler can
+    succeed for one and raise for the other in either direction, and the
+    backward still aborts with "Something went unexpectedly wrong in activation
+    checkpoint".
+
+    Latching leaves exactly one inconsistent step, the one during which the
+    latch flips, and `force_eager_fallback` exists for unsloth to catch that
+    single assertion and retry that step.
+    """
+    c, e, calls = _pair(FailOnRecompileLimitHit("recompile_limit reached"))
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    for _ in range(5):
+        assert w(1) == 2
+    assert calls["c"] == 1, "the compiler must not be re-entered after the latch"
+    assert calls["e"] == 5
+
+
+def test_the_latch_is_per_wrapper_not_global():
+    """Two separately wrapped functions must not knock each other eager."""
+    c1, e1, calls1 = _pair(FailOnRecompileLimitHit("recompile_limit reached"))
+    c2, e2, calls2 = _pair()
+    w1 = _fall_back_to_eager_on_recompile_limit(c1, e1, "A.forward")
+    w2 = _fall_back_to_eager_on_recompile_limit(c2, e2, "B.forward")
+    w1(1); w1(1)
+    assert w2(5) == 10
+    assert calls2 == {"c": 1, "e": 0}
+
+
+def test_recompile_limit_exceeded_is_also_caught():
+    from torch._dynamo.exc import RecompileLimitExceeded
+    c, e, _ = _pair(RecompileLimitExceeded("recompile_limit reached"))
+    assert _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")(4) == 8
+
+
+# ---- what must still raise ------------------------------------------------
+
+def test_a_real_graph_break_still_raises():
+    from torch._dynamo.exc import Unsupported
+    c, e, calls = _pair(Unsupported("call_function BuiltinVariable"))
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    with pytest.raises(Unsupported):
+        w(1)
+    assert calls["e"] == 0, "a graph break is a correctness signal, not a perf one"
+
+
+def test_an_ordinary_error_still_raises():
+    c, e, calls = _pair(ValueError("something is actually wrong"))
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    with pytest.raises(ValueError):
+        w(1)
+    assert calls["e"] == 0
+
+
+# ---- the happy path is untouched ------------------------------------------
+
+def test_compiled_path_is_used_when_nothing_goes_wrong():
+    c, e, calls = _pair()
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    assert w(5) == 10
+    assert calls == {"c": 1, "e": 0}
+
+
+# ---- introspection other code depends on ----------------------------------
+
+def test_signature_and_metadata_survive():
+    c, e, _ = _pair()
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    import inspect
+    assert list(inspect.signature(w).parameters) == ["x"]
+    assert w.__doc__ == "Eager docstring."
+    assert w.__wrapped__ is e
+
+
+def test_unwrapping_still_reaches_the_eager_function():
+    # patch_function unwraps anything carrying get_compiler_config via
+    # __wrapped__, so double-patching must not nest compiles.
+    c, e, _ = _pair()
+    c.get_compiler_config = lambda: {}
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    assert hasattr(w, "get_compiler_config")
+    assert w.__wrapped__ is e
+
+
+def test_compiled_callable_stays_reachable():
+    c, e, _ = _pair()
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    assert w._unsloth_compiled_func is c
+
+
+def test_no_wrapper_when_torch_exposes_no_such_errors(monkeypatch):
+    # Older torch without these names: return the compiled function
+    # unchanged rather than guessing at which exception to catch.
+    #
+    # BOTH sources must be empty now. The wrapper also catches the graph
+    # break Unsloth causes itself by registering a `torch.compiler.disable`d
+    # gradient-checkpointing hook inside a fullgraph region, so a torch that
+    # has `Unsupported` but no recompile-limit errors still needs wrapping.
+    import unsloth_zoo.temporary_patches.utils as u
+    monkeypatch.setattr(u, "_recompile_limit_errors", lambda: ())
+    monkeypatch.setattr(u, "_disabled_hook_graph_break_error", lambda: ())
+    c, e, _ = _pair()
+    assert u._fall_back_to_eager_on_recompile_limit(c, e, "M.forward") is c
+
+
+def test_wrapper_is_added_for_the_graph_break_alone(monkeypatch):
+    """A torch with `Unsupported` but no recompile-limit names still gets the
+    fallback, because the disabled-hook collision can still happen there."""
+    import unsloth_zoo.temporary_patches.utils as u
+    monkeypatch.setattr(u, "_recompile_limit_errors", lambda: ())
+    c, e, _ = _pair()
+    if not u._disabled_hook_graph_break_error():
+        pytest.skip("this torch has no torch._dynamo.exc.Unsupported")
+    assert u._fall_back_to_eager_on_recompile_limit(c, e, "M.forward") is not c
+
+
+def test_error_tuple_is_non_empty_on_this_torch():
+    errs = _recompile_limit_errors()
+    assert FailOnRecompileLimitHit in errs
+    assert all(issubclass(x, BaseException) for x in errs)
+
+
+# ---- wiring into patch_function -------------------------------------------
+
+def test_only_fullgraph_patches_get_the_wrapper():
+    src = Path(
+        sys.modules["unsloth_zoo.temporary_patches.utils"].__file__
+    ).read_text(encoding = "utf-8")
+    i = src.index("new_func = torch.compile(")
+    tail = src[i:i + 800]
+    assert "if fullgraph:" in tail, "fullgraph=False already falls back by itself"
+    assert "_fall_back_to_eager_on_recompile_limit(" in tail
+
+
+def test_real_cache_exhaustion_completes_with_correct_numerics():
+    """The synthetic raises above prove the wrapper; this proves the premise.
+
+    Exhausts a real Dynamo cache by giving each module instance a different
+    python int attribute, which Dynamo guards on by value.
+    """
+    from unsloth_zoo.temporary_patches.utils import patch_function
+
+    class M(torch.nn.Module):
+        def __init__(self, k):
+            super().__init__()
+            self.k = k
+
+        def forward(self, x):
+            return x * self.k
+
+    def forward(self, x):
+        return x * self.k + 0.0
+
+    torch._dynamo.reset()
+    with torch._dynamo.config.patch(recompile_limit = 2,
+                                    accumulated_recompile_limit = 2):
+        assert patch_function(M, "forward", forward,
+                              fullgraph = True, force = True)
+        got = [M(k)(torch.tensor([1.0, 2.0])).tolist() for k in range(8)]
+    assert got == [[k * 1.0, k * 2.0] for k in range(8)]
+
+
+def test_end_to_end_through_patch_function():
+    from unsloth_zoo.temporary_patches.utils import patch_function
+
+    class M:
+        def forward(self, x):
+            return x + 1
+
+    def forward(self, x):
+        return x + 1
+
+    assert patch_function(M, "forward", forward, fullgraph = True, force = True)
+    assert M().forward(torch.tensor(1.0)).item() == 2.0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_recompile_limit_fallback.py
+++ b/tests/test_recompile_limit_fallback.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Exhausting the recompile cache must slow a run down, not end it.
 
 `patch_function(..., fullgraph = True)` compiles with fullgraph, and Dynamo

--- a/tests/test_recompile_limit_fallback.py
+++ b/tests/test_recompile_limit_fallback.py
@@ -58,6 +58,16 @@ _LIMIT_ERROR = next(
     None,
 )
 
+# Dynamo renamed its cache-limit knobs in torch 2.7. 2.4 to 2.6, all inside the
+# same declared range, only have the cache_size_limit spelling, and
+# `config.patch` looks each key up and raises on one the installed torch does
+# not define.
+_LIMIT_KEYS = (
+    ("recompile_limit", "accumulated_recompile_limit")
+    if hasattr(torch._dynamo.config, "recompile_limit")
+    else ("cache_size_limit", "accumulated_cache_size_limit")
+)
+
 pytestmark = pytest.mark.skipif(
     _LIMIT_ERROR is None,
     reason = "this torch exposes no Dynamo recompile-limit exception",
@@ -225,6 +235,34 @@ def test_no_version_specific_dynamo_name_is_imported_at_module_level():
         assert f"import {name}" not in src, f"{name} must be looked up with getattr"
 
 
+def test_the_dynamo_limit_keys_exist_on_this_torch():
+    """A hardcoded spelling turns the cache-exhaustion test below into an
+    error on torch 2.4 to 2.6 rather than a run of it."""
+    for key in _LIMIT_KEYS:
+        assert hasattr(torch._dynamo.config, key), key
+
+
+@pytest.mark.parametrize("message", [
+    "cache_size_limit reached",
+    "accumulated_cache_size_limit reached",
+    "recompile_limit reached",
+])
+def test_cache_exhaustion_reported_as_a_bare_unsupported_falls_back(message):
+    """torch 2.4 has no cache-limit exception class: `convert_frame` ends that
+    branch in `unimplemented(f"{limit_type} reached")`, so exhaustion arrives
+    as a plain `Unsupported` and re-raising it ends the run instead of slowing
+    it. 2.5 and 2.6 reach the same `unimplemented` with
+    skip_code_recursive_on_cache_limit_hit off."""
+    from torch._dynamo.exc import Unsupported
+    c, e, calls = _pair(Unsupported(message))
+    w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
+    assert w(3) == 6
+    assert calls == {"c": 1, "e": 1}
+    # And it latches, like every other fallback reason.
+    assert w(3) == 6
+    assert calls["c"] == 1
+
+
 def test_error_tuple_is_non_empty_on_this_torch():
     errs = _recompile_limit_errors()
     assert _LIMIT_ERROR in errs
@@ -263,8 +301,7 @@ def test_real_cache_exhaustion_completes_with_correct_numerics():
         return x * self.k + 0.0
 
     torch._dynamo.reset()
-    with torch._dynamo.config.patch(recompile_limit = 2,
-                                    accumulated_recompile_limit = 2):
+    with torch._dynamo.config.patch({key: 2 for key in _LIMIT_KEYS}):
         assert patch_function(M, "forward", forward,
                               fullgraph = True, force = True)
         got = [M(k)(torch.tensor([1.0, 2.0])).tolist() for k in range(8)]

--- a/tests/test_recompile_limit_fallback.py
+++ b/tests/test_recompile_limit_fallback.py
@@ -24,7 +24,28 @@ from unsloth_zoo.temporary_patches.utils import (  # noqa: E402
     _recompile_limit_errors,
 )
 
-from torch._dynamo.exc import FailOnRecompileLimitHit  # noqa: E402
+import torch._dynamo.exc as _dynamo_exc  # noqa: E402
+
+# Dynamo does not agree on these names across the torch>=2.4,<2.13 pyproject
+# declares: 2.4 has none of them, 2.5 has only CacheLimitExceeded, 2.6+ has
+# RecompileLimitExceeded and FailOnRecompileLimitHit. Importing one by name
+# would kill collection on a supported torch, so look them up the way
+# _recompile_limit_errors does.
+_LIMIT_ERROR = next(
+    (
+        e for e in (
+            getattr(_dynamo_exc, n, None)
+            for n in ("FailOnRecompileLimitHit", "RecompileLimitExceeded", "CacheLimitExceeded")
+        )
+        if isinstance(e, type) and issubclass(e, BaseException)
+    ),
+    None,
+)
+
+pytestmark = pytest.mark.skipif(
+    _LIMIT_ERROR is None,
+    reason = "this torch exposes no Dynamo recompile-limit exception",
+)
 
 
 def _pair(compiled_raises = None, calls = None):
@@ -47,7 +68,7 @@ def _pair(compiled_raises = None, calls = None):
 # ---- the failure that must stop being fatal -------------------------------
 
 def test_recompile_limit_falls_back_instead_of_raising():
-    c, e, calls = _pair(FailOnRecompileLimitHit("recompile_limit reached"))
+    c, e, calls = _pair(_LIMIT_ERROR("recompile_limit reached"))
     w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
     assert w(3) == 6
     assert calls == {"c": 1, "e": 1}
@@ -69,7 +90,7 @@ def test_the_fallback_latches():
     latch flips, and `force_eager_fallback` exists for unsloth to catch that
     single assertion and retry that step.
     """
-    c, e, calls = _pair(FailOnRecompileLimitHit("recompile_limit reached"))
+    c, e, calls = _pair(_LIMIT_ERROR("recompile_limit reached"))
     w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
     for _ in range(5):
         assert w(1) == 2
@@ -79,7 +100,7 @@ def test_the_fallback_latches():
 
 def test_the_latch_is_per_wrapper_not_global():
     """Two separately wrapped functions must not knock each other eager."""
-    c1, e1, calls1 = _pair(FailOnRecompileLimitHit("recompile_limit reached"))
+    c1, e1, calls1 = _pair(_LIMIT_ERROR("recompile_limit reached"))
     c2, e2, calls2 = _pair()
     w1 = _fall_back_to_eager_on_recompile_limit(c1, e1, "A.forward")
     w2 = _fall_back_to_eager_on_recompile_limit(c2, e2, "B.forward")
@@ -89,7 +110,9 @@ def test_the_latch_is_per_wrapper_not_global():
 
 
 def test_recompile_limit_exceeded_is_also_caught():
-    from torch._dynamo.exc import RecompileLimitExceeded
+    RecompileLimitExceeded = getattr(_dynamo_exc, "RecompileLimitExceeded", None)
+    if RecompileLimitExceeded is None:
+        pytest.skip("this torch has no torch._dynamo.exc.RecompileLimitExceeded")
     c, e, _ = _pair(RecompileLimitExceeded("recompile_limit reached"))
     assert _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")(4) == 8
 
@@ -175,9 +198,20 @@ def test_wrapper_is_added_for_the_graph_break_alone(monkeypatch):
     assert u._fall_back_to_eager_on_recompile_limit(c, e, "M.forward") is not c
 
 
+def test_no_version_specific_dynamo_name_is_imported_at_module_level():
+    """torch 2.4 has none of the recompile-limit exceptions and 2.5 has only
+    CacheLimitExceeded, both inside the torch>=2.4,<2.13 pyproject declares. A
+    top-level `from torch._dynamo.exc import <name>` would therefore fail
+    collection on a supported torch instead of exercising the compatibility
+    path the helper under test exists for."""
+    src = Path(__file__).read_text(encoding = "utf-8")
+    for name in ("FailOnRecompileLimitHit", "RecompileLimitExceeded", "CacheLimitExceeded"):
+        assert f"import {name}" not in src, f"{name} must be looked up with getattr"
+
+
 def test_error_tuple_is_non_empty_on_this_torch():
     errs = _recompile_limit_errors()
-    assert FailOnRecompileLimitHit in errs
+    assert _LIMIT_ERROR in errs
     assert all(issubclass(x, BaseException) for x in errs)
 
 

--- a/tests/test_recompile_limit_fallback.py
+++ b/tests/test_recompile_limit_fallback.py
@@ -28,6 +28,7 @@ The fallback is narrow on purpose. A genuine graph break under fullgraph
 still raises, because that is a correctness signal about the patch itself.
 """
 
+import contextlib
 import sys
 from pathlib import Path
 
@@ -328,37 +329,50 @@ if __name__ == "__main__":
 
 # ---- the one case where falling back is the wrong answer ------------------
 
+@contextlib.contextmanager
+def _hard_failure(enabled):
+    """Set whichever spelling this torch has, and put it back.
+
+    2.6 only has fail_on_cache_limit_hit; 2.7 renamed it to
+    fail_on_recompile_limit_hit and kept the old name as an alias. Reading a
+    fixed name here would AttributeError on 2.6, which pyproject allows.
+    """
+    import torch._dynamo.config as config
+
+    names = [n for n in ("fail_on_recompile_limit_hit", "fail_on_cache_limit_hit")
+             if hasattr(config, n)]
+    if not names:
+        pytest.skip("this torch has no recompile-limit hard-failure flag")
+    previous = {n: getattr(config, n) for n in names}
+    # One name, since on 2.7+ the second is an alias of the first and writing
+    # both would just set the same value twice.
+    setattr(config, names[0], enabled)
+    try:
+        yield
+    finally:
+        for n, v in previous.items():
+            setattr(config, n, v)
+
+
 def test_the_hard_failure_flag_is_respected():
     """torch raises FailOnRecompileLimitHit from two branches with the same
     class: fullgraph=True, where falling back is exactly right, and
     `fail_on_recompile_limit_hit`, where the user asked for the run to stop.
     The exception cannot tell them apart, so the flag has to be read."""
-    import torch._dynamo.config as config
-
     c, e, calls = _pair(_LIMIT_ERROR("recompile_limit reached"))
     w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
-    previous = config.fail_on_recompile_limit_hit
-    config.fail_on_recompile_limit_hit = True
-    try:
+    with _hard_failure(True):
         with pytest.raises(_LIMIT_ERROR):
             w(3)
-    finally:
-        config.fail_on_recompile_limit_hit = previous
     # Nothing latched either, or a later call would silently go eager.
     assert calls == {"c": 1, "e": 0}
 
 
 def test_the_flag_being_off_keeps_the_fallback():
-    import torch._dynamo.config as config
-
-    previous = config.fail_on_recompile_limit_hit
-    config.fail_on_recompile_limit_hit = False
-    try:
+    with _hard_failure(False):
         c, e, calls = _pair(_LIMIT_ERROR("recompile_limit reached"))
         w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
         assert w(3) == 6
-    finally:
-        config.fail_on_recompile_limit_hit = previous
     assert calls == {"c": 1, "e": 1}
 
 

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Tests _run_eagerly_under_compile in peft_utils.py.
 
 The gradient-checkpointing hooks call `requires_grad_()`, which Dynamo cannot

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -1,0 +1,126 @@
+"""Tests _run_eagerly_under_compile in peft_utils.py.
+
+The gradient-checkpointing hooks call `requires_grad_()`, which Dynamo cannot
+trace, so a compiled model carrying one dies with
+
+    Unsupported: Unsupported Tensor.requires_grad_() call
+
+Making the hooks opaque to Dynamo fixes that, but has a second-order hazard:
+register_other_hooks() decides which hooks are OURS by matching
+__name__/__qualname__ against "requires_grad_pre_hook" and
+"requires_grad_post_hook". If wrapping lost those names, our hooks would stop
+being recognised and would be re-registered on top of themselves. torch 2.9
+carries them through torch._dynamo.disable, but that is an internal detail of
+a private module and this has to hold from torch 2.6 up, so the wrapper copies
+them explicitly.
+
+No GPU needed.
+"""
+
+import ast
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+PEFT_UTILS = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "peft_utils.py"
+_SRC = PEFT_UTILS.read_text(encoding = "utf-8")
+
+
+def _load():
+    for node in ast.parse(_SRC).body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_run_eagerly_under_compile":
+            ns = {"torch": torch}
+            exec(ast.get_source_segment(_SRC, node), ns)
+            return ns[node.name]
+    raise AssertionError("_run_eagerly_under_compile not found in peft_utils.py")
+
+
+run_eagerly = _load()
+
+
+def _hook(module, args, kwargs):
+    return "called"
+
+
+_hook.__name__ = "requires_grad_pre_hook"
+_hook.__qualname__ = "requires_grad_for_gradient_checkpointing.<locals>.requires_grad_pre_hook"
+
+
+def test_names_survive_wrapping():
+    # register_other_hooks matches on these; losing them re-registers our
+    # hooks on top of themselves.
+    w = run_eagerly(_hook)
+    assert w.__name__ == "requires_grad_pre_hook"
+    assert "requires_grad_pre_hook" in w.__qualname__
+
+
+def test_wrapped_hook_still_runs():
+    assert run_eagerly(_hook)(None, (), {}) == "called"
+
+
+def test_register_other_hooks_still_recognises_it():
+    # Mirrors the matching in register_other_hooks exactly.
+    w = run_eagerly(_hook)
+    name1 = name2 = "requires_grad_pre_hook"
+    qualname = getattr(w, "__qualname__", "")
+    name = getattr(w, "__name__", "")
+    recognised = (name1 in qualname or name2 in qualname) or (name2 in name)
+    assert recognised, "our own hook would be treated as a foreign hook"
+
+
+@pytest.fixture
+def _fake_dynamo():
+    # `import torch._dynamo as x` resolves the ATTRIBUTE on the torch package
+    # once the submodule is in sys.modules, so both have to be swapped.
+    saved_mod = sys.modules.get("torch._dynamo")
+    saved_attr = getattr(torch, "_dynamo", None)
+
+    def install(mod):
+        sys.modules["torch._dynamo"] = mod
+        torch._dynamo = mod
+
+    yield install
+
+    if saved_mod is None: sys.modules.pop("torch._dynamo", None)
+    else: sys.modules["torch._dynamo"] = saved_mod
+    if saved_attr is not None: torch._dynamo = saved_attr
+
+
+def test_falls_back_when_disable_is_absent(_fake_dynamo):
+    # Older / stripped torch builds: must be a no-op, not a crash.
+    _fake_dynamo(types.ModuleType("torch._dynamo"))
+    assert run_eagerly(_hook) is _hook
+
+
+def test_falls_back_when_disable_raises(_fake_dynamo):
+    mod = types.ModuleType("torch._dynamo")
+    def _boom(fn): raise RuntimeError("nope")
+    mod.disable = _boom
+    _fake_dynamo(mod)
+    assert run_eagerly(_hook) is _hook
+
+
+def test_tolerates_unsettable_attributes(_fake_dynamo):
+    # A C-implemented or slotted callable may refuse __name__ assignment.
+    class _Callable:
+        __slots__ = ()
+        def __call__(self, *a, **k): return "called"
+    mod = types.ModuleType("torch._dynamo")
+    mod.disable = lambda fn: _Callable()
+    _fake_dynamo(mod)
+    w = run_eagerly(_hook)          # must not raise
+    assert w(None, (), {}) == "called"
+
+
+def test_both_hooks_are_decorated_in_source():
+    for hook in ("requires_grad_pre_hook", "requires_grad_post_hook"):
+        i = _SRC.index(f"def {hook}(")
+        preceding = _SRC[:i].rstrip().splitlines()[-1]
+        assert "_run_eagerly_under_compile" in preceding, hook
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -289,6 +289,46 @@ def get_lora_layer_modules():
 pass
 
 
+def _run_eagerly_under_compile(fn):
+    """Make `fn` opaque to TorchDynamo, so torch.compile runs it eagerly.
+
+    The gradient-enabling hooks mutate `requires_grad`, which Dynamo cannot
+    trace:
+
+        Unsupported: Unsupported Tensor.requires_grad_() call
+
+    They are autograd bookkeeping rather than compute -- one tensor, once per
+    forward -- so running them eagerly and graph-breaking around them is both
+    correct and cheap.
+
+    Degrades to a no-op decorator on a torch without `_dynamo`, so eager users
+    and older torch builds are unaffected.
+    """
+    try:
+        import torch._dynamo as _torch_dynamo
+    except Exception:
+        return fn
+    disable = getattr(_torch_dynamo, "disable", None)
+    if disable is None:
+        return fn
+    try:
+        wrapped = disable(fn)
+    except Exception:
+        return fn
+    # register_other_hooks() identifies our hooks by matching __name__ /
+    # __qualname__, so the names must survive the wrapper or the hooks stop
+    # being recognised as ours and get re-registered on top of themselves.
+    # torch 2.9 does carry them through disable(), but that is an internal
+    # detail of a private module and this has to hold from torch 2.6 up.
+    for _attr in ("__name__", "__qualname__", "__doc__"):
+        try:
+            setattr(wrapped, _attr, getattr(fn, _attr))
+        except (AttributeError, TypeError):
+            pass
+    return wrapped
+pass
+
+
 def requires_grad_for_gradient_checkpointing(model):
     # All Unsloth Zoo code licensed under LGPLv3
     # Enables requires_grad to make gradient checkpointing work on
@@ -326,6 +366,7 @@ def requires_grad_for_gradient_checkpointing(model):
     pass
 
     # Add post forward hook
+    @_run_eagerly_under_compile
     def requires_grad_post_hook(module, input, output):
         type_output = type(output)
         if type_output is torch.Tensor:
@@ -348,6 +389,7 @@ def requires_grad_for_gradient_checkpointing(model):
                 raise RuntimeError(f"Unsloth: Failed to make output require gradients: {e}")
     pass
 
+    @_run_eagerly_under_compile
     def requires_grad_pre_hook(module, args, kwargs):
         # Try positional args first (normal text models)
         if args:

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -44,3 +44,7 @@ from .moe_utils_bnb4bit import *
 from .moe_grouped_modulelist import *
 from .moe_utils_fp8 import *
 from .flex_attention_bwd import *
+# The eager-fallback recovery hook unsloth calls when a backward dies inside
+# activation checkpointing. Named rather than star-imported: `utils` also
+# exports names this package has never re-exported.
+from .utils import eager_fallback_state, force_eager_fallback

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -717,6 +717,24 @@ def _is_recompile_limit_unsupported(exc):
             or "recompile_limit reached" in text)
 
 
+# The complete set of texts Dynamo uses to refuse a disabled callable, one per
+# wording, each a literal from the single `_torchdynamo_disable` branch of
+# `UserFunctionVariable.call_function` in `torch/_dynamo/variables/functions.py`.
+# Nothing else in Dynamo emits them, which is what keeps the match narrow.
+#
+#   torch 2.4 to 2.6  unimplemented(f"call torch._dynamo.disable() wrapped
+#                     function {self.value}")   (2.4.0 L604, 2.5.1 L655, 2.6.0 L620)
+#   torch 2.7+        unimplemented_v2(gb_type="Skip calling
+#                     `torch.compiler.disable()`d function", ...)  (2.7.0 L1173)
+#
+# Both spellings stay listed: pyproject allows torch>=2.4, and the older one is
+# all those releases ever emit.
+_DISABLED_HOOK_SIGNATURES = (
+    ("Skip calling", "torch.compiler.disable"),
+    ("torch._dynamo.disable() wrapped function",),
+)
+
+
 def _is_our_own_disabled_hook(exc):
     """Did we break our own graph with our own `torch.compiler.disable`?
 
@@ -725,15 +743,21 @@ def _is_our_own_disabled_hook(exc):
 
         Unsupported: Skip calling `torch.compiler.disable()`d function
 
-    Matched narrowly on that signature: any other graph break under fullgraph
+    or, before torch 2.7 renamed it,
+
+        Unsupported: call torch._dynamo.disable() wrapped function <...>
+
+    Matched narrowly on those signatures: any other graph break under fullgraph
     must still raise, since those point at real problems.
     """
     try:
         text = str(exc)
     except Exception:
         return False
-    return ("torch.compiler.disable" in text
-            and "Skip calling" in text)
+    return any(
+        all(part in text for part in signature)
+        for signature in _DISABLED_HOOK_SIGNATURES
+    )
 
 
 def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -36,6 +36,8 @@ __all__ = [
     "ProcessorMixin",
     "_get_unique_storage_name",
     "dedent",
+    "eager_fallback_state",
+    "force_eager_fallback",
 ]
 import functools
 import inspect
@@ -694,6 +696,27 @@ def _disabled_hook_graph_break_error():
     return ()
 
 
+def _is_recompile_limit_unsupported(exc):
+    """Cache exhaustion reported as a plain graph break.
+
+    torch 2.4 has no exception class for it: `convert_frame` ends the
+    cache-limit branch in `unimplemented(f"{limit_type} reached")`, which
+    raises `Unsupported`, so `_recompile_limit_errors()` is empty there and
+    the message is all that is left to match on. 2.5 added `CacheLimitExceeded`
+    and 2.6 `RecompileLimitExceeded`, but both still fall through to the same
+    `unimplemented` when `skip_code_recursive_on_cache_limit_hit` is off.
+
+    `limit_type` is `cache_size_limit` or `accumulated_cache_size_limit`,
+    renamed to `recompile_limit` / `accumulated_recompile_limit` in torch 2.7.
+    """
+    try:
+        text = str(exc)
+    except Exception:
+        return False
+    return ("cache_size_limit reached" in text
+            or "recompile_limit reached" in text)
+
+
 def _is_our_own_disabled_hook(exc):
     """Did we break our own graph with our own `torch.compiler.disable`?
 
@@ -765,8 +788,17 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             )
             return eager_func(*args, **kwargs)
         except graph_break_errors as e:
-            # Only our own `torch.compiler.disable` hook. Anything else is a
-            # real graph break and must keep raising.
+            # Cache exhaustion on a torch that has no exception class for it
+            # (2.4), then our own `torch.compiler.disable` hook. Anything else
+            # is a real graph break and must keep raising.
+            if _is_recompile_limit_unsupported(e):
+                state["eager"] = True
+                _warn(
+                    f"Unsloth: torch.compile ran out of recompilation cache "
+                    f"for {label}; running it eagerly from here. Training is "
+                    f"unaffected apart from speed. ({type(e).__name__})"
+                )
+                return eager_func(*args, **kwargs)
             if not _is_our_own_disabled_hook(e):
                 raise
             state["eager"] = True

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -37,7 +37,9 @@ __all__ = [
     "_get_unique_storage_name",
     "dedent",
 ]
+import functools
 import inspect
+import weakref
 import typing as t
 import torch
 from textwrap import dedent
@@ -661,6 +663,178 @@ def _get_unique_storage_name(
 pass
 
 
+def _recompile_limit_errors():
+    """Dynamo's cache-exhaustion exceptions on whichever torch is installed.
+
+    Looked up by name: torch 2.6 to 2.11 do not agree on which exist, and a
+    missing one must not stop the tuple from being built.
+    """
+    try:
+        import torch._dynamo.exc as _exc
+    except Exception:
+        return ()
+    found = []
+    for _n in ("FailOnRecompileLimitHit", "RecompileLimitExceeded",
+               "CacheLimitExceeded"):
+        _e = getattr(_exc, _n, None)
+        if isinstance(_e, type) and issubclass(_e, BaseException):
+            found.append(_e)
+    return tuple(found)
+
+
+def _disabled_hook_graph_break_error():
+    """Dynamo's graph-break exception, if this torch has one."""
+    try:
+        import torch._dynamo.exc as _exc
+    except Exception:
+        return ()
+    _e = getattr(_exc, "Unsupported", None)
+    if isinstance(_e, type) and issubclass(_e, BaseException):
+        return (_e,)
+    return ()
+
+
+def _is_our_own_disabled_hook(exc):
+    """Did we break our own graph with our own `torch.compiler.disable`?
+
+    Our `torch.compiler.disable`d requires_grad hooks can be invoked from
+    inside a `fullgraph = True` region, and Dynamo refuses with
+
+        Unsupported: Skip calling `torch.compiler.disable()`d function
+
+    Matched narrowly on that signature: any other graph break under fullgraph
+    must still raise, since those point at real problems.
+    """
+    try:
+        text = str(exc)
+    except Exception:
+        return False
+    return ("torch.compiler.disable" in text
+            and "Skip calling" in text)
+
+
+def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
+    """Run eager instead of dying when the recompile cache is exhausted.
+
+    `fullgraph = True` makes Dynamo raise on cache exhaustion rather than fall
+    back, turning a performance problem into a hard training failure:
+
+        FailOnRecompileLimitHit: recompile_limit reached with fullgraph=True
+
+    Only cache exhaustion and our own disabled-hook graph break are caught, so
+    any other graph break under fullgraph still raises exactly as before.
+
+    The fallback LATCHES. Do not make it retry per call. Non-reentrant
+    activation checkpointing recomputes each packed forward during backward and
+    compares the saved intermediates, and a compiled pack recomputed eagerly
+    aborts the backward with "Something went unexpectedly wrong in activation
+    checkpoint". Per-call retry does not fix that: the pack and the recompute
+    run under different guards (grad mode differs, and the recompute is inside
+    backward), so the compiler can succeed for one and raise for the other in
+    either direction. Latching makes every call after the first failure eager,
+    so every later pack and recompute agree.
+
+    That leaves one mixed step, the one during which the latch flips. See
+    `force_eager_fallback` below, which unsloth uses to close it.
+    """
+    errors = _recompile_limit_errors()
+    graph_break_errors = _disabled_hook_graph_break_error()
+    if not errors and not graph_break_errors:
+        return compiled_func
+
+    # Warn once. The condition repeats every call, and the log should not.
+    state = {"warned": False, "eager": False}
+
+    def _warn(message):
+        if not state["warned"]:
+            state["warned"] = True
+            logger.warning(message)
+
+    @functools.wraps(eager_func)
+    def wrapper(*args, **kwargs):
+        if state["eager"]:
+            return eager_func(*args, **kwargs)
+        try:
+            return compiled_func(*args, **kwargs)
+        except errors as e:
+            state["eager"] = True
+            _warn(
+                f"Unsloth: torch.compile ran out of recompilation cache for "
+                f"{label}; running it eagerly from here. Training is "
+                f"unaffected apart from speed. ({type(e).__name__})"
+            )
+            return eager_func(*args, **kwargs)
+        except graph_break_errors as e:
+            # Only our own `torch.compiler.disable` hook. Anything else is a
+            # real graph break and must keep raising.
+            if not _is_our_own_disabled_hook(e):
+                raise
+            state["eager"] = True
+            _warn(
+                f"Unsloth: torch.compile hit one of Unsloth's own "
+                f"`torch.compiler.disable`d gradient-checkpointing hooks "
+                f"inside {label}; running it eagerly from here. Training is "
+                f"unaffected apart from speed."
+            )
+            return eager_func(*args, **kwargs)
+
+    # Keep the compiled callable reachable for anything that unwraps it, and
+    # keep `get_compiler_config` present so the unwrap check below still sees
+    # a compiled function and reaches `__wrapped__` (the eager original).
+    wrapper._unsloth_compiled_func = compiled_func
+    _gcc = getattr(compiled_func, "get_compiler_config", None)
+    if _gcc is not None:
+        wrapper.get_compiler_config = _gcc
+
+    wrapper._unsloth_fallback_state = state
+    wrapper._unsloth_fallback_label = label
+    _EAGER_FALLBACK_WRAPPERS.append(weakref.ref(wrapper))
+    return wrapper
+
+
+# Every wrapper built above, weakly, so a patched-then-discarded model does not
+# keep its functions alive. Weak refs also mean the registry cannot report a
+# switch for something nobody is calling any more.
+_EAGER_FALLBACK_WRAPPERS: list = []
+
+
+def eager_fallback_state() -> dict[str, bool]:
+    """{label: already fell back} for every live wrapper. For tests and logs."""
+    out = {}
+    for ref in _EAGER_FALLBACK_WRAPPERS:
+        w = ref()
+        if w is not None:
+            out[w._unsloth_fallback_label] = bool(w._unsloth_fallback_state["eager"])
+    return out
+
+
+def force_eager_fallback(only_if_already_triggered: bool = True) -> int:
+    """Latch every wrapper to eager. Returns how many are eager afterwards.
+
+    For unsloth to call when a backward dies inside activation checkpointing,
+    so the retry of that step is consistent. The limit is hit per function, so
+    one fallback can strand a checkpointed region spanning several; switching
+    them together removes the whole class of mismatch.
+
+    Returns a count of live wrappers, not of changes: the wrapper that caused
+    the trouble has already latched itself, so "how many changed" would be 0 in
+    exactly the case that matters.
+
+    `only_if_already_triggered` refuses to switch off compilation for a model
+    that never fell back. A caller that gets 0 has learned the checkpoint
+    assertion was not a compile-mode flip, and should re-raise rather than
+    retry.
+    """
+    live = [w for w in (ref() for ref in _EAGER_FALLBACK_WRAPPERS)
+            if w is not None]
+    if only_if_already_triggered and not any(
+            w._unsloth_fallback_state["eager"] for w in live):
+        return 0
+    for w in live:
+        w._unsloth_fallback_state["eager"] = True
+    return len(live)
+
+
 def patch_function(
     target_obj: Any,
     attr_name: str,
@@ -686,12 +860,20 @@ def patch_function(
             new_func = new_func.__wrapped__
         if hasattr(original_func, "get_compiler_config"):
             original_func = original_func.__wrapped__
+        _eager_func = new_func
         new_func = torch.compile(
             new_func,
             fullgraph = fullgraph,
             dynamic = dynamic,
             options = torch_compile_options,
         )
+        if fullgraph:
+            # Only fullgraph turns cache exhaustion into a raise; without it
+            # Dynamo already falls back on its own.
+            new_func = _fall_back_to_eager_on_recompile_limit(
+                new_func, _eager_func,
+                f"{getattr(target_obj, '__name__', target_obj)}.{attr_name}",
+            )
     pass
 
     # Stash original under a unique name for later restoration.

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -684,6 +684,24 @@ def _recompile_limit_errors():
     return tuple(found)
 
 
+def _wants_hard_recompile_failure():
+    """Did the user ask Dynamo to make cache exhaustion fatal?
+
+    torch raises FailOnRecompileLimitHit from two branches with the same class
+    -- this flag, and fullgraph=True -- so the exception cannot tell them
+    apart. Falling back to eager is right for the second and wrong for the
+    first, whose whole purpose is to stop the run. Read the flag instead.
+    Renamed in 2.7 (fail_on_cache_limit_hit -> fail_on_recompile_limit_hit)
+    with the old name kept as an alias, so check both to cover 2.6.
+    """
+    try:
+        import torch._dynamo.config as _config
+    except Exception:
+        return False
+    return bool(getattr(_config, "fail_on_recompile_limit_hit", False) or
+                getattr(_config, "fail_on_cache_limit_hit", False))
+
+
 def _disabled_hook_graph_break_error():
     """Dynamo's graph-break exception, if this torch has one."""
     try:
@@ -804,6 +822,8 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         try:
             return compiled_func(*args, **kwargs)
         except errors as e:
+            if _wants_hard_recompile_failure():
+                raise
             state["eager"] = True
             _warn(
                 f"Unsloth: torch.compile ran out of recompilation cache for "


### PR DESCRIPTION
Four related failures, all of them a compiled forward dying rather than degrading.

### `requires_grad` hooks cannot be traced

The gradient-enabling hooks mutate `requires_grad`, which Dynamo refuses:

```
Unsupported: Unsupported Tensor.requires_grad_() call
```

They are autograd bookkeeping rather than compute, one tensor once per forward, so they now run eagerly with a graph break around them. On a torch without `_dynamo` the decorator degrades to a no-op, so eager users and older builds are untouched.

The wrapper copies `__name__` / `__qualname__` back, because `register_other_hooks()` identifies our hooks by matching those names. Without it the hooks stop being recognised as ours and get registered on top of themselves. torch 2.9 happens to carry them through `disable()`, but that is an internal detail of a private module and this has to hold from torch 2.6 up.

### `fullgraph = True` turns cache exhaustion into a hard failure

```
FailOnRecompileLimitHit: recompile_limit reached with fullgraph=True
```

which is a performance problem presented as a training failure. The patched function now falls back to eager. Only cache exhaustion and our own disabled-hook graph break are caught; any other graph break under `fullgraph` still raises exactly as before.

The exception classes are looked up by name because torch 2.6 through 2.11 do not agree on which of `FailOnRecompileLimitHit`, `RecompileLimitExceeded` and `CacheLimitExceeded` exist, and a missing one must not stop the tuple from being built.

### Our own disabled hook breaking our own graph

The `torch.compiler.disable`d hooks above can be invoked from inside a `fullgraph = True` region, and Dynamo refuses:

```
Unsupported: Skip calling `torch.compiler.disable()`d function
```

Matched narrowly on that signature, so any other graph break still raises.

### The fallback has to latch, and this is the subtle one

Non-reentrant activation checkpointing recomputes each packed forward during backward and compares the saved intermediates. A pack compiled and then recomputed eagerly aborts the backward with "Something went unexpectedly wrong in activation checkpoint".

Per-call retry does **not** fix this, and it was tried first. The pack and the recompute run under different guards (grad mode differs, and the recompute is inside backward), so the compiler can succeed for one and raise for the other in either direction. Latching makes every call after the first failure eager, so every later pack and recompute agree.

That leaves exactly one mixed step, the one during which the latch flips. `force_eager_fallback()` closes it: unsloth calls it when a backward dies inside activation checkpointing, so the retry of that step is consistent. It returns a count of live wrappers rather than of changes, because the wrapper that caused the trouble has already latched itself and "how many changed" would be 0 in precisely the case that matters. `only_if_already_triggered` refuses to switch off compilation for a model that never fell back, so a caller that gets 0 has learned the checkpoint assertion was not a compile-mode flip and should re-raise rather than retry.

The wrapper registry holds weak references, so a patched-then-discarded model does not keep its functions alive, and the registry cannot report a switch for something nobody is calling any more.

### Tests

**560 passed, 37 skipped, 0 failed.**

- 54 new across four files: the hook decorator, the recompile-limit fallback, the disabled-hook graph break, and the latch itself (including that the latch is per wrapper and not global).
- 506 passed / 37 skipped across 15 existing suites touching compile fallback, requires_grad hooks, activation checkpointing and recompute, and `patch_function`.

Both `test_the_fallback_latches` tests carry an explicit note not to reverse the assertion, because an earlier revision of this work asserted non-latching and per-call retry is what the activation-checkpoint failure above rules out.
