### PR TITLE
Do not stand in for a trl that already logs aux_loss

### DIFF
--- a/tests/test_trl_sft_logits_metrics.py
+++ b/tests/test_trl_sft_logits_metrics.py
@@ -385,9 +385,9 @@ def test_the_1x_shape_keeps_real_metrics():
 def trl_logs_aux(sft):
     """Does the INSTALLED trl log aux_loss once the metric block is skipped?
 
-    0.23.0-0.25.x keep it inside the `use_liger_kernel` branch; 0.29.0 and
-    1.x moved it out (0.29.1 sft_trainer.py:1323), where it logs either way.
-    Asked by running it, so a future move in either direction is picked up.
+    0.23.0-0.25.x keep it inside the `use_liger_kernel` branch; 0.29.0 and 1.x
+    moved it out (0.29.1 sft_trainer.py:1323). Asked by running it, so a future
+    move either way is picked up.
     """
     from transformers import Trainer
     Out = collections.namedtuple("Out", "loss logits aux_loss")
@@ -403,8 +403,7 @@ def trl_logs_aux(sft):
         self = _trainer(sft)
         self.aux_loss_enabled = True
         self.args.use_liger_kernel = True
-        # trl's own compute_loss, not the wrapper: the wrapper is what this
-        # answer is for, and it would replay on top of the reading.
+        # trl's own compute_loss: the wrapper would replay on top of the reading.
         inner = getattr(sft.SFTTrainer.compute_loss, "__wrapped__",
                         sft.SFTTrainer.compute_loss)
         with warnings.catch_warnings():
@@ -462,10 +461,9 @@ def test_aux_loss_survives_the_skipped_metric_block(sft, sentinel):
 @pytest.mark.parametrize("sentinel", SENTINELS)
 def test_aux_loss_is_not_logged_twice(sft, trl_logs_aux, sentinel):
     """trl 1.x logs it outside the branch, so replaying would double-count.
-    Gated on the count rather than on a version number.
-
-    Only stand in for that when the installed trl does not already do it,
-    otherwise the stand-in is a second logger and counts twice by itself.
+    Gated on the count rather than on a version number. Stand in for that only
+    when the installed trl does not already do it, or the stand-in is a second
+    logger and doubles the count by itself.
     """
     self = _run_with_aux(sft, sentinel(), steps = 3,
                          trainer_logs_aux = not trl_logs_aux)

--- a/tests/test_trl_sft_logits_metrics.py
+++ b/tests/test_trl_sft_logits_metrics.py
@@ -381,6 +381,43 @@ def test_the_1x_shape_keeps_real_metrics():
 
 # ---- aux_loss is not logits-derived and must survive the skip --------------
 
+@pytest.fixture(scope = "module")
+def trl_logs_aux(sft):
+    """Does the INSTALLED trl log aux_loss once the metric block is skipped?
+
+    0.23.0-0.25.x keep it inside the `use_liger_kernel` branch; 0.29.0 and
+    1.x moved it out (0.29.1 sft_trainer.py:1323), where it logs either way.
+    Asked by running it, so a future move in either direction is picked up.
+    """
+    from transformers import Trainer
+    Out = collections.namedtuple("Out", "loss logits aux_loss")
+    loss, aux = torch.tensor(1.0), torch.tensor(0.25)
+
+    def fake(self, model, inputs, return_outputs = False, num_items_in_batch = None):
+        out = Out(loss, EmptyLogits(), aux)
+        return (loss, out) if return_outputs else loss
+
+    original = Trainer.compute_loss
+    Trainer.compute_loss = fake
+    try:
+        self = _trainer(sft)
+        self.aux_loss_enabled = True
+        self.args.use_liger_kernel = True
+        # trl's own compute_loss, not the wrapper: the wrapper is what this
+        # answer is for, and it would replay on top of the reading.
+        inner = getattr(sft.SFTTrainer.compute_loss, "__wrapped__",
+                        sft.SFTTrainer.compute_loss)
+        with warnings.catch_warnings():
+            # There is no liger here, so trl's report would go to that project.
+            warnings.filterwarnings("ignore", message = ".*token_accuracy.*")
+            inner(self, self.model, _inputs(), num_items_in_batch = None)
+        return bool(self._metrics["train"]["aux_loss"])
+    except Exception:
+        return False
+    finally:
+        Trainer.compute_loss = original
+
+
 def _run_with_aux(sftmod, logits, steps = 3, aux = torch.tensor(0.25),
                   trainer_logs_aux = False):
     """As `_run_steps`, but the outputs carry `aux_loss` and the trainer is a
@@ -423,10 +460,15 @@ def test_aux_loss_survives_the_skipped_metric_block(sft, sentinel):
 
 
 @pytest.mark.parametrize("sentinel", SENTINELS)
-def test_aux_loss_is_not_logged_twice(sft, sentinel):
+def test_aux_loss_is_not_logged_twice(sft, trl_logs_aux, sentinel):
     """trl 1.x logs it outside the branch, so replaying would double-count.
