### PR TITLE
fix: Add XPU device support for CUDA skipped tests

### DIFF
--- a/tests/test_fused_forward_install.py
+++ b/tests/test_fused_forward_install.py
@@ -23,9 +23,11 @@ import pytest
 
 
 def get_device_type():
+    # Broad except: a torch that fails on missing driver libs must degrade to a
+    # skip, not error out the whole module during collection.
     try:
         import torch as _torch
-    except ImportError:
+    except Exception:
         return "cpu"
     if hasattr(_torch, "cuda") and _torch.cuda.is_available():
         return "cuda"

--- a/tests/test_fused_forward_install.py
+++ b/tests/test_fused_forward_install.py
@@ -23,8 +23,7 @@ import pytest
 
 
 def get_device_type():
-    # Broad except: a torch that fails on missing driver libs must degrade to a
-    # skip, not error out the whole module during collection.
+    # Broad except: a torch broken by missing driver libs must skip, not fail collection.
     try:
         import torch as _torch
     except Exception:

--- a/tests/test_fused_forward_install.py
+++ b/tests/test_fused_forward_install.py
@@ -22,6 +22,23 @@ import types
 import pytest
 
 
+def get_device_type():
+    try:
+        import torch as _torch
+    except ImportError:
+        return "cpu"
+    if hasattr(_torch, "cuda") and _torch.cuda.is_available():
+        return "cuda"
+    elif hasattr(_torch, "xpu") and _torch.xpu.is_available():
+        return "xpu"
+    else:
+        return "cpu"
+
+
+device = get_device_type()
+gpu_available = device in ("cuda", "xpu")
+
+
 # Reset module state between tests so install registries don't bleed.
 @pytest.fixture
 def fresh_install():
@@ -407,8 +424,8 @@ def forward(self, hidden_states, labels=None, **kwargs):
 
 def test_rewritten_forward_loss_matches_reference(fresh_install, enable_env):
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("fused CE kernel requires a CUDA device")
+    if not gpu_available:
+        pytest.skip("fused CE kernel requires a CUDA or XPU device")
 
     cls = _make_synthetic_class(_toy_forward_src(), name="ToyForCausalLM")
 
@@ -420,7 +437,7 @@ def test_rewritten_forward_loss_matches_reference(fresh_install, enable_env):
 
     instance = cls()
     instance.config = _Config()
-    instance.lm_head = torch.nn.Linear(H, V, bias=False).cuda().to(torch.bfloat16)
+    instance.lm_head = torch.nn.Linear(H, V, bias=False).to(device).to(torch.bfloat16)
 
     def _reference_loss(logits, labels, vocab_size, **kw):
         # Mirror unsloth_fused_ce_loss's causal one-token label shift.
@@ -434,8 +451,8 @@ def test_rewritten_forward_loss_matches_reference(fresh_install, enable_env):
         )
     instance.loss_function = _reference_loss
 
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16, requires_grad=True)
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.bfloat16, requires_grad=True)
+    labels = torch.randint(0, V, (B, T), device=device)
 
     ref_loss, _ = instance.forward(hidden, labels=labels)
     ref_loss_value = float(ref_loss.detach().cpu().item())
@@ -459,14 +476,14 @@ def test_rewritten_forward_loss_matches_reference(fresh_install, enable_env):
 
 def test_fused_kernel_respects_ignore_index():
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("fused CE kernel requires a CUDA device")
+    if not gpu_available:
+        pytest.skip("fused CE kernel requires a CUDA or XPU device")
     from unsloth_zoo.fused_losses import unsloth_fused_ce_loss
 
     B, T, H, V = 1, 16, 8, 32
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    weight = torch.randn(V, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.float32, requires_grad=True)
+    weight = torch.randn(V, H, device=device, dtype=torch.float32, requires_grad=True)
+    labels = torch.randint(0, V, (B, T), device=device)
     labels[0, 0] = 99  # would be a CUDA-side assert if not masked out
 
     loss = unsloth_fused_ce_loss(
@@ -486,14 +503,14 @@ def test_fused_kernel_accepts_int_n_items():
     # num_items_in_batch. The kernel must promote it to a tensor before
     # the DataParallel .numel()/.ravel() guard.
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("fused CE kernel requires a CUDA device")
+    if not gpu_available:
+        pytest.skip("fused CE kernel requires a CUDA or XPU device")
     from unsloth_zoo.fused_losses import unsloth_fused_ce_loss
 
     B, T, H, V = 1, 8, 8, 16
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    weight = torch.randn(V, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.float32, requires_grad=True)
+    weight = torch.randn(V, H, device=device, dtype=torch.float32, requires_grad=True)
+    labels = torch.randint(0, V, (B, T), device=device)
 
     loss = unsloth_fused_ce_loss(
         trainer=None, hidden_states=hidden, lm_head_weight=weight, lm_head_bias=None,
@@ -531,15 +548,15 @@ def _ce_reference(hidden, lm_head, labels, shift_labels=None, n_items=None,
 
 def test_adapter_auto_shift_matches_F_cross_entropy():
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
+    if not gpu_available:
+        pytest.skip("requires CUDA or XPU")
     from unsloth_zoo.fused_losses import unsloth_fused_lm_head_loss
 
     torch.manual_seed(0)
     B, T, H, V = 2, 32, 64, 128
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    lm_head = torch.nn.Linear(H, V, bias=False).cuda().float()
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.float32, requires_grad=True)
+    lm_head = torch.nn.Linear(H, V, bias=False).to(device).float()
+    labels = torch.randint(0, V, (B, T), device=device)
     labels[0, 5:8] = -100  # sprinkle ignore_index
 
     fused = unsloth_fused_lm_head_loss(hidden, lm_head, labels, vocab_size=V)
@@ -551,15 +568,15 @@ def test_adapter_auto_shift_matches_F_cross_entropy():
 
 def test_adapter_pre_shifted_tensor_matches_F_cross_entropy():
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
+    if not gpu_available:
+        pytest.skip("requires CUDA or XPU")
     from unsloth_zoo.fused_losses import unsloth_fused_lm_head_loss
 
     torch.manual_seed(1)
     B, T, H, V = 2, 32, 64, 128
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    lm_head = torch.nn.Linear(H, V, bias=False).cuda().float()
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.float32, requires_grad=True)
+    lm_head = torch.nn.Linear(H, V, bias=False).to(device).float()
+    labels = torch.randint(0, V, (B, T), device=device)
     # Simulate trl padding_free pre-shifted target: shift labels left by 1,
     # last position becomes ignore_index. Same shape as logits.
     shift = torch.full_like(labels, -100)
@@ -576,17 +593,17 @@ def test_adapter_pre_shifted_tensor_matches_F_cross_entropy():
 
 def test_adapter_shift_labels_false_matches_F_cross_entropy():
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
+    if not gpu_available:
+        pytest.skip("requires CUDA or XPU")
     from unsloth_zoo.fused_losses import unsloth_fused_lm_head_loss
 
     torch.manual_seed(2)
     B, T, H, V = 2, 32, 64, 128
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    lm_head = torch.nn.Linear(H, V, bias=False).cuda().float()
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.float32, requires_grad=True)
+    lm_head = torch.nn.Linear(H, V, bias=False).to(device).float()
     # Caller hands us labels that are already pre-shifted (the bool=False
     # contract: do not shift again, treat labels as the target tensor).
