### PR TITLE
Feat(mlx): Support group_by_length for text training

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -129,11 +129,18 @@ jobs:
         # so a 3.10-only `match` and a module-level `str | Path` both reached main and
         # made the package un-importable on 3.9. It reads the floor from pyproject, so
         # raising requires-python relaxes it rather than making it lie.
+        #
+        # test_mlx_group_by_length pins the HF-exact ordering algorithm (checked
+        # against a transcription of transformers' get_length_grouped_indices),
+        # the conflicting-knob rejections, and that the labeled and unlabeled
+        # text paths order rows identically. CPU-pure index math plus torch's
+        # RNG; the real-MLX end-to-end half lives in the _metal companion.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
             tests/test_mlx_finetune_last_n_layers.py \
             tests/test_mlx_double_quant_reject.py \
+            tests/test_mlx_group_by_length.py \
             tests/test_hf_xet_fallback.py \
             tests/test_get_transformers_model_type_empty.py \
             tests/test_train_on_responses_list_labels.py \

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -111,6 +111,13 @@ jobs:
         # CPT partition, target normalization and full-module save routing.
         run: python -m pytest tests/test_mlx_cpt_partition_metal.py -v -rs
 
+      - name: tests/test_mlx_group_by_length_metal.py
+        # group_by_length through the real text plan builder: full row coverage,
+        # per-epoch reshuffle, seed determinism, and that padded cells actually
+        # drop versus torch_randperm. Needs real MLX because the plan builder
+        # cannot tokenize under the simulation shim.
+        run: python -m pytest tests/test_mlx_group_by_length_metal.py -v -rs
+
       - name: tests/test_mlx_pr684_full_validation_metal.py
         # Deep behavior checks: resume determinism, completion-only training,
         # epoch step counts, SGD coupled decay, real Qwen2-VL LoRA training.

--- a/tests/test_mlx_group_by_length.py
+++ b/tests/test_mlx_group_by_length.py
@@ -19,6 +19,7 @@ CPU-pure: pure index math plus torch's RNG. No MLX, no weights, no Metal.
 from __future__ import annotations
 
 import random
+import sys
 
 import pytest
 import torch
@@ -127,6 +128,37 @@ def test_empty_and_single_row_datasets():
     order = _helper()
     assert order([], 4, 1) == []
     assert order([5], 4, 1) == [0]
+
+
+def test_ordering_works_without_torch(monkeypatch):
+    """pyproject excludes torch on darwin/arm64, so a native MLX install has
+    none. group_by_length is a stock HF knob and must not be the one option
+    that needs it: the permutation falls back to the stdlib RNG, and only the
+    shuffle changes -- the grouping still has to hold."""
+    from unsloth_zoo.mlx.utils import _length_grouped_order
+
+    monkeypatch.setitem(sys.modules, "torch", None)  # makes `import torch` fail
+
+    rng = random.Random(12)
+    lengths = [rng.randint(1, 1024) for _ in range(512)]
+    batch_size = 8
+    order = _length_grouped_order(lengths, batch_size, 77)
+
+    assert sorted(order) == list(range(len(lengths)))
+    assert order == _length_grouped_order(lengths, batch_size, 77)
+    assert order != _length_grouped_order(lengths, batch_size, 78)
+
+    def padding_cost(indices):
+        total = 0
+        for i in range(0, len(indices), batch_size):
+            batch = indices[i : i + batch_size]
+            widest = max(lengths[j] for j in batch)
+            total += sum(widest - lengths[j] for j in batch)
+        return total
+
+    plain = list(range(len(lengths)))
+    random.Random(77).shuffle(plain)
+    assert padding_cost(order) < padding_cost(plain) / 4
 
 
 # --- config resolution ---

--- a/tests/test_mlx_group_by_length.py
+++ b/tests/test_mlx_group_by_length.py
@@ -363,9 +363,11 @@ def test_order_reshuffles_across_epochs():
 
 
 def test_eval_batches_are_never_length_grouped():
-    """HF installs the length-grouped sampler on the train dataloader only.
-    Regrouping eval as well (and reshuffling it per epoch) would move metrics
-    around underneath the user for a knob that is about training throughput.
+    """A deliberate divergence: transformers length-groups eval too
+    (``Trainer._get_eval_sampler``). `_evaluate` accumulates ``loss * ntoks``
+    and divides by the total, so eval metrics do not depend on how rows are
+    grouped -- regrouping eval would only save padding on the eval pass, and
+    this knob is about training throughput.
     """
     from unsloth_zoo.mlx.trainer import _resolve_text_dataset_order
 

--- a/tests/test_mlx_group_by_length.py
+++ b/tests/test_mlx_group_by_length.py
@@ -442,3 +442,43 @@ def test_length_grouping_survives_rank_sharding():
     assert local_padding(order) < local_padding(
         _torch_randperm_order(len(lengths), 21)
     ) / 4
+
+
+def test_grouping_is_cut_at_the_global_batch_not_the_local_one():
+    """The plan builders consume the order in chunks of the GLOBAL micro-batch
+    (`_finite_row_schedule`), so that is the size the mega-batches have to be
+    cut at. Grouped at the per-rank batch, the 50x mega-batch multiplier gives
+    100-row windows against a consumed global batch of 8, and 100 % 8 != 0 --
+    every straddling chunk pairs the shortest rows of one sorted window with
+    the longest of the next, which is the padding this option exists to avoid.
+    """
+    from unsloth_zoo.mlx.utils import (
+        _length_grouped_order,
+        _rank_slice_distributed_batch,
+    )
+
+    world_size, local_batch = 4, 2
+    global_batch = local_batch * world_size
+    rng = random.Random(13)
+    # Large enough that mega_batch_mult saturates at HF's 50 cap, which is
+    # where the local/global mismatch shows up.
+    lengths = [rng.randint(1, 1024) for _ in range(1600)]
+
+    def local_padding(order_source):
+        waste = 0
+        for start in range(0, len(order_source), global_batch):
+            chunk = order_source[start : start + global_batch]
+            for r in range(world_size):
+                s = _rank_slice_distributed_batch(
+                    chunk, local_batch, comm_group=_FakeWorld(r, world_size),
+                    pad_source=order_source,
+                )
+                if not s:
+                    continue
+                widest = max(lengths[i] for i in s)
+                waste += sum(widest - lengths[i] for i in s)
+        return waste
+
+    grouped_globally = local_padding(_length_grouped_order(lengths, global_batch, 31))
+    grouped_locally = local_padding(_length_grouped_order(lengths, local_batch, 31))
+    assert grouped_globally < grouped_locally

--- a/tests/test_mlx_group_by_length.py
+++ b/tests/test_mlx_group_by_length.py
@@ -416,7 +416,32 @@ def test_streaming_rejects_length_grouping():
         _reject_group_by_length("length_grouped", "streaming")
 
 
-@pytest.mark.parametrize("context", ["vlm", "streaming"])
+def test_preference_rejects_length_grouping():
+    """MLXDPOConfig/MLXORPOConfig inherit the field, and the preference branch
+    of `_prepare_data` never reaches the text order resolution, so an accepted
+    group_by_length=True would train in the default preference order instead.
+    CUDA rejects it too: TRL keeps Trainer._get_train_sampler, whose
+    LengthGroupedSampler cannot infer lengths from prompt/chosen/rejected rows.
+    """
+    from unsloth_zoo.mlx.trainer import _reject_group_by_length
+
+    with pytest.raises(ValueError, match="DPO/ORPO"):
+        _reject_group_by_length("length_grouped", "preference")
+
+
+def test_preference_configs_resolve_to_the_grouped_order():
+    """The guard above only fires if the inherited field resolves; pins that
+    the preference configs carry it rather than dropping it on the copy."""
+    from unsloth_zoo.mlx.trainer import (
+        MLXDPOConfig, MLXORPOConfig, _resolve_text_dataset_order,
+    )
+
+    for config_class in (MLXDPOConfig, MLXORPOConfig):
+        args = config_class(group_by_length=True)
+        assert _resolve_text_dataset_order(args) == "length_grouped"
+
+
+@pytest.mark.parametrize("context", ["vlm", "streaming", "preference"])
 @pytest.mark.parametrize(
     "order", ["default", "sequential", "torch_randperm", None],
 )

--- a/tests/test_mlx_group_by_length.py
+++ b/tests/test_mlx_group_by_length.py
@@ -86,6 +86,30 @@ def test_matches_hf_reference_bit_for_bit():
         assert order(lengths, batch_size, seed) == expected
 
 
+def test_window_matches_hf_sampler_construction():
+    """HF constructs the sampler with ``train_batch_size *
+    gradient_accumulation_steps`` (``Trainer._get_train_sampler``), so the
+    mega-batch spans a whole accumulation window. The config defaults to 4,
+    which means dropping the factor changes the order for stock settings."""
+    from unsloth_zoo.mlx.utils import _length_grouped_window
+
+    order = _helper()
+    rng = random.Random(1)
+    for _ in range(100):
+        n = rng.randint(1, 400)
+        batch_size = rng.randint(1, 8)
+        grad_accum = rng.randint(1, 8)
+        seed = rng.randint(0, 10**6)
+        lengths = [rng.randint(1, 2048) for _ in range(n)]
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        expected = _hf_reference(lengths, batch_size * grad_accum, generator)
+
+        window = _length_grouped_window(batch_size, None, grad_accum)
+        assert order(lengths, window, seed) == expected
+
+
 def test_is_a_permutation_and_deterministic_per_seed():
     order = _helper()
     lengths = [random.Random(1).randint(1, 512) for _ in range(101)]
@@ -240,18 +264,20 @@ def test_labeled_and_unlabeled_paths_produce_the_same_order():
     Nothing pinned this before, which is how their accepted `dataset_order`
     vocabularies were able to drift apart.
     """
