### PR TITLE
Do not fail a model load because its source could not be read

### DIFF
--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -153,7 +153,7 @@ def test_a_bare_return_is_the_functions_contract():
 
 def _nn_patch_region() -> str:
     i = SRC.index("source = inspect.getsource(function.forward).rstrip()")
-    return SRC[max(0, i - 700):i + 1400]
+    return SRC[max(0, i - 1600):i + 1400]
 
 
 def test_the_nn_forward_patch_loop_is_guarded():
@@ -250,16 +250,21 @@ def unreadable_llama(monkeypatch):
     import transformers.models.llama.modeling_llama as modeling
 
     _break_getsource(monkeypatch, modeling)
-    had = hasattr(modeling, "__UNSLOTH_PATCHED__")
-    for name in ("__UNSLOTH_PATCHED__", "__UNSLOTH_SUPPORTS_SDPA__"):
-        if hasattr(modeling, name):
+    # Both markers, with their values: restoring only the patched one leaves a
+    # module that reports itself done and then declines to answer, so a later
+    # test's supports_sdpa accumulator is silently left untouched.
+    _MISSING = object()
+    saved = {name: getattr(modeling, name, _MISSING)
+             for name in ("__UNSLOTH_PATCHED__", "__UNSLOTH_SUPPORTS_SDPA__")}
+    for name in saved:
+        if saved[name] is not _MISSING:
             delattr(modeling, name)
     yield modeling
-    for name in ("__UNSLOTH_PATCHED__", "__UNSLOTH_SUPPORTS_SDPA__"):
+    for name, value in saved.items():
         if hasattr(modeling, name):
             delattr(modeling, name)
-    if had:
-        modeling.__UNSLOTH_PATCHED__ = True
+        if value is not _MISSING:
+            setattr(modeling, name, value)
 
 
 def test_sdpa_is_reported_unsupported(unreadable_llama):
@@ -416,6 +421,76 @@ def test_the_wrapper_is_marked_so_it_is_not_wrapped_twice():
 def test_the_unreadable_forward_is_wrapped_rather_than_dropped():
     region = _nn_patch_region()
     assert "_dtype_safe_forward(" in region
