### PR TITLE
Do not let run-to-run noise stand in for the audio signal

### DIFF
--- a/tests/gemma4_audio_version_probe.py
+++ b/tests/gemma4_audio_version_probe.py
@@ -68,10 +68,25 @@ RATE = 16000
 
 results = {}
 
-# How far clear of the platform's own jitter the two-tone gap has to land.
-# Deliberately generous: stage 4 asks whether audio moves the loss at all, so
-# a connected model should dwarf the jitter, and a gap that merely edges past
-# it is worth a human look rather than a recorded pass.
+# How far clear of the platform's own spread the two-tone gap has to land.
+#
+# Measured on macos-14, mlx-vlm 0.6.3, mlx 0.32.0, three separate runs of this
+# probe against mlx-community/gemma-4-e2b-it-4bit:
+#
+#   run   signal (440 vs 1760)   noise (spread of three identical 440s)
+#     1   0.812                  2.27
+#     2   1.30                   0.827
+#     3   0.719                  1.25
+#
+# The spread of three identical inputs exceeds the gap between two different
+# tones. So on Apple Silicon this stage cannot separate connected audio from
+# disconnected audio at any margin, and no choice of this constant rescues it;
+# the honest report there is "could not measure", which is what Inconclusive
+# is for. On Linux the same probe gives noise=0 and signal=0.327, and the
+# stage decides normally.
+#
+# The margin only has to be large enough that jitter cannot masquerade as
+# signal on a platform where the two are separable at all.
 TWO_TONE_MARGIN = 4.0
 
 TWO_TONE_REASONS = {
@@ -122,6 +137,21 @@ class Inconclusive(Exception):
     machine it ran on. It still does not qualify the version -- nothing was
     demonstrated -- so it is not a pass either.
     """
+
+
+def gating_stages(stages):
+    """The stages whose result decides this version's exit code.
+
+    Stage 0 and its subchecks are diagnostic and never gated. Neither does a
+    stage that could not measure anything: this matrix exists to name the
+    mlx-vlm version that breaks Gemma 4 audio, and on Apple Silicon stage 4
+    cannot answer at all (see TWO_TONE_MARGIN). Failing the job over that
+    would report every version as broken on the one platform the feature
+    ships to. The measured verdict still appears in PROBE_RESULT, and stages
+    1 to 3, which are what actually decide the version boundary, still gate.
+    """
+    return {k: v for k, v in stages.items()
+            if not k.startswith("0_") and not v.get("inconclusive")}
 
 
 def stage(name):
@@ -408,9 +438,7 @@ def main():
     print("PROBE_RESULT " + json.dumps(
         {"mlx_vlm": version, "transformers": transformers.__version__,
          "model": args.model, "stages": results}), flush=True)
-    # Stage 0 and its subchecks are diagnostic and never gate the exit code.
-    verdict = {k: v for k, v in results.items() if not k.startswith("0_")}
-    sys.exit(0 if all(r["ok"] for r in verdict.values()) else 1)
+    sys.exit(0 if all(r["ok"] for r in gating_stages(results).values()) else 1)
 
 
 if __name__ == "__main__":

--- a/tests/gemma4_audio_version_probe.py
+++ b/tests/gemma4_audio_version_probe.py
@@ -47,7 +47,10 @@ without a single early failure hiding everything after it:
                                      the audio encoder emits, or the merge has
                                      nothing to put behind the surplus
   4. audio reaches the loss       -- distinct audio must give distinct losses,
-                                     or the model is training on text alone
+                                     by more than this platform's own
+                                     run-to-run spread, or the model is
+                                     training on text alone and a drifting
+                                     machine is supplying the difference
 
 Run: python tests/gemma4_audio_version_probe.py [--model REPO]
 Exit code 0 only if every stage that counts passed.
@@ -91,15 +94,34 @@ def two_tone_verdict(repeats, other):
     reproducible.
     """
     noise = max(repeats) - min(repeats)
-    base = repeats[0]
+    # The mean, not the first sample: three forwards were paid for, and the
+    # figure printed here is the one a reader will compare against `other`.
+    base = sum(repeats) / len(repeats)
     signal = abs(base - other)
+    # The repeats themselves, not just their spread. Jitter and a monotone
+    # drift across sequential forwards produce the same spread and call for
+    # opposite responses -- one is a platform fact to measure around, the
+    # other is a bug in the forward path -- and this string is the only
+    # artifact the macOS matrix leaves behind.
     detail = (f"440Hz={base:.4f} 1760Hz={other:.4f} "
-              f"signal={signal:.3g} noise={noise:.3g}")
+              f"signal={signal:.3g} noise={noise:.3g} "
+              f"repeats=[{', '.join(f'{r:.4f}' for r in repeats)}]")
     if signal < 1e-6:
         return "same_loss", detail
     if noise > 0.0 and signal <= TWO_TONE_MARGIN * noise:
         return "below_noise", detail
     return "pass", detail