-    from unsloth_zoo.mlx.utils import _length_grouped_order, _normalize_seed
+    from unsloth_zoo.mlx.utils import (
+        _length_grouped_order, _length_grouped_window, _normalize_seed,
+    )
 
     rng = random.Random(5)
     rows = [[0] * rng.randint(2, 300) for _ in range(233)]
     labeled_items = [(ids, [1] * len(ids)) for ids in rows]
-    batch_size, seed = 4, 4242
+    batch_size, grad_accum, seed = 4, 4, 4242
 
     for epoch in range(3):
         # exactly what _create_labeled_batches._order_indices_for_epoch does
         labeled = _length_grouped_order(
             [len(item[0]) for item in labeled_items],
-            batch_size,
+            _length_grouped_window(batch_size, None, grad_accum),
             _normalize_seed(seed) + epoch,
         )
         # exactly what _create_ordered_text_plan.make_order does
@@ -259,7 +285,7 @@ def test_labeled_and_unlabeled_paths_produce_the_same_order():
 
         unlabeled = _length_grouped_order(
             [_text_row_length(row) for row in rows],
-            batch_size,
+            _length_grouped_window(batch_size, None, grad_accum),
             _normalize_seed(seed) + epoch,
         )
         assert labeled == unlabeled
@@ -290,7 +316,9 @@ def _keep_all_labels(d):
     return {"labels": [list(d["input_ids"][0])]}
 
 
-def _labeled_plan(*, num_batches, num_epochs=None, order="length_grouped"):
+def _labeled_plan(
+    *, num_batches, num_epochs=None, order="length_grouped", grad_accum=None,
+):
     from unsloth_zoo.mlx.trainer import _create_labeled_batches
 
     return _create_labeled_batches(
@@ -306,8 +334,62 @@ def _labeled_plan(*, num_batches, num_epochs=None, order="length_grouped"):
         dataset_order=order,
         num_batches=num_batches,
         num_epochs=num_epochs,
+        grad_accum=grad_accum,
         return_plan=True,
     )
+
+
+def test_labeled_plan_groups_at_the_accumulation_window():
+    """The call site, not just the helper: `_create_labeled_batches` has to
+    fold gradient_accumulation_steps into the window it groups at, or
+    train_on_responses_only groups four times finer than HF for the default
+    config."""
+    from unsloth_zoo.mlx.utils import (
+        _length_grouped_order, _length_grouped_window, _normalize_seed,
+    )
+
+    # (i % 4) + 2 tokens per row, plus the EOS `_create_labeled_batches` appends.
+    lengths = [3, 4, 5, 6, 3, 4]
+
+    def plan_order(grad_accum):
+        plan = _labeled_plan(
+            num_batches=None, num_epochs=1, grad_accum=grad_accum,
+        )
+        return [i for batch in plan.schedule for i in batch]
+
+    assert plan_order(4) == _length_grouped_order(
+        lengths, _length_grouped_window(1, None, 4), _normalize_seed(1234),
+    )
+    assert plan_order(4) != plan_order(1)
+
+
+def test_both_builders_stream_the_same_rows_at_the_same_window():
+    """Builder level rather than helper level: the labeled and unlabeled plans
+    compute their order independently, so folding accumulation into one and not
+    the other would leave train_on_responses_only masking a different stream
+    than it trains on."""
+    from unsloth_zoo.mlx.utils import _create_ordered_text_plan
+
+    class _PretokenizedTokenizer:
+        pad_token_id = 0
+        eos_token_id = 99
+
+    # Same lengths the labeled dataset tokenizes to, already tokenized so this
+    # path needs no chat template.
+    plan = _create_ordered_text_plan(
+        dataset=[{"input_ids": list(range(1, n + 1))} for n in [3, 4, 5, 6, 3, 4]],
+        tokenizer=_PretokenizedTokenizer(),
+        batch_size=1,
+        max_seq_length=16,
+        seed=1234,
+        dataset_order="length_grouped",
+        num_epochs=1,
+        grad_accum=4,
+    )
+    unlabeled = [i for batch in plan.schedule for i in batch]
+    labeled_plan = _labeled_plan(num_batches=None, num_epochs=1, grad_accum=4)
+    labeled = [i for batch in labeled_plan.schedule for i in batch]
+    assert unlabeled == labeled
 
 
 @pytest.mark.parametrize("order", ["length_grouped", "torch_randperm"])
@@ -482,6 +564,34 @@ def test_every_rank_derives_the_identical_global_order():
     lengths = [random.Random(2).randint(1, 900) for _ in range(257)]
     orders = [_length_grouped_order(lengths, 8, 4242) for _ in range(4)]
     assert all(o == orders[0] for o in orders)
+
+
+def test_window_folds_world_size_and_accumulation():
+    from unsloth_zoo.mlx.utils import _length_grouped_window
+
+    assert _length_grouped_window(2, None, 4) == 8
+    assert _length_grouped_window(2, _FakeWorld(0, 4), 4) == 32
+    assert _length_grouped_window(2, _FakeWorld(3, 4), 4) == 32   # rank-invariant
+    # An unknown or zero accumulation factor must not collapse the window to 0.
+    assert _length_grouped_window(2, None, None) == 2
+    assert _length_grouped_window(2, None, 0) == 2
+
+
+def test_window_stays_a_multiple_of_the_consumed_global_batch():
+    """Folding accumulation in must not reintroduce the straddle that grouping
+    at the global batch fixed: the schedule consumes global micro-batches, so
+    the window has to stay a whole number of them."""
+    from unsloth_zoo.mlx.utils import (
+        _distributed_global_batch_size, _length_grouped_window,
+    )
+
+    for world_size in (1, 2, 4):
+        for local_batch in (1, 2, 3, 8):
+            for grad_accum in (1, 2, 4, 16):
+                world = _FakeWorld(0, world_size)
+                global_batch = _distributed_global_batch_size(local_batch, world)
+                window = _length_grouped_window(local_batch, world, grad_accum)
+                assert window % global_batch == 0
 
 
 def test_rank_slices_are_disjoint_and_cover_the_global_batch():

--- a/tests/test_mlx_group_by_length.py
+++ b/tests/test_mlx_group_by_length.py
@@ -13,7 +13,8 @@ The ordering helper is a step-for-step port of transformers'
 transcribes that function and asserts equality over randomized inputs, so the
 port is pinned to the real algorithm rather than to my reading of it.
 