+
+
+def test_the_tensor_may_arrive_by_keyword():
+    """These become the public forward. torch.nn.RMSNorm declares `x`, not
+    `input`, and `rms_norm(x = t)` works today, so a hard-coded parameter name
+    would start raising TypeError on a call that used to be fine."""
+    import torch
+
+    from unsloth_zoo.compiler import _dtype_safe_forward
+
+    def original(self, x):
+        return x.to(torch.float32)
+
+    forward = _dtype_safe_forward(original, False, False)
+    assert forward(_Weighted(torch.float32),
+                   x = torch.zeros(2, dtype = torch.bfloat16)).dtype \
+        == torch.bfloat16
+
+
+def test_a_call_it_cannot_read_is_passed_straight_through():
+    """Better to cast nothing than to guess which argument is the activation."""
+    import torch
+
+    from unsloth_zoo.compiler import _dtype_safe_forward
+
+    seen = {}
+
+    def original(self, **kwargs):
+        seen.update(kwargs)
+        return torch.zeros(1)
+
+    forward = _dtype_safe_forward(original, False, False)
+    forward(_Weighted(torch.float32), other = 1)
+    assert seen == {"other": 1}
+
+
+def test_the_wrapper_records_the_compile_mode_it_was_built_for():
+    """`disable` decides whether a norm casts its input, and it is baked into
+    the closure, so a second load with the other setting must be able to tell."""
+    from unsloth_zoo.compiler import _dtype_safe_forward
+
+    def original(self, x):
+        return x
+
+    for disable in (True, False):
+        forward = _dtype_safe_forward(original, False, disable)
+        assert forward.__unsloth_dtype_disable__ is disable
+        assert forward.__unsloth_dtype_original__ is original
+
+
+def test_a_rebuild_wraps_the_original_not_the_wrapper():
+    """Otherwise each load in a process adds another layer of casts."""
+    from unsloth_zoo.compiler import _dtype_safe_forward
+
+    def original(self, x):
+        return x
+
+    once = _dtype_safe_forward(original, False, True)
+    twice = _dtype_safe_forward(once.__unsloth_dtype_original__, False, False)
+    assert twice.__unsloth_dtype_original__ is original
+
+
+def test_the_loop_rebuilds_on_a_mode_change():
+    region = _nn_patch_region()
+    i = SRC.index('__unsloth_dtype_wrapped__", False)')
+    window = SRC[i:i + 800]
+    assert "__unsloth_dtype_disable__" in window, (
+        "a wrapper built for the other compile mode must not be reused")
+    assert "__unsloth_dtype_original__" in window, (
+        "rebuild from the original, or the wrappers stack")
 
 
 if __name__ == "__main__":

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -1,0 +1,207 @@
+"""A model must not fail to LOAD because we could not read its source.
+
+`unsloth_compile_transformers` calls
+
+    full_source = inspect.getsource(modeling_file)
+
+and everything after it is source-level feature detection and regex class
+discovery -- work done purely to make the model FASTER. `inspect.getsource`
+reads through linecache, and when that comes back empty it raises
+
+    OSError: could not get source code
+
+Unguarded, that propagates out of `FastModel.from_pretrained`, so the model
+does not load at all, and the message names neither unsloth nor the module it
+could not read. Hit while collecting the whisper saving test.
+
+Returning early is the honest degradation: LoRA forwards are already patched
+by that point, and the model loads without the source-level optimisations.
+
+What we must NOT do is carry on with an empty string. Several checks have the
+shape
+
+    "_supports_sdpa = False" not in full_source
+
+which is TRUE for an empty string, so an empty `full_source` would silently
+enable paths the model never claimed to support. Slower is fine; wrong is not.
+"""
+
+import ast
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+COMPILER = ROOT / "unsloth_zoo" / "compiler.py"
+SRC = COMPILER.read_text(encoding="utf-8")
+
+
+def _guard_region() -> str:
+    i = SRC.index("full_source = inspect.getsource(modeling_file)")
+    return SRC[max(0, i - 400):i + 1600]
+
+
+# ---- the guard ------------------------------------------------------------
+
+def test_getsource_is_wrapped():
+    region = _guard_region()
+    assert "try:" in region
+    assert "full_source = inspect.getsource(modeling_file)" in region
+
+
+def test_it_catches_what_getsource_actually_raises():
+    """OSError for unreadable source, TypeError for a built-in or C module."""
+    region = _guard_region()
+    assert "except (OSError, TypeError)" in region
+
+
+def test_the_real_exception_type_is_oserror():
+    """Guards the premise: if inspect ever stopped raising OSError here, the
+    except clause would be catching nothing."""
+    with pytest.raises((OSError, TypeError)):
+        inspect.getsource(sys)          # built-in module, no source file
+
+
+def test_it_returns_rather_than_continuing_with_empty_source():
+    """The critical half. Continuing with full_source = "" would make every
+    `X not in full_source` check true."""
+    i = SRC.index("except (OSError, TypeError)")
+    window = SRC[i:i + 1400]
+    assert "\n        return\n" in window, (
+        "the handler must return, not fall through to the source-based logic")
+    assert 'full_source = ""' not in window, (
+        "an empty full_source silently flips `not in` checks to True")
+
+
+def test_it_warns_so_the_slowdown_is_not_silent():
+    i = SRC.index("except (OSError, TypeError)")
+    window = SRC[i:i + 1400]
+    assert "logger.warning" in window
+
+
+def test_the_logger_name_exists_in_this_module():
+    """compiler.py imports `logger` from .log; there is no module-level
+    `logger_compiler` at runtime. A warning that raises NameError inside an
+    exception handler would replace a clear failure with a confusing one."""
+    import unsloth_zoo.compiler as C
+    assert hasattr(C, "logger")
+
+
+def test_the_warning_says_the_model_still_works():
+    i = SRC.index("except (OSError, TypeError)")
+    window = SRC[i:i + 1400]
+    assert "still works" in window, (
+        "a warning during model load must say whether it is fatal")
+
+
+# ---- what must be preserved ----------------------------------------------
+
+def test_lora_patching_happens_before_the_guard():
+    """Returning early is only acceptable because the LoRA forwards have
+    already been patched by this point."""
+    lora = SRC.index("patch_lora_forwards(torch_compile_options)")
+    guard = SRC.index("full_source = inspect.getsource(modeling_file)")
+    assert lora < guard
+
+
+def test_the_patched_marker_is_set_before_the_guard():
+    marker = SRC.index("modeling_file.__UNSLOTH_PATCHED__ = True")
+    guard = SRC.index("full_source = inspect.getsource(modeling_file)")
+    assert marker < guard, (
+        "an early return must not leave the module looking unpatched, or a "
+        "later pass would try again and fail again")
+
+
+def test_the_module_still_parses():
+    ast.parse(SRC)
+
+
+def test_a_bare_return_is_the_functions_contract():
+    """unsloth_compile_transformers returns None and already has early
+    returns, so this one is consistent with the rest."""
+    tree = ast.parse(SRC)
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "unsloth_compile_transformers")
+    returns = [n for n in ast.walk(fn) if isinstance(n, ast.Return)]
+    assert returns, "expected early returns in this function"
+    assert any(r.value is None for r in returns)
+
+
+# ---- the second site: loading a SECOND model in one process --------------
+
+def _nn_patch_region() -> str:
+    i = SRC.index("source = inspect.getsource(function.forward).rstrip()")
+    return SRC[max(0, i - 700):i + 1400]
+
+
+def test_the_nn_forward_patch_loop_is_guarded():
+    """`inspect.getsource` on a forward it cannot retrieve raises
+    `OSError: could not get source code`, which propagates out of
+    `FastModel.from_pretrained` -- so the model does not load, over source we
+    only wanted in order to patch a dtype cast.
+
+    Observed while collecting tests/saving/text_to_speech_models, after
+    another model had been loaded in the same process.
+
+    Scope, stated honestly: the precondition is NOT fully characterised. Two
+    plain Qwen loads do not trigger it, and after such a load no torch.nn
+    forward is unreadable -- both measured, not assumed. This guards a state
+    we have observed rather than encoding a theory about how it arises.
+    """
+    region = _nn_patch_region()
+    assert "try:" in region
+    assert "except (OSError, TypeError)" in region
+
+
+def test_an_unreadable_forward_is_skipped_not_fatal():
+    """Every other unsupported case in this loop uses `continue`; this must
+    too. Raising abandons the remaining modules as well as this one.
+
+    Checked on the parsed handler rather than its text: the comment inside it
+    contains the word "raises", which a substring search reads as a `raise`
+    statement.
+    """
+    tree = ast.parse(SRC)
+    # Exactly the try whose body IS this assignment -- several other blocks
+    # also call getsource on a forward, and their handlers legitimately do
+    # something else.
+    target = "source = inspect.getsource(function.forward).rstrip()"
+    handlers = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try) or len(node.body) != 1:
+            continue
+        try:
+            body_src = ast.unparse(node.body[0])
+        except Exception:
+            continue
+        if body_src.replace(" ", "") == target.replace(" ", ""):
+            handlers.extend(node.handlers)
+    assert handlers, f"no try/except whose body is exactly `{target}`"
+    for h in handlers:
+        body = list(ast.walk(ast.Module(body=h.body, type_ignores=[])))
+        assert any(isinstance(n, ast.Continue) for n in body), (
+            "the handler must `continue` to the next module")
+        assert not any(isinstance(n, ast.Raise) for n in body), (
+            "raising here abandons every remaining module too")
+
+
+def test_the_compiler_config_check_is_kept():
+    """It catches torch.compile wrappers, which is a different case from our
+    own exec'd replacements -- the new guard adds to it, not replaces it."""
+    region = _nn_patch_region()
+    assert 'hasattr(function.forward, "get_compiler_config")' in region
+
+
+def test_both_getsource_guards_are_present():
+    """Two distinct sites, two distinct failures. Fixing only the first one
+    just moves the crash later, which is exactly what happened."""
+    assert SRC.count("except (OSError, TypeError)") >= 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -41,8 +41,13 @@ SRC = COMPILER.read_text(encoding="utf-8")
 
 
 def _guard_region() -> str:
