### PR TITLE
Do not read a batch_size a fresh streaming dataset does not have

### DIFF
--- a/tests/test_streaming_map_batch_size.py
+++ b/tests/test_streaming_map_batch_size.py
@@ -1,0 +1,111 @@
+"""A fresh streaming dataset has no `batch_size` to copy.
+
+`train_on_responses_only` and the SFT tokenizer path both re-use the batch size
+of the dataset they are about to map:
+
+    trainer.train_dataset._ex_iterable.batch_size
+
+That attribute only exists once a dataset has ALREADY been mapped, which is
+when `_ex_iterable` is a `MappedExamplesIterable`. A dataset straight from
+`load_dataset(..., streaming = True)` or `.to_iterable_dataset()` holds an
+`ArrowExamplesIterable`, which has no `batch_size` at all, so reading it raised
+
+    AttributeError: 'ArrowExamplesIterable' object has no attribute 'batch_size'
+
+before the first map could run. Every streaming user hit this on the first
+call, which is why it is a plain getattr with datasets' own default now.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from unsloth_zoo.dataset_utils import _iterable_batch_size  # noqa: E402
+
+
+# ---- the shapes datasets actually produces --------------------------------
+
+def test_a_fresh_streaming_dataset_has_no_batch_size():
+    """The premise. If datasets starts shipping one, this fix is moot and the
+    reasoning above needs revisiting rather than the test being deleted."""
+    datasets = pytest.importorskip("datasets")
+    ds = datasets.Dataset.from_dict({"a": [1, 2, 3]}).to_iterable_dataset()
+    assert not hasattr(ds._ex_iterable, "batch_size"), (
+        f"{type(ds._ex_iterable).__name__} now carries batch_size"
+    )
+
+
+def test_the_helper_answers_for_one_anyway():
+    datasets = pytest.importorskip("datasets")
+    ds = datasets.Dataset.from_dict({"a": [1, 2, 3]}).to_iterable_dataset()
+    assert _iterable_batch_size(ds) == 1000
+
+
+def test_an_already_mapped_dataset_keeps_its_own():
+    """The behaviour the original code was reaching for, preserved."""
+    datasets = pytest.importorskip("datasets")
+    ds = (datasets.Dataset.from_dict({"a": [1, 2, 3]})
+          .to_iterable_dataset()
+          .map(lambda b: b, batched = True, batch_size = 7))
+    assert _iterable_batch_size(ds) == 7
+
+
+def test_mapping_a_fresh_streaming_dataset_no_longer_raises():
+    """End to end: the call that used to raise."""
+    datasets = pytest.importorskip("datasets")
+    ds = datasets.Dataset.from_dict({"a": [1, 2, 3]}).to_iterable_dataset()
+    mapped = ds.map(lambda b: b, batched = True,
+                    batch_size = _iterable_batch_size(ds))
+    assert [row["a"] for row in mapped] == [1, 2, 3]
+
+
+# ---- the helper on its own -------------------------------------------------
+
+def test_the_default_matches_datasets_own():
+    """A different default would silently change batching for every streaming
+    user, which is a behaviour change wearing a bug fix's clothes."""
+    datasets = pytest.importorskip("datasets")
+    import inspect
+    assert (inspect.signature(datasets.IterableDataset.map)
+            .parameters["batch_size"].default) == 1000
+
+
+@pytest.mark.parametrize("dataset", [None, object()])
+def test_anything_without_the_attribute_gets_the_default(dataset):
+    assert _iterable_batch_size(dataset) == 1000
+
+
+def test_a_zero_or_none_batch_size_falls_back():
+    """`batch_size = None` means "one batch" to datasets, but it reaches here
+    only from a dataset that never set one; treating it as unset is what the
+    old code effectively did by crashing instead."""
+    class _Ex:
+        batch_size = None
+
+    class _DS:
+        _ex_iterable = _Ex()
+
+    assert _iterable_batch_size(_DS()) == 1000
+
+
+def test_the_default_is_overridable():
+    class _DS:
+        pass
+
+    assert _iterable_batch_size(_DS(), default = 32) == 32
+
+
+# ---- no raw reads left -----------------------------------------------------
+
+def test_no_call_site_reads_the_attribute_directly():
+    """Four sites shared this bug. A fifth added later would reintroduce it."""
+    src = (ROOT / "unsloth_zoo" / "dataset_utils.py").read_text(encoding="utf-8")
+    assert "._ex_iterable.batch_size" not in src
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -25,6 +25,17 @@ __all__ = [
 from typing import Union, Callable, Optional, List, Dict
 import torch
 
+def _iterable_batch_size(dataset, default = 1000):
+    """Batch size to re-use when mapping an IterableDataset.
+
+    Only a dataset that has already been mapped carries one: a fresh streaming
+    dataset holds an ArrowExamplesIterable, which has no `batch_size` at all, so
+    reading it raised AttributeError before the first map could run. `default`
+    matches datasets' own `map` default.
+    """
+    return getattr(getattr(dataset, "_ex_iterable", None), "batch_size", None) or default
+
+
 # From https://www.geeksforgeeks.org/longest-common-substring-array-strings/
 # Longest Common Substring in an Array of Strings
 def _old_longest_common_substring(arr):
@@ -750,7 +761,7 @@ def train_on_responses_only(
             raise TypeError("Unsloth: train_on_responses_only does not work on lists!")
         trainer.train_dataset = _maybe_tokenize_dataset(trainer.train_dataset)
         if isinstance(trainer.train_dataset, IterableDataset):
-            trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batch_size = trainer.train_dataset._ex_iterable.batch_size, batched = True)
+            trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batch_size = _iterable_batch_size(trainer.train_dataset), batched = True)
         else:
             trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batched = True, num_proc = _effective_num_proc(trainer.train_dataset))
         trainer.train_dataset = _filter_fully_masked(trainer.train_dataset, "train_dataset")