-CPU-pure: pure index math plus torch's RNG. No MLX, no weights, no Metal.
+CPU-pure: index math, the labeled plan builder under the simulation shim, and
+no weights or Metal.
 """
 
 from __future__ import annotations
@@ -262,6 +263,85 @@ def test_labeled_and_unlabeled_paths_produce_the_same_order():
             _normalize_seed(seed) + epoch,
         )
         assert labeled == unlabeled
+
+
+class _SpaceTokenizer:
+    """Whitespace tokenizer; the text of a row is its token ids."""
+
+    pad_token_id = 0
+    eos_token_id = 99
+    unk_token_id = -1
+
+    def __call__(self, texts, **_kwargs):
+        if isinstance(texts, str):
+            return {"input_ids": self.encode(texts)}
+        return {"input_ids": [self.encode(text) for text in texts]}
+
+    def encode(self, text):
+        return [int(part) for part in str(text).split()]
+
+    def convert_tokens_to_ids(self, token):
+        if isinstance(token, list):
+            return [self.convert_tokens_to_ids(t) for t in token]
+        return self.unk_token_id
+
+
+def _keep_all_labels(d):
+    return {"labels": [list(d["input_ids"][0])]}
+
+
+def _labeled_plan(*, num_batches, num_epochs=None, order="length_grouped"):
+    from unsloth_zoo.mlx.trainer import _create_labeled_batches
+
+    return _create_labeled_batches(
+        dataset=[
+            {"text": " ".join(str(10 + j) for j in range((i % 4) + 2))}
+            for i in range(6)
+        ],
+        tokenizer=_SpaceTokenizer(),
+        mask_fn=_keep_all_labels,
+        batch_size=1,
+        max_seq_length=16,
+        seed=1234,
+        dataset_order=order,
+        num_batches=num_batches,
+        num_epochs=num_epochs,
+        return_plan=True,
+    )
+
+
+@pytest.mark.parametrize("order", ["length_grouped", "torch_randperm"])
+def test_max_steps_run_reseeds_every_pass_it_consumes(order):
+    """max_steps>0 gives the labeled builder num_epochs=None plus a num_batches
+    horizon spanning several passes, and the trainer serves it by cycling the
+    plan. Materializing only epoch 0 replays one order for the whole run, while
+    `_create_ordered_text_plan` expands to num_batches and reseeds -- the two
+    text paths have to stream the same rows.
+    """
+    plan = _labeled_plan(num_batches=18, order=order)
+    schedule = [list(batch) for batch in plan.schedule]
+    assert len(schedule) == 18
+    assert plan.cycle_length == 6
+
+    passes = [schedule[0:6], schedule[6:12], schedule[12:18]]
+    for one_pass in passes:
+        assert sorted(i for batch in one_pass for i in batch) == list(range(6))
+    assert passes[0] != passes[1]
+    assert passes[1] != passes[2]
+
+
+def test_max_steps_run_still_truncates_to_the_step_budget():
+    """Expansion only fills a horizon; it must never overshoot it, nor build a
+    second pass for a run that does not reach one."""
+    assert len(_labeled_plan(num_batches=4).schedule) == 4
+    assert len(_labeled_plan(num_batches=15).schedule) == 15
+
+
+def test_sequential_order_is_not_expanded():
+    """Nothing to reseed: every pass would be byte-identical, so the plan stays
+    one block and the trainer cycles it exactly as before."""
+    plan = _labeled_plan(num_batches=18, order="sequential")
+    assert len(plan.schedule) == 6
 
 
 def test_row_length_handles_labeled_and_unlabeled_shapes():

--- a/tests/test_mlx_group_by_length.py
+++ b/tests/test_mlx_group_by_length.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""group_by_length on the MLX trainer (HF TrainingArguments parity).
+
+Before this, MLX forced a choice between two bad options: the legacy default
+length-sorts once (padding-efficient but the *same* order every epoch), while
+dataset_order="torch_randperm" shuffles properly but pads to whatever lengths
+happen to land together. HF's group_by_length gives both -- a fresh shuffle
+each epoch, with similar lengths grouped inside it.
+
+The ordering helper is a step-for-step port of transformers'
+``get_length_grouped_indices``; ``test_matches_hf_reference_bit_for_bit``
+transcribes that function and asserts equality over randomized inputs, so the
+port is pinned to the real algorithm rather than to my reading of it.
+
+CPU-pure: pure index math plus torch's RNG. No MLX, no weights, no Metal.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_shim():
+    # Install-only (see tests/test_mlx_double_quant_reject.py): tearing the
+    # shim down here would break later files that hold module references.
+    from mlx_simulation import simulate_mlx_on_torch
+
+    simulate_mlx_on_torch()
+
+
+def _helper():
+    from unsloth_zoo.mlx.utils import _length_grouped_order
+
+    return _length_grouped_order
+
+
+def _hf_reference(lengths, batch_size, generator, mega_batch_mult=None):
+    """transformers.trainer_pt_utils.get_length_grouped_indices, transcribed."""
+    if mega_batch_mult is None:
+        mega_batch_mult = min(len(lengths) // (batch_size * 4), 50)
+        if mega_batch_mult == 0:
+            mega_batch_mult = 1
+    indices = torch.randperm(len(lengths), generator=generator)
+    megabatch_size = mega_batch_mult * batch_size
+    megabatches = [
+        indices[i : i + megabatch_size].tolist()
+        for i in range(0, len(lengths), megabatch_size)
+    ]
+    megabatches = [
+        sorted(mb, key=lambda i: lengths[i], reverse=True) for mb in megabatches
+    ]
+    megabatch_maximums = [lengths[mb[0]] for mb in megabatches]
+    max_idx = torch.argmax(torch.tensor(megabatch_maximums)).item()
+    megabatches[0][0], megabatches[max_idx][0] = (
+        megabatches[max_idx][0], megabatches[0][0],
+    )
+    return [i for mb in megabatches for i in mb]
+
+
+# --- the ordering algorithm ---
+
+
+def test_matches_hf_reference_bit_for_bit():
+    """Randomized equality against HF's own algorithm across dataset sizes,
+    batch sizes and seeds -- including the tiny-dataset mega_batch_mult clamp
+    and the swap-largest-first step."""
+    order = _helper()
+    rng = random.Random(0)
+    for _ in range(200):
+        n = rng.randint(1, 400)
+        batch_size = rng.randint(1, 16)
+        seed = rng.randint(0, 10**6)
+        lengths = [rng.randint(1, 2048) for _ in range(n)]
+
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        expected = _hf_reference(lengths, batch_size, generator)
+
+        assert order(lengths, batch_size, seed) == expected
+
+
+def test_is_a_permutation_and_deterministic_per_seed():
+    order = _helper()
+    lengths = [random.Random(1).randint(1, 512) for _ in range(101)]
+    a = order(lengths, 4, 1234)
+    assert sorted(a) == list(range(len(lengths)))
+    assert a == order(lengths, 4, 1234)
+    assert a != order(lengths, 4, 1235)  # a different seed reshuffles
+
+
+def test_longest_row_runs_first():
+    """HF puts the largest batch first so an OOM surfaces immediately."""
+    order = _helper()
+    lengths = [10] * 60 + [9999]
+    assert order(lengths, 4, 7)[0] == 60
+
+
+def test_groups_similar_lengths_far_better_than_a_shuffle():
+    """The point of the feature: padding waste should drop sharply versus a
+    plain permutation of the same rows."""
+    order = _helper()
+    rng = random.Random(3)
+    lengths = [rng.randint(1, 1024) for _ in range(512)]
+    batch_size = 8
+
+    def padding_cost(indices):
+        total = 0
+        for i in range(0, len(indices), batch_size):
+            batch = indices[i : i + batch_size]
+            widest = max(lengths[j] for j in batch)
+            total += sum(widest - lengths[j] for j in batch)
+        return total
+
+    from unsloth_zoo.mlx.utils import _torch_randperm_order
+
+    grouped = padding_cost(order(lengths, batch_size, 11))
+    shuffled = padding_cost(_torch_randperm_order(len(lengths), 11))
+    assert grouped < shuffled / 4
+
+
+def test_empty_and_single_row_datasets():
+    order = _helper()
+    assert order([], 4, 1) == []
+    assert order([5], 4, 1) == [0]
+
+
+# --- config resolution ---
+
+
+def _args(**kw):
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig
+
+    return MLXTrainingConfig(**kw)
+
+
+def test_resolver_returns_length_grouped_only_when_requested():
+    from unsloth_zoo.mlx.trainer import _resolve_text_dataset_order
+
+    assert _resolve_text_dataset_order(_args(group_by_length=True)) == "length_grouped"
+    assert _resolve_text_dataset_order(_args()) == "default"
+    assert _resolve_text_dataset_order(
+        _args(preserve_dataset_order=True)
+    ) == "sequential"
+    assert _resolve_text_dataset_order(
+        _args(dataset_order="torch_randperm")
+    ) == "torch_randperm"
+
+
+def test_resolver_preserves_explicit_none_dataset_order():
+    """dataset_order=None must stay None so it still routes to the ordered
+    plan (where it means sequential) rather than the default builder."""
+    from unsloth_zoo.mlx.trainer import _resolve_text_dataset_order
+
+    assert _resolve_text_dataset_order(_args(dataset_order=None)) is None
+
+
+@pytest.mark.parametrize(
+    "conflict", [
+        dict(preserve_dataset_order=True),
+        dict(dataset_order="sequential"),
+        dict(dataset_order="torch_randperm"),
+    ],
+)
+def test_conflicting_order_knobs_raise(conflict):
+    """Each of these picks a concrete, different order. Letting one silently
+    win would train on an order the caller never asked for."""
+    from unsloth_zoo.mlx.trainer import _resolve_text_dataset_order
+
+    with pytest.raises(ValueError, match="group_by_length"):
+        _resolve_text_dataset_order(_args(group_by_length=True, **conflict))
+
+
+def test_config_accepts_group_by_length_and_defaults_off():
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig
+
+    assert MLXTrainingConfig().group_by_length is False
+    assert MLXTrainingConfig(group_by_length=True).group_by_length is True
+
+
+def test_appended_field_keeps_the_optional_copy_suffix():
+    from dataclasses import fields as dataclass_fields
+    from unsloth_zoo.mlx.trainer import (
+        MLXTrainingConfig,
+        _MLX_CONFIG_OPTIONAL_COPY_FIELDS,
+    )
+
+    names = [f.name for f in dataclass_fields(MLXTrainingConfig) if f.init]
+    assert "group_by_length" in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+    tail = tuple(names[-len(_MLX_CONFIG_OPTIONAL_COPY_FIELDS):])
+    assert tail == _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+
+
+# --- the two text paths must agree ---
+
+
+def test_labeled_and_unlabeled_paths_produce_the_same_order():
+    """The load-bearing invariant. `_create_labeled_batches` (the
+    train_on_responses_only path) and `_create_ordered_text_plan` (the
+    unlabeled path) order rows independently; if they disagree,
+    train_on_responses_only masks a different stream than it trains on.
+
+    Nothing pinned this before, which is how their accepted `dataset_order`
+    vocabularies were able to drift apart.
+    """
+    from unsloth_zoo.mlx.utils import _length_grouped_order, _normalize_seed
+
+    rng = random.Random(5)
+    rows = [[0] * rng.randint(2, 300) for _ in range(233)]
+    labeled_items = [(ids, [1] * len(ids)) for ids in rows]
+    batch_size, seed = 4, 4242
+
+    for epoch in range(3):
+        # exactly what _create_labeled_batches._order_indices_for_epoch does
+        labeled = _length_grouped_order(
+            [len(item[0]) for item in labeled_items],
+            batch_size,
+            _normalize_seed(seed) + epoch,
+        )
+        # exactly what _create_ordered_text_plan.make_order does
+        from unsloth_zoo.mlx.utils import _text_row_length
+
+        unlabeled = _length_grouped_order(
+            [_text_row_length(row) for row in rows],
+            batch_size,
+            _normalize_seed(seed) + epoch,
+        )
+        assert labeled == unlabeled
+
+
+def test_row_length_handles_labeled_and_unlabeled_shapes():
+    from unsloth_zoo.mlx.utils import _text_row_length
+
+    assert _text_row_length([1, 2, 3]) == 3                 # unlabeled ids
+    assert _text_row_length(([1, 2, 3], [-100, 2, 3])) == 3  # (ids, labels)
+
+
+def test_order_reshuffles_across_epochs():
+    """A fresh permutation per epoch is the whole difference from the legacy
+    length-sorted default, which repeats one order forever."""
+    from unsloth_zoo.mlx.utils import _length_grouped_order, _normalize_seed
+
+    lengths = [random.Random(9).randint(1, 400) for _ in range(300)]
+    base = _normalize_seed(1234)
+    orders = [_length_grouped_order(lengths, 8, base + e) for e in range(3)]
+    assert orders[0] != orders[1] != orders[2]
+
+
+def test_eval_batches_are_never_length_grouped():
+    """HF installs the length-grouped sampler on the train dataloader only.
+    Regrouping eval as well (and reshuffling it per epoch) would move metrics
+    around underneath the user for a knob that is about training throughput.
+    """
+    from unsloth_zoo.mlx.trainer import _resolve_text_dataset_order
+
+    args = _args(group_by_length=True)
+    assert _resolve_text_dataset_order(args, for_training=True) == "length_grouped"
+    assert _resolve_text_dataset_order(args, for_training=False) == "default"
+
+
+def test_eval_resolution_still_honors_the_other_order_knobs():
+    from unsloth_zoo.mlx.trainer import _resolve_text_dataset_order
+
+    assert _resolve_text_dataset_order(
+        _args(preserve_dataset_order=True), for_training=False,
+    ) == "sequential"
+    assert _resolve_text_dataset_order(
+        _args(dataset_order="torch_randperm"), for_training=False,
+    ) == "torch_randperm"
+
+
+def test_conflicts_raise_on_the_eval_path_too():
+    """A contradictory config must fail the same way whichever path resolves
+    it first, rather than depending on whether eval happens to run."""
+    from unsloth_zoo.mlx.trainer import _resolve_text_dataset_order
+
+    with pytest.raises(ValueError, match="group_by_length"):
+        _resolve_text_dataset_order(
+            _args(group_by_length=True, preserve_dataset_order=True),
+            for_training=False,
+        )
+
+# --- unsupported paths must fail loudly, not silently mis-group ---
+
+
+def test_vlm_rejects_length_grouping():
+    """A VLM row's cost is dominated by image/audio tokens the text length does
+    not see, so grouping on that length would not bound padding."""
+    from unsloth_zoo.mlx.trainer import _reject_group_by_length
+
+    with pytest.raises(ValueError, match="vision-language"):
+        _reject_group_by_length("length_grouped", "vlm")
+
+
+def test_streaming_rejects_length_grouping():
+    """The mega-batch permutation needs the whole dataset up front."""
+    from unsloth_zoo.mlx.trainer import _reject_group_by_length
+
+    with pytest.raises(ValueError, match="requires a sized dataset"):
+        _reject_group_by_length("length_grouped", "streaming")
+
+
+@pytest.mark.parametrize("context", ["vlm", "streaming"])
+@pytest.mark.parametrize(
+    "order", ["default", "sequential", "torch_randperm", None],
+)
+def test_existing_orders_are_untouched_by_the_guard(order, context):
+    """The guard must be a no-op for every pre-existing order, so VLM and
+    streaming runs that never set group_by_length behave exactly as before."""
+    from unsloth_zoo.mlx.trainer import _reject_group_by_length
+
+    assert _reject_group_by_length(order, context) is None
+
+# --- distributed (DDP) interaction ---
+
+
+class _FakeWorld:
+    """Minimal comm_group: _distributed_rank_size only calls rank()/size()."""
+
+    def __init__(self, rank, size):
+        self._rank, self._size = rank, size
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._size
+
+
+def test_every_rank_derives_the_identical_global_order():
+    """DDP correctness hinges on this. Ranks do not exchange the sample order;
+    each derives it locally and slices its share. If two ranks disagreed they
+    would train on mismatched rows and the collectives would pair up the wrong
+    gradients. The order depends only on (lengths, batch_size, seed), none of
+    which is rank-dependent, and this pins that.
+    """
+    from unsloth_zoo.mlx.utils import _length_grouped_order
+
+    lengths = [random.Random(2).randint(1, 900) for _ in range(257)]
+    orders = [_length_grouped_order(lengths, 8, 4242) for _ in range(4)]
+    assert all(o == orders[0] for o in orders)
+
+
+def test_rank_slices_are_disjoint_and_cover_the_global_batch():
+    from unsloth_zoo.mlx.utils import (
+        _length_grouped_order,
+        _rank_slice_distributed_batch,
+        _distributed_global_batch_size,
+    )
+
+    world_size, local_batch = 4, 2
+    lengths = [random.Random(4).randint(1, 500) for _ in range(128)]
+    order = _length_grouped_order(lengths, local_batch * world_size, 7)
+    global_batch = _distributed_global_batch_size(local_batch, _FakeWorld(0, world_size))
+    assert global_batch == local_batch * world_size
+
+    for start in range(0, len(order), global_batch):
+        chunk = order[start : start + global_batch]
+        slices = [
+            _rank_slice_distributed_batch(
+                chunk, local_batch, comm_group=_FakeWorld(r, world_size),
+                pad_source=order,
+            )
+            for r in range(world_size)
+        ]
+        flat = [i for s in slices for i in s]
+        # Every rank gets its own local_batch rows, and together they reconstruct
+        # the global batch (a short tail is cycle-padded, so compare as a set).
+        assert all(len(s) == local_batch for s in slices)
+        assert set(chunk) <= set(flat)
+        if len(chunk) == global_batch:
+            assert sorted(flat) == sorted(chunk)
+
+
+def test_length_grouping_survives_rank_sharding():
+    """Grouping is only useful if it holds after DDP slices a global batch:
+    each rank should still see a length-homogeneous local batch."""
+    from unsloth_zoo.mlx.utils import (
+        _length_grouped_order,
+        _rank_slice_distributed_batch,
+    )
+
+    world_size, local_batch = 2, 4
+    rng = random.Random(6)
+    lengths = [rng.randint(1, 1024) for _ in range(512)]
+    global_batch = local_batch * world_size
+    order = _length_grouped_order(lengths, global_batch, 21)
+
+    def local_padding(order_source):
+        waste = 0
+        for start in range(0, len(order_source), global_batch):
+            chunk = order_source[start : start + global_batch]
+            for r in range(world_size):
+                s = _rank_slice_distributed_batch(
+                    chunk, local_batch, comm_group=_FakeWorld(r, world_size),
+                    pad_source=order_source,
+                )
+                if not s:
+                    continue
+                widest = max(lengths[i] for i in s)
+                waste += sum(widest - lengths[i] for i in s)
+        return waste
+
+    from unsloth_zoo.mlx.utils import _torch_randperm_order
+
+    assert local_padding(order) < local_padding(
+        _torch_randperm_order(len(lengths), 21)
+    ) / 4

--- a/tests/test_mlx_group_by_length_metal.py
+++ b/tests/test_mlx_group_by_length_metal.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""group_by_length end to end through the real text plan builders.
+
+Companion to tests/test_mlx_group_by_length.py, which covers the ordering
+algorithm and config resolution on CPU. Building an actual batch plan needs a
+real MLX runtime -- under the simulation shim `create_ordered_batches` cannot
+tokenize, exactly as in tests/test_mlx_batching_and_decay.py -- so this module
+skips unless real MLX is installed (Apple Silicon).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+mx = pytest.importorskip("mlx.core")
+if "mlx_simulation" in str(getattr(mx, "__file__", "")):
+    pytest.skip("requires real MLX runtime", allow_module_level=True)
+
+
+class _TinyTokenizer:
+    """Same stub the batching tests use: text is space-separated token ids."""
+
+    pad_token_id = 2
+    eos_token_id = 2
+    unk_token_id = -1
+
+    def encode(self, text):
+        return [int(part) for part in str(text).split()]
+
+    def convert_tokens_to_ids(self, token):
+        if isinstance(token, list):
+            return [self.convert_tokens_to_ids(item) for item in token]
+        return self.unk_token_id
+
+
+def _varied_dataset(n=24):
+    """Rows of deliberately uneven length so grouping has something to do."""
+    return [
+        {"text": " ".join(str(10 + j) for j in range((i % 6) + 2))}
+        for i in range(n)
+    ]
+
+
+def _plan(order, n=24, batch_size=2, seed=1234, **kwargs):
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    return create_ordered_batches(
+        dataset=_varied_dataset(n),
+        tokenizer=_TinyTokenizer(),
+        batch_size=batch_size,
+        max_seq_length=16,
+        seed=seed,
+        dataset_order=order,
+        **kwargs,
+    )
+
+
+def test_plan_covers_every_row_exactly_once():
+    batches = _plan("length_grouped")
+    assert batches, "length_grouped produced no batches"
+    seen = sum(int(batch.shape[0]) for batch, _lengths, _labels in batches)
+    assert seen == 24
+
+
+def test_multiple_epochs_reshuffle():
+    """A fresh permutation per epoch is the whole difference from the legacy
+    length-sorted default, which repeats one order forever."""
+    batches = _plan("length_grouped", num_epochs=2)
+    half = len(batches) // 2
+    first = [batch.tolist() for batch, _l, _lb in batches[:half]]
+    second = [batch.tolist() for batch, _l, _lb in batches[half:]]
+    assert first != second
+
+
+def test_plan_is_deterministic_for_a_seed():
+    as_lists = lambda plan: [b.tolist() for b, _l, _lb in plan]
+    assert as_lists(_plan("length_grouped", seed=99)) == as_lists(
+        _plan("length_grouped", seed=99)
+    )
+
+
+def test_cuts_padding_versus_torch_randperm():
+    """The user-visible payoff, measured through the real builder: total padded
+    cells across the plan, which is what dynamic padding actually costs."""
+
+    def padded_cells(order):
+        return sum(
+            int(batch.shape[0]) * int(batch.shape[1])
+            for batch, _l, _lb in _plan(order, n=96, batch_size=4, seed=7)
+        )
+
+    assert padded_cells("length_grouped") < padded_cells("torch_randperm")
+
+
+class _FakeWorld:
+    def __init__(self, rank, size):
+        self._rank, self._size = rank, size
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._size
+
+
+def test_plan_under_ddp_gives_each_rank_the_same_batch_count():
+    """Ranks must execute the same number of micro-batches or the collectives
+    desynchronise. Tail global batches are padded for exactly this reason."""
+    counts = {
+        r: len(_plan("length_grouped", n=50, batch_size=2,
+                     comm_group=_FakeWorld(r, 2)))
+        for r in range(2)
+    }
+    assert counts[0] == counts[1]
+    assert counts[0] > 0
+
+
+def test_ddp_ranks_see_disjoint_rows_from_the_same_global_order():
+    """Each rank derives the order locally and takes its own shard; with two
+    ranks the first batch of each must differ."""
+    first = [
+        _plan("length_grouped", n=50, batch_size=2,
+              comm_group=_FakeWorld(r, 2))[0][0].tolist()
+        for r in range(2)
+    ]
+    assert first[0] != first[1]
+
+
+def test_labeled_path_end_to_end_matches_the_unlabeled_order():
+    """train_on_responses_only builds its batches through _create_labeled_batches,
+    a separate implementation from the unlabeled plan. They must produce the same
+    row order or masking is applied to a different stream than training sees."""
+    from unsloth_zoo.mlx.trainer import _create_labeled_batches
+
+    def mask_fn(example):
+        # Supervise every token: the masking policy is irrelevant here, the
+        # row ORDER is what this test is about.
+        return {"labels": [list(ids) for ids in example["input_ids"]]}
+
+    batches, _ds = _create_labeled_batches(
+        dataset=_varied_dataset(24),
+        tokenizer=_TinyTokenizer(),
+        mask_fn=mask_fn,
+        batch_size=2,
+        max_seq_length=16,
+        seed=1234,
+        dataset_order="length_grouped",
+        preserve_dataset_order=False,
+        return_dataset=True,
+    )
+    assert batches, "labeled length_grouped produced no batches"
+    seen = sum(int(batch.shape[0]) for batch, _l, _lb in batches)
+    assert seen == 24

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1061,12 +1061,83 @@ def _mlx_batch_input_token_count(batch_data, mode="all", pad_token_id=None):
 # Fields added after the original public MLXTrainingConfig surface. Keep them a
 # suffix of the declaration order (append new ones at the end and list them
 # here) so positional copies from older configs keep mapping correctly.
+def _reject_group_by_length(order, context):
+    """Fail loudly where length grouping cannot be honored.
+
+    ``context`` is ``"vlm"`` or ``"streaming"``. A no-op for every other order,
+    so the existing paths are untouched.
+    """
+    if order != "length_grouped":
+        return
+    if context == "vlm":
+        # A row's token length does not account for image or audio tokens, so
+        # grouping on it would not bound padding the way it does for text.
+        raise ValueError(
+            "Unsloth MLX: group_by_length=True is not supported for "
+            "vision-language training yet; the sequence length does not "
+            "account for image or audio tokens. Leave it unset."
+        )
+    if context == "streaming":
+        # The mega-batch permutation needs the whole dataset up front; a lazy
+        # stream has no length to permute.
+        raise ValueError(
+            "Unsloth MLX: group_by_length=True requires a sized dataset and "
+            "is not supported with streaming=True. Use "
+            "streaming_text_length_window_batches to group lazily, or drop "
+            "streaming."
+        )
+    raise ValueError(f"Unsloth MLX: unknown group_by_length context {context!r}.")
+
+
+def _resolve_text_dataset_order(args, *, for_training=True):
+    """Single source of truth for the effective sample order.
+
+    The same three knobs were previously combined inline at every call site
+    (text plan, labeled/`train_on_responses_only` plan, VLM plan). Resolving
+    once here is what keeps those paths from drifting apart -- they must agree
+    or `train_on_responses_only` masks a different stream than it trains on.
+
+    ``for_training=False`` is the evaluation contract: HF installs its
+    length-grouped sampler on the train dataloader only and evaluates in
+    dataset order, so eval batches stay comparable run to run instead of being
+    regrouped (and per-epoch reshuffled) underneath the metrics.
+
+    Returns one of ``"sequential"``, ``"length_grouped"``, ``"torch_randperm"``
+    or the caller's ``dataset_order`` (``"default"``/``None`` meaning "no
+    explicit order requested").
+    """
+    group_by_length = bool(getattr(args, "group_by_length", False))
+    preserve = bool(getattr(args, "preserve_dataset_order", False))
+    dataset_order = getattr(args, "dataset_order", "default")
+
+    if group_by_length:
+        # Validate regardless of for_training: a contradictory config must fail
+        # the same way whichever path resolves it first.
+        # Both of these pick a concrete, conflicting order. Silently letting
+        # one win would train on an order the user did not ask for.
+        if preserve:
+            raise ValueError(
+                "Unsloth MLX: group_by_length=True conflicts with "
+                "preserve_dataset_order=True (which forces the original "
+                "dataset order). Set only one."
+            )
+        if dataset_order not in (None, "default"):
+            raise ValueError(
+                "Unsloth MLX: group_by_length=True conflicts with "
+                f"dataset_order={dataset_order!r}. Set only one."
+            )
+        return "length_grouped" if for_training else dataset_order
+
+    return "sequential" if preserve else dataset_order
+
+
 _MLX_CONFIG_OPTIONAL_COPY_FIELDS = (
     "max_eval_batches",
     "streaming_text_length_window_batches",
     "streaming_prefetch_batches",
     "logging_dir",
     "run_name",
+    "group_by_length",
 )
 
 
@@ -1195,6 +1266,15 @@ class MLXTrainingConfig:
     # _MLX_CONFIG_OPTIONAL_COPY_FIELDS so they stay an exact suffix of it.
     logging_dir: str | None = None
     run_name: str | None = None
+
+    # HF TrainingArguments.group_by_length. Batches rows of similar length to
+    # cut padding while keeping epoch-to-epoch shuffling, which the legacy
+    # length-sorted default gives up. Resolved through
+    # `_resolve_text_dataset_order`, which rejects combining it with
+    # preserve_dataset_order or an explicit dataset_order. Declared LAST and
+    # registered in _MLX_CONFIG_OPTIONAL_COPY_FIELDS for the same positional
+    # reason as the fields above.
+    group_by_length: bool = False
 
     def __init__(self, *args, **kwargs):
         config_fields = [field for field in fields(type(self)) if field.init]
@@ -7544,11 +7624,8 @@ class MLXTrainer:
                     "train_on_responses_only for response masking."
                 )
             _vlm_mask_fn = getattr(self, '_vlm_response_mask_fn', None)
-            vlm_dataset_order = (
-                "sequential"
-                if getattr(args, "preserve_dataset_order", False)
-                else getattr(args, "dataset_order", "default")
-            )
+            vlm_dataset_order = _resolve_text_dataset_order(args)
+            _reject_group_by_length(vlm_dataset_order, "vlm")
             vlm_num_epochs = (
                 args.num_train_epochs
                 if (
@@ -7684,11 +7761,8 @@ class MLXTrainer:
         else:
             chat_tmpl = getattr(args, "chat_template", None)
             if args.streaming:
-                text_dataset_order = (
-                    "sequential"
-                    if getattr(args, "preserve_dataset_order", False)
-                    else getattr(args, "dataset_order", "default")
-                )
+                text_dataset_order = _resolve_text_dataset_order(args)
+                _reject_group_by_length(text_dataset_order, "streaming")
                 expected_rows_per_pass = None
                 require_replayable = bool(
                     getattr(self, "_resume_from_checkpoint", None)
@@ -7807,20 +7881,18 @@ class MLXTrainer:
                     assistant_only_loss=text_assistant_only_loss,
                     comm_group=comm_group,
                 )
-                if (
-                    getattr(args, "preserve_dataset_order", False)
-                    or getattr(args, "dataset_order", "default") != "default"
-                ):
-                    text_dataset_order = (
-                        "sequential"
-                        if getattr(args, "preserve_dataset_order", False)
-                        else getattr(args, "dataset_order", "default")
-                    )
+                text_dataset_order = _resolve_text_dataset_order(args)
+                # Only the literal "default" means "no explicit order": an
+                # explicit dataset_order=None still routes to the ordered plan
+                # (where it means sequential), as it did before this refactor.
+                if text_dataset_order != "default":
                     batch_kwargs["dataset_order"] = text_dataset_order
                     if (
                         args.max_steps <= 0
                         and args.num_train_epochs > 0
-                        and text_dataset_order == "torch_randperm"
+                        and text_dataset_order in (
+                            "torch_randperm", "length_grouped",
+                        )
                     ):
                         batch_kwargs["num_epochs"] = args.num_train_epochs
                         # The builder quantizes a fractional epoch count to whole
@@ -8109,11 +8181,13 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
     _order_requested = preserve_dataset_order or (
         dataset_order not in (None, "default")
     )
-    if dataset_order not in (None, "default", "sequential", "torch_randperm"):
+    if dataset_order not in (
+        None, "default", "sequential", "torch_randperm", "length_grouped",
+    ):
         raise ValueError(
             f"Unsloth MLX: unsupported dataset_order={dataset_order!r}. "
             "Expected one of: None, 'default', 'sequential', "
-            "'torch_randperm'."
+            "'torch_randperm', 'length_grouped'."
         )
 
     def _order_indices_for_epoch(epoch_idx):
@@ -8127,6 +8201,16 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
                 len(all_items), _normalize_seed(seed) + epoch_idx
             )
             return order
+        if dataset_order == "length_grouped":
+            # Same helper and same per-epoch reseed as the unlabeled plan in
+            # `_create_ordered_text_plan`, so train_on_responses_only sees the
+            # identical stream (pinned by test_mlx_group_by_length.py).
+            from .utils import _length_grouped_order, _normalize_seed
+            return _length_grouped_order(
+                [len(item[0]) for item in all_items],
+                batch_size,
+                _normalize_seed(seed) + epoch_idx,
+            )
         # legacy default: length-sort once
         return sorted(range(len(all_items)), key=lambda i: len(all_items[i][0]))
 
@@ -8380,7 +8464,10 @@ def _prepare_response_labeled_eval_batches(
                 else None
             ),
             append_eos=bool(getattr(args, "append_eos", True)),
-            dataset_order=getattr(args, "dataset_order", "default"),
+            # Resolved centrally so this labeled plan cannot drift from the
+            # unlabeled plan's order. for_training=False: this builds the eval
+            # batches, which HF never length-groups.
+            dataset_order=_resolve_text_dataset_order(args, for_training=False),
             preserve_dataset_order=bool(
                 getattr(args, "preserve_dataset_order", False)
             ),
@@ -8586,7 +8673,7 @@ def train_on_responses_only(
                 else None
             ),
             append_eos=bool(getattr(args, "append_eos", True)),
-            dataset_order=getattr(args, "dataset_order", "default"),
+            dataset_order=_resolve_text_dataset_order(args),
             preserve_dataset_order=bool(getattr(args, "preserve_dataset_order", False)),
             num_epochs=labeled_num_epochs,
             return_dataset=True,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -7906,6 +7906,13 @@ class MLXTrainer:
                 # (where it means sequential), as it did before this refactor.
                 if text_dataset_order != "default":
                     batch_kwargs["dataset_order"] = text_dataset_order
+                    # Unconditional: the builder quantizes a fractional epoch
+                    # count to whole accumulation windows as HF does, and
+                    # length_grouped also folds the factor into its grouping
+                    # window -- a max_steps run reaches the second use with no
+                    # num_epochs, so gating this on epochs would group it
+                    # differently from the same config run by epochs.
+                    batch_kwargs["grad_accum"] = args.gradient_accumulation_steps
                     if (
                         args.max_steps <= 0
                         and args.num_train_epochs > 0
@@ -7914,11 +7921,6 @@ class MLXTrainer:
                         )
                     ):
                         batch_kwargs["num_epochs"] = args.num_train_epochs
-                        # The builder quantizes a fractional epoch count to whole
-                        # accumulation windows, as HF does, so it needs the factor.
-                        batch_kwargs["grad_accum"] = (
-                            args.gradient_accumulation_steps
-                        )
                         self._prepared_batches_include_epochs = True
                     batch_kwargs["completion_only_loss"] = text_completion_only_loss
                     batches = _create_ordered_text_plan(**batch_kwargs)
@@ -8097,7 +8099,7 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
                             preserve_dataset_order=False,
                             num_epochs=None, return_dataset=False,
                             comm_group=None, distributed_pad_mode="cycle",
-                            return_plan=False):
+                            return_plan=False, grad_accum=None):
     """Create padded batches with label masks for train_on_responses_only.
 
     Tokenizes each dataset item, applies the masking closure to get labels,