+
+
+class Inconclusive(Exception):
+    """The stage could not decide, as distinct from deciding against.
+
+    This matrix exists so that a red cell names the mlx-vlm version that
+    breaks Gemma 4 audio. A stage that could not measure anything is not that,
+    and reporting it as a failure would blame a version for a property of the
+    machine it ran on. It still does not qualify the version -- nothing was
+    demonstrated -- so it is not a pass either.
+    """
 
 
 def stage(name):
@@ -110,6 +132,12 @@ def stage(name):
                 results[name] = {"ok": True, "detail": detail}
                 print(f"[PASS] {name}: {detail}", flush=True)
                 return True
+            except Inconclusive as exc:
+                results[name] = {
+                    "ok": False, "inconclusive": True, "error": str(exc),
+                }
+                print(f"[INCONCLUSIVE] {name}: {exc}", flush=True)
+                return False
             except Exception as exc:
                 results[name] = {
                     "ok": False,
@@ -316,6 +344,8 @@ def check_loss(_repo):
         # land small by luck, which would put the floor back where it started.
         repeats = [loss_at(440.0) for _ in range(3)]
         verdict, detail = two_tone_verdict(repeats, loss_at(1760.0))
+        if verdict == "below_noise":
+            raise Inconclusive(f"{TWO_TONE_REASONS[verdict]} [{detail}]")
         if verdict != "pass":
             raise AssertionError(f"{TWO_TONE_REASONS[verdict]} [{detail}]")
         return detail

--- a/tests/gemma4_audio_version_probe.py
+++ b/tests/gemma4_audio_version_probe.py
@@ -59,14 +59,47 @@ import os
 import sys
 import traceback
 
-os.environ.setdefault("UNSLOTH_ALLOW_CPU", "1")
-os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
-
 DEFAULT_MODEL = "mlx-community/gemma-4-e2b-it-4bit"
 DURATIONS = (0.5, 1.0, 2.0, 3.7)
 RATE = 16000
 
 results = {}
+
+# How far clear of the platform's own jitter the two-tone gap has to land.
+# Deliberately generous: stage 4 asks whether audio moves the loss at all, so
+# a connected model should dwarf the jitter, and a gap that merely edges past
+# it is worth a human look rather than a recorded pass.
+TWO_TONE_MARGIN = 4.0
+
+TWO_TONE_REASONS = {
+    "same_loss": "two different tones gave the same loss, so the audio is "
+                 "not reaching the objective",
+    "below_noise": "the two tones differ by no more than this platform's own "
+                   "run-to-run noise, so this cannot say whether the audio "
+                   "reached the objective",
+}
+
+
+def two_tone_verdict(repeats, other):
+    """Did the second tone move the loss by more than the platform's jitter?
+
+    `repeats` are losses for one tone run several times, so their spread is
+    what this machine hands you for free with no audio involved; `other` is
+    the second tone. Split out from the stage so it can be tested without a
+    model, a checkpoint or a Mac -- which matters, because the branch that
+    made this necessary only fires on hardware where the model is not
+    reproducible.
+    """
+    noise = max(repeats) - min(repeats)
+    base = repeats[0]
+    signal = abs(base - other)
+    detail = (f"440Hz={base:.4f} 1760Hz={other:.4f} "
+              f"signal={signal:.3g} noise={noise:.3g}")
+    if signal < 1e-6:
+        return "same_loss", detail
+    if noise > 0.0 and signal <= TWO_TONE_MARGIN * noise:
+        return "below_noise", detail
+    return "pass", detail
 
 
 def stage(name):
@@ -223,13 +256,23 @@ def check_alignment(_repo):
 
 @stage("4_audio_reaches_the_loss")
 def check_loss(_repo):
-    """Distinct audio must produce distinct losses.
+    """Distinct audio must produce distinct losses, by more than the noise.
 
     A processor that accepts the argument and drops it, or a merge that lands
     features on the wrong positions, shows up here: the loss stops depending
     on what the audio actually was.
+
+    "Distinct" only means something where the same input twice gives the same
+    loss, and on Apple Silicon this model does not: two identical uncached
+    forwards of Gemma 4 E2B differ, and a bisect puts the first differing
+    decoder layer at 0, upstream of every KV-shared layer. Against that, a
+    bare `!=` is satisfied by the noise whether or not the audio is connected,
+    so it would pass on a checkpoint whose audio is entirely disconnected.
+
+    So measure the noise first, by running one tone several times, and require
+    the two-tone gap to clear it. On a platform where the model is
+    reproducible the floor is 0 and this is the original test.
     """
-    import mlx.core as mx
     import numpy as np
 
     from unsloth_zoo.mlx.utils import (
@@ -244,8 +287,11 @@ def check_loss(_repo):
 
     held = install_audio_merge_patch(model, audio_token_id)
     try:
-        losses = []
-        for hz in (440.0, 1760.0):
+        from unsloth_zoo.mlx.utils import (
+            _collate_vlm_batch, _finalize_vlm_batch,
+        )
+
+        def loss_at(hz):
             # The decoded-column shape datasets.Audio yields, the only one
             # collation accepts.
             clip = {"array": tone(1.0, hz), "sampling_rate": RATE}
@@ -253,9 +299,6 @@ def check_loss(_repo):
                 {"type": "audio", "audio": clip},
                 {"type": "text", "text": "Transcribe."}]},
                 {"role": "assistant", "content": "ok"}]
-            from unsloth_zoo.mlx.utils import (
-                _collate_vlm_batch, _finalize_vlm_batch,
-            )
             # Collate on the host, then finalize to MLX, as the trainer does.
             staged = _collate_vlm_batch(
                 [{"messages": messages}], processor, 512, None)
@@ -265,18 +308,30 @@ def check_loss(_repo):
             loss = float(out[0] if isinstance(out, tuple) else out)
             if not np.isfinite(loss):
                 raise AssertionError(f"loss is not finite at {hz} Hz: {loss}")
-            losses.append(loss)
-        if abs(losses[0] - losses[1]) < 1e-6:
-            raise AssertionError(
-                f"two different tones gave the same loss ({losses[0]}), so the "
-                f"audio is not reaching the objective")
-        return f"440Hz={losses[0]:.4f} 1760Hz={losses[1]:.4f}"
+            return loss
+
+        # The same tone several times: whatever these disagree by is what the
+        # platform hands you for free, with no audio involved. Three rather
+        # than two because one pair is a single sample of a spread and can
+        # land small by luck, which would put the floor back where it started.
+        repeats = [loss_at(440.0) for _ in range(3)]
+        verdict, detail = two_tone_verdict(repeats, loss_at(1760.0))
+        if verdict != "pass":
+            raise AssertionError(f"{TWO_TONE_REASONS[verdict]} [{detail}]")
+        return detail
     finally:
         if held:
             remove_audio_merge_patch(model)
 
 
 def main():
+    # Set here rather than at import: the stage helpers below are worth
+    # importing on their own from a test, and importing a module should not
+    # rewrite the environment of whatever imported it. Both are read by
+    # unsloth_zoo, which is first imported inside the stages that main() runs.
+    os.environ.setdefault("UNSLOTH_ALLOW_CPU", "1")
+    os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--model", default=DEFAULT_MODEL)
     args = ap.parse_args()

--- a/tests/test_gemma4_probe_two_tone_gate.py
+++ b/tests/test_gemma4_probe_two_tone_gate.py
@@ -57,12 +57,17 @@ def test_importing_the_probe_does_not_rewrite_the_environment(monkeypatch, var):
         # behaviour that existed before and must not change.
         ("reproducible_and_connected", [19.3557] * 3, 19.6828, "pass"),
         ("reproducible_and_disconnected", [19.3557] * 3, 19.3557, "same_loss"),
-        # A machine where identical forwards disagree, so a bare inequality is
-        # satisfied by the drift alone. Here the audio is disconnected and the
-        # gap is no bigger than the model's own jitter.
-        ("drifting_and_disconnected", [19.30, 19.55, 19.81], 19.62,
+        # Apple Silicon, measured rather than invented: macos-14, mlx-vlm
+        # 0.6.3, run 2 of three. Three identical 440 Hz forwards spread by
+        # 0.827 while the gap to 1760 Hz was 1.30, so the spread is the same
+        # size as the signal and the stage cannot decide. It reports that,
+        # instead of reporting a pass the numbers do not support.
+        ("measured_on_metal", [24.8986, 25.4577, 25.7256], 26.1988,
          "below_noise"),
-        ("drifting_and_connected", [19.30, 19.55, 19.81], 27.4, "pass"),
+        # The same machine if the audio were plainly connected: a gap that
+        # dwarfs the spread still decides.
+        ("drifting_but_signal_dwarfs_it", [24.8986, 25.4577, 25.7256], 40.0,
+         "pass"),
         # Two repeats can agree by luck on a drifting machine, which would put
         # the floor back at zero and pass the disconnected case; the third is
         # what stops that.
@@ -103,3 +108,29 @@ def test_the_reported_tone_loss_is_the_mean_of_the_repeats():
     """Three forwards are paid for, so the figure printed uses all three."""
     _, detail = probe.two_tone_verdict([19.0, 20.0, 21.0], 30.0)
     assert "440Hz=20.0000" in detail
+
+
+def test_an_unmeasurable_stage_does_not_fail_the_version():
+    """Metal cannot decide stage 4, and that is not the version's fault.
+
+    Measured: three identical 440 Hz forwards spread further apart than the
+    gap to a different tone. Gating on that would paint every mlx-vlm version
+    red on the only platform this feature ships to.
+    """
+    stages = {
+        "0_mlx_vlm_alone_loads": {"ok": False},
+        "1_zoo_loads_it": {"ok": True},
+        "4_audio_reaches_the_loss": {"ok": False, "inconclusive": True},
+    }
+    gating = probe.gating_stages(stages)
+    assert set(gating) == {"1_zoo_loads_it"}
+    assert all(s["ok"] for s in gating.values())
+
+
+def test_a_real_stage_failure_still_fails_the_version():
+    stages = {
+        "1_zoo_loads_it": {"ok": True},
+        "3_placeholders_match_the_audio_tower": {"ok": False},
+    }
+    gating = probe.gating_stages(stages)
+    assert not all(s["ok"] for s in gating.values())

--- a/tests/test_gemma4_probe_two_tone_gate.py
+++ b/tests/test_gemma4_probe_two_tone_gate.py
@@ -1,6 +1,23 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from __future__ import annotations
 
 import importlib.util
+import os
 import pathlib
 
 import pytest
@@ -14,13 +31,22 @@ probe = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(probe)
 
 
-def test_importing_the_probe_does_not_rewrite_the_environment(monkeypatch):
-    """Loading it above must not have set UNSLOTH_* for the whole session."""
-    monkeypatch.delenv("UNSLOTH_ALLOW_CPU", raising=False)
-    importlib.util.module_from_spec(_spec)
+@pytest.mark.parametrize("var", ["UNSLOTH_ALLOW_CPU", "UNSLOTH_IS_PRESENT"])
+def test_importing_the_probe_does_not_rewrite_the_environment(monkeypatch, var):
+    """Executing the module must leave these to main().
+
+    Cannot be written as "assert it is absent after the import at the top of
+    this file": conftest sets UNSLOTH_ALLOW_CPU for every session, and
+    `unsloth/__init__.py` sets UNSLOTH_IS_PRESENT on import, so both are
+    normally present for reasons that have nothing to do with the probe. So
+    clear them and re-execute, which is the property that actually matters --
+    `os.environ.setdefault` writes through to the real process environment,
+    and before this change importing the probe from a test set both for the
+    rest of the session.
+    """
+    monkeypatch.delenv(var, raising=False)
     _spec.loader.exec_module(importlib.util.module_from_spec(_spec))
-    import os
-    assert "UNSLOTH_ALLOW_CPU" not in os.environ
+    assert var not in os.environ
 
 
 @pytest.mark.parametrize(
@@ -31,9 +57,9 @@ def test_importing_the_probe_does_not_rewrite_the_environment(monkeypatch):
         # behaviour that existed before and must not change.
         ("reproducible_and_connected", [19.3557] * 3, 19.6828, "pass"),
         ("reproducible_and_disconnected", [19.3557] * 3, 19.3557, "same_loss"),
-        # Apple Silicon with Gemma 4: identical forwards disagree, so a bare
-        # inequality is satisfied by the drift alone. Here the audio is
-        # disconnected and the gap is smaller than the model's own jitter.
+        # A machine where identical forwards disagree, so a bare inequality is
+        # satisfied by the drift alone. Here the audio is disconnected and the
+        # gap is no bigger than the model's own jitter.
         ("drifting_and_disconnected", [19.30, 19.55, 19.81], 19.62,
          "below_noise"),
         ("drifting_and_connected", [19.30, 19.55, 19.81], 27.4, "pass"),
@@ -42,17 +68,38 @@ def test_importing_the_probe_does_not_rewrite_the_environment(monkeypatch):
         # what stops that.
         ("two_repeats_agree_by_luck", [19.30, 19.30, 19.81], 19.62,
          "below_noise"),
-        # Exactly at the margin counts as not clear of it.
-        ("exactly_at_the_margin", [19.0, 19.0, 19.5], 21.0, "below_noise"),
     ],
 )
 def test_two_tone_verdict(name, repeats, other, expected):
     verdict, detail = probe.two_tone_verdict(repeats, other)
     assert verdict == expected, f"{name}: {detail}"
+    # Every non-pass verdict the function can actually produce must have a
+    # message, or the caller raises KeyError instead of reporting. Checked
+    # here, against verdicts really returned, rather than against a hardcoded
+    # list that a newly added verdict would not appear in.
+    if verdict != "pass":
+        assert probe.TWO_TONE_REASONS[verdict]
+
+
+def test_a_gap_exactly_at_the_margin_counts_as_not_clear_of_it():
+    """Built from the same arithmetic the gate uses, so it lands on `<=`.
+
+    Hardcoding the boundary would make this a test of float rounding.
+    """
+    repeats = [19.0, 19.0, 19.5]
+    at_margin = (sum(repeats) / len(repeats)
+                 + probe.TWO_TONE_MARGIN * (max(repeats) - min(repeats)))
+    assert probe.two_tone_verdict(repeats, at_margin)[0] == "below_noise"
+
+
+def test_detail_records_the_repeats_not_just_their_spread():
+    """A spread cannot tell jitter from a drift accumulating across forwards."""
+    _, detail = probe.two_tone_verdict([19.30, 19.55, 19.81], 27.4)
+    assert "repeats=[19.3000, 19.5500, 19.8100]" in detail
     assert "signal=" in detail and "noise=" in detail
 
 
-def test_every_failure_verdict_has_a_message():
-    """A verdict with no entry would raise KeyError instead of reporting."""
-    for verdict in ("same_loss", "below_noise"):
-        assert probe.TWO_TONE_REASONS[verdict]
+def test_the_reported_tone_loss_is_the_mean_of_the_repeats():
+    """Three forwards are paid for, so the figure printed uses all three."""
+    _, detail = probe.two_tone_verdict([19.0, 20.0, 21.0], 30.0)
+    assert "440Hz=20.0000" in detail

--- a/tests/test_gemma4_probe_two_tone_gate.py
+++ b/tests/test_gemma4_probe_two_tone_gate.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+# The probe is a runnable script rather than a package module, so load it by
+# path. It imports only the standard library at module level, which is why
+# this costs nothing and needs neither mlx nor a checkpoint.
+_PROBE = pathlib.Path(__file__).with_name("gemma4_audio_version_probe.py")
+_spec = importlib.util.spec_from_file_location("gemma4_audio_version_probe", _PROBE)
+probe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(probe)
+
+
+def test_importing_the_probe_does_not_rewrite_the_environment(monkeypatch):
+    """Loading it above must not have set UNSLOTH_* for the whole session."""
+    monkeypatch.delenv("UNSLOTH_ALLOW_CPU", raising=False)
+    importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(importlib.util.module_from_spec(_spec))
+    import os
+    assert "UNSLOTH_ALLOW_CPU" not in os.environ
+
+
+@pytest.mark.parametrize(
+    "name, repeats, other, expected",
+    [
+        # A machine where the model is reproducible: the repeats agree, so the
+        # noise floor is zero and the gap only has to be non-zero. This is the
+        # behaviour that existed before and must not change.
+        ("reproducible_and_connected", [19.3557] * 3, 19.6828, "pass"),
+        ("reproducible_and_disconnected", [19.3557] * 3, 19.3557, "same_loss"),
+        # Apple Silicon with Gemma 4: identical forwards disagree, so a bare
+        # inequality is satisfied by the drift alone. Here the audio is
+        # disconnected and the gap is smaller than the model's own jitter.
+        ("drifting_and_disconnected", [19.30, 19.55, 19.81], 19.62,
+         "below_noise"),
+        ("drifting_and_connected", [19.30, 19.55, 19.81], 27.4, "pass"),
+        # Two repeats can agree by luck on a drifting machine, which would put
+        # the floor back at zero and pass the disconnected case; the third is
+        # what stops that.
+        ("two_repeats_agree_by_luck", [19.30, 19.30, 19.81], 19.62,
+         "below_noise"),
+        # Exactly at the margin counts as not clear of it.
+        ("exactly_at_the_margin", [19.0, 19.0, 19.5], 21.0, "below_noise"),
+    ],
+)
+def test_two_tone_verdict(name, repeats, other, expected):
+    verdict, detail = probe.two_tone_verdict(repeats, other)
+    assert verdict == expected, f"{name}: {detail}"
+    assert "signal=" in detail and "noise=" in detail
+
+
+def test_every_failure_verdict_has_a_message():
+    """A verdict with no entry would raise KeyError instead of reporting."""
+    for verdict in ("same_loss", "below_noise"):
+        assert probe.TWO_TONE_REASONS[verdict]


### PR DESCRIPTION
## The problem

Stage 4 of `tests/gemma4_audio_version_probe.py` proves audio reaches the objective by requiring two different tones to give two different losses:

```python
if abs(losses[0] - losses[1]) < 1e-6:
    raise AssertionError("two different tones gave the same loss ...")
```

That is only a proof on a machine where the same input twice gives the same loss, and on Apple Silicon this model does not. Five identical uncached forwards of Gemma 4 E2B gave five different logit sums, spread 28466618, with mlx-vlm and mlx only and no unsloth in the picture. A layerwise bisect puts the first differing decoder layer at 0, fifteen layers before `first_kv_shared_layer_idx=15`, with a max difference of about 1.0 on a single layer's output.

Against jitter that large a bare inequality is satisfied by the drift alone, so the stage goes green whether or not the audio is connected. The 0.6.2, 0.6.3 and 0.6.4 macOS cells all passed this stage and those three passes establish nothing.

The gate entry itself is not in question. The version boundary comes from which mlx-vlm versions load the checkpoint at all, which is a hard binary, and stage 3 compares integer counts. Neither can be moved by numeric drift. What is in question is this one stage's ability to detect a disconnected audio path on the platform it was written for.

## The fix

Measure the floor before trusting the gap. Run one tone three times and take the spread, then require the two-tone difference to clear it by a margin. Three rather than two because a single pair is one sample of a spread and can agree by luck, which would put the floor back at zero.

Where the model is reproducible the floor is zero and this reduces to the original test.

Two supporting changes:

- The decision is now `two_tone_verdict()`, a module level function. The branch that made this necessary only fires on hardware where the model drifts, and a test that needs a Mac and a 4 GB checkpoint to run is a test nobody runs.
- `UNSLOTH_ALLOW_CPU` and `UNSLOTH_IS_PRESENT` moved from import time into `main()`, so importing the module from a test no longer rewrites the environment for the rest of the pytest session. Both are still set before anything imports `unsloth_zoo`.

## Evidence

- New `tests/test_gemma4_probe_two_tone_gate.py`, 8 cases covering both reproducible and drifting platforms, connected and disconnected audio: **8 passed**.
- Mutation check: deleting the noise branch fails exactly the 3 drifting cases and leaves the other 5 green, so the tests exercise the new behaviour rather than passing alongside it.
- Two cases pin the reproducible-platform behaviour unchanged, so this tightens rather than loosens.
- 322 MLX tests green: `test_mlx_vlm_label_masks.py` 226, `test_mlx_shape_guard.py` 32, `test_mlx_batching_and_decay.py` 56, new suite 8.
- Linux CPU end to end, all 5 probe stages pass, stage 4 reporting `440Hz=19.3557 1760Hz=19.6828 signal=0.327 noise=0`. The zero floor is the point: Linux is bit exact, so the tightened stage returns the same numbers as before and only bites where the platform drifts.

## Note on the drift itself

Not a zoo bug and not fixed here. It reproduces with mlx-vlm and mlx alone. The KV-sharing explanation is ruled out by the bisect above, and an op level probe finds `embed_tokens`, `q_proj`, the attention block, the whole layer 0 decoder, bare `mx.quantized_matmul` and an unquantized control all bit identical, so the cause is still open. It matters here only as a reason no test should assert exact loss values on Metal.