-    target = torch.randint(0, V, (B, T), device="cuda")
+    target = torch.randint(0, V, (B, T), device=device)
     target[..., -1] = -100  # canonical pre-shift fills last position
     fused = unsloth_fused_lm_head_loss(
         hidden, lm_head, labels=target, vocab_size=V, shift_labels=False,
@@ -599,15 +616,15 @@ def test_adapter_shift_labels_false_matches_F_cross_entropy():
 
 def test_adapter_num_items_in_batch_divides_correctly():
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
+    if not gpu_available:
+        pytest.skip("requires CUDA or XPU")
     from unsloth_zoo.fused_losses import unsloth_fused_lm_head_loss
 
     torch.manual_seed(3)
     B, T, H, V = 2, 16, 32, 64
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    lm_head = torch.nn.Linear(H, V, bias=False).cuda().float()
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.float32, requires_grad=True)
+    lm_head = torch.nn.Linear(H, V, bias=False).to(device).float()
+    labels = torch.randint(0, V, (B, T), device=device)
     labels[:, :2] = -100  # pad-like prefix
 
     # Effective token count after causal shift: only positions where the
@@ -627,17 +644,17 @@ def test_adapter_num_items_in_batch_divides_correctly():
 
 def test_adapter_num_items_in_batch_as_int_and_tensor_equal():
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
+    if not gpu_available:
+        pytest.skip("requires CUDA or XPU")
     from unsloth_zoo.fused_losses import unsloth_fused_lm_head_loss
 
     torch.manual_seed(4)
     B, T, H, V = 2, 16, 32, 64
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    lm_head = torch.nn.Linear(H, V, bias=False).cuda().float()
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.float32, requires_grad=True)
+    lm_head = torch.nn.Linear(H, V, bias=False).to(device).float()
+    labels = torch.randint(0, V, (B, T), device=device)
     n_items_int = 17