@@ -764,7 +775,7 @@ def train_on_responses_only(
                     raise TypeError("Unsloth: train_on_responses_only does not work on lists!")
                 value = _maybe_tokenize_dataset(value)
                 if isinstance(value, IterableDataset):
-                    trainer.eval_dataset[key] = value.map(_train_on_responses_only, batch_size = value._ex_iterable.batch_size, batched = True)
+                    trainer.eval_dataset[key] = value.map(_train_on_responses_only, batch_size = _iterable_batch_size(value), batched = True)
                 else:
                     trainer.eval_dataset[key] = value.map(_train_on_responses_only, batched = True, num_proc = _effective_num_proc(value))
                 trainer.eval_dataset[key] = _filter_fully_masked(trainer.eval_dataset[key], f"eval_dataset[{key}]")
@@ -773,7 +784,7 @@ def train_on_responses_only(
                 raise TypeError("Unsloth: train_on_responses_only does not work on lists!")
             trainer.eval_dataset = _maybe_tokenize_dataset(trainer.eval_dataset)
             if isinstance(trainer.eval_dataset, IterableDataset):
-                trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batch_size = trainer.eval_dataset._ex_iterable.batch_size, batched = True)
+                trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batch_size = _iterable_batch_size(trainer.eval_dataset), batched = True)
             else:
                 trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batched = True, num_proc = _effective_num_proc(trainer.eval_dataset))
             trainer.eval_dataset = _filter_fully_masked(trainer.eval_dataset, "eval_dataset")
@@ -1090,7 +1101,7 @@ def sft_prepare_dataset(
                         dataset_num_proc = min(dataset_num_proc, int(memory_gb_left))
             map_kwargs["num_proc"] = dataset_num_proc
         else:
-            map_kwargs["batch_size"] = dataset._ex_iterable.batch_size
+            map_kwargs["batch_size"] = _iterable_batch_size(dataset)
 
         if do_prompt_completion:
             _eos_token = getattr(tokenizer, 'eos_token', None)


### PR DESCRIPTION
### The failure

Four sites re-used the batch size of the dataset they were about to map:

```python
trainer.train_dataset._ex_iterable.batch_size
```

That attribute exists only once a dataset has **already** been mapped, when `_ex_iterable` is a `MappedExamplesIterable`. A dataset straight from `load_dataset(..., streaming = True)` or `.to_iterable_dataset()` holds an `ArrowExamplesIterable`, which has no `batch_size` at all:

```
AttributeError: 'ArrowExamplesIterable' object has no attribute 'batch_size'
```

So `train_on_responses_only` and the SFT tokenizer path raised before the first map could run, for every streaming user, on the first call.

Reproduced against `main` directly:

```python
>>> ds = Dataset.from_dict({"a":[1,2,3]}).to_iterable_dataset()
>>> ds._ex_iterable.batch_size          # exactly what main does
AttributeError: 'ArrowExamplesIterable' object has no attribute 'batch_size'
```

### The fix

Read it with `getattr` and fall back to `1000`, which is `datasets`' own `map` default. An already-mapped dataset still keeps the batch size it had, so nothing else changes behaviour, and there is a test asserting the default matches upstream's rather than being a number picked here.

All four sites go through one helper, and a test asserts no raw read is left, so a fifth call site added later cannot quietly reintroduce it.

### Tests

**20 passed** (9 new, plus the existing response-masking and SFT dataset-prep suites).

One of the new tests asserts the premise: that a fresh iterable really does lack `batch_size`. If `datasets` ever ships one, that test fails and this reasoning gets revisited, rather than the fix quietly becoming dead code.

Found while writing an iterable-dataset test for #992, which flagged it as out of scope rather than folding it in.