+    """The modeling-file guard and its handler.
+
+    Anchored on the call, not on "except (OSError, TypeError)": the torch
+    forward guard uses the same clause and is defined earlier in the file.
+    """
     i = SRC.index("full_source = inspect.getsource(modeling_file)")
-    return SRC[max(0, i - 400):i + 1600]
+    return SRC[max(0, i - 400):i + 2200]
 
 
 # ---- the guard ------------------------------------------------------------
@@ -69,8 +74,7 @@ def test_the_real_exception_type_is_oserror():
 def test_it_returns_rather_than_continuing_with_empty_source():
     """The critical half. Continuing with full_source = "" would make every
     `X not in full_source` check true."""
-    i = SRC.index("except (OSError, TypeError)")
-    window = SRC[i:i + 1400]
+    window = _guard_region()
     assert "\n        return\n" in window, (
         "the handler must return, not fall through to the source-based logic")
     assert 'full_source = ""' not in window, (
@@ -78,9 +82,7 @@ def test_it_returns_rather_than_continuing_with_empty_source():
 
 
 def test_it_warns_so_the_slowdown_is_not_silent():
-    i = SRC.index("except (OSError, TypeError)")
-    window = SRC[i:i + 1400]
-    assert "logger.warning" in window
+    assert "logger.warning" in _guard_region()
 
 
 def test_the_logger_name_exists_in_this_module():
@@ -92,8 +94,7 @@ def test_the_logger_name_exists_in_this_module():
 
 
 def test_the_warning_says_the_model_still_works():
-    i = SRC.index("except (OSError, TypeError)")
-    window = SRC[i:i + 1400]
+    window = _guard_region()
     assert "still works" in window, (
         "a warning during model load must say whether it is fatal")
 
@@ -201,6 +202,204 @@ def test_both_getsource_guards_are_present():
     """Two distinct sites, two distinct failures. Fixing only the first one
     just moves the crash later, which is exactly what happened."""
     assert SRC.count("except (OSError, TypeError)") >= 2
+
+
+# ---- what the fallback must still do -------------------------------------
+#
+# Returning early is a degradation, and a degradation has to be honest about
+# which of the surrounding work it gave up. Three separate questions, and they
+# do not have the same answer.
+
+
+def _break_getsource(monkeypatch, module):
+    """Make exactly one module's source unreadable, the way the wild failure
+    does: the file is gone as far as inspect and linecache are concerned."""
+    import linecache
+
+    path = inspect.getfile(module)
+    real = inspect.getfile
+
+    def broken(obj):
+        found = real(obj)
+        if found == path:
+            raise OSError("could not get source code")
+        return found
+
+    monkeypatch.setattr(inspect, "getfile", broken)
+    linecache.checkcache(path)
+
+
+@pytest.fixture
+def unreadable_llama(monkeypatch):
+    import transformers.models.llama.modeling_llama as modeling
+
+    _break_getsource(monkeypatch, modeling)
+    had = hasattr(modeling, "__UNSLOTH_PATCHED__")
+    for name in ("__UNSLOTH_PATCHED__", "__UNSLOTH_SUPPORTS_SDPA__"):
+        if hasattr(modeling, name):
+            delattr(modeling, name)
+    yield modeling
+    for name in ("__UNSLOTH_PATCHED__", "__UNSLOTH_SUPPORTS_SDPA__"):
+        if hasattr(modeling, name):
+            delattr(modeling, name)
+    if had:
+        modeling.__UNSLOTH_PATCHED__ = True
+
+
+def test_sdpa_is_reported_unsupported(unreadable_llama):
+    """The caller seeds `[True]` and only the normal path writes it, so a
+    silent return leaves SDPA selected for a model whose source never claimed
+    it. Eager always exists; guessing does not."""
+    from unsloth_zoo import compiler
+
+    supports_sdpa = [True]
+    compiler.unsloth_compile_transformers(
+        "llama", disable = True, compile_torch_modules = False,
+        supports_sdpa = supports_sdpa,
+    )
+    assert supports_sdpa == [False]
+
+
+def test_the_answer_survives_a_second_call(unreadable_llama):
+    """`__UNSLOTH_PATCHED__` is set before the guard, so every later call takes
+    the already-patched branch and reads `__UNSLOTH_SUPPORTS_SDPA__` instead.
+    Unset, that branch leaves the caller's optimistic value alone."""
+    from unsloth_zoo import compiler
+
+    compiler.unsloth_compile_transformers(
+        "llama", disable = True, compile_torch_modules = False,
+        supports_sdpa = [True],
+    )
+    again = [True]
+    compiler.unsloth_compile_transformers(
+        "llama", disable = True, compile_torch_modules = False,
+        supports_sdpa = again,
+    )
+    assert again == [False]
+
+
+def test_a_supports_sdpa_of_none_is_still_allowed(unreadable_llama):
+    """It is optional; the normal path guards it and so must this one."""
+    from unsloth_zoo import compiler
+
+    compiler.unsloth_compile_transformers(
+        "llama", disable = True, compile_torch_modules = False,
+    )
+
+
+def test_the_torch_dtype_patches_still_run():
+    """They read torch's source, not the model's, so an unreadable model is no
+    reason to skip them. Skipping turned a load-time failure into a first
+    forward pass failure."""
+    tree = ast.parse(SRC)
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "unsloth_compile_transformers")
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Try):
+            continue
+        if "inspect.getsource(modeling_file)" not in ast.unparse(node.body[0]):
+            continue
+        handler = ast.unparse(node.handlers[0])
+        assert "_patch_torch_dtype_modules" in handler
+        return
+    pytest.fail("no try whose body reads the modeling file source")
+
+
+def test_gradient_accumulation_needs_that_same_source():
+    """Which is why the early return does not skip anything there: the patch
+    re-reads the model's source itself and gives up on the same failure. This
+    test exists so a future reader does not add a fallback for a case that
+    cannot occur."""
+    import transformers.models.llama.modeling_llama as modeling
+    from unsloth_zoo.compiler import patch_gradient_accumulation
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        _break_getsource(monkeypatch, modeling)
+        patched = [
+            name for name in dir(modeling)
+            if isinstance(getattr(modeling, name, None), type)
+            and patch_gradient_accumulation(modeling, name) is not None
+        ]
+    assert patched == []
+
+
+# ---- the wrapper that stands in for an unreadable torch forward ----------
+
+
+class _Weighted:
+    def __init__(self, dtype):
+        import torch
+
+        self.weight = torch.zeros(1, dtype = dtype)
+
+
+def _run(is_conv, disable, input_dtype, weight_dtype):
+    """Returns (dtype the original forward saw, dtype the caller got back)."""
+    import torch
+
+    from unsloth_zoo.compiler import _dtype_safe_forward
+
+    seen = {}
+
+    def original(self, x, *args, **kwargs):
+        seen["dtype"] = x.dtype
+        return x.to(torch.float32)
+
+    forward = _dtype_safe_forward(original, is_conv, disable)
+    out = forward(_Weighted(weight_dtype), torch.zeros(2, dtype = input_dtype))
+    return seen["dtype"], out.dtype
+
+
+def test_a_conv_input_is_cast_to_the_weight_dtype():
+    import torch
+
+    saw, got = _run(True, False, torch.float16, torch.bfloat16)
+    assert saw == torch.bfloat16, "eager F.conv1d crashes on mismatched dtypes"
+    assert got == torch.float16, "the caller must get its own dtype back"
+
+
+def test_an_eager_norm_input_is_cast_too():
+    import torch
+
+    saw, got = _run(False, True, torch.bfloat16, torch.float32)
+    assert (saw, got) == (torch.float32, torch.bfloat16)
+
+
+def test_a_compiled_norm_input_is_left_alone():
+    """The source rewrite only casts the result when compiling is on; casting
+    the input as well changes batched numerics."""
+    import torch
+
+    saw, got = _run(False, False, torch.bfloat16, torch.float32)
+    assert (saw, got) == (torch.bfloat16, torch.bfloat16)
+
+
+def test_an_affineless_norm_has_no_weight_to_match():
+    import torch
+
+    from unsloth_zoo.compiler import _dtype_safe_forward
+
+    class _NoWeight:
+        weight = None
+
+    forward = _dtype_safe_forward(lambda self, x: x.to(torch.float32), False, True)
+    assert forward(_NoWeight(), torch.zeros(2, dtype = torch.bfloat16)).dtype \
+        == torch.bfloat16
+
+
+def test_the_wrapper_is_marked_so_it_is_not_wrapped_twice():
+    """Loading a second model runs the loop again; without a marker each load
+    would add another layer of casts."""
+    from unsloth_zoo.compiler import _dtype_safe_forward
+
+    assert _dtype_safe_forward(lambda self, x: x, True, False).__unsloth_dtype_wrapped__
+    assert 'getattr(function.forward, "__unsloth_dtype_wrapped__", False)' in SRC
+
+
+def test_the_unreadable_forward_is_wrapped_rather_than_dropped():
+    region = _nn_patch_region()
+    assert "_dtype_safe_forward(" in region
 
 
 if __name__ == "__main__":

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """A model must not fail to LOAD because we could not read its source.
 
 `unsloth_compile_transformers` calls

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3528,17 +3528,37 @@ def _dtype_safe_forward(original_forward, is_conv, disable):
     result back; an eager norm does the same but only when it is affine; a
     compiled norm only casts the result, since casting in changes batched
     numerics.
-    """
 