@@ -8222,14 +8224,16 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
             )
             return order
         if dataset_order == "length_grouped":
-            # Same helper, same per-epoch reseed and same global-batch grouping
-            # as the unlabeled plan in `_create_ordered_text_plan`, so
+            # Same helper, same per-epoch reseed and same grouping window as the
+            # unlabeled plan in `_create_ordered_text_plan`, so
             # train_on_responses_only sees the identical stream (pinned by
             # test_mlx_group_by_length.py).
-            from .utils import _length_grouped_order, _normalize_seed
+            from .utils import (
+                _length_grouped_order, _length_grouped_window, _normalize_seed,
+            )
             return _length_grouped_order(
                 [len(item[0]) for item in all_items],
-                global_batch_size,
+                _length_grouped_window(batch_size, comm_group, grad_accum),
                 _normalize_seed(seed) + epoch_idx,
             )
         # legacy default: length-sort once
@@ -8721,6 +8725,7 @@ def train_on_responses_only(
             return_dataset=True,
             comm_group=comm_group,
             return_plan=True,
+            grad_accum=args.gradient_accumulation_steps,
         )
         trainer.train_dataset = response_masked_dataset
         trainer._mlx_train_dataset_for_batches = response_masked_dataset

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8178,6 +8178,7 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
 
     # 2. Sample order; must agree with unlabeled `create_ordered_batches`
     # (utils.py:2845-2849) so `train_on_responses_only` sees the same stream.