-    Gated on the count rather than on a version number."""
-    self = _run_with_aux(sft, sentinel(), steps = 3, trainer_logs_aux = True)
+    Gated on the count rather than on a version number.
+
+    Only stand in for that when the installed trl does not already do it,
+    otherwise the stand-in is a second logger and counts twice by itself.
+    """
+    self = _run_with_aux(sft, sentinel(), steps = 3,
+                         trainer_logs_aux = not trl_logs_aux)
     assert self._metrics["train"]["aux_loss"] == [0.25, 0.25, 0.25]
 
 


### PR DESCRIPTION
`tests/test_trl_sft_logits_metrics.py::test_aux_loss_is_not_logged_twice` fails on trl 0.29.x and 1.x. It is red today in the unsloth Core job `unsloth_zoo @ main - full pytest (CPU)` on both matrix legs, so it blocks every open unsloth PR:

```
assert self._metrics["train"]["aux_loss"] == [0.25, 0.25, 0.25]
E   assert [0.25, 0.25, ...5, 0.25, 0.25] == [0.25, 0.25, 0.25]
E     Left contains 3 more items, first extra item: 0.25
```

The product code is fine. The test harness is what counts twice.

`_run_with_aux(trainer_logs_aux = True)` simulates a trl that logs `aux_loss` outside the `use_liger_kernel` branch. On trl 0.23.0 through 0.25.x that metric really does sit inside the branch (0.25.1 `sft_trainer.py:1180`, nested under `if not self.args.use_liger_kernel:` at `:1142`), so the stand-in is the only logger and the count is 3. trl moved it out in 0.29.0 (0.29.1 `sft_trainer.py:1323`, top level), so from there on the real trl logs it as well and the stand-in is a second logger: 3 from trl plus 3 from the stand-in is 6.

`_sft_replay_aux_loss` is already gated on the count rather than on a version and does the right thing on every version tested. Nothing in `unsloth_zoo/` changes here.

## Fix

A module-scoped `trl_logs_aux` fixture asks the installed trl the question directly: run its own `compute_loss` with `use_liger_kernel` on and see whether `aux_loss` was logged. The stand-in is only installed when the answer is no. Asked by running it rather than by a version window, so a future move in either direction is picked up.

## Verification

`tests/test_trl_sft_logits_metrics.py`, transformers 4.57.6:

| trl | before | after |
|---|---|---|
| 0.22.2 | 44 passed | 44 passed |
| 0.25.1 | 44 passed | 44 passed |
| 0.29.1 | 2 failed, 42 passed | 44 passed |
| 1.9.2 | 2 failed, 42 passed | 44 passed |

Both CI legs reproduced locally before the change and green after. The wider selection (`-k "trl or sft or metrics or entropy"`) is 96 passed, 12 skipped.