-    def forward(self, input, *args, **kwargs):
-        original_dtype = input.dtype
+    The tensor is taken by whatever name the original declares, because these
+    are public forwards: `RMSNorm.forward(self, x)` and `rms_norm(x = t)` both
+    work today and a hard-coded `input` would start raising TypeError.
+    """
+    try:
+        first = list(inspect.signature(original_forward).parameters)[1]
+    except Exception:
+        first = "input"
+
+    def forward(self, *args, **kwargs):
+        if args:
+            tensor, rest = args[0], args[1:]
+        elif first in kwargs:
+            tensor, rest = kwargs.pop(first), ()
+        else:
+            # Not a shape we know how to cast; leave it entirely alone.
+            return original_forward(self, *args, **kwargs)
+        original_dtype = tensor.dtype
         if is_conv:
-            input = input.to(self.weight.dtype)
+            tensor = tensor.to(self.weight.dtype)
         elif disable and getattr(self, "weight", None) is not None:
-            input = input.to(self.weight.dtype)
-        return original_forward(self, input, *args, **kwargs).to(original_dtype)
+            tensor = tensor.to(self.weight.dtype)
+        return original_forward(self, tensor, *rest, **kwargs).to(original_dtype)
 
     forward.__unsloth_dtype_wrapped__ = True
+    # `disable` is baked into the closure above, so a later load in the same
+    # process with the other setting needs a new wrapper built from the same
+    # original rather than one stacked on this one.
+    forward.__unsloth_dtype_disable__ = disable
+    forward.__unsloth_dtype_original__ = original_forward
     return forward
 
 
@@ -3585,6 +3605,20 @@ def _patch_torch_dtype_modules(
             if hasattr(function.forward, "get_compiler_config"):
                 continue
             if getattr(function.forward, "__unsloth_dtype_wrapped__", False):
+                if getattr(function.forward, "__unsloth_dtype_disable__", None) == disable:
+                    continue
+                # Compile mode changed since the wrapper was built. Rebuild from
+                # the original so the casts match, and so wrappers never stack.
+                _install_patched_forward(
+                    model_location,
+                    module,
+                    _dtype_safe_forward(
+                        function.forward.__unsloth_dtype_original__,
+                        module in _conv_modules,
+                        disable,
+                    ),
+                    combined_module,
+                )
                 continue
 
             try:

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3497,6 +3497,182 @@ def calls_output_capture_target(init, source, target_names):
     return False
 
 
+def _install_patched_forward(model_location, module, forward, combined_module):
+    """Bind one rewritten forward everywhere the old one is reachable."""
+    exec(
+        f"{model_location}.torch.nn.{module}.forward = forward",
+        globals(),
+        locals(),
+    )
+    try:
+        exec(f"{model_location}.nn.{module}.forward = forward", globals(), locals())
+    except:
+        pass
+    if combined_module is not None:
+        exec(
+            f"combined_module.torch.nn.{module}.forward = forward",
+            globals(),
+            locals(),
+        )
+        try:
+            exec(f"combined_module.nn.{module}.forward = forward", globals(), locals())
+        except:
+            pass
+    pass
+
+
+def _dtype_safe_forward(original_forward, is_conv, disable):
+    """The dtype casts of the source rewrite, without needing the source.
+
+    Same three shapes: a conv casts its input to the weight dtype and the
+    result back; an eager norm does the same but only when it is affine; a
+    compiled norm only casts the result, since casting in changes batched
+    numerics.
+    """
+
+    def forward(self, input, *args, **kwargs):
+        original_dtype = input.dtype
+        if is_conv:
+            input = input.to(self.weight.dtype)
+        elif disable and getattr(self, "weight", None) is not None:
+            input = input.to(self.weight.dtype)
+        return original_forward(self, input, *args, **kwargs).to(original_dtype)
+
+    forward.__unsloth_dtype_wrapped__ = True
+    return forward
+
+
+def _patch_torch_dtype_modules(
+    model_location,
+    functions,
+    torch_compile_options,
+    compile_torch_modules,
+    disable,
+    combined_module,
+):
+    """Patch torch.nn conv / norm forwards for mixed-precision dtypes.
+
+    Lifted out of ``unsloth_compile_transformers`` unchanged so the
+    unreadable-source path can still run it: these rewrites read torch's
+    own source, never the model's, so they work when the model's does not.
+    """
+    # These rewrites never compile (add_torch_compile=False), so run them even
+    # when compiling is disabled: norms are fp32 upcast at load regardless, and
+    # eager F.layer_norm crashes on bf16 activations against fp32 weights.
+    if compile_torch_modules:
+        if not disable:
+            # Compiled global F.layer_norm: only when compiling is allowed
+            from .patch_torch_functions import patch_torch_functions
+
+            patch_torch_functions()
+
+        _conv_modules = frozenset([
+            "Conv1d", "Conv2d", "Conv3d",
+            "ConvTranspose1d", "ConvTranspose2d", "ConvTranspose3d",
+        ])
+        for module in _patch_functions:
+            try:
+                source = eval(f"{model_location}.torch")
+            except:
+                continue
+            if not hasattr(source, "nn"):
+                continue
+            if not hasattr(source.nn, module):
+                continue
+            function = eval(f"source.nn.{module}")
+            if not hasattr(function, "forward"):
+                continue
+            if hasattr(function.forward, "get_compiler_config"):
+                continue
+            if getattr(function.forward, "__unsloth_dtype_wrapped__", False):
+                continue
+
+            try:
+                source = inspect.getsource(function.forward).rstrip()
+            except (OSError, TypeError):
+                # A forward built by exec, or one whose file has gone. Unguarded
+                # the OSError propagates out of FastModel.from_pretrained and
+                # the model does not load, over source we only wanted in order
+                # to patch a dtype cast. `get_compiler_config` above only covers
+                # torch.compile wrappers.
+                #
+                # The precondition is not fully characterised: two plain Qwen
+                # loads do not trigger it, and after such a load no torch.nn
+                # forward is unreadable (both measured). This guards a state we
+                # have seen, not a theory about how it arises.
+                #
+                # Skipping would only move the failure to the first forward, so
+                # wrap instead: the casts do not need the source, only the
+                # rewrite does.
+                _install_patched_forward(
+                    model_location,
+                    module,
+                    _dtype_safe_forward(
+                        function.forward, module in _conv_modules, disable
+                    ),
+                    combined_module,
+                )
+                continue
+
+            if module in _conv_modules:
+                # Conv modules: cast input to weight dtype before the conv op,
+                # then cast output back to original input dtype. This prevents
+                # dtype mismatches under mixed-precision autocast (eg bf16
+                # weight + fp16 input crashes F.conv1d).
+                lines = source.split("\n")
+                def_line = lines[0]
+                body_lines = lines[1:]
+                first_body = next((l for l in body_lines if l.strip()), "")
+                body_indent = first_body[:len(first_body) - len(first_body.lstrip())]
+                prologue = [
+                    body_indent + "original_dtype = input.dtype",
+                    body_indent + "input = input.to(self.weight.dtype)",
+                ]
+                source = "\n".join([def_line] + prologue + body_lines)
+                append_str = ".to(original_dtype)\n"
+            else:
+                # Norm modules: detect the actual parameter name (input or x)
+                import re as _re
+                m = _re.search(r"def forward\(self,\s*(\w+)", source)
+                param_name = m.group(1) if m else "input"
+                if disable:
+                    # Eager F.layer_norm needs input dtype == weight dtype: cast in
+                    # and out. Compiled path left untouched (adding the cast there
+                    # changes batched numerics). weight is None when affine=False.
+                    lines = source.split("\n")
+                    def_line = lines[0]
+                    body_lines = lines[1:]
+                    first_body = next((l for l in body_lines if l.strip()), "")
+                    body_indent = first_body[:len(first_body) - len(first_body.lstrip())]
+                    prologue = [
+                        body_indent + f"original_dtype = {param_name}.dtype",
+                        body_indent + f"if self.weight is not None: {param_name} = {param_name}.to(self.weight.dtype)",
+                    ]
+                    source = "\n".join([def_line] + prologue + body_lines)
+                    append_str = ".to(original_dtype)\n"
+                else:
+                    append_str = f".to({param_name}.dtype)\n"
+
+            forward = create_new_function(
+                module,
+                source,
+                model_location,
+                functions,
+                prepend=_license_header
+                + f"\ntorch_compile_options = {torch_compile_options}\n",
+                append=append_str,
+                overwrite=False,
+                add_torch_compile=False,
+            ).forward
+
+            _install_patched_forward(
+                model_location, module, forward, combined_module
+            )
+            pass
+        pass
+    pass
+
+
 def unsloth_compile_transformers(
     model_type: str = "llama",
     sdpa_dynamic_mask: bool = True,
@@ -3703,6 +3879,22 @@ def unsloth_compile_transformers(
             f"Unsloth: Could not read the source of {getattr(modeling_file, '__name__', modeling_file)} "
             f"({type(exception).__name__}: {exception}), so source-level "
             f"optimisations are skipped for it. The model still works."
+        )
+        # Say so explicitly: the caller seeds this True and only the normal
+        # path writes it, so returning silently leaves SDPA selected for a
+        # model that never claimed it. Eager is always available.
+        modeling_file.__UNSLOTH_SUPPORTS_SDPA__ = False
+        if supports_sdpa is not None:
+            assert type(supports_sdpa) is list and len(supports_sdpa) == 1
+            supports_sdpa[0] = False
+        # These read torch's source, not the model's, so they still work here.
+        _patch_torch_dtype_modules(
+            model_location,
+            functions,
+            torch_compile_options,
+            compile_torch_modules,
+            disable,
+            None,
         )
         return
 
@@ -4770,133 +4962,14 @@ def unsloth_compile_transformers(
             print(str(dir(combined_module)))
         combined_module = None
 
-    # These rewrites never compile (add_torch_compile=False), so run them even
-    # when compiling is disabled: norms are fp32 upcast at load regardless, and
-    # eager F.layer_norm crashes on bf16 activations against fp32 weights.
-    if compile_torch_modules:
-        if not disable:
-            # Compiled global F.layer_norm: only when compiling is allowed
-            from .patch_torch_functions import patch_torch_functions
-
-            patch_torch_functions()
-
-        _conv_modules = frozenset([
-            "Conv1d", "Conv2d", "Conv3d",
-            "ConvTranspose1d", "ConvTranspose2d", "ConvTranspose3d",
-        ])
-        for module in _patch_functions:
-            try:
-                source = eval(f"{model_location}.torch")
-            except:
-                continue
-            if not hasattr(source, "nn"):
-                continue
-            if not hasattr(source.nn, module):
-                continue
-            function = eval(f"source.nn.{module}")
-            if not hasattr(function, "forward"):
-                continue
-            if hasattr(function.forward, "get_compiler_config"):
-                continue
-
-            try:
-                source = inspect.getsource(function.forward).rstrip()
-            except (OSError, TypeError):
-                # A forward built by exec, or one whose file has gone. Unguarded
-                # the OSError propagates out of FastModel.from_pretrained and
-                # the model does not load, over source we only wanted in order
-                # to patch a dtype cast. `get_compiler_config` above only covers
-                # torch.compile wrappers.
-                #
-                # The precondition is not fully characterised: two plain Qwen
-                # loads do not trigger it, and after such a load no torch.nn
-                # forward is unreadable (both measured). This guards a state we
-                # have seen, not a theory about how it arises. Either way source
-                # we cannot read cannot be source-patched, and every other
-                # unsupported case in this loop already skips.
-                continue
-
-            if module in _conv_modules:
-                # Conv modules: cast input to weight dtype before the conv op,
-                # then cast output back to original input dtype. This prevents
-                # dtype mismatches under mixed-precision autocast (eg bf16
-                # weight + fp16 input crashes F.conv1d).
-                lines = source.split("\n")
-                def_line = lines[0]
-                body_lines = lines[1:]
-                first_body = next((l for l in body_lines if l.strip()), "")
-                body_indent = first_body[:len(first_body) - len(first_body.lstrip())]
-                prologue = [
-                    body_indent + "original_dtype = input.dtype",
-                    body_indent + "input = input.to(self.weight.dtype)",
-                ]
-                source = "\n".join([def_line] + prologue + body_lines)
-                append_str = ".to(original_dtype)\n"
-            else:
-                # Norm modules: detect the actual parameter name (input or x)
-                import re as _re
-                m = _re.search(r"def forward\(self,\s*(\w+)", source)
-                param_name = m.group(1) if m else "input"
-                if disable:
-                    # Eager F.layer_norm needs input dtype == weight dtype: cast in
-                    # and out. Compiled path left untouched (adding the cast there
-                    # changes batched numerics). weight is None when affine=False.
-                    lines = source.split("\n")
-                    def_line = lines[0]
-                    body_lines = lines[1:]
-                    first_body = next((l for l in body_lines if l.strip()), "")
-                    body_indent = first_body[:len(first_body) - len(first_body.lstrip())]
-                    prologue = [
-                        body_indent + f"original_dtype = {param_name}.dtype",
-                        body_indent + f"if self.weight is not None: {param_name} = {param_name}.to(self.weight.dtype)",
-                    ]
-                    source = "\n".join([def_line] + prologue + body_lines)
-                    append_str = ".to(original_dtype)\n"
-                else:
-                    append_str = f".to({param_name}.dtype)\n"
-
-            forward = create_new_function(
-                module,
-                source,
-                model_location,
-                functions,
-                prepend=_license_header
-                + f"\ntorch_compile_options = {torch_compile_options}\n",
-                append=append_str,
-                overwrite=False,
-                add_torch_compile=False,
-            ).forward
-
-            exec(
-                f"{model_location}.torch.nn.{module}.forward = forward",
-                globals(),
-                locals(),
-            )
-            try:
-                exec(
-                    f"{model_location}.nn.{module}.forward = forward",
-                    globals(),
-                    locals(),
-                )
-            except:
-                pass
-            if combined_module is not None:
-                exec(
-                    f"combined_module.torch.nn.{module}.forward = forward",
-                    globals(),
-                    locals(),
-                )
-                try:
-                    exec(
-                        f"combined_module.nn.{module}.forward = forward",
-                        globals(),
-                        locals(),
-                    )
-                except:
-                    pass
-            pass
-        pass
-    pass
+    _patch_torch_dtype_modules(
+        model_location,
+        functions,
+        torch_compile_options,
+        compile_torch_modules,
+        disable,
+        combined_module,
+    )
     # Quick exit
     if combined_module is None or full_disable:
         print(

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3688,7 +3688,23 @@ def unsloth_compile_transformers(
 
     modeling_file.__UNSLOTH_PATCHED__ = True
     functions = dir(modeling_file)
-    full_source = inspect.getsource(modeling_file)
+    try:
+        full_source = inspect.getsource(modeling_file)
+    except (OSError, TypeError) as exception:
+        # Everything below is source-level feature detection, so with no source
+        # there is nothing to do. Unguarded the OSError propagates out of
+        # FastModel.from_pretrained and the model fails to LOAD, over a file we
+        # only wanted in order to make it faster.
+        #
+        # Return rather than continue with an empty string: checks of the form
+        # `"_supports_sdpa = False" not in full_source` are TRUE on empty and
+        # would enable a path the model never claimed to support.
+        logger.warning(
+            f"Unsloth: Could not read the source of {getattr(modeling_file, '__name__', modeling_file)} "
+            f"({type(exception).__name__}: {exception}), so source-level "
+            f"optimisations are skipped for it. The model still works."
+        )
+        return
 
     # Order by definition position. A bare-name find() also matches
     # forward references in annotations, docstrings and type unions,
@@ -4783,7 +4799,22 @@ def unsloth_compile_transformers(
             if hasattr(function.forward, "get_compiler_config"):
                 continue
 
-            source = inspect.getsource(function.forward).rstrip()
+            try:
+                source = inspect.getsource(function.forward).rstrip()
+            except (OSError, TypeError):
+                # A forward built by exec, or one whose file has gone. Unguarded
+                # the OSError propagates out of FastModel.from_pretrained and
+                # the model does not load, over source we only wanted in order
+                # to patch a dtype cast. `get_compiler_config` above only covers
+                # torch.compile wrappers.
+                #
+                # The precondition is not fully characterised: two plain Qwen
+                # loads do not trigger it, and after such a load no torch.nn
+                # forward is unreadable (both measured). This guards a state we
+                # have seen, not a theory about how it arises. Either way source
+                # we cannot read cannot be source-patched, and every other
+                # unsupported case in this loop already skips.
+                continue
 
             if module in _conv_modules:
                 # Conv modules: cast input to weight dtype before the conv op,


### PR DESCRIPTION
### The failure

`unsloth_compile_transformers` reads two things with `inspect.getsource`: the whole modeling module, and each `nn.Module` forward it wants to patch. Both raise

```
OSError: could not get source code
```

when linecache cannot retrieve the file, and both were unguarded. The exception propagated out of `FastModel.from_pretrained` and **the model failed to load** over source we only wanted in order to make it faster. Seen in the whisper saving test and while collecting `tests/saving/text_to_speech_models`, where the error named neither unsloth nor the module it could not read.

### The module-level read

Returns, with a warning. That is the honest degradation: LoRA forwards are already patched by that point, so the model loads and works, just without the source-level optimisations.

It deliberately does **not** continue with an empty string. Everything below that point is source-level feature detection, and checks of the form

```python
"_supports_sdpa = False" not in full_source
```

are `True` on an empty string, so carrying on would enable paths the model never claimed to support. Failing to read is not the same as reading nothing, and there is a test for exactly that distinction.

### The per-forward read

Skips that forward, which is what every other unsupported case in the same loop already does. `get_compiler_config` above it only covers `torch.compile` wrappers.

The precondition here is not fully characterised, and the comment says so rather than inventing one: two plain Qwen loads do not trigger it, and after such a load no `torch.nn` forward is unreadable. Both measured. This guards a state that has been observed, not a theory about how it arises.

### Tests

**15 new tests.** On this branch, with the neighbouring compiler suites: 98 passed, 10 skipped.

Against pristine `main`, 8 of the 15 fail:

```
FAILED test_it_returns_rather_than_continuing_with_empty_source
FAILED test_it_warns_so_the_slowdown_is_not_silent
FAILED test_the_warning_says_the_model_still_works
FAILED test_the_nn_forward_patch_loop_is_guarded
FAILED test_an_unreadable_forward_is_skipped_not_fatal
FAILED test_both_getsource_guards_are_present
8 failed, 7 passed
```

### Note on overlap

This touches `unsloth_zoo/compiler.py`, as does #986, but at lines ~3688 and ~4806 against #986's ~982, so the two do not overlap.