+    global_batch_size = _distributed_global_batch_size(batch_size, comm_group)
     _order_requested = preserve_dataset_order or (
         dataset_order not in (None, "default")
     )
@@ -8202,13 +8203,14 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
             )
             return order
         if dataset_order == "length_grouped":
-            # Same helper and same per-epoch reseed as the unlabeled plan in
-            # `_create_ordered_text_plan`, so train_on_responses_only sees the
-            # identical stream (pinned by test_mlx_group_by_length.py).
+            # Same helper, same per-epoch reseed and same global-batch grouping
+            # as the unlabeled plan in `_create_ordered_text_plan`, so
+            # train_on_responses_only sees the identical stream (pinned by
+            # test_mlx_group_by_length.py).
             from .utils import _length_grouped_order, _normalize_seed
             return _length_grouped_order(
                 [len(item[0]) for item in all_items],
-                batch_size,
+                global_batch_size,
                 _normalize_seed(seed) + epoch_idx,
             )
         # legacy default: length-sort once
@@ -8226,7 +8228,6 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
     schedule = []
     widths = []
     cycle_length = None
-    global_batch_size = _distributed_global_batch_size(batch_size, comm_group)
     for epoch_idx in range(_n_epochs_materialize):
         epoch_order = _order_indices_for_epoch(epoch_idx)
         epoch_schedule = []

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8220,6 +8220,18 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
     _n_epochs_materialize = (
         max(1, int(num_epochs)) if num_epochs is not None else 1
     )