-    n_items_tensor = torch.tensor(17, device="cuda")
+    n_items_tensor = torch.tensor(17, device=device)
 
     fused_int = unsloth_fused_lm_head_loss(
         hidden, lm_head, labels, vocab_size=V, num_items_in_batch=n_items_int,
@@ -667,7 +684,7 @@ def _toy_instance(cls, dtype, V=64, H=32):
         vocab_size = V
     inst = cls()
     inst.config = _Config()
-    inst.lm_head = torch.nn.Linear(H, V, bias=False).cuda().to(dtype)
+    inst.lm_head = torch.nn.Linear(H, V, bias=False).to(device).to(dtype)
     def _reference_loss(logits, labels, vocab_size, **kw):
         shifted = labels.clone()
         shifted[..., :-1] = labels[..., 1:]
@@ -689,14 +706,14 @@ def test_rewritten_forward_returns_real_logits_when_env_set(
     # those materialised logits. Critically, only ONE lm_head matmul
     # happens (no fused-kernel re-matmul).
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
+    if not gpu_available:
+        pytest.skip("requires CUDA or XPU")
 
     cls = _install_toy_cls(fresh_install)
     B, T, H, V = 2, 8, 32, 64
     inst = _toy_instance(cls, dtype=torch.bfloat16, V=V, H=H)
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.bfloat16)
+    labels = torch.randint(0, V, (B, T), device=device)
 
     # Count lm_head invocations to prove single-matmul on the opt-in path.
     lm_head_calls = {"n": 0}
@@ -737,14 +754,14 @@ def test_rewritten_forward_default_labels_branch_yields_empty_logits(
     # don't pay the lm_head matmul on the hot path. Byte-identical to
     # the pre-PR behaviour.
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
+    if not gpu_available:
+        pytest.skip("requires CUDA or XPU")
 
     cls = _install_toy_cls(fresh_install)
     B, T, H, V = 2, 8, 32, 64
     inst = _toy_instance(cls, dtype=torch.bfloat16, V=V, H=H)
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.bfloat16)
+    labels = torch.randint(0, V, (B, T), device=device)
 
     monkeypatch.delenv("UNSLOTH_RETURN_LOGITS", raising=False)
     loss, logits = cls.forward(inst, hidden, labels=labels)
@@ -755,14 +772,14 @@ def test_rewritten_forward_default_labels_branch_yields_empty_logits(
 
 def test_fused_kernel_label_smoothing_changes_loss():
     torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("fused CE kernel requires a CUDA device")
+    if not gpu_available:
+        pytest.skip("fused CE kernel requires a CUDA or XPU device")
     from unsloth_zoo.fused_losses import unsloth_fused_ce_loss
 
     B, T, H, V = 1, 8, 8, 16
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    weight = torch.randn(V, H, device="cuda", dtype=torch.float32, requires_grad=True)
-    labels = torch.randint(0, V, (B, T), device="cuda")
+    hidden = torch.randn(B, T, H, device=device, dtype=torch.float32, requires_grad=True)
+    weight = torch.randn(V, H, device=device, dtype=torch.float32, requires_grad=True)
+    labels = torch.randint(0, V, (B, T), device=device)
 
     loss_plain = unsloth_fused_ce_loss(
         trainer=None, hidden_states=hidden, lm_head_weight=weight, lm_head_bias=None,

--- a/tests/test_moe_bnb4bit_adaptive_recompute.py
+++ b/tests/test_moe_bnb4bit_adaptive_recompute.py
@@ -22,8 +22,12 @@ os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
 bnb = pytest.importorskip("bitsandbytes")
 from bitsandbytes.nn import Params4bit
 
-if not torch.cuda.is_available():
-    pytest.skip("bnb 4-bit dequant needs CUDA", allow_module_level=True)
+from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
+
+gpu_available = DEVICE_TYPE_TORCH in ("cuda", "xpu")
+
+if not gpu_available:
+    pytest.skip("bnb 4-bit dequant needs CUDA or XPU", allow_module_level=True)
 
 import unsloth_zoo.temporary_patches.moe_utils as mu
 from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import forward_moe_backend_bnb4bit
@@ -32,7 +36,7 @@ from unsloth_zoo.gradient_checkpointing import _gradient_checkpoint_recompute_ma
 
 def _quantized_expert_param(shape=(4, 32, 64)):
     w = torch.randn(*shape, dtype=torch.bfloat16)
-    p = Params4bit(w, requires_grad=False, quant_type="nf4", compress_statistics=True).to("cuda")
+    p = Params4bit(w, requires_grad=False, quant_type="nf4", compress_statistics=True).to(DEVICE_TYPE_TORCH)
     p._original_shape = torch.Size(shape)
     return p
 
@@ -49,15 +53,15 @@ def _run_and_record(monkeypatch):
     monkeypatch.setattr(mu, "select_moe_backend", lambda: "grouped_mm")
     monkeypatch.setattr(
         mu, "forward_native_grouped_mm",
-        lambda self, hs, ti, tw: (calls.append("provider"), torch.zeros(1, device="cuda"))[1],
+        lambda self, hs, ti, tw: (calls.append("provider"), torch.zeros(1, device=DEVICE_TYPE_TORCH))[1],
     )
     monkeypatch.setattr(
         mu, "swap_moe_weights_for_call",
-        lambda self, gu, dn, fn, *a: (calls.append("swap"), torch.zeros(1, device="cuda"))[1],
+        lambda self, gu, dn, fn, *a: (calls.append("swap"), torch.zeros(1, device=DEVICE_TYPE_TORCH))[1],
     )
     self = _FakeExperts()
-    hs = torch.randn(3, 32, dtype=torch.bfloat16, device="cuda")
-    forward_moe_backend_bnb4bit(self, hs, torch.zeros(3, 1, dtype=torch.long, device="cuda"), None)
+    hs = torch.randn(3, 32, dtype=torch.bfloat16, device=DEVICE_TYPE_TORCH)
+    forward_moe_backend_bnb4bit(self, hs, torch.zeros(3, 1, dtype=torch.long, device=DEVICE_TYPE_TORCH), None)
     return calls
 
 
@@ -90,7 +94,7 @@ def test_pre_dequantized_dense_is_never_recomputed(monkeypatch):
     # dense stack must not be scheduled for a backward recompute (which would re-hold it
     # for no memory benefit).
     monkeypatch.setattr(mu, "_base_is_recomputable", lambda src: True)
-    dense = torch.randn(4, 32, 64, dtype=torch.bfloat16, device="cuda")  # requires_grad False
+    dense = torch.randn(4, 32, 64, dtype=torch.bfloat16, device=DEVICE_TYPE_TORCH)  # requires_grad False
     monkeypatch.setenv("UNSLOTH_MOE_RECOMPUTE", "0")
     assert mu._moe_recompute_enabled(dense) is False
     monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
@@ -102,7 +106,7 @@ def test_source_pins_large_dequant_classifies_4bit_only(monkeypatch):
     # Only a frozen bnb 4-bit expert reports a "large dequant" pinned form; a plain
     # dense base pins its own storage, so it is not flagged.
     q = _quantized_expert_param()
-    dense = torch.randn(4, 32, 64, dtype=torch.bfloat16, device="cuda")
+    dense = torch.randn(4, 32, 64, dtype=torch.bfloat16, device=DEVICE_TYPE_TORCH)
     assert mu._source_pins_large_dequant(q) is True
     assert mu._source_pins_large_dequant(dense) is False
 
@@ -113,7 +117,7 @@ def test_4bit_prefers_recompute_but_dense_still_pins_under_gc(monkeypatch):
     # GC recompute pass; the 4-bit base recomputes to avoid the bf16 dequant pin.
     monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
     q = _quantized_expert_param()
-    dense = torch.randn(4, 32, 64, dtype=torch.bfloat16, device="cuda")  # frozen
+    dense = torch.randn(4, 32, 64, dtype=torch.bfloat16, device=DEVICE_TYPE_TORCH)  # frozen
     with _gradient_checkpoint_recompute_marker():
         assert mu._moe_recompute_enabled(q) is True       # 4-bit -> recompute
         assert mu._moe_recompute_enabled(dense) is False  # dense -> pin (unchanged)

--- a/tests/test_moe_bnb4bit_adaptive_recompute.py
+++ b/tests/test_moe_bnb4bit_adaptive_recompute.py
@@ -22,13 +22,18 @@ os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
 bnb = pytest.importorskip("bitsandbytes")
 from bitsandbytes.nn import Params4bit
 
-from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
+# DEVICE_TYPE_TORCH names the device, it does not prove one exists: conftest sets
+# UNSLOTH_ALLOW_CPU=1, which makes it report "cuda" on a GPU-less host. Probe torch.
+gpu_available = (
+    (hasattr(torch, "cuda") and torch.cuda.is_available())
+    or (hasattr(torch, "xpu") and torch.xpu.is_available())
+)
 
-gpu_available = DEVICE_TYPE_TORCH in ("cuda", "xpu")
-
+# Skip before importing unsloth_zoo so a CPU-only host stays a clean module skip.
 if not gpu_available:
     pytest.skip("bnb 4-bit dequant needs CUDA or XPU", allow_module_level=True)
 
+from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
 import unsloth_zoo.temporary_patches.moe_utils as mu
 from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import forward_moe_backend_bnb4bit
 from unsloth_zoo.gradient_checkpointing import _gradient_checkpoint_recompute_marker

--- a/tests/test_moe_bnb4bit_adaptive_recompute.py
+++ b/tests/test_moe_bnb4bit_adaptive_recompute.py
@@ -22,8 +22,7 @@ os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
 bnb = pytest.importorskip("bitsandbytes")
 from bitsandbytes.nn import Params4bit
 
-# DEVICE_TYPE_TORCH names the device, it does not prove one exists: conftest sets
-# UNSLOTH_ALLOW_CPU=1, which makes it report "cuda" on a GPU-less host. Probe torch.
+# conftest sets UNSLOTH_ALLOW_CPU=1, so DEVICE_TYPE_TORCH says "cuda" even with no GPU: probe torch.
 gpu_available = (
     (hasattr(torch, "cuda") and torch.cuda.is_available())
     or (hasattr(torch, "xpu") and torch.xpu.is_available())

--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -39,11 +39,14 @@ if not hasattr(_core_model_loading.WeightConverter, "target_patterns"):
 
 from transformers.core_model_loading import ConversionOps, WeightConverter
 
+from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
 from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import (
     _AUX_SUFFIXES,
     _bnb4bit_per_expert_conversions,
     _quantstate_absmax_fp32,
 )
+
+gpu_available = DEVICE_TYPE_TORCH in ("cuda", "xpu")
 
 
 class _StubMerge(ConversionOps):
@@ -193,7 +196,7 @@ def test_fused_unquantized_falls_back_to_original_ops():
     assert out[op.base_source].shape == (3, 2, 4)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for bnb 4-bit")
+@pytest.mark.skipif(not gpu_available, reason="needs CUDA or XPU for bnb 4-bit")
 def test_fused_prequantized_builds_params4bit():
     import bitsandbytes as bnb
     import torch.nn as nn
@@ -202,7 +205,7 @@ def test_fused_prequantized_builds_params4bit():
     twin = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)[0]
     op = twin.operations[0]
 
-    w = torch.randn(2, 8, 16, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(2, 8, 16, device=DEVICE_TYPE_TORCH, dtype=torch.bfloat16)
     packed, qs = bnb.functional.quantize_4bit(w, quant_type="nf4")
     base = op.base_source
     input_dict = {base + "." + k: v for k, v in qs.as_dict(packed=True).items()}
@@ -229,7 +232,7 @@ def test_fused_prequantized_builds_params4bit():
     assert torch.allclose(deq.float(), w.float(), atol=0.5)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for bnb 4-bit")
+@pytest.mark.skipif(not gpu_available, reason="needs CUDA or XPU for bnb 4-bit")
 def test_fused_prequantized_orientation_mismatch_raises():
     """A blob quantized in the transposed (checkpoint) layout must fail loudly:
     a transpose op cannot be applied to packed 4-bit data."""
@@ -240,7 +243,7 @@ def test_fused_prequantized_orientation_mismatch_raises():
     twin = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)[0]
     op = twin.operations[0]
 
-    w = torch.randn(2, 16, 8, device="cuda", dtype=torch.bfloat16)  # transposed layout
+    w = torch.randn(2, 16, 8, device=DEVICE_TYPE_TORCH, dtype=torch.bfloat16)  # transposed layout
     packed, qs = bnb.functional.quantize_4bit(w, quant_type="nf4")
     base = op.base_source
     input_dict = {base + "." + k: v for k, v in qs.as_dict(packed=True).items()}
@@ -288,7 +291,7 @@ def _stack_input_dict(op, weights_per_src):
     return input_dict
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for bnb 4-bit")
+@pytest.mark.skipif(not gpu_available, reason="needs CUDA or XPU for bnb 4-bit")
 @pytest.mark.parametrize(
     "out_dim,in_dim,exact",
     [
@@ -306,7 +309,7 @@ def test_stack_prequantized_block_alignment(out_dim, in_dim, exact):
 
     n_experts = 2
     weights_per_src = [
-        [torch.randn(out_dim, in_dim, device="cuda", dtype=torch.bfloat16) for _ in range(n_experts)]
+        [torch.randn(out_dim, in_dim, device=DEVICE_TYPE_TORCH, dtype=torch.bfloat16) for _ in range(n_experts)]
         for _ in range(len(op.base_sources))
     ]
     input_dict = _stack_input_dict(op, weights_per_src)
@@ -350,7 +353,7 @@ def test_stack_prequantized_block_alignment(out_dim, in_dim, exact):
         assert err < 0.25, err
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for bnb 4-bit")
+@pytest.mark.skipif(not gpu_available, reason="needs CUDA or XPU for bnb 4-bit")
 def test_plain_dequant_skips_bnb_embedding4bit():
     import bitsandbytes as bnb
     import torch.nn as nn
@@ -364,10 +367,10 @@ def test_plain_dequant_skips_bnb_embedding4bit():
 
     model = Holder()
     model.emb = bnb.nn.Embedding4bit(16, 64)
-    model.emb = model.emb.cuda()  # quantizes weight into Params4bit
+    model.emb = model.emb.to(DEVICE_TYPE_TORCH)  # quantizes weight into Params4bit
     model.plain = Holder()
     packed, qs = bnb.functional.quantize_4bit(
-        torch.randn(4, 64, device="cuda", dtype=torch.bfloat16), quant_type="nf4"
+        torch.randn(4, 64, device=DEVICE_TYPE_TORCH, dtype=torch.bfloat16), quant_type="nf4"
     )
     from bitsandbytes.nn import Params4bit
     router = torch.Tensor._make_subclass(Params4bit, packed)

--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -46,8 +46,7 @@ from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import (
     _quantstate_absmax_fp32,
 )
 
-# DEVICE_TYPE_TORCH names the device, it does not prove one exists: conftest sets
-# UNSLOTH_ALLOW_CPU=1, which makes it report "cuda" on a GPU-less host. Probe torch.
+# conftest sets UNSLOTH_ALLOW_CPU=1, so DEVICE_TYPE_TORCH says "cuda" even with no GPU: probe torch.
 gpu_available = (
     (hasattr(torch, "cuda") and torch.cuda.is_available())
     or (hasattr(torch, "xpu") and torch.xpu.is_available())

--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -46,7 +46,12 @@ from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import (
     _quantstate_absmax_fp32,
 )
 
-gpu_available = DEVICE_TYPE_TORCH in ("cuda", "xpu")
+# DEVICE_TYPE_TORCH names the device, it does not prove one exists: conftest sets
+# UNSLOTH_ALLOW_CPU=1, which makes it report "cuda" on a GPU-less host. Probe torch.
+gpu_available = (
+    (hasattr(torch, "cuda") and torch.cuda.is_available())
+    or (hasattr(torch, "xpu") and torch.xpu.is_available())
+)
 
 
 class _StubMerge(ConversionOps):

--- a/tests/test_moe_fused_baddbmm_equiv.py
+++ b/tests/test_moe_fused_baddbmm_equiv.py
@@ -5,6 +5,9 @@ import pytest
 import torch
 
 from unsloth_zoo.saving_utils import _apply_fused_expert_lora_delta
+from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
+
+gpu_available = DEVICE_TYPE_TORCH in ("cuda", "xpu")
 
 
 def _loop_reference(merged, lora_A, lora_B, num_experts, rank, alpha, use_transpose):
@@ -35,24 +38,24 @@ def test_cpu_path_matches_loop(use_transpose):
     assert torch.equal(got, ref)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for the baddbmm path")
+@pytest.mark.skipif(not gpu_available, reason="needs CUDA or XPU for the baddbmm path")
 @pytest.mark.parametrize("use_transpose", [False, True])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
-def test_cuda_baddbmm_matches_loop(use_transpose, dtype):
+def test_gpu_baddbmm_matches_loop(use_transpose, dtype):
     # 128 experts, same device: only batching differs, so it must be bitwise-identical.
     E, rank, dim_A, dim_B, alpha = 128, 16, 64, 96, 1.7
-    merged, A, B = _make(E, rank, dim_A, dim_B, use_transpose, dtype, "cuda")
+    merged, A, B = _make(E, rank, dim_A, dim_B, use_transpose, dtype, DEVICE_TYPE_TORCH)
     ref = _loop_reference(merged, A, B, E, rank, alpha, use_transpose)
     got = _apply_fused_expert_lora_delta(merged.clone(), A, B, E, rank, dim_A, dim_B, alpha, use_transpose)
     assert torch.equal(got, ref), (got - ref).abs().max().item()
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for the batched path")
+@pytest.mark.skipif(not gpu_available, reason="needs CUDA or XPU for the batched path")
 @pytest.mark.parametrize("use_transpose", [False, True])
 def test_bmm_oom_falls_back_to_loop(monkeypatch, use_transpose):
     """On a batched-delta OOM the helper completes via the per-expert loop (matmul, not bmm)."""
     E, rank, dim_A, dim_B, alpha = 16, 8, 32, 48, 1.3
-    merged, A, B = _make(E, rank, dim_A, dim_B, use_transpose, torch.float32, "cuda")
+    merged, A, B = _make(E, rank, dim_A, dim_B, use_transpose, torch.float32, DEVICE_TYPE_TORCH)
     ref = _loop_reference(merged, A, B, E, rank, alpha, use_transpose)
 
     def oom(*a, **k):
@@ -63,11 +66,11 @@ def test_bmm_oom_falls_back_to_loop(monkeypatch, use_transpose):
     assert torch.equal(got, ref), "OOM fallback loop must match the batched result"
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for the batched path")
+@pytest.mark.skipif(not gpu_available, reason="needs CUDA or XPU for the batched path")
 def test_non_oom_runtimeerror_propagates(monkeypatch):
     """A non-OOM error from the batched path is a real bug and must not be swallowed."""
     E, rank, dim_A, dim_B, alpha = 4, 4, 8, 8, 1.0
-    merged, A, B = _make(E, rank, dim_A, dim_B, False, torch.float32, "cuda")
+    merged, A, B = _make(E, rank, dim_A, dim_B, False, torch.float32, DEVICE_TYPE_TORCH)
 
     def boom(*a, **k):
         raise RuntimeError("some real shape error")

--- a/tests/test_moe_fused_baddbmm_equiv.py
+++ b/tests/test_moe_fused_baddbmm_equiv.py
@@ -7,8 +7,7 @@ import torch
 from unsloth_zoo.saving_utils import _apply_fused_expert_lora_delta
 from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
 
-# DEVICE_TYPE_TORCH names the device, it does not prove one exists: conftest sets
-# UNSLOTH_ALLOW_CPU=1, which makes it report "cuda" on a GPU-less host. Probe torch.
+# conftest sets UNSLOTH_ALLOW_CPU=1, so DEVICE_TYPE_TORCH says "cuda" even with no GPU: probe torch.
 gpu_available = (
     (hasattr(torch, "cuda") and torch.cuda.is_available())
     or (hasattr(torch, "xpu") and torch.xpu.is_available())

--- a/tests/test_moe_fused_baddbmm_equiv.py
+++ b/tests/test_moe_fused_baddbmm_equiv.py
@@ -7,7 +7,12 @@ import torch
 from unsloth_zoo.saving_utils import _apply_fused_expert_lora_delta
 from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
 
-gpu_available = DEVICE_TYPE_TORCH in ("cuda", "xpu")
+# DEVICE_TYPE_TORCH names the device, it does not prove one exists: conftest sets
+# UNSLOTH_ALLOW_CPU=1, which makes it report "cuda" on a GPU-less host. Probe torch.
+gpu_available = (
+    (hasattr(torch, "cuda") and torch.cuda.is_available())
+    or (hasattr(torch, "xpu") and torch.xpu.is_available())
+)
 
 
 def _loop_reference(merged, lora_A, lora_B, num_experts, rank, alpha, use_transpose):

--- a/tests/test_moe_grouped_mm_no_copy.py
+++ b/tests/test_moe_grouped_mm_no_copy.py
@@ -11,12 +11,17 @@ import torch
 
 
 def _grouped_mm_ok():
-    if not torch.cuda.is_available():
+    try:
+        from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
+    except Exception:
+        return False
+    gpu = DEVICE_TYPE_TORCH if DEVICE_TYPE_TORCH in ("cuda", "xpu") else None
+    if gpu is None:
         return False
     try:
-        x = torch.randn(2, 8, device="cuda", dtype=torch.bfloat16)
-        w = torch.randn(1, 8, 8, device="cuda", dtype=torch.bfloat16)
-        torch._grouped_mm(x, w, offs=torch.tensor([2], dtype=torch.int32, device="cuda"))
+        x = torch.randn(2, 8, device=gpu, dtype=torch.bfloat16)
+        w = torch.randn(1, 8, 8, device=gpu, dtype=torch.bfloat16)
+        torch._grouped_mm(x, w, offs=torch.tensor([2], dtype=torch.int32, device=gpu))
         return True
     except Exception:
         return False
@@ -90,15 +95,16 @@ def test_probe_does_not_perturb_global_rng(monkeypatch):
 
 @pytest.mark.skipif(not _grouped_mm_ok(), reason="torch._grouped_mm unsupported on this device")
 def test_view_matches_copy_forward():
+    from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
     from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
 
     torch.manual_seed(0)
     E, K, N, T = 3, 64, 128, 40
-    inputs = torch.randn(T, K, device="cuda", dtype=torch.bfloat16)
-    base = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16)  # (E, out, in) as stored
+    inputs = torch.randn(T, K, device=DEVICE_TYPE_TORCH, dtype=torch.bfloat16)
+    base = torch.randn(E, N, K, device=DEVICE_TYPE_TORCH, dtype=torch.bfloat16)  # (E, out, in) as stored
     weight_view = base.transpose(1, 2)          # (E, K, N) non-contiguous view (what the fix keeps)
     weight_copy = weight_view.contiguous()      # what the old path forced
-    offsets = torch.tensor([16, 28, 40], dtype=torch.int32, device="cuda")
+    offsets = torch.tensor([16, 28, 40], dtype=torch.int32, device=DEVICE_TYPE_TORCH)
 
     out_view = _grouped_mm_with_backward_fix(inputs, weight_view, offsets)
     out_copy = _grouped_mm_with_backward_fix(inputs, weight_copy, offsets)
@@ -107,15 +113,16 @@ def test_view_matches_copy_forward():
 
 @pytest.mark.skipif(not _grouped_mm_ok(), reason="torch._grouped_mm unsupported on this device")
 def test_view_matches_copy_backward():
+    from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
     from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
 
     torch.manual_seed(0)
     E, K, N, T = 3, 64, 128, 40
-    offsets = torch.tensor([16, 28, 40], dtype=torch.int32, device="cuda")
+    offsets = torch.tensor([16, 28, 40], dtype=torch.int32, device=DEVICE_TYPE_TORCH)
 
     def run(force_copy):
-        x = torch.randn(T, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
-        base = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        x = torch.randn(T, K, device=DEVICE_TYPE_TORCH, dtype=torch.bfloat16, requires_grad=True)
+        base = torch.randn(E, N, K, device=DEVICE_TYPE_TORCH, dtype=torch.bfloat16, requires_grad=True)
         torch.manual_seed(1)  # identical draws across both runs
         x.data.normal_(); base.data.normal_()
         w = base.transpose(1, 2)

--- a/tests/test_moe_grouped_modulelist_parity.py
+++ b/tests/test_moe_grouped_modulelist_parity.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import pytest
 
+from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
 from unsloth_zoo.temporary_patches.moe_grouped_modulelist import (
     grouped_moe_forward,
     enable_grouped_moe,
@@ -25,10 +26,10 @@ from unsloth_zoo.temporary_patches.moe_grouped_modulelist import (
     HAS_BNB,
 )
 
-DEV = "cuda"
+DEV = DEVICE_TYPE_TORCH
 DTYPE = torch.bfloat16
 pytestmark = pytest.mark.skipif(
-    not (torch.cuda.is_available() and _grouped_mm_supported()),
+    not (DEVICE_TYPE_TORCH in ("cuda", "xpu") and _grouped_mm_supported()),
     reason="torch._grouped_mm unsupported on this device",
 )
 

--- a/tests/test_unsloth_zoo_lora_merge.py
+++ b/tests/test_unsloth_zoo_lora_merge.py
@@ -16,7 +16,7 @@
 
 """Tier 0 LoRA merge correctness tests for unsloth_zoo/saving_utils.py.
 
-Run on Linux+CUDA without an MLX shim. Cover _active_merge_device(), _merge_lora
+Run on Linux+CUDA/XPU without an MLX shim. Cover _active_merge_device(), _merge_lora
 (base merge, vocab-resize, non-finite guard), and the 5 MoE expert-merge variants
 against a numpy reference.
 """
@@ -27,6 +27,7 @@ import numpy as np
 import pytest
 import torch
 
+from unsloth_zoo.device_type import DEVICE_TYPE_TORCH
 from unsloth_zoo.saving_utils import (
     LoraStats,
     _active_merge_device,
@@ -38,6 +39,7 @@ from unsloth_zoo.saving_utils import (
     _merge_moe_up_expert,
 )
 
+gpu_available = DEVICE_TYPE_TORCH in ("cuda", "xpu")
 
 SEED = 1234
 
@@ -50,10 +52,10 @@ def _ls(lora_A: torch.Tensor, lora_B: torch.Tensor, alpha: float) -> LoraStats:
 # 1. _active_merge_device — recent fix that replaced the W-based helper.
 # ---------------------------------------------------------------------------
 
-def test_active_merge_device_returns_string_on_cuda_host():
-    if not torch.cuda.is_available():
-        pytest.skip("requires CUDA")
-    assert _active_merge_device() == "cuda"
+def test_active_merge_device_returns_string_on_gpu():
+    if not gpu_available:
+        pytest.skip("requires CUDA or XPU")
+    assert _active_merge_device() == DEVICE_TYPE_TORCH
 
 
 def test_active_merge_device_takes_no_args():
@@ -104,14 +106,16 @@ def test_merge_lora_moves_cpu_inputs_to_active_device():
     The W-based helper returned an indexless torch.device('cuda') for CPU W
     (unreliable on multi-GPU); the fix returns the string 'cuda' instead.
     """
-    if not torch.cuda.is_available():
-        pytest.skip("requires CUDA")
+    if not gpu_available:
+        pytest.skip("requires CUDA or XPU")
     torch.manual_seed(SEED)
     W = torch.randn(64, 32, dtype=torch.bfloat16)
     lora_A = torch.randn(8, 32, dtype=torch.bfloat16) * 0.05
     lora_B = torch.randn(64, 8, dtype=torch.bfloat16) * 0.05
     out = _merge_lora(W.clone(), _ls(lora_A, lora_B, alpha=16.0), name="cpu_input")
-    assert out.is_cuda, "expected merge result on CUDA after _active_merge_device()"
+    assert out.device.type == DEVICE_TYPE_TORCH, (
+        f"expected merge result on {DEVICE_TYPE_TORCH} after _active_merge_device(), got {out.device}"
+    )
 
 
 def test_merge_lora_vocab_resize():

--- a/tests/test_unsloth_zoo_lora_merge.py
+++ b/tests/test_unsloth_zoo_lora_merge.py
@@ -39,7 +39,12 @@ from unsloth_zoo.saving_utils import (
     _merge_moe_up_expert,
 )
 
-gpu_available = DEVICE_TYPE_TORCH in ("cuda", "xpu")
+# DEVICE_TYPE_TORCH names the device, it does not prove one exists: conftest sets
+# UNSLOTH_ALLOW_CPU=1, which makes it report "cuda" on a GPU-less host. Probe torch.
+gpu_available = (
+    (hasattr(torch, "cuda") and torch.cuda.is_available())
+    or (hasattr(torch, "xpu") and torch.xpu.is_available())
+)
 
 SEED = 1234
 

--- a/tests/test_unsloth_zoo_lora_merge.py
+++ b/tests/test_unsloth_zoo_lora_merge.py
@@ -39,8 +39,7 @@ from unsloth_zoo.saving_utils import (
     _merge_moe_up_expert,
 )
 
-# DEVICE_TYPE_TORCH names the device, it does not prove one exists: conftest sets
-# UNSLOTH_ALLOW_CPU=1, which makes it report "cuda" on a GPU-less host. Probe torch.
+# conftest sets UNSLOTH_ALLOW_CPU=1, so DEVICE_TYPE_TORCH says "cuda" even with no GPU: probe torch.
 gpu_available = (
     (hasattr(torch, "cuda") and torch.cuda.is_available())
     or (hasattr(torch, "xpu") and torch.xpu.is_available())

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -62,10 +62,16 @@ def _grouped_mm_supported() -> bool:
         ok = bool(_check_torch_grouped_mm_supported())
     except Exception:
         try:
-            if hasattr(torch, "_grouped_mm") and torch.cuda.is_available():
-                x = torch.ones((1, 8), device="cuda", dtype=torch.bfloat16)
-                w = torch.ones((1, 8, 8), device="cuda", dtype=torch.bfloat16)
-                torch._grouped_mm(x, w, offs=torch.tensor([1], device="cuda", dtype=torch.int32))
+            if torch.cuda.is_available():
+                dev = "cuda"
+            elif hasattr(torch, "xpu") and torch.xpu.is_available():
+                dev = "xpu"
+            else:
+                dev = None
+            if hasattr(torch, "_grouped_mm") and dev is not None:
+                x = torch.ones((1, 8), device=dev, dtype=torch.bfloat16)
+                w = torch.ones((1, 8, 8), device=dev, dtype=torch.bfloat16)
+                torch._grouped_mm(x, w, offs=torch.tensor([1], device=dev, dtype=torch.int32))
                 ok = True
         except Exception:
             ok = False
@@ -201,7 +207,7 @@ def grouped_moe_forward(self, hidden_states: torch.Tensor):
     experts = self.experts
     # Run the original loop unless this is the frozen-expert CUDA path in a low-precision dtype
     # with every expert grouped-ready (CPU/offload, LoRA, fp32, dtype/device mismatch fall back).
-    if (not hidden_states.is_cuda) \
+    if hidden_states.device.type not in ("cuda", "xpu") \
             or hidden_states.dtype not in (torch.bfloat16, torch.float16) \
             or not _experts_grouped_ready(experts, spec, hidden_states.device, hidden_states.dtype):
         return self._orig_moe_forward(hidden_states)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -299,10 +299,12 @@ def _check_torch_grouped_mm_supported():
         _TORCH_GROUPED_MM_SUPPORTED = False
         return False
 
+    # Typed device, not a bare index: torch resolves an int against the compiled-in
+    # accelerator, so it would not carry the branch taken here.
     if torch.cuda.is_available():
-        device = torch.cuda.current_device()
+        device = torch.device("cuda", torch.cuda.current_device())
     elif hasattr(torch, "xpu") and torch.xpu.is_available():
-        device = torch.xpu.current_device()
+        device = torch.device("xpu", torch.xpu.current_device())
     else:
         _TORCH_GROUPED_MM_SUPPORTED = False
         return False
@@ -339,9 +341,9 @@ def _transposed_view_grouped_mm_is_safe():
     safe = False
     try:
         if torch.cuda.is_available():
-            device = torch.cuda.current_device()
+            device = torch.device("cuda", torch.cuda.current_device())
         elif hasattr(torch, "xpu") and torch.xpu.is_available():
-            device = torch.xpu.current_device()
+            device = torch.device("xpu", torch.xpu.current_device())
         else:
             device = None
         if _TORCH_GROUPED_MM_AVAILABLE and device is not None:
@@ -1369,9 +1371,14 @@ def forward_native_grouped_mm(
 
     # Runtime safety check (defense in depth).
     if not _check_torch_grouped_mm_supported():
-        major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
+        # Compute Capability is CUDA-only; on XPU it would mask this message.
+        if torch.cuda.is_available():
+            major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
+            where = f"this device (Compute Capability {major}.{minor})"
+        else:
+            where = "this device"
         raise RuntimeError(
-            f"torch._grouped_mm is not supported on this device (Compute Capability {major}.{minor}). "
+            f"torch._grouped_mm is not supported on {where}. "
             f"Set UNSLOTH_MOE_BACKEND='unsloth_triton' or 'native_torch' to use a compatible backend."
         )
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -299,8 +299,7 @@ def _check_torch_grouped_mm_supported():
         _TORCH_GROUPED_MM_SUPPORTED = False
         return False
 
-    # Typed device, not a bare index: torch resolves an int against the compiled-in
-    # accelerator, so it would not carry the branch taken here.
+    # Typed device, not a bare index: an int resolves to the default accelerator, losing this branch.
     if torch.cuda.is_available():
         device = torch.device("cuda", torch.cuda.current_device())
     elif hasattr(torch, "xpu") and torch.xpu.is_available():

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -299,13 +299,16 @@ def _check_torch_grouped_mm_supported():
         _TORCH_GROUPED_MM_SUPPORTED = False
         return False
 
-    if not torch.cuda.is_available():
+    if torch.cuda.is_available():
+        device = torch.cuda.current_device()
+    elif hasattr(torch, "xpu") and torch.xpu.is_available():
+        device = torch.xpu.current_device()
+    else:
         _TORCH_GROUPED_MM_SUPPORTED = False
         return False
 
     try:
         # Dummy call verifies real support (symbol may exist but hardware unsupported, e.g. < H100).
-        device = torch.cuda.current_device()
         dtype = torch.float16
 
         # 1 expert, 1 token, dim 8 (safe alignment).
@@ -335,8 +338,13 @@ def _transposed_view_grouped_mm_is_safe():
 
     safe = False
     try:
-        if _TORCH_GROUPED_MM_AVAILABLE and torch.cuda.is_available():
+        if torch.cuda.is_available():
             device = torch.cuda.current_device()
+        elif hasattr(torch, "xpu") and torch.xpu.is_available():
+            device = torch.xpu.current_device()
+        else:
+            device = None
+        if _TORCH_GROUPED_MM_AVAILABLE and device is not None:
             E, N, K, M = 4, 64, 32, 32
             # local generator: never touch the process-wide RNG (manual_seed would shift training)
             gen = torch.Generator(device=device).manual_seed(0)


### PR DESCRIPTION
## What This PR Does

Adds Intel XPU compatibility for the tests listed below found under `tests/`. Removes the hardcoded CUDA device conditions and adds XPU device option.

## Changes

**1. `tests/test_fused_forward_install.py`**
Added `get_device_type()` which tries to import torch and gets the device type on the current machine. If torch is not found, returns `cpu` instead.
Centralize pytest gates for `torch.cuda.is_available()` into `gpu_available`, which checks for either CUDA or XPU availability.
Hardcoded CUDA devices replaced with `device` from `get_device_type()`.

I guard the function with try except so that this test script follows its original implementation to skip tests without torch dependency.

**2. `tests/test_moe_bnb4bit_adaptive_recompute.py`, `tests/test_moe_bnb4bit_per_expert_conversions.py`**
Added XPU support for bnb 4bit tests. Pytest checks for `gpu_available` which checks for both CUDA and XPU availability. 

**3. `tests/test_moe_fused_baddbmm_equiv.py`**
Added XPU support by checking `gpu_available`.

**4. `tests/test_moe_grouped_mm_no_copy.py`, `tests/test_moe_grouped_modulelist_parity.py`**
Added XPU support for grouped GEMM tests. Intel XPUs do not yet have a dedicated native dispatch kernel registered for `torch.nn.functional.grouped_mm`, but the operation works with the `CompositeExplicitAutograd` fallback listed in [native_functions.yaml](https://github.com/pytorch/pytorch/blob/efdc71c47d8481ba254a9cb44a784b7353bf840f/aten/src/ATen/native/native_functions.yaml#L7166). Grouped GEMM is planned for XPU support at a later PyTorch release.

Added XPU path for `unsloth_zoo/temporary_patches/moe_utils.py` functions `_check_torch_grouped_mm_supported()` and `_transposed_view_grouped_mm_is_safe()` to enable XPU for grouped GEMM. Similarly, updated `unsloth_zoo/temporary_patches/moe_grouped_modulelist.py` file `_grouped_mm_supported()` for grouped MoE precheck.

**5. `tests/test_unsloth_zoo_lora_merge.py`**
Added XPU support.

**Note about using `get_device_type` local helper and DEVICE_TYPE_TORCH string:**
For test scripts which do not import unsloth_zoo, a helper function `get_device_type` is added instead of using `unsloth_zoo.device_type.DEVICE_TYPE_TORCH` so that it preserves the original implementation of avoiding the unsloth_zoo import. 

## Validation

### Tests Summary

Hardware: Intel Arc Pro B60 24GB (XPU)
No GPUs: 1
torch: 2.12.0+xpu
bitsandbytes: 0.50.0
transformers: 5.14.1

Modified tests are validated by running the following pytest command:
```bash
pytest tests/test_fused_forward_install.py tests/test_moe_bnb4bit_adaptive_recompute.py tests/test_moe_fused_baddbmm_equiv.py tests/test_moe_grouped_mm_no_copy.py tests/test_moe_grouped_modulelist_parity.py tests/test_unsloth_zoo_lora_merge.py
```

Summary: 
90 passed, 0 skipped, 0 failed

### Grouped GEMM Benchmark

Throughput and peak memory benchmark of `torch._grouped_mm` versus per-expert loop on a Qwen3 MoE config for both XPU and CUDA.
On XPU, `torch._grouped_mm` fallbacks to `CompositeExplicitAutograd` implementation.

The configuration follows that of the [Qwen/Qwen3-30B-A3B-Base](https://huggingface.co/Qwen/Qwen3-30B-A3B-Base) model:
`hidden_size`=2048 
`intermediate_size`=768 
`num_experts`=128
`num_experts_per_tok`=8
`number of tokens`=4096 
`iterations`=20
`warmup iterations`=5

Results compiled on a Intel Arc Pro B60 24GB (XPU) and NVIDIA A100 hardware:
Backend | Pass | Path | tokens/s | ms/iter | peak MB
-- | -- | -- | -- | -- | --
XPU | Forward | grouped | 89,523 | 45.75 | 2834.6
XPU | Forward | per-expert loop | 73,770 | 55.52 | 1220.1
XPU | Fwd+Bwd | grouped (recompute) | 40,962 | 100.00 | 4053.8
XPU | Fwd+Bwd | per-expert loop | 21,041 | 194.67 | 3060.5
CUDA | Forward | grouped | 251,316 | 16.30 | 2842.8
CUDA | Forward | per-expert loop | 157,274 | 26.04 | 1228.3
CUDA | Fwd+Bwd | grouped (recompute) | 106,355 | 38.51 | 4070.0
CUDA | Fwd+Bwd | per-expert loop | 49,621 | 82.55 | 3076.8