### PR TITLE
Fix three unrelated hard failures: response-only masking, pad token range, torchao import

### DIFF
--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -473,3 +473,53 @@ def test_non_special_fim_pad_is_eligible():
                         non_special = ["<|fim_pad|>"])
     res = fix_pad_token(tok)
     assert res["changed"] and tok.pad_token == "<|fim_pad|>"
+
+
+def test_composite_model_text_vocab_size_is_used_for_pad_range():
+    """Sesame CSM: config.vocab_size is the audio codebook (2051) while the text
+    tokenizer holds 128256 ids and declares pad_token_id = 128004."""
+    tok = FakeTokenizer(
+        {"<|end_of_text|>": 128001, "<|finetune_right_pad_id|>": 128004},
+        pad_token="<|end_of_text|>",
+        eos_token="<|end_of_text|>",
+    )
+    cfg = type("Cfg", (), {
+        "model_type": "csm",
+        "vocab_size": 2051,            # audio codebook
+        "text_vocab_size": 128256,     # the tokenizer's actual range
+        "pad_token_id": 128004,
+        "eos_token_id": 128001,
+    })()
+    res = fix_pad_token(tok, model_config=cfg)
+    assert res["added"] is False, res
+    assert res["new_pad"] == "<|finetune_right_pad_id|>", res
+    assert tok.pad_token != tok.eos_token
+
+
+def test_nested_text_config_vocab_size_is_preferred():
+    tok = FakeTokenizer(
+        {"<|eot|>": 700, "<|pad|>": 900},
+        pad_token="<|eot|>", eos_token="<|eot|>",
+    )
+    text_cfg = type("TextCfg", (), {"vocab_size": 1024})()
+    cfg = type("Cfg", (), {
+        "model_type": "multimodal", "vocab_size": 64,
+        "text_config": text_cfg, "pad_token_id": 900, "eos_token_id": 700,
+    })()
+    res = fix_pad_token(tok, model_config=cfg)
+    assert res["added"] is False, res
+    assert res["new_pad"] == "<|pad|>", res
+
+
+def test_single_vocab_models_keep_the_old_bound():
+    """No text vocab declared -> behave exactly as before: an out-of-range
+    declared pad is still rejected."""
+    tok = FakeTokenizer(
+        {"<|eot|>": 10}, pad_token="<|eot|>", eos_token="<|eot|>",
+    )
+    cfg = type("Cfg", (), {
+        "model_type": "llama", "vocab_size": 32,
+        "pad_token_id": 9999, "eos_token_id": 10,
+    })()
+    with pytest.raises(RuntimeError):
+        fix_pad_token(tok, model_config=cfg)

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -512,8 +512,7 @@ def test_nested_text_config_vocab_size_is_preferred():
 
 
 def test_single_vocab_models_keep_the_old_bound():
-    """No text vocab declared -> behave exactly as before: an out-of-range
-    declared pad is still rejected."""
+    """No text vocab declared -> the old bound, so an out-of-range pad is rejected."""
     tok = FakeTokenizer(
         {"<|eot|>": 10}, pad_token="<|eot|>", eos_token="<|eot|>",
     )

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2922,3 +2922,69 @@ def test_a_list_of_media_paths_is_not_proven_text():
         "a string sequence is still not treated like a bare string"
     assert "_looks_like_media_value(value)" in src, \
         "the value scan still weighs only data URIs, not media suffixes"
+
+
+# ── round sixteen: what the TEXT path must not be handed ────────────────────
+
+
+def test_retained_metadata_is_stripped_before_the_text_collator():
+    """The signature whitelist is global, so widening it for the media path
+    kept a benign `url`/`prompt`/`content` column alive for EVERY split. The
+    text collator tensorizes every key it is handed, so the retained string
+    killed the batch that `_has_media` correctly sent its way."""
+    seen = {}
+
+    class Text:
+        def __call__(self, features):
+            seen["keys"] = sorted(features[0].keys())
+            return {"ok": True}
+
+    class Media:
+        def __call__(self, features):
+            seen["media"] = True
+            return {"ok": True}
+
+    from unsloth_zoo.dataset_utils import _MediaAwareCollator
+    d = _MediaAwareCollator(Text(), Media(), {"pixel_values"},
+                            {"url"}, {"prompt", "caption"})
+    row = {"input_ids": [1, 2], "labels": [1, 2],
+           "url": "https://example.com/article", "prompt": "describe it"}
+    d([dict(row)])
+
+    assert "media" not in seen, "a text row went to the vision collator"
+    assert seen["keys"] == ["input_ids", "labels"], seen["keys"]
+    # And the caller's row is untouched: the strip works on copies.
+    assert set(row) == {"input_ids", "labels", "url", "prompt"}
+
+
+def test_the_media_path_still_sees_every_kept_column():
+    """The strip is on the text path only. A media batch needs the prompt that
+    goes with its image, which is why those columns are kept at all."""
+    seen = {}
+
+    class Text:
+        def __call__(self, features): seen["text"] = True
+
+    class Media:
+        def __call__(self, features): seen["keys"] = sorted(features[0].keys())
+
+    from unsloth_zoo.dataset_utils import _MediaAwareCollator
+    d = _MediaAwareCollator(Text(), Media(), {"pixel_values"},
+                            {"url"}, {"prompt"})
+    d([{"input_ids": [1], "pixel_values": [[0.0]], "prompt": "describe it"}])
+
+    assert "text" not in seen
+    assert seen["keys"] == ["input_ids", "pixel_values", "prompt"]
+
+
+def test_a_configured_label_survives_raw_column_removal():
+    """`_keep_media_columns` kept `args.label_names` in the signature while the
+    raw-column keep-list deleted the same columns from the split itself."""
+    from unsloth_zoo import dataset_utils as D
+    import inspect
+
+    src = inspect.getsource(D.train_on_responses_only)
+    body = src[src.index("def _model_input_columns"):]
+    body = body[:body.index("_keep_columns = ")]
+    assert 'label_names' in body, \
+        "the raw-column keep-list still drops a custom trainer's configured labels"

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2374,3 +2374,37 @@ def test_a_model_input_column_is_never_judged_by_one_row():
 
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert "token_type_ids" in out.train_dataset.column_names
+
+
+def test_a_singular_label_alias_is_dropped_beside_the_masked_labels():
+    """`DataCollatorForSeq2Seq` reads `"label" if "label" in features[0] else
+    "labels"`, so a numeric `label` surviving the opt-out wins outright and the
+    response-only masks just built are never used."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW), [1] * len(ROW)],
+        "label": [0, 1],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    kept = out.train_dataset.column_names
+    assert "labels" in kept
+    assert "label" not in kept, "the alias would outrank the masks"
+
+
+@pytest.mark.parametrize("column", ("picture", "pictures", "photo", "photos"))
+def test_picture_and_photo_name_media_as_plainly_as_image(column):
+    """A pretokenized VLM set keeping "cat.jpg" under `picture` has a string
+    schema, so only the name can say it is media. `image` was listed and its two
+    commonest synonyms were not, so the bypass replaced the vision collator and
+    dropped the column, training those rows without their images."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        column: ["cat.jpg", "dog.jpg"],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1526,3 +1526,113 @@ def test_an_undecoded_image_struct_is_still_refused():
     trainer = _meta_trainer([{"bytes": b"\x89PNG", "path": "a"}] * 2)
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+# ---- what the third review round found --------------------------------------
+
+@pytest.mark.parametrize("key, value", [
+    ("image_path",     "images/cat.jpg"),
+    ("video_path",     "clips/intro.mp4"),
+    ("audio_path",     "clips/take1.wav"),
+    ("image_file",     "images/cat.png"),
+    ("image_filename", "cat.jpg"),
+    ("image_url",      "https://example.com/cat.jpg"),
+])
+def test_a_nested_path_style_media_key_is_refused(key, value):
+    """The same name is media at the top level, so it is media one level down
+    too: a turn carrying `{"image_path": ...}` holds a plain string, which is
+    what the schema and the sampled values both see, so only the key can say it
+    is an image the text path would drop."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), Dataset.from_dict({
+        "input_ids": [list(ROW)] * 2,
+        "messages": [[{"role": "user", "content": "describe", key: value}]] * 2,
+    }))
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "messages" in trainer.train_dataset.column_names, "the media was dropped"
+
+
+def test_a_nested_media_path_in_a_plain_struct_is_refused():
+    """Not only conversations: a `meta` struct pointing at the media file is the
+    same silent text-only run."""
+    trainer = _meta_trainer([{"video_path": "clips/intro.mp4",
+                              "source": "youtube"}] * 2)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+@pytest.mark.parametrize("column, value", [
+    ("video_filename",  "intro.mp4"),
+    ("audio_filename",  "take1.wav"),
+    ("image_filename",  "cat.jpg"),
+    ("video_filenames", ["intro.mp4"]),
+    ("audio_filenames", ["take1.wav"]),
+])
+def test_a_media_filename_column_is_refused(column, value):
+    """`*_filename` is as ordinary a spelling as `*_path`, and only the image one
+    was listed: the column is `string`, so nothing else can catch it."""
+    collator = MyVisionCollator(StubProcessor())
+    trainer = StubTrainer(collator, Dataset.from_dict({
+        "input_ids": [list(ROW)] * 2,
+        column: [value] * 2,
+    }))
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.data_collator is collator, "the user's collator was replaced"
+    assert column in trainer.train_dataset.column_names, "the media column was dropped"
+
+
+class ProcessorWithoutImages:
+    """A processor half with no `.pad` and no `image_processor`, so the vision
+    bypass never sees it and only the `.pad` repair can fire."""
+    def __init__(self):
+        self.feature_extractor = object()
+        self.tokenizer = StubTokenizer()
+
+
+class SelfPackingCollator:
+    """A user's own packing collator: it holds a processor for its own use and
+    concatenates the batch itself, so it never calls `.pad` on anything."""
+    def __init__(self, processor):
+        self.processor = processor
+
+    def __call__(self, features):
+        ids, position_ids = [], []
+        for feature in features:
+            ids += list(feature["input_ids"])
+            position_ids += list(range(len(feature["input_ids"])))
+        return {"input_ids": [ids], "position_ids": [position_ids]}
+
+
+def test_a_self_packing_collator_holding_a_processor_is_left_alone():
+    """Holding a processor is not proof of padding through it. This one packs and
+    batches itself, so replacing it with DataCollatorForSeq2Seq silently drops the
+    packed `position_ids` - exactly what the packing gate exists to prevent."""
+    collator = SelfPackingCollator(ProcessorWithoutImages())
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.processing_class = StubTokenizer()      # a plain text run
+    trainer.args.packing = True
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert out.data_collator is collator, "the custom packing collator was replaced"
+    rows = [out.train_dataset[i] for i in range(len(out.train_dataset))]
+    assert "position_ids" in out.data_collator(rows), "its packing did not survive"
+
+
+def test_a_seq2seq_collator_holding_a_processor_is_still_repaired_under_packing():
+    """The other direction: a class that really does pad through `.pad` is still
+    rebuilt even with packing on, since it dies on the first batch either way."""
+    collator = DataCollatorForSeq2Seq(tokenizer = ProcessorWithoutImages())
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.processing_class = StubTokenizer()
+    trainer.args.packing = True
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert out.data_collator is not collator, "still padding through the processor"
+    assert hasattr(out.data_collator.tokenizer, "pad")

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1215,3 +1215,81 @@ def test_a_raw_eval_split_with_a_media_url_column_is_refused():
     })
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+# ---- an ambiguous media column is read to the end ---------------------------
+
+def test_an_ambiguous_media_column_is_scanned_past_the_sample():
+    """`url`/`path` are `string` either way, so the schema cannot rule them out
+    and the 16-row sample skips row 5. Read the column instead: it decodes no
+    images, so a full scan is cheap."""
+    n = 200
+    urls = ["https://en.wikipedia.org/wiki/Anarchism"] * n
+    urls[5] = "https://example.com/cat.jpg"
+    collator = MyVisionCollator(StubProcessor())
+    trainer = StubTrainer(collator, Dataset.from_dict({
+        "input_ids": [list(ROW)] * n, "url": urls,
+    }))
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.data_collator is collator
+    assert "url" in trainer.train_dataset.column_names, "the media column was dropped"
+
+
+def test_a_raw_eval_split_with_an_unsampled_media_url_is_refused():
+    """The eval half samples the same 16 positions, so it needs the scan too."""
+    n = 200
+    paths = ["corpus/shard_0007.jsonl"] * n
+    paths[5] = "/data/images/0001.png"
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"] * n, "path": paths,
+    })
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_wholly_benign_ambiguous_column_still_passes_the_scan():
+    """The scan must not turn every text corpus with a `path` column into a refusal."""
+    n = 200
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), Dataset.from_dict({
+        "input_ids": [list(ROW)] * n, "path": [f"corpus/shard_{i}.jsonl" for i in range(n)],
+    }))
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in out.train_dataset.column_names, "the text path never ran"
+
+
+# ---- a collator holding an image processor directly -------------------------
+
+class DirectImageProcessorCollator:
+    """`_is_vision_collator` accepts a bare `collator.image_processor`, so the
+    column names that half declares have to be derived from it as well."""
+    def __init__(self, image_names):
+        self.image_processor = type("ImageProcessor", (), {
+            "model_input_names": list(image_names),
+        })()
+
+    def __call__(self, features):
+        return {"mine": True}
+
+
+def test_columns_of_a_directly_held_image_processor_are_multimodal():
+    collator = DirectImageProcessorCollator(["my_pixels"])
+    trainer = StubTrainer(collator, Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)], "my_pixels": [[0.0, 1.0], [0.0, 1.0]],
+    }))
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.data_collator is collator
+    assert "my_pixels" in trainer.train_dataset.column_names, "the media column was dropped"
+
+
+def test_a_directly_held_image_processor_still_lets_text_only_rows_through():
+    """The derivation must widen the multimodal set, not refuse every run."""
+    trainer = StubTrainer(DirectImageProcessorCollator(["my_pixels"]), _text_rows())
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in out.train_dataset.column_names, "the text path never ran"

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -318,8 +318,13 @@ def test_a_processor_backed_padding_collator_is_repaired_under_packing():
 
 def test_a_collator_holding_only_a_processor_is_repaired_under_packing():
     """TRL's `DataCollatorForVisionLanguageModeling` keeps the processor under
-    `.processor`, not `.tokenizer`, with the same problem."""
-    trainer = _text_only_trainer()          # MyVisionCollator holds `.processor`
+    `.processor`, not `.tokenizer`, with the same problem. It rebuilds labels
+    through that processor, so it is a class we know how to answer for and the
+    repair still runs with packing on."""
+    from trl.trainer.sft_trainer import DataCollatorForVisionLanguageModeling
+
+    trainer = _text_only_trainer()
+    trainer.data_collator = DataCollatorForVisionLanguageModeling(processor = StubProcessor())
     trainer.args.packing = True
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
@@ -359,13 +364,12 @@ class LabelRebuildingVisionCollator:
         return batch
 
 
-def test_a_label_rebuilding_vision_collator_is_replaced_under_packing():
-    """It pads through a real tokenizer, so the `.pad` repair does not fire. If
-    packing then leaves it attached it rebuilds `labels` at collate time, throwing
-    away the dataset-level mask this function just wrote: training on prompts."""
+def test_a_label_rebuilding_vision_collator_is_replaced():
+    """It pads through a real tokenizer, so the `.pad` repair does not fire. Left
+    attached it rebuilds `labels` at collate time, throwing away the dataset-level
+    mask this function just wrote: training on prompts."""
     collator = LabelRebuildingVisionCollator(StubProcessor())
     trainer = StubTrainer(collator, _text_rows())
-    trainer.args.packing = True
 
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
@@ -373,6 +377,18 @@ def test_a_label_rebuilding_vision_collator_is_replaced_under_packing():
     rows = [out.train_dataset[i] for i in range(len(out.train_dataset))]
     labels = out.data_collator(rows)["labels"]
     assert -100 in list(labels[0]), "the response mask did not survive collation"
+
+
+def test_a_label_rebuilding_vision_collator_is_refused_under_packing():
+    """With packing on the same collator has no right answer: this file cannot
+    tell a custom label rebuilder from a custom packer, and both readings lose
+    something silently. Refuse instead of picking one."""
+    collator = LabelRebuildingVisionCollator(StubProcessor())
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.args.packing = True
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
 
 def test_a_real_tokenizer_padding_collator_is_untouched_under_packing():
@@ -1848,3 +1864,34 @@ def test_remove_unused_columns_false_keeps_the_users_columns():
     columns = set(out.train_dataset.column_names)
     assert "sample_weight" in columns, sorted(columns)
     assert out.train_dataset[0]["sample_weight"] == 0.25
+
+
+def test_a_bypassed_self_packing_collator_is_refused_under_packing():
+    """Neither answer is right here, so neither may be taken silently.
+
+    `_is_vision_collator` matches any collator merely holding a processor, and
+    the bypass disjunct is not packing-gated, so a custom self-packing collator
+    was replaced with `DataCollatorForSeq2Seq` and its packing, its
+    `position_ids` and any block-attention inputs went with it. Keeping it is no
+    safer: its `__call__` may rebuild `labels` over the mask just written.
+    """
+    collator = SelfPackingCollator(StubProcessor())   # a processor, so bypassed
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.args.packing = True
+
+    with pytest.raises(ValueError, match = "does not support response-only") as excinfo:
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "SelfPackingCollator" in str(excinfo.value), "the refusal does not name the collator"
+    assert trainer.data_collator is collator, "the user's collator was replaced anyway"
+
+
+def test_a_bypassed_self_packing_collator_is_untouched_without_packing():
+    """The blast radius: with packing off there is nothing to lose, so the
+    replacement runs exactly as before."""
+    collator = SelfPackingCollator(StubProcessor())
+    trainer = StubTrainer(collator, _text_rows())
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2988,3 +2988,77 @@ def test_a_configured_label_survives_raw_column_removal():
     body = body[:body.index("_keep_columns = ")]
     assert 'label_names' in body, \
         "the raw-column keep-list still drops a custom trainer's configured labels"
+
+
+def test_case_variant_media_columns_survive_unused_column_removal():
+    """`_has_media` matches by lowercasing a column name, so a split naming its
+    media `Image` or `IMAGE_URL` dispatches correctly -- but only if the column
+    is still there. The signature whitelist held lowercase spellings alone, so
+    `remove_unused_columns` stripped it first and the batch went to the text
+    collator that cannot encode it."""
+    from unsloth_zoo.dataset_utils import _keep_media_columns
+
+    class Split:
+        column_names = ["Image", "IMAGE_URL", "text", "unrelated"]
+
+    class Trainer:
+        _signature_columns = None
+        train_dataset = Split()
+        eval_dataset = None
+        args = None
+        model = None
+
+    trainer = Trainer()
+    _keep_media_columns(trainer, {"image", "image_url"})
+    kept = set(trainer._signature_columns)
+    assert {"Image", "IMAGE_URL", "image", "image_url"} <= kept
+    assert "unrelated" not in kept
+
+
+def test_a_later_split_gets_the_common_case_spellings_anyway():
+    """The signature is cached once, so a split handed to `predict()` afterwards
+    cannot contribute its own column names. Cover the spellings that actually
+    occur rather than leaving that case wholly unprotected."""
+    from unsloth_zoo.dataset_utils import _keep_media_columns
+
+    class Trainer:
+        _signature_columns = None
+        train_dataset = None
+        eval_dataset = None
+        args = None
+        model = None
+
+    trainer = Trainer()
+    _keep_media_columns(trainer, {"image", "image_url"})
+    kept = set(trainer._signature_columns)
+    assert {"Image", "IMAGE", "Image_Url", "IMAGE_URL"} <= kept
+
+
+def test_case_variants_read_every_stored_eval_split():
+    from unsloth_zoo.dataset_utils import _case_variants
+
+    class Split:
+        def __init__(self, names): self.column_names = names
+
+    class Trainer:
+        train_dataset = None
+        eval_dataset = {"a": Split(["Audio"]), "b": Split(["Videos"])}
+
+    found = _case_variants(Trainer(), {"audio", "videos"})
+    assert {"Audio", "Videos"} <= found
+
+
+def test_case_variants_survive_a_split_that_refuses_its_columns():
+    """A custom split with no usable `column_names` must not take the whitelist
+    down with it: the fixed variants are still the answer."""
+    from unsloth_zoo.dataset_utils import _case_variants
+
+    class Angry:
+        @property
+        def column_names(self): raise RuntimeError("no")
+
+    class Trainer:
+        train_dataset = Angry()
+        eval_dataset = None
+
+    assert "Image" in _case_variants(Trainer(), {"image"})

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2855,3 +2855,70 @@ def test_the_conversation_keys_are_still_not_dispatch_keys():
     assert "messages" not in dispatcher.media_keys
     assert not dispatcher._has_media([{"messages": "a plain string, not a conversation"}])
     assert dispatcher._has_media([{"messages": [{"role": "user"}]}])
+
+
+# ── round fifteen: what the deferred media collator actually needs ───────────
+
+
+def _r15_bypass(**args):
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    for k, v in args.items(): setattr(trainer.args, k, v)
+    return train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_the_prompt_that_goes_with_the_media_survives():
+    """A raw `{"text": prompt, "image": image}` row kept its image and lost its
+    prompt, so the vision collator had nothing to tokenize."""
+    out = _r15_bypass()
+    signature = getattr(out, "_signature_columns", None)
+    assert signature, "signature columns were never seeded"
+    for key in ("text", "caption", "image"):
+        assert key in signature, f"{key} would be stripped before the collator"
+
+
+def test_a_configured_label_name_survives():
+    """Trainer's own derivation adds `self.label_names`; supervision consumed by
+    a custom `compute_loss` is not declared by `forward` and was dropped."""
+    out = _r15_bypass(label_names = ["expert_score", "aux_target"])
+    signature = getattr(out, "_signature_columns", None)
+    for key in ("expert_score", "aux_target"):
+        assert key in signature, f"{key} is a configured label and would be stripped"
+
+
+@pytest.mark.parametrize("key", ["image_base64", "speech", "path"])
+def test_every_recognized_media_form_is_dispatchable(key):
+    """The guard that refuses the bypass recognises these; the dispatcher did
+    not, so a later split storing one of them went to the text collator."""
+    out = _r15_bypass()
+    dispatcher = out.data_collator
+    keys = dispatcher.media_keys | dispatcher.ambiguous_keys
+    assert key in keys, f"{key} is recognized by the guard but not dispatchable"
+
+
+def test_an_ambiguous_name_is_still_weighed_by_its_value():
+    """`path`/`url` is a media reference or ordinary provenance. Matching the
+    name alone would send every row carrying a plain URL to the vision
+    collator, which is the looseness the conversation keys already avoid."""
+    d = _r15_bypass().data_collator
+    assert "path" in d.ambiguous_keys and "path" not in d.media_keys
+    assert not d._has_media([{"path": "https://example.com/article"}])
+    assert d._has_media([{"path": "https://example.com/cat.jpg?w=64"}])
+    assert d._has_media([{"path": "data:image/png;base64,iVBOR"}])
+
+
+def test_a_list_of_media_paths_is_not_proven_text():
+    """`attachments = ["cat.jpg"]` is a `Sequence(Value("string"))`, which
+    passed the plain-text schema check, so the value scan was skipped and the
+    column was dropped -- training silently without the media."""
+    from unsloth_zoo import dataset_utils as D
+    import inspect
+
+    src = inspect.getsource(D.train_on_responses_only)
+    assert "_feature_is_bare_string(inner, _depth + 1)" in src, \
+        "a string sequence is still not treated like a bare string"
+    assert "_looks_like_media_value(value)" in src, \
+        "the value scan still weighs only data URIs, not media suffixes"

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -353,3 +353,95 @@ def test_a_real_tokenizer_padding_collator_is_untouched_under_packing():
     trainer.args.packing = True
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert out.data_collator is collator
+
+
+# ---- raw columns must not reach the collator -------------------------------
+
+class StrictPadTokenizer(StubTokenizer):
+    """Pads like the real thing: it tensorizes every key it is handed, so a raw
+    string column raises exactly as `tokenizer.pad(return_tensors = "pt")` does."""
+    def pad(self, features, **kwargs):
+        for feature in features:
+            for key, value in feature.items():
+                probe = value
+                while isinstance(probe, (list, tuple)) and probe:
+                    probe = probe[0]
+                if not isinstance(probe, (int, float, bool)):
+                    raise ValueError(
+                        f"Unable to create tensor ... (`{key}` in this case)"
+                    )
+        return StubTokenizer.pad(self, features, **kwargs)
+
+
+class StrictProcessor(StubProcessor):
+    def __init__(self):
+        super().__init__()
+        self.tokenizer = StrictPadTokenizer()
+
+
+def _collate_every_row(trainer):
+    dataset = trainer.train_dataset
+    return trainer.data_collator([dataset[i] for i in range(len(dataset))])
+
+
+def test_a_leftover_text_column_never_reaches_the_collator():
+    """Pretokenizing with `dataset.map` and no `remove_columns` leaves `text`
+    behind. Unused-column removal is off for token-type-id models, so the raw
+    string reaches the swapped-in collator and dies while tensorizing."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "text": ["q0", "q1"],
+    })
+    trainer = StubTrainer(MyVisionCollator(StrictProcessor()), dataset)
+    trainer.processing_class = StrictProcessor()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "text" not in out.train_dataset.column_names
+    _collate_every_row(out)     # used to raise ValueError while tensorizing
+
+
+def test_a_leftover_conversational_column_never_reaches_the_collator():
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "messages": [[{"role": "user", "content": "q"}]] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StrictProcessor()), dataset)
+    trainer.processing_class = StrictProcessor()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "messages" not in out.train_dataset.column_names
+    _collate_every_row(out)
+
+
+def test_numeric_model_columns_survive_the_strip():
+    """token_type_ids is exactly why unused-column removal was turned off, so
+    dropping raw columns must not take it (or any other numeric column) along."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+        "token_type_ids": [[0] * len(ROW)] * 2,
+        "text": ["q0", "q1"],
+    })
+    trainer = StubTrainer(MyVisionCollator(StrictProcessor()), dataset)
+    trainer.processing_class = StrictProcessor()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    for column in ("input_ids", "attention_mask", "token_type_ids", "labels"):
+        assert column in out.train_dataset.column_names, column
+    assert "text" not in out.train_dataset.column_names
+
+
+def test_a_tokenized_eval_split_keeps_no_raw_text():
+    """The raw eval split the bypass tokenizes for the user must come back with
+    the text column replaced, not beside it."""
+    trainer = StubTrainer(MyVisionCollator(StrictProcessor()), _text_rows())
+    trainer.processing_class = StrictProcessor()
+    trainer.eval_dataset = {"raw": _raw_text_rows(), "pretok": _text_rows()}
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "text" not in out.eval_dataset["raw"].column_names
+    assert "labels" in out.eval_dataset["raw"].column_names

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1636,3 +1636,32 @@ def test_a_seq2seq_collator_holding_a_processor_is_still_repaired_under_packing(
 
     assert out.data_collator is not collator, "still padding through the processor"
     assert hasattr(out.data_collator.tokenizer, "pad")
+
+
+# --- what the fourth review round found -----------------------------------
+
+def test_a_model_input_column_survives_raw_text_tokenization():
+    """A field the model is fed but the tokenizer does not recreate must survive.
+
+    The raw-text tokenize path removed every original column except `labels`, so
+    a per-row `sample_weight` (or any custom auxiliary target declared by
+    `model.forward`) vanished before the later model-input keep-list could save
+    it, leaving a missing required forward argument at train time.
+    """
+    class _ModelWithExtraInput:
+        def forward(self, input_ids = None, attention_mask = None, labels = None,
+                    sample_weight = None):
+            raise AssertionError("not called")
+
+    trainer = _text_only_trainer()
+    rows = _raw_text_rows(2).add_column("sample_weight", [0.25, 0.75])
+    trainer.eval_dataset = rows
+    trainer.model = _ModelWithExtraInput()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    columns = set(out.eval_dataset.column_names)
+    assert "sample_weight" in columns, sorted(columns)
+    assert out.eval_dataset[0]["sample_weight"] == 0.25
+    # The raw text it replaced is still gone: the collator cannot stack strings.
+    assert "text" not in columns, sorted(columns)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1,0 +1,169 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""What the pretokenized bypass is allowed to hand to the text path.
+
+The bypass lets a text-only fine-tune of a multimodal model reach dataset-level
+masking instead of being refused. Two things it must not do on the way:
+
+* fire for rows that still carry images, since the text path replaces the
+  collator and the user's image handling would go with it; and
+* leave behind a `DataCollatorForSeq2Seq` that pads through a processor, which
+  has no `.pad`, so the run dies on the first batch.
+
+CPU-pure and offline: everything here is a local stub, no weights are loaded.
+"""
+
+import pytest
+from datasets import Dataset
+from transformers import DataCollatorForSeq2Seq
+
+from unsloth_zoo.dataset_utils import train_on_responses_only
+
+
+INSTRUCTION_PART = "<|user|>"
+RESPONSE_PART = "<|assistant|>"
+USER_ID, ASSISTANT_ID, PAD_ID = 1, 2, 0
+ROW = [USER_ID, 10, 11, ASSISTANT_ID, 20, 21]
+
+
+class StubTokenizer:
+    """A text tokenizer: it can pad, which is the whole point below."""
+    padding_side = "right"
+    pad_token_id = PAD_ID
+    model_input_names = ["input_ids", "attention_mask"]
+
+    def __call__(self, text, add_special_tokens = False):
+        result = type("R", (), {})()
+        if text == INSTRUCTION_PART:   result.input_ids = [USER_ID]
+        elif text == RESPONSE_PART:    result.input_ids = [ASSISTANT_ID]
+        else:                          result.input_ids = [ord(c) for c in text]
+        return result
+
+    def pad(self, features, padding = True, max_length = None,
+            pad_to_multiple_of = None, return_tensors = None, **kwargs):
+        width = max(len(f["input_ids"]) for f in features)
+        return {
+            "input_ids": [f["input_ids"] + [PAD_ID] * (width - len(f["input_ids"]))
+                          for f in features],
+        }
+
+
+class StubProcessor:
+    """What a multimodal model hands the trainer as its tokenizer. No `.pad`."""
+    def __init__(self):
+        self.image_processor = object()
+        self.tokenizer = StubTokenizer()
+
+
+class MyVisionCollator:
+    """A user's own collator, holding the processor so it can batch images."""
+    def __init__(self, processor):
+        self.processor = processor
+
+    def __call__(self, features):
+        return {"mine": True}
+
+
+class StubTrainer:
+    def __init__(self, collator, train_dataset):
+        self.data_collator = collator
+        self.train_dataset = train_dataset
+        self.eval_dataset = None
+        self.processing_class = StubProcessor()
+        self.args = type("Args", (), {"packing": False})()
+
+
+def _text_rows():
+    return Dataset.from_dict({"input_ids": [list(ROW), list(ROW)]})
+
+
+def _multimodal_rows():
+    return Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "pixel_values": [[[0.0] * 4], [[0.0] * 4]],
+        "image_grid_thw": [[1, 2, 2], [1, 2, 2]],
+    })
+
+
+# ---- images must not be dropped -------------------------------------------
+
+@pytest.mark.parametrize("extra_column", [
+    "pixel_values", "pixel_values_videos", "image_grid_thw", "input_features",
+])
+def test_multimodal_rows_are_still_refused(extra_column):
+    """`input_ids` alone does not make a row text-only. The text path swaps the
+    collator for a text one, so firing here would silently drop the user's
+    image handling and mis-shape (or fail to batch) the image columns."""
+    collator = MyVisionCollator(StubProcessor())
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        extra_column: [[0.0], [0.0]],
+    })
+    trainer = StubTrainer(collator, dataset)
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.data_collator is collator, "the user's collator was replaced"
+
+
+def test_multimodal_iterable_rows_are_still_refused():
+    """No column_names, so the row peek has to make the same call."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          _multimodal_rows().to_iterable_dataset())
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+# ---- the run has to survive the first batch --------------------------------
+
+def test_a_processor_backed_seq2seq_collator_is_rebuilt():
+    """`DataCollatorForSeq2Seq(tokenizer = processor)` is the collator the
+    bypass exists for. Left alone it pads via `self.tokenizer.pad`, which a
+    processor does not have, so the first batch dies with
+    `AttributeError: ... object has no attribute 'pad'`."""
+    processor = StubProcessor()
+    trainer = StubTrainer(DataCollatorForSeq2Seq(tokenizer = processor),
+                          _text_rows())
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    collator = out.data_collator
+    assert isinstance(collator, DataCollatorForSeq2Seq)
+    assert hasattr(collator.tokenizer, "pad"), \
+        f"still padding through {type(collator.tokenizer).__name__}"
+
+    rows = [out.train_dataset[i] for i in range(len(out.train_dataset))]
+    batch = collator(rows)     # used to raise AttributeError
+    assert "input_ids" in batch and "labels" in batch
+
+
+def test_a_tokenizer_backed_seq2seq_collator_is_left_alone():
+    """The pre-existing path: a seq2seq collator that already pads through a
+    real tokenizer keeps its own settings."""
+    collator = DataCollatorForSeq2Seq(tokenizer = StubTokenizer(),
+                                      pad_to_multiple_of = 8)
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.data_collator = collator
+    # Not a vision collator, so this exercises the plain text path.
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert out.data_collator is collator
+    assert out.data_collator.pad_to_multiple_of == 8
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -27,9 +27,11 @@ masking instead of being refused. Two things it must not do on the way:
 CPU-pure and offline: everything here is a local stub, no weights are loaded.
 """
 
+import re
+
 import pytest
 from datasets import Dataset
-from transformers import DataCollatorForSeq2Seq
+from transformers import DataCollatorForSeq2Seq, DataCollatorWithPadding
 
 from unsloth_zoo.dataset_utils import train_on_responses_only
 
@@ -40,18 +42,35 @@ USER_ID, ASSISTANT_ID, PAD_ID = 1, 2, 0
 ROW = [USER_ID, 10, 11, ASSISTANT_ID, 20, 21]
 
 
+class _Encoding(dict):
+    """Mapping (what `datasets.map` wants) that also answers `.input_ids`."""
+    @property
+    def input_ids(self):
+        return self["input_ids"]
+
+
 class StubTokenizer:
     """A text tokenizer: it can pad, which is the whole point below."""
     padding_side = "right"
     pad_token_id = PAD_ID
     model_input_names = ["input_ids", "attention_mask"]
 
-    def __call__(self, text, add_special_tokens = False):
-        result = type("R", (), {})()
-        if text == INSTRUCTION_PART:   result.input_ids = [USER_ID]
-        elif text == RESPONSE_PART:    result.input_ids = [ASSISTANT_ID]
-        else:                          result.input_ids = [ord(c) for c in text]
-        return result
+    @staticmethod
+    def _ids(text):
+        # Markers are single tokens; everything else is one token per character.
+        ids = []
+        for piece in re.split(f"({re.escape(INSTRUCTION_PART)}|{re.escape(RESPONSE_PART)})", text):
+            if piece == INSTRUCTION_PART:   ids.append(USER_ID)
+            elif piece == RESPONSE_PART:    ids.append(ASSISTANT_ID)
+            else:                           ids.extend(ord(c) for c in piece)
+        return ids
+
+    def __call__(self, text, add_special_tokens = False, **kwargs):
+        if isinstance(text, (list, tuple)):
+            batch = [self._ids(t) for t in text]
+            return _Encoding(input_ids = batch,
+                             attention_mask = [[1] * len(ids) for ids in batch])
+        return _Encoding(input_ids = self._ids(text))
 
     def pad(self, features, padding = True, max_length = None,
             pad_to_multiple_of = None, return_tensors = None, **kwargs):
@@ -84,7 +103,9 @@ class StubTrainer:
         self.train_dataset = train_dataset
         self.eval_dataset = None
         self.processing_class = StubProcessor()
-        self.args = type("Args", (), {"packing": False})()
+        self.args = type("Args", (), {
+            "packing": False, "max_length": 64, "dataset_text_field": "text",
+        })()
 
 
 def _text_rows():
@@ -232,3 +253,120 @@ def test_the_rebuild_keeps_the_settings_the_caller_chose():
     assert trainer.data_collator.pad_to_multiple_of == 8
     assert trainer.data_collator.label_pad_token_id == -123
     assert hasattr(trainer.data_collator.tokenizer, "pad")
+
+
+# ---- raw text-only splits reach the text path too --------------------------
+
+def _raw_text_rows(n = 2):
+    return Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{i}{RESPONSE_PART}a{i}" for i in range(n)],
+    })
+
+
+def test_a_raw_text_only_eval_split_is_allowed_through():
+    """A text-only eval split that is not pretokenized is tokenized by the text
+    path with the inner text tokenizer, and the same dataset-level masking then
+    applies to it. Refusing it would make adding evaluation to a supported
+    text-only VLM run fail unless the user pretokenizes eval by hand."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = _raw_text_rows()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    eval_split = out.eval_dataset
+    assert "labels" in eval_split.column_names, "eval was never tokenized/masked"
+    row = eval_split[0]
+    unmasked = [i for i, l in enumerate(row["labels"]) if l != -100]
+    assert unmasked, "eval labels are all -100"
+    # Only the answer is trained on; the question and both markers stay masked.
+    assert [row["input_ids"][i] for i in unmasked] == [ord("a"), ord("0")]
+    assert row["labels"][row["input_ids"].index(ASSISTANT_ID)] == -100
+
+
+def test_a_raw_text_only_split_in_an_eval_dict_is_allowed_through():
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = {"pretok": _text_rows(), "raw": _raw_text_rows()}
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in out.eval_dataset["raw"].column_names
+
+
+def test_a_raw_split_carrying_images_is_still_refused():
+    """Raw does not mean text-only: an image column means the text path would
+    throw the user's image handling away with the collator."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"],
+        "images": [[0.0]],
+    })
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_raw_split_with_no_text_column_is_still_refused():
+    """Conversational multimodal data carries its images inside the turns, so
+    the columns alone look text-only. There is nothing for the text path to
+    tokenize, so this must keep the old refusal rather than empty the split."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({"messages": [[{"role": "user"}]]})
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+# ---- non-seq2seq collators that pad through a processor --------------------
+
+def test_a_processor_backed_padding_collator_is_repaired_under_packing():
+    """`DataCollatorWithPadding(tokenizer = processor)` pads through
+    `self.tokenizer.pad` exactly like the seq2seq one does, so packing being on
+    must not leave it attached: the first batch dies with
+    `AttributeError: ... object has no attribute 'pad'` either way."""
+    collator = DataCollatorWithPadding(tokenizer = StubProcessor())
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.args.packing = True
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert out.data_collator is not collator, "still padding through the processor"
+    assert hasattr(out.data_collator.tokenizer, "pad")
+    rows = [out.train_dataset[i] for i in range(len(out.train_dataset))]
+    batch = out.data_collator(rows)   # used to raise AttributeError
+    assert "input_ids" in batch and "labels" in batch
+
+
+def test_a_collator_holding_only_a_processor_is_repaired_under_packing():
+    """TRL's `DataCollatorForVisionLanguageModeling` keeps the processor under
+    `.processor`, not `.tokenizer`, and has the same problem."""
+    trainer = _text_only_trainer()          # MyVisionCollator holds `.processor`
+    trainer.args.packing = True
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+    assert hasattr(out.data_collator.tokenizer, "pad")
+
+
+class PackingCollator:
+    """Stand-in for TRL's packing `DataCollatorForLanguageModeling`: it takes a
+    bare `pad_token_id` and holds no tokenizer or processor at all."""
+    def __init__(self):
+        self.pad_token_id = PAD_ID
+
+    def __call__(self, features):
+        return {"packed": True}
+
+
+def test_a_packing_collator_that_holds_no_tokenizer_is_left_alone():
+    """The reason the swap is gated on packing: a packing collator builds the
+    packed `position_ids` itself, and DataCollatorForSeq2Seq would not. Nothing
+    above may widen far enough to catch one."""
+    collator = PackingCollator()
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.args.packing = True
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert out.data_collator is collator
+
+
+def test_a_real_tokenizer_padding_collator_is_untouched_under_packing():
+    """It can pad on its own, so packing keeps it as before."""
+    collator = DataCollatorWithPadding(tokenizer = StubTokenizer())
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.args.packing = True
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert out.data_collator is collator

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2408,3 +2408,39 @@ def test_picture_and_photo_name_media_as_plainly_as_image(column):
     trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_nested_integer_column_is_refused_rather_than_dropped():
+    """A wide-int sequence is the shape every pretokenized column has, so it is
+    allowed. A sequence OF them is not: `Sequence(Sequence(int64))` under
+    `frames` is a numeric block, quantised patches, and the leaf-dtype allowance
+    passed it on its leaf alone. That marked the column schema-proven, so its
+    values were never read and the vision collator it needs was replaced."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "frames": [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_schema_proof_does_not_survive_a_custom_transform():
+    """`with_format("torch")` re-types a column and keeps its meaning, which is
+    why the schema may speak for every row. `with_transform` rewrites the rows:
+    a `string` column can be decoded into an image on the way out, so trusting
+    the stored dtype dropped a column that reaches the collator as media."""
+    Image = pytest.importorskip("PIL.Image")
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "payload": ["cat", "dog"],
+    })
+
+    def _decode(batch):
+        batch["payload"] = [Image.new("RGB", (2, 2)) for _ in batch["payload"]]
+        return batch
+
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          rows.with_transform(_decode))
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -957,6 +957,69 @@ def test_a_raw_eval_split_whose_later_row_is_not_text_is_refused():
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
 
+def test_a_raw_eval_split_whose_null_is_past_the_sample_is_refused():
+    """`Value('string')` is nullable, so the dtype still reads as text and the
+    bounded sample skips row 20. Left through, the plain tokenizer meets the null
+    halfway through `map` and dies there instead of refusing here."""
+    n, null_at = 200, 20
+    texts = [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"] * n
+    texts[null_at] = None
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({"text": texts})
+    assert null_at not in {i * (n - 1) // 15 for i in range(16)}, "row is sampled"
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+# ---- what the whole-column scan is allowed to cost -------------------------
+
+@pytest.mark.parametrize("column", ["urls", "paths", "files"])
+def test_an_ambiguous_column_of_media_lists_is_refused(column):
+    """A plural media column holds a list of URLs per row, and `List(string)` is
+    provably text, so the bypass used to strip the column and train on the text
+    alone."""
+    n = 4
+    trainer = StubTrainer(MyVisionCollator(StrictProcessor()), Dataset.from_dict({
+        "input_ids": [list(ROW)] * n,
+        column: [["https://example.com/cat.jpg", "https://example.com/dog.png"]] * n,
+    }))
+    trainer.processing_class = StrictProcessor()
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_an_ambiguous_image_column_is_never_decoded_by_the_scan(monkeypatch):
+    """`media` is an ambiguous name, but its dtype is `PIL.Image.Image`, so no
+    string in it can name a file. Scanning it anyway decoded every image (~9ms
+    and ~3MB of pixels a row) only to reach the refusal the schema already gave."""
+    import io
+    import datasets.features.image as image_feature
+    from PIL import Image as PILImage
+    from datasets import Image as ImageFeature
+
+    n = 300
+    buffer = io.BytesIO()
+    PILImage.new("RGB", (8, 8)).save(buffer, format = "PNG")
+    blob = {"bytes": buffer.getvalue(), "path": None}
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW)] * n, "media": [blob] * n,
+    }).cast_column("media", ImageFeature())
+    decoded = []
+    original = image_feature.Image.decode_example
+    monkeypatch.setattr(image_feature.Image, "decode_example",
+                        lambda self, value, **kw: (decoded.append(1),
+                                                   original(self, value, **kw))[1])
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    # Only the bounded row sample may decode; the whole-column scan may not.
+    assert len(decoded) <= 16, f"{len(decoded)} images decoded for {n} rows"
+
+
 # ---- the processor may live only on the collator ---------------------------
 
 def test_the_collators_processor_derives_the_multimodal_columns():

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2794,3 +2794,64 @@ def test_an_ordinary_string_column_is_still_not_base64_media():
         StubTrainer(MyVisionCollator(StubProcessor()), rows),
         INSTRUCTION_PART, RESPONSE_PART)
     assert "labels" in out.train_dataset.column_names
+
+
+def test_a_declared_forward_input_survives_the_seeded_signature():
+    """Seeding `_signature_columns` stops the trainer deriving it later, so a
+    fixed list silently dropped anything the model actually declares: a
+    caller-supplied `position_ids` or a custom `sample_weight` was removed
+    before collation and the run trained on different inputs."""
+    class Model:
+        def forward(self, input_ids = None, attention_mask = None, labels = None,
+                    position_ids = None, sample_weight = None, **kw):
+            return None
+
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.model = Model()
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    signature = getattr(out, "_signature_columns", None)
+    assert signature, "signature columns were never seeded"
+    for key in ("position_ids", "sample_weight"):
+        assert key in signature, f"{key} is declared by forward and would be stripped"
+    # And the media keys it was seeded for are still there.
+    assert "pixel_values" in signature
+
+
+def test_a_conversation_column_survives_unused_column_removal():
+    """Media in a raw VLM split can live only inside `messages`, which
+    `_has_media` recognises but the dispatch set deliberately excludes. Without
+    it in the kept columns the conversation was stripped before the dispatcher
+    saw it and the batch went to the text collator."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    signature = getattr(out, "_signature_columns", None)
+    assert signature, "signature columns were never seeded"
+    for key in ("messages", "conversations"):
+        assert key in signature, f"{key} would be stripped before the dispatcher"
+
+
+def test_the_conversation_keys_are_still_not_dispatch_keys():
+    """Kept, but not matched on the name alone: `_has_media` requires the value
+    to be a real message list, and widening the dispatch set would drop that
+    check and send any row with a `chat` string to the vision collator."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    dispatcher = out.data_collator
+    assert "messages" not in dispatcher.media_keys
+    assert not dispatcher._has_media([{"messages": "a plain string, not a conversation"}])
+    assert dispatcher._has_media([{"messages": [{"role": "user"}]}])

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1138,3 +1138,80 @@ def test_an_eval_only_trainer_on_the_plain_text_path_is_not_a_crash():
     trainer.eval_dataset = _text_rows()
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert "labels" in out.eval_dataset.column_names
+
+
+# ---- a media URL/path column is media, even as a plain string ---------------
+
+@pytest.mark.parametrize("column", [
+    "image_url", "video_url", "audio_url", "input_image", "input_video",
+    "image_path", "img_url", "image_file",
+])
+def test_a_top_level_media_url_column_is_refused(column):
+    """A pretokenized VLM set often stores its media as a URL string beside
+    `input_ids`. The value is a string, so only the column name says it is media,
+    and dropping it would leave a text-only run over a vision dataset."""
+    collator = MyVisionCollator(StubProcessor())
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        column: ["https://example.com/cat.jpg"] * 2,
+    })
+    trainer = StubTrainer(collator, dataset)
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.data_collator is collator, "the user's collator was replaced"
+    assert column in trainer.train_dataset.column_names, "the media column was dropped"
+
+
+@pytest.mark.parametrize("column, value", [
+    ("path",      "/data/images/0001.png"),
+    ("file_name", "clips/intro.mp4"),
+    ("url",       "https://example.com/a.jpeg?width=64"),
+    ("uri",       "data:image/png;base64,AAAA"),
+])
+def test_an_ambiguous_column_pointing_at_media_is_refused(column, value):
+    """`path`/`url` are media only sometimes, so the value decides."""
+    collator = MyVisionCollator(StubProcessor())
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        column: [value] * 2,
+    })
+    trainer = StubTrainer(collator, dataset)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert trainer.data_collator is collator
+
+
+@pytest.mark.parametrize("column, value", [
+    ("path",      "corpus/shard_0007.jsonl"),
+    ("path",      "wiki/en/Anarchism"),
+    ("url",       "https://en.wikipedia.org/wiki/Anarchism"),
+    ("file_name", "notes.txt"),
+    ("source",    "wikipedia"),
+    ("doc_id",    "id-42"),
+])
+def test_a_benign_metadata_column_is_still_allowed(column, value):
+    """The other direction: `path` is a source file in plenty of text corpora, so
+    a name alone must not refuse an ordinary text-only run."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        column: [value] * 2,
+    }))
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "labels" in out.train_dataset.column_names, "the text path never ran"
+    assert column not in out.train_dataset.column_names
+
+
+def test_a_raw_eval_split_with_a_media_url_column_is_refused():
+    """The same column on a raw eval split, which `_maybe_tokenize_dataset` would
+    tokenize from `text` and strip the media from."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"],
+        "image_url": ["https://example.com/cat.png"],
+    })
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -816,3 +816,162 @@ def test_a_raw_iterable_eval_split_of_real_text_is_still_allowed():
     trainer.eval_dataset = _raw_text_rows().to_iterable_dataset()
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert "labels" in next(iter(out.eval_dataset))
+
+
+# ---- one row is not the whole split ----------------------------------------
+
+def _rows_with_an_image_at(n, image_at):
+    """`n` pretokenized rows; only row `image_at` carries an image, under a column
+    name no static list mentions. Exactly what a partly-illustrated set looks like."""
+    import io
+    from PIL import Image as PILImage
+    from datasets import Image as ImageFeature
+
+    buffer = io.BytesIO()
+    PILImage.new("RGB", (2, 2)).save(buffer, format = "PNG")
+    media = [{"bytes": buffer.getvalue(), "path": None} if i == image_at else None
+             for i in range(n)]
+    return Dataset.from_dict({
+        "input_ids": [list(ROW)] * n, "media": media,
+    }).cast_column("media", ImageFeature())
+
+
+def test_a_later_row_hiding_an_image_is_refused():
+    """Row 0 has no image, so the old one-row peek cleared the guard and the strip
+    below then dropped the column, images and all."""
+    n = 5
+    collator = MyVisionCollator(StubProcessor())
+    trainer = StubTrainer(collator, _rows_with_an_image_at(n, image_at = n - 1))
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.data_collator is collator
+    assert "media" in trainer.train_dataset.column_names
+
+
+def test_the_bounded_scan_reaches_the_end_of_a_long_split():
+    """The scan is a small constant, so it samples across the split (first and
+    last row included) rather than the first N rows."""
+    n = 200
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          _rows_with_an_image_at(n, image_at = n - 1))
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_long_plain_text_split_is_still_allowed():
+    """The other half: scanning more rows must not refuse an honest text run."""
+    n = 200
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW)] * n,
+        "messages": _messages_of_plain_text() * n,
+    })
+    trainer = StubTrainer(MyVisionCollator(StrictProcessor()), dataset)
+    trainer.processing_class = StrictProcessor()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "messages" not in out.train_dataset.column_names
+
+
+def test_a_later_streaming_row_hiding_an_image_is_refused():
+    """Streaming rows arrive as they were written, so row 0 really can be plain
+    while a later one carries inline image parts."""
+    from datasets import IterableDataset
+
+    rows = [{"input_ids": list(ROW), "messages": _messages_of_plain_text()[0]},
+            {"input_ids": list(ROW), "messages": _messages_of_plain_text()[0]},
+            {"input_ids": list(ROW), "messages": _messages_with_an_image()[0]}]
+    dataset = IterableDataset.from_generator(lambda: iter(rows))
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert len(list(trainer.train_dataset)) == len(rows), "the peek consumed the stream"
+
+
+def test_a_raw_eval_split_whose_later_row_is_not_text_is_refused():
+    """The same one-row peek also admitted a mixed raw eval split to the plain
+    tokenizer, which cannot encode a null."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a", None],
+    })
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+# ---- the processor may live only on the collator ---------------------------
+
+def test_the_collators_processor_derives_the_multimodal_columns():
+    """With the public `tokenizer =` override the multimodal processor is no
+    longer `processing_class`, but the collator still holds it, so its derived
+    output names must still block the bypass."""
+    processor = DerivedProcessor(image_names = ["widget_patches"])
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW)],
+        "widget_patches": [[0.0]],
+    })
+    collator = MyVisionCollator(processor)
+    trainer = StubTrainer(collator, dataset)
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART,
+                                tokenizer = StubTokenizer())
+
+    assert trainer.data_collator is collator
+    assert "widget_patches" in trainer.train_dataset.column_names
+
+
+def test_the_tokenizer_override_still_allows_a_text_only_run():
+    """Deriving from the collator only adds names, so a text-only split passes."""
+    trainer = StubTrainer(MyVisionCollator(StrictProcessor()), _text_rows())
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART,
+                                  tokenizer = StrictPadTokenizer())
+    assert "labels" in out.train_dataset.column_names
+
+
+# ---- a streaming split cannot be filtered, so sample its labels -------------
+
+def _unmatched_rows(n = 3):
+    # No response marker anywhere: every label ends up -100.
+    return Dataset.from_dict({"input_ids": [[10, 11, 12]] * n})
+
+
+def test_a_fully_masked_streaming_train_split_is_reported():
+    """`_filter_fully_masked` and `fix_zero_training_loss` both skip streaming, so
+    the bypass would otherwise start a run with no training signal at all."""
+    dataset = _unmatched_rows().to_iterable_dataset()
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+
+    with pytest.raises(ValueError, match = "nothing to train on"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_the_streaming_label_check_does_not_consume_the_stream():
+    dataset = _unmatched_rows(n = 5).to_iterable_dataset()
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+    with pytest.raises(ValueError, match = "nothing to train on"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert len(list(dataset)) == 5
+
+
+def test_a_fully_masked_streaming_eval_split_names_the_split():
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), _text_rows())
+    trainer.eval_dataset = {"bad": _unmatched_rows().to_iterable_dataset()}
+    with pytest.raises(ValueError, match = r"eval_dataset\[bad\]"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_partly_masked_streaming_split_still_trains():
+    """Only an all -100 sample is an error; rows without a response are normal."""
+    from datasets import concatenate_datasets
+
+    dataset = concatenate_datasets([_unmatched_rows(n = 2), _text_rows()])
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset.to_iterable_dataset())
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert len(list(out.train_dataset)) == 4

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1356,3 +1356,105 @@ def test_a_directly_held_image_processor_still_lets_text_only_rows_through():
     trainer = StubTrainer(DirectImageProcessorCollator(["my_pixels"]), _text_rows())
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert "labels" in out.train_dataset.column_names, "the text path never ran"
+
+
+# ---- what the second review round found ------------------------------------
+
+@pytest.mark.parametrize("suffix", [".avif", ".jfif", ".jpe", ".apng", ".ogv", ".wma"])
+def test_less_common_media_suffixes_are_recognized(suffix):
+    """A suffix missing from the list makes the column look like prose, so the
+    bypass fires and the media column is dropped: VLM rows trained as text."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "url": [f"https://example.com/cat{suffix}", f"https://example.com/dog{suffix}"],
+    }))
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "url" in trainer.train_dataset.column_names, "the media column was dropped"
+
+
+def test_an_unscannable_ambiguous_column_is_refused():
+    """A stream cannot be read past its prefix, so a `cat.jpg` further down goes
+    unseen. Assuming text there drops the column silently, so refuse instead."""
+    n = 40
+    urls = ["some prose, not a file"] * n
+    urls[30] = "https://example.com/cat.jpg"        # past the 16-row prefix
+    dataset = Dataset.from_dict({"input_ids": [list(ROW)] * n, "url": urls})
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          dataset.to_iterable_dataset())
+
+    with pytest.raises(ValueError, match = "cannot be read past its first rows") as excinfo:
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "['url']" in str(excinfo.value), "the refusal does not name the column"
+
+
+def test_an_unscannable_non_string_column_is_not_called_media():
+    """Only a string can name a file, so an ambiguous name over ints stays text."""
+    n = 40
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), Dataset.from_dict({
+        "input_ids": [list(ROW)] * n, "file": list(range(n)),
+    }).to_iterable_dataset())
+    train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_padding_collator_rebuild_keeps_the_padding_the_caller_chose():
+    """`DataCollatorWithPadding` forwards these to `tokenizer.pad` exactly as the
+    replacement does, so dropping them turns max_length padding into dynamic."""
+    collator = DataCollatorWithPadding(tokenizer = StubProcessor(),
+                                       padding = "max_length", max_length = 32,
+                                       pad_to_multiple_of = 8)
+    trainer = StubTrainer(collator, _text_rows())
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert out.data_collator is not collator
+    assert out.data_collator.padding == "max_length"
+    assert out.data_collator.max_length == 32
+    assert out.data_collator.pad_to_multiple_of == 8
+    assert hasattr(out.data_collator.tokenizer, "pad")
+
+
+class OffsetTokenizer(StubTokenizer):
+    """The caller's own text tokenizer: same text, a different vocabulary."""
+    OFF = 1000
+
+    @classmethod
+    def _ids(cls, text):
+        return [i + cls.OFF for i in StubTokenizer._ids(text)]
+
+
+def test_a_raw_eval_split_is_tokenized_with_the_override_tokenizer():
+    """The response markers were tokenized with the `tokenizer =` override, so
+    encoding the eval split with the trainer's processor gives IDs that can
+    never match and the whole split comes back masked."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          Dataset.from_dict({"input_ids": [[i + OffsetTokenizer.OFF
+                                                            for i in ROW]] * 2}))
+    trainer.eval_dataset = _raw_text_rows()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART,
+                                  tokenizer = OffsetTokenizer())
+
+    row = out.eval_dataset[0]
+    assert all(i >= OffsetTokenizer.OFF for i in row["input_ids"]), \
+        "eval was encoded with the trainer's processor, not the override"
+    assert any(l != -100 for l in row["labels"]), "eval labels are all -100"
+
+
+def test_precomputed_labels_survive_the_raw_column_drop():
+    """A raw split can carry token-level `labels` the caller already masked;
+    the masking pass intersects with them, so they must not be removed with the
+    raw text or every response token gets un-masked."""
+    text = f"{INSTRUCTION_PART}ab{RESPONSE_PART}cd"
+    ids = StubTokenizer._ids(text)
+    old = [-100] * len(ids)
+    old[-2] = ids[-2]                    # the caller masked the final token
+
+    trainer = StubTrainer(DataCollatorForSeq2Seq(tokenizer = StubTokenizer()),
+                          Dataset.from_dict({"text": [text] * 2,
+                                             "labels": [list(old)] * 2}))
+    trainer.processing_class = StubTokenizer()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert out.train_dataset[0]["labels"] == old, "the caller's mask was lost"

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -346,6 +346,35 @@ def test_a_packing_collator_that_holds_no_tokenizer_is_left_alone():
     assert out.data_collator is collator
 
 
+class LabelRebuildingVisionCollator:
+    """A user's vision collator holding the processor for images and the text
+    tokenizer for padding, and rebuilding `labels` from `input_ids` on collate."""
+    def __init__(self, processor):
+        self.processor = processor
+        self.tokenizer = processor.tokenizer
+
+    def __call__(self, features):
+        batch = self.tokenizer.pad(features)
+        batch["labels"] = [list(ids) for ids in batch["input_ids"]]
+        return batch
+
+
+def test_a_label_rebuilding_vision_collator_is_replaced_under_packing():
+    """It pads through a real tokenizer, so the `.pad` repair does not fire. If
+    packing then leaves it attached it rebuilds `labels` at collate time, throwing
+    away the dataset-level mask this function just wrote: training on prompts."""
+    collator = LabelRebuildingVisionCollator(StubProcessor())
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.args.packing = True
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert out.data_collator is not collator, "the masked labels get overwritten"
+    rows = [out.train_dataset[i] for i in range(len(out.train_dataset))]
+    labels = out.data_collator(rows)["labels"]
+    assert -100 in list(labels[0]), "the response mask did not survive collation"
+
+
 def test_a_real_tokenizer_padding_collator_is_untouched_under_packing():
     """It can pad on its own, so packing keeps it as before."""
     collator = DataCollatorWithPadding(tokenizer = StubTokenizer())
@@ -576,10 +605,13 @@ def _refuses(dataset, processor):
 def test_fuyu_style_image_columns_are_refused(column):
     """Fuyu spells its preprocessed images `image_patches`/`image_patches_indices`
     beside `input_ids`, so the columns alone look text-only."""
-    from transformers.models.fuyu.image_processing_fuyu import FuyuImageProcessor
-
+    # Literal copy of FuyuImageProcessor.model_input_names: importing it pulls in
+    # torchvision (transformers 5.x), which is not a dependency of this package.
+    fuyu_image_names = ["images", "image_input_ids", "image_patches",
+                        "image_patch_indices_per_batch",
+                        "image_patch_indices_per_subsequence"]
     processor = DerivedProcessor(
-        image_names = FuyuImageProcessor.model_input_names,
+        image_names = fuyu_image_names,
         # FuyuProcessor.model_input_names adds this one on top of the image half.
         own_names = ["image_patches", "image_patches_indices"],
     )
@@ -758,6 +790,28 @@ def test_an_eval_split_hiding_images_in_messages_is_refused():
     trainer.eval_dataset = dataset
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+@pytest.mark.parametrize("kind", ["input_image", "input_video"])
+def test_pretokenized_rows_hiding_an_input_image_part_are_refused(kind):
+    """`input_image`/`input_video` are the other spelling of an inline media part
+    (the one `mlx/loader.py` already recognises), and name media just like
+    `image` does."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW)],
+        "messages": [[
+            {"role": "user", "content": [{"type": kind, kind: "cat.png"},
+                                         {"type": "text", "text": "q"}]},
+        ]],
+    })
+    collator = MyVisionCollator(StubProcessor())
+    trainer = StubTrainer(collator, dataset)
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.data_collator is collator, "the user's collator was replaced"
+    assert "messages" in trainer.train_dataset.column_names
 
 
 def test_pretokenized_rows_with_plain_text_messages_still_pass():

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2667,3 +2667,39 @@ class _PicklableCollator:
     """Module-level, so the pickling test measures the wrapper and not itself."""
     def __call__(self, features):
         return {"n": len(features)}
+
+
+@pytest.mark.parametrize("key", ["pixel_values", "image_grid_thw", "input_features"])
+def test_an_already_processed_batch_reaches_the_vision_collator(key):
+    """A split that has been through the processor carries the processor's own
+    output keys, not `images`. Those live only in `_MULTIMODAL_COLUMNS`, so a
+    dispatcher told about `_MEDIA_COLUMNS` alone sent a processed `predict`
+    batch to the text collator, which stacks them unpadded or drops them."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    mine = MyVisionCollator(StubProcessor())
+    collator = train_on_responses_only(
+        StubTrainer(mine, rows), INSTRUCTION_PART, RESPONSE_PART).data_collator
+
+    assert collator([{"input_ids": list(ROW), key: object()}]) == {"mine": True}
+
+
+@pytest.mark.parametrize("kind", ["image", "video", "audio"])
+def test_a_data_uri_outside_the_sampled_rows_is_still_media(kind):
+    """`_sample_rows` reads 16 rows. A bare string column got no other value
+    check, so a self-identifying URI anywhere else was invisible and the column
+    was dropped, silently removing that example's media."""
+    n = 400
+    sampled = sorted({i * (n - 1) // 15 for i in range(16)})
+    hidden = next(i for i in range(n) if i not in sampled)
+    notes = ["plain text"] * n
+    notes[hidden] = f"data:{kind}/png;base64,iVBORw0KGgo="
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW)] * n,
+        "image_data": notes,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -32,6 +32,21 @@ from transformers import DataCollatorForSeq2Seq, DataCollatorWithPadding
 from unsloth_zoo.dataset_utils import train_on_responses_only
 
 
+@pytest.fixture(scope = "module", autouse = True)
+def _hand_back_a_clean_dynamo():
+    """A few hundred cases here leave torch._dynamo's code cache where they found
+    it plus their own. `test_rmsnorm_recompile_guards` asserts on a realistic
+    recompile budget, and in a full-suite run that accumulation pushed three of
+    its cases over; they pass again with this reset, and in isolation either way.
+    """
+    yield
+    try:
+        import torch
+        torch._dynamo.reset()
+    except Exception:
+        pass
+
+
 INSTRUCTION_PART = "<|user|>"
 RESPONSE_PART = "<|assistant|>"
 USER_ID, ASSISTANT_ID, PAD_ID = 1, 2, 0
@@ -340,6 +355,9 @@ def test_a_collator_holding_only_a_processor_is_repaired():
     """TRL's `DataCollatorForVisionLanguageModeling` keeps the processor under
     `.processor`, not `.tokenizer`, with the same problem. It rebuilds labels
     through that processor, so it is a class we know how to answer for."""
+    # Skipped, not errored, where TRL is absent: the macOS runner has no TRL and
+    # a bare import turned both of these red on a gap in the runner, not the code.
+    pytest.importorskip("trl.trainer.sft_trainer")
     from trl.trainer.sft_trainer import DataCollatorForVisionLanguageModeling
 
     trainer = _text_only_trainer()
@@ -350,6 +368,7 @@ def test_a_collator_holding_only_a_processor_is_repaired():
 
 
 def test_a_collator_holding_only_a_processor_under_packing_is_refused():
+    pytest.importorskip("trl.trainer.sft_trainer")
     from trl.trainer.sft_trainer import DataCollatorForVisionLanguageModeling
 
     trainer = _text_only_trainer()

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -975,3 +975,112 @@ def test_a_partly_masked_streaming_split_still_trains():
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
     assert len(list(out.train_dataset)) == 4
+
+
+# ---- a 16-row sample is not the whole split either --------------------------
+
+def test_an_image_on_an_unsampled_row_is_refused():
+    """The bounded scan reads 16 fixed positions, so a 200-row split checks rows
+    0, 13, 26, ... and an image on row 5 was never looked at. The column type is
+    uniform down the whole split, so the schema settles it for every row."""
+    n = 200
+    collator = MyVisionCollator(StubProcessor())
+    trainer = StubTrainer(collator, _rows_with_an_image_at(n, image_at = 5))
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.data_collator is collator
+    assert "media" in trainer.train_dataset.column_names, "the images were dropped"
+
+
+def test_a_raw_eval_split_with_an_image_on_an_unsampled_row_is_refused():
+    """`_eval_split_is_raw_text_only` samples the same 16 positions, so the eval
+    half needs the schema just as much as the train half does."""
+    import io
+    from PIL import Image as PILImage
+    from datasets import Image as ImageFeature
+
+    buffer = io.BytesIO()
+    PILImage.new("RGB", (2, 2)).save(buffer, format = "PNG")
+    n = 200
+    media = [{"bytes": buffer.getvalue(), "path": None} if i == 5 else None
+             for i in range(n)]
+    eval_split = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"] * n, "media": media,
+    }).cast_column("media", ImageFeature())
+
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = eval_split
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "media" in trainer.eval_dataset.column_names
+
+
+# ---- a masked prefix is not a masked stream --------------------------------
+
+def test_a_stream_whose_responses_start_later_still_trains():
+    """A sorted or filtered stream can put every prompt-only row first. The
+    bounded prefix cannot see past row 16, so it must not refuse the run."""
+    from datasets import IterableDataset
+
+    rows = [{"input_ids": [10, 11, 12]} for _ in range(16)]
+    rows += [{"input_ids": list(ROW)} for _ in range(4)]
+    dataset = IterableDataset.from_generator(lambda: iter(rows))
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    got = list(out.train_dataset)
+    assert len(got) == len(rows)
+    assert [l for l in got[-1]["labels"] if l != -100] == [20, 21]
+
+
+def test_a_stream_masked_past_the_prefix_warns_instead(capsys):
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          _unmatched_rows(n = 40).to_iterable_dataset())
+    train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "nothing to train on" in capsys.readouterr().out
+
+
+# ---- empty splits ----------------------------------------------------------
+
+def test_an_empty_raw_eval_split_is_handled():
+    """`_maybe_tokenize_dataset` peeks one row, and an empty split has none."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), _text_rows())
+    trainer.eval_dataset = Dataset.from_dict({"text": []})
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert len(out.eval_dataset) == 0
+    assert "labels" in out.train_dataset.column_names
+
+
+def test_an_empty_pretokenized_eval_split_is_handled():
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), _text_rows())
+    trainer.eval_dataset = Dataset.from_dict({"input_ids": []})
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert len(out.eval_dataset) == 0
+
+
+# ---- a trainer need not have a train split ---------------------------------
+
+def test_an_eval_only_trainer_is_not_a_crash():
+    """`Trainer(eval_dataset = ...)` with no train split: the final all-masked
+    check calls len() on it, so it must not run with nothing there."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), None)
+    trainer.eval_dataset = _text_rows()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert out.train_dataset is None
+    assert "labels" in out.eval_dataset.column_names
+
+
+def test_an_eval_only_trainer_on_the_plain_text_path_is_not_a_crash():
+    """Same call, reached without the bypass at all."""
+    trainer = StubTrainer(DataCollatorForSeq2Seq(tokenizer = StubTokenizer()), None)
+    trainer.eval_dataset = _text_rows()
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in out.eval_dataset.column_names

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -17,14 +17,10 @@
 """What the pretokenized bypass is allowed to hand to the text path.
 
 The bypass lets a text-only fine-tune of a multimodal model reach dataset-level
-masking instead of being refused. Two things it must not do on the way:
-
-* fire for rows that still carry images, since the text path replaces the
-  collator and the user's image handling would go with it; and
-* leave behind a `DataCollatorForSeq2Seq` that pads through a processor, which
-  has no `.pad`, so the run dies on the first batch.
-
-CPU-pure and offline: everything here is a local stub, no weights are loaded.
+masking instead of being refused. Two things it must not do on the way: fire for
+rows that still carry images (the text path replaces the collator, and the user's
+image handling with it), or leave behind a collator padding through a processor,
+which has no `.pad`, so the run dies on the first batch. CPU-pure and offline.
 """
 
 import re
@@ -126,9 +122,8 @@ def _multimodal_rows():
     "pixel_values", "pixel_values_videos", "image_grid_thw", "input_features",
 ])
 def test_multimodal_rows_are_still_refused(extra_column):
-    """`input_ids` alone does not make a row text-only. The text path swaps the
-    collator for a text one, so firing here would silently drop the user's
-    image handling and mis-shape (or fail to batch) the image columns."""
+    """`input_ids` alone does not make a row text-only: the text path swaps in a
+    text collator, silently dropping the user's image handling."""
     collator = MyVisionCollator(StubProcessor())
     dataset = Dataset.from_dict({
         "input_ids": [list(ROW), list(ROW)],
@@ -153,10 +148,8 @@ def test_multimodal_iterable_rows_are_still_refused():
 # ---- the run has to survive the first batch --------------------------------
 
 def test_a_processor_backed_seq2seq_collator_is_rebuilt():
-    """`DataCollatorForSeq2Seq(tokenizer = processor)` is the collator the
-    bypass exists for. Left alone it pads via `self.tokenizer.pad`, which a
-    processor does not have, so the first batch dies with
-    `AttributeError: ... object has no attribute 'pad'`."""
+    """`DataCollatorForSeq2Seq(tokenizer = processor)` is what the bypass exists
+    for: left alone it pads via a `self.tokenizer.pad` a processor does not have."""
     processor = StubProcessor()
     trainer = StubTrainer(DataCollatorForSeq2Seq(tokenizer = processor),
                           _text_rows())
@@ -174,8 +167,7 @@ def test_a_processor_backed_seq2seq_collator_is_rebuilt():
 
 
 def test_a_tokenizer_backed_seq2seq_collator_is_left_alone():
-    """The pre-existing path: a seq2seq collator that already pads through a
-    real tokenizer keeps its own settings."""
+    """The pre-existing path: one padding through a real tokenizer keeps its settings."""
     collator = DataCollatorForSeq2Seq(tokenizer = StubTokenizer(),
                                       pad_to_multiple_of = 8)
     trainer = StubTrainer(collator, _text_rows())
@@ -197,8 +189,8 @@ def _text_only_trainer():
 
 
 def test_a_multimodal_eval_split_still_refuses():
-    """The collator is swapped for the whole trainer, so a text-only train set
-    beside a multimodal eval set must not clear the guard."""
+    """The swap is trainer-wide, so a text-only train set beside a multimodal
+    eval set must not clear the guard."""
     trainer = _text_only_trainer()
     trainer.eval_dataset = _multimodal_rows()
     with pytest.raises(ValueError, match = "does not support response-only"):
@@ -223,8 +215,7 @@ def test_a_text_only_eval_split_is_fine():
     "flattened_patches", "high_res_pixel_values",
 ])
 def test_processor_specific_column_names_are_refused_too(column):
-    """phi4_multimodal, pix2struct and kosmos-2.5 do not spell these the way
-    the common families do."""
+    """phi4_multimodal, pix2struct and kosmos-2.5 spell these their own way."""
     dataset = Dataset.from_dict({
         "input_ids": [list(ROW), list(ROW)],
         column: [[0.0], [0.0]],
@@ -235,8 +226,7 @@ def test_processor_specific_column_names_are_refused_too(column):
 
 
 def test_a_processor_backed_collator_is_rebuilt_even_with_packing():
-    """It raises on its first batch whether or not packing is on, so the
-    tokenizer repair cannot be gated on packing the way the swap is."""
+    """It raises on the first batch either way, so the repair is not packing-gated."""
     trainer = StubTrainer(DataCollatorForSeq2Seq(tokenizer = StubProcessor()),
                           _text_rows())
     trainer.args.packing = True
@@ -264,10 +254,8 @@ def _raw_text_rows(n = 2):
 
 
 def test_a_raw_text_only_eval_split_is_allowed_through():
-    """A text-only eval split that is not pretokenized is tokenized by the text
-    path with the inner text tokenizer, and the same dataset-level masking then
-    applies to it. Refusing it would make adding evaluation to a supported
-    text-only VLM run fail unless the user pretokenizes eval by hand."""
+    """A raw text-only eval split is tokenized by the text path with the inner
+    tokenizer and masked the same way, so users need not pretokenize it by hand."""
     trainer = _text_only_trainer()
     trainer.eval_dataset = _raw_text_rows()
 
@@ -291,8 +279,7 @@ def test_a_raw_text_only_split_in_an_eval_dict_is_allowed_through():
 
 
 def test_a_raw_split_carrying_images_is_still_refused():
-    """Raw does not mean text-only: an image column means the text path would
-    throw the user's image handling away with the collator."""
+    """Raw does not mean text-only: an image column still needs its collator."""
     trainer = _text_only_trainer()
     trainer.eval_dataset = Dataset.from_dict({
         "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"],
@@ -303,9 +290,8 @@ def test_a_raw_split_carrying_images_is_still_refused():
 
 
 def test_a_raw_split_with_no_text_column_is_still_refused():
-    """Conversational multimodal data carries its images inside the turns, so
-    the columns alone look text-only. There is nothing for the text path to
-    tokenize, so this must keep the old refusal rather than empty the split."""
+    """Conversational multimodal data hides its images inside the turns, so the
+    columns look text-only. Nothing to tokenize, so refuse rather than empty it."""
     trainer = _text_only_trainer()
     trainer.eval_dataset = Dataset.from_dict({"messages": [[{"role": "user"}]]})
     with pytest.raises(ValueError, match = "does not support response-only"):
@@ -315,10 +301,8 @@ def test_a_raw_split_with_no_text_column_is_still_refused():
 # ---- non-seq2seq collators that pad through a processor --------------------
 
 def test_a_processor_backed_padding_collator_is_repaired_under_packing():
-    """`DataCollatorWithPadding(tokenizer = processor)` pads through
-    `self.tokenizer.pad` exactly like the seq2seq one does, so packing being on
-    must not leave it attached: the first batch dies with
-    `AttributeError: ... object has no attribute 'pad'` either way."""
+    """`DataCollatorWithPadding(tokenizer = processor)` pads through the same
+    missing `.pad`, so packing being on must not leave it attached."""
     collator = DataCollatorWithPadding(tokenizer = StubProcessor())
     trainer = StubTrainer(collator, _text_rows())
     trainer.args.packing = True
@@ -334,7 +318,7 @@ def test_a_processor_backed_padding_collator_is_repaired_under_packing():
 
 def test_a_collator_holding_only_a_processor_is_repaired_under_packing():
     """TRL's `DataCollatorForVisionLanguageModeling` keeps the processor under
-    `.processor`, not `.tokenizer`, and has the same problem."""
+    `.processor`, not `.tokenizer`, with the same problem."""
     trainer = _text_only_trainer()          # MyVisionCollator holds `.processor`
     trainer.args.packing = True
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
@@ -343,8 +327,8 @@ def test_a_collator_holding_only_a_processor_is_repaired_under_packing():
 
 
 class PackingCollator:
-    """Stand-in for TRL's packing `DataCollatorForLanguageModeling`: it takes a
-    bare `pad_token_id` and holds no tokenizer or processor at all."""
+    """Stand-in for TRL's packing `DataCollatorForLanguageModeling`: a bare
+    `pad_token_id`, no tokenizer or processor at all."""
     def __init__(self):
         self.pad_token_id = PAD_ID
 
@@ -353,9 +337,8 @@ class PackingCollator:
 
 
 def test_a_packing_collator_that_holds_no_tokenizer_is_left_alone():
-    """The reason the swap is gated on packing: a packing collator builds the
-    packed `position_ids` itself, and DataCollatorForSeq2Seq would not. Nothing
-    above may widen far enough to catch one."""
+    """Why the swap is packing-gated: a packing collator builds the packed
+    `position_ids` itself and DataCollatorForSeq2Seq would not."""
     collator = PackingCollator()
     trainer = StubTrainer(collator, _text_rows())
     trainer.args.packing = True

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1758,3 +1758,27 @@ def test_a_token_classification_collator_keeps_its_padding_settings():
     assert repaired.padding == "max_length", repaired.padding
     assert repaired.max_length == 128, repaired.max_length
     assert repaired.pad_to_multiple_of == 8, repaired.pad_to_multiple_of
+
+
+# --- what the fifth review round found ---------------------------------------
+
+def test_a_raw_eval_split_whose_full_scan_fails_is_refused():
+    """A failed exhaustive scan proves nothing, so it must not read as proof.
+
+    A custom transform that needs a column `select_columns([name])` removed makes
+    the whole-column scan raise, and only the 16 sampled rows were ever checked.
+    Calling the column all-strings there lets the bypass through, and a `None`
+    further down then crashes `_maybe_tokenize_dataset` partway.
+    """
+    def _needs_both(batch):
+        return {"text": [t + str(w) for t, w in zip(batch["text"], batch["weight"])]}
+
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{i}{RESPONSE_PART}a{i}" for i in range(4)],
+        "weight": [1, 2, 3, 4],
+    }).with_transform(_needs_both)
+
+    with pytest.raises(ValueError, match = "does not support response-only") as excinfo:
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "['text']" in str(excinfo.value), "the refusal does not name the column"

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1674,10 +1674,14 @@ def test_a_nested_generic_alias_holding_provenance_still_passes():
 
 
 class ProcessorWithoutImages:
-    """A processor half with no `.pad` and no `image_processor`, so the vision
-    bypass never sees it and only the `.pad` repair can fire."""
+    """A processor half with no `.pad` and no modality half, so the multimodal
+    bypass never sees it and only the `.pad` repair can fire.
+
+    It used to carry a `feature_extractor` as an inert marker. That is an audio
+    half, and now marks the holder as multimodal like `image_processor` always
+    did, so it would take this stub down the bypass the tests below want to miss.
+    """
     def __init__(self):
-        self.feature_extractor = object()
         self.tokenizer = StubTokenizer()
 
 
@@ -2280,3 +2284,93 @@ def test_remove_unused_columns_false_without_a_text_column_is_untouched():
 
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert "sample_weight" in out.train_dataset.column_names
+
+
+# --- what the seventh review round found -----------------------------------
+
+class AudioOnlyProcessor:
+    """Whisper and friends: a processor whose only half is audio."""
+    def __init__(self):
+        self.feature_extractor = object()
+        self.tokenizer = StubTokenizer()
+
+
+class VideoOnlyProcessor:
+    def __init__(self):
+        self.video_processor = object()
+        self.tokenizer = StubTokenizer()
+
+
+@pytest.mark.parametrize("processor, column", [
+    (AudioOnlyProcessor, "input_features"),
+    (VideoOnlyProcessor, "pixel_values_videos"),
+])
+def test_an_audio_or_video_processor_is_multimodal_too(processor, column):
+    """`image_processor` was the only half that counted, so a collator holding an
+    audio- or video-only processor missed every multimodal guard and fell through
+    to the `.pad` repair, which rebuilds it around the plain tokenizer and drops
+    the modality column it was holding the processor to batch."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW), [1] * len(ROW)],
+        column: [[0.1, 0.2], [0.3, 0.4]],
+    })
+    collator = DataCollatorForSeq2Seq(tokenizer = processor())
+    trainer = StubTrainer(collator, rows)
+    trainer.processing_class = StubTokenizer()
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert trainer.data_collator is collator, "the multimodal collator was rebuilt"
+    assert column in trainer.train_dataset.column_names, "the modality column went"
+
+
+def test_a_processor_half_the_column_deriver_asks_for_is_a_multimodal_marker():
+    """The two lists must not drift: a half `_derive_multimodal_columns` reads
+    outputs from is by definition a half that makes its holder multimodal."""
+    import inspect as _inspect
+    from unsloth_zoo import dataset_utils as D
+    source = _inspect.getsource(D)
+    for half in ("image_processor", "video_processor", "feature_extractor",
+                 "audio_processor", "qformer_tokenizer"):
+        assert source.count(f'"{half}"') >= 2, \
+            f"{half} is asked for in one place only, so the two lists have drifted"
+
+
+def test_remove_unused_columns_false_drops_columns_no_collator_can_stack():
+    """`tokenizer.pad(..., return_tensors = "pt")` tensorizes every key it is
+    handed, so a kept `messages`/`source` dies on the first batch, before the
+    custom `compute_loss` the opt-out exists for ever runs."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW), [1] * len(ROW)],
+        "messages": [[{"role": "user", "content": "hi"}]] * 2,
+        "source": ["a", "b"],
+        "sample_weight": [1.0, 2.0],
+        "aux_target": [[1, 2], [3, 4]],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    kept = out.train_dataset.column_names
+    assert "messages" not in kept, "a list of dicts cannot be tensorized"
+    assert "source" not in kept, "a string column cannot be tensorized"
+    assert "sample_weight" in kept, "a numeric column is what the opt-out is for"
+    assert "aux_target" in kept, "a nested numeric column is tensorizable"
+
+
+def test_a_model_input_column_is_never_judged_by_one_row():
+    """`token_type_ids` and friends are the collator's job. Whatever a sampled
+    row holds for them, they are fed to the model and must not be dropped."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW), [1] * len(ROW)],
+        "token_type_ids": [None, None],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "token_type_ids" in out.train_dataset.column_names

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2,16 +2,16 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """What the pretokenized bypass is allowed to hand to the text path.
@@ -167,3 +167,68 @@ def test_a_tokenizer_backed_seq2seq_collator_is_left_alone():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+# ---- the follow-on cases the first round of this fix missed ---------------
+
+def _text_only_trainer():
+    return StubTrainer(MyVisionCollator(StubProcessor()), _text_rows())
+
+
+def test_a_multimodal_eval_split_still_refuses():
+    """The collator is swapped for the whole trainer, so a text-only train set
+    beside a multimodal eval set must not clear the guard."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = _multimodal_rows()
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_multimodal_split_in_an_eval_dict_still_refuses():
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = {"a": _text_rows(), "b": _multimodal_rows()}
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_text_only_eval_split_is_fine():
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = _text_rows()
+    train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+@pytest.mark.parametrize("column", [
+    "image_pixel_values", "audio_input_features", "audio_embed_sizes",
+    "flattened_patches", "high_res_pixel_values",
+])
+def test_processor_specific_column_names_are_refused_too(column):
+    """phi4_multimodal, pix2struct and kosmos-2.5 do not spell these the way
+    the common families do."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        column: [[0.0], [0.0]],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_processor_backed_collator_is_rebuilt_even_with_packing():
+    """It raises on its first batch whether or not packing is on, so the
+    tokenizer repair cannot be gated on packing the way the swap is."""
+    trainer = StubTrainer(DataCollatorForSeq2Seq(tokenizer = StubProcessor()),
+                          _text_rows())
+    trainer.args.packing = True
+    train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert hasattr(trainer.data_collator.tokenizer, "pad")
+
+
+def test_the_rebuild_keeps_the_settings_the_caller_chose():
+    collator = DataCollatorForSeq2Seq(tokenizer = StubProcessor(),
+                                      pad_to_multiple_of = 8,
+                                      label_pad_token_id = -123)
+    trainer = StubTrainer(collator, _text_rows())
+    train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert trainer.data_collator.pad_to_multiple_of == 8
+    assert trainer.data_collator.label_pad_token_id == -123
+    assert hasattr(trainer.data_collator.tokenizer, "pad")

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -634,6 +634,20 @@ def test_a_column_name_this_file_has_never_heard_of_is_refused():
     _refuses(dataset, processor)
 
 
+@pytest.mark.parametrize("column", ["num_crops", "num_tiles"])
+def test_an_integer_side_car_is_refused_without_the_processor(column):
+    """Gemma 3 declares `num_crops` and Llama 3.2 Vision `num_tiles` beside
+    `pixel_values`. Their dtype is an ordinary int, so the schema calls them
+    plain and only the name can refuse - and a processor that will not name its
+    own outputs leaves the static set as the only thing that knows."""
+    processor = DerivedProcessor()          # declares nothing to derive from
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        column: [4, 4],
+    })
+    _refuses(dataset, processor)
+
+
 def test_a_raw_eval_split_with_a_derived_column_is_refused():
     """`_eval_split_is_raw_text_only` reads the same set."""
     processor = DerivedProcessor(image_names = ["widget_patches"])

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -3181,3 +3181,65 @@ def test_a_sized_labels_value_is_still_treated_as_supervision():
 
     assert "labels" in out.train_dataset.column_names
     assert len(out.train_dataset["labels"][0]) == len(ROW)
+
+
+class LabelTakingModel:
+    """The ordinary causal-LM signature: `forward` declares `labels`."""
+    def forward(self, input_ids = None, attention_mask = None, labels = None): ...
+
+
+def test_a_scalar_labels_column_is_dropped_even_when_forward_declares_labels():
+    """The keep-list starts from everything `forward` names, and every causal LM
+    names `labels`, so a scalar `labels` was already kept before the scalar check
+    ran -- and that check only ever added. The int reached the masking pass:
+    `TypeError: object of type 'int' has no len()`."""
+    trainer = _text_only_trainer()
+    trainer.model = LabelTakingModel()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"],
+        "labels": [3],
+    })
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "labels" in out.eval_dataset.column_names
+    assert len(out.eval_dataset["labels"][0]) == len(out.eval_dataset["input_ids"][0])
+
+
+def test_a_nullable_token_level_labels_column_survives_a_null_first_row():
+    """The scalar/sequence verdict was read off row 0 alone. A nullable
+    token-level `labels` column whose first row is null therefore looked absent,
+    the column was dropped, and the masking pass regenerated labels from
+    `input_ids` -- silently un-masking what the caller had masked."""
+    text = f"{INSTRUCTION_PART}ab{RESPONSE_PART}cd"
+    ids = StubTokenizer._ids(text)
+    old = [-100] * len(ids)
+    old[-1] = ids[-1]                    # the caller kept only the final token
+
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [text, text],
+        "labels": [None, list(old)],
+    })
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "labels" in out.eval_dataset.column_names
+    assert out.eval_dataset[1]["labels"] == old, "the caller's mask was silently dropped"
+
+
+def test_a_nullable_scalar_labels_column_is_still_dropped_on_a_null_first_row():
+    """The mirror of the above, and why the verdict is read off the feature and
+    not just "keep whatever might be a sequence": a nullable class-id column is
+    still a class id, and keeping it walks back into `len(int)`."""
+    trainer = _text_only_trainer()
+    trainer.model = LabelTakingModel()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"] * 2,
+        "labels": [None, 3],
+    })
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "labels" in out.eval_dataset.column_names
+    assert len(out.eval_dataset["labels"][0]) == len(out.eval_dataset["input_ids"][0])

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2247,3 +2247,36 @@ def test_a_raw_bypass_without_packing_is_untouched():
     trainer = StubTrainer(collator, rows)
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+
+
+def test_remove_unused_columns_false_still_drops_the_raw_text():
+    """`sft_prepare_dataset` turns the opt-out on by itself for a token-type-id
+    model. A pretokenized split carrying its source `text` never reaches the
+    tokenizing strip, so the opt-out was the only thing keeping the strings, and
+    the replacement collator died tensorizing them on the first batch."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW), [1] * len(ROW)],
+        "text": ["a", "b"],
+        "sample_weight": [1.0, 2.0],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    kept = out.train_dataset.column_names
+    assert "text" not in kept, "the raw strings survived the opt-out"
+    assert "sample_weight" in kept, "the opt-out must still keep the user's own columns"
+
+
+def test_remove_unused_columns_false_without_a_text_column_is_untouched():
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "sample_weight": [1.0, 2.0],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "sample_weight" in out.train_dataset.column_names

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -104,6 +104,16 @@ class StubTrainer:
         })()
 
 
+def _text_collator_of(collator):
+    """The seq2seq collator the repair installed.
+
+    When a media-capable collator was displaced it is kept alongside, and the
+    trainer holds a dispatcher that picks per batch, so the padding collator is
+    one level in. Everywhere else the dispatcher is not installed at all.
+    """
+    return getattr(collator, "text", collator)
+
+
 def _text_rows():
     return Dataset.from_dict({"input_ids": [list(ROW), list(ROW)]})
 
@@ -157,7 +167,7 @@ def test_a_processor_backed_seq2seq_collator_is_rebuilt():
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
     collator = out.data_collator
-    assert isinstance(collator, DataCollatorForSeq2Seq)
+    assert isinstance(_text_collator_of(collator), DataCollatorForSeq2Seq)
     assert hasattr(collator.tokenizer, "pad"), \
         f"still padding through {type(collator.tokenizer).__name__}"
 
@@ -335,7 +345,7 @@ def test_a_collator_holding_only_a_processor_is_repaired():
     trainer = _text_only_trainer()
     trainer.data_collator = DataCollatorForVisionLanguageModeling(processor = StubProcessor())
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
-    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+    assert isinstance(_text_collator_of(out.data_collator), DataCollatorForSeq2Seq)
     assert hasattr(out.data_collator.tokenizer, "pad")
 
 
@@ -1930,7 +1940,7 @@ def test_a_bypassed_self_packing_collator_is_untouched_without_packing():
 
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
-    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+    assert isinstance(_text_collator_of(out.data_collator), DataCollatorForSeq2Seq)
 
 
 
@@ -2048,7 +2058,7 @@ def test_a_custom_label_pad_value_survives_the_repair():
     )
     trainer = StubTrainer(collator, _text_rows())
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
-    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+    assert isinstance(_text_collator_of(out.data_collator), DataCollatorForSeq2Seq)
     assert out.data_collator.label_pad_token_id == -1
     assert out.data_collator.padding == "max_length"
     assert out.data_collator.max_length == 32
@@ -2169,7 +2179,7 @@ def test_a_pretokenized_bypass_without_packing_is_still_repaired():
     collator = DataCollatorForTokenClassification(tokenizer = StubProcessor())
     trainer = StubTrainer(collator, _text_rows())
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
-    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+    assert isinstance(_text_collator_of(out.data_collator), DataCollatorForSeq2Seq)
 
 
 @pytest.mark.parametrize("dtype", ("int8", "int16", "uint8", "uint16"))
@@ -2252,7 +2262,7 @@ def test_a_raw_bypass_without_packing_is_untouched():
     ]})
     trainer = StubTrainer(collator, rows)
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
-    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+    assert isinstance(_text_collator_of(out.data_collator), DataCollatorForSeq2Seq)
 
 
 def test_remove_unused_columns_false_still_drops_the_raw_text():
@@ -2544,3 +2554,116 @@ def test_packing_off_does_not_reclassify_every_split():
         f"the split schema was read {reads['n']} times for one call; the "
         f"packing guard is classifying splits it immediately discards"
     )
+
+
+@pytest.mark.parametrize("dtype", ["int16", "int32", "int64"])
+def test_raw_pcm_stays_media_at_every_width(dtype):
+    """32-bit PCM is as much a waveform as the 16-bit kind.
+
+    Only float and sub-32-bit sequences were refused, because a wide integer
+    sequence is the shape every pretokenized column has. `Sequence(int32)` under
+    `speech` is not that, and the name is the only thing that can say so, since
+    `_feature_is_plain_text` never sees it. The column was dropped and the run
+    trained as text with the audio thrown away.
+    """
+    from datasets import Features, Sequence, Value
+
+    rows = Dataset.from_dict(
+        {"input_ids": [list(ROW), list(ROW)], "speech": [[1, 2, 3], [4, 5, 6]]},
+        features = Features({
+            "input_ids": Sequence(Value("int32")),
+            "speech": Sequence(Value(dtype)),
+        }),
+    )
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_wide_int_sequence_under_a_text_name_is_still_plain():
+    """The control. The wide-int allowance exists for token ids, and a numeric
+    auxiliary column must keep passing."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+        "aux_target": [[1, 2], [3, 4]],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "aux_target" in out.train_dataset.column_names
+
+
+@pytest.mark.parametrize("kind", ["image", "video", "audio"])
+def test_a_data_uri_is_media_whatever_the_column_is_called(kind):
+    """A `data:` URI names its own media type, so unlike an extensionless http
+    URL there is nothing to weigh. `image_data` is on no name list, its schema
+    is `string`, so the column was proven plain and stripped."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "image_data": [f"data:{kind}/png;base64,iVBORw0KGgo="] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_an_ordinary_string_column_is_still_plain():
+    """The control for the data-URI check and for dropping bare string columns
+    from the schema proof: a normal text column must still pass."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+        "notes": ["some free text", "http://example.com/page"],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in out.train_dataset.column_names
+
+
+def test_a_later_multimodal_split_still_reaches_the_vision_collator():
+    """The swap outlives construction.
+
+    `predict(test_dataset = ...)` and an `evaluate` override both build their
+    dataloader from `trainer.data_collator`, so a multimodal split handed over
+    after construction met a text collator that cannot process images. The
+    displaced collator is kept and chosen per batch instead.
+    """
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    mine = MyVisionCollator(StubProcessor())
+    trainer = StubTrainer(mine, rows)
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    collator = out.data_collator
+
+    # A text batch still goes the text way.
+    text_batch = collator([{"input_ids": list(ROW), "labels": list(ROW)}])
+    assert "mine" not in text_batch
+
+    # A batch carrying images goes back to the collator that can handle them.
+    assert collator([{"input_ids": list(ROW), "images": [object()]}]) == {"mine": True}
+    assert collator.media is mine, "the displaced collator was thrown away"
+
+
+def test_the_dispatching_collator_is_picklable():
+    """A DataLoader worker under `spawn` pickles the collator by module and
+    qualified name, so it cannot be a closure or a `type()`-built class."""
+    import pickle
+
+    from unsloth_zoo.dataset_utils import _MediaAwareCollator
+
+    assert _MediaAwareCollator.__module__ == "unsloth_zoo.dataset_utils"
+    revived = pickle.loads(pickle.dumps(
+        _MediaAwareCollator(_PicklableCollator(), _PicklableCollator(), {"images"})))
+    assert revived.media_keys == frozenset({"images"})
+
+
+class _PicklableCollator:
+    """Module-level, so the pickling test measures the wrapper and not itself."""
+    def __call__(self, features):
+        return {"n": len(features)}

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1895,3 +1895,36 @@ def test_a_bypassed_self_packing_collator_is_untouched_without_packing():
 
     assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
 
+
+
+def test_remove_unused_columns_false_survives_raw_text_tokenization():
+    """The opt-out has to hold on the raw path too, not just the pretokenized one.
+
+    Tokenization runs first, and its own strip kept only `labels` and the declared
+    forward parameters, so a `sample_weight` that a custom `compute_loss` pops was
+    already deleted by the time the model-input keep-list consulted the flag.
+    """
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = _raw_text_rows(2).add_column("sample_weight", [0.25, 0.75])
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    columns = set(out.eval_dataset.column_names)
+    assert "sample_weight" in columns, sorted(columns)
+    assert out.eval_dataset[0]["sample_weight"] == 0.25
+    # The text just consumed still goes: no collator can stack a string.
+    assert "text" not in columns, sorted(columns)
+
+
+def test_remove_unused_columns_false_survives_a_raw_train_split():
+    """Same strip, the train side of it, reached with a plain text collator."""
+    rows = _raw_text_rows(2).add_column("sample_weight", [0.25, 0.75])
+    trainer = StubTrainer(DataCollatorForSeq2Seq(tokenizer = StubTokenizer()), rows)
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    columns = set(out.train_dataset.column_names)
+    assert "sample_weight" in columns, sorted(columns)
+    assert "text" not in columns, sorted(columns)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1826,3 +1826,25 @@ def test_a_formatted_image_column_is_still_refused(fmt):
 
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_remove_unused_columns_false_keeps_the_users_columns():
+    """`remove_unused_columns = False` is an explicit instruction, not a hint.
+
+    A custom `Trainer.compute_loss` that pops `sample_weight` before calling the
+    model leaves that field out of `model.forward`, so the model-input keep-list
+    deleted it and the weighting was silently lost. HF's Trainer honours the flag;
+    so must the strip.
+    """
+    trainer = _text_only_trainer()
+    trainer.train_dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "sample_weight": [0.25, 0.75],
+    })
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    columns = set(out.train_dataset.column_names)
+    assert "sample_weight" in columns, sorted(columns)
+    assert out.train_dataset[0]["sample_weight"] == 0.25

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1932,3 +1932,99 @@ def test_remove_unused_columns_false_survives_a_raw_train_split():
     columns = set(out.train_dataset.column_names)
     assert "sample_weight" in columns, sorted(columns)
     assert "text" not in columns, sorted(columns)
+
+
+# ---- round N: three more Codex items ---------------------------------------
+
+def test_the_packing_refusal_lands_before_the_dataset_is_touched():
+    """It is a deterministic configuration error, so it must not cost a full
+    tokenize/map/mask/filter pass over a large corpus first -- and the failed
+    call used to leave the trainer's datasets rewritten behind it."""
+    collator = LabelRebuildingVisionCollator(StubProcessor())
+    rows = Dataset.from_dict({"text": ["a" * 4, "b" * 4]})
+    trainer = StubTrainer(collator, rows)
+    trainer.args.packing = True
+    before = trainer.train_dataset
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.train_dataset is before, "the split was mutated before refusing"
+    assert trainer.train_dataset.column_names == ["text"]
+
+
+def test_the_packing_refusal_does_not_map_the_eval_split_either():
+    collator = LabelRebuildingVisionCollator(StubProcessor())
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.eval_dataset = Dataset.from_dict({"input_ids": [list(ROW)]})
+    trainer.args.packing = True
+    before = trainer.eval_dataset
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert trainer.eval_dataset is before
+
+
+def test_a_type_tagged_struct_column_is_still_scanned():
+    """`{"type": "image", "content": "cat.jpg"}` is all `string`, so the schema
+    called the column plain and marked it proven -- which is exactly what makes
+    `_row_is_plain_text` skip it, so the `type` tag was never read and the image
+    column was dropped, training the row as text."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "part": [{"type": "text", "content": "hello"},
+                 {"type": "image", "content": "cat.jpg"}],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_type_tagged_struct_of_real_text_still_passes():
+    """The scan answers per value, so an ordinary tagged text part is fine and
+    the run is not refused for carrying a `type` field."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "part": [{"type": "text", "content": "hello"},
+                 {"type": "text", "content": "there"}],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert out is trainer
+
+
+def test_a_nested_type_tag_is_scanned_too():
+    """A tag one level down inside a list of turns is the same shape."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "turns": [[{"type": "text", "content": "hi"}],
+                  [{"type": "image", "content": "dog.png"}]],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_custom_label_pad_value_survives_the_repair():
+    """DataCollatorForSeq2Seq takes `label_pad_token_id` too, so a caller who
+    chose one keeps it; dropping it padded with -100 instead."""
+    from transformers import DataCollatorForTokenClassification
+    collator = DataCollatorForTokenClassification(
+        tokenizer = StubProcessor(), padding = "max_length", max_length = 32,
+        label_pad_token_id = -1,
+    )
+    trainer = StubTrainer(collator, _text_rows())
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+    assert out.data_collator.label_pad_token_id == -1
+    assert out.data_collator.padding == "max_length"
+    assert out.data_collator.max_length == 32
+
+
+def test_the_default_label_pad_value_is_unchanged():
+    """The copy must not move the default off -100 for everyone else."""
+    from transformers import DataCollatorForTokenClassification
+    collator = DataCollatorForTokenClassification(tokenizer = StubProcessor())
+    trainer = StubTrainer(collator, _text_rows())
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert out.data_collator.label_pad_token_id == -100

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1586,6 +1586,41 @@ def test_a_media_filename_column_is_refused(column, value):
     assert column in trainer.train_dataset.column_names, "the media column was dropped"
 
 
+@pytest.mark.parametrize("key, value", [
+    ("file_path",  "images/cat.jpg"),
+    ("filepath",   "images/cat.jpg"),
+    ("file_name",  "cat.jpg"),
+    ("filename",   "cat.jpg"),
+    ("file",       "clips/intro.mp4"),
+    ("uri",        "https://example.com/cat.jpg"),
+    ("media",      "clips/take1.wav"),
+    ("source_url", "https://example.com/cat.png"),
+    ("paths",      ["images/cat.jpg"]),
+    ("urls",       ["https://example.com/cat.jpg"]),
+])
+def test_a_nested_generic_media_alias_is_scanned_by_value(key, value):
+    """Only `path`/`url` were value-scanned one level down, so every other
+    generic spelling the top level treats as ambiguous was called text and the
+    media it pointed at was dropped with the column."""
+    trainer = _meta_trainer([{key: value}] * 2)
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "meta" in trainer.train_dataset.column_names, "the media was dropped"
+
+
+def test_a_nested_generic_alias_holding_provenance_still_passes():
+    """The value still decides: a shard path under the same keys is what a text
+    corpus carries, so widening the nested set must not refuse it."""
+    trainer = _meta_trainer([{"file_path": "corpus/shard.jsonl",
+                              "uri": "s3://bucket/key.txt"}] * 2)
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert any(l != -100 for l in out.train_dataset[0]["labels"])
+
+
 class ProcessorWithoutImages:
     """A processor half with no `.pad` and no `image_processor`, so the vision
     bypass never sees it and only the `.pad` repair can fire."""

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1458,3 +1458,71 @@ def test_precomputed_labels_survive_the_raw_column_drop():
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
     assert out.train_dataset[0]["labels"] == old, "the caller's mask was lost"
+
+
+# ---- provenance structs are not media --------------------------------------
+
+def _meta_trainer(meta, n = 2, iterable = False):
+    dataset = Dataset.from_dict({"input_ids": [list(ROW)] * n, "meta": meta})
+    if iterable: dataset = dataset.to_iterable_dataset()
+    return StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+
+
+def test_a_nested_provenance_struct_is_not_refused_as_media():
+    """`meta = {"url": ..., "path": ...}` is what every web-scraped text corpus
+    carries. Judged on the key name alone it refused a text-only run, while the
+    same strings in top-level `path`/`url` columns are value-scanned and pass."""
+    trainer = _meta_trainer([{"url": "https://en.wikipedia.org/wiki/Cat",
+                              "path": "corpus/shard.jsonl",
+                              "source": "wiki"}] * 2)
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert any(l != -100 for l in out.train_dataset[0]["labels"])
+
+
+def test_a_nested_media_reference_is_still_refused():
+    """The value, not the key, is what decides: a `cat.jpg` under the same key
+    still points at an image the text path would drop."""
+    trainer = _meta_trainer([{"path": "images/cat.jpg"}] * 2)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_nested_media_reference_past_the_sample_is_still_refused():
+    """The 16-row sample never reads row 137, so the whole column is scanned."""
+    n = 300
+    meta = [{"path": "corpus/shard.jsonl"} for _ in range(n)]
+    meta[137] = {"path": "images/cat.jpg"}
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(_meta_trainer(meta, n), INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_an_unscannable_nested_provenance_struct_is_refused_by_name():
+    """A stream hands over no more than a prefix, so the rows it never reads
+    cannot be called text; the refusal names the column to drop."""
+    trainer = _meta_trainer([{"path": "corpus/shard.jsonl"}] * 40, n = 40,
+                            iterable = True)
+    with pytest.raises(ValueError, match = "cannot be read past its first rows") as excinfo:
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "['meta']" in str(excinfo.value), "the refusal does not name the column"
+
+
+def test_an_inline_image_url_part_is_still_refused():
+    """`image_url` is unambiguous, so a chat turn holding one never reaches the
+    value scan - the struct is refused on the key."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), Dataset.from_dict({
+        "input_ids": [list(ROW)] * 2,
+        "messages": [[{"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": "https://x/cat.jpg"}}]}]] * 2,
+    }))
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_an_undecoded_image_struct_is_still_refused():
+    """`datasets.Image(decode = False)` is `{"bytes": ..., "path": ...}`; `bytes`
+    stays a hard reject so relaxing `path` cannot let an image through."""
+    trainer = _meta_trainer([{"bytes": b"\x89PNG", "path": "a"}] * 2)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2028,3 +2028,104 @@ def test_the_default_label_pad_value_is_unchanged():
     trainer = StubTrainer(collator, _text_rows())
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert out.data_collator.label_pad_token_id == -100
+
+
+# ---- round N+1: three more Codex items --------------------------------------
+
+def test_a_float_sequence_column_is_not_proven_text():
+    """`Sequence(float32)` under a generic name is a waveform, and the leaf
+    dtype check called it plain, so the column was marked proven, its values
+    were never read, and the audio was dropped before training."""
+    from datasets import Dataset, Features, Sequence, Value
+    rows = Dataset.from_dict(
+        {"input_ids": [list(ROW), list(ROW)],
+         "speech": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]},
+        features = Features({
+            "input_ids": Sequence(Value("int64")),
+            "speech": Sequence(Value("float32")),
+        }),
+    )
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_an_integer_sequence_column_is_still_proven_text():
+    """Every pretokenized column has exactly that shape, so refusing them
+    would refuse the case this bypass exists for."""
+    from datasets import Dataset, Features, Sequence, Value
+    rows = Dataset.from_dict(
+        {"input_ids": [list(ROW), list(ROW)],
+         "position_ids": [[0, 1, 2], [0, 1, 2]]},
+        features = Features({
+            "input_ids": Sequence(Value("int64")),
+            "position_ids": Sequence(Value("int64")),
+        }),
+    )
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    assert train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART) is trainer
+
+
+def test_a_multidimensional_numeric_column_is_not_proven_text():
+    """Array4D under `frames` is video however plain its leaf dtype reads."""
+    from datasets import Array2D, Dataset, Features, Sequence, Value
+    rows = Dataset.from_dict(
+        {"input_ids": [list(ROW), list(ROW)],
+         "frames": [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]},
+        features = Features({
+            "input_ids": Sequence(Value("int64")),
+            "frames": Array2D(shape = (2, 2), dtype = "int32"),
+        }),
+    )
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_top_level_bytes_column_is_media():
+    """A flattened base64 payload has a string schema, so the name has to say
+    so -- `bytes` is already an unambiguous media key one level down."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "bytes": ["iVBORw0KGgo=", "iVBORw0KGgo="],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_packing_on_a_raw_bypass_is_refused():
+    """The exemption above is about who pads, not who packs. A raw split going
+    through the dataset-level path is tokenized row by row and collated by a
+    plain DataCollatorForSeq2Seq, so `packing = True` silently does nothing."""
+    from transformers import DataCollatorForTokenClassification
+    collator = DataCollatorForTokenClassification(tokenizer = StubProcessor())
+    rows = Dataset.from_dict({"text": ["a" * 4, "b" * 4]})
+    trainer = StubTrainer(collator, rows)
+    trainer.args.packing = True
+    with pytest.raises(ValueError, match = "packing = True` is not supported"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_packing_on_a_pretokenized_bypass_is_unchanged():
+    """Those rows carry their own `input_ids`, so nothing here claims to pack
+    them and the exemption still applies."""
+    from transformers import DataCollatorForTokenClassification
+    collator = DataCollatorForTokenClassification(tokenizer = StubProcessor())
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.args.packing = True
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+
+
+def test_a_raw_bypass_without_packing_is_untouched():
+    """The refusal is gated on packing, not on the split being raw."""
+    from transformers import DataCollatorForTokenClassification
+    collator = DataCollatorForTokenClassification(tokenizer = StubProcessor())
+    rows = Dataset.from_dict({"text": [
+        f"{INSTRUCTION_PART}hi{RESPONSE_PART}there",
+        f"{INSTRUCTION_PART}yo{RESPONSE_PART}hello",
+    ]})
+    trainer = StubTrainer(collator, rows)
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -3062,3 +3062,112 @@ def test_case_variants_survive_a_split_that_refuses_its_columns():
         eval_dataset = None
 
     assert "Image" in _case_variants(Trainer(), {"image"})
+
+
+def test_a_tensorizable_companion_column_survives_the_text_path():
+    """`output`, `response`, `content` are ordinary English words. Under
+    `remove_unused_columns=False` a caller's numeric auxiliary input under one of
+    those names was dropped from every text batch, so its custom `compute_loss`
+    never saw a column it explicitly asked to keep. What the text collator cannot
+    stack is a raw STRING; a number stays."""
+    from unsloth_zoo.dataset_utils import _MediaAwareCollator
+
+    seen = {}
+    def text(features): seen["f"] = features; return "text"
+    collator = _MediaAwareCollator(text, lambda f: "media", {"image"},
+                                   ambiguous_keys = {"url"},
+                                   companion_keys = {"output", "content"})
+    collator([{"input_ids": [1, 2], "output": 0.5, "content": [1, 2], "url": 3}])
+    assert seen["f"][0] == {"input_ids": [1, 2], "output": 0.5,
+                            "content": [1, 2], "url": 3}
+
+
+def test_a_raw_text_companion_column_is_still_stripped():
+    from unsloth_zoo.dataset_utils import _MediaAwareCollator
+
+    seen = {}
+    def text(features): seen["f"] = features; return "text"
+    collator = _MediaAwareCollator(text, lambda f: "media", {"image"},
+                                   ambiguous_keys = {"url"},
+                                   companion_keys = {"output", "content"})
+    collator([{"input_ids": [1], "output": "hello", "url": "a.txt",
+               "content": ["a", "b"]}])
+    assert seen["f"][0] == {"input_ids": [1]}
+
+
+def test_holds_raw_text_sees_through_a_nest():
+    from unsloth_zoo.dataset_utils import _holds_raw_text
+    assert _holds_raw_text("a") is True
+    assert _holds_raw_text([{"c": "a"}]) is True
+    assert _holds_raw_text([[1, 2], [3]]) is False
+    assert _holds_raw_text(0) is False
+    assert _holds_raw_text(None) is False
+
+
+def test_prose_ending_in_a_media_suffix_is_still_text():
+    """A formatted sample whose assistant answer reads `cat.jpg` is prose. The
+    generic suffix check called the whole column a media reference and the split
+    was refused with the vision-collator error, for text the tokenizer handles
+    fine."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}which file{RESPONSE_PART}cat.jpg"],
+    })
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "labels" in out.eval_dataset.column_names
+    assert "text" not in out.eval_dataset.column_names
+
+
+def test_a_media_suffix_outside_the_text_field_is_still_media():
+    """The exemption is for the configured text field only."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"],
+        "attachments": ["cat.jpg"],
+    })
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_structured_text_field_is_still_scanned():
+    """Only a BARE string is exempt: a `messages`-style field holding a list of
+    turns can carry inline image parts, and skipping it would drop them."""
+    trainer = _text_only_trainer()
+    trainer.args.dataset_text_field = "messages"
+    trainer.eval_dataset = Dataset.from_dict({"messages": _messages_of_plain_text()})
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_scalar_labels_column_on_a_raw_split_is_not_kept_as_supervision():
+    """A raw split can carry a SCALAR `labels` (a class id). Keeping it as
+    token-level supervision sent an int into the masking pass, which calls
+    `len(old_labels)` on it: `TypeError: object of type 'int' has no len()`."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"],
+        "labels": [3],
+    })
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "labels" in out.eval_dataset.column_names
+    assert len(out.eval_dataset["labels"][0]) == len(out.eval_dataset["input_ids"][0])
+
+
+def test_a_sized_labels_value_is_still_treated_as_supervision():
+    """The exemption is for SCALARS only. Anything with a length is the caller's
+    own token-level masking, and dropping it would un-mask what they masked."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "labels": [list(ROW), list(ROW)],
+    })
+
+    out = _bypass(dataset)
+
+    assert "labels" in out.train_dataset.column_names
+    assert len(out.train_dataset["labels"][0]) == len(ROW)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1832,7 +1832,9 @@ def test_a_raw_eval_split_whose_full_scan_fails_is_refused():
 
     with pytest.raises(ValueError, match = "does not support response-only") as excinfo:
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
-    assert "['text']" in str(excinfo.value), "the refusal does not name the column"
+    # Named, not an exact list: a custom transform makes every non-tokenizer
+    # column unreadable, so `weight` is reported beside `text` now.
+    assert "'text'" in str(excinfo.value), "the refusal does not name the column"
 
 
 @pytest.mark.parametrize("fmt", ["torch", "numpy"])
@@ -2444,3 +2446,101 @@ def test_a_schema_proof_does_not_survive_a_custom_transform():
                           rows.with_transform(_decode))
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_custom_transform_is_refused_at_an_unsampled_row_too():
+    """Clearing the schema proof was not enough.
+
+    `provable` still said "no column is media in storage", and that is only
+    checked against the sampled rows, so a transform that decodes an image at
+    row 5000 passed both and had its column dropped. Only the sampled prefix is
+    plain text here, and the split must still be refused."""
+    Image = pytest.importorskip("PIL.Image")
+    n = 64
+    # The sample is spread and always includes the first and last row, so the
+    # media has to sit at an index it genuinely never reads or the test proves
+    # only that sampling works.
+    sampled = sorted({i * (n - 1) // 15 for i in range(16)})
+    hidden = next(i for i in range(n) if i not in sampled)
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW)] * n,
+        "payload": [f"row{i}" for i in range(n)],
+    })
+
+    def _decode(batch):
+        batch["payload"] = [
+            Image.new("RGB", (2, 2)) if p == f"row{hidden}" else p
+            for p in batch["payload"]
+        ]
+        return batch
+
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          rows.with_transform(_decode))
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_numpy_formatted_raw_split_reaches_the_tokenizer():
+    """`with_format("numpy")` hands a column back as an ndarray, and
+    `examples.get(field) or examples.get("text", [])` boolean-tested it, so
+    tokenization raised "truth value of an array ... is ambiguous" before a row
+    was read. Presence is the question there, not truthiness."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{i}{RESPONSE_PART}a{i}" for i in range(4)],
+    }).with_format("numpy")
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in out.eval_dataset.column_names
+
+
+def test_a_numpy_formatted_pretokenized_split_is_masked():
+    """Same format, the other path. `input_ids` arrives as an ndarray, and
+    slicing one to compare against a multi-token marker gives an array, so the
+    `if` around that comparison raised. Only `torch.Tensor` was normalised."""
+    class _MultiTokenTokenizer(StubTokenizer):
+        @staticmethod
+        def _ids(text):
+            return {"<<U>>": [7, 8], "<<A>>": [9, 10]}.get(text) or [
+                ord(c) for c in text]
+
+    rows = Dataset.from_dict({
+        "input_ids": [[7, 8, 50, 51, 9, 10, 60, 61]] * 4,
+    }).with_format("numpy")
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.processing_class.tokenizer = _MultiTokenTokenizer()
+
+    out = train_on_responses_only(trainer, "<<U>>", "<<A>>")
+    assert "labels" in out.train_dataset.column_names
+
+
+def test_packing_off_does_not_reclassify_every_split():
+    """The guard returns immediately when packing is off, but its argument was
+    built first: `_dataset_is_pretokenized` ran over every split again, and that
+    performs whole-column scans for ambiguous metadata. `evaluate()` reaches
+    this on each call, so a large corpus was traversed for a thrown-away list."""
+    from unittest.mock import patch
+
+    # `PropertyMock` never sees `self`, so count through a plain property that
+    # delegates to the real one.
+    reads = {"n": 0}
+    real = Dataset.features
+
+    def _counting(self):
+        reads["n"] += 1
+        return real.fget(self)
+
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.packing = False
+
+    with patch.object(Dataset, "features", property(_counting)):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert reads["n"] <= 4, (
+        f"the split schema was read {reads['n']} times for one call; the "
+        f"packing guard is classifying splits it immediately discards"
+    )

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1665,3 +1665,47 @@ def test_a_model_input_column_survives_raw_text_tokenization():
     assert out.eval_dataset[0]["sample_weight"] == 0.25
     # The raw text it replaced is still gone: the collator cannot stack strings.
     assert "text" not in columns, sorted(columns)
+
+
+def test_a_bare_image_column_of_paths_is_refused():
+    """`img` holding "cat.jpg" is media, and looked like text on schema alone.
+
+    `_MEDIA_KEYS` already treats the bare names as unambiguous media one level
+    down; the top-level list only carried the compound spellings, so a
+    pretokenized VLM split keeping its images in a plain `img` column passed the
+    bypass and had the column dropped before training.
+    """
+    trainer = _text_only_trainer()
+    trainer.train_dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "img": ["images/cat.jpg", "images/dog.png"],
+    })
+
+    with pytest.raises(Exception):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_token_classification_collator_keeps_its_padding_settings():
+    """Every pad-delegating collator's padding fields must survive the repair.
+
+    `DataCollatorForTokenClassification` is a separate class, not a subclass of
+    `DataCollatorWithPadding`, so an isinstance check on that one class dropped
+    `padding = "max_length"` and silently reshaped every batch to dynamic.
+    """
+    from transformers import DataCollatorForTokenClassification
+
+    collator = DataCollatorForTokenClassification(
+        tokenizer = StubProcessor(),
+        padding = "max_length",
+        max_length = 128,
+        pad_to_multiple_of = 8,
+    )
+    trainer = _text_only_trainer()
+    trainer.data_collator = collator
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    repaired = out.data_collator
+    assert repaired.padding == "max_length", repaired.padding
+    assert repaired.max_length == 128, repaired.max_length
+    assert repaired.pad_to_multiple_of == 8, repaired.pad_to_multiple_of

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -225,13 +225,15 @@ def test_processor_specific_column_names_are_refused_too(column):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
 
-def test_a_processor_backed_collator_is_rebuilt_even_with_packing():
-    """It raises on the first batch either way, so the repair is not packing-gated."""
+def test_a_processor_backed_collator_under_packing_is_refused():
+    """The repair rebuilds it as a plain DataCollatorForSeq2Seq, which packs
+    nothing and drops the inputs a packed batch needs, so say so rather than
+    train an unpacked run the caller did not ask for."""
     trainer = StubTrainer(DataCollatorForSeq2Seq(tokenizer = StubProcessor()),
                           _text_rows())
     trainer.args.packing = True
-    train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
-    assert hasattr(trainer.data_collator.tokenizer, "pad")
+    with pytest.raises(ValueError, match = "packing = True` is not supported"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
 
 def test_the_rebuild_keeps_the_settings_the_caller_chose():
@@ -300,12 +302,20 @@ def test_a_raw_split_with_no_text_column_is_still_refused():
 
 # ---- non-seq2seq collators that pad through a processor --------------------
 
-def test_a_processor_backed_padding_collator_is_repaired_under_packing():
+def test_a_processor_backed_padding_collator_under_packing_is_refused():
     """`DataCollatorWithPadding(tokenizer = processor)` pads through the same
-    missing `.pad`, so packing being on must not leave it attached."""
+    missing `.pad`, so it is replaced too, and the replacement does not pack."""
     collator = DataCollatorWithPadding(tokenizer = StubProcessor())
     trainer = StubTrainer(collator, _text_rows())
     trainer.args.packing = True
+
+    with pytest.raises(ValueError, match = "packing = True` is not supported"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_processor_backed_padding_collator_is_repaired():
+    collator = DataCollatorWithPadding(tokenizer = StubProcessor())
+    trainer = StubTrainer(collator, _text_rows())
 
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
@@ -316,19 +326,27 @@ def test_a_processor_backed_padding_collator_is_repaired_under_packing():
     assert "input_ids" in batch and "labels" in batch
 
 
-def test_a_collator_holding_only_a_processor_is_repaired_under_packing():
+def test_a_collator_holding_only_a_processor_is_repaired():
     """TRL's `DataCollatorForVisionLanguageModeling` keeps the processor under
     `.processor`, not `.tokenizer`, with the same problem. It rebuilds labels
-    through that processor, so it is a class we know how to answer for and the
-    repair still runs with packing on."""
+    through that processor, so it is a class we know how to answer for."""
+    from trl.trainer.sft_trainer import DataCollatorForVisionLanguageModeling
+
+    trainer = _text_only_trainer()
+    trainer.data_collator = DataCollatorForVisionLanguageModeling(processor = StubProcessor())
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+    assert hasattr(out.data_collator.tokenizer, "pad")
+
+
+def test_a_collator_holding_only_a_processor_under_packing_is_refused():
     from trl.trainer.sft_trainer import DataCollatorForVisionLanguageModeling
 
     trainer = _text_only_trainer()
     trainer.data_collator = DataCollatorForVisionLanguageModeling(processor = StubProcessor())
     trainer.args.packing = True
-    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
-    assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
-    assert hasattr(out.data_collator.tokenizer, "pad")
+    with pytest.raises(ValueError, match = "packing = True` is not supported"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
 
 class PackingCollator:
@@ -1693,13 +1711,22 @@ def test_a_self_packing_collator_holding_a_processor_is_left_alone():
     assert "position_ids" in out.data_collator(rows), "its packing did not survive"
 
 
-def test_a_seq2seq_collator_holding_a_processor_is_still_repaired_under_packing():
-    """The other direction: a class that really does pad through `.pad` is still
-    rebuilt even with packing on, since it dies on the first batch either way."""
+def test_a_seq2seq_collator_holding_a_processor_is_refused_under_packing():
+    """The other direction: a class that really does pad through `.pad` would be
+    rebuilt, and the rebuilt collator packs nothing, so packing is refused."""
     collator = DataCollatorForSeq2Seq(tokenizer = ProcessorWithoutImages())
     trainer = StubTrainer(collator, _text_rows())
     trainer.processing_class = StubTokenizer()
     trainer.args.packing = True
+
+    with pytest.raises(ValueError, match = "packing = True` is not supported"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_seq2seq_collator_holding_a_processor_is_still_repaired_without_packing():
+    collator = DataCollatorForSeq2Seq(tokenizer = ProcessorWithoutImages())
+    trainer = StubTrainer(collator, _text_rows())
+    trainer.processing_class = StubTokenizer()
 
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
@@ -2107,15 +2134,106 @@ def test_packing_on_a_raw_bypass_is_refused():
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
 
-def test_packing_on_a_pretokenized_bypass_is_unchanged():
-    """Those rows carry their own `input_ids`, so nothing here claims to pack
-    them and the exemption still applies."""
+def test_packing_on_a_pretokenized_bypass_is_refused_too():
+    """Pretokenized is not packed. Either the rows were never concatenated, or
+    they were and the replacement DataCollatorForSeq2Seq drops the `seq_lengths`
+    that rebuild `position_ids`, so the packed examples attend to each other."""
     from transformers import DataCollatorForTokenClassification
     collator = DataCollatorForTokenClassification(tokenizer = StubProcessor())
     trainer = StubTrainer(collator, _text_rows())
     trainer.args.packing = True
+    with pytest.raises(ValueError, match = "position_ids"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_packing_subclass_of_a_known_collator_is_refused():
+    """`isinstance` marks a packing subclass of a padding collator as known, so
+    the foreign-collator refusal skips it and the bypass would replace it with a
+    plain DataCollatorForSeq2Seq, discarding its packing."""
+    class PackingSeq2Seq(DataCollatorForSeq2Seq): pass
+    trainer = StubTrainer(PackingSeq2Seq(tokenizer = StubProcessor()), _text_rows())
+    trainer.args.packing = True
+    with pytest.raises(ValueError, match = "packing = True` is not supported"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_pretokenized_bypass_without_packing_is_still_repaired():
+    """The new refusal is gated on packing, not on the rows being pretokenized."""
+    from transformers import DataCollatorForTokenClassification
+    collator = DataCollatorForTokenClassification(tokenizer = StubProcessor())
+    trainer = StubTrainer(collator, _text_rows())
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert isinstance(out.data_collator, DataCollatorForSeq2Seq)
+
+
+@pytest.mark.parametrize("dtype", ("int8", "int16", "uint8", "uint16"))
+def test_a_narrow_integer_sequence_column_is_not_proven_text(dtype):
+    """int16 PCM under `speech` is the same waveform as the float32 case, and
+    only float sequences were rejected, so the column read as plain text, its
+    values were never sampled and the audio was dropped before training."""
+    from datasets import Dataset, Features, Sequence, Value
+    rows = Dataset.from_dict(
+        {"input_ids": [list(ROW), list(ROW)], "speech": [[1, 2, 3], [4, 5, 6]]},
+        features = Features({
+            "input_ids": Sequence(Value("int64")),
+            "speech": Sequence(Value(dtype)),
+        }),
+    )
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+@pytest.mark.parametrize("dtype", ("int32", "int64"))
+def test_a_token_width_integer_sequence_is_still_proven_text(dtype):
+    """Token ids arrive at int32 or wider from every tokenizer."""
+    from datasets import Dataset, Features, Sequence, Value
+    rows = Dataset.from_dict(
+        {"input_ids": [list(ROW), list(ROW)],
+         "position_ids": [[0, 1, 2], [0, 1, 2]]},
+        features = Features({
+            "input_ids": Sequence(Value("int64")),
+            "position_ids": Sequence(Value(dtype)),
+        }),
+    )
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    assert train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART) is trainer
+
+
+class TextTakingModel:
+    """A `forward` that happens to declare `text`, which is a real signature on
+    models whose processor is folded into the module."""
+    def forward(self, input_ids = None, attention_mask = None, labels = None,
+                text = None): ...
+
+
+def test_a_forward_declaring_text_does_not_keep_the_raw_string_column():
+    """The keep-list saves anything `forward` names, so a `text` parameter kept
+    the raw string the tokenizer had just replaced, and DataCollatorForSeq2Seq
+    died tensorizing it on the first batch."""
+    rows = Dataset.from_dict({"text": [
+        f"{INSTRUCTION_PART}hi{RESPONSE_PART}there",
+        f"{INSTRUCTION_PART}yo{RESPONSE_PART}hello",
+    ]})
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.model = TextTakingModel()
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "text" not in out.train_dataset.column_names
+    assert "input_ids" in out.train_dataset.column_names
+
+
+def test_a_forward_declaring_text_does_not_keep_a_pretokenized_string_column():
+    """Same hole one keep-list later: an already-tokenized split that still
+    carries its source `text` never reaches the tokenizing strip."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW), [1] * len(ROW)],
+        "text": ["a", "b"],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.model = TextTakingModel()
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "text" not in out.train_dataset.column_names
 
 
 def test_a_raw_bypass_without_packing_is_untouched():

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2703,3 +2703,94 @@ def test_a_data_uri_outside_the_sampled_rows_is_still_media(kind):
     trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_repaired_padding_collator_is_not_kept_as_the_media_fallback():
+    """The `_processor_backed` repair replaces a collator whose tokenizer is a
+    processor with no `.pad`. That object is broken for EVERY batch, not just
+    text, so keeping it as the fallback routed a later media batch straight back
+    into the `processor.pad` AttributeError the repair exists to remove."""
+    class _NoPad:
+        pad_token_id = 0
+        def __call__(self, *a, **k): raise AssertionError("should not be called")
+
+    from transformers import DataCollatorWithPadding
+
+    broken = DataCollatorWithPadding(tokenizer = StubProcessor())
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    out = train_on_responses_only(StubTrainer(broken, rows),
+                                  INSTRUCTION_PART, RESPONSE_PART)
+    # A plain text collator, not a dispatcher holding the broken one.
+    assert not hasattr(out.data_collator, "media"), \
+        "the unusable collator was preserved as the media fallback"
+
+
+def test_the_media_keys_survive_unused_column_removal():
+    """`remove_unused_columns` is on by default and the trainer caches its
+    signature columns from the model's forward, so a later `evaluate`/`predict`
+    split had its media stripped BEFORE the collator ran: the fallback the
+    dispatcher advertises could never fire."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert hasattr(out.data_collator, "media"), "no dispatcher was installed"
+    signature = getattr(out, "_signature_columns", None)
+    assert signature, "signature columns were never seeded"
+    for key in ("images", "pixel_values", "input_features"):
+        assert key in signature, f"{key} would be stripped before the collator"
+    # The columns the loss needs are still there.
+    for key in ("input_ids", "labels"):
+        assert key in signature, key
+
+
+def test_a_raw_conversation_batch_reaches_the_media_collator():
+    """A conversation carries its images INSIDE `messages`, as `{"type":
+    "image", ...}` parts, so no top-level key names them and the batch went to
+    the text collator, which cannot read the conversation at all."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    mine = MyVisionCollator(StubProcessor())
+    collator = train_on_responses_only(
+        StubTrainer(mine, rows), INSTRUCTION_PART, RESPONSE_PART).data_collator
+
+    conversation = [{"role": "user", "content": [{"type": "image", "image": object()}]}]
+    assert collator([{"messages": conversation}]) == {"mine": True}
+    # A text batch is unaffected.
+    assert "mine" not in collator([{"input_ids": list(ROW), "labels": list(ROW)}])
+
+
+@pytest.mark.parametrize("column", ["image_base64", "img_b64", "image_bytes"])
+def test_a_bare_base64_payload_under_a_media_name_is_media(column):
+    """A bare payload carries no `data:` prefix, so the value check cannot see
+    it and the column was dropped, training the example without its image.
+    Base64-decoding to sniff magic bytes is neither cheap nor reliable, so the
+    name is the evidence, as it already is for PCM."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        column: ["iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_an_ordinary_string_column_is_still_not_base64_media():
+    """The control: the name list must not swallow a normal text column."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+        "caption": ["a photo of a cat", "a photo of a dog"],
+    })
+    out = train_on_responses_only(
+        StubTrainer(MyVisionCollator(StubProcessor()), rows),
+        INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in out.train_dataset.column_names

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -445,3 +445,106 @@ def test_a_tokenized_eval_split_keeps_no_raw_text():
 
     assert "text" not in out.eval_dataset["raw"].column_names
     assert "labels" in out.eval_dataset["raw"].column_names
+
+
+# ---- only model inputs may reach the collator ------------------------------
+
+class TensorizingPadTokenizer(StrictPadTokenizer):
+    """Pads the keys a real tokenizer knows about and tensorizes the rest, so a
+    ragged leftover raises exactly as `tokenizer.pad(return_tensors = "pt")` does."""
+    _PADDED = ("input_ids", "attention_mask", "token_type_ids", "special_tokens_mask")
+
+    def pad(self, features, **kwargs):
+        for key in features[0]:
+            if key in self._PADDED: continue
+            widths = {len(f[key]) if isinstance(f[key], (list, tuple)) else None
+                      for f in features}
+            if len(widths) > 1:
+                raise ValueError(
+                    f"Unable to create tensor ... (`{key}` in this case)"
+                )
+        return StrictPadTokenizer.pad(self, features, **kwargs)
+
+
+class TensorizingProcessor(StubProcessor):
+    def __init__(self):
+        super().__init__()
+        self.tokenizer = TensorizingPadTokenizer()
+
+
+def _bypass(dataset, model = None):
+    trainer = StubTrainer(MyVisionCollator(TensorizingProcessor()), dataset)
+    trainer.processing_class = TensorizingProcessor()
+    if model is not None: trainer.model = model
+    return train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_scalar_label_column_never_reaches_the_collator():
+    """`DataCollatorForSeq2Seq` reads `label` in preference to `labels`, so a
+    kept scalar `label` both loses the masked labels and dies on `len(int)`."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "label": [0, 1],
+    })
+    out = _bypass(dataset)
+
+    batch = _collate_every_row(out)     # used to raise TypeError: len() of int
+    assert "label" not in out.train_dataset.column_names
+    assert len(batch["labels"][0]) == len(ROW)
+
+
+def test_a_ragged_numeric_column_never_reaches_the_collator():
+    """Pretokenizing a prompt/completion split leaves `prompt_ids` behind. It is
+    numeric, but `tokenizer.pad` pads only its own keys, so stacking it fails."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "prompt_ids": [[1, 2], [1, 2, 3]],
+    })
+    out = _bypass(dataset)
+
+    _collate_every_row(out)             # used to raise ValueError while tensorizing
+    assert "prompt_ids" not in out.train_dataset.column_names
+
+
+def test_a_numeric_metadata_column_is_dropped():
+    """`id`/`sample_idx` tensorize cleanly but are not model inputs."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "id": [7, 8],
+        "sample_idx": [0, 1],
+    })
+    out = _bypass(dataset)
+
+    assert "id" not in out.train_dataset.column_names
+    assert "sample_idx" not in out.train_dataset.column_names
+    assert "input_ids" in out.train_dataset.column_names
+
+
+def test_model_and_processor_declared_inputs_survive():
+    """The kept names come from the processor and the model's own forward, so a
+    multimodal input this file has never heard of still gets through."""
+    class FakeModel:
+        def forward(self, input_ids = None, attention_mask = None, labels = None,
+                    pixel_values = None, deepstack_visual_embeds = None, **kwargs):
+            pass
+
+    processor_names = ["input_ids", "attention_mask", "mm_token_type_ids"]
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "token_type_ids": [[0] * len(ROW)] * 2,
+        "mm_token_type_ids": [[0] * len(ROW)] * 2,
+        "deepstack_visual_embeds": [[0] * len(ROW)] * 2,
+        "id": [1, 2],
+    })
+    trainer = StubTrainer(MyVisionCollator(TensorizingProcessor()), dataset)
+    trainer.processing_class = TensorizingProcessor()
+    trainer.processing_class.tokenizer.model_input_names = processor_names
+    trainer.model = FakeModel()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    kept = out.train_dataset.column_names
+    for column in ("input_ids", "labels", "token_type_ids", "mm_token_type_ids",
+                   "deepstack_visual_embeds"):
+        assert column in kept, column
+    assert "id" not in kept

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -3262,3 +3262,53 @@ def test_a_nullable_scalar_labels_column_is_still_dropped_on_a_null_first_row():
 
     assert "labels" in out.eval_dataset.column_names
     assert len(out.eval_dataset["labels"][0]) == len(out.eval_dataset["input_ids"][0])
+
+
+# ---- the keep-lists, round 3 ----------------------------------------------
+
+def _raw_text_split(**extra):
+    rows = {"text": ["<|user|>q0<|assistant|>a0", "<|user|>q1<|assistant|>a1"]}
+    rows.update(extra)
+    return Dataset.from_dict(rows)
+
+
+def test_a_scalar_labels_column_is_dropped_even_under_the_opt_out():
+    """`remove_unused_columns = False` re-added every raw column, which undid the
+    scalar-`labels` discard and sent an int into the masking pass:
+    `TypeError: object of type 'int' has no len()`."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          _raw_text_split(labels = [3, 7]))
+    trainer.args.remove_unused_columns = False
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    labels = out.train_dataset[0]["labels"]
+    assert isinstance(labels, list), f"scalar labels survived as {labels!r}"
+
+
+def test_a_configured_label_name_survives_raw_tokenization():
+    """A label consumed by a custom `compute_loss` is not declared by `forward`,
+    and `remove_columns` here deletes it for good, so the later keep-lists that
+    do honour `label_names` never see it."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          _raw_text_split(my_reward = [0.5, 1.5]))
+    trainer.args.label_names = ["my_reward"]
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "my_reward" in out.train_dataset.column_names, \
+        "the configured label was tokenized away"
+
+
+def test_index_is_not_seeded_into_the_signature():
+    """Trainer's own derivation is `+= list(set(["label", "label_ids"] +
+    self.label_names))` on transformers 4.57 through 5.14 -- no `index`. Seeding it
+    keeps a metadata column through unused-column removal, and the text collator
+    then tensorizes it into an `index =` argument `forward` never declared."""
+    trainer = _text_only_trainer()
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    seeded = getattr(out, "_signature_columns", None) or []
+    assert "index" not in seeded, seeded
+    # The columns HF really does always keep are still there.
+    assert {"label", "label_ids", "input_ids", "labels"} <= set(seeded)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -2979,15 +2979,25 @@ def test_the_media_path_still_sees_every_kept_column():
 
 def test_a_configured_label_survives_raw_column_removal():
     """`_keep_media_columns` kept `args.label_names` in the signature while the
-    raw-column keep-list deleted the same columns from the split itself."""
-    from unsloth_zoo import dataset_utils as D
-    import inspect
+    raw-column keep-list deleted the same columns from the split itself.
 
-    src = inspect.getsource(D.train_on_responses_only)
-    body = src[src.index("def _model_input_columns"):]
-    body = body[:body.index("_keep_columns = ")]
-    assert 'label_names' in body, \
-        "the raw-column keep-list still drops a custom trainer's configured labels"
+    Asserted on the resulting split, not on the source. This was a grep for
+    `label_names` in the function body, and the four lines of comment above the
+    line it meant to pin contain that string too, so deleting the line left the
+    test green.
+    """
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW)] * 2,
+        "attention_mask": [[1] * len(ROW)] * 2,
+        "expert_score": [0.5, 0.25],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.label_names = ["expert_score"]
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "expert_score" in out.train_dataset.column_names, (
+        f"configured label dropped from split: {out.train_dataset.column_names}"
+    )
 
 
 def test_case_variant_media_columns_survive_unused_column_removal():

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -697,3 +697,122 @@ def test_a_columnless_streaming_dataset_reaches_masking():
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     row = next(iter(out.train_dataset))     # used to raise AttributeError
     assert [l for l in row["labels"] if l != -100] == [20, 21]
+
+
+# ---- a text column is a column that actually holds text --------------------
+
+def _messages_with_an_image():
+    return [[
+        {"role": "user", "content": [{"type": "image", "image": "cat.png"},
+                                     {"type": "text",  "text": "q"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "a"}]},
+    ]]
+
+
+def _messages_of_plain_text():
+    return [[
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "a"},
+    ]]
+
+
+def test_pretokenized_rows_hiding_images_in_messages_are_refused():
+    """The column names look text-only, but `messages` carries inline image parts
+    the user's collator is what turns into pixels. The strip drops the column, so
+    the images would be lost silently."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW)],
+        "messages": _messages_with_an_image(),
+    })
+    collator = MyVisionCollator(StubProcessor())
+    trainer = StubTrainer(collator, dataset)
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert trainer.data_collator is collator, "the user's collator was replaced"
+    assert "messages" in trainer.train_dataset.column_names
+
+
+def test_a_pretokenized_iterable_hiding_images_in_messages_is_refused():
+    """No column_names to read, so the row peek has to make the same call - and
+    it must not eat the row it peeked."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW)],
+        "messages": _messages_with_an_image(),
+    }).to_iterable_dataset()
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert len(list(trainer.train_dataset)) == 1, "the peek consumed the stream"
+
+
+def test_an_eval_split_hiding_images_in_messages_is_refused():
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW)],
+        "messages": _messages_with_an_image(),
+    })
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = dataset
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_pretokenized_rows_with_plain_text_messages_still_pass():
+    """The other half of the same check: a conversation of plain strings holds no
+    image handling to lose, so `dataset.map` without remove_columns keeps working."""
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW)],
+        "messages": _messages_of_plain_text(),
+    })
+    trainer = StubTrainer(MyVisionCollator(StrictProcessor()), dataset)
+    trainer.processing_class = StrictProcessor()
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "messages" not in out.train_dataset.column_names
+    _collate_every_row(out)
+
+
+def test_dataset_text_field_pointing_at_conversations_is_refused():
+    """`dataset_text_field = "messages"` used to clear the guard by name alone,
+    and the raw conversations then reached the plain tokenizer with no chat
+    template applied, failing after the collator had already been swapped."""
+    trainer = _text_only_trainer()
+    trainer.args.dataset_text_field = "messages"
+    trainer.eval_dataset = Dataset.from_dict({"messages": _messages_of_plain_text()})
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_dataset_text_field_pointing_at_a_real_string_column_is_allowed():
+    """The bypass is about strings, not about the name `text`."""
+    trainer = _text_only_trainer()
+    trainer.args.dataset_text_field = "prompt"
+    trainer.eval_dataset = Dataset.from_dict({
+        "prompt": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"],
+    })
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "labels" in out.eval_dataset.column_names
+    assert "prompt" not in out.eval_dataset.column_names
+
+
+def test_a_raw_eval_split_whose_text_column_is_structured_is_refused():
+    """Same column name, non-string rows: `text` holding message dicts is not
+    something the plain tokenizer can encode."""
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = Dataset.from_dict({"text": _messages_of_plain_text()})
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_a_raw_iterable_eval_split_of_real_text_is_still_allowed():
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = _raw_text_rows().to_iterable_dataset()
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in next(iter(out.eval_dataset))

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -1782,3 +1782,47 @@ def test_a_raw_eval_split_whose_full_scan_fails_is_refused():
     with pytest.raises(ValueError, match = "does not support response-only") as excinfo:
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert "['text']" in str(excinfo.value), "the refusal does not name the column"
+
+
+@pytest.mark.parametrize("fmt", ["torch", "numpy"])
+def test_a_formatted_numeric_column_still_reaches_masking(fmt):
+    """A schema-proven column must not be re-judged through its row value.
+
+    Under `with_format("torch")`/`with_format("numpy")` an auxiliary numeric
+    column such as `sample_weight` or `source_id` comes back as a tensor/array,
+    which `_is_plain_text` does not recognise, so a perfectly good text-only run
+    was refused with the vision-collator error. The schema already judged every
+    row of that column, so the row check has nothing left to add.
+    """
+    trainer = _text_only_trainer()
+    trainer.train_dataset = Dataset.from_dict({
+        "input_ids": [list(ROW)] * 4,
+        "sample_weight": [0.25, 0.75, 0.5, 1.0],
+        "source_id": [1, 2, 3, 4],
+    }).with_format(fmt)
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "labels" in out.train_dataset.column_names, "the split was never masked"
+
+
+@pytest.mark.parametrize("fmt", ["torch", "numpy"])
+def test_a_formatted_image_column_is_still_refused(fmt):
+    """The guard that matters: an image is a numeric tensor under these formats
+    too, so skipping the row check must only ever cover what the schema proved."""
+    from datasets import Features, Image, Sequence, Value
+    from PIL import Image as PILImage
+
+    picture = PILImage.new("RGB", (2, 2))
+    dataset = Dataset.from_dict(
+        {"input_ids": [list(ROW)] * 2, "picture": [picture, picture]},
+        features = Features({
+            "input_ids": Sequence(Value("int32")),
+            "picture": Image(),
+        }),
+    ).with_format(fmt)
+    trainer = _text_only_trainer()
+    trainer.train_dataset = dataset
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -548,3 +548,152 @@ def test_model_and_processor_declared_inputs_survive():
                    "deepstack_visual_embeds"):
         assert column in kept, column
     assert "id" not in kept
+
+
+# ---- the multimodal set follows the installed processor --------------------
+
+class DerivedProcessor(StubProcessor):
+    """A processor whose image half declares its own output names, the way every
+    transformers image processor / feature extractor does."""
+    def __init__(self, image_names = (), own_names = ()):
+        super().__init__()
+        self.image_processor = type("ImageProcessor", (), {
+            "model_input_names": list(image_names),
+        })()
+        if own_names:
+            self.model_input_names = list(self.tokenizer.model_input_names) + list(own_names)
+
+
+def _refuses(dataset, processor):
+    trainer = StubTrainer(MyVisionCollator(processor), dataset)
+    trainer.processing_class = processor
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    return trainer
+
+
+@pytest.mark.parametrize("column", ["image_patches", "image_patches_indices"])
+def test_fuyu_style_image_columns_are_refused(column):
+    """Fuyu spells its preprocessed images `image_patches`/`image_patches_indices`
+    beside `input_ids`, so the columns alone look text-only."""
+    from transformers.models.fuyu.image_processing_fuyu import FuyuImageProcessor
+
+    processor = DerivedProcessor(
+        image_names = FuyuImageProcessor.model_input_names,
+        # FuyuProcessor.model_input_names adds this one on top of the image half.
+        own_names = ["image_patches", "image_patches_indices"],
+    )
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        column: [[0.0], [0.0]],
+    })
+    trainer = _refuses(dataset, processor)
+    assert isinstance(trainer.data_collator, MyVisionCollator)
+
+
+def test_a_column_name_this_file_has_never_heard_of_is_refused():
+    """The point of deriving: a processor output no static list mentions still
+    keeps the user's collator."""
+    processor = DerivedProcessor(image_names = ["widget_patches", "widget_offsets"])
+    dataset = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "widget_patches": [[0.0], [0.0]],
+    })
+    _refuses(dataset, processor)
+
+
+def test_a_raw_eval_split_with_a_derived_column_is_refused():
+    """`_eval_split_is_raw_text_only` reads the same set."""
+    processor = DerivedProcessor(image_names = ["widget_patches"])
+    trainer = StubTrainer(MyVisionCollator(processor), _text_rows())
+    trainer.processing_class = processor
+    trainer.eval_dataset = Dataset.from_dict({
+        "text": [f"{INSTRUCTION_PART}q{RESPONSE_PART}a"],
+        "widget_patches": [[0.0]],
+    })
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_deriving_never_denylists_the_text_columns():
+    """An image processor that repeats `input_ids`/`attention_mask` must not turn
+    every text-only row into a refusal."""
+    processor = DerivedProcessor(
+        image_names = ["input_ids", "attention_mask", "token_type_ids", "labels"],
+    )
+    trainer = StubTrainer(MyVisionCollator(processor), _text_rows())
+    trainer.processing_class = processor
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in out.train_dataset.column_names
+
+
+# ---- a DatasetDict eval is a dict of splits, not one dataset ---------------
+
+def test_a_datasetdict_eval_is_normalized_per_split():
+    """`type(x) is dict` is False for a DatasetDict, so the eval branches used to
+    treat the whole mapping as one dataset: `column_names` came back a dict, the
+    raw `text` column was never dropped, and the collator died tensorizing it."""
+    from datasets import DatasetDict
+
+    trainer = StubTrainer(MyVisionCollator(StrictProcessor()), _text_rows())
+    trainer.processing_class = StrictProcessor()
+    trainer.eval_dataset = DatasetDict({"raw": _raw_text_rows(),
+                                        "pretok": _text_rows()})
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    for key in ("raw", "pretok"):
+        columns = out.eval_dataset[key].column_names
+        assert "labels" in columns, f"{key} was never masked"
+        assert "text" not in columns, f"{key} kept its raw text column"
+        split = out.eval_dataset[key]
+        out.data_collator([split[i] for i in range(len(split))])
+
+
+def test_a_multimodal_split_in_a_datasetdict_eval_still_refuses():
+    from datasets import DatasetDict
+
+    trainer = _text_only_trainer()
+    trainer.eval_dataset = DatasetDict({"a": _text_rows(), "b": _multimodal_rows()})
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_an_iterable_datasetdict_eval_is_normalized_per_split():
+    from datasets import IterableDatasetDict
+
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), _text_rows())
+    trainer.eval_dataset = IterableDatasetDict(
+        {"a": _text_rows().to_iterable_dataset()},
+    )
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "labels" in next(iter(out.eval_dataset["a"]))
+
+
+# ---- a fresh streaming dataset carries no batch_size -----------------------
+
+def test_a_pretokenized_streaming_dataset_reaches_masking():
+    """The bypass accepts an IterableDataset, so the map below must not read a
+    `_ex_iterable.batch_size` a fresh ArrowExamplesIterable does not have."""
+    dataset = _text_rows().to_iterable_dataset()
+    assert not hasattr(dataset._ex_iterable, "batch_size")
+
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    row = next(iter(out.train_dataset))     # used to raise AttributeError
+    assert [l for l in row["labels"] if l != -100] == [20, 21]
+
+
+def test_a_columnless_streaming_dataset_reaches_masking():
+    """`load_dataset(streaming = True)` can resolve no features, so the bypass
+    peeks a row instead - and the same map still has to run."""
+    dataset = _text_rows().to_iterable_dataset()
+    dataset._info.features = None       # what an unresolved stream looks like
+    assert dataset.column_names is None
+    assert not hasattr(dataset._ex_iterable, "batch_size")
+
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), dataset)
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    row = next(iter(out.train_dataset))     # used to raise AttributeError
+    assert [l for l in row["labels"] if l != -100] == [20, 21]

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -665,7 +665,7 @@ def test_an_integer_side_car_is_refused_without_the_processor(column):
 
 
 def test_a_raw_eval_split_with_a_derived_column_is_refused():
-    """`_eval_split_is_raw_text_only` reads the same set."""
+    """`_split_is_raw_text_only` reads the same set."""
     processor = DerivedProcessor(image_names = ["widget_patches"])
     trainer = StubTrainer(MyVisionCollator(processor), _text_rows())
     trainer.processing_class = processor
@@ -1047,7 +1047,11 @@ def test_an_ambiguous_image_column_is_never_decoded_by_the_scan(monkeypatch):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
     # Only the bounded row sample may decode; the whole-column scan may not.
-    assert len(decoded) <= 16, f"{len(decoded)} images decoded for {n} rows"
+    # 16 per split, and the train split is now scanned as well as the eval one
+    # (train no longer has to be pretokenized), so the bound is per split. What
+    # matters is that it stays a constant and does not grow with `n`.
+    assert len(decoded) <= 16 * 2, f"{len(decoded)} images decoded for {n} rows"
+    assert len(decoded) < n / 4, "the sample is scaling with the dataset"
 
 
 # ---- the processor may live only on the collator ---------------------------
@@ -1142,7 +1146,7 @@ def test_an_image_on_an_unsampled_row_is_refused():
 
 
 def test_a_raw_eval_split_with_an_image_on_an_unsampled_row_is_refused():
-    """`_eval_split_is_raw_text_only` samples the same 16 positions, so the eval
+    """`_split_is_raw_text_only` samples the same 16 positions, so the eval
     half needs the schema just as much as the train half does."""
     import io
     from PIL import Image as PILImage

--- a/tests/test_text_only_multimodal_masking.py
+++ b/tests/test_text_only_multimodal_masking.py
@@ -2,16 +2,16 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """``train_on_responses_only`` on a text-only fine-tune of a multimodal model.

--- a/tests/test_text_only_multimodal_masking.py
+++ b/tests/test_text_only_multimodal_masking.py
@@ -17,11 +17,9 @@
 """``train_on_responses_only`` on a text-only fine-tune of a multimodal model.
 
 Such a run still carries a processor as its ``tokenizer``, so a plain text
-collator trips the vision-collator check and used to raise. When the rows are
-already tokenized, labels are not rebuilt at collate time, so dataset-level
-masking is correct and the call must go through.
-
-CPU-pure and offline: the tokenizer is a local stub, no weights are loaded.
+collator trips the vision-collator check and used to raise. Already-tokenized
+rows are not relabelled at collate time, so dataset-level masking is correct
+and the call must go through. CPU-pure and offline: the tokenizer is a stub.
 """
 
 import pytest
@@ -97,8 +95,7 @@ def test_pretokenized_rows_get_dataset_level_masking():
 
 
 def test_untokenized_rows_still_refuse():
-    """Without input_ids the collator really may rebuild labels, so refusing is
-    still right: silently unmasked responses would be worse."""
+    """Without input_ids the collator may really rebuild labels, so still refuse."""
     processor = StubProcessor()
     trainer = StubTrainer(TextCollator(processor), _raw_text())
 
@@ -121,8 +118,7 @@ def test_unsloth_vision_collator_is_configured_not_bypassed():
 
 def test_iterable_dataset_clears_the_guard():
     """An IterableDataset has no column_names, so detection peeks a row instead.
-    Asserted through the guard only: the shared text path it reaches afterwards
-    is out of scope here."""
+    Only the guard is asserted; the text path it then reaches is out of scope."""
     trainer = StubTrainer(TextCollator(StubProcessor()),
                           _pretokenized().to_iterable_dataset())
 

--- a/tests/test_text_only_multimodal_masking.py
+++ b/tests/test_text_only_multimodal_masking.py
@@ -1,0 +1,138 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""``train_on_responses_only`` on a text-only fine-tune of a multimodal model.
+
+Such a run still carries a processor as its ``tokenizer``, so a plain text
+collator trips the vision-collator check and used to raise. When the rows are
+already tokenized, labels are not rebuilt at collate time, so dataset-level
+masking is correct and the call must go through.
+
+CPU-pure and offline: the tokenizer is a local stub, no weights are loaded.
+"""
+
+import pytest
+from datasets import Dataset
+
+from unsloth_zoo.dataset_utils import train_on_responses_only
+
+
+INSTRUCTION_PART = "<|user|>"
+RESPONSE_PART = "<|assistant|>"
+USER_ID, ASSISTANT_ID = 1, 2
+ROW = [USER_ID, 10, 11, ASSISTANT_ID, 20, 21]
+
+
+class StubTokenizer:
+    def __call__(self, text, add_special_tokens = False):
+        result = type("R", (), {})()
+        if text == INSTRUCTION_PART:   result.input_ids = [USER_ID]
+        elif text == RESPONSE_PART:    result.input_ids = [ASSISTANT_ID]
+        else:                          result.input_ids = [ord(c) for c in text]
+        return result
+
+
+class StubProcessor:
+    """A processor: what a multimodal model hands the trainer as its tokenizer."""
+    def __init__(self):
+        self.image_processor = object()
+        self.tokenizer = StubTokenizer()
+
+
+class TextCollator:
+    """A plain text collator that happens to hold the processor."""
+    def __init__(self, processor):
+        self.tokenizer = processor
+
+
+class UnslothVisionDataCollator:
+    """Name-matched by the real check; rebuilds labels at collate time."""
+    def __init__(self, processor):
+        self.processor = processor
+        self.image_processor = processor.image_processor
+
+
+class StubTrainer:
+    def __init__(self, collator, train_dataset):
+        self.data_collator = collator
+        self.train_dataset = train_dataset
+        self.eval_dataset = None
+        self.processing_class = StubProcessor()
+        self.args = type("Args", (), {"packing": False})()
+
+
+def _pretokenized():
+    return Dataset.from_dict({"input_ids": [list(ROW), list(ROW)]})
+
+
+def _raw_text():
+    return Dataset.from_dict({"text": ["<|user|>hi<|assistant|>yes"] * 2})
+
+
+def test_pretokenized_rows_get_dataset_level_masking():
+    """The regression: this used to raise ValueError."""
+    processor = StubProcessor()
+    trainer = StubTrainer(TextCollator(processor), _pretokenized())
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    labels = out.train_dataset["labels"]
+    assert len(labels) == 2
+    for row in labels:
+        assert row[:3] == [-100, -100, -100], row
+        assert any(label != -100 for label in row), "everything was masked"
+
+
+def test_untokenized_rows_still_refuse():
+    """Without input_ids the collator really may rebuild labels, so refusing is
+    still right: silently unmasked responses would be worse."""
+    processor = StubProcessor()
+    trainer = StubTrainer(TextCollator(processor), _raw_text())
+
+    with pytest.raises(ValueError, match = "does not support response-only"):
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+
+def test_unsloth_vision_collator_is_configured_not_bypassed():
+    """The real vision path must be untouched even with pretokenized rows."""
+    processor = StubProcessor()
+    collator = UnslothVisionDataCollator(processor)
+    trainer = StubTrainer(collator, _pretokenized())
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert out is trainer
+    assert callable(collator.train_on_responses_only)
+    assert "labels" not in out.train_dataset.column_names
+
+
+def test_iterable_dataset_clears_the_guard():
+    """An IterableDataset has no column_names, so detection peeks a row instead.
+    Asserted through the guard only: the shared text path it reaches afterwards
+    is out of scope here."""
+    trainer = StubTrainer(TextCollator(StubProcessor()),
+                          _pretokenized().to_iterable_dataset())
+
+    try:
+        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    except ValueError as exception:
+        pytest.fail(f"pretokenized iterable dataset was refused: {exception}")
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_text_only_multimodal_masking.py
+++ b/tests/test_text_only_multimodal_masking.py
@@ -34,13 +34,35 @@ USER_ID, ASSISTANT_ID = 1, 2
 ROW = [USER_ID, 10, 11, ASSISTANT_ID, 20, 21]
 
 
+class StubEncoding(dict):
+    """What a real tokenizer returns: a mapping that also has attributes.
+
+    `datasets.map` rejects anything that is not a dict, and the raw-text path
+    feeds tokenizer output straight into it.
+    """
+    __getattr__ = dict.__getitem__
+
+
 class StubTokenizer:
-    def __call__(self, text, add_special_tokens = False):
-        result = type("R", (), {})()
-        if text == INSTRUCTION_PART:   result.input_ids = [USER_ID]
-        elif text == RESPONSE_PART:    result.input_ids = [ASSISTANT_ID]
-        else:                          result.input_ids = [ord(c) for c in text]
-        return result
+    # `**kwargs` because the raw-text path calls with truncation/max_length,
+    # which nothing reached while that path still refused.
+    def __call__(self, text, add_special_tokens = False, **kwargs):
+        if isinstance(text, (list, tuple)):
+            ids = [self(t).input_ids for t in text]
+            return StubEncoding(input_ids = ids,
+                                attention_mask = [[1] * len(r) for r in ids])
+        ids = []
+        rest = text
+        while rest:
+            for marker, tid in ((INSTRUCTION_PART, USER_ID), (RESPONSE_PART, ASSISTANT_ID)):
+                if rest.startswith(marker):
+                    ids.append(tid)
+                    rest = rest[len(marker):]
+                    break
+            else:
+                ids.append(ord(rest[0]))
+                rest = rest[1:]
+        return StubEncoding(input_ids = ids, attention_mask = [1] * len(ids))
 
 
 class StubProcessor:
@@ -94,13 +116,33 @@ def test_pretokenized_rows_get_dataset_level_masking():
         assert any(label != -100 for label in row), "everything was masked"
 
 
-def test_untokenized_rows_still_refuse():
-    """Without input_ids the collator may really rebuild labels, so still refuse."""
+def test_raw_text_rows_are_tokenized_and_masked():
+    """Raw text is the COMMON case, not a reason to refuse.
+
+    This asserted a refusal on the theory that a collator handed raw rows may
+    rebuild labels itself and discard ours. Measured on the real path it does
+    not: TRL 0.22.2 gives a plain text SFT on gemma-3-4b-it its own
+    `DataCollatorForVisionLanguageModeling` and leaves the dataset at
+    `["text"]`, and after `_maybe_tokenize_dataset` the columns are
+    `input_ids/attention_mask/labels` with the text column GONE, so there is
+    nothing left for a collator to rebuild from. A real batch came back 12/16
+    masked with the prompt masked at the front.
+
+    Refusing instead cost four shipped notebooks: Gemma3_(4B),
+    Gemma3N_(4B)-Conversational, Gemma3_(27B)_A100-Conversational and
+    Qwen_3_5_27B_A100(80GB).
+    """
     processor = StubProcessor()
     trainer = StubTrainer(TextCollator(processor), _raw_text())
 
-    with pytest.raises(ValueError, match = "does not support response-only"):
-        train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert "text" not in out.train_dataset.column_names, \
+        "the consumed text column must not survive for a collator to re-read"
+    labels = out.train_dataset["labels"]
+    for row in labels:
+        assert any(l == -100 for l in row), "nothing was masked"
+        assert any(l != -100 for l in row), "everything was masked"
 
 
 def test_unsloth_vision_collator_is_configured_not_bypassed():

--- a/tests/test_torchao_torch_mismatch.py
+++ b/tests/test_torchao_torch_mismatch.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """A torchao built for a newer torch must give a readable error.
 
 The ImportError lands in the `Unpack` guard in temporary_patches/utils.py

--- a/tests/test_torchao_torch_mismatch.py
+++ b/tests/test_torchao_torch_mismatch.py
@@ -16,10 +16,9 @@
 
 """A torchao built for a newer torch must give a readable error.
 
-The ImportError lands in the `Unpack` guard in temporary_patches/utils.py
-and used to fall through to a bare `raise Exception(e)`, naming neither
-torchao nor torch. These cover what the new branch must catch, what it must
-leave alone, and that it cannot itself raise.
+The ImportError lands in the `Unpack` guard in temporary_patches/utils.py, which
+used to fall through to a bare `raise Exception(e)` naming neither package. These
+cover what the new branch must catch, must leave alone, and must not raise on.
 """
 
 import ast
@@ -32,11 +31,8 @@ UTILS = (Path(__file__).resolve().parents[1] / "unsloth_zoo"
 
 
 def _load_helpers():
-    """Exec just the two helpers.
-
-    Importing the module would run the very import guard under test and,
-    on a healthy install, do nothing interesting -- and on a broken one,
-    raise before a single assertion ran.
+    """Exec just the two helpers: importing the module would run the very guard
+    under test, which on a broken install raises before any assertion runs.
     """
     tree = ast.parse(UTILS.read_text(encoding="utf-8"))
     wanted = {"_torchao_is_newer_than_torch", "_torchao_torch_mismatch_message"}
@@ -80,8 +76,7 @@ def test_the_other_torchao_symbols(sym):
 # ---- what it must NOT catch ----------------------------------------------
 
 def test_the_unpack_move_is_left_alone():
-    """It sits directly beside the Unpack branch; swallowing that would
-    hide a different problem with a different fix."""
+    """It sits beside the Unpack branch; swallowing that hides a different bug."""
     assert looks_like(
         "cannot import name 'Unpack' from 'transformers.processing_utils'"
     ) is False
@@ -115,8 +110,7 @@ def test_the_message_names_both_versions():
 
 
 def test_the_message_survives_missing_metadata(monkeypatch):
-    """Version lookup is best-effort; it must not turn a diagnostic into a
-    second exception."""
+    """Version lookup is best-effort: it must not raise a second exception."""
     import importlib.metadata as md
     monkeypatch.setattr(md, "version",
                         lambda *_a, **_k: (_ for _ in ()).throw(Exception("no")))

--- a/tests/test_torchao_torch_mismatch.py
+++ b/tests/test_torchao_torch_mismatch.py
@@ -1,0 +1,130 @@
+"""A torchao built for a newer torch must give a readable error.
+
+The ImportError lands in the `Unpack` guard in temporary_patches/utils.py
+and used to fall through to a bare `raise Exception(e)`, naming neither
+torchao nor torch. These cover what the new branch must catch, what it must
+leave alone, and that it cannot itself raise.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+UTILS = (Path(__file__).resolve().parents[1] / "unsloth_zoo"
+         / "temporary_patches" / "utils.py")
+
+
+def _load_helpers():
+    """Exec just the two helpers.
+
+    Importing the module would run the very import guard under test and,
+    on a healthy install, do nothing interesting -- and on a broken one,
+    raise before a single assertion ran.
+    """
+    tree = ast.parse(UTILS.read_text(encoding="utf-8"))
+    wanted = {"_torchao_is_newer_than_torch", "_torchao_torch_mismatch_message"}
+    ns: dict = {}
+    for node in tree.body:
+        keep = False
+        if isinstance(node, ast.FunctionDef) and node.name in wanted:
+            keep = True
+        elif isinstance(node, ast.Assign) and any(
+                getattr(t, "id", "") == "_TORCHAO_TORCH_SYMBOLS"
+                for t in node.targets):
+            keep = True
+        if keep:
+            exec(compile(ast.Module([node], []), "<utils>", "exec"), ns)
+    missing = wanted - set(ns)
+    assert not missing, f"helpers not found in utils.py: {missing}"
+    return ns
+
+
+HELPERS = _load_helpers()
+looks_like = HELPERS["_torchao_is_newer_than_torch"]
+message_of = HELPERS["_torchao_torch_mismatch_message"]
+
+REAL = ("cannot import name 'ScalingType' from 'torch.nn.functional' "
+        "(/usr/local/lib/python3.12/dist-packages/torch/nn/functional.py)")
+
+
+# ---- what it must catch ---------------------------------------------------
+
+def test_the_error_seen_in_the_wild():
+    assert looks_like(REAL) is True
+
+
+@pytest.mark.parametrize("sym", ["ScalingType", "ScalingGranularity",
+                                 "Float8Tensor"])
+def test_the_other_torchao_symbols(sym):
+    assert looks_like(
+        f"cannot import name '{sym}' from 'torch.nn.functional'") is True
+
+
+# ---- what it must NOT catch ----------------------------------------------
+
+def test_the_unpack_move_is_left_alone():
+    """It sits directly beside the Unpack branch; swallowing that would
+    hide a different problem with a different fix."""
+    assert looks_like(
+        "cannot import name 'Unpack' from 'transformers.processing_utils'"
+    ) is False
+
+
+def test_the_same_symbol_from_a_non_torch_module():
+    assert looks_like("cannot import name 'ScalingType' from 'somelib.x'") is False
+
+
+def test_a_non_import_error():
+    assert looks_like("torchvision::nms does not exist") is False
+
+
+def test_an_unrelated_missing_name_from_torch():
+    assert looks_like(
+        "cannot import name 'some_new_api' from 'torch.nn.functional'") is False
+
+
+# ---- the guard must never be what raises ---------------------------------
+
+@pytest.mark.parametrize("bad", [None, 123, object()])
+def test_non_string_input_does_not_raise(bad):
+    assert looks_like(bad) in (True, False)
+
+
+def test_the_message_names_both_versions():
+    m = message_of(REAL)
+    assert "torchao" in m and "torch " in m
+    assert REAL.split(" (")[0] in m, "the original error must survive"
+    assert "torchao<0.18" in m, "the user needs something to run"
+
+
+def test_the_message_survives_missing_metadata(monkeypatch):
+    """Version lookup is best-effort; it must not turn a diagnostic into a
+    second exception."""
+    import importlib.metadata as md
+    monkeypatch.setattr(md, "version",
+                        lambda *_a, **_k: (_ for _ in ()).throw(Exception("no")))
+    m = message_of(REAL)
+    assert "unknown" in m
+
+
+# ---- the call site --------------------------------------------------------
+
+def test_the_branch_runs_before_the_generic_reraise():
+    """Placed after `raise Exception(e)` it would never be reached."""
+    src = UTILS.read_text(encoding="utf-8")
+    guard = src.index("_torchao_is_newer_than_torch(e)")
+    generic = src.index('elif "Unpack" not in e:')
+    assert guard < generic, (
+        "the torchao branch must precede the generic re-raise")
+
+
+def test_the_branch_raises_runtimeerror_not_a_bare_exception():
+    src = UTILS.read_text(encoding="utf-8")
+    i = src.index("_torchao_is_newer_than_torch(e)")
+    window = src[i:i + 200]
+    assert "RuntimeError(_torchao_torch_mismatch_message(e))" in window
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -495,6 +495,16 @@ _RAW_TEXT_COMPANION_COLUMNS = frozenset((
 ))
 
 
+def _holds_raw_text(value, _depth = 0):
+    """A string, or a nest of them, that no collator can stack into a tensor."""
+    if isinstance(value, str): return True
+    if isinstance(value, (list, tuple)):
+        return _depth < 4 and any(_holds_raw_text(v, _depth + 1) for v in value)
+    if isinstance(value, dict):
+        return _depth < 4 and any(_holds_raw_text(v, _depth + 1) for v in value.values())
+    return False
+
+
 class _MediaAwareCollator:
     """The text collator, falling back to the caller's own when a batch has media.
 
@@ -557,9 +567,22 @@ class _MediaAwareCollator:
         # batch. Removed here, not from the keep-list: the media path still
         # needs those columns, and this is the only point that knows which path
         # a batch took. Copies, so the caller's rows are left alone.
-        drop = self.media_keys | self.ambiguous_keys | self.companion_keys
+        # By VALUE for the ambiguous and companion names, not by name alone. Both
+        # sets are ordinary English words, so under `remove_unused_columns=False`
+        # a caller's tensorizable auxiliary input called `output` or `content`
+        # was dropped from every text batch and its custom `compute_loss` never
+        # saw it. What the text collator cannot stack is a raw STRING; a number
+        # or a tensor under the same name is a model input and stays.
+        # The media names go on sight: they are never model inputs, and a text
+        # batch is one `_has_media` already declined to call multimodal.
+        maybe = self.ambiguous_keys | self.companion_keys
+        def _keep(key, value):
+            if not isinstance(key, str): return True
+            lower = key.lower()
+            if lower in self.media_keys: return False
+            return not (lower in maybe and _holds_raw_text(value))
         stripped = [
-            {k: v for k, v in f.items() if not (isinstance(k, str) and k.lower() in drop)}
+            {k: v for k, v in f.items() if _keep(k, v)}
             if isinstance(f, dict) else f
             for f in features or ()
         ]
@@ -862,8 +885,20 @@ def train_on_responses_only(
         # which the later model-input keep-list never gets the chance to save.
         _raw_columns = getattr(dataset, "column_names", None) or list(sample.keys())
         if not isinstance(_raw_columns, dict):
-            _keep = {"labels"} | _model_forward_parameter_names(
-                getattr(trainer, "model", None))
+            _keep = _model_forward_parameter_names(getattr(trainer, "model", None))
+            # `labels` only when it really is token-level. A raw split can carry
+            # a SCALAR `labels` (a class id), and keeping that as supervision
+            # sent an int into `_train_on_responses_only`, which calls
+            # `len(old_labels)` on it: `TypeError: object of type 'int' has no
+            # len()`. A scalar is metadata for the tokenized split and goes with
+            # the other raw columns, unless `forward` asks for it above.
+            _sample_labels = sample.get("labels") if isinstance(sample, dict) else None
+            if _sample_labels is not None and not isinstance(_sample_labels, (str, bytes)):
+                try:
+                    len(_sample_labels)
+                    _keep = _keep | {"labels"}
+                except TypeError:
+                    pass
             # The raw text always goes, whatever else asks for it: it was just
             # turned into `input_ids`, and a `forward` that happens to declare a
             # `text` parameter would otherwise keep the string column for the
@@ -1312,14 +1347,27 @@ def train_on_responses_only(
         return False
     pass
 
+    def _configured_text_field():
+        return getattr(getattr(trainer, "args", None),
+                       "dataset_text_field", None) or "text"
+
     def _row_is_plain_text(row, schema_proven = frozenset()):
         # Tokenizer/model columns are numeric by construction; the rest is what
         # can smuggle in images. A column the schema already proved needs no
         # second opinion: it judged EVERY row, where re-reading it as a value is
         # strictly weaker and misreads the tensor/ndarray `with_format("torch")`
         # and `with_format("numpy")` hand back for an ordinary numeric column.
+        # The configured text field, when it really is a bare string, is prose by
+        # definition and is exempt from the filename-suffix test. Otherwise an
+        # assistant answer that happens to read `cat.jpg` classified the whole
+        # column as a media reference and the text bypass was refused with the
+        # vision-collator error, for a split the tokenizer handles fine. Only a
+        # bare string: a `messages`-style field holding a list of turns can still
+        # carry inline image parts, so that one is scanned as before.
+        field = _configured_text_field()
         return all(_is_plain_text(v) for k, v in row.items()
-                   if k not in _TEXT_COLUMNS and k not in schema_proven)
+                   if k not in _TEXT_COLUMNS and k not in schema_proven
+                   and not (k == field and isinstance(v, str)))
     pass
 
     # A one-row peek calls a mixed split text-only: row 0 holds plain `messages`
@@ -1559,6 +1607,15 @@ def train_on_responses_only(
                     # refuse every streamed text column there is.
                     _scan = _feature_needs_a_value_scan(feature) or (
                         _feature_is_bare_string(feature) and _is_map_style(split))
+                    # Never the configured text field, when its schema says bare
+                    # string. Its contents are prose the tokenizer will encode,
+                    # so weighing them for filename suffixes refused a whole
+                    # split over an assistant answer that read `cat.jpg`. The
+                    # caller still proves the column is all strings separately;
+                    # a STRUCTURED text field is not exempt and is scanned here
+                    # as before, because a list of turns can hold image parts.
+                    if name == _configured_text_field() and _feature_is_bare_string(feature):
+                        _scan = False
                     if _scan and not _column_values_are_plain_text(split, name):
                         return False, proven
                     # A plain string column is NOT added: `proven` exists so a

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -23,6 +23,7 @@ __all__ = [
 ]
 
 from typing import Union, Callable, Optional, List, Dict
+import itertools as _itertools
 import torch
 
 def _iterable_batch_size(dataset, default = 1000):
@@ -672,9 +673,42 @@ def train_on_responses_only(
         print("Unsloth: Warning: " + message)
     pass
 
+    def _no_training_signal(dataset_name, how_many):
+        return ValueError(
+            f"Unsloth: train_on_responses_only masked every label to -100 in {dataset_name}"
+            f"{how_many}, so there is nothing to train on. The response marker "
+            f"{repr(response_part)} was not found in any sample - check that "
+            "instruction_part and response_part match your chat template."
+        )
+    pass
+
+    # Streaming rows cannot be counted or filtered, and fix_zero_training_loss
+    # skips them too, so sample a bounded prefix instead: all -100 there means the
+    # markers do not match this template. Iterating restarts the stream, so no rows
+    # are consumed.
+    _STREAM_SCAN_ROWS = 16
+
+    def _check_streaming_labels(dataset, dataset_name):
+        seen = 0
+        try:
+            for row in _itertools.islice(iter(dataset), _STREAM_SCAN_ROWS):
+                labels = row.get("labels") if isinstance(row, dict) else None
+                if labels is None: return
+                if getattr(labels, "tolist", None): labels = labels.tolist()
+                if any(l != -100 for l in labels): return
+                seen += 1
+        except Exception:
+            return  # unreadable stream: leave it exactly as before
+        if seen == 0: return
+        raise _no_training_signal(dataset_name, f" (first {seen} samples)")
+    pass
+
     def _filter_fully_masked(dataset, dataset_name="dataset"):
         if isinstance(dataset, IterableDataset):
-            return dataset  # Cannot filter IterableDataset efficiently
+            # Cannot filter an IterableDataset efficiently, but a fully masked one
+            # would otherwise train on no signal at all.
+            _check_streaming_labels(dataset, dataset_name)
+            return dataset
         if "labels" not in dataset.column_names:
             return dataset
         # filter rewrites the whole Arrow table even when it drops nothing, so scan the
@@ -702,11 +736,7 @@ def train_on_responses_only(
         # Everything masked and not from truncation: the markers do not match the
         # template at all, so fail clearly instead of returning an empty dataset.
         if len(dropped) == n_before:
-            raise ValueError(
-                f"Unsloth: train_on_responses_only masked every label to -100 in {dataset_name}, "
-                f"so there is nothing to train on. The response marker {repr(response_part)} was not "
-                "found in any sample - check that instruction_part and response_part match your chat template."
-            )
+            raise _no_training_signal(dataset_name, "")
         # Drop via filter (Arrow mask), not select(keep_indices): a keep list would be one
         # Python int per surviving row (GBs on a large corpus). _has_valid_labels is the
         # exact inverse of `dropped`, so survivors are identical.
@@ -767,13 +797,21 @@ def train_on_responses_only(
         every new model spells its own. Each processor half declares its outputs
         in `model_input_names`, so ask them and subtract the text half.
         """
+        _halves = ("image_processor", "video_processor", "feature_extractor",
+                   "audio_processor", "qformer_tokenizer")
         names = set()
-        holders = [getattr(processor, attr, None) for attr in
-                   ("image_processor", "video_processor", "feature_extractor",
-                    "audio_processor", "qformer_tokenizer")]
+        holders = [getattr(processor, attr, None) for attr in _halves]
         # The processor's own list merges text and vision (that is the only place
         # FuyuProcessor names `image_patches_indices`), so take it too.
         if processor is not tokenizer: holders.append(processor)
+        # With the `tokenizer =` override `processor` is the unwrapped text
+        # tokenizer, and the real multimodal processor is only on the collator.
+        _coll = getattr(trainer, "data_collator", None)
+        for attr in ("processor", "tokenizer"):
+            held = getattr(_coll, attr, None)
+            if held is None or held is processor or held is tokenizer: continue
+            holders.append(held)
+            holders += [getattr(held, a, None) for a in _halves]
         for holder in holders:
             if holder is None: continue
             try: names.update(getattr(holder, "model_input_names", None) or ())
@@ -824,10 +862,29 @@ def train_on_responses_only(
         return all(_is_plain_text(v) for k, v in row.items() if k not in _TEXT_COLUMNS)
     pass
 
-    def _split_views(dataset):
-        """`(column names, first row)` per split, row `None` when unreadable.
+    # A one-row peek calls a mixed split text-only: row 0 holds plain `messages`
+    # while a later row hides an inline image. Sample a small fixed number of rows
+    # instead - bounded, so a huge or streaming split stays cheap.
+    _SCAN_ROWS = 16
 
-        `iter()` restarts a datasets IterableDataset, so peeking one row does not
+    def _sample_rows(split):
+        try: n = len(split)
+        except Exception: n = None
+        if n is None:
+            # Streaming: a prefix is all that can be read without consuming it.
+            return list(_itertools.islice(iter(split), _SCAN_ROWS))
+        if n == 0: return []
+        # Spread the sample over the whole split, first and last row included;
+        # random access is cheap on Arrow.
+        if n <= _SCAN_ROWS: idx = range(n)
+        else: idx = sorted({i * (n - 1) // (_SCAN_ROWS - 1) for i in range(_SCAN_ROWS)})
+        return [split[i] for i in idx]
+    pass
+
+    def _split_views(dataset):
+        """`(column names, sampled rows)` per split, rows `[]` when unreadable.
+
+        `iter()` restarts a datasets IterableDataset, so peeking rows does not
         consume the stream (this is how `_maybe_tokenize_dataset` peeks too).
         """
         splits = list(dataset.values()) if isinstance(dataset, dict) else [dataset]
@@ -836,18 +893,16 @@ def train_on_responses_only(
             if split is None: continue
             names = getattr(split, "column_names", None)
             if isinstance(names, dict): names = None
-            row = None
+            rows = []
             try:
-                row = next(iter(split))
-            except StopIteration:
-                row = None          # empty split: nothing to inspect
+                rows = [r for r in _sample_rows(split) if isinstance(r, dict)]
             except Exception:
                 if not names: raise
-            if not isinstance(row, dict): row = None
+                rows = []
             if not names:
-                if row is None: raise ValueError("Unsloth: cannot read the dataset columns")
-                names = list(row.keys())
-            views.append((set(names), row))
+                if not rows: raise ValueError("Unsloth: cannot read the dataset columns")
+                names = list(rows[0].keys())
+            views.append((set(names), rows))
         return views
     pass
 
@@ -864,12 +919,13 @@ def train_on_responses_only(
         except Exception:
             return False
         if not views: return False
-        for names, row in views:
+        for names, rows in views:
             if "input_ids" not in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
             # Columns look text-only, so check the values: a `messages` column can
             # carry inline images that the strip below would throw away.
-            if row is not None and not _row_is_plain_text(row): return False
+            for row in rows:
+                if not _row_is_plain_text(row): return False
         return True
     pass
 
@@ -890,13 +946,13 @@ def train_on_responses_only(
         except Exception:
             return False
         if not views: return False
-        for names, row in views:
+        for names, rows in views:
             if "input_ids" in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
             # The column `_maybe_tokenize_dataset` would actually read.
             field = text_field if text_field in names else "text"
             if field not in names: return False
-            if row is not None:
+            for row in rows:
                 if not isinstance(row.get(field), str): return False
                 if not _row_is_plain_text(row): return False
         return True

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -713,25 +713,45 @@ def train_on_responses_only(
         return hasattr(collator, "image_processor")
     pass
 
+    # What a processor emits beside `input_ids`. A row carrying any of these
+    # still needs the collator that knows how to batch it.
+    _MULTIMODAL_COLUMNS = frozenset((
+        "pixel_values", "pixel_values_videos", "pixel_attention_mask",
+        "image_grid_thw", "video_grid_thw", "image_sizes", "image_sizes_videos",
+        "images", "image", "videos", "video", "audio", "audios",
+        "token_type_ids_images", "input_features", "input_features_mask",
+        "audio_values", "audio_attention_mask", "input_audio_embeds",
+        "aspect_ratio_ids", "aspect_ratio_mask", "cross_attention_mask",
+    ))
+
     def _dataset_is_pretokenized(dataset):
-        """True when rows already carry `input_ids`.
+        """True when rows carry `input_ids` and nothing else to collate.
 
         Separates "the collator rebuilds labels from a processor at collate time"
         from "text was tokenized up front and the collator only pads", where
         dataset-level masking is correct. Anything unreadable returns False, so
         the caller keeps the old strict behaviour.
+
+        Rows that also carry image/video/audio columns are NOT that case: the
+        text path below swaps the collator for a text one, which would throw
+        away the user's image handling, so those keep the old refusal.
         """
         if dataset is None:
             return False
+
+        def _text_only(names):
+            names = set(names)
+            return "input_ids" in names and names.isdisjoint(_MULTIMODAL_COLUMNS)
+
         try:
             names = getattr(dataset, "column_names", None)
             if isinstance(names, dict):  # DatasetDict
                 names = [c for v in names.values() for c in (v or [])]
             if names:
-                return "input_ids" in names
+                return _text_only(names)
             # IterableDataset and friends expose no column_names; peek one row.
             for row in dataset:
-                return isinstance(row, dict) and "input_ids" in row
+                return isinstance(row, dict) and _text_only(row.keys())
         except Exception:
             return False
         return False
@@ -824,9 +844,19 @@ def train_on_responses_only(
     # only pads already-tokenized text.
     from transformers import DataCollatorForSeq2Seq
     packing_enabled = getattr(trainer.args, "packing", False)
+    _collator = getattr(trainer, "data_collator", None)
+    # DataCollatorForSeq2Seq(tokenizer = <VLM processor>) pads through
+    # self.tokenizer.pad / .padding_side, which processors do not have, so it
+    # dies on the first batch. Rebuild that one around the unwrapped text
+    # tokenizer too; gate on the capability rather than the processor type, so
+    # this stays right if transformers ever gives ProcessorMixin a .pad.
+    _rebuild = (
+        not isinstance(_collator, DataCollatorForSeq2Seq)
+        or not hasattr(getattr(_collator, "tokenizer", None), "pad")
+    )
     if (
         hasattr(trainer, "data_collator")
-        and not isinstance(trainer.data_collator, DataCollatorForSeq2Seq)
+        and _rebuild
         and not packing_enabled
     ):
         trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer)

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -667,6 +667,11 @@ def train_on_responses_only(
         if not isinstance(_raw_columns, dict):
             _keep = {"labels"} | _model_forward_parameter_names(
                 getattr(trainer, "model", None))
+            # The raw text always goes, whatever else asks for it: it was just
+            # turned into `input_ids`, and a `forward` that happens to declare a
+            # `text` parameter would otherwise keep the string column for the
+            # collator to fail on.
+            _keep -= {text_field, "text"}
             # This strip runs before the keep-list at the end of the function, so
             # it has to honour the opt-out itself or the column is already gone.
             # Only the text just tokenized still goes: it is the string the
@@ -1169,6 +1174,20 @@ def train_on_responses_only(
         return isinstance(dtype, str) and dtype.startswith(
             ("float", "double", "half", "bfloat"))
 
+    def _leaf_dtype_is_narrow_int(feature, _depth = 0):
+        """Does this feature bottom out in a sub-32-bit integer?
+
+        That is a raw buffer, not tokens: int16 PCM, uint8 pixels. Token ids
+        arrive as int32/int64 from every tokenizer, and the columns they land in
+        are exempted by `_TEXT_COLUMNS` before this is ever asked.
+        """
+        if feature is None or _depth >= 8: return False
+        inner = getattr(feature, "feature", None)
+        if inner is not None: return _leaf_dtype_is_narrow_int(inner, _depth + 1)
+        dtype = getattr(feature, "dtype", None)
+        return isinstance(dtype, str) and dtype.startswith(
+            ("int8", "int16", "uint8", "uint16"))
+
     def _is_numeric_array_feature(feature):
         """`Array2D`/`Array3D`/`Array4D`/`Array5D`, by shape rather than name."""
         return (getattr(feature, "shape", None) is not None
@@ -1196,10 +1215,12 @@ def train_on_responses_only(
         inner = getattr(feature, "feature", None)           # Sequence/List/LargeList
         if inner is not None:
             # Same for a float sequence: `Sequence(float32)` under `speech` is a
-            # waveform. Integer sequences stay plain -- that is the shape every
-            # pretokenized column has, and refusing them would refuse the case
-            # this bypass exists for.
+            # waveform, and `Sequence(int16)` under the same name is the same
+            # waveform stored as PCM. Wider integer sequences stay plain -- that
+            # is the shape every pretokenized column has, and refusing them would
+            # refuse the case this bypass exists for.
             if _leaf_dtype_is_float(inner): return False
+            if _leaf_dtype_is_narrow_int(inner): return False
             return _feature_is_plain_text(inner, _depth + 1)
         # Value/ClassLabel name a primitive dtype. Image is "PIL.Image.Image" and
         # Audio/Video a dict, so anything unrecognised stays unsafe.
@@ -1376,6 +1397,13 @@ def train_on_responses_only(
     # trainer without `.args` used to reach one of them.
     packing_enabled = getattr(getattr(trainer, "args", None), "packing", False)
 
+    def _pads_through_a_processor(collator):
+        """A pad-delegating collator holding a processor, which has no `.pad`."""
+        source = getattr(collator, "tokenizer", None)
+        if source is None: source = getattr(collator, "processor", None)
+        return (source is not None and not hasattr(source, "pad")
+                and isinstance(collator, _PAD_DELEGATING_COLLATORS))
+
     def _is_known_bypassed_collator(collator):
         if isinstance(collator, _PAD_DELEGATING_COLLATORS): return True
         # TRL's vision collator rebuilds labels through its processor. Matched by
@@ -1384,20 +1412,25 @@ def train_on_responses_only(
                    for b in type(collator).__mro__)
 
     def _refuse_packing_that_will_not_happen(collator, raw_splits):
-        """A raw split taking the bypass gets no packing at all.
+        """Nothing that takes this bypass gets packed.
 
-        `_maybe_tokenize_dataset` tokenizes each row on its own and the swap
-        below installs a plain DataCollatorForSeq2Seq, so nothing concatenates
-        the examples and nothing builds the packing-specific inputs. That is
-        true even for the collators exempted just above, because the exemption
-        is about who pads, not about who packs.
+        A raw split is tokenized row by row, so nothing concatenates the
+        examples. A pretokenized one is no better off: either the rows were
+        never packed, or they were and the plain DataCollatorForSeq2Seq the swap
+        installs drops the `seq_lengths` the packed batch needs to rebuild
+        `position_ids`, silently letting the packed examples attend to each
+        other. That holds for the collators exempted just above, and for a
+        packing subclass of one, because the exemption is about who pads.
         """
-        if not packing_enabled or not raw_splits: return
+        if not packing_enabled: return
+        _how = ("tokenizes each row on its own" if raw_splits else
+                "cannot rebuild the packed batch's `position_ids`")
         raise ValueError(
             f"Unsloth: `packing = True` is not supported here. `{type(collator).__name__}` "
             "holds a processor, so response-only masking is applied at the dataset level, "
-            "and that path tokenizes each row on its own -- nothing packs them. Turn packing "
-            "off, or pre-tokenize the dataset so the trainer's own packing runs."
+            f"and that path {_how} -- packing would be silently dropped. Turn packing off, or "
+            "build UnslothVisionDataCollator(..., train_on_responses_only = True, "
+            "instruction_part = ..., response_part = ...) so masking runs at collate time."
         )
 
     def _refuse_packing_with_a_foreign_collator(collator):
@@ -1496,6 +1529,13 @@ def train_on_responses_only(
             return trainer
     pass
 
+    # The other route to the same replacement: a pad-delegating collator holding
+    # a processor is rebuilt around the text tokenizer below, which packs no more
+    # than the swap above does. Refused here, before either split is mapped, and
+    # after the block above so a collator that masks for itself is left alone.
+    if _pads_through_a_processor(getattr(trainer, "data_collator", None)):
+        _refuse_packing_that_will_not_happen(trainer.data_collator, None)
+
     if hasattr(trainer, "train_dataset") and trainer.train_dataset is not None:
         if not hasattr(trainer.train_dataset, "map"):
             raise TypeError("Unsloth: train_on_responses_only does not work on lists!")
@@ -1546,11 +1586,7 @@ def train_on_responses_only(
     # replacing that one throws its packing away. So only the classes that provably
     # delegate to `.pad` are repaired from the attribute; TRL's vision collator
     # calls its processor instead and is already covered by the bypass flag below.
-    _pad_source = getattr(_collator, "tokenizer", None)
-    if _pad_source is None:
-        _pad_source = getattr(_collator, "processor", None)
-    _processor_backed = _pad_source is not None and not hasattr(_pad_source, "pad") \
-        and isinstance(_collator, _PAD_DELEGATING_COLLATORS)
+    _processor_backed = _pads_through_a_processor(_collator)
     # That repair is not packing-gated like the swap: it fails either way. The
     # bypassed-collator case under packing already refused above, before
     # anything was mapped.
@@ -1609,6 +1645,10 @@ def train_on_responses_only(
             # Unwrap PEFT/compile wrappers: their own forward hides pixel_values.
             names.update(_model_forward_parameter_names(getattr(trainer, "model", None)))
             names.discard("self")
+            # Same reason as the tokenizing strip above: a `forward` declaring
+            # `text` must not keep a raw string column no collator can tensorize.
+            names -= {getattr(getattr(trainer, "args", None),
+                              "dataset_text_field", None) or "text", "text"}
             return names
         _keep_columns = _model_input_columns()
         def _drop_raw_columns(dataset):

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -390,6 +390,43 @@ def _model_forward_parameter_names(model):
     return names
 
 
+class _MediaAwareCollator:
+    """The text collator, falling back to the caller's own when a batch has media.
+
+    The bypass swaps the trainer-wide collator, and that swap outlives
+    construction: `predict(test_dataset = ...)` and an `evaluate` override both
+    build their dataloader from `trainer.data_collator`, so a multimodal split
+    handed over later reached a collator that cannot process images and either
+    failed or trained the modality away. Keeping the original and choosing per
+    batch is the only thing that can answer for a split nobody has seen yet.
+
+    Module level so a DataLoader worker under `spawn` can pickle it, which a
+    closure or a `type()`-built class cannot.
+    """
+    def __init__(self, text, media, media_keys):
+        self.text = text
+        self.media = media
+        self.media_keys = frozenset(media_keys)
+
+    def _has_media(self, features):
+        for feature in features or ():
+            keys = feature.keys() if isinstance(feature, dict) else ()
+            if any(isinstance(k, str) and k.lower() in self.media_keys for k in keys):
+                return True
+        return False
+
+    def __call__(self, features):
+        collator = self.media if self._has_media(features) else self.text
+        return collator(features)
+
+    def __getattr__(self, attribute):
+        # Only for names this class does not define; `text` is set in __init__,
+        # so this cannot recurse through it.
+        if attribute.startswith("__"): raise AttributeError(attribute)
+        return getattr(self.__dict__["text"], attribute)
+pass
+
+
 def train_on_responses_only(
     trainer,
     instruction_part  = None,
@@ -1132,7 +1169,13 @@ def train_on_responses_only(
         would drop the images. So anything the text path cannot encode -- a dict
         naming media, a PIL image, bytes -- is not plain text.
         """
-        if isinstance(value, str) or value is None: return True
+        # A `data:` URI names its own media type, so unlike an extensionless
+        # http URL there is nothing to weigh: it is an image/video/audio payload
+        # wherever it turns up, including a column no name list covers.
+        if isinstance(value, str):
+            return not value[:32].lower().startswith(
+                ("data:image/", "data:video/", "data:audio/"))
+        if value is None: return True
         if isinstance(value, (bool, int, float)): return True
         if _depth >= 6: return False
         if isinstance(value, dict):
@@ -1212,6 +1255,25 @@ def train_on_responses_only(
         return isinstance(dtype, str) and dtype.startswith(
             ("int8", "int16", "uint8", "uint16"))
 
+    # Column names that hold raw audio samples. 32-bit PCM is as much a waveform
+    # as the 16-bit kind, so width cannot settle it and the name has to: the
+    # wide-int allowance below exists for pretokenized token ids, and these are
+    # not that.
+    _RAW_SAMPLE_COLUMNS = frozenset((
+        "speech", "speeches", "waveform", "waveforms", "pcm",
+        "raw_audio", "raw_speech", "audio_array", "audio_arrays",
+        "audio_values", "speech_values",
+    ))
+
+    def _leaf_dtype_is_numeric(feature, _depth = 0):
+        """Does this feature bottom out in any number at all?"""
+        if feature is None or _depth >= 8: return False
+        inner = getattr(feature, "feature", None)
+        if inner is not None: return _leaf_dtype_is_numeric(inner, _depth + 1)
+        dtype = getattr(feature, "dtype", None)
+        return isinstance(dtype, str) and dtype.startswith(
+            ("int", "uint", "float", "double", "half", "bfloat"))
+
     def _is_numeric_array_feature(feature):
         """`Array2D`/`Array3D`/`Array4D`/`Array5D`, by shape rather than name."""
         return (getattr(feature, "shape", None) is not None
@@ -1265,6 +1327,12 @@ def train_on_responses_only(
         if _seq_depth >= 2 and dtype.startswith(("int", "uint")): return False
         return dtype.startswith(_PLAIN_DTYPES)
     pass
+
+    def _feature_is_bare_string(feature):
+        """A top-level `Value("string")`/`large_string`, nothing nested."""
+        if getattr(feature, "feature", None) is not None: return False
+        dtype = getattr(feature, "dtype", None)
+        return isinstance(dtype, str) and dtype.startswith(("string", "large_string"))
 
     def _feature_needs_a_value_scan(feature, _depth = 0):
         """Whether the dtypes alone cannot settle this column.
@@ -1321,10 +1389,22 @@ def train_on_responses_only(
             try:
                 for name, feature in features.items():
                     if name in _TEXT_COLUMNS: continue
+                    # Name plus shape, because `_feature_is_plain_text` never sees
+                    # the column name and int32 PCM is indistinguishable from token
+                    # ids by dtype alone.
+                    if str(name).lower() in _RAW_SAMPLE_COLUMNS and \
+                        getattr(feature, "feature", None) is not None and \
+                        _leaf_dtype_is_numeric(feature): return False, proven
                     if not _feature_is_plain_text(feature): return False, proven
                     if _feature_needs_a_value_scan(feature) and \
                         not _column_values_are_plain_text(split, name): return False, proven
-                    proven.add(name)
+                    # A plain string column is NOT added: `proven` exists so a
+                    # numeric column that `with_format` hands back as a tensor is
+                    # not re-judged by value, and a string stays a string under
+                    # every format. Leaving it out costs nothing -- the sampled
+                    # rows are read either way -- and is what lets a `data:` URI
+                    # in an unlisted column be seen at all.
+                    if not _feature_is_bare_string(feature): proven.add(name)
                 return True, proven
             except Exception:
                 return False, proven
@@ -1692,7 +1772,12 @@ def train_on_responses_only(
             for name in _names
             if (_same_class or _padding_class) and hasattr(_collator, name)
         }
-        trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer, **_kept)
+        _text_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer, **_kept)
+        # Only when a media-capable collator was displaced. Everywhere else the
+        # replacement is the whole point and there is nothing to fall back to.
+        trainer.data_collator = _MediaAwareCollator(
+            _text_collator, _collator, _MEDIA_COLUMNS,
+        ) if _bypassed_vision_collator else _text_collator
 
         # `tokenizer.pad(..., return_tensors = "pt")` stacks every key it is
         # handed, and only pads the few it knows, so any leftover column kills

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1488,7 +1488,13 @@ def train_on_responses_only(
             names.discard("self")
             return names
         _keep_columns = _model_input_columns()
+        # `remove_unused_columns = False` is the user asking for their columns to
+        # survive, and HF's Trainer honours it: a custom `compute_loss` can pop a
+        # `sample_weight` the model itself never declares, so the keep-list above
+        # would delete the weighting the run depends on.
+        _keep_every_column = not getattr(trainer.args, "remove_unused_columns", True)
         def _drop_raw_columns(dataset):
+            if _keep_every_column: return dataset
             if dataset is None or not hasattr(dataset, "remove_columns"): return dataset
             try:
                 names = getattr(dataset, "column_names", None)

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -851,6 +851,13 @@ def train_on_responses_only(
         "bytes", "path", "url",
     ))
 
+    # The subset of those keys that is media only half the time: `meta = {"url":
+    # ..., "path": "corpus/shard.jsonl"}` is ordinary provenance on a text corpus,
+    # so refusing on the key name alone refuses a healthy text-only run. Judged by
+    # value instead, exactly like `_AMBIGUOUS_MEDIA_COLUMNS` at the top level.
+    # `bytes` stays a hard reject: raw binary is never text.
+    _AMBIGUOUS_MEDIA_KEYS = frozenset(("path", "url"))
+
     # Top-level column names that only ever point at media. A pretokenized VLM
     # set often keeps its media as a plain URL/path string beside `input_ids`,
     # and a string value alone looks like text, so the name has to say so.
@@ -1014,7 +1021,10 @@ def train_on_responses_only(
         if isinstance(value, dict):
             for key, item in value.items():
                 if not isinstance(key, str): return False
-                if key.lower() in _MEDIA_KEYS: return False
+                lower = key.lower()
+                if lower in _AMBIGUOUS_MEDIA_KEYS:
+                    if _looks_like_media_value(item): return False
+                elif lower in _MEDIA_KEYS: return False
                 if not _is_plain_text(item, _depth + 1): return False
             kind = value.get("type")
             if isinstance(kind, str) and kind.lower() in _MEDIA_KEYS: return False
@@ -1063,7 +1073,11 @@ def train_on_responses_only(
         if feature is None or _depth >= 8: return False
         if isinstance(feature, dict):                       # struct
             for key, value in feature.items():
-                if not isinstance(key, str) or key.lower() in _MEDIA_KEYS: return False
+                if not isinstance(key, str): return False
+                lower = key.lower()
+                # An ambiguous key is settled by the value scan below, not by name.
+                if lower in _MEDIA_KEYS and lower not in _AMBIGUOUS_MEDIA_KEYS:
+                    return False
                 if not _feature_is_plain_text(value, _depth + 1): return False
             return True
         if isinstance(feature, (list, tuple)):
@@ -1077,12 +1091,52 @@ def train_on_responses_only(
         return dtype.startswith(_PLAIN_DTYPES)
     pass
 
+    def _feature_has_ambiguous_media_key(feature, _depth = 0):
+        """Whether this column's schema nests a `path`/`url`, whose dtype is
+        `string` for both a media reference and ordinary provenance."""
+        if feature is None or _depth >= 8: return False
+        if isinstance(feature, dict):
+            return any(isinstance(k, str) and (k.lower() in _AMBIGUOUS_MEDIA_KEYS or
+                                               _feature_has_ambiguous_media_key(v, _depth + 1))
+                       for k, v in feature.items())
+        if isinstance(feature, (list, tuple)):
+            return any(_feature_has_ambiguous_media_key(f, _depth + 1) for f in feature)
+        inner = getattr(feature, "feature", None)           # Sequence/List/LargeList
+        if inner is not None: return _feature_has_ambiguous_media_key(inner, _depth + 1)
+        return False
+    pass
+
+    def _column_values_are_plain_text(split, name):
+        """Whether EVERY row of a struct column with a nested `path`/`url` is text.
+
+        The 16-row sample misses a `cat.jpg` on row 5000 and the schema says
+        `string` either way, so read the whole column - the same trade the
+        top-level ambiguous columns already make. Callers gate on
+        `_feature_is_plain_text` first, so no Image/Audio column is ever decoded.
+        """
+        try:
+            len(split)                                   # map-style only
+            batches = split.select_columns([name]).iter(batch_size = 1000)
+            for batch in batches:
+                if not all(_is_plain_text(v) for v in batch[name]): return False
+            return True
+        except Exception:
+            # A stream cannot speak for the rows it never hands over; guessing
+            # "text" would drop a media column silently, so refuse instead.
+            _unscannable_media_columns.add(name)
+            return False
+    pass
+
     def _columns_are_provably_text(split, names):
         features = getattr(split, "features", None)
         if features:
             try:
-                return all(_feature_is_plain_text(f) for name, f in features.items()
-                           if name not in _TEXT_COLUMNS)
+                for name, feature in features.items():
+                    if name in _TEXT_COLUMNS: continue
+                    if not _feature_is_plain_text(feature): return False
+                    if _feature_has_ambiguous_media_key(feature) and \
+                        not _column_values_are_plain_text(split, name): return False
+                return True
             except Exception:
                 return False
         # No schema (an unresolved stream): a sample cannot prove what the rows it

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -826,11 +826,17 @@ def train_on_responses_only(
         if collator is None: return False
         if any(b.__name__ == "UnslothVisionDataCollator" for b in type(collator).__mro__): return True
         # A vision collator may hold the processor under .processor or the common .tokenizer field
-        # (e.g. DataCollatorForSeq2Seq(tokenizer=processor)); either exposing image_processor marks it.
+        # (e.g. DataCollatorForSeq2Seq(tokenizer=processor)); any multimodal half marks it.
+        # Not `image_processor` alone: a Whisper/audio or video-only processor exposes
+        # `feature_extractor`/`audio_processor`/`video_processor` and nothing else, so it
+        # missed every guard below and went straight to the collator repair, which drops
+        # the modality columns. Same list `_derive_multimodal_columns` asks for outputs.
+        _halves = ("image_processor", "video_processor", "feature_extractor",
+                   "audio_processor", "qformer_tokenizer")
         for attr in ("processor", "tokenizer"):
             obj = getattr(collator, attr, None)
-            if obj is not None and hasattr(obj, "image_processor"): return True
-        return hasattr(collator, "image_processor")
+            if obj is not None and any(hasattr(obj, h) for h in _halves): return True
+        return any(hasattr(collator, h) for h in _halves)
     pass
 
     # Processor outputs beside `input_ids`; a row with any of these needs its collator.
@@ -1653,19 +1659,60 @@ def train_on_responses_only(
         _keep_columns = _model_input_columns()
         _text_columns = {getattr(getattr(trainer, "args", None),
                                  "dataset_text_field", None) or "text", "text"}
+
+        import numbers as _numbers
+        def _is_tensorizable(value, _depth = 0):
+            """Can `tokenizer.pad(..., return_tensors = 'pt')` stack this?
+
+            It tensorizes every key it is handed, so under the opt-out a kept
+            `messages`/`source`/string id fails the first batch before any
+            custom `compute_loss` sees it. Numbers and nests of numbers survive,
+            which is what a per-row `sample_weight` or auxiliary target is.
+            """
+            if _depth >= 6: return False
+            # str before Sequence: it is one, of one-character strings, forever.
+            if isinstance(value, (str, bytes, bytearray, dict)) or value is None:
+                return False
+            # Tensors and arrays answer at once, by their own dtype: iterating a
+            # long one element-wise to reach the same answer is pure cost, and
+            # `numbers` misses `np.int64`, which is not an `int` subclass.
+            kind = getattr(getattr(value, "dtype", None), "kind", None)
+            if kind is not None: return kind in "biufc"
+            if isinstance(value, torch.Tensor): return True
+            if isinstance(value, _numbers.Number): return True
+            try: items = list(value)
+            except Exception: return False
+            return all(_is_tensorizable(v, _depth + 1) for v in items)
+
+        def _untensorizable_columns(dataset):
+            """Named from a sampled row, so a column is judged by what it holds.
+
+            Nothing the model is fed is ever named here, however odd it looks:
+            those columns are the collator's job, not a guess from one row.
+            """
+            try: row = next(iter(dataset), None)
+            except Exception: return set()
+            if not isinstance(row, dict): return set()
+            return {k for k, v in row.items()
+                    if k not in _keep_columns and not _is_tensorizable(v)}
+
         def _drop_raw_columns(dataset):
             if dataset is None or not hasattr(dataset, "remove_columns"): return dataset
             try:
                 names = getattr(dataset, "column_names", None)
                 if names is None: names = list(next(iter(dataset)).keys())
                 if isinstance(names, dict): return dataset
-                # The opt-out keeps the caller's own columns, but never the raw
-                # text: an already-tokenized split carrying its source `text`
-                # never reaches the tokenizing strip, and the replacement
-                # collator dies tensorizing the strings on the first batch.
-                drop = [c for c in names
-                        if c in _text_columns] if _keep_every_column else \
-                       [c for c in names if c not in _keep_columns]
+                # The opt-out keeps the caller's own columns, but only the ones
+                # `tokenizer.pad(..., return_tensors = "pt")` can actually
+                # stack. It tensorizes every key it is handed, so a surviving
+                # `text`/`messages`/`source` dies on the first batch, before the
+                # custom `compute_loss` the opt-out exists for ever runs. A
+                # numeric `sample_weight` or auxiliary target still comes through.
+                if _keep_every_column:
+                    unusable = _text_columns | _untensorizable_columns(dataset)
+                    drop = [c for c in names if c in unusable]
+                else:
+                    drop = [c for c in names if c not in _keep_columns]
             except Exception:
                 return dataset
             if not drop: return dataset

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1651,14 +1651,21 @@ def train_on_responses_only(
                               "dataset_text_field", None) or "text", "text"}
             return names
         _keep_columns = _model_input_columns()
+        _text_columns = {getattr(getattr(trainer, "args", None),
+                                 "dataset_text_field", None) or "text", "text"}
         def _drop_raw_columns(dataset):
-            if _keep_every_column: return dataset
             if dataset is None or not hasattr(dataset, "remove_columns"): return dataset
             try:
                 names = getattr(dataset, "column_names", None)
                 if names is None: names = list(next(iter(dataset)).keys())
                 if isinstance(names, dict): return dataset
-                drop = [c for c in names if c not in _keep_columns]
+                # The opt-out keeps the caller's own columns, but never the raw
+                # text: an already-tokenized split carrying its source `text`
+                # never reaches the tokenizing strip, and the replacement
+                # collator dies tensorizing the strings on the first batch.
+                drop = [c for c in names
+                        if c in _text_columns] if _keep_every_column else \
+                       [c for c in names if c not in _keep_columns]
             except Exception:
                 return dataset
             if not drop: return dataset

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -869,8 +869,18 @@ def train_on_responses_only(
         "image_path", "image_paths", "img_path", "img_paths",
         "video_path", "video_paths", "audio_path", "audio_paths",
         "image_file", "image_files", "video_file", "video_files",
-        "audio_file", "audio_files", "image_filename", "image_bytes",
+        "audio_file", "audio_files", "image_bytes",
+        # `*_filename` is as common a spelling as `*_path`, and only `image_`
+        # was here: a `video_filename`/`audio_filename` column matched neither
+        # list, so its plain string schema called the split text-only.
+        "image_filename", "image_filenames", "video_filename", "video_filenames",
+        "audio_filename", "audio_filenames",
     ))
+
+    # A name that only ever points at media points at media nested too: a turn
+    # storing `{"image_path": "cat.jpg"}` is exactly the top-level column moved
+    # one level down, and a nested string is what `_is_plain_text` calls text.
+    _MEDIA_KEYS = _MEDIA_KEYS | _MEDIA_COLUMNS
 
     # Names that are media half the time and an ordinary text field the other
     # half (`path` is a source file, `url` a citation), so refusing on the name
@@ -1333,16 +1343,28 @@ def train_on_responses_only(
     from transformers import DataCollatorForSeq2Seq, DataCollatorWithPadding
     packing_enabled = getattr(trainer.args, "packing", False)
     _collator = getattr(trainer, "data_collator", None)
-    # A collator holding a processor (DataCollatorForSeq2Seq/WithPadding, TRL's
-    # DataCollatorForVisionLanguageModeling) pads through a `.pad` processors do
-    # not have, so it dies on the first batch; rebuild it around the unwrapped
-    # text tokenizer. Key on a held padding object that cannot pad rather than on
-    # the type, so a collator holding none stays untouched (TRL's packing
+    # A collator holding a processor (DataCollatorForSeq2Seq/WithPadding) pads
+    # through a `.pad` processors do not have, so it dies on the first batch;
+    # rebuild it around the unwrapped text tokenizer. A collator holding no
+    # padding object at all stays untouched (TRL's packing
     # DataCollatorForLanguageModeling takes a bare pad_token_id).
+    # Holding the object is not proof it is padded through: a custom collator can
+    # keep a processor for its own use and batch (and pack) everything itself, and
+    # replacing that one throws its packing away. So only the classes that provably
+    # delegate to `.pad` are repaired from the attribute; TRL's vision collator
+    # calls its processor instead and is already covered by the bypass flag below.
+    import transformers as _transformers
+    _PAD_DELEGATING_COLLATORS = tuple(_cls for _cls in (
+        DataCollatorForSeq2Seq, DataCollatorWithPadding,
+        getattr(_transformers, "DataCollatorForTokenClassification", None),
+        getattr(_transformers, "DataCollatorForLanguageModeling", None),
+        getattr(_transformers, "DataCollatorForMultipleChoice", None),
+    ) if isinstance(_cls, type))
     _pad_source = getattr(_collator, "tokenizer", None)
     if _pad_source is None:
         _pad_source = getattr(_collator, "processor", None)
-    _processor_backed = _pad_source is not None and not hasattr(_pad_source, "pad")
+    _processor_backed = _pad_source is not None and not hasattr(_pad_source, "pad") \
+        and isinstance(_collator, _PAD_DELEGATING_COLLATORS)
     # That repair is not packing-gated like the swap: it fails either way.
     # Nor is a collator we bypassed above: it can rebuild `labels` in `__call__`
     # and throw away the mask just written, which is silent training on prompts.

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -825,6 +825,9 @@ def train_on_responses_only(
             if held is None or held is processor or held is tokenizer: continue
             holders.append(held)
             holders += [getattr(held, a, None) for a in _halves]
+        # `_is_vision_collator` also accepts a half held straight on the collator
+        # (`collator.image_processor`), and that half names its own outputs too.
+        holders += [getattr(_coll, a, None) for a in _halves]
         for holder in holders:
             if holder is None: continue
             try: names.update(getattr(holder, "model_input_names", None) or ())
@@ -888,15 +891,31 @@ def train_on_responses_only(
         return text.endswith(_MEDIA_SUFFIXES)
     pass
 
-    def _has_media_column(names, rows):
+    def _ambiguous_column_holds_media(split, name, rows):
+        """Whether an ambiguous column points at media, over EVERY row when the
+        split can be indexed: the 16-row sample misses a `cat.jpg` on row 5, and
+        its dtype is `string` either way, so the schema cannot answer for it.
+        Reading one string column is cheap - no image is ever decoded.
+        """
+        try:
+            len(split)                                  # map-style only
+            batches = split.select_columns([name]).iter(batch_size = 1000)
+            for batch in batches:
+                if any(_looks_like_media_value(v) for v in batch[name]): return True
+            return False
+        except Exception:
+            # Streaming, or a column a custom transform owns: the bounded sample
+            # is all that can be read without consuming/rewriting the split.
+            return any(_looks_like_media_value(row.get(name)) for row in rows)
+    pass
+
+    def _has_media_column(names, rows, split = None):
         """True when a top-level column points at media the text path would drop."""
-        for name in names:
-            if not isinstance(name, str) or name in _TEXT_COLUMNS: continue
-            lowered = name.lower()
-            if lowered in _MEDIA_COLUMNS: return True
-            if lowered in _AMBIGUOUS_MEDIA_COLUMNS and \
-                any(_looks_like_media_value(row.get(name)) for row in rows): return True
-        return False
+        names = [n for n in names if isinstance(n, str) and n not in _TEXT_COLUMNS]
+        if any(n.lower() in _MEDIA_COLUMNS for n in names): return True
+        # An ambiguous name costs a scan, so only reach it if no name settled it.
+        return any(n.lower() in _AMBIGUOUS_MEDIA_COLUMNS and
+                   _ambiguous_column_holds_media(split, n, rows) for n in names)
     pass
 
     def _is_plain_text(value, _depth = 0):
@@ -990,7 +1009,7 @@ def train_on_responses_only(
     pass
 
     def _split_views(dataset):
-        """`(column names, sampled rows, provably text)` per split.
+        """`(column names, sampled rows, provably text, split)` per split.
 
         `iter()` restarts a datasets IterableDataset, so peeking rows does not
         consume the stream (this is how `_maybe_tokenize_dataset` peeks too).
@@ -1010,7 +1029,7 @@ def train_on_responses_only(
             if not names:
                 if not rows: raise ValueError("Unsloth: cannot read the dataset columns")
                 names = list(rows[0].keys())
-            views.append((set(names), rows, _columns_are_provably_text(split, names)))
+            views.append((set(names), rows, _columns_are_provably_text(split, names), split))
         return views
     pass
 
@@ -1027,10 +1046,10 @@ def train_on_responses_only(
         except Exception:
             return False
         if not views: return False
-        for names, rows, provable in views:
+        for names, rows, provable, split in views:
             if "input_ids" not in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
-            if _has_media_column(names, rows): return False
+            if _has_media_column(names, rows, split): return False
             # Columns look text-only, so check the values too: a `messages` column
             # can carry inline images that the strip below would throw away.
             if not provable: return False
@@ -1056,10 +1075,10 @@ def train_on_responses_only(
         except Exception:
             return False
         if not views: return False
-        for names, rows, provable in views:
+        for names, rows, provable, split in views:
             if "input_ids" in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
-            if _has_media_column(names, rows): return False
+            if _has_media_column(names, rows, split): return False
             # The column `_maybe_tokenize_dataset` would actually read.
             field = text_field if text_field in names else "text"
             if field not in names: return False

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -911,29 +911,59 @@ def train_on_responses_only(
         trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer, **_kept)
 
         # `tokenizer.pad(..., return_tensors = "pt")` stacks every key it is
-        # handed, so a raw `text`/`messages` column left on an already tokenized
-        # split kills the first batch. The trainer normally strips it, but not
+        # handed, and only pads the few it knows, so any leftover column kills
+        # the first batch: a raw `text`/`messages` cannot be tensorized, a
+        # ragged `prompt_ids` is stacked unpadded, and a scalar `label` is taken
+        # for the labels themselves. The trainer normally strips them, but not
         # when unused-column removal is off (token-type-id models above turn it
-        # off). Drop by value shape so numeric model columns are all kept.
-        import numbers as _numbers
-        def _cannot_be_tensorized(value):
-            while isinstance(value, (list, tuple)):
-                if len(value) == 0: return False
-                value = value[0]
-            if value is None: return True
-            # Tensor, ndarray or numpy scalar: already numeric.
-            if hasattr(value, "dtype"): return False
-            return not isinstance(value, _numbers.Number)
+        # off). So keep only what the model is actually fed.
+        import inspect as _inspect
+        def _model_input_columns():
+            # token_type_ids is why unused-column removal is off; the rest are
+            # asked of the processor and the model so this cannot rot.
+            names = {"input_ids", "attention_mask", "token_type_ids", "labels"}
+            holders = [processor, tokenizer]
+            holders += [getattr(processor, attr, None) for attr in
+                        ("tokenizer", "image_processor", "feature_extractor",
+                         "video_processor", "audio_processor")]
+            for holder in holders:
+                try: names.update(getattr(holder, "model_input_names", None) or ())
+                except Exception: pass
+            # Unwrap PEFT/compile wrappers: their own forward hides pixel_values.
+            model = getattr(trainer, "model", None)
+            for _ in range(6):
+                if model is None: break
+                forward = getattr(model, "forward", None)
+                if forward is not None:
+                    try:
+                        names.update(
+                            name for name, p in _inspect.signature(forward).parameters.items()
+                            if p.kind not in (p.VAR_KEYWORD, p.VAR_POSITIONAL)
+                        )
+                    except (TypeError, ValueError): pass
+                unwrap = getattr(model, "get_base_model", None)
+                nxt = None
+                if callable(unwrap):
+                    try: nxt = unwrap()
+                    except Exception: nxt = None
+                if nxt is None or nxt is model:
+                    nxt = getattr(model, "_orig_mod", None) or getattr(model, "base_model", None)
+                model = None if nxt is model else nxt
+            names.discard("self")
+            return names
+        _keep_columns = _model_input_columns()
         def _drop_raw_columns(dataset):
             if dataset is None or not hasattr(dataset, "remove_columns"): return dataset
             try:
-                row = next(iter(dataset))
-                names = getattr(dataset, "column_names", None) or list(row.keys())
+                names = getattr(dataset, "column_names", None)
+                if names is None: names = list(next(iter(dataset)).keys())
                 if isinstance(names, dict): return dataset
-                drop = [c for c in names if c in row and _cannot_be_tensorized(row[c])]
+                drop = [c for c in names if c not in _keep_columns]
             except Exception:
                 return dataset
-            return dataset.remove_columns(drop) if drop else dataset
+            if not drop: return dataset
+            print(f"Unsloth: Dropping columns the model is not fed: {sorted(drop)}")
+            return dataset.remove_columns(drop)
         if hasattr(trainer, "train_dataset"):
             trainer.train_dataset = _drop_raw_columns(trainer.train_dataset)
         _eval_now = getattr(trainer, "eval_dataset", None)

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -953,6 +953,11 @@ def train_on_responses_only(
     # called text and its media dropped.
     _AMBIGUOUS_MEDIA_KEYS = _AMBIGUOUS_MEDIA_KEYS | _AMBIGUOUS_MEDIA_COLUMNS
 
+    # Keys whose dtype cannot settle the column. `type` joins the ambiguous
+    # media names because the chat-part convention puts the modality in the
+    # value: `{"type": "image", "content": "cat.jpg"}` is all `string`.
+    _VALUE_SCAN_KEYS = _AMBIGUOUS_MEDIA_KEYS | frozenset(("type",))
+
     # Every suffix a missing entry costs is a VLM row silently trained as text,
     # so cover the modern web formats too (`.avif` is what most image CDNs serve
     # now) and the older spellings of the ones already here.
@@ -1173,23 +1178,30 @@ def train_on_responses_only(
         return dtype.startswith(_PLAIN_DTYPES)
     pass
 
-    def _feature_has_ambiguous_media_key(feature, _depth = 0):
-        """Whether this column's schema nests a `path`/`url`, whose dtype is
-        `string` for both a media reference and ordinary provenance."""
+    def _feature_needs_a_value_scan(feature, _depth = 0):
+        """Whether the dtypes alone cannot settle this column.
+
+        Two all-string shapes decide at value level. A nested `path`/`url` is
+        `string` for both a media reference and ordinary provenance. So is a
+        `type` tag: `{"type": "image", "content": "cat.jpg"}` is an image part
+        and `{"type": "text", ...}` is not, and calling the schema plain marked
+        the column proven, which skips the tag check in `_row_is_plain_text` and
+        drops the media silently.
+        """
         if feature is None or _depth >= 8: return False
         if isinstance(feature, dict):
-            return any(isinstance(k, str) and (k.lower() in _AMBIGUOUS_MEDIA_KEYS or
-                                               _feature_has_ambiguous_media_key(v, _depth + 1))
+            return any(isinstance(k, str) and (k.lower() in _VALUE_SCAN_KEYS or
+                                               _feature_needs_a_value_scan(v, _depth + 1))
                        for k, v in feature.items())
         if isinstance(feature, (list, tuple)):
-            return any(_feature_has_ambiguous_media_key(f, _depth + 1) for f in feature)
+            return any(_feature_needs_a_value_scan(f, _depth + 1) for f in feature)
         inner = getattr(feature, "feature", None)           # Sequence/List/LargeList
-        if inner is not None: return _feature_has_ambiguous_media_key(inner, _depth + 1)
+        if inner is not None: return _feature_needs_a_value_scan(inner, _depth + 1)
         return False
     pass
 
     def _column_values_are_plain_text(split, name):
-        """Whether EVERY row of a struct column with a nested `path`/`url` is text.
+        """Whether EVERY row of a struct the schema could not settle is text.
 
         The 16-row sample misses a `cat.jpg` on row 5000 and the schema says
         `string` either way, so read the whole column - the same trade the
@@ -1222,7 +1234,7 @@ def train_on_responses_only(
                 for name, feature in features.items():
                     if name in _TEXT_COLUMNS: continue
                     if not _feature_is_plain_text(feature): return False, proven
-                    if _feature_has_ambiguous_media_key(feature) and \
+                    if _feature_needs_a_value_scan(feature) and \
                         not _column_values_are_plain_text(split, name): return False, proven
                     proven.add(name)
                 return True, proven
@@ -1318,6 +1330,46 @@ def train_on_responses_only(
         return True
     pass
 
+    # Classified up here rather than beside the swap below, so the packing
+    # refusal can run before either split is tokenized: it is a deterministic
+    # configuration error, and raising it after a full preprocessing pass makes
+    # a large corpus pay for the answer twice and leaves the datasets mutated.
+    from transformers import DataCollatorForSeq2Seq, DataCollatorWithPadding
+    import transformers as _transformers
+    _PAD_DELEGATING_COLLATORS = tuple(_cls for _cls in (
+        DataCollatorForSeq2Seq, DataCollatorWithPadding,
+        getattr(_transformers, "DataCollatorForTokenClassification", None),
+        getattr(_transformers, "DataCollatorForLanguageModeling", None),
+        getattr(_transformers, "DataCollatorForMultipleChoice", None),
+    ) if isinstance(_cls, type))
+    # Read defensively: this now runs ahead of the early returns below, and a
+    # trainer without `.args` used to reach one of them.
+    packing_enabled = getattr(getattr(trainer, "args", None), "packing", False)
+
+    def _is_known_bypassed_collator(collator):
+        if isinstance(collator, _PAD_DELEGATING_COLLATORS): return True
+        # TRL's vision collator rebuilds labels through its processor. Matched by
+        # name so this does not depend on which TRL version is installed.
+        return any(b.__name__ == "DataCollatorForVisionLanguageModeling"
+                   for b in type(collator).__mro__)
+
+    def _refuse_packing_with_a_foreign_collator(collator):
+        """The case with no right answer: `_is_vision_collator` matches one
+        merely holding a processor, and a custom self-packing collator does
+        exactly that. Replacing it discards its packing, its `position_ids` and
+        any block-attention inputs; keeping it risks its `__call__` rebuilding
+        `labels` over the mask. Both are silently wrong, so say so."""
+        if not packing_enabled or _is_known_bypassed_collator(collator): return
+        raise ValueError(
+            f"Unsloth: `{type(collator).__name__}` holds a processor and does not support "
+            "response-only masking, and `packing = True` asks that same collator to build the "
+            "packed batch. Both cannot be honoured: replacing it discards its packing, its "
+            "`position_ids` and any block-attention inputs, while keeping it risks its "
+            "`__call__` rebuilding `labels` over the mask just written. Turn packing off, or "
+            "build UnslothVisionDataCollator(..., train_on_responses_only = True, "
+            "instruction_part = ..., response_part = ...) so masking runs at collate time."
+        )
+
     # Set when a foreign vision collator is let through to the text path below.
     _bypassed_vision_collator = False
     data_collator = getattr(trainer, "data_collator", None)
@@ -1367,6 +1419,7 @@ def train_on_responses_only(
                     + _hint
                 )
             # Fall through to the dataset-level text path below.
+            _refuse_packing_with_a_foreign_collator(data_collator)
             _bypassed_vision_collator = True
             print(
                 f"Unsloth: `{type(data_collator).__name__}` holds a processor but the "
@@ -1431,8 +1484,6 @@ def train_on_responses_only(
 
     # Edit data collator to DataCollatorForSeq2Seq. Collators that rebuild labels
     # from a processor already returned above, so what is left here only pads.
-    from transformers import DataCollatorForSeq2Seq, DataCollatorWithPadding
-    packing_enabled = getattr(trainer.args, "packing", False)
     _collator = getattr(trainer, "data_collator", None)
     # A collator holding a processor (DataCollatorForSeq2Seq/WithPadding) pads
     # through a `.pad` processors do not have, so it dies on the first batch;
@@ -1444,45 +1495,14 @@ def train_on_responses_only(
     # replacing that one throws its packing away. So only the classes that provably
     # delegate to `.pad` are repaired from the attribute; TRL's vision collator
     # calls its processor instead and is already covered by the bypass flag below.
-    import transformers as _transformers
-    _PAD_DELEGATING_COLLATORS = tuple(_cls for _cls in (
-        DataCollatorForSeq2Seq, DataCollatorWithPadding,
-        getattr(_transformers, "DataCollatorForTokenClassification", None),
-        getattr(_transformers, "DataCollatorForLanguageModeling", None),
-        getattr(_transformers, "DataCollatorForMultipleChoice", None),
-    ) if isinstance(_cls, type))
     _pad_source = getattr(_collator, "tokenizer", None)
     if _pad_source is None:
         _pad_source = getattr(_collator, "processor", None)
     _processor_backed = _pad_source is not None and not hasattr(_pad_source, "pad") \
         and isinstance(_collator, _PAD_DELEGATING_COLLATORS)
-    # That repair is not packing-gated like the swap: it fails either way.
-    # Nor is a collator we bypassed above whose class we recognise: it either
-    # delegates its padding to `.pad` or rebuilds `labels` in `__call__`, and the
-    # latter throws away the mask just written, which is silent training on prompts.
-    def _is_known_bypassed_collator(collator):
-        if isinstance(collator, _PAD_DELEGATING_COLLATORS): return True
-        # TRL's vision collator rebuilds labels through its processor. Matched by
-        # name so this does not depend on which TRL version is installed.
-        return any(b.__name__ == "DataCollatorForVisionLanguageModeling"
-                   for b in type(collator).__mro__)
-    # Any other bypassed collator under packing is the case with no right answer:
-    # `_is_vision_collator` matches one merely holding a processor, and a custom
-    # self-packing collator does exactly that. Replacing it discards its packing,
-    # its `position_ids` and any block-attention inputs; keeping it risks its
-    # `__call__` rebuilding `labels` over the mask. Both are silently wrong, so
-    # say so rather than guess.
-    if packing_enabled and _bypassed_vision_collator and \
-        not _is_known_bypassed_collator(_collator):
-        raise ValueError(
-            f"Unsloth: `{type(_collator).__name__}` holds a processor and does not support "
-            "response-only masking, and `packing = True` asks that same collator to build the "
-            "packed batch. Both cannot be honoured: replacing it discards its packing, its "
-            "`position_ids` and any block-attention inputs, while keeping it risks its "
-            "`__call__` rebuilding `labels` over the mask just written. Turn packing off, or "
-            "build UnslothVisionDataCollator(..., train_on_responses_only = True, "
-            "instruction_part = ..., response_part = ...) so masking runs at collate time."
-        )
+    # That repair is not packing-gated like the swap: it fails either way. The
+    # bypassed-collator case under packing already refused above, before
+    # anything was mapped.
     if hasattr(trainer, "data_collator") and (
         _processor_backed or _bypassed_vision_collator
         or (not isinstance(_collator, DataCollatorForSeq2Seq) and not packing_enabled)
@@ -1501,9 +1521,14 @@ def train_on_responses_only(
             hasattr(_collator, _n)
             for _n in ("padding", "max_length", "pad_to_multiple_of")
         )
+        # `label_pad_token_id` means the same thing to DataCollatorForSeq2Seq as
+        # it does to a DataCollatorForTokenClassification, so a caller who chose
+        # a non-default one keeps it; dropping it padded unequal-length batches
+        # with -100 instead and can break a loss that reads the pad value.
         _names = ("model", "padding", "max_length", "pad_to_multiple_of",
                   "label_pad_token_id", "return_tensors") if _same_class else \
-                 ("padding", "max_length", "pad_to_multiple_of", "return_tensors")
+                 ("padding", "max_length", "pad_to_multiple_of",
+                  "label_pad_token_id", "return_tensors")
         _kept = {
             name: getattr(_collator, name)
             for name in _names

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -829,6 +829,9 @@ def train_on_responses_only(
         "high_res_pixel_values", "flattened_patches",
         # Fuyu keeps its preprocessed images here, beside `input_ids`.
         "image_patches", "image_patches_indices",
+        # Integer side-cars whose dtype reads as plain, so only the name refuses:
+        # Gemma 3 declares `num_crops`, Llama 3.2 Vision `num_tiles`.
+        "num_crops", "num_tiles",
     ))
 
     # Names the text tokenizer owns; a processor half repeating one of these must

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1203,8 +1203,12 @@ def train_on_responses_only(
         return (getattr(feature, "shape", None) is not None
                 and isinstance(getattr(feature, "dtype", None), str))
 
-    def _feature_is_plain_text(feature, _depth = 0):
-        """True only when this column type cannot hold media in any row."""
+    def _feature_is_plain_text(feature, _depth = 0, _seq_depth = 0):
+        """True only when this column type cannot hold media in any row.
+
+        `_seq_depth` counts sequence nesting only, so a struct holding a token
+        column stays at the depth its sequence gives it.
+        """
         if feature is None or _depth >= 8: return False
         if isinstance(feature, dict):                       # struct
             for key, value in feature.items():
@@ -1213,10 +1217,12 @@ def train_on_responses_only(
                 # An ambiguous key is settled by the value scan below, not by name.
                 if lower in _MEDIA_KEYS and lower not in _AMBIGUOUS_MEDIA_KEYS:
                     return False
-                if not _feature_is_plain_text(value, _depth + 1): return False
+                if not _feature_is_plain_text(value, _depth + 1, _seq_depth):
+                    return False
             return True
         if isinstance(feature, (list, tuple)):
-            return all(_feature_is_plain_text(f, _depth + 1) for f in feature)
+            return all(_feature_is_plain_text(f, _depth + 1, _seq_depth + 1)
+                       for f in feature)
         # A multi-dimensional numeric block is a tensor, whatever the column is
         # called: `Array4D(float32)` under `frames` is video, and the leaf dtype
         # check below called it plain, so the column was marked proven, its
@@ -1231,11 +1237,18 @@ def train_on_responses_only(
             # refuse the case this bypass exists for.
             if _leaf_dtype_is_float(inner): return False
             if _leaf_dtype_is_narrow_int(inner): return False
-            return _feature_is_plain_text(inner, _depth + 1)
+            return _feature_is_plain_text(inner, _depth + 1, _seq_depth + 1)
         # Value/ClassLabel name a primitive dtype. Image is "PIL.Image.Image" and
         # Audio/Video a dict, so anything unrecognised stays unsafe.
         dtype = getattr(feature, "dtype", None)
         if not isinstance(dtype, str): return False
+        # A sequence OF sequences of integers is a numeric block, not tokens:
+        # `Sequence(Sequence(int64))` under `frames` is quantised video, and the
+        # wide-int allowance above waved it through on its leaf dtype alone,
+        # marking the column proven so its values were never read. A pretokenized
+        # column reaches its integers one sequence down; anything deeper is a
+        # tensor by shape, exactly as `Array2D` is above.
+        if _seq_depth >= 2 and dtype.startswith(("int", "uint")): return False
         return dtype.startswith(_PLAIN_DTYPES)
     pass
 
@@ -1306,6 +1319,23 @@ def train_on_responses_only(
         return not (set(names) - _TEXT_COLUMNS), set()
     pass
 
+    def _has_custom_transform(split):
+        """Does this split rewrite its rows on the way out?
+
+        `with_format("torch")`/`("numpy")` re-type a column and keep its meaning,
+        which is why the schema is allowed to speak for every row. `with_transform`
+        does not: a `Value("string")` column can be decoded into a PIL image at
+        read time, so the schema describes the storage and not what the collator
+        will see. Drop the proof and let the rows be judged on their values.
+        """
+        try:
+            fmt = getattr(split, "format", None)
+            kind = fmt.get("type") if isinstance(fmt, dict) else None
+            return (kind or getattr(split, "_format_type", None)) == "custom"
+        except Exception:
+            return False
+    pass
+
     def _split_views(dataset):
         """`(column names, sampled rows, provably text, schema-proven, split)` per split.
 
@@ -1328,6 +1358,7 @@ def train_on_responses_only(
                 if not rows: raise ValueError("Unsloth: cannot read the dataset columns")
                 names = list(rows[0].keys())
             provable, proven = _columns_are_provably_text(split, names)
+            if _has_custom_transform(split): proven = set()
             views.append((set(names), rows, provable, proven, split))
         return views
     pass

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -602,9 +602,10 @@ def train_on_responses_only(
     def _maybe_tokenize_dataset(dataset):
         if dataset is None:
             return dataset
-        sample = next(iter(dataset))
-        if "input_ids" in sample:
-            return dataset  # Already tokenized
+        # An empty split has no row to peek at and nothing to tokenize.
+        sample = next(iter(dataset), None)
+        if sample is None or "input_ids" in sample:
+            return dataset  # Empty, or already tokenized
         _tokenizer = trainer.processing_class if hasattr(trainer, "processing_class") else trainer.tokenizer
         # Use the actual tokenizer, not the processor
         if hasattr(_tokenizer, "tokenizer"):
@@ -673,8 +674,8 @@ def train_on_responses_only(
         print("Unsloth: Warning: " + message)
     pass
 
-    def _no_training_signal(dataset_name, how_many):
-        return ValueError(
+    def _no_training_signal_message(dataset_name, how_many):
+        return (
             f"Unsloth: train_on_responses_only masked every label to -100 in {dataset_name}"
             f"{how_many}, so there is nothing to train on. The response marker "
             f"{repr(response_part)} was not found in any sample - check that "
@@ -682,25 +683,37 @@ def train_on_responses_only(
         )
     pass
 
+    def _no_training_signal(dataset_name, how_many):
+        return ValueError(_no_training_signal_message(dataset_name, how_many))
+    pass
+
     # Streaming rows cannot be counted or filtered, and fix_zero_training_loss
-    # skips them too, so sample a bounded prefix instead: all -100 there means the
-    # markers do not match this template. Iterating restarts the stream, so no rows
-    # are consumed.
+    # skips them too, so read a bounded prefix instead. Iterating restarts the
+    # stream, so no rows are consumed.
     _STREAM_SCAN_ROWS = 16
 
     def _check_streaming_labels(dataset, dataset_name):
-        seen = 0
+        rows = 0
         try:
-            for row in _itertools.islice(iter(dataset), _STREAM_SCAN_ROWS):
+            # One row past the bound, to tell "the whole stream" from "a prefix".
+            for row in _itertools.islice(iter(dataset), _STREAM_SCAN_ROWS + 1):
+                rows += 1
+                if rows > _STREAM_SCAN_ROWS: break
                 labels = row.get("labels") if isinstance(row, dict) else None
                 if labels is None: return
                 if getattr(labels, "tolist", None): labels = labels.tolist()
                 if any(l != -100 for l in labels): return
-                seen += 1
         except Exception:
             return  # unreadable stream: leave it exactly as before
-        if seen == 0: return
-        raise _no_training_signal(dataset_name, f" (first {seen} samples)")
+        if rows == 0: return
+        # Only a stream that ENDED inside the prefix is provably all masked. A
+        # longer one may be sorted or filtered so that responses start later, and
+        # refusing it would block a run that trains fine, so only warn.
+        if rows <= _STREAM_SCAN_ROWS:
+            raise _no_training_signal(dataset_name, "")
+        print("Unsloth: Warning: " + _no_training_signal_message(
+            dataset_name, f" (first {_STREAM_SCAN_ROWS} samples)",
+        ) + "\nLater samples may still carry responses, so training continues.")
     pass
 
     def _filter_fully_masked(dataset, dataset_name="dataset"):
@@ -881,8 +894,49 @@ def train_on_responses_only(
         return [split[i] for i in idx]
     pass
 
+    # A sample of any fixed size is guesswork: a 200-row split reads 16 positions,
+    # so an image on row 5 goes unseen and the strip below drops it. Arrow types
+    # are uniform down a column, so the schema answers for EVERY row at once, and
+    # reading it is constant time - where scanning one `datasets.Image` column
+    # exhaustively decodes each image (~1ms/row, ~94s per 100k rows).
+    _PLAIN_DTYPES = ("string", "large_string", "bool", "null", "int", "uint",
+                     "float", "double", "decimal", "date", "time", "duration",
+                     "timestamp")
+
+    def _feature_is_plain_text(feature, _depth = 0):
+        """True only when this column type cannot hold media in any row."""
+        if feature is None or _depth >= 8: return False
+        if isinstance(feature, dict):                       # struct
+            for key, value in feature.items():
+                if not isinstance(key, str) or key.lower() in _MEDIA_KEYS: return False
+                if not _feature_is_plain_text(value, _depth + 1): return False
+            return True
+        if isinstance(feature, (list, tuple)):
+            return all(_feature_is_plain_text(f, _depth + 1) for f in feature)
+        inner = getattr(feature, "feature", None)           # Sequence/List/LargeList
+        if inner is not None: return _feature_is_plain_text(inner, _depth + 1)
+        # Value/ClassLabel name a primitive dtype. Image is "PIL.Image.Image" and
+        # Audio/Video a dict, so anything unrecognised stays unsafe.
+        dtype = getattr(feature, "dtype", None)
+        if not isinstance(dtype, str): return False
+        return dtype.startswith(_PLAIN_DTYPES)
+    pass
+
+    def _columns_are_provably_text(split, names):
+        features = getattr(split, "features", None)
+        if features:
+            try:
+                return all(_feature_is_plain_text(f) for name, f in features.items()
+                           if name not in _TEXT_COLUMNS)
+            except Exception:
+                return False
+        # No schema (an unresolved stream): a sample cannot prove what the rows it
+        # never reads hold, so trust only the tokenizer's own columns.
+        return not (set(names) - _TEXT_COLUMNS)
+    pass
+
     def _split_views(dataset):
-        """`(column names, sampled rows)` per split, rows `[]` when unreadable.
+        """`(column names, sampled rows, provably text)` per split.
 
         `iter()` restarts a datasets IterableDataset, so peeking rows does not
         consume the stream (this is how `_maybe_tokenize_dataset` peeks too).
@@ -902,7 +956,7 @@ def train_on_responses_only(
             if not names:
                 if not rows: raise ValueError("Unsloth: cannot read the dataset columns")
                 names = list(rows[0].keys())
-            views.append((set(names), rows))
+            views.append((set(names), rows, _columns_are_provably_text(split, names)))
         return views
     pass
 
@@ -919,11 +973,12 @@ def train_on_responses_only(
         except Exception:
             return False
         if not views: return False
-        for names, rows in views:
+        for names, rows, provable in views:
             if "input_ids" not in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
-            # Columns look text-only, so check the values: a `messages` column can
-            # carry inline images that the strip below would throw away.
+            # Columns look text-only, so check the values too: a `messages` column
+            # can carry inline images that the strip below would throw away.
+            if not provable: return False
             for row in rows:
                 if not _row_is_plain_text(row): return False
         return True
@@ -946,12 +1001,13 @@ def train_on_responses_only(
         except Exception:
             return False
         if not views: return False
-        for names, rows in views:
+        for names, rows, provable in views:
             if "input_ids" in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
             # The column `_maybe_tokenize_dataset` would actually read.
             field = text_field if text_field in names else "text"
             if field not in names: return False
+            if not provable: return False
             for row in rows:
                 if not isinstance(row.get(field), str): return False
                 if not _row_is_plain_text(row): return False
@@ -1144,8 +1200,10 @@ def train_on_responses_only(
     pass
 
     # Check if all labels randomnly got masked to nothing - maybe wrong chat template?
+    # Eval-only trainers have no train split, and this check calls len() on it.
     from .training_utils import fix_zero_training_loss
-    fix_zero_training_loss(None, tokenizer, trainer.train_dataset)
+    if getattr(trainer, "train_dataset", None) is not None:
+        fix_zero_training_loss(None, tokenizer, trainer.train_dataset)
     return trainer
 pass
 

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1284,14 +1284,15 @@ def train_on_responses_only(
         return True
     pass
 
-    def _eval_split_is_raw_text_only(dataset):
-        """True when an eval split carries no `input_ids` but a real string column.
+    def _split_is_raw_text_only(dataset):
+        """True when a split carries no `input_ids` but a real string column.
 
-        Eval only: train must still be pretokenized, since that is the evidence
-        the run is text-only, and `_maybe_tokenize_dataset` below tokenizes a raw
-        eval split with the same text tokenizer. The column it would tokenize has
-        to hold strings, not conversations: a list of turns needs a chat template,
-        and its content can be inline images.
+        Applies to train and eval alike: proving every row of the text column is
+        a string IS the evidence that the run is text-only, and it does not get
+        stronger by the split's name. `_maybe_tokenize_dataset` below tokenizes
+        such a split with the same text tokenizer. The column has to hold
+        strings, not conversations: a list of turns needs a chat template, and
+        its content can be inline images.
         """
         if dataset is None:
             return False
@@ -1334,10 +1335,20 @@ def train_on_responses_only(
             _eval = getattr(trainer, "eval_dataset", None)
             _eval_splits = list(_eval.values()) if isinstance(_eval, dict) else [_eval]
             _train = getattr(trainer, "train_dataset", None)
+            # The train split gets the same allowance as an eval one. Requiring
+            # it to be PRE-tokenized refused the common case: TRL 0.22.2 hands
+            # a plain text SFT on a multimodal checkpoint its own
+            # `DataCollatorForVisionLanguageModeling` and leaves the dataset at
+            # `["text"]`, tokenizing inside the collator. Nothing there is a
+            # vision run, and `_split_is_raw_text_only` proves it over every
+            # row, so refusing lost Gemma3_(4B), Gemma3N_(4B)-Conversational,
+            # Gemma3_(27B)_A100 and Qwen_3_5_27B for a masking pass that is
+            # exactly what the dataset path below does correctly.
+            def _collatable(d):
+                return _dataset_is_pretokenized(d) or _split_is_raw_text_only(d)
             if not (
-                (_train is None or _dataset_is_pretokenized(_train))
-                and all(_dataset_is_pretokenized(d) or _eval_split_is_raw_text_only(d)
-                        for d in _eval_splits if d is not None)
+                (_train is None or _collatable(_train))
+                and all(_collatable(d) for d in _eval_splits if d is not None)
             ):
                 # Cannot configure this collator, so refuse rather than silently
                 # return with responses left unmasked.

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -713,6 +713,30 @@ def train_on_responses_only(
         return hasattr(collator, "image_processor")
     pass
 
+    def _dataset_is_pretokenized(dataset):
+        """True when rows already carry `input_ids`.
+
+        Separates "the collator rebuilds labels from a processor at collate time"
+        from "text was tokenized up front and the collator only pads", where
+        dataset-level masking is correct. Anything unreadable returns False, so
+        the caller keeps the old strict behaviour.
+        """
+        if dataset is None:
+            return False
+        try:
+            names = getattr(dataset, "column_names", None)
+            if isinstance(names, dict):  # DatasetDict
+                names = [c for v in names.values() for c in (v or [])]
+            if names:
+                return "input_ids" in names
+            # IterableDataset and friends expose no column_names; peek one row.
+            for row in dataset:
+                return isinstance(row, dict) and "input_ids" in row
+        except Exception:
+            return False
+        return False
+    pass
+
     data_collator = getattr(trainer, "data_collator", None)
     if _is_vision_collator(data_collator):
         masking = getattr(data_collator, "train_on_responses_only", None)
@@ -720,29 +744,44 @@ def train_on_responses_only(
             return trainer  # collator already masks responses; nothing to do
         is_unsloth = any(b.__name__ == "UnslothVisionDataCollator" for b in type(data_collator).__mro__)
         if not is_unsloth:
-            # A processor-style collator we cannot reliably configure: do not return as
-            # if masking were applied (it would leave responses unmasked silently).
-            raise ValueError(
-                "Unsloth: Detected a vision data collator that does not support response-only "
-                "masking. Build UnslothVisionDataCollator(..., train_on_responses_only = True, "
-                "instruction_part = ..., response_part = ...) so masking runs at collate time."
+            # A multimodal model fine-tuned on text only still carries a processor
+            # as its `tokenizer`, so a plain text collator (e.g.
+            # DataCollatorForSeq2Seq) trips `_is_vision_collator` even though it
+            # never rebuilds labels from images. Discriminate on the data: rows
+            # that already hold `input_ids` were tokenized up front, so the text
+            # path below is correct.
+            if not _dataset_is_pretokenized(getattr(trainer, "train_dataset", None)):
+                # A processor-style collator we cannot reliably configure: do not return as
+                # if masking were applied (it would leave responses unmasked silently).
+                raise ValueError(
+                    "Unsloth: Detected a vision data collator that does not support response-only "
+                    "masking. Build UnslothVisionDataCollator(..., train_on_responses_only = True, "
+                    "instruction_part = ..., response_part = ...) so masking runs at collate time."
+                )
+            # Fall through to the dataset-level text path below; configuring a
+            # collator we do not own would silently do nothing.
+            print(
+                f"Unsloth: `{type(data_collator).__name__}` holds a processor but the "
+                "dataset is already tokenized, so response-only masking is applied at "
+                "the dataset level (image handling is untouched)."
             )
-        # If the collator's tokenizer already carries the parts, let the nested call
-        # read them; passing them explicitly would hit the "already set" guard.
-        coll_proc = getattr(data_collator, "processor", tokenizer)
-        coll_tok = coll_proc.tokenizer if hasattr(coll_proc, "tokenizer") else coll_proc
-        parts = {} if hasattr(coll_tok, "_unsloth_input_part") else \
-            dict(instruction_part = instruction_part, response_part = response_part)
-        data_collator.train_on_responses_only = train_on_responses_only(
-            None,
-            force_match        = force_match,
-            tokenizer          = coll_proc,
-            return_function    = True,
-            last_response_only = last_response_only,
-            **parts,
-        )
-        print(f"Unsloth: Enabled response-only masking on your {type(data_collator).__name__} (image handling kept intact).")
-        return trainer
+        else:
+            # If the collator's tokenizer already carries the parts, let the nested call
+            # read them; passing them explicitly would hit the "already set" guard.
+            coll_proc = getattr(data_collator, "processor", tokenizer)
+            coll_tok = coll_proc.tokenizer if hasattr(coll_proc, "tokenizer") else coll_proc
+            parts = {} if hasattr(coll_tok, "_unsloth_input_part") else \
+                dict(instruction_part = instruction_part, response_part = response_part)
+            data_collator.train_on_responses_only = train_on_responses_only(
+                None,
+                force_match        = force_match,
+                tokenizer          = coll_proc,
+                return_function    = True,
+                last_response_only = last_response_only,
+                **parts,
+            )
+            print(f"Unsloth: Enabled response-only masking on your {type(data_collator).__name__} (image handling kept intact).")
+            return trainer
     pass
 
     if hasattr(trainer, "train_dataset") and trainer.train_dataset is not None:
@@ -780,8 +819,9 @@ def train_on_responses_only(
         pass
     pass
 
-    # Edit data collator to DataCollatorForSeq2Seq (vision collators were handled
-    # earlier and returned, so trainer.data_collator here is a text collator).
+    # Edit data collator to DataCollatorForSeq2Seq. Collators that rebuild labels
+    # from a processor were handled earlier and returned, so what is left here
+    # only pads already-tokenized text.
     from transformers import DataCollatorForSeq2Seq
     packing_enabled = getattr(trainer.args, "packing", False)
     if (

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -628,6 +628,13 @@ def train_on_responses_only(
         return num_proc
     pass
 
+    # `remove_unused_columns = False` is the user asking for their columns to
+    # survive, and HF's Trainer honours it: a custom `compute_loss` can pop a
+    # `sample_weight` the model itself never declares, so the model-input
+    # keep-lists below would delete the weighting the run depends on.
+    _keep_every_column = not getattr(
+        getattr(trainer, "args", None), "remove_unused_columns", True)
+
     # transformers 5.0+ VLMs skip dataset prep in SFTTrainer.__init__
     # (skip_prepare_dataset=True when _is_vlm), so tokenize before masking.
     def _maybe_tokenize_dataset(dataset):
@@ -660,6 +667,12 @@ def train_on_responses_only(
         if not isinstance(_raw_columns, dict):
             _keep = {"labels"} | _model_forward_parameter_names(
                 getattr(trainer, "model", None))
+            # This strip runs before the keep-list at the end of the function, so
+            # it has to honour the opt-out itself or the column is already gone.
+            # Only the text just tokenized still goes: it is the string the
+            # collator cannot stack, and its tokens replace it.
+            if _keep_every_column:
+                _keep |= set(_raw_columns) - {text_field, "text"}
             _map_kwargs["remove_columns"] = [c for c in _raw_columns if c not in _keep]
         import warnings as _w
         with _w.catch_warnings():
@@ -1511,11 +1524,6 @@ def train_on_responses_only(
             names.discard("self")
             return names
         _keep_columns = _model_input_columns()
-        # `remove_unused_columns = False` is the user asking for their columns to
-        # survive, and HF's Trainer honours it: a custom `compute_loss` can pop a
-        # `sample_weight` the model itself never declares, so the keep-list above
-        # would delete the weighting the run depends on.
-        _keep_every_column = not getattr(trainer.args, "remove_unused_columns", True)
         def _drop_raw_columns(dataset):
             if _keep_every_column: return dataset
             if dataset is None or not hasattr(dataset, "remove_columns"): return dataset

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -401,12 +401,18 @@ def _keep_media_columns(trainer, keys):
         existing = getattr(trainer, "_signature_columns", None)
         names = sorted(k for k in keys if isinstance(k, str))
         if existing is None:
+            # Seeding it stops the trainer deriving the signature later, so the
+            # model's own forward parameters go in here: a declared
+            # `position_ids` or a custom `sample_weight` outside a fixed list
+            # would otherwise be removed before collation, silently changing
+            # what the model is trained on.
             # `index`/`label`/`label_ids` are what HF always keeps; without them
             # a seeded list would drop the columns the loss itself needs.
-            trainer._signature_columns = names + [
+            declared = _model_forward_parameter_names(getattr(trainer, "model", None))
+            trainer._signature_columns = sorted(set(names) | declared | {
                 "label", "label_ids", "index", "input_ids", "attention_mask",
                 "labels", "completion_mask", "assistant_masks", "token_type_ids",
-            ]
+            })
         else:
             trainer._signature_columns = list(existing) + [
                 n for n in names if n not in existing]
@@ -1870,7 +1876,14 @@ def train_on_responses_only(
             # model's forward, so a later `evaluate`/`predict` split had its
             # media stripped BEFORE the collator ever ran and the dispatcher saw
             # text-only keys: the fallback it advertises could not fire at all.
-            _keep_media_columns(trainer, _dispatch_keys)
+            # Conversation keys too, though they are deliberately NOT dispatch
+            # keys: `_has_media` matches them only when the value is a real
+            # message list, and widening the dispatch set would drop that check.
+            # Media in a raw VLM split can live only inside `messages`, so
+            # without them the conversation was stripped before the dispatcher
+            # ever saw it and the batch went to the text collator.
+            _keep_media_columns(
+                trainer, _dispatch_keys | _MediaAwareCollator._CONVERSATION_KEYS)
 
         # `tokenizer.pad(..., return_tensors = "pt")` stacks every key it is
         # handed, and only pads the few it knows, so any leftover column kills

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -839,9 +839,12 @@ def train_on_responses_only(
         pass
 
     # Keys and `type` tags a chat turn uses to point at an image/video/audio.
+    # `input_image`/`input_video` are the responses-API spelling of the same
+    # parts, and `mlx/loader.py` already renders them as media.
     _MEDIA_KEYS = frozenset((
         "image", "images", "image_url", "video", "videos", "video_url",
         "audio", "audios", "audio_url", "input_audio", "pixel_values",
+        "input_image", "input_video",
         "bytes", "path", "url",
     ))
 
@@ -1014,6 +1017,8 @@ def train_on_responses_only(
         return True
     pass
 
+    # Set when a foreign vision collator is let through to the text path below.
+    _bypassed_vision_collator = False
     data_collator = getattr(trainer, "data_collator", None)
     if _is_vision_collator(data_collator):
         masking = getattr(data_collator, "train_on_responses_only", None)
@@ -1042,6 +1047,7 @@ def train_on_responses_only(
                     "instruction_part = ..., response_part = ...) so masking runs at collate time."
                 )
             # Fall through to the dataset-level text path below.
+            _bypassed_vision_collator = True
             print(
                 f"Unsloth: `{type(data_collator).__name__}` holds a processor but the "
                 "dataset is already tokenized, so response-only masking is applied at "
@@ -1119,9 +1125,12 @@ def train_on_responses_only(
         _pad_source = getattr(_collator, "processor", None)
     _processor_backed = _pad_source is not None and not hasattr(_pad_source, "pad")
     # That repair is not packing-gated like the swap: it fails either way.
+    # Nor is a collator we bypassed above: it can rebuild `labels` in `__call__`
+    # and throw away the mask just written, which is silent training on prompts.
+    # It is no packing collator either, so the gate has nothing to protect here.
     if hasattr(trainer, "data_collator") and (
-        _processor_backed or (not isinstance(_collator, DataCollatorForSeq2Seq)
-                              and not packing_enabled)
+        _processor_backed or _bypassed_vision_collator
+        or (not isinstance(_collator, DataCollatorForSeq2Seq) and not packing_enabled)
     ):
         # Keep the caller's settings when only swapping the tokenizer on a seq2seq
         # collator; for any other class this is a replacement, not a swap, and its

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1433,9 +1433,32 @@ def train_on_responses_only(
     _processor_backed = _pad_source is not None and not hasattr(_pad_source, "pad") \
         and isinstance(_collator, _PAD_DELEGATING_COLLATORS)
     # That repair is not packing-gated like the swap: it fails either way.
-    # Nor is a collator we bypassed above: it can rebuild `labels` in `__call__`
-    # and throw away the mask just written, which is silent training on prompts.
-    # It is no packing collator either, so the gate has nothing to protect here.
+    # Nor is a collator we bypassed above whose class we recognise: it either
+    # delegates its padding to `.pad` or rebuilds `labels` in `__call__`, and the
+    # latter throws away the mask just written, which is silent training on prompts.
+    def _is_known_bypassed_collator(collator):
+        if isinstance(collator, _PAD_DELEGATING_COLLATORS): return True
+        # TRL's vision collator rebuilds labels through its processor. Matched by
+        # name so this does not depend on which TRL version is installed.
+        return any(b.__name__ == "DataCollatorForVisionLanguageModeling"
+                   for b in type(collator).__mro__)
+    # Any other bypassed collator under packing is the case with no right answer:
+    # `_is_vision_collator` matches one merely holding a processor, and a custom
+    # self-packing collator does exactly that. Replacing it discards its packing,
+    # its `position_ids` and any block-attention inputs; keeping it risks its
+    # `__call__` rebuilding `labels` over the mask. Both are silently wrong, so
+    # say so rather than guess.
+    if packing_enabled and _bypassed_vision_collator and \
+        not _is_known_bypassed_collator(_collator):
+        raise ValueError(
+            f"Unsloth: `{type(_collator).__name__}` holds a processor and does not support "
+            "response-only masking, and `packing = True` asks that same collator to build the "
+            "packed batch. Both cannot be honoured: replacing it discards its packing, its "
+            "`position_ids` and any block-attention inputs, while keeping it risks its "
+            "`__call__` rebuilding `labels` over the mask just written. Turn packing off, or "
+            "build UnslothVisionDataCollator(..., train_on_responses_only = True, "
+            "instruction_part = ..., response_part = ...) so masking runs at collate time."
+        )
     if hasattr(trainer, "data_collator") and (
         _processor_backed or _bypassed_vision_collator
         or (not isinstance(_collator, DataCollatorForSeq2Seq) and not packing_enabled)

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -480,8 +480,11 @@ def _keep_media_columns(trainer, keys):
             # `position_ids` or a custom `sample_weight` outside a fixed list
             # would otherwise be removed before collation, silently changing
             # what the model is trained on.
-            # `index`/`label`/`label_ids` are what HF always keeps; without them
-            # a seeded list would drop the columns the loss itself needs.
+            # `label`/`label_ids` are what HF always keeps; without them a seeded
+            # list would drop the columns the loss itself needs. NOT `index`:
+            # Trainer's derivation is `+= list(set(["label", "label_ids"] +
+            # self.label_names))` on 4.57 through 5.14, so keeping `index` would
+            # hand a metadata column to the collator and then to `forward`.
             declared = _model_forward_parameter_names(getattr(trainer, "model", None))
             # Trainer's own derivation does `+= list(set(["label", "label_ids"]
             # + self.label_names))`, so a custom trainer whose supervision is
@@ -489,7 +492,7 @@ def _keep_media_columns(trainer, keys):
             # it dropped here and on every later split.
             declared |= set(getattr(getattr(trainer, "args", None), "label_names", None) or ())
             trainer._signature_columns = sorted(set(names) | declared | {
-                "label", "label_ids", "index", "input_ids", "attention_mask",
+                "label", "label_ids", "input_ids", "attention_mask",
                 "labels", "completion_mask", "assistant_masks", "token_type_ids",
             })
         else:
@@ -932,6 +935,12 @@ def train_on_responses_only(
         _raw_columns = getattr(dataset, "column_names", None) or list(sample.keys())
         if not isinstance(_raw_columns, dict):
             _keep = _model_forward_parameter_names(getattr(trainer, "model", None))
+            # `args.label_names` too, as the keep-lists further down already do:
+            # supervision consumed by a custom `compute_loss` is not declared by
+            # `forward`, and `remove_columns` here deletes it for good, so those
+            # later lists never get the chance to save it.
+            _keep |= set(
+                getattr(getattr(trainer, "args", None), "label_names", None) or ())
             # `labels` only when it really is token-level. A raw split can carry
             # a SCALAR `labels` (a class id), and keeping that as supervision
             # sent an int into `_train_on_responses_only`, which calls
@@ -957,6 +966,11 @@ def train_on_responses_only(
             # collator cannot stack, and its tokens replace it.
             if _keep_every_column:
                 _keep |= set(_raw_columns) - {text_field, "text"}
+                # Minus the scalar `labels` again: this union re-added every raw
+                # column, so it undid the discard above and sent an int into
+                # `_train_on_responses_only`, which calls `len(old_labels)` on it.
+                if _labels_are_token_level(dataset, sample) is False:
+                    _keep -= {"labels"}
             _map_kwargs["remove_columns"] = [c for c in _raw_columns if c not in _keep]
         import warnings as _w
         with _w.catch_warnings():

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -787,64 +787,119 @@ def train_on_responses_only(
     except Exception:
         pass
 
-    def _dataset_is_pretokenized(dataset):
-        """True when rows carry `input_ids` and no image/video/audio column, i.e.
-        text tokenized up front where dataset-level masking is correct. Multimodal
-        or unreadable rows return False, keeping the caller's old refusal (the text
-        path swaps in a text collator and would drop the image handling).
+    # Keys and `type` tags a chat turn uses to point at an image/video/audio.
+    _MEDIA_KEYS = frozenset((
+        "image", "images", "image_url", "video", "videos", "video_url",
+        "audio", "audios", "audio_url", "input_audio", "pixel_values",
+        "bytes", "path", "url",
+    ))
+
+    def _is_plain_text(value, _depth = 0):
+        """True only for text/scalars and nests of them.
+
+        A column name says nothing about its contents: `messages` holds a list of
+        turns whose content can be inline image parts, and dropping that column
+        would drop the images. So anything the text path cannot encode -- a dict
+        naming media, a PIL image, bytes -- is not plain text.
         """
-        if dataset is None:
-            return False
-
-        def _text_only(names):
-            names = set(names)
-            return "input_ids" in names and names.isdisjoint(_MULTIMODAL_COLUMNS)
-
-        try:
-            names = getattr(dataset, "column_names", None)
-            if isinstance(names, dict):  # DatasetDict
-                names = [c for v in names.values() for c in (v or [])]
-            if names:
-                return _text_only(names)
-            # No column_names (IterableDataset and friends): peek one row.
-            for row in dataset:
-                return isinstance(row, dict) and _text_only(row.keys())
-        except Exception:
-            return False
+        if isinstance(value, str) or value is None: return True
+        if isinstance(value, (bool, int, float)): return True
+        if _depth >= 6: return False
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if not isinstance(key, str): return False
+                if key.lower() in _MEDIA_KEYS: return False
+                if not _is_plain_text(item, _depth + 1): return False
+            kind = value.get("type")
+            if isinstance(kind, str) and kind.lower() in _MEDIA_KEYS: return False
+            return True
+        if isinstance(value, (list, tuple)):
+            return all(_is_plain_text(v, _depth + 1) for v in value)
         return False
     pass
 
+    def _row_is_plain_text(row):
+        # Tokenizer/model columns are numeric by construction; the rest is what
+        # can smuggle in images.
+        return all(_is_plain_text(v) for k, v in row.items() if k not in _TEXT_COLUMNS)
+    pass
+
+    def _split_views(dataset):
+        """`(column names, first row)` per split, row `None` when unreadable.
+
+        `iter()` restarts a datasets IterableDataset, so peeking one row does not
+        consume the stream (this is how `_maybe_tokenize_dataset` peeks too).
+        """
+        splits = list(dataset.values()) if isinstance(dataset, dict) else [dataset]
+        views = []
+        for split in splits:
+            if split is None: continue
+            names = getattr(split, "column_names", None)
+            if isinstance(names, dict): names = None
+            row = None
+            try:
+                row = next(iter(split))
+            except StopIteration:
+                row = None          # empty split: nothing to inspect
+            except Exception:
+                if not names: raise
+            if not isinstance(row, dict): row = None
+            if not names:
+                if row is None: raise ValueError("Unsloth: cannot read the dataset columns")
+                names = list(row.keys())
+            views.append((set(names), row))
+        return views
+    pass
+
+    def _dataset_is_pretokenized(dataset):
+        """True when rows carry `input_ids` and nothing but plain text beside them,
+        i.e. text tokenized up front where dataset-level masking is correct.
+        Multimodal or unreadable rows return False, keeping the caller's old refusal
+        (the text path swaps in a text collator and would drop the image handling).
+        """
+        if dataset is None:
+            return False
+        try:
+            views = _split_views(dataset)
+        except Exception:
+            return False
+        if not views: return False
+        for names, row in views:
+            if "input_ids" not in names: return False
+            if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
+            # Columns look text-only, so check the values: a `messages` column can
+            # carry inline images that the strip below would throw away.
+            if row is not None and not _row_is_plain_text(row): return False
+        return True
+    pass
+
     def _eval_split_is_raw_text_only(dataset):
-        """True when an eval split carries no `input_ids` but a text column.
+        """True when an eval split carries no `input_ids` but a real string column.
 
         Eval only: train must still be pretokenized, since that is the evidence
         the run is text-only, and `_maybe_tokenize_dataset` below tokenizes a raw
-        eval split with the same text tokenizer. A split with neither `input_ids`
-        nor a text column stays refused, which keeps conversational multimodal
-        splits (`messages` alone, images inline) on the old refusal.
+        eval split with the same text tokenizer. The column it would tokenize has
+        to hold strings, not conversations: a list of turns needs a chat template,
+        and its content can be inline images.
         """
         if dataset is None:
             return False
         text_field = getattr(getattr(trainer, "args", None), "dataset_text_field", None) or "text"
-
-        def _raw_text(names):
-            names = set(names)
-            if "input_ids" in names: return False
-            if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
-            return text_field in names or "text" in names
-
         try:
-            names = getattr(dataset, "column_names", None)
-            if isinstance(names, dict):  # DatasetDict
-                names = [c for v in names.values() for c in (v or [])]
-            if names:
-                return _raw_text(names)
-            # No column_names (IterableDataset and friends): peek one row.
-            for row in dataset:
-                return isinstance(row, dict) and _raw_text(row.keys())
+            views = _split_views(dataset)
         except Exception:
             return False
-        return False
+        if not views: return False
+        for names, row in views:
+            if "input_ids" in names: return False
+            if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
+            # The column `_maybe_tokenize_dataset` would actually read.
+            field = text_field if text_field in names else "text"
+            if field not in names: return False
+            if row is not None:
+                if not isinstance(row.get(field), str): return False
+                if not _row_is_plain_text(row): return False
+        return True
     pass
 
     data_collator = getattr(trainer, "data_collator", None)

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -931,6 +931,12 @@ def train_on_responses_only(
         "file_path", "filepath", "file_name", "filename", "media", "source_url",
     ))
 
+    # Those names are ambiguous nested too: `{"file_path": "images/cat.jpg"}` in a
+    # turn or a `meta` struct is the top-level column moved one level down, and
+    # only `path`/`url` were value-scanned there, so every other spelling was
+    # called text and its media dropped.
+    _AMBIGUOUS_MEDIA_KEYS = _AMBIGUOUS_MEDIA_KEYS | _AMBIGUOUS_MEDIA_COLUMNS
+
     # Every suffix a missing entry costs is a VLM row silently trained as text,
     # so cover the modern web formats too (`.avif` is what most image CDNs serve
     # now) and the older spellings of the ones already here.

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -390,6 +390,33 @@ def _model_forward_parameter_names(model):
     return names
 
 
+def _case_variants(trainer, keys):
+    """`keys` plus the spellings the trainer's own splits actually use.
+
+    `_has_media` matches by lowercasing a column name, but this whitelist held
+    only the lowercase spellings, so `remove_unused_columns` stripped an `Image`
+    or `IMAGE_URL` column before the dispatcher could see it and the batch went
+    to the text collator that cannot encode it. The observed names are read from
+    the splits the trainer holds; the fixed variants below cover a later split
+    that only reaches us after the signature is already cached.
+    """
+    found = set(keys)
+    for key in keys:
+        found.update((key.upper(), key.title(), key[:1].upper() + key[1:]))
+    lowered = {k.lower() for k in keys}
+    splits = [getattr(trainer, "train_dataset", None), getattr(trainer, "eval_dataset", None)]
+    while splits:
+        split = splits.pop()
+        if isinstance(split, dict):
+            splits.extend(split.values())
+            continue
+        try: names = getattr(split, "column_names", None) or ()
+        except Exception: continue
+        if isinstance(names, dict): names = [n for v in names.values() for n in v or ()]
+        found.update(n for n in names if isinstance(n, str) and n.lower() in lowered)
+    return found
+
+
 def _keep_media_columns(trainer, keys):
     """Stop `remove_unused_columns` stripping media before the collator sees it.
 
@@ -399,7 +426,8 @@ def _keep_media_columns(trainer, keys):
     """
     try:
         existing = getattr(trainer, "_signature_columns", None)
-        names = sorted(k for k in keys if isinstance(k, str))
+        names = sorted(k for k in _case_variants(
+            trainer, {k for k in keys if isinstance(k, str)}))
         if existing is None:
             # Seeding it stops the trainer deriving the signature later, so the
             # model's own forward parameters go in here: a declared

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -911,6 +911,11 @@ def train_on_responses_only(
         # list, so its plain string schema called the split text-only.
         "image_filename", "image_filenames", "video_filename", "video_filenames",
         "audio_filename", "audio_filenames",
+        # Bare names, which `_MEDIA_KEYS` already treats as unambiguous media one
+        # level down. A pretokenized set storing "cat.jpg" in a plain `img` column
+        # looked like text on schema alone, so the value was never examined and the
+        # images were dropped before training.
+        "img", "imgs", "image", "images", "video", "videos", "audio", "audios",
     ))
 
     # A name that only ever points at media points at media nested too: a turn
@@ -1413,12 +1418,16 @@ def train_on_responses_only(
         # collator; for any other class this is a replacement, not a swap, and its
         # same-named attributes need not mean the same thing.
         _same_class = _processor_backed and isinstance(_collator, DataCollatorForSeq2Seq)
-        # DataCollatorWithPadding hands these four to `tokenizer.pad` exactly as
-        # DataCollatorForSeq2Seq does, so a repair that dropped them would turn a
-        # `padding = "max_length"` run into a dynamically padded one, silently
-        # reshaping every batch.
-        _padding_class = _processor_backed and not _same_class and \
-            isinstance(_collator, DataCollatorWithPadding)
+        # These are handed to `tokenizer.pad` with the same meaning by every
+        # pad-delegating collator, not just DataCollatorWithPadding: a
+        # DataCollatorForTokenClassification carrying `padding = "max_length"` is
+        # a separate class, not a subclass, so an isinstance check on that one
+        # class dropped its settings and silently turned the run into a
+        # dynamically padded one. Ask whether the fields are there.
+        _padding_class = _processor_backed and not _same_class and any(
+            hasattr(_collator, _n)
+            for _n in ("padding", "max_length", "pad_to_multiple_of")
+        )
         _names = ("model", "padding", "max_length", "pad_to_multiple_of",
                   "label_pad_token_id", "return_tensors") if _same_class else \
                  ("padding", "max_length", "pad_to_multiple_of", "return_tensors")

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -494,12 +494,20 @@ def train_on_responses_only(
         if type(input_ids_) is torch_Tensor:
             use_tensors = True
             input_ids_ = input_ids_.tolist()
+        elif not isinstance(input_ids_, list) and hasattr(input_ids_, "tolist"):
+            # `with_format("numpy")` hands back an ndarray. Slicing one and
+            # comparing it to the marker list gives an array, and the `if` on
+            # that raised "truth value ... is ambiguous" before a single row was
+            # masked. Not `use_tensors`: numpy is a read-side format that
+            # `datasets` re-applies on the way out, so lists are what to return.
+            input_ids_ = input_ids_.tolist()
         if "labels" in examples:
             # Type-check labels the same way input_ids is above: under
             # datasets.map(batched = True) a "labels" column arrives as a plain
             # list of lists, which has no .tolist() and raised AttributeError.
             labels_ = examples["labels"]
-            if type(labels_) is torch_Tensor:
+            if type(labels_) is torch_Tensor or (
+                not isinstance(labels_, list) and hasattr(labels_, "tolist")):
                 labels_ = labels_.tolist()
             assert(len(labels_) == len(input_ids_))
         else:
@@ -651,7 +659,13 @@ def train_on_responses_only(
         max_length = getattr(trainer.args, "max_length", None) or getattr(trainer.args, "max_seq_length", 2048)
         text_field = getattr(trainer.args, "dataset_text_field", "text")
         def _tokenize_fn(examples):
-            texts = examples.get(text_field) or examples.get("text", [])
+            texts = examples.get(text_field)
+            if texts is None: texts = examples.get("text", [])
+            # `or` boolean-tested the column, which under `with_format("numpy")`
+            # is an ndarray and raises "truth value ... is ambiguous". Presence,
+            # not truthiness, is the question, and the tokenizer wants a list.
+            if not isinstance(texts, list) and hasattr(texts, "tolist"):
+                texts = texts.tolist()
             return _tok(texts, truncation=True, max_length=max_length, padding=False)
         _map_kwargs = {"batched": True, "num_proc": _effective_num_proc(dataset)}
         if isinstance(dataset, IterableDataset):
@@ -1358,7 +1372,19 @@ def train_on_responses_only(
                 if not rows: raise ValueError("Unsloth: cannot read the dataset columns")
                 names = list(rows[0].keys())
             provable, proven = _columns_are_provably_text(split, names)
-            if _has_custom_transform(split): proven = set()
+            # `provable` too, not just `proven`. Clearing the proof alone still
+            # left the schema saying "no media in storage", and that is only
+            # checked against the 16 sampled rows: a transform that decodes an
+            # image at row 5000 passed both and the column was dropped. The
+            # whole-column scan cannot settle it either, since it reads through
+            # `select_columns`, which a transform needing the other columns
+            # breaks. So refuse, the way an unscannable stream already is -- and
+            # name the columns, which is what makes that refusal actionable.
+            if _has_custom_transform(split):
+                provable, proven = False, set()
+                _unscannable_media_columns.update(
+                    n for n in names
+                    if isinstance(n, str) and n not in _TEXT_COLUMNS)
             views.append((set(names), rows, provable, proven, split))
         return views
     pass
@@ -1464,6 +1490,10 @@ def train_on_responses_only(
         packing subclass of one, because the exemption is about who pads.
         """
         if not packing_enabled: return
+        # Built here, not by the caller: classifying every split costs whole
+        # column scans, and with packing off the return above threw all of it
+        # away. `predict`/`evaluate` reach this guard on each call.
+        if callable(raw_splits): raw_splits = raw_splits()
         _how = ("tokenizes each row on its own" if raw_splits else
                 "cannot rebuild the packed batch's `position_ids`")
         raise ValueError(
@@ -1543,8 +1573,8 @@ def train_on_responses_only(
             _refuse_packing_with_a_foreign_collator(data_collator)
             _refuse_packing_that_will_not_happen(
                 data_collator,
-                [d for d in [_train] + _eval_splits
-                 if d is not None and not _dataset_is_pretokenized(d)])
+                lambda: [d for d in [_train] + _eval_splits
+                         if d is not None and not _dataset_is_pretokenized(d)])
             _bypassed_vision_collator = True
             print(
                 f"Unsloth: `{type(data_collator).__name__}` holds a processor but the "

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -600,6 +600,11 @@ def train_on_responses_only(
         _map_kwargs = {"batched": True, "num_proc": _effective_num_proc(dataset)}
         if isinstance(dataset, IterableDataset):
             _map_kwargs = {"batched": True}
+        # Drop the raw columns we just tokenized. Keeping them would hand the
+        # collator a string column it cannot stack into a tensor.
+        _raw_columns = getattr(dataset, "column_names", None) or list(sample.keys())
+        if not isinstance(_raw_columns, dict):
+            _map_kwargs["remove_columns"] = list(_raw_columns)
         import warnings as _w
         with _w.catch_warnings():
             _w.filterwarnings("ignore", message=".*couldn't be hashed properly.*")
@@ -904,6 +909,40 @@ def train_on_responses_only(
             if _same_class and hasattr(_collator, name)
         }
         trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer, **_kept)
+
+        # `tokenizer.pad(..., return_tensors = "pt")` stacks every key it is
+        # handed, so a raw `text`/`messages` column left on an already tokenized
+        # split kills the first batch. The trainer normally strips it, but not
+        # when unused-column removal is off (token-type-id models above turn it
+        # off). Drop by value shape so numeric model columns are all kept.
+        import numbers as _numbers
+        def _cannot_be_tensorized(value):
+            while isinstance(value, (list, tuple)):
+                if len(value) == 0: return False
+                value = value[0]
+            if value is None: return True
+            # Tensor, ndarray or numpy scalar: already numeric.
+            if hasattr(value, "dtype"): return False
+            return not isinstance(value, _numbers.Number)
+        def _drop_raw_columns(dataset):
+            if dataset is None or not hasattr(dataset, "remove_columns"): return dataset
+            try:
+                row = next(iter(dataset))
+                names = getattr(dataset, "column_names", None) or list(row.keys())
+                if isinstance(names, dict): return dataset
+                drop = [c for c in names if c in row and _cannot_be_tensorized(row[c])]
+            except Exception:
+                return dataset
+            return dataset.remove_columns(drop) if drop else dataset
+        if hasattr(trainer, "train_dataset"):
+            trainer.train_dataset = _drop_raw_columns(trainer.train_dataset)
+        _eval_now = getattr(trainer, "eval_dataset", None)
+        if type(_eval_now) is dict:
+            for _key in list(_eval_now.keys()):
+                _eval_now[_key] = _drop_raw_columns(_eval_now[_key])
+        elif _eval_now is not None:
+            trainer.eval_dataset = _drop_raw_columns(_eval_now)
+    pass
 
     # Check if all labels randomnly got masked to nothing - maybe wrong chat template?
     from .training_utils import fix_zero_training_loss

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -932,6 +932,11 @@ def train_on_responses_only(
         # looked like text on schema alone, so the value was never examined and the
         # images were dropped before training.
         "img", "imgs", "image", "images", "video", "videos", "audio", "audios",
+        # `bytes` is already an unambiguous media key one level down, and the
+        # top-level list did not have it: a flattened base64 payload in a
+        # `bytes` column has a string schema, so it read as text and the
+        # replacement collator dropped it.
+        "bytes",
     ))
 
     # A name that only ever points at media points at media nested too: a turn
@@ -1155,6 +1160,20 @@ def train_on_responses_only(
                      "float", "double", "decimal", "date", "time", "duration",
                      "timestamp")
 
+    def _leaf_dtype_is_float(feature, _depth = 0):
+        """Does this feature bottom out in a float dtype?"""
+        if feature is None or _depth >= 8: return False
+        inner = getattr(feature, "feature", None)
+        if inner is not None: return _leaf_dtype_is_float(inner, _depth + 1)
+        dtype = getattr(feature, "dtype", None)
+        return isinstance(dtype, str) and dtype.startswith(
+            ("float", "double", "half", "bfloat"))
+
+    def _is_numeric_array_feature(feature):
+        """`Array2D`/`Array3D`/`Array4D`/`Array5D`, by shape rather than name."""
+        return (getattr(feature, "shape", None) is not None
+                and isinstance(getattr(feature, "dtype", None), str))
+
     def _feature_is_plain_text(feature, _depth = 0):
         """True only when this column type cannot hold media in any row."""
         if feature is None or _depth >= 8: return False
@@ -1169,8 +1188,19 @@ def train_on_responses_only(
             return True
         if isinstance(feature, (list, tuple)):
             return all(_feature_is_plain_text(f, _depth + 1) for f in feature)
+        # A multi-dimensional numeric block is a tensor, whatever the column is
+        # called: `Array4D(float32)` under `frames` is video, and the leaf dtype
+        # check below called it plain, so the column was marked proven, its
+        # values never read, and the media dropped.
+        if _is_numeric_array_feature(feature): return False
         inner = getattr(feature, "feature", None)           # Sequence/List/LargeList
-        if inner is not None: return _feature_is_plain_text(inner, _depth + 1)
+        if inner is not None:
+            # Same for a float sequence: `Sequence(float32)` under `speech` is a
+            # waveform. Integer sequences stay plain -- that is the shape every
+            # pretokenized column has, and refusing them would refuse the case
+            # this bypass exists for.
+            if _leaf_dtype_is_float(inner): return False
+            return _feature_is_plain_text(inner, _depth + 1)
         # Value/ClassLabel name a primitive dtype. Image is "PIL.Image.Image" and
         # Audio/Video a dict, so anything unrecognised stays unsafe.
         dtype = getattr(feature, "dtype", None)
@@ -1353,6 +1383,23 @@ def train_on_responses_only(
         return any(b.__name__ == "DataCollatorForVisionLanguageModeling"
                    for b in type(collator).__mro__)
 
+    def _refuse_packing_that_will_not_happen(collator, raw_splits):
+        """A raw split taking the bypass gets no packing at all.
+
+        `_maybe_tokenize_dataset` tokenizes each row on its own and the swap
+        below installs a plain DataCollatorForSeq2Seq, so nothing concatenates
+        the examples and nothing builds the packing-specific inputs. That is
+        true even for the collators exempted just above, because the exemption
+        is about who pads, not about who packs.
+        """
+        if not packing_enabled or not raw_splits: return
+        raise ValueError(
+            f"Unsloth: `packing = True` is not supported here. `{type(collator).__name__}` "
+            "holds a processor, so response-only masking is applied at the dataset level, "
+            "and that path tokenizes each row on its own -- nothing packs them. Turn packing "
+            "off, or pre-tokenize the dataset so the trainer's own packing runs."
+        )
+
     def _refuse_packing_with_a_foreign_collator(collator):
         """The case with no right answer: `_is_vision_collator` matches one
         merely holding a processor, and a custom self-packing collator does
@@ -1420,6 +1467,10 @@ def train_on_responses_only(
                 )
             # Fall through to the dataset-level text path below.
             _refuse_packing_with_a_foreign_collator(data_collator)
+            _refuse_packing_that_will_not_happen(
+                data_collator,
+                [d for d in [_train] + _eval_splits
+                 if d is not None and not _dataset_is_pretokenized(d)])
             _bypassed_vision_collator = True
             print(
                 f"Unsloth: `{type(data_collator).__name__}` holds a processor but the "

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1055,7 +1055,12 @@ def train_on_responses_only(
                 if not all(isinstance(v, str) for v in batch[name]): return False
             return True
         except Exception:
-            return True
+            # The scan blew up partway (a custom transform needing the columns
+            # `select_columns` just removed), so only the sampled rows were ever
+            # checked and the rest are unproven. Refuse, exactly as the ambiguous
+            # media scan does, rather than call the failure a proof.
+            _unscannable_media_columns.add(name)
+            return False
     pass
 
     def _has_media_column(names, rows, split = None):

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -390,6 +390,52 @@ def _model_forward_parameter_names(model):
     return names
 
 
+def _labels_are_token_level(dataset, sample):
+    """Is a raw split's `labels` column token-level supervision? True / False /
+    None for "cannot tell".
+
+    Judging by the first row's value alone is wrong twice over: a nullable
+    token-level column whose first row is null looks like no column at all, and
+    dropping it makes the masking pass rebuild labels from `input_ids`, silently
+    un-masking exactly what the caller masked. So ask the FEATURE first, then
+    the first NON-null row, then give up.
+
+    Everything here is duck-typed rather than version-gated: `Sequence`, `List`
+    and `LargeList` all expose their element type as `.feature`, a bare `[...]`
+    is the other list spelling, and `Value` / `ClassLabel` are the scalar ones.
+    """
+    features = getattr(dataset, "features", None)
+    feature = None
+    try:
+        if features is not None: feature = features["labels"]
+    except (KeyError, TypeError): feature = None
+    if feature is not None:
+        if isinstance(feature, (list, tuple)) or hasattr(feature, "feature"): return True
+        if type(feature).__name__ in ("Value", "ClassLabel"): return False
+        return None  # some nested/unknown feature: ambiguous, and the caller keeps
+    # No usable features: an in-memory dict-of-lists, or an IterableDataset.
+    value = sample.get("labels") if isinstance(sample, dict) else None
+    if value is None:
+        # Scan for the first non-null row, capped so a streaming or huge split
+        # is not walked end to end for a column verdict.
+        try:
+            for i, row in enumerate(dataset):
+                if i >= 100: break
+                if not isinstance(row, dict): break
+                value = row.get("labels")
+                if value is not None: break
+        except Exception: value = None
+    if value is None: return None
+    # A string/bytes `labels` is a class NAME, not tokens; it can never be
+    # supervision, so it goes with the other raw columns.
+    if isinstance(value, (str, bytes)): return False
+    try:
+        len(value)
+        return True
+    except TypeError:
+        return False
+
+
 def _case_variants(trainer, keys):
     """`keys` plus the spellings the trainer's own splits actually use.
 
@@ -891,14 +937,15 @@ def train_on_responses_only(
             # sent an int into `_train_on_responses_only`, which calls
             # `len(old_labels)` on it: `TypeError: object of type 'int' has no
             # len()`. A scalar is metadata for the tokenized split and goes with
-            # the other raw columns, unless `forward` asks for it above.
-            _sample_labels = sample.get("labels") if isinstance(sample, dict) else None
-            if _sample_labels is not None and not isinstance(_sample_labels, (str, bytes)):
-                try:
-                    len(_sample_labels)
-                    _keep = _keep | {"labels"}
-                except TypeError:
-                    pass
+            # the other raw columns. This has to DISCARD rather than decline to
+            # add: `_keep` already holds every name `forward` declares, and every
+            # causal LM declares `labels`, so the scalar was kept regardless.
+            # Ambiguity resolves to keeping: a kept scalar raises loudly at the
+            # masking pass, while a dropped sequence corrupts the run in silence.
+            if _labels_are_token_level(dataset, sample) is False:
+                _keep = _keep - {"labels"}
+            else:
+                _keep = _keep | {"labels"}
             # The raw text always goes, whatever else asks for it: it was just
             # turned into `input_ids`, and a `forward` that happens to declare a
             # `text` parameter would otherwise keep the string column for the

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -359,6 +359,37 @@ def get_chat_template_parts(tokenizer):
 pass
 
 
+def _model_forward_parameter_names(model):
+    """Every named parameter of `model.forward`, unwrapping PEFT / compile layers.
+
+    A wrapper's own forward hides the real signature, so walk down to the base
+    model. Used to decide what a dataset column must survive for: anything the
+    model is actually fed.
+    """
+    import inspect as _inspect
+    names = set()
+    for _ in range(6):
+        if model is None: break
+        forward = getattr(model, "forward", None)
+        if forward is not None:
+            try:
+                names.update(
+                    name for name, p in _inspect.signature(forward).parameters.items()
+                    if p.kind not in (p.VAR_KEYWORD, p.VAR_POSITIONAL)
+                )
+            except (TypeError, ValueError): pass
+        unwrap = getattr(model, "get_base_model", None)
+        nxt = None
+        if callable(unwrap):
+            try: nxt = unwrap()
+            except Exception: nxt = None
+        if nxt is None or nxt is model:
+            nxt = getattr(model, "_orig_mod", None) or getattr(model, "base_model", None)
+        model = None if nxt is model else nxt
+    names.discard("self")
+    return names
+
+
 def train_on_responses_only(
     trainer,
     instruction_part  = None,
@@ -619,12 +650,17 @@ def train_on_responses_only(
         if isinstance(dataset, IterableDataset):
             _map_kwargs = {"batched": True}
         # Drop the raw columns we just tokenized. Keeping them would hand the
-        # collator a string column it cannot stack into a tensor. `labels` is the
-        # one exception: it is already token-level, and the masking pass below
-        # intersects with it, so removing it would un-mask what the caller masked.
+        # collator a string column it cannot stack into a tensor. Two exceptions:
+        # `labels`, which is already token-level and which the masking pass below
+        # intersects with, so removing it would un-mask what the caller masked;
+        # and anything `model.forward` declares, such as a per-row `sample_weight`
+        # or a custom auxiliary target, which the tokenizer does not recreate and
+        # which the later model-input keep-list never gets the chance to save.
         _raw_columns = getattr(dataset, "column_names", None) or list(sample.keys())
         if not isinstance(_raw_columns, dict):
-            _map_kwargs["remove_columns"] = [c for c in _raw_columns if c != "labels"]
+            _keep = {"labels"} | _model_forward_parameter_names(
+                getattr(trainer, "model", None))
+            _map_kwargs["remove_columns"] = [c for c in _raw_columns if c not in _keep]
         import warnings as _w
         with _w.catch_warnings():
             _w.filterwarnings("ignore", message=".*couldn't be hashed properly.*")
@@ -1413,25 +1449,7 @@ def train_on_responses_only(
                 try: names.update(getattr(holder, "model_input_names", None) or ())
                 except Exception: pass
             # Unwrap PEFT/compile wrappers: their own forward hides pixel_values.
-            model = getattr(trainer, "model", None)
-            for _ in range(6):
-                if model is None: break
-                forward = getattr(model, "forward", None)
-                if forward is not None:
-                    try:
-                        names.update(
-                            name for name, p in _inspect.signature(forward).parameters.items()
-                            if p.kind not in (p.VAR_KEYWORD, p.VAR_POSITIONAL)
-                        )
-                    except (TypeError, ValueError): pass
-                unwrap = getattr(model, "get_base_model", None)
-                nxt = None
-                if callable(unwrap):
-                    try: nxt = unwrap()
-                    except Exception: nxt = None
-                if nxt is None or nxt is model:
-                    nxt = getattr(model, "_orig_mod", None) or getattr(model, "base_model", None)
-                model = None if nxt is model else nxt
+            names.update(_model_forward_parameter_names(getattr(trainer, "model", None)))
             names.discard("self")
             return names
         _keep_columns = _model_input_columns()

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -761,6 +761,47 @@ def train_on_responses_only(
         return False
     pass
 
+    def _eval_split_is_raw_text_only(dataset):
+        """True when an eval split carries no `input_ids` but a text column.
+
+        Only ever asked about eval splits. The TRAIN split is the evidence that
+        the run is text-only at all, so it still has to be pretokenized; once it
+        is, the collator is already going to be replaced by a text one, and
+        `_maybe_tokenize_dataset` below tokenizes a raw eval split with the same
+        unwrapped text tokenizer, after which the dataset-level masking lands on
+        it exactly as it does on a pretokenized one. Refusing it would only force
+        users to pretokenize eval by hand to be able to evaluate at all.
+
+        Deliberately narrow: a split carrying neither `input_ids` nor a text
+        column stays refused, because there would be nothing for the text path to
+        tokenize. That is what keeps a conversational multimodal split (columns
+        like `messages` alone, images inline in the turns) on the old refusal
+        instead of being silently emptied.
+        """
+        if dataset is None:
+            return False
+        text_field = getattr(getattr(trainer, "args", None), "dataset_text_field", None) or "text"
+
+        def _raw_text(names):
+            names = set(names)
+            if "input_ids" in names: return False
+            if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
+            return text_field in names or "text" in names
+
+        try:
+            names = getattr(dataset, "column_names", None)
+            if isinstance(names, dict):  # DatasetDict
+                names = [c for v in names.values() for c in (v or [])]
+            if names:
+                return _raw_text(names)
+            # IterableDataset and friends expose no column_names; peek one row.
+            for row in dataset:
+                return isinstance(row, dict) and _raw_text(row.keys())
+        except Exception:
+            return False
+        return False
+    pass
+
     data_collator = getattr(trainer, "data_collator", None)
     if _is_vision_collator(data_collator):
         masking = getattr(data_collator, "train_on_responses_only", None)
@@ -776,11 +817,17 @@ def train_on_responses_only(
             # path below is correct.
             # Every split that will be collated, not just train: the collator is
             # swapped for the whole trainer below, so a multimodal eval set would
-            # lose its image handling on a train-only check.
-            _splits = [getattr(trainer, "train_dataset", None)]
+            # lose its image handling on a train-only check. Eval splits may also
+            # be raw text, which the text path tokenizes itself; train may not,
+            # since it is what tells us the run is text-only in the first place.
             _eval = getattr(trainer, "eval_dataset", None)
-            _splits += list(_eval.values()) if isinstance(_eval, dict) else [_eval]
-            if not all(_dataset_is_pretokenized(d) for d in _splits if d is not None):
+            _eval_splits = list(_eval.values()) if isinstance(_eval, dict) else [_eval]
+            _train = getattr(trainer, "train_dataset", None)
+            if not (
+                (_train is None or _dataset_is_pretokenized(_train))
+                and all(_dataset_is_pretokenized(d) or _eval_split_is_raw_text_only(d)
+                        for d in _eval_splits if d is not None)
+            ):
                 # A processor-style collator we cannot reliably configure: do not return as
                 # if masking were applied (it would leave responses unmasked silently).
                 raise ValueError(
@@ -860,10 +907,16 @@ def train_on_responses_only(
     # dies on the first batch. Rebuild that one around the unwrapped text
     # tokenizer too; gate on the capability rather than the processor type, so
     # this stays right if transformers ever gives ProcessorMixin a .pad.
-    _processor_backed = (
-        isinstance(_collator, DataCollatorForSeq2Seq)
-        and not hasattr(getattr(_collator, "tokenizer", None), "pad")
-    )
+    # Not only the seq2seq one: DataCollatorWithPadding(tokenizer = processor)
+    # and TRL's DataCollatorForVisionLanguageModeling(processor) pad through the
+    # same missing `.pad` and die the same way. Key on a HELD padding object that
+    # cannot pad, so a collator that holds none at all is untouched - that is what
+    # keeps TRL's packing `DataCollatorForLanguageModeling`, which takes a bare
+    # `pad_token_id` and builds the packed position_ids itself, off this path.
+    _pad_source = getattr(_collator, "tokenizer", None)
+    if _pad_source is None:
+        _pad_source = getattr(_collator, "processor", None)
+    _processor_backed = _pad_source is not None and not hasattr(_pad_source, "pad")
     # A processor-backed collator raises on its first batch whatever packing
     # says, so that repair is not gated on packing the way the swap is.
     if hasattr(trainer, "data_collator") and (
@@ -871,12 +924,15 @@ def train_on_responses_only(
                               and not packing_enabled)
     ):
         # Carry the settings across when we are only swapping the tokenizer,
-        # so a caller's pad_to_multiple_of or label_pad_token_id survives.
+        # so a caller's pad_to_multiple_of or label_pad_token_id survives. Only
+        # for a seq2seq collator: for any other class this is a replacement, not
+        # a tokenizer swap, and its same-named attributes need not mean the same.
+        _same_class = _processor_backed and isinstance(_collator, DataCollatorForSeq2Seq)
         _kept = {
             name: getattr(_collator, name)
             for name in ("model", "padding", "max_length", "pad_to_multiple_of",
                          "label_pad_token_id", "return_tensors")
-            if _processor_backed and hasattr(_collator, name)
+            if _same_class and hasattr(_collator, name)
         }
         trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer, **_kept)
 

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1377,6 +1377,15 @@ def train_on_responses_only(
             return False
     pass
 
+    def _is_map_style(split):
+        """Can this split be indexed and scanned, or is it a one-pass stream?"""
+        try:
+            len(split)
+            return True
+        except Exception:
+            return False
+    pass
+
     def _columns_are_provably_text(split, names):
         """`(every column is text, the columns the schema itself proved)`.
 
@@ -1396,8 +1405,21 @@ def train_on_responses_only(
                         getattr(feature, "feature", None) is not None and \
                         _leaf_dtype_is_numeric(feature): return False, proven
                     if not _feature_is_plain_text(feature): return False, proven
-                    if _feature_needs_a_value_scan(feature) and \
-                        not _column_values_are_plain_text(split, name): return False, proven
+                    # Bare strings too, not just the structs the schema cannot
+                    # settle. A `data:image/...` URI identifies itself, and an
+                    # unlisted column holding one on row 5000 is invisible to the
+                    # 16 sampled rows that were the only value check a bare
+                    # string got. The scan is a `startswith` per row.
+                    #
+                    # Map-style only, unlike the struct case. A struct advertises
+                    # its own ambiguity with a `path`/`url`/`type` key, so a
+                    # stream that cannot be scanned is right to be refused; a
+                    # bare `string` advertises nothing, and refusing it would
+                    # refuse every streamed text column there is.
+                    _scan = _feature_needs_a_value_scan(feature) or (
+                        _feature_is_bare_string(feature) and _is_map_style(split))
+                    if _scan and not _column_values_are_plain_text(split, name):
+                        return False, proven
                     # A plain string column is NOT added: `proven` exists so a
                     # numeric column that `with_format` hands back as a tensor is
                     # not re-judged by value, and a string stays a string under
@@ -1776,7 +1798,12 @@ def train_on_responses_only(
         # Only when a media-capable collator was displaced. Everywhere else the
         # replacement is the whole point and there is nothing to fall back to.
         trainer.data_collator = _MediaAwareCollator(
-            _text_collator, _collator, _MEDIA_COLUMNS,
+            # Both sets. `_MEDIA_COLUMNS` names what a user hands in, and a split
+            # that has already been through the processor carries `pixel_values`
+            # / `image_grid_thw` / `input_features` instead: those live only in
+            # `_MULTIMODAL_COLUMNS`, so a processed `predict` batch matched
+            # nothing and went to the text collator that cannot tensorize it.
+            _text_collator, _collator, _MEDIA_COLUMNS | _MULTIMODAL_COLUMNS,
         ) if _bypassed_vision_collator else _text_collator
 
         # `tokenizer.pad(..., return_tensors = "pt")` stacks every key it is

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -943,6 +943,10 @@ def train_on_responses_only(
         # looked like text on schema alone, so the value was never examined and the
         # images were dropped before training.
         "img", "imgs", "image", "images", "video", "videos", "audio", "audios",
+        # `picture`/`photo` name an image as unambiguously as `image` does, and
+        # neither list had them: a pretokenized set keeping "cat.jpg" under
+        # `picture` read as text on schema alone and lost its images.
+        "picture", "pictures", "photo", "photos",
         # `bytes` is already an unambiguous media key one level down, and the
         # top-level list did not have it: a flattened base64 payload in a
         # `bytes` column has a string schema, so it read as text and the
@@ -1710,6 +1714,14 @@ def train_on_responses_only(
                 # numeric `sample_weight` or auxiliary target still comes through.
                 if _keep_every_column:
                     unusable = _text_columns | _untensorizable_columns(dataset)
+                    # `label` is a reserved collator alias, not an extra column:
+                    # DataCollatorForSeq2Seq reads `"label" if "label" in
+                    # features[0] else "labels"`, so a numeric `label` beside the
+                    # response-only `labels` we just built wins, and the masks are
+                    # thrown away. Only when both are present: a set carrying
+                    # `label` alone is supervising with it.
+                    if "labels" in names and "label" in names:
+                        unusable = unusable | {"label"}
                     drop = [c for c in names if c in unusable]
                 else:
                     drop = [c for c in names if c not in _keep_columns]

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -480,9 +480,13 @@ class _MediaAwareCollator:
     Module level so a DataLoader worker under `spawn` can pickle it, which a
     closure or a `type()`-built class cannot.
     """
-    def __init__(self, text, media, media_keys, ambiguous_keys = ()):
+    def __init__(self, text, media, media_keys, ambiguous_keys = (),
+                 companion_keys = ()):
         self.text = text
         self.media = media
+        # Kept so the media collator can read the prompt beside its image, and
+        # stripped again on the text path, which cannot tensorize a raw string.
+        self.companion_keys = frozenset(companion_keys)
         # Split, not merged: an ambiguous name is decided by its value below,
         # and folding the two would match `url` on the name alone.
         self.ambiguous_keys = frozenset(ambiguous_keys)
@@ -516,8 +520,22 @@ class _MediaAwareCollator:
         return False
 
     def __call__(self, features):
-        collator = self.media if self._has_media(features) else self.text
-        return collator(features)
+        if self._has_media(features):
+            return self.media(features)
+        # Strip what only the MEDIA path wanted kept. The signature whitelist is
+        # global, so a benign `url`/`path`/`prompt`/`content` column now survives
+        # unused-column removal for every split -- and the text collator
+        # tensorizes every key it is handed, so a retained string kills the
+        # batch. Removed here, not from the keep-list: the media path still
+        # needs those columns, and this is the only point that knows which path
+        # a batch took. Copies, so the caller's rows are left alone.
+        drop = self.media_keys | self.ambiguous_keys | self.companion_keys
+        stripped = [
+            {k: v for k, v in f.items() if not (isinstance(k, str) and k.lower() in drop)}
+            if isinstance(f, dict) else f
+            for f in features or ()
+        ]
+        return self.text(stripped)
 
     def __getattr__(self, attribute):
         # Only for names this class does not define; `text` is set in __init__,
@@ -1900,6 +1918,10 @@ def train_on_responses_only(
         # repair exists to remove. The bypass flag is the case where the
         # displaced collator is a working vision collator.
         _media_capable = _bypassed_vision_collator and not _processor_backed
+        # The training text column is NOT a companion to strip: it is what the
+        # text collator is there to read.
+        _text_field = getattr(getattr(trainer, "args", None),
+                              "dataset_text_field", None) or "text"
         # Every media form the initial-split guard recognises, not just the two
         # sets: a later split storing `image_base64`, a `speech` waveform or an
         # ambiguous `path` matched nothing and went to the text collator.
@@ -1913,6 +1935,7 @@ def train_on_responses_only(
             # `_MULTIMODAL_COLUMNS`, so a processed `predict` batch matched
             # nothing and went to the text collator that cannot tensorize it.
             _text_collator, _collator, _dispatch_keys, _AMBIGUOUS_MEDIA_COLUMNS,
+            _RAW_TEXT_COMPANION_COLUMNS - {_text_field},
         ) if _media_capable else _text_collator
         if _media_capable:
             # And the keys have to survive `remove_unused_columns`, which is on
@@ -1934,8 +1957,7 @@ def train_on_responses_only(
                 # "image": ...}` row reached the vision collator with its text
                 # already stripped, so it had nothing to tokenize.
                 | _RAW_TEXT_COMPANION_COLUMNS
-                | {getattr(getattr(trainer, "args", None),
-                           "dataset_text_field", None) or "text"},
+                | {_text_field},
             )
 
         # `tokenizer.pad(..., return_tensors = "pt")` stacks every key it is
@@ -1959,6 +1981,11 @@ def train_on_responses_only(
                 except Exception: pass
             # Unwrap PEFT/compile wrappers: their own forward hides pixel_values.
             names.update(_model_forward_parameter_names(getattr(trainer, "model", None)))
+            # `args.label_names` too, exactly as `_keep_media_columns` does and
+            # as Trainer's own signature derivation does. Supervision consumed
+            # by a custom `compute_loss` is not declared by `forward`, so the
+            # signature kept it while THIS list deleted it from the split.
+            names.update(getattr(getattr(trainer, "args", None), "label_names", None) or ())
             names.discard("self")
             # Same reason as the tokenizing strip above: a `forward` declaring
             # `text` must not keep a raw string column no collator can tensorize.

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1099,10 +1099,14 @@ def train_on_responses_only(
         return False
     pass
 
-    def _row_is_plain_text(row):
+    def _row_is_plain_text(row, schema_proven = frozenset()):
         # Tokenizer/model columns are numeric by construction; the rest is what
-        # can smuggle in images.
-        return all(_is_plain_text(v) for k, v in row.items() if k not in _TEXT_COLUMNS)
+        # can smuggle in images. A column the schema already proved needs no
+        # second opinion: it judged EVERY row, where re-reading it as a value is
+        # strictly weaker and misreads the tensor/ndarray `with_format("torch")`
+        # and `with_format("numpy")` hand back for an ordinary numeric column.
+        return all(_is_plain_text(v) for k, v in row.items()
+                   if k not in _TEXT_COLUMNS and k not in schema_proven)
     pass
 
     # A one-row peek calls a mixed split text-only: row 0 holds plain `messages`
@@ -1193,24 +1197,31 @@ def train_on_responses_only(
     pass
 
     def _columns_are_provably_text(split, names):
+        """`(every column is text, the columns the schema itself proved)`.
+
+        The second half is threaded down to `_row_is_plain_text`, which must not
+        re-judge a column the schema has already settled for every row.
+        """
         features = getattr(split, "features", None)
         if features:
+            proven = set()
             try:
                 for name, feature in features.items():
                     if name in _TEXT_COLUMNS: continue
-                    if not _feature_is_plain_text(feature): return False
+                    if not _feature_is_plain_text(feature): return False, proven
                     if _feature_has_ambiguous_media_key(feature) and \
-                        not _column_values_are_plain_text(split, name): return False
-                return True
+                        not _column_values_are_plain_text(split, name): return False, proven
+                    proven.add(name)
+                return True, proven
             except Exception:
-                return False
+                return False, proven
         # No schema (an unresolved stream): a sample cannot prove what the rows it
         # never reads hold, so trust only the tokenizer's own columns.
-        return not (set(names) - _TEXT_COLUMNS)
+        return not (set(names) - _TEXT_COLUMNS), set()
     pass
 
     def _split_views(dataset):
-        """`(column names, sampled rows, provably text, split)` per split.
+        """`(column names, sampled rows, provably text, schema-proven, split)` per split.
 
         `iter()` restarts a datasets IterableDataset, so peeking rows does not
         consume the stream (this is how `_maybe_tokenize_dataset` peeks too).
@@ -1230,7 +1241,8 @@ def train_on_responses_only(
             if not names:
                 if not rows: raise ValueError("Unsloth: cannot read the dataset columns")
                 names = list(rows[0].keys())
-            views.append((set(names), rows, _columns_are_provably_text(split, names), split))
+            provable, proven = _columns_are_provably_text(split, names)
+            views.append((set(names), rows, provable, proven, split))
         return views
     pass
 
@@ -1247,7 +1259,7 @@ def train_on_responses_only(
         except Exception:
             return False
         if not views: return False
-        for names, rows, provable, split in views:
+        for names, rows, provable, proven, split in views:
             if "input_ids" not in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
             if _has_media_column(names, rows, split): return False
@@ -1255,7 +1267,7 @@ def train_on_responses_only(
             # can carry inline images that the strip below would throw away.
             if not provable: return False
             for row in rows:
-                if not _row_is_plain_text(row): return False
+                if not _row_is_plain_text(row, proven): return False
         return True
     pass
 
@@ -1276,7 +1288,7 @@ def train_on_responses_only(
         except Exception:
             return False
         if not views: return False
-        for names, rows, provable, split in views:
+        for names, rows, provable, proven, split in views:
             if "input_ids" in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
             if _has_media_column(names, rows, split): return False
@@ -1286,7 +1298,7 @@ def train_on_responses_only(
             if not provable: return False
             for row in rows:
                 if not isinstance(row.get(field), str): return False
-                if not _row_is_plain_text(row): return False
+                if not _row_is_plain_text(row, proven): return False
             # The sample says these rows are text; the tokenizer reads every row.
             if not _column_is_all_strings(split, field): return False
         return True

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -737,6 +737,7 @@ def train_on_responses_only(
     pass
 
     # Processor outputs beside `input_ids`; a row with any of these needs its collator.
+    # Only the floor: the real set is derived below from the installed processor.
     _MULTIMODAL_COLUMNS = frozenset((
         "pixel_values", "pixel_values_videos", "pixel_attention_mask",
         "image_grid_thw", "video_grid_thw", "image_sizes", "image_sizes_videos",
@@ -747,7 +748,44 @@ def train_on_responses_only(
         # Processor-specific spellings: phi4_multimodal, pix2struct, kosmos-2.5.
         "image_pixel_values", "audio_input_features", "audio_embed_sizes",
         "high_res_pixel_values", "flattened_patches",
+        # Fuyu keeps its preprocessed images here, beside `input_ids`.
+        "image_patches", "image_patches_indices",
     ))
+
+    # Names the text tokenizer owns; a processor half repeating one of these must
+    # not turn every text-only row into a refusal.
+    _TEXT_COLUMNS = frozenset((
+        "input_ids", "attention_mask", "token_type_ids", "position_ids",
+        "labels", "label", "label_ids", "special_tokens_mask",
+        "offset_mapping", "length",
+    ))
+
+    def _derive_multimodal_columns():
+        """The non-text names this processor actually produces.
+
+        A hand list rots: Fuyu emits `image_patches`/`image_patches_indices` and
+        every new model spells its own. Each processor half declares its outputs
+        in `model_input_names`, so ask them and subtract the text half.
+        """
+        names = set()
+        holders = [getattr(processor, attr, None) for attr in
+                   ("image_processor", "video_processor", "feature_extractor",
+                    "audio_processor", "qformer_tokenizer")]
+        # The processor's own list merges text and vision (that is the only place
+        # FuyuProcessor names `image_patches_indices`), so take it too.
+        if processor is not tokenizer: holders.append(processor)
+        for holder in holders:
+            if holder is None: continue
+            try: names.update(getattr(holder, "model_input_names", None) or ())
+            except Exception: pass
+        names -= set(getattr(tokenizer, "model_input_names", None) or ())
+        return frozenset(names - _TEXT_COLUMNS)
+    pass
+
+    try:
+        _MULTIMODAL_COLUMNS = _MULTIMODAL_COLUMNS | _derive_multimodal_columns()
+    except Exception:
+        pass
 
     def _dataset_is_pretokenized(dataset):
         """True when rows carry `input_ids` and no image/video/audio column, i.e.
@@ -873,8 +911,10 @@ def train_on_responses_only(
     pass
 
     if hasattr(trainer, "eval_dataset") and trainer.eval_dataset is not None:
-        # Eval datasets could be a dict!
-        if type(trainer.eval_dataset) is dict:
+        # Eval datasets could be a dict! DatasetDict subclasses dict, so match on
+        # isinstance: `type(...) is dict` sent it down the single-dataset path,
+        # where column_names is a dict of splits and every per-split step no-ops.
+        if isinstance(trainer.eval_dataset, dict):
             for key, value in trainer.eval_dataset.items():
                 if not hasattr(value, "map"):
                     raise TypeError("Unsloth: train_on_responses_only does not work on lists!")
@@ -985,7 +1025,7 @@ def train_on_responses_only(
         if hasattr(trainer, "train_dataset"):
             trainer.train_dataset = _drop_raw_columns(trainer.train_dataset)
         _eval_now = getattr(trainer, "eval_dataset", None)
-        if type(_eval_now) is dict:
+        if isinstance(_eval_now, dict):
             for _key in list(_eval_now.keys()):
                 _eval_now[_key] = _drop_raw_columns(_eval_now[_key])
         elif _eval_now is not None:

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -722,6 +722,10 @@ def train_on_responses_only(
         "token_type_ids_images", "input_features", "input_features_mask",
         "audio_values", "audio_attention_mask", "input_audio_embeds",
         "aspect_ratio_ids", "aspect_ratio_mask", "cross_attention_mask",
+        # Processor-specific spellings: phi4_multimodal, then pix2struct and
+        # kosmos-2.5, which emit flattened_patches with nothing else alongside.
+        "image_pixel_values", "audio_input_features", "audio_embed_sizes",
+        "high_res_pixel_values", "flattened_patches",
     ))
 
     def _dataset_is_pretokenized(dataset):
@@ -770,7 +774,13 @@ def train_on_responses_only(
             # never rebuilds labels from images. Discriminate on the data: rows
             # that already hold `input_ids` were tokenized up front, so the text
             # path below is correct.
-            if not _dataset_is_pretokenized(getattr(trainer, "train_dataset", None)):
+            # Every split that will be collated, not just train: the collator is
+            # swapped for the whole trainer below, so a multimodal eval set would
+            # lose its image handling on a train-only check.
+            _splits = [getattr(trainer, "train_dataset", None)]
+            _eval = getattr(trainer, "eval_dataset", None)
+            _splits += list(_eval.values()) if isinstance(_eval, dict) else [_eval]
+            if not all(_dataset_is_pretokenized(d) for d in _splits if d is not None):
                 # A processor-style collator we cannot reliably configure: do not return as
                 # if masking were applied (it would leave responses unmasked silently).
                 raise ValueError(
@@ -850,16 +860,25 @@ def train_on_responses_only(
     # dies on the first batch. Rebuild that one around the unwrapped text
     # tokenizer too; gate on the capability rather than the processor type, so
     # this stays right if transformers ever gives ProcessorMixin a .pad.
-    _rebuild = (
-        not isinstance(_collator, DataCollatorForSeq2Seq)
-        or not hasattr(getattr(_collator, "tokenizer", None), "pad")
+    _processor_backed = (
+        isinstance(_collator, DataCollatorForSeq2Seq)
+        and not hasattr(getattr(_collator, "tokenizer", None), "pad")
     )
-    if (
-        hasattr(trainer, "data_collator")
-        and _rebuild
-        and not packing_enabled
+    # A processor-backed collator raises on its first batch whatever packing
+    # says, so that repair is not gated on packing the way the swap is.
+    if hasattr(trainer, "data_collator") and (
+        _processor_backed or (not isinstance(_collator, DataCollatorForSeq2Seq)
+                              and not packing_enabled)
     ):
-        trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer)
+        # Carry the settings across when we are only swapping the tokenizer,
+        # so a caller's pad_to_multiple_of or label_pad_token_id survives.
+        _kept = {
+            name: getattr(_collator, name)
+            for name in ("model", "padding", "max_length", "pad_to_multiple_of",
+                         "label_pad_token_id", "return_tensors")
+            if _processor_backed and hasattr(_collator, name)
+        }
+        trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer, **_kept)
 
     # Check if all labels randomnly got masked to nothing - maybe wrong chat template?
     from .training_utils import fix_zero_training_loss

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -606,12 +606,10 @@ def train_on_responses_only(
         sample = next(iter(dataset), None)
         if sample is None or "input_ids" in sample:
             return dataset  # Empty, or already tokenized
-        _tokenizer = trainer.processing_class if hasattr(trainer, "processing_class") else trainer.tokenizer
-        # Use the actual tokenizer, not the processor
-        if hasattr(_tokenizer, "tokenizer"):
-            _tok = _tokenizer.tokenizer
-        else:
-            _tok = _tokenizer
+        # The already-unwrapped text tokenizer, and the `tokenizer =` override
+        # when the caller gave one: the response markers were tokenized with it,
+        # so encoding here with anything else yields IDs they can never match.
+        _tok = tokenizer
         max_length = getattr(trainer.args, "max_length", None) or getattr(trainer.args, "max_seq_length", 2048)
         text_field = getattr(trainer.args, "dataset_text_field", "text")
         def _tokenize_fn(examples):
@@ -621,10 +619,12 @@ def train_on_responses_only(
         if isinstance(dataset, IterableDataset):
             _map_kwargs = {"batched": True}
         # Drop the raw columns we just tokenized. Keeping them would hand the
-        # collator a string column it cannot stack into a tensor.
+        # collator a string column it cannot stack into a tensor. `labels` is the
+        # one exception: it is already token-level, and the masking pass below
+        # intersects with it, so removing it would un-mask what the caller masked.
         _raw_columns = getattr(dataset, "column_names", None) or list(sample.keys())
         if not isinstance(_raw_columns, dict):
-            _map_kwargs["remove_columns"] = list(_raw_columns)
+            _map_kwargs["remove_columns"] = [c for c in _raw_columns if c != "labels"]
         import warnings as _w
         with _w.catch_warnings():
             _w.filterwarnings("ignore", message=".*couldn't be hashed properly.*")
@@ -873,11 +873,17 @@ def train_on_responses_only(
         "file_path", "filepath", "file_name", "filename", "media", "source_url",
     ))
 
+    # Every suffix a missing entry costs is a VLM row silently trained as text,
+    # so cover the modern web formats too (`.avif` is what most image CDNs serve
+    # now) and the older spellings of the ones already here.
     _MEDIA_SUFFIXES = (
-        ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".tif", ".tiff",
-        ".svg", ".heic", ".heif", ".ppm", ".pgm",
+        ".jpg", ".jpeg", ".jpe", ".jfif", ".png", ".apng", ".gif", ".bmp", ".dib",
+        ".webp", ".avif", ".tif", ".tiff", ".svg", ".heic", ".heif", ".heics",
+        ".jp2", ".j2k", ".jxl", ".ppm", ".pgm", ".pnm", ".pbm",
         ".mp4", ".mov", ".avi", ".mkv", ".webm", ".mpg", ".mpeg", ".m4v",
+        ".ogv", ".3gp", ".3g2", ".wmv", ".flv", ".m2ts", ".mts",
         ".wav", ".mp3", ".flac", ".ogg", ".oga", ".m4a", ".aac", ".opus",
+        ".wma", ".aiff", ".aif", ".aifc", ".amr", ".mka", ".weba",
     )
 
     def _looks_like_media_value(value, _depth = 0):
@@ -928,6 +934,20 @@ def train_on_responses_only(
             return None
     pass
 
+    def _column_holds_strings(split, name):
+        """Whether the schema says this column's values are strings."""
+        features = getattr(split, "features", None)
+        if not features: return False
+        try:
+            return _feature_holds_strings(features.get(name))
+        except Exception:
+            return False
+    pass
+
+    # Ambiguous string columns that could not be read past the sample. Named in
+    # the refusal below, since dropping the column is the fix when it is text.
+    _unscannable_media_columns = set()
+
     def _ambiguous_column_holds_media(split, name, rows):
         """Whether an ambiguous column points at media, over EVERY row when the
         split can be scanned: the 16-row sample misses a `cat.jpg` on row 5, and
@@ -935,16 +955,23 @@ def train_on_responses_only(
         Reading one string column is cheap - no image is ever decoded.
         """
         batches = _string_column_batches(split, name)
-        # Streaming, or a column a custom transform owns: the bounded sample is
-        # all that can be read without consuming/rewriting the split.
         if batches is None:
-            return any(_looks_like_media_value(row.get(name)) for row in rows)
+            # Not strings, so the name alone cannot make the column media.
+            if not _column_holds_strings(split, name):
+                return any(_looks_like_media_value(row.get(name)) for row in rows)
+            # Strings this split will not hand over in full (streaming, or a
+            # column a custom transform owns). The sample cannot speak for the
+            # rows it never reads, and guessing "text" drops a media column
+            # silently, so refuse instead.
+            _unscannable_media_columns.add(name)
+            return True
         try:
             for batch in batches:
                 if any(_looks_like_media_value(v) for v in batch[name]): return True
             return False
         except Exception:
-            return any(_looks_like_media_value(row.get(name)) for row in rows)
+            _unscannable_media_columns.add(name)
+            return True
     pass
 
     def _column_is_all_strings(split, name):
@@ -1170,10 +1197,19 @@ def train_on_responses_only(
             ):
                 # Cannot configure this collator, so refuse rather than silently
                 # return with responses left unmasked.
+                _hint = ""
+                if _unscannable_media_columns:
+                    _hint = (
+                        f" Column(s) {sorted(_unscannable_media_columns)} may point at "
+                        "images/videos/audio and this split cannot be read past its first "
+                        "rows to tell, so they are assumed to be media - drop them with "
+                        "`dataset.remove_columns([...])` if they are ordinary text."
+                    )
                 raise ValueError(
                     "Unsloth: Detected a vision data collator that does not support response-only "
                     "masking. Build UnslothVisionDataCollator(..., train_on_responses_only = True, "
                     "instruction_part = ..., response_part = ...) so masking runs at collate time."
+                    + _hint
                 )
             # Fall through to the dataset-level text path below.
             _bypassed_vision_collator = True
@@ -1240,7 +1276,7 @@ def train_on_responses_only(
 
     # Edit data collator to DataCollatorForSeq2Seq. Collators that rebuild labels
     # from a processor already returned above, so what is left here only pads.
-    from transformers import DataCollatorForSeq2Seq
+    from transformers import DataCollatorForSeq2Seq, DataCollatorWithPadding
     packing_enabled = getattr(trainer.args, "packing", False)
     _collator = getattr(trainer, "data_collator", None)
     # A collator holding a processor (DataCollatorForSeq2Seq/WithPadding, TRL's
@@ -1265,11 +1301,19 @@ def train_on_responses_only(
         # collator; for any other class this is a replacement, not a swap, and its
         # same-named attributes need not mean the same thing.
         _same_class = _processor_backed and isinstance(_collator, DataCollatorForSeq2Seq)
+        # DataCollatorWithPadding hands these four to `tokenizer.pad` exactly as
+        # DataCollatorForSeq2Seq does, so a repair that dropped them would turn a
+        # `padding = "max_length"` run into a dynamically padded one, silently
+        # reshaping every batch.
+        _padding_class = _processor_backed and not _same_class and \
+            isinstance(_collator, DataCollatorWithPadding)
+        _names = ("model", "padding", "max_length", "pad_to_multiple_of",
+                  "label_pad_token_id", "return_tensors") if _same_class else \
+                 ("padding", "max_length", "pad_to_multiple_of", "return_tensors")
         _kept = {
             name: getattr(_collator, name)
-            for name in ("model", "padding", "max_length", "pad_to_multiple_of",
-                         "label_pad_token_id", "return_tensors")
-            if _same_class and hasattr(_collator, name)
+            for name in _names
+            if (_same_class or _padding_class) and hasattr(_collator, name)
         }
         trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer, **_kept)
 

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -409,6 +409,11 @@ def _keep_media_columns(trainer, keys):
             # `index`/`label`/`label_ids` are what HF always keeps; without them
             # a seeded list would drop the columns the loss itself needs.
             declared = _model_forward_parameter_names(getattr(trainer, "model", None))
+            # Trainer's own derivation does `+= list(set(["label", "label_ids"]
+            # + self.label_names))`, so a custom trainer whose supervision is
+            # consumed by `compute_loss` rather than declared by `forward` had
+            # it dropped here and on every later split.
+            declared |= set(getattr(getattr(trainer, "args", None), "label_names", None) or ())
             trainer._signature_columns = sorted(set(names) | declared | {
                 "label", "label_ids", "index", "input_ids", "attention_mask",
                 "labels", "completion_mask", "assistant_masks", "token_type_ids",
@@ -418,6 +423,48 @@ def _keep_media_columns(trainer, keys):
                 n for n in names if n not in existing]
     except Exception:
         pass
+
+
+# Every suffix a missing entry costs is a VLM row silently trained as text,
+# so cover the modern web formats too (`.avif` is what most image CDNs serve
+# now) and the older spellings of the ones already here.
+_MEDIA_SUFFIXES = (
+    ".jpg", ".jpeg", ".jpe", ".jfif", ".png", ".apng", ".gif", ".bmp", ".dib",
+    ".webp", ".avif", ".tif", ".tiff", ".svg", ".heic", ".heif", ".heics",
+    ".jp2", ".j2k", ".jxl", ".ppm", ".pgm", ".pnm", ".pbm",
+    ".mp4", ".mov", ".avi", ".mkv", ".webm", ".mpg", ".mpeg", ".m4v",
+    ".ogv", ".3gp", ".3g2", ".wmv", ".flv", ".m2ts", ".mts",
+    ".wav", ".mp3", ".flac", ".ogg", ".oga", ".m4a", ".aac", ".opus",
+    ".wma", ".aiff", ".aif", ".aifc", ".amr", ".mka", ".weba",
+)
+
+def _looks_like_media_value(value, _depth = 0):
+    """A string naming an image/video/audio file, by extension or data URI.
+
+    A plural ambiguous column (`urls`, `paths`, `files`) holds a *list* of
+    those strings per row, so recurse rather than call the row safe.
+    """
+    if isinstance(value, (list, tuple)):
+        return _depth < 4 and \
+            any(_looks_like_media_value(v, _depth + 1) for v in value)
+    if not isinstance(value, str): return False
+    text = value.strip().lower()
+    if text.startswith(("data:image/", "data:video/", "data:audio/")): return True
+    # Drop a query string/fragment: `.../cat.jpg?width=64`.
+    for sep in ("?", "#"):
+        text = text.split(sep, 1)[0]
+    return text.endswith(_MEDIA_SUFFIXES)
+
+
+# The prose that goes WITH the media. Tokenizer outputs live in `_TEXT_COLUMNS`;
+# these are the raw columns a vision collator still has to read, and a keep-list
+# that held the image but not its prompt left that collator nothing to tokenize.
+_RAW_TEXT_COMPANION_COLUMNS = frozenset((
+    "text", "texts", "prompt", "prompts", "question", "questions",
+    "caption", "captions", "instruction", "instructions", "input", "inputs",
+    "query", "queries", "answer", "answers", "output", "outputs",
+    "completion", "completions", "response", "responses", "content",
+))
 
 
 class _MediaAwareCollator:
@@ -433,10 +480,13 @@ class _MediaAwareCollator:
     Module level so a DataLoader worker under `spawn` can pickle it, which a
     closure or a `type()`-built class cannot.
     """
-    def __init__(self, text, media, media_keys):
+    def __init__(self, text, media, media_keys, ambiguous_keys = ()):
         self.text = text
         self.media = media
-        self.media_keys = frozenset(media_keys)
+        # Split, not merged: an ambiguous name is decided by its value below,
+        # and folding the two would match `url` on the name alone.
+        self.ambiguous_keys = frozenset(ambiguous_keys)
+        self.media_keys = frozenset(media_keys) - self.ambiguous_keys
 
     # Raw conversational columns. Their images sit INSIDE the value, as
     # `{"type": "image", ...}` parts, so no top-level key names them and a batch
@@ -453,6 +503,13 @@ class _MediaAwareCollator:
             for k in keys:
                 if not isinstance(k, str): continue
                 lowered = k.lower()
+                # An ambiguous name is weighed by its VALUE, the same trade the
+                # initial-split guard makes: `path`/`url` is a media reference
+                # or ordinary provenance, and matching the name alone would send
+                # every row carrying a plain URL to the vision collator.
+                if lowered in self.ambiguous_keys:
+                    if _looks_like_media_value(feature.get(k)): return True
+                    continue
                 if lowered in self.media_keys: return True
                 if lowered in self._CONVERSATION_KEYS and \
                     isinstance(feature.get(k), (list, tuple)): return True
@@ -1072,36 +1129,6 @@ def train_on_responses_only(
     # value: `{"type": "image", "content": "cat.jpg"}` is all `string`.
     _VALUE_SCAN_KEYS = _AMBIGUOUS_MEDIA_KEYS | frozenset(("type",))
 
-    # Every suffix a missing entry costs is a VLM row silently trained as text,
-    # so cover the modern web formats too (`.avif` is what most image CDNs serve
-    # now) and the older spellings of the ones already here.
-    _MEDIA_SUFFIXES = (
-        ".jpg", ".jpeg", ".jpe", ".jfif", ".png", ".apng", ".gif", ".bmp", ".dib",
-        ".webp", ".avif", ".tif", ".tiff", ".svg", ".heic", ".heif", ".heics",
-        ".jp2", ".j2k", ".jxl", ".ppm", ".pgm", ".pnm", ".pbm",
-        ".mp4", ".mov", ".avi", ".mkv", ".webm", ".mpg", ".mpeg", ".m4v",
-        ".ogv", ".3gp", ".3g2", ".wmv", ".flv", ".m2ts", ".mts",
-        ".wav", ".mp3", ".flac", ".ogg", ".oga", ".m4a", ".aac", ".opus",
-        ".wma", ".aiff", ".aif", ".aifc", ".amr", ".mka", ".weba",
-    )
-
-    def _looks_like_media_value(value, _depth = 0):
-        """A string naming an image/video/audio file, by extension or data URI.
-
-        A plural ambiguous column (`urls`, `paths`, `files`) holds a *list* of
-        those strings per row, so recurse rather than call the row safe.
-        """
-        if isinstance(value, (list, tuple)):
-            return _depth < 4 and \
-                any(_looks_like_media_value(v, _depth + 1) for v in value)
-        if not isinstance(value, str): return False
-        text = value.strip().lower()
-        if text.startswith(("data:image/", "data:video/", "data:audio/")): return True
-        # Drop a query string/fragment: `.../cat.jpg?width=64`.
-        for sep in ("?", "#"):
-            text = text.split(sep, 1)[0]
-        return text.endswith(_MEDIA_SUFFIXES)
-    pass
 
     def _feature_holds_strings(feature, _depth = 0):
         """True when this column's values are strings, or lists of them."""
@@ -1216,8 +1243,10 @@ def train_on_responses_only(
         # http URL there is nothing to weigh: it is an image/video/audio payload
         # wherever it turns up, including a column no name list covers.
         if isinstance(value, str):
-            return not value[:32].lower().startswith(
-                ("data:image/", "data:video/", "data:audio/"))
+            # Suffix as well as data URI: `attachments = ["cat.jpg"]` is a media
+            # reference the text path cannot encode, and a scan that only weighed
+            # `data:` called the column proven and dropped it.
+            return not _looks_like_media_value(value)
         if value is None: return True
         if isinstance(value, (bool, int, float)): return True
         if _depth >= 6: return False
@@ -1382,9 +1411,19 @@ def train_on_responses_only(
         return dtype.startswith(_PLAIN_DTYPES)
     pass
 
-    def _feature_is_bare_string(feature):
-        """A top-level `Value("string")`/`large_string`, nothing nested."""
-        if getattr(feature, "feature", None) is not None: return False
+    def _feature_is_bare_string(feature, _depth = 0):
+        """A `Value("string")`/`large_string`, bare or in a list of them.
+
+        `Sequence(Value("string"))` too: `attachments = ["cat.jpg"]` advertises
+        nothing in its dtype, so declaring it proven text skipped the value scan
+        and the column was dropped, training silently without the media.
+        """
+        inner = getattr(feature, "feature", None)
+        if inner is not None:
+            return _depth < 3 and _feature_is_bare_string(inner, _depth + 1)
+        if isinstance(feature, (list, tuple)):
+            return (_depth < 3 and len(feature) == 1
+                    and _feature_is_bare_string(feature[0], _depth + 1))
         dtype = getattr(feature, "dtype", None)
         return isinstance(dtype, str) and dtype.startswith(("string", "large_string"))
 
@@ -1861,14 +1900,19 @@ def train_on_responses_only(
         # repair exists to remove. The bypass flag is the case where the
         # displaced collator is a working vision collator.
         _media_capable = _bypassed_vision_collator and not _processor_backed
-        _dispatch_keys = _MEDIA_COLUMNS | _MULTIMODAL_COLUMNS
+        # Every media form the initial-split guard recognises, not just the two
+        # sets: a later split storing `image_base64`, a `speech` waveform or an
+        # ambiguous `path` matched nothing and went to the text collator.
+        _dispatch_keys = (_MEDIA_COLUMNS | _MULTIMODAL_COLUMNS
+                          | _BASE64_MEDIA_COLUMNS | _AMBIGUOUS_MEDIA_COLUMNS
+                          | _RAW_SAMPLE_COLUMNS)
         trainer.data_collator = _MediaAwareCollator(
             # Both sets. `_MEDIA_COLUMNS` names what a user hands in, and a split
             # that has already been through the processor carries `pixel_values`
             # / `image_grid_thw` / `input_features` instead: those live only in
             # `_MULTIMODAL_COLUMNS`, so a processed `predict` batch matched
             # nothing and went to the text collator that cannot tensorize it.
-            _text_collator, _collator, _dispatch_keys,
+            _text_collator, _collator, _dispatch_keys, _AMBIGUOUS_MEDIA_COLUMNS,
         ) if _media_capable else _text_collator
         if _media_capable:
             # And the keys have to survive `remove_unused_columns`, which is on
@@ -1883,7 +1927,16 @@ def train_on_responses_only(
             # without them the conversation was stripped before the dispatcher
             # ever saw it and the batch went to the text collator.
             _keep_media_columns(
-                trainer, _dispatch_keys | _MediaAwareCollator._CONVERSATION_KEYS)
+                trainer,
+                _dispatch_keys
+                | _MediaAwareCollator._CONVERSATION_KEYS
+                # The prompt that goes WITH the media: a raw `{"text": ...,
+                # "image": ...}` row reached the vision collator with its text
+                # already stripped, so it had nothing to tokenize.
+                | _RAW_TEXT_COMPANION_COLUMNS
+                | {getattr(getattr(trainer, "args", None),
+                           "dataset_text_field", None) or "text"},
+            )
 
         # `tokenizer.pad(..., return_tensors = "pt")` stacks every key it is
         # handed, and only pads the few it knows, so any leftover column kills

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -880,8 +880,15 @@ def train_on_responses_only(
         ".wav", ".mp3", ".flac", ".ogg", ".oga", ".m4a", ".aac", ".opus",
     )
 
-    def _looks_like_media_value(value):
-        """A string naming an image/video/audio file, by extension or data URI."""
+    def _looks_like_media_value(value, _depth = 0):
+        """A string naming an image/video/audio file, by extension or data URI.
+
+        A plural ambiguous column (`urls`, `paths`, `files`) holds a *list* of
+        those strings per row, so recurse rather than call the row safe.
+        """
+        if isinstance(value, (list, tuple)):
+            return _depth < 4 and \
+                any(_looks_like_media_value(v, _depth + 1) for v in value)
         if not isinstance(value, str): return False
         text = value.strip().lower()
         if text.startswith(("data:image/", "data:video/", "data:audio/")): return True
@@ -891,22 +898,70 @@ def train_on_responses_only(
         return text.endswith(_MEDIA_SUFFIXES)
     pass
 
+    def _feature_holds_strings(feature, _depth = 0):
+        """True when this column's values are strings, or lists of them."""
+        if feature is None or _depth >= 8: return False
+        if isinstance(feature, (list, tuple)):
+            return bool(feature) and \
+                all(_feature_holds_strings(f, _depth + 1) for f in feature)
+        inner = getattr(feature, "feature", None)        # Sequence/List/LargeList
+        if inner is not None: return _feature_holds_strings(inner, _depth + 1)
+        dtype = getattr(feature, "dtype", None)          # Value/ClassLabel
+        return isinstance(dtype, str) and dtype.endswith("string")
+    pass
+
+    def _string_column_batches(split, name):
+        """The whole column in batches, or None when it must not be scanned.
+
+        Reading a `datasets.Image`/audio column decodes every row (minutes and
+        gigabytes on a real VLM set) to learn what its dtype already says, and
+        `_columns_are_provably_text` refuses such a column anyway, so only ever
+        scan a column the schema calls a string.
+        """
+        features = getattr(split, "features", None)
+        if not features: return None                     # an unresolved stream
+        try:
+            if not _feature_holds_strings(features.get(name)): return None
+            len(split)                                   # map-style only
+            return split.select_columns([name]).iter(batch_size = 1000)
+        except Exception:
+            return None
+    pass
+
     def _ambiguous_column_holds_media(split, name, rows):
         """Whether an ambiguous column points at media, over EVERY row when the
-        split can be indexed: the 16-row sample misses a `cat.jpg` on row 5, and
+        split can be scanned: the 16-row sample misses a `cat.jpg` on row 5, and
         its dtype is `string` either way, so the schema cannot answer for it.
         Reading one string column is cheap - no image is ever decoded.
         """
+        batches = _string_column_batches(split, name)
+        # Streaming, or a column a custom transform owns: the bounded sample is
+        # all that can be read without consuming/rewriting the split.
+        if batches is None:
+            return any(_looks_like_media_value(row.get(name)) for row in rows)
         try:
-            len(split)                                  # map-style only
-            batches = split.select_columns([name]).iter(batch_size = 1000)
             for batch in batches:
                 if any(_looks_like_media_value(v) for v in batch[name]): return True
             return False
         except Exception:
-            # Streaming, or a column a custom transform owns: the bounded sample
-            # is all that can be read without consuming/rewriting the split.
             return any(_looks_like_media_value(row.get(name)) for row in rows)
+    pass
+
+    def _column_is_all_strings(split, name):
+        """Whether EVERY row of a text column really holds a string.
+
+        `Value('string')` is nullable, so a `None` past the sample keeps the
+        dtype and would reach the plain tokenizer, crashing the run mid-`map`
+        instead of being refused here.
+        """
+        batches = _string_column_batches(split, name)
+        if batches is None: return True                  # the sample decided
+        try:
+            for batch in batches:
+                if not all(isinstance(v, str) for v in batch[name]): return False
+            return True
+        except Exception:
+            return True
     pass
 
     def _has_media_column(names, rows, split = None):
@@ -1086,6 +1141,8 @@ def train_on_responses_only(
             for row in rows:
                 if not isinstance(row.get(field), str): return False
                 if not _row_is_plain_text(row): return False
+            # The sample says these rows are text; the tokenizer reads every row.
+            if not _column_is_all_strings(split, field): return False
         return True
     pass
 

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -713,8 +713,7 @@ def train_on_responses_only(
         return hasattr(collator, "image_processor")
     pass
 
-    # What a processor emits beside `input_ids`. A row carrying any of these
-    # still needs the collator that knows how to batch it.
+    # Processor outputs beside `input_ids`; a row with any of these needs its collator.
     _MULTIMODAL_COLUMNS = frozenset((
         "pixel_values", "pixel_values_videos", "pixel_attention_mask",
         "image_grid_thw", "video_grid_thw", "image_sizes", "image_sizes_videos",
@@ -722,23 +721,16 @@ def train_on_responses_only(
         "token_type_ids_images", "input_features", "input_features_mask",
         "audio_values", "audio_attention_mask", "input_audio_embeds",
         "aspect_ratio_ids", "aspect_ratio_mask", "cross_attention_mask",
-        # Processor-specific spellings: phi4_multimodal, then pix2struct and
-        # kosmos-2.5, which emit flattened_patches with nothing else alongside.
+        # Processor-specific spellings: phi4_multimodal, pix2struct, kosmos-2.5.
         "image_pixel_values", "audio_input_features", "audio_embed_sizes",
         "high_res_pixel_values", "flattened_patches",
     ))
 
     def _dataset_is_pretokenized(dataset):
-        """True when rows carry `input_ids` and nothing else to collate.
-
-        Separates "the collator rebuilds labels from a processor at collate time"
-        from "text was tokenized up front and the collator only pads", where
-        dataset-level masking is correct. Anything unreadable returns False, so
-        the caller keeps the old strict behaviour.
-
-        Rows that also carry image/video/audio columns are NOT that case: the
-        text path below swaps the collator for a text one, which would throw
-        away the user's image handling, so those keep the old refusal.
+        """True when rows carry `input_ids` and no image/video/audio column, i.e.
+        text tokenized up front where dataset-level masking is correct. Multimodal
+        or unreadable rows return False, keeping the caller's old refusal (the text
+        path swaps in a text collator and would drop the image handling).
         """
         if dataset is None:
             return False
@@ -753,7 +745,7 @@ def train_on_responses_only(
                 names = [c for v in names.values() for c in (v or [])]
             if names:
                 return _text_only(names)
-            # IterableDataset and friends expose no column_names; peek one row.
+            # No column_names (IterableDataset and friends): peek one row.
             for row in dataset:
                 return isinstance(row, dict) and _text_only(row.keys())
         except Exception:
@@ -764,19 +756,11 @@ def train_on_responses_only(
     def _eval_split_is_raw_text_only(dataset):
         """True when an eval split carries no `input_ids` but a text column.
 
-        Only ever asked about eval splits. The TRAIN split is the evidence that
-        the run is text-only at all, so it still has to be pretokenized; once it
-        is, the collator is already going to be replaced by a text one, and
-        `_maybe_tokenize_dataset` below tokenizes a raw eval split with the same
-        unwrapped text tokenizer, after which the dataset-level masking lands on
-        it exactly as it does on a pretokenized one. Refusing it would only force
-        users to pretokenize eval by hand to be able to evaluate at all.
-
-        Deliberately narrow: a split carrying neither `input_ids` nor a text
-        column stays refused, because there would be nothing for the text path to
-        tokenize. That is what keeps a conversational multimodal split (columns
-        like `messages` alone, images inline in the turns) on the old refusal
-        instead of being silently emptied.
+        Eval only: train must still be pretokenized, since that is the evidence
+        the run is text-only, and `_maybe_tokenize_dataset` below tokenizes a raw
+        eval split with the same text tokenizer. A split with neither `input_ids`
+        nor a text column stays refused, which keeps conversational multimodal
+        splits (`messages` alone, images inline) on the old refusal.
         """
         if dataset is None:
             return False
@@ -794,7 +778,7 @@ def train_on_responses_only(
                 names = [c for v in names.values() for c in (v or [])]
             if names:
                 return _raw_text(names)
-            # IterableDataset and friends expose no column_names; peek one row.
+            # No column_names (IterableDataset and friends): peek one row.
             for row in dataset:
                 return isinstance(row, dict) and _raw_text(row.keys())
         except Exception:
@@ -809,17 +793,11 @@ def train_on_responses_only(
             return trainer  # collator already masks responses; nothing to do
         is_unsloth = any(b.__name__ == "UnslothVisionDataCollator" for b in type(data_collator).__mro__)
         if not is_unsloth:
-            # A multimodal model fine-tuned on text only still carries a processor
-            # as its `tokenizer`, so a plain text collator (e.g.
-            # DataCollatorForSeq2Seq) trips `_is_vision_collator` even though it
-            # never rebuilds labels from images. Discriminate on the data: rows
-            # that already hold `input_ids` were tokenized up front, so the text
-            # path below is correct.
-            # Every split that will be collated, not just train: the collator is
-            # swapped for the whole trainer below, so a multimodal eval set would
-            # lose its image handling on a train-only check. Eval splits may also
-            # be raw text, which the text path tokenizes itself; train may not,
-            # since it is what tells us the run is text-only in the first place.
+            # A text-only run on a multimodal model still carries a processor as its
+            # `tokenizer`, so a plain text collator trips `_is_vision_collator`.
+            # Discriminate on the data instead, over every split that gets collated:
+            # the swap below is trainer-wide, so a train-only check would strip a
+            # multimodal eval set of its image handling.
             _eval = getattr(trainer, "eval_dataset", None)
             _eval_splits = list(_eval.values()) if isinstance(_eval, dict) else [_eval]
             _train = getattr(trainer, "train_dataset", None)
@@ -828,23 +806,22 @@ def train_on_responses_only(
                 and all(_dataset_is_pretokenized(d) or _eval_split_is_raw_text_only(d)
                         for d in _eval_splits if d is not None)
             ):
-                # A processor-style collator we cannot reliably configure: do not return as
-                # if masking were applied (it would leave responses unmasked silently).
+                # Cannot configure this collator, so refuse rather than silently
+                # return with responses left unmasked.
                 raise ValueError(
                     "Unsloth: Detected a vision data collator that does not support response-only "
                     "masking. Build UnslothVisionDataCollator(..., train_on_responses_only = True, "
                     "instruction_part = ..., response_part = ...) so masking runs at collate time."
                 )
-            # Fall through to the dataset-level text path below; configuring a
-            # collator we do not own would silently do nothing.
+            # Fall through to the dataset-level text path below.
             print(
                 f"Unsloth: `{type(data_collator).__name__}` holds a processor but the "
                 "dataset is already tokenized, so response-only masking is applied at "
                 "the dataset level (image handling is untouched)."
             )
         else:
-            # If the collator's tokenizer already carries the parts, let the nested call
-            # read them; passing them explicitly would hit the "already set" guard.
+            # Parts already on the collator's tokenizer: let the nested call read
+            # them, since passing them again hits the "already set" guard.
             coll_proc = getattr(data_collator, "processor", tokenizer)
             coll_tok = coll_proc.tokenizer if hasattr(coll_proc, "tokenizer") else coll_proc
             parts = {} if hasattr(coll_tok, "_unsloth_input_part") else \
@@ -897,36 +874,28 @@ def train_on_responses_only(
     pass
 
     # Edit data collator to DataCollatorForSeq2Seq. Collators that rebuild labels
-    # from a processor were handled earlier and returned, so what is left here
-    # only pads already-tokenized text.
+    # from a processor already returned above, so what is left here only pads.
     from transformers import DataCollatorForSeq2Seq
     packing_enabled = getattr(trainer.args, "packing", False)
     _collator = getattr(trainer, "data_collator", None)
-    # DataCollatorForSeq2Seq(tokenizer = <VLM processor>) pads through
-    # self.tokenizer.pad / .padding_side, which processors do not have, so it
-    # dies on the first batch. Rebuild that one around the unwrapped text
-    # tokenizer too; gate on the capability rather than the processor type, so
-    # this stays right if transformers ever gives ProcessorMixin a .pad.
-    # Not only the seq2seq one: DataCollatorWithPadding(tokenizer = processor)
-    # and TRL's DataCollatorForVisionLanguageModeling(processor) pad through the
-    # same missing `.pad` and die the same way. Key on a HELD padding object that
-    # cannot pad, so a collator that holds none at all is untouched - that is what
-    # keeps TRL's packing `DataCollatorForLanguageModeling`, which takes a bare
-    # `pad_token_id` and builds the packed position_ids itself, off this path.
+    # A collator holding a processor (DataCollatorForSeq2Seq/WithPadding, TRL's
+    # DataCollatorForVisionLanguageModeling) pads through a `.pad` processors do
+    # not have, so it dies on the first batch; rebuild it around the unwrapped
+    # text tokenizer. Key on a held padding object that cannot pad rather than on
+    # the type, so a collator holding none stays untouched (TRL's packing
+    # DataCollatorForLanguageModeling takes a bare pad_token_id).
     _pad_source = getattr(_collator, "tokenizer", None)
     if _pad_source is None:
         _pad_source = getattr(_collator, "processor", None)
     _processor_backed = _pad_source is not None and not hasattr(_pad_source, "pad")
-    # A processor-backed collator raises on its first batch whatever packing
-    # says, so that repair is not gated on packing the way the swap is.
+    # That repair is not packing-gated like the swap: it fails either way.
     if hasattr(trainer, "data_collator") and (
         _processor_backed or (not isinstance(_collator, DataCollatorForSeq2Seq)
                               and not packing_enabled)
     ):
-        # Carry the settings across when we are only swapping the tokenizer,
-        # so a caller's pad_to_multiple_of or label_pad_token_id survives. Only
-        # for a seq2seq collator: for any other class this is a replacement, not
-        # a tokenizer swap, and its same-named attributes need not mean the same.
+        # Keep the caller's settings when only swapping the tokenizer on a seq2seq
+        # collator; for any other class this is a replacement, not a swap, and its
+        # same-named attributes need not mean the same thing.
         _same_class = _processor_backed and isinstance(_collator, DataCollatorForSeq2Seq)
         _kept = {
             name: getattr(_collator, name)

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -848,6 +848,57 @@ def train_on_responses_only(
         "bytes", "path", "url",
     ))
 
+    # Top-level column names that only ever point at media. A pretokenized VLM
+    # set often keeps its media as a plain URL/path string beside `input_ids`,
+    # and a string value alone looks like text, so the name has to say so.
+    _MEDIA_COLUMNS = frozenset((
+        "image_url", "image_urls", "img_url", "img_urls", "image_link",
+        "video_url", "video_urls", "audio_url", "audio_urls",
+        "input_image", "input_images", "input_video", "input_videos",
+        "input_audio", "input_audios",
+        "image_path", "image_paths", "img_path", "img_paths",
+        "video_path", "video_paths", "audio_path", "audio_paths",
+        "image_file", "image_files", "video_file", "video_files",
+        "audio_file", "audio_files", "image_filename", "image_bytes",
+    ))
+
+    # Names that are media half the time and an ordinary text field the other
+    # half (`path` is a source file, `url` a citation), so refusing on the name
+    # would refuse good text runs. Ask the value instead.
+    _AMBIGUOUS_MEDIA_COLUMNS = frozenset((
+        "path", "paths", "url", "urls", "uri", "file", "files",
+        "file_path", "filepath", "file_name", "filename", "media", "source_url",
+    ))
+
+    _MEDIA_SUFFIXES = (
+        ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".tif", ".tiff",
+        ".svg", ".heic", ".heif", ".ppm", ".pgm",
+        ".mp4", ".mov", ".avi", ".mkv", ".webm", ".mpg", ".mpeg", ".m4v",
+        ".wav", ".mp3", ".flac", ".ogg", ".oga", ".m4a", ".aac", ".opus",
+    )
+
+    def _looks_like_media_value(value):
+        """A string naming an image/video/audio file, by extension or data URI."""
+        if not isinstance(value, str): return False
+        text = value.strip().lower()
+        if text.startswith(("data:image/", "data:video/", "data:audio/")): return True
+        # Drop a query string/fragment: `.../cat.jpg?width=64`.
+        for sep in ("?", "#"):
+            text = text.split(sep, 1)[0]
+        return text.endswith(_MEDIA_SUFFIXES)
+    pass
+
+    def _has_media_column(names, rows):
+        """True when a top-level column points at media the text path would drop."""
+        for name in names:
+            if not isinstance(name, str) or name in _TEXT_COLUMNS: continue
+            lowered = name.lower()
+            if lowered in _MEDIA_COLUMNS: return True
+            if lowered in _AMBIGUOUS_MEDIA_COLUMNS and \
+                any(_looks_like_media_value(row.get(name)) for row in rows): return True
+        return False
+    pass
+
     def _is_plain_text(value, _depth = 0):
         """True only for text/scalars and nests of them.
 
@@ -979,6 +1030,7 @@ def train_on_responses_only(
         for names, rows, provable in views:
             if "input_ids" not in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
+            if _has_media_column(names, rows): return False
             # Columns look text-only, so check the values too: a `messages` column
             # can carry inline images that the strip below would throw away.
             if not provable: return False
@@ -1007,6 +1059,7 @@ def train_on_responses_only(
         for names, rows, provable in views:
             if "input_ids" in names: return False
             if not names.isdisjoint(_MULTIMODAL_COLUMNS): return False
+            if _has_media_column(names, rows): return False
             # The column `_maybe_tokenize_dataset` would actually read.
             field = text_field if text_field in names else "text"
             if field not in names: return False

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -390,6 +390,30 @@ def _model_forward_parameter_names(model):
     return names
 
 
+def _keep_media_columns(trainer, keys):
+    """Stop `remove_unused_columns` stripping media before the collator sees it.
+
+    `_signature_columns` is cached lazily off the model's forward signature, so
+    seeding it here is what a later split reads; the trainer only fills it when
+    still None, and extending an existing list is additive.
+    """
+    try:
+        existing = getattr(trainer, "_signature_columns", None)
+        names = sorted(k for k in keys if isinstance(k, str))
+        if existing is None:
+            # `index`/`label`/`label_ids` are what HF always keeps; without them
+            # a seeded list would drop the columns the loss itself needs.
+            trainer._signature_columns = names + [
+                "label", "label_ids", "index", "input_ids", "attention_mask",
+                "labels", "completion_mask", "assistant_masks", "token_type_ids",
+            ]
+        else:
+            trainer._signature_columns = list(existing) + [
+                n for n in names if n not in existing]
+    except Exception:
+        pass
+
+
 class _MediaAwareCollator:
     """The text collator, falling back to the caller's own when a batch has media.
 
@@ -408,11 +432,24 @@ class _MediaAwareCollator:
         self.media = media
         self.media_keys = frozenset(media_keys)
 
+    # Raw conversational columns. Their images sit INSIDE the value, as
+    # `{"type": "image", ...}` parts, so no top-level key names them and a batch
+    # of them went to the text collator that cannot read the conversation at all,
+    # let alone its images. Routed to the media collator on the column's
+    # presence: that collator handles this TRL format, and the text one cannot.
+    _CONVERSATION_KEYS = frozenset((
+        "messages", "conversations", "conversation", "chat",
+    ))
+
     def _has_media(self, features):
         for feature in features or ():
             keys = feature.keys() if isinstance(feature, dict) else ()
-            if any(isinstance(k, str) and k.lower() in self.media_keys for k in keys):
-                return True
+            for k in keys:
+                if not isinstance(k, str): continue
+                lowered = k.lower()
+                if lowered in self.media_keys: return True
+                if lowered in self._CONVERSATION_KEYS and \
+                    isinstance(feature.get(k), (list, tuple)): return True
         return False
 
     def __call__(self, features):
@@ -1259,6 +1296,17 @@ def train_on_responses_only(
     # as the 16-bit kind, so width cannot settle it and the name has to: the
     # wide-int allowance below exists for pretokenized token ids, and these are
     # not that.
+    # Columns whose NAME says base64 media, whatever the value looks like. A bare
+    # payload carries no `data:` prefix, so the value check cannot see it, and
+    # base64-decoding to sniff magic bytes is neither cheap nor reliable. The
+    # name is the evidence here, the same trade `_RAW_SAMPLE_COLUMNS` makes for
+    # PCM.
+    _BASE64_MEDIA_COLUMNS = frozenset((
+        "image_base64", "img_base64", "image_b64", "img_b64", "image_data",
+        "audio_base64", "audio_b64", "video_base64", "video_b64",
+        "images_base64", "image_bytes", "audio_bytes", "video_bytes",
+    ))
+
     _RAW_SAMPLE_COLUMNS = frozenset((
         "speech", "speeches", "waveform", "waveforms", "pcm",
         "raw_audio", "raw_speech", "audio_array", "audio_arrays",
@@ -1401,6 +1449,8 @@ def train_on_responses_only(
                     # Name plus shape, because `_feature_is_plain_text` never sees
                     # the column name and int32 PCM is indistinguishable from token
                     # ids by dtype alone.
+                    if str(name).lower() in _BASE64_MEDIA_COLUMNS:
+                        return False, proven
                     if str(name).lower() in _RAW_SAMPLE_COLUMNS and \
                         getattr(feature, "feature", None) is not None and \
                         _leaf_dtype_is_numeric(feature): return False, proven
@@ -1797,14 +1847,30 @@ def train_on_responses_only(
         _text_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer, **_kept)
         # Only when a media-capable collator was displaced. Everywhere else the
         # replacement is the whole point and there is nothing to fall back to.
+        # Only when the displaced collator can actually take a media batch. The
+        # `_processor_backed` repair replaces a collator whose "tokenizer" is a
+        # processor with no `.pad`, and that object is broken for EVERY batch,
+        # not just text: keeping it as the fallback would route a later media
+        # batch straight back into the `processor.pad` AttributeError this
+        # repair exists to remove. The bypass flag is the case where the
+        # displaced collator is a working vision collator.
+        _media_capable = _bypassed_vision_collator and not _processor_backed
+        _dispatch_keys = _MEDIA_COLUMNS | _MULTIMODAL_COLUMNS
         trainer.data_collator = _MediaAwareCollator(
             # Both sets. `_MEDIA_COLUMNS` names what a user hands in, and a split
             # that has already been through the processor carries `pixel_values`
             # / `image_grid_thw` / `input_features` instead: those live only in
             # `_MULTIMODAL_COLUMNS`, so a processed `predict` batch matched
             # nothing and went to the text collator that cannot tensorize it.
-            _text_collator, _collator, _MEDIA_COLUMNS | _MULTIMODAL_COLUMNS,
-        ) if _bypassed_vision_collator else _text_collator
+            _text_collator, _collator, _dispatch_keys,
+        ) if _media_capable else _text_collator
+        if _media_capable:
+            # And the keys have to survive `remove_unused_columns`, which is on
+            # by default. The trainer caches its signature columns from the
+            # model's forward, so a later `evaluate`/`predict` split had its
+            # media stripped BEFORE the collator ever ran and the dispatcher saw
+            # text-only keys: the fallback it advertises could not fire at all.
+            _keep_media_columns(trainer, _dispatch_keys)
 
         # `tokenizer.pad(..., return_tensors = "pt")` stacks every key it is
         # handed, and only pads the few it knows, so any leftover column kills

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -121,6 +121,27 @@ def _eos_id_set(*values):
     return ids
 
 
+def _text_vocab_size(cfg):
+    """Vocab size that bounds the text tokenizer's ids.
+
+    Composite configs size `vocab_size` for something else (Sesame CSM: 2051, the
+    audio codebook, against a 128256-entry text tokenizer), which rejects a valid
+    declared pad. Prefer an explicitly declared text vocab, else `config.vocab_size`
+    as before, so single-vocab models are untouched.
+    """
+    if cfg is None:
+        return None
+    text_cfg = getattr(cfg, "text_config", None)
+    for source, attr in ((text_cfg, "vocab_size"), (cfg, "text_vocab_size")):
+        if source is None:
+            continue
+        value = getattr(source, attr, None)
+        if type(value) is int and value > 0:
+            return value
+    value = getattr(cfg, "vocab_size", None)
+    return value if type(value) is int else None
+
+
 def _classify_bad_pad(inner, vocab_size):
     """Return a reason string if the current pad_token is bad, else None.
 
@@ -296,7 +317,7 @@ def fix_pad_token(
         return result
 
     cfg = model_config if model_config is not None else getattr(model, "config", None)
-    vocab_size = getattr(cfg, "vocab_size", None)
+    vocab_size = _text_vocab_size(cfg)
     if type(vocab_size) is not int:
         # A malformed (e.g. string) vocab_size must not crash a later `id >= vocab_size`
         # comparison; treat it as unknown and skip range checks.

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -125,9 +125,8 @@ def _text_vocab_size(cfg):
     """Vocab size that bounds the text tokenizer's ids.
 
     Composite configs size `vocab_size` for something else (Sesame CSM: 2051, the
-    audio codebook, against a 128256-entry text tokenizer), which rejects a valid
-    declared pad. Prefer an explicitly declared text vocab, else `config.vocab_size`
-    as before, so single-vocab models are untouched.
+    audio codebook, against a 128256-entry text tokenizer), rejecting a valid
+    declared pad. Prefer a declared text vocab, else `config.vocab_size` as before.
     """
     if cfg is None:
         return None

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -260,6 +260,50 @@ del _ROCmTorchaoLoader, _ROCmTorchaoFinder
 del _MetaPathFinder, _Loader, _ModuleSpec, _sys_rocm_stub, _types_rocm_stub
 del _is_windows_rocm
 
+# A torchao built for a newer torch imports symbols straight out of torch
+# (`from torch.nn.functional import ScalingType`). On an older pinned torch the
+# symbol is absent, and the ImportError arrives here naming neither package.
+_TORCHAO_TORCH_SYMBOLS = ("ScalingType", "ScalingGranularity", "Float8Tensor")
+
+
+def _torchao_is_newer_than_torch(message):
+    """Does this ImportError look like torchao reaching into a torch that lacks
+    the symbol?
+
+    Narrow on purpose: the symbol must be one torchao pulls from torch and the
+    failing module must be a torch one, so unrelated errors keep their own text.
+    """
+    try:
+        message = str(message)
+    except Exception:                                    # noqa: BLE001
+        return False
+    if "cannot import name" not in message:
+        return False
+    if "torch" not in message:
+        return False
+    return any(sym in message for sym in _TORCHAO_TORCH_SYMBOLS)
+
+
+def _torchao_torch_mismatch_message(message):
+    """Name both versions, because the raw error names neither."""
+    def _ver(mod):
+        try:
+            import importlib.metadata as _md
+            return _md.version(mod)
+        except Exception:                                # noqa: BLE001
+            return "unknown"
+    torch_v, ao_v = _ver("torch"), _ver("torchao")
+    return (
+        f"***** Unsloth: torchao {ao_v} was built for a newer torch than the "
+        f"torch {torch_v} you have installed, so importing it fails with:\n"
+        f"    {message}\n"
+        f"Install a torchao that matches your torch, e.g.\n"
+        f"    pip install --upgrade --force-reinstall --no-cache-dir "
+        f"\"torchao<0.18\"\n"
+        f"or upgrade torch instead. Then restart your runtime/kernel. *****"
+    )
+
+
 try:
     from transformers.processing_utils import Unpack
     assert \
@@ -280,6 +324,8 @@ except ImportError as e:
             f"***** Your Pillow (PIL) version is incompatible with torchvision. "
             f"Please run `pip install --upgrade --force-reinstall Pillow` then restart your runtime/kernel. *****"
         )
+    elif _torchao_is_newer_than_torch(e):
+        raise RuntimeError(_torchao_torch_mismatch_message(e)) from None
     elif "Unpack" not in e:
         raise Exception(e)
     raise RuntimeError(

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -260,18 +260,17 @@ del _ROCmTorchaoLoader, _ROCmTorchaoFinder
 del _MetaPathFinder, _Loader, _ModuleSpec, _sys_rocm_stub, _types_rocm_stub
 del _is_windows_rocm
 
-# A torchao built for a newer torch imports symbols straight out of torch
-# (`from torch.nn.functional import ScalingType`). On an older pinned torch the
+# A torchao built for a newer torch imports symbols straight out of torch (e.g.
+# `from torch.nn.functional import ScalingType`). On an older pinned torch the
 # symbol is absent, and the ImportError arrives here naming neither package.
 _TORCHAO_TORCH_SYMBOLS = ("ScalingType", "ScalingGranularity", "Float8Tensor")
 
 
 def _torchao_is_newer_than_torch(message):
-    """Does this ImportError look like torchao reaching into a torch that lacks
-    the symbol?
+    """Is this ImportError torchao reaching into a torch that lacks the symbol?
 
-    Narrow on purpose: the symbol must be one torchao pulls from torch and the
-    failing module must be a torch one, so unrelated errors keep their own text.
+    Narrow on purpose: both the symbol and the failing module must be torch's,
+    so unrelated errors keep their own text.
     """
     try:
         message = str(message)


### PR DESCRIPTION
Three unrelated fixes, sharing only that each one stopped a run outright.

### Response-only masking refused for a text-only fine-tune of a multimodal model

`train_on_responses_only` checks for a vision collator and refuses, on the reasoning that a vision collator does its own masking. But a multimodal model fine-tuned on a plain text dataset carries the vision collator while having no images at all, so a legitimate text-only run was rejected:

```
Unsloth: Detected a vision data collator that does not support response-only masking
```

Pretokenized rows now fall through to dataset-level masking instead of being refused.

### `pad_token_id` bounded by the wrong vocabulary

`fix_pad_token` range-checked the declared pad against `config.vocab_size`. On a composite config that number sizes something else entirely: Sesame CSM reports 2051, the audio codebook, against a 128256-entry text tokenizer. A perfectly valid declared pad was rejected as out of range.

The bound now comes from an explicitly declared text vocab (`text_config.vocab_size`, or `text_vocab_size`) when there is one, falling back to `config.vocab_size` exactly as before. Single-vocab models are untouched, and a malformed non-integer value is still treated as unknown rather than crashing a later comparison.

### A torchao/torch mismatch surfaced as a confusing ImportError

The `Unpack` import guard swallowed it into an unrelated message. It now says what actually happened.

### Tests

**248 passed, 24 skipped, 0 failed** across the three new files plus the existing pad-token, vision-collator, response-masking and temporary-patch suites. The 24 skips are the network and model-gated vision-collator cases (`UNSLOTH_TEST_VLM_COLLATOR` unset) plus transformers-version gates; none are new.

The regression is demonstrated rather than asserted. Running the new tests against pristine `main`:

```
FAILED tests/test_pad_token.py::test_composite_model_text_vocab_size_is_used_for_pad_range
FAILED tests/test_pad_token.py::test_nested_text_config_vocab_size_is_preferred
FAILED tests/test_text_only_multimodal_masking.py::test_pretokenized_rows_get_dataset_level_masking
FAILED tests/test_text_only_multimodal_masking.py::test_iterable_dataset_clears_the_guard
4 failed, 34 passed
```

and `tests/test_torchao_torch_mismatch.py` does not even collect on `main`, since the helpers it checks do not exist there. All pass on this branch.

The masking fix shipped originally without a test; one was written for it here.

### Noted, not fixed here

While writing the iterable-dataset test, a separate pre-existing bug turned up on the text path: `dataset_utils.py` reads `trainer.train_dataset._ex_iterable.batch_size`, which raises `AttributeError: 'ArrowExamplesIterable' object has no attribute 'batch_size'` on current `datasets`. It is on `main` too and is out of scope for this PR, so that test asserts only that the guard is cleared. Worth its own fix.