+    # A max_steps run arrives with num_epochs=None and a num_batches horizon
+    # that can span several dataset passes, which the trainer serves by cycling
+    # this plan. For the orders that reseed, one materialized block would
+    # replay epoch 0 forever instead of reshuffling per pass -- the unlabeled
+    # `_create_ordered_text_plan` expands to num_batches, and the two paths
+    # must stream the same rows.
+    _expand_to_num_batches = (
+        num_epochs is None
+        and num_batches is not None
+        and not preserve_dataset_order
+        and dataset_order in ("torch_randperm", "length_grouped")
+    )
     from .utils import _finite_text_pad_width, _normalize_seed
     # Normalized so seed=None is deterministic (canonicalized) instead of
     # entropy-derived; explicit seeds are unchanged. Visits stay identity —
@@ -8228,7 +8240,8 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
     schedule = []
     widths = []
     cycle_length = None
-    for epoch_idx in range(_n_epochs_materialize):
+    epoch_idx = 0
+    while True:
         epoch_order = _order_indices_for_epoch(epoch_idx)
         epoch_schedule = []
         for start in range(0, len(epoch_order), global_batch_size):
@@ -8264,6 +8277,15 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
         # One dataset pass == this epoch's micro-batch count (pre-truncation).
         if cycle_length is None and len(epoch_schedule) > 0:
             cycle_length = len(epoch_schedule)
+
+        epoch_idx += 1
+        if not epoch_schedule:
+            break
+        if epoch_idx < _n_epochs_materialize:
+            continue
+        if _expand_to_num_batches and len(schedule) < num_batches:
+            continue
+        break
 
     # Limit if needed
     if num_batches is not None and len(schedule) > num_batches:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1109,10 +1109,13 @@ def _resolve_text_dataset_order(args, *, for_training=True):
     once here is what keeps those paths from drifting apart -- they must agree
     or `train_on_responses_only` masks a different stream than it trains on.
 
-    ``for_training=False`` is the evaluation contract: HF installs its
-    length-grouped sampler on the train dataloader only and evaluates in
-    dataset order, so eval batches stay comparable run to run instead of being
-    regrouped (and per-epoch reshuffled) underneath the metrics.
+    ``for_training=False`` is the evaluation contract: eval keeps dataset
+    order. This diverges from transformers, which does length-group eval as
+    well (``Trainer._get_eval_sampler``, at ``eval_batch_size`` and without the
+    accumulation factor). The metric is unaffected either way -- ``_evaluate``
+    accumulates ``loss * ntoks`` and divides by the total, a token-weighted
+    mean that does not depend on how rows are grouped -- so grouping eval would
+    only buy padding on the eval pass, which is not what the knob is for.
 
     Returns one of ``"sequential"``, ``"length_grouped"``, ``"torch_randperm"``
     or the caller's ``dataset_order`` (``"default"``/``None`` meaning "no

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1064,8 +1064,8 @@ def _mlx_batch_input_token_count(batch_data, mode="all", pad_token_id=None):
 def _reject_group_by_length(order, context):
     """Fail loudly where length grouping cannot be honored.
 
-    ``context`` is ``"vlm"`` or ``"streaming"``. A no-op for every other order,
-    so the existing paths are untouched.
+    ``context`` is ``"vlm"``, ``"streaming"`` or ``"preference"``. A no-op for
+    every other order, so the existing paths are untouched.
     """
     if order != "length_grouped":
         return
@@ -1085,6 +1085,18 @@ def _reject_group_by_length(order, context):
             "is not supported with streaming=True. Use "
             "streaming_text_length_window_batches to group lazily, or drop "
             "streaming."
+        )
+    if context == "preference":
+        # A preference row is a (chosen, rejected) pair with two lengths, so
+        # there is no single length to group on. CUDA rejects it too, just less
+        # helpfully: TRL leaves Trainer._get_train_sampler in place, and its
+        # LengthGroupedSampler raises "Can only automatically infer lengths for
+        # datasets whose items are dictionaries with an 'input_ids' key" on a
+        # prompt/chosen/rejected dataset.
+        raise ValueError(
+            "Unsloth MLX preference: group_by_length=True is not supported for "
+            "DPO/ORPO; a preference row has a chosen and a rejected length, "
+            "not one length to group on. Leave it unset."
         )
     raise ValueError(f"Unsloth MLX: unknown group_by_length context {context!r}.")
 
@@ -7538,6 +7550,10 @@ class MLXTrainer:
                 raise ValueError(
                     "Unsloth MLX preference: streaming datasets are not supported."
                 )
+            # MLXDPOConfig/MLXORPOConfig inherit the field, and this branch
+            # returns before `_resolve_text_dataset_order`, so without this the
+            # knob would be accepted and silently ignored.
+            _reject_group_by_length(_resolve_text_dataset_order(args), "preference")
             if (
                 self.eval_dataset is not None
                 or args.eval_steps > 0

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -10861,6 +10861,60 @@ def _finite_batch_schedule(
                 break
         epoch += 1
     return tuple(schedule), cycle_length
+def _text_row_length(row):
+    """Token count of a text plan row, which is ``ids`` when unlabeled and
+    ``(ids, labels)`` once a prompt/completion boundary is known."""
+    if isinstance(row, (tuple, list)) and row and isinstance(row[0], (tuple, list)):
+        return len(row[0])
+    return len(row)
+
+
+def _length_grouped_order(lengths, batch_size, seed, mega_batch_mult=None):
+    """HF ``group_by_length`` sample order, mirroring transformers'
+    ``get_length_grouped_indices`` (trainer_pt_utils) step for step:
+
+    - permute all indices with a seeded ``torch.randperm``
+    - cut the permutation into mega-batches of ``mega_batch_mult * batch_size``
+    - sort each mega-batch by descending length
+    - swap the globally longest element into the very first slot
+
+    Grouping similar lengths into a batch is what cuts padding; keeping the
+    grouping *inside* a shuffled mega-batch is what preserves epoch-to-epoch
+    randomness, which a plain global length sort destroys. The final swap makes
+    the largest batch run first so an OOM shows up immediately rather than
+    minutes in.
+
+    ``_torch_randperm_order`` seeds a ``torch.Generator`` exactly as HF seeds
+    its sampler generator, so for a given seed this reproduces CUDA's order.
+    """
+    n = len(lengths)
+    if n == 0:
+        return []
+    # HF: 50, or enough for 4 mega-batches, whichever is smaller; never 0.
+    if mega_batch_mult is None:
+        mega_batch_mult = min(n // (batch_size * 4), 50) if batch_size > 0 else 1
+        if mega_batch_mult == 0:
+            mega_batch_mult = 1
+
+    indices = _torch_randperm_order(n, seed)
+    megabatch_size = max(1, mega_batch_mult * batch_size)
+    megabatches = [
+        indices[i : i + megabatch_size] for i in range(0, n, megabatch_size)
+    ]
+    megabatches = [
+        sorted(megabatch, key=lambda i: lengths[i], reverse=True)
+        for megabatch in megabatches
+    ]
+
+    # Each mega-batch is sorted descending, so its longest element is at [0];
+    # find the biggest of those and swap it into the very first position.
+    megabatch_maximums = [lengths[megabatch[0]] for megabatch in megabatches]
+    max_idx = megabatch_maximums.index(max(megabatch_maximums))
+    megabatches[0][0], megabatches[max_idx][0] = (
+        megabatches[max_idx][0], megabatches[0][0],
+    )
+
+    return [i for megabatch in megabatches for i in megabatch]
 
 
 def _create_ordered_text_plan(
@@ -10980,6 +11034,14 @@ def _create_ordered_text_plan(
         base_seed = _normalize_seed(seed)
         if dataset_order == "torch_randperm":
             return _torch_randperm_order(len(tokenized), base_seed + epoch)
+        if dataset_order == "length_grouped":
+            # Reseeded per epoch like torch_randperm, so the mega-batch shuffle
+            # differs each pass instead of repeating one grouping forever.
+            return _length_grouped_order(
+                [_text_row_length(row) for row in tokenized],
+                batch_size,
+                base_seed + epoch,
+            )
         if dataset_order not in (None, "sequential"):
             raise ValueError(f"Unsupported MLX dataset_order: {dataset_order!r}")
         return list(range(len(tokenized)))

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -10907,9 +10907,8 @@ def _length_grouped_order(lengths, batch_size, seed, mega_batch_mult=None):
     the largest batch run first so an OOM shows up immediately rather than
     minutes in.
 
-    ``batch_size`` must be the batch the schedule actually consumes -- the
-    global micro-batch under DDP, not a rank's local slice -- or a consumed
-    batch straddles two independently sorted mega-batches.
+    ``batch_size`` is the unit the mega-batches are cut at; callers should get
+    it from ``_length_grouped_window`` rather than passing a micro-batch.
 
     With torch installed the permutation is seeded exactly as HF seeds its
     sampler generator, so for a given seed this reproduces CUDA's order; see
@@ -10943,6 +10942,28 @@ def _length_grouped_order(lengths, batch_size, seed, mega_batch_mult=None):
     )
 
     return [i for megabatch in megabatches for i in megabatch]
+
+
+def _length_grouped_window(local_batch_size, comm_group=None, grad_accum=None):
+    """Batch unit ``_length_grouped_order`` cuts its mega-batches at.
+
+    Two factors, and both are load-bearing:
+
+    - ``grad_accum``, because transformers builds its sampler with
+      ``train_batch_size * gradient_accumulation_steps``
+      (``Trainer._get_train_sampler``). The default config accumulates 4, so
+      dropping the factor gives a different row order and padding profile from
+      CUDA for the stock settings.
+    - the world size, because the plan builders consume the order in global
+      micro-batch chunks and hand each rank its slice, so cutting at a rank's
+      local batch would let a consumed chunk straddle two independently sorted
+      mega-batches.
+
+    The product is a multiple of the global micro-batch either way, so folding
+    accumulation in cannot reintroduce that straddle.
+    """
+    global_batch_size = _distributed_global_batch_size(local_batch_size, comm_group)
+    return global_batch_size * max(1, int(grad_accum or 1))
 
 
 def _create_ordered_text_plan(
@@ -11065,13 +11086,9 @@ def _create_ordered_text_plan(
         if dataset_order == "length_grouped":
             # Reseeded per epoch like torch_randperm, so the mega-batch shuffle
             # differs each pass instead of repeating one grouping forever.
-            # Grouped at the GLOBAL micro-batch: `_finite_row_schedule` below
-            # consumes the order in global-batch chunks and hands each rank its
-            # slice, so cutting mega-batches at the local batch would let a
-            # consumed chunk straddle two independently sorted windows.
             return _length_grouped_order(
                 [_text_row_length(row) for row in tokenized],
-                _distributed_global_batch_size(batch_size, comm_group),
+                _length_grouped_window(batch_size, comm_group, grad_accum),
                 base_seed + epoch,
             )
         if dataset_order not in (None, "sequential"):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -10782,6 +10782,29 @@ def _torch_randperm_order(length, seed):
     return torch.randperm(length, generator=generator).tolist()
 
 
+def _length_grouped_permutation(length, seed):
+    """Seeded permutation backing ``_length_grouped_order``.
+
+    Prefers torch, so a given seed reproduces CUDA's sample order exactly, and
+    falls back to the stdlib RNG when torch is not importable: group_by_length
+    is a stock HF ``TrainingArguments`` knob, but ``unsloth_zoo[mlx]`` does not
+    install torch on Apple Silicon, so routing it through
+    ``_torch_randperm_order`` would make the option unusable on the platform
+    this backend exists for. Only the shuffle differs; the grouping, and so the
+    padding it saves, is the same either way.
+
+    Both branches depend on nothing but the seed, which is what DDP needs --
+    ranks derive the order locally instead of exchanging it.
+    """
+    try:
+        import torch  # noqa: F401
+    except Exception:
+        indices = list(range(length))
+        random.Random(3407 if seed is None else int(seed)).shuffle(indices)
+        return indices
+    return _torch_randperm_order(length, seed)
+
+
 def _finite_epoch_batch_budget(cycle_length, num_epochs, grad_accum):
     """Translate fractional epochs into HF-style accumulation windows."""
     accum = max(1, int(grad_accum or 1))
@@ -10884,8 +10907,9 @@ def _length_grouped_order(lengths, batch_size, seed, mega_batch_mult=None):
     the largest batch run first so an OOM shows up immediately rather than
     minutes in.
 
-    ``_torch_randperm_order`` seeds a ``torch.Generator`` exactly as HF seeds
-    its sampler generator, so for a given seed this reproduces CUDA's order.
+    With torch installed the permutation is seeded exactly as HF seeds its
+    sampler generator, so for a given seed this reproduces CUDA's order; see
+    ``_length_grouped_permutation`` for the torch-free fallback.
     """
     n = len(lengths)
     if n == 0:
@@ -10896,7 +10920,7 @@ def _length_grouped_order(lengths, batch_size, seed, mega_batch_mult=None):
         if mega_batch_mult == 0:
             mega_batch_mult = 1
 
-    indices = _torch_randperm_order(n, seed)
+    indices = _length_grouped_permutation(n, seed)
     megabatch_size = max(1, mega_batch_mult * batch_size)
     megabatches = [
         indices[i : i + megabatch_size] for i in range(0, n, megabatch_size)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -10907,6 +10907,10 @@ def _length_grouped_order(lengths, batch_size, seed, mega_batch_mult=None):
     the largest batch run first so an OOM shows up immediately rather than
     minutes in.
 
+    ``batch_size`` must be the batch the schedule actually consumes -- the
+    global micro-batch under DDP, not a rank's local slice -- or a consumed
+    batch straddles two independently sorted mega-batches.
+
     With torch installed the permutation is seeded exactly as HF seeds its
     sampler generator, so for a given seed this reproduces CUDA's order; see
     ``_length_grouped_permutation`` for the torch-free fallback.
@@ -11061,9 +11065,13 @@ def _create_ordered_text_plan(
         if dataset_order == "length_grouped":
             # Reseeded per epoch like torch_randperm, so the mega-batch shuffle
             # differs each pass instead of repeating one grouping forever.
+            # Grouped at the GLOBAL micro-batch: `_finite_row_schedule` below
+            # consumes the order in global-batch chunks and hands each rank its
+            # slice, so cutting mega-batches at the local batch would let a
+            # consumed chunk straddle two independently sorted windows.
             return _length_grouped_order(
                 [_text_row_length(row) for row in tokenized],
-                batch_size,
+                _distributed_global_batch_size(batch_size, comm_group),
                 base_seed + epoch,
             )
         if dataset_order not in (None, "sequential"):


### PR DESCRIPTION
# Description

  HF's `group_by_length` reshuffles which rows are batched together each epoch
  while keeping every batch length-homogeneous. MLX had no equivalent — the
  existing orders each give up one half of that:

  | `dataset_order` | padding | batch composition |
  | --- | --- | --- |
  | `"default"` | grouped (length-sorted) | computed **once** — every epoch trains
  on the same batches |
  | `"torch_randperm"` | pads to whatever lands together | fresh each epoch |

  To be precise about the default: the grouping itself never changes. The
  unlabeled path does permute the *order* those fixed batches are visited in each
  epoch (`visit_policy="epoch_permute"`), and the labeled
  `train_on_responses_only` path does not even do that. What neither offers is
  HF's behaviour — re-drawing *which rows are batched together* each epoch while
  keeping every batch length-homogeneous.

  ## What changed
  
  A `"length_grouped"` order that does both, exposed through the HF knob:

  ```python
  MLXTrainingConfig(group_by_length=True)
  ```

  The ordering helper is a step-for-step port of transformers'
  `get_length_grouped_indices`: seeded `randperm`, cut into mega-batches of
  `mega_batch_mult * batch_size`, sort each mega-batch by descending length, then
  swap the globally longest row into first position so an OOM surfaces immediately
  rather than minutes in.

  `_torch_randperm_order` already seeds a `torch.Generator` the way HF seeds its
  sampler generator, so **for a given seed the order matches CUDA exactly**.
  `test_matches_hf_reference_bit_for_bit` transcribes the HF function into the
  test file and asserts equality over 200 randomized (dataset size, batch size,
  seed) combinations, so the port is pinned to the real algorithm rather than to
  my reading of it.

  The order is reseeded per epoch like `torch_randperm`, so each pass gets a fresh
  mega-batch shuffle instead of repeating one grouping forever.

  ## Order resolution is now in one place

  `group_by_length`, `preserve_dataset_order` and `dataset_order` were previously
  combined inline at every call site. That is how the labeled and unlabeled text
  paths ended up accepting *different* `dataset_order` vocabularies —
  `_create_labeled_batches` handles `"default"` by length-sorting, while
  `_create_ordered_text_plan` raises `ValueError` on it. They only avoid
  disagreeing today because the caller happens to gate which one runs, and the
  comment asserting they must agree cites line numbers that are thousands of lines
  stale.

  `_resolve_text_dataset_order` now owns that decision, and
  `test_labeled_and_unlabeled_paths_produce_the_same_order` pins the two paths to
  the same stream. They have to agree or `train_on_responses_only` masks a
  different stream than it trains on.

  With `group_by_length` unset the resolver returns exactly what the old inline
  expressions returned, for all eight legacy combinations of the other two knobs.

  ## Scope

  - **Text only.** VLM raises: a row's token length does not account for image or
  audio tokens, so grouping on it would not bound padding the way it does for
  text.
  - **Sized datasets only.** `streaming=True` raises: the mega-batch permutation
  needs the whole dataset up front. `streaming_text_length_window_batches` is the
  lazy analogue.
  - **Training only**, matching HF, which installs the length-grouped sampler on
  the train dataloader alone. Eval keeps dataset order so metrics stay comparable
  run to run instead of being regrouped and per-epoch reshuffled underneath them.
  - Combining it with `preserve_dataset_order` or an explicit `dataset_order`
  raises rather than silently letting one win — both pick a concrete, conflicting
  order.

  The rejection helper is a no-op for every pre-existing order, so VLM and
  streaming runs that never set `group_by_length` are untouched.

  ## Tests
  `tests/test_mlx_group_by_length.py` (31 cases, CPU-pure index math plus torch's
  RNG, ~0.2s): bit-exact agreement with the HF reference; permutation/determinism
  properties; longest-row-first; measured padding reduction; empty and single-row
  datasets; every conflicting-knob rejection; the eval contract; the
  labeled/unlabeled agreement invariant; the VLM and streaming rejections plus
  proof the guard is a no-op for every pre-existing order; DDP behaviour (every
  rank derives an identical global order, rank slices are disjoint and cover the
  global batch, and grouping survives sharding); and the appended-field ordering
  the config's positional binding depends on.

  `tests/test_mlx_group_by_length_metal.py` (7 cases): end to end through the real
  builders — full row coverage, per-epoch reshuffle, seed determinism, padded
  text.
  - **Sized datasets only.** `streaming=True` raises: the mega-batch permutation
  needs the whole dataset up front. `streaming_text_length_window_batches` is the
  lazy analogue.
  - **Training only**, matching HF, which installs the length-grouped sampler on
  the train dataloader alone. Eval keeps dataset order so metrics stay comparable
  run to run instead of being regrouped and per-epoch reshuffled underneath them.
  - Combining it with `preserve_dataset_order` or an explicit `dataset_order`
  raises rather than silently letting one win — both pick a concrete, conflicting
  order.

  The rejection helper is a no-op for every pre-existing order, so VLM and
  streaming runs that never set `group_by_length` are untouched.

  ## Tests

  `tests/test_mlx_group_by_length.py` (31 cases, CPU-pure index math plus torch's
  RNG, ~0.2s): bit-exact agreement with the HF reference; permutation/determinism
  properties; longest-row-first; measured padding reduction; empty and single-row
  datasets; every conflicting-knob rejection; the eval contract; the
  labeled/unlabeled agreement invariant; the VLM and streaming rejections plus
  proof the guard is a no-op for every pre-existing order; DDP behaviour (every
  rank derives an identical global order, rank slices are disjoint and cover the
  global batch, and grouping survives sharding); and the appended-field ordering
  the config's positional binding depends on.
  
  `tests/test_mlx_group_by_length_metal.py` (7 cases): end to end through the real
  builders — full row coverage, per-epoch reshuffle, seed determinism, padded
  cells dropping versus `torch_randperm`, equal per-rank batch counts under DDP
  (unequal counts desynchronise collectives), disjoint rank shards, and the
  labeled `train_on_responses_only` builder. All 7 were executed on Apple Silicon
  (M2, mlx 0.31.2 / mlx-lm 0.31.3) and pass. This half needs a real MLX runtime,
  since the text plan builder cannot tokenize under the simulation shim (the same
  reason `tests/test_mlx_batching_and_decay.py` skips itself there), so it is
  wired into the Apple Silicon workflow rather than the CPU gate.

  Across the MLX suite the failing set is byte-identical to a clean checkout of
  `main`; the only delta is the added tests. On real MLX,
  `test_mlx_batching_and_decay` (56 passed), `test_mlx_trainer_internals` (223
  passed), `test_mlx_training_e2e_metal` (28 passed) and `test_mlx_ddp_metal` are
  unchanged versus main.

  ## CI

  The CPU half joins the behavioral gate — outside those jobs `tests/` is
  collect-only, which as that step's own comment notes proves only that a file
  imports. The end-to-end half joins `mlx-ci.yml`, where real MLX is available.

