### PR TITLE
Skip the gradient-checkpointing hooks while Dynamo is tracing

### DIFF
--- a/tests/test_compile_disable_partial.py
+++ b/tests/test_compile_disable_partial.py
@@ -1,0 +1,91 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""UNSLOTH_COMPILE_DISABLE=partial must also switch off the temporary patches.
+
+compiler.py reads the flag as `in ("1", "partial")`, so "partial" means "keep
+the source rewrites, drop torch.compile". temporary_patches/common.py read it
+as `== "1"`, so the same value left every patch_function(fullgraph = ...)
+compiling. The escape hatch therefore could not be used to work around a
+compile-only crash such as the Gemma 3N embedder one.
+
+The flag is read at import, so each value is probed in a subprocess.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_SCRIPT = textwrap.dedent("""
+    import json
+    try:
+        import transformers.models.gemma3n.modeling_gemma3n as M
+    except Exception:
+        print("PROBE " + json.dumps({"skip": True})); raise SystemExit
+    from unsloth_zoo.temporary_patches.common import UNSLOTH_COMPILE_DISABLE
+    from unsloth_zoo.temporary_patches.gemma3n import (
+        patch_Gemma3nMultimodalEmbedder_forward,
+    )
+    patch_Gemma3nMultimodalEmbedder_forward()
+    print("PROBE " + json.dumps({
+        "skip"     : False,
+        "flag"     : bool(UNSLOTH_COMPILE_DISABLE),
+        "compiled" : hasattr(M.Gemma3nMultimodalEmbedder.forward, "get_compiler_config"),
+    }))
+""")
+
+
+def _probe(value):
+    env = dict(os.environ, PYTHONPATH = str(ROOT), UNSLOTH_COMPILE_DISABLE = value)
+    r = subprocess.run(
+        [sys.executable, "-c", _SCRIPT],
+        capture_output = True, text = True, timeout = 900, env = env,
+    )
+    line = [l for l in r.stdout.splitlines() if l.startswith("PROBE ")]
+    assert line, (r.stdout[-2000:], r.stderr[-3000:])
+    out = json.loads(line[0][len("PROBE "):])
+    if out["skip"]: pytest.skip("transformers has no gemma3n")
+    return out
+
+
+def test_unset_still_compiles():
+    out = _probe("0")
+    assert out["flag"] is False
+    assert out["compiled"] is True, "the patch stopped compiling altogether"
+
+
+def test_one_disables_compile():
+    out = _probe("1")
+    assert out["flag"] is True
+    assert out["compiled"] is False
+
+
+def test_partial_disables_compile():
+    # The bug: "partial" left the patch compiled with fullgraph = True.
+    out = _probe("partial")
+    assert out["flag"] is True
+    assert out["compiled"] is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_compile_disable_partial.py
+++ b/tests/test_compile_disable_partial.py
@@ -53,8 +53,20 @@ _SCRIPT = textwrap.dedent("""
 """)
 
 
+def _probe_env(value):
+    # Without the separate `unsloth` package installed, unsloth_zoo/__init__ raises
+    # "Please install Unsloth" before the probe prints anything; this env var takes
+    # the lightweight import path and reads the same flag.
+    return dict(
+        os.environ,
+        PYTHONPATH = str(ROOT),
+        UNSLOTH_COMPILE_DISABLE = value,
+        UNSLOTH_ZOO_DISABLE_GPU_INIT = "1",
+    )
+
+
 def _probe(value):
-    env = dict(os.environ, PYTHONPATH = str(ROOT), UNSLOTH_COMPILE_DISABLE = value)
+    env = _probe_env(value)
     r = subprocess.run(
         [sys.executable, "-c", _SCRIPT],
         capture_output = True, text = True, timeout = 900, env = env,
@@ -64,6 +76,12 @@ def _probe(value):
     out = json.loads(line[0][len("PROBE "):])
     if out["skip"]: pytest.skip("transformers has no gemma3n")
     return out
+
+
+def test_probe_survives_a_zoo_only_checkout():
+    """CI installs `unsloth` with `|| true`, so it can legitimately be absent."""
+    env = _probe_env("0")
+    assert env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] == "1"
 
 
 def test_unset_still_compiles():

--- a/tests/test_compile_disable_partial.py
+++ b/tests/test_compile_disable_partial.py
@@ -16,11 +16,10 @@
 
 """UNSLOTH_COMPILE_DISABLE=partial must also switch off the temporary patches.
 
-compiler.py reads the flag as `in ("1", "partial")`, but common.py read it as
-`== "1"`, so "partial" left every patch_function(fullgraph = ...) compiling and
-the escape hatch could not work around a compile-only crash.
-
-The flag is read at import, so each value is probed in a subprocess.
+compiler.py reads the flag as `in ("1", "partial")` but common.py read it as `== "1"`,
+so "partial" left every patch_function(fullgraph = ...) compiling and the escape hatch
+could not work around a compile-only crash. The flag is read at import, so each value
+is probed in a subprocess.
 """
 
 import json
@@ -54,9 +53,8 @@ _SCRIPT = textwrap.dedent("""
 
 
 def _probe_env(value):
-    # Without the separate `unsloth` package installed, unsloth_zoo/__init__ raises
-    # "Please install Unsloth" before the probe prints anything; this env var takes
-    # the lightweight import path and reads the same flag.
+    # Without the `unsloth` package, unsloth_zoo/__init__ raises "Please install Unsloth"
+    # before the probe prints; this env var takes the light import path, same flag.
     return dict(
         os.environ,
         PYTHONPATH = str(ROOT),

--- a/tests/test_compile_disable_partial.py
+++ b/tests/test_compile_disable_partial.py
@@ -16,11 +16,9 @@
 
 """UNSLOTH_COMPILE_DISABLE=partial must also switch off the temporary patches.
 
-compiler.py reads the flag as `in ("1", "partial")`, so "partial" means "keep
-the source rewrites, drop torch.compile". temporary_patches/common.py read it
-as `== "1"`, so the same value left every patch_function(fullgraph = ...)
-compiling. The escape hatch therefore could not be used to work around a
-compile-only crash such as the Gemma 3N embedder one.
+compiler.py reads the flag as `in ("1", "partial")`, but common.py read it as
+`== "1"`, so "partial" left every patch_function(fullgraph = ...) compiling and
+the escape hatch could not work around a compile-only crash.
 
 The flag is read at import, so each value is probed in a subprocess.
 """
@@ -81,7 +79,6 @@ def test_one_disables_compile():
 
 
 def test_partial_disables_compile():
-    # The bug: "partial" left the patch compiled with fullgraph = True.
     out = _probe("partial")
     assert out["flag"] is True
     assert out["compiled"] is False

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -14,128 +14,207 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Tests _run_eagerly_under_compile in peft_utils.py.
+"""The gradient-checkpointing hooks must not run while Dynamo is tracing.
 
-The gradient-checkpointing hooks call `requires_grad_()`, which Dynamo cannot
-trace, so a compiled model carrying one dies with
+requires_grad_pre_hook / requires_grad_post_hook call `requires_grad_()`,
+which Dynamo cannot trace:
 
     Unsupported: Unsupported Tensor.requires_grad_() call
 
-Making the hooks opaque to Dynamo fixes that, but has a second-order hazard:
-register_other_hooks() decides which hooks are OURS by matching
-__name__/__qualname__ against "requires_grad_pre_hook" and
-"requires_grad_post_hook". If wrapping lost those names, our hooks would stop
-being recognised and would be re-registered on top of themselves. torch 2.9
-carries them through torch._dynamo.disable, but that is an internal detail of
-a private module and this has to hold from torch 2.6 up, so the wrapper copies
-them explicitly.
+Outside a fullgraph region that is only a graph break, but Gemma 3N puts a
+LoRA target (embed_audio.embedding_projection) inside a forward that
+temporary_patches/gemma3n.py compiles with fullgraph = True, so the same hook
+becomes a hard error and trainer.train() dies. torch._dynamo.disable() does
+not rescue it either -- under fullgraph it turns into "Skip calling
+torch.compiler.disable()d function". Guarding on
+`torch.compiler.is_compiling()` does, and is a no-op in eager.
 
-No GPU needed.
+These tests use the real hooks, pulled off a model that
+requires_grad_for_gradient_checkpointing() has actually hooked, so they break
+if the hooks are renamed or moved. CPU only.
 """
 
 import ast
-import sys
-import types
+from collections import OrderedDict
 from pathlib import Path
 
 import pytest
 import torch
+import torch.nn as nn
 
-PEFT_UTILS = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "peft_utils.py"
-_SRC = PEFT_UTILS.read_text(encoding = "utf-8")
+from unsloth_zoo.peft_utils import requires_grad_for_gradient_checkpointing
 
-
-def _load():
-    for node in ast.parse(_SRC).body:
-        if isinstance(node, ast.FunctionDef) and node.name == "_run_eagerly_under_compile":
-            ns = {"torch": torch}
-            exec(ast.get_source_segment(_SRC, node), ns)
-            return ns[node.name]
-    raise AssertionError("_run_eagerly_under_compile not found in peft_utils.py")
+_ZOO = Path(__file__).resolve().parents[1] / "unsloth_zoo"
 
 
-run_eagerly = _load()
+class _Inner(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(8, 8, bias = False)
+
+    def forward(self, hidden_states):
+        return self.proj(hidden_states)
 
 
-def _hook(module, args, kwargs):
-    return "called"
+class _PreHookModel(nn.Module):
+    """`self.proj(` inside _Inner.forward makes proj a pre-hook target."""
+    def __init__(self):
+        super().__init__()
+        self.vision = _Inner()
+
+    def forward(self, hidden_states):
+        return self.vision(hidden_states)
 
 
-_hook.__name__ = "requires_grad_pre_hook"
-_hook.__qualname__ = "requires_grad_for_gradient_checkpointing.<locals>.requires_grad_pre_hook"
+class _PostHookModel(nn.Module):
+    """`head` is never called as `self.head(`, so it becomes a fallback
+    (post-hook) target instead."""
+    def __init__(self):
+        super().__init__()
+        self.head = nn.Linear(8, 8, bias = False)
+
+    def forward(self, hidden_states):
+        return torch.nn.functional.linear(hidden_states, self.head.weight)
 
 
-def test_names_survive_wrapping():
-    # register_other_hooks matches on these; losing them re-registers our
-    # hooks on top of themselves.
-    w = run_eagerly(_hook)
-    assert w.__name__ == "requires_grad_pre_hook"
-    assert "requires_grad_pre_hook" in w.__qualname__
+def _real_pre_hook():
+    model = _PreHookModel()
+    model.requires_grad_(False)
+    model.vision.proj.weight.requires_grad_(True)
+    requires_grad_for_gradient_checkpointing(model)
+    hooks = list(model.vision.proj._forward_pre_hooks.values())
+    assert len(hooks) == 1, hooks
+    assert "requires_grad_pre_hook" in hooks[0].__qualname__
+    return hooks[0]
 
 
-def test_wrapped_hook_still_runs():
-    assert run_eagerly(_hook)(None, (), {}) == "called"
+def _real_post_hook():
+    model = _PostHookModel()
+    model.requires_grad_(False)
+    model.head.weight.requires_grad_(True)
+    requires_grad_for_gradient_checkpointing(model)
+    hooks = list(model.head._forward_hooks.values())
+    assert len(hooks) == 1, hooks
+    assert "requires_grad_post_hook" in hooks[0].__qualname__
+    return hooks[0]
 
 
-def test_register_other_hooks_still_recognises_it():
-    # Mirrors the matching in register_other_hooks exactly.
-    w = run_eagerly(_hook)
-    name1 = name2 = "requires_grad_pre_hook"
-    qualname = getattr(w, "__qualname__", "")
-    name = getattr(w, "__name__", "")
-    recognised = (name1 in qualname or name2 in qualname) or (name2 in name)
-    assert recognised, "our own hook would be treated as a foreign hook"
+# ---------------------------------------------------------------- eager path
+
+def test_pre_hook_still_fires_eagerly():
+    hook = _real_pre_hook()
+    x = torch.randn(2, 8)
+    hook(None, (x,), {})
+    assert x.requires_grad
 
 
-@pytest.fixture
-def _fake_dynamo():
-    # `import torch._dynamo as x` resolves the ATTRIBUTE on the torch package
-    # once the submodule is in sys.modules, so both have to be swapped.
-    saved_mod = sys.modules.get("torch._dynamo")
-    saved_attr = getattr(torch, "_dynamo", None)
-
-    def install(mod):
-        sys.modules["torch._dynamo"] = mod
-        torch._dynamo = mod
-
-    yield install
-
-    if saved_mod is None: sys.modules.pop("torch._dynamo", None)
-    else: sys.modules["torch._dynamo"] = saved_mod
-    if saved_attr is not None: torch._dynamo = saved_attr
+def test_pre_hook_still_fires_eagerly_on_kwargs():
+    hook = _real_pre_hook()
+    x = torch.randn(2, 8)
+    hook(None, (), {"inputs_embeds" : x})
+    assert x.requires_grad
 
 
-def test_falls_back_when_disable_is_absent(_fake_dynamo):
-    # Older / stripped torch builds: must be a no-op, not a crash.
-    _fake_dynamo(types.ModuleType("torch._dynamo"))
-    assert run_eagerly(_hook) is _hook
+def test_post_hook_still_fires_eagerly():
+    hook = _real_post_hook()
+    y = torch.randn(2, 8)
+    hook(None, None, y)
+    assert y.requires_grad
 
 
-def test_falls_back_when_disable_raises(_fake_dynamo):
-    mod = types.ModuleType("torch._dynamo")
-    def _boom(fn): raise RuntimeError("nope")
-    mod.disable = _boom
-    _fake_dynamo(mod)
-    assert run_eagerly(_hook) is _hook
+# -------------------------------------------------------------- under compile
+
+def test_pre_hook_no_ops_while_compiling(monkeypatch):
+    hook = _real_pre_hook()
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    x = torch.randn(2, 8)
+    hook(None, (x,), {})
+    assert not x.requires_grad
 
 
-def test_tolerates_unsettable_attributes(_fake_dynamo):
-    # A C-implemented or slotted callable may refuse __name__ assignment.
-    class _Callable:
-        __slots__ = ()
-        def __call__(self, *a, **k): return "called"
-    mod = types.ModuleType("torch._dynamo")
-    mod.disable = lambda fn: _Callable()
-    _fake_dynamo(mod)
-    w = run_eagerly(_hook)          # must not raise
-    assert w(None, (), {}) == "called"
+def test_post_hook_no_ops_while_compiling(monkeypatch):
+    hook = _real_post_hook()
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    y = torch.randn(2, 8)
+    hook(None, None, y)
+    assert not y.requires_grad
 
 
-def test_both_hooks_are_decorated_in_source():
-    for hook in ("requires_grad_pre_hook", "requires_grad_post_hook"):
-        i = _SRC.index(f"def {hook}(")
-        preceding = _SRC[:i].rstrip().splitlines()[-1]
-        assert "_run_eagerly_under_compile" in preceding, hook
+def test_post_hook_does_not_raise_on_unknown_output_while_compiling(monkeypatch):
+    # Eagerly this output shape raises "Neither loss, logits, nor
+    # last_hidden_state are available"; under compile it must be skipped.
+    hook = _real_post_hook()
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    hook(None, None, {"not" : "a tensor"})
+
+
+def test_fullgraph_compiled_module_with_pre_hook_runs():
+    # The Gemma 3N failure, reduced: a hooked module inside a
+    # fullgraph = True region. Before the guard this raised
+    # "Unsupported: Unsupported Tensor.requires_grad_() call".
+    torch._dynamo.reset()
+    model = _PreHookModel()
+    model.requires_grad_(False)
+    model.vision.proj.weight.requires_grad_(True)
+    requires_grad_for_gradient_checkpointing(model)
+
+    compiled = torch.compile(
+        _PreHookModel.forward.__get__(model), fullgraph = True, dynamic = True,
+    )
+    x = torch.randn(2, 8)
+    out = compiled(x)
+    assert out.shape == (2, 8)
+    # The LoRA-style trainable weight still carries the graph.
+    assert out.requires_grad
+
+
+def test_fullgraph_compiled_module_with_post_hook_runs():
+    torch._dynamo.reset()
+    model = _PostHookModel()
+    model.requires_grad_(False)
+    model.head.weight.requires_grad_(True)
+    requires_grad_for_gradient_checkpointing(model)
+
+    compiled = torch.compile(
+        _PostHookModel.forward.__get__(model), fullgraph = True, dynamic = True,
+    )
+    out = compiled(torch.randn(2, 8))
+    assert out.shape == (2, 8)
+
+
+# ---------------------------------------------------------------- source shape
+
+def _guarded_functions(path, names):
+    """Which of `names` open with `if torch.compiler.is_compiling(): return`?"""
+    src = path.read_text(encoding = "utf-8")
+    found = OrderedDict()
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.FunctionDef) or node.name not in names:
+            continue
+        body = [n for n in node.body if not (
+            isinstance(n, ast.Expr) and isinstance(n.value, ast.Constant)
+        )]
+        first = body[0] if body else None
+        found[node.name] = (
+            isinstance(first, ast.If)
+            and "is_compiling" in ast.dump(first.test)
+            and any(isinstance(n, ast.Return) for n in first.body)
+        )
+    return found
+
+
+def test_both_gradient_checkpointing_hooks_are_guarded():
+    names = ("requires_grad_pre_hook", "requires_grad_post_hook")
+    guarded = _guarded_functions(_ZOO / "peft_utils.py", names)
+    assert set(guarded) == set(names), guarded
+    assert all(guarded.values()), guarded
+
+
+def test_make_inputs_require_grad_is_guarded():
+    guarded = _guarded_functions(
+        _ZOO / "training_utils.py", ("make_inputs_require_grad",),
+    )
+    assert guarded == {"make_inputs_require_grad" : True}, guarded
 
 
 if __name__ == "__main__":

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -16,22 +16,14 @@
 
 """The gradient-checkpointing hooks must not run while Dynamo is tracing.
 
-requires_grad_pre_hook / requires_grad_post_hook call `requires_grad_()`,
-which Dynamo cannot trace:
+requires_grad_pre_hook / requires_grad_post_hook call `requires_grad_()`, which
+Dynamo cannot trace. Outside a fullgraph region that is only a graph break, but
+Gemma 3N compiles a LoRA target with fullgraph = True, so it becomes a hard
+error and trainer.train() dies. torch._dynamo.disable() does not rescue it;
+guarding on `torch.compiler.is_compiling()` does, and is a no-op in eager.
 
-    Unsupported: Unsupported Tensor.requires_grad_() call
-
-Outside a fullgraph region that is only a graph break, but Gemma 3N puts a
-LoRA target (embed_audio.embedding_projection) inside a forward that
-temporary_patches/gemma3n.py compiles with fullgraph = True, so the same hook
-becomes a hard error and trainer.train() dies. torch._dynamo.disable() does
-not rescue it either -- under fullgraph it turns into "Skip calling
-torch.compiler.disable()d function". Guarding on
-`torch.compiler.is_compiling()` does, and is a no-op in eager.
-
-These tests use the real hooks, pulled off a model that
-requires_grad_for_gradient_checkpointing() has actually hooked, so they break
-if the hooks are renamed or moved. CPU only.
+Hooks are pulled off a real hooked model, so these break if they are renamed or
+moved. CPU only.
 """
 
 import ast
@@ -67,8 +59,7 @@ class _PreHookModel(nn.Module):
 
 
 class _PostHookModel(nn.Module):
-    """`head` is never called as `self.head(`, so it becomes a fallback
-    (post-hook) target instead."""
+    """`head` is never called as `self.head(`, so it is a post-hook target."""
     def __init__(self):
         super().__init__()
         self.head = nn.Linear(8, 8, bias = False)
@@ -141,17 +132,15 @@ def test_post_hook_no_ops_while_compiling(monkeypatch):
 
 
 def test_post_hook_does_not_raise_on_unknown_output_while_compiling(monkeypatch):
-    # Eagerly this output shape raises "Neither loss, logits, nor
-    # last_hidden_state are available"; under compile it must be skipped.
+    # Eagerly this output shape raises; under compile it must be skipped.
     hook = _real_post_hook()
     monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
     hook(None, None, {"not" : "a tensor"})
 
 
 def test_fullgraph_compiled_module_with_pre_hook_runs():
-    # The Gemma 3N failure, reduced: a hooked module inside a
-    # fullgraph = True region. Before the guard this raised
-    # "Unsupported: Unsupported Tensor.requires_grad_() call".
+    # The Gemma 3N failure, reduced: a hooked module in a fullgraph = True
+    # region. Before the guard this raised "Unsupported Tensor.requires_grad_()".
     torch._dynamo.reset()
     model = _PreHookModel()
     model.requires_grad_(False)
@@ -164,7 +153,6 @@ def test_fullgraph_compiled_module_with_pre_hook_runs():
     x = torch.randn(2, 8)
     out = compiled(x)
     assert out.shape == (2, 8)
-    # The LoRA-style trainable weight still carries the graph.
     assert out.requires_grad
 
 
@@ -211,12 +199,9 @@ def test_both_gradient_checkpointing_hooks_are_guarded():
 
 
 def test_make_inputs_require_grad_is_NOT_guarded():
-    """The peft_utils hooks sit on LoRA modules whose output already requires
-    grad, so skipping them under tracing changes nothing. This one is the only
-    thing making a FROZEN embedding's output require grad, and reentrant
-    gradient checkpointing needs at least one grad-carrying input. Guarding it
-    would leave that tensor detached and silently stop gradients reaching the
-    adapters, which is worse than the graph break it would have avoided.
+    """Unlike the peft_utils hooks, this is the only thing making a FROZEN
+    embedding's output require grad, which reentrant checkpointing needs.
+    Guarding it would silently stop gradients reaching the adapters.
     """
     guarded = _guarded_functions(
         _ZOO / "training_utils.py", ("make_inputs_require_grad",),

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -14,13 +14,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""The gradient-checkpointing hooks must not run while Dynamo is tracing.
+"""The gradient-checkpointing hooks must not flip requires_grad while Dynamo traces.
 
 requires_grad_pre_hook / requires_grad_post_hook call `requires_grad_()`, which
-Dynamo cannot trace. Outside a fullgraph region that is only a graph break, but
-Gemma 3N compiles a LoRA target with fullgraph = True, so it becomes a hard
-error and trainer.train() dies. torch._dynamo.disable() does not rescue it;
-guarding on `torch.compiler.is_compiling()` does, and is a no-op in eager.
+Dynamo rejects when it would change the flag. Outside a fullgraph region that is
+only a graph break, but Gemma 3N compiles a LoRA target with fullgraph = True, so
+it becomes a hard error and trainer.train() dies. torch._dynamo.disable() does not
+rescue it; guarding on `torch.compiler.is_compiling()` does, and is a no-op in eager.
+
+The post hook also lands on `get_input_embeddings()`, where it is the only thing
+making a FROZEN embedding's output require grad, so it may skip only the no-op
+case; skipping unconditionally there loses every adapter gradient.
 
 Hooks are pulled off a real hooked model, so these break if they are renamed or
 moved. CPU only.
@@ -33,6 +37,7 @@ from pathlib import Path
 import pytest
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 
 from unsloth_zoo.peft_utils import requires_grad_for_gradient_checkpointing
 
@@ -66,6 +71,42 @@ class _PostHookModel(nn.Module):
 
     def forward(self, hidden_states):
         return torch.nn.functional.linear(hidden_states, self.head.weight)
+
+
+class _Layer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.adapter = nn.Linear(8, 8, bias = False)   # the only trainable weight
+
+    def forward(self, hidden_states):
+        return self.adapter(hidden_states)
+
+
+class _LanguageModel(nn.Module):
+    """`for layer in self.layers:` makes this itself the hook target, and it has
+    get_input_embeddings(), so the post hook lands on the FROZEN embedding."""
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(16, 8)
+        self.layers = nn.ModuleList([_Layer()])
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def forward(self, input_ids):
+        hidden_states = self.embed_tokens(input_ids)
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return hidden_states
+
+
+class _EmbeddingHookModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.language_model = _LanguageModel()
+
+    def forward(self, input_ids):
+        return self.language_model(input_ids)
 
 
 def _real_pre_hook():
@@ -123,12 +164,23 @@ def test_pre_hook_no_ops_while_compiling(monkeypatch):
     assert not x.requires_grad
 
 
-def test_post_hook_no_ops_while_compiling(monkeypatch):
+def test_post_hook_no_ops_while_compiling_when_output_already_requires_grad(monkeypatch):
+    hook = _real_post_hook()
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    y = torch.randn(2, 8, requires_grad = True)
+    hook(None, None, y)  # nothing to flip, so nothing Dynamo could reject
+    assert y.requires_grad
+
+
+def test_post_hook_still_flips_a_frozen_output_while_compiling(monkeypatch):
+    """The post hook also lands on `get_input_embeddings()`, where it is the only
+    thing making a FROZEN embedding's output require grad. Skipping it there loses
+    gradients, so only the no-op case may be skipped."""
     hook = _real_post_hook()
     monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
     y = torch.randn(2, 8)
     hook(None, None, y)
-    assert not y.requires_grad
+    assert y.requires_grad
 
 
 def test_post_hook_does_not_raise_on_unknown_output_while_compiling(monkeypatch):
@@ -170,6 +222,34 @@ def test_fullgraph_compiled_module_with_post_hook_runs():
     assert out.shape == (2, 8)
 
 
+def test_compiled_frozen_embedding_still_carries_gradients():
+    """The end-to-end shape of the post hook on `get_input_embeddings()`: compile the
+    frozen embedding, then feed it to a reentrant-checkpointed trainable layer. If the
+    hook no-ops while tracing, checkpointing sees no grad-carrying input and the
+    adapter gets no gradient at all."""
+    torch._dynamo.reset()
+    model = _EmbeddingHookModel()
+    model.requires_grad_(False)
+    layer = model.language_model.layers[0]
+    layer.adapter.weight.requires_grad_(True)
+    requires_grad_for_gradient_checkpointing(model)
+
+    embedding = model.language_model.embed_tokens
+    hooks = list(embedding._forward_hooks.values())
+    assert len(hooks) == 1, hooks
+    assert "requires_grad_post_hook" in hooks[0].__qualname__
+    assert not embedding.weight.requires_grad
+
+    # aot_eager keeps this off inductor's C++ codegen; the hook behaviour is the same.
+    hidden_states = torch.compile(embedding, backend = "aot_eager")(
+        torch.randint(0, 16, (2, 4))
+    )
+    assert hidden_states.requires_grad, "compiled frozen embedding lost requires_grad"
+
+    checkpoint(layer, hidden_states, use_reentrant = True).float().sum().backward()
+    assert layer.adapter.weight.grad is not None, "no gradient reached the adapter"
+
+
 # ---------------------------------------------------------------- source shape
 
 def _guarded_functions(path, names):
@@ -191,11 +271,28 @@ def _guarded_functions(path, names):
     return found
 
 
-def test_both_gradient_checkpointing_hooks_are_guarded():
-    names = ("requires_grad_pre_hook", "requires_grad_post_hook")
-    guarded = _guarded_functions(_ZOO / "peft_utils.py", names)
-    assert set(guarded) == set(names), guarded
-    assert all(guarded.values()), guarded
+def test_pre_hook_is_guarded():
+    guarded = _guarded_functions(_ZOO / "peft_utils.py", ("requires_grad_pre_hook",))
+    assert guarded == {"requires_grad_pre_hook" : True}, guarded
+
+
+def test_post_hook_guard_is_not_unconditional():
+    """A bare `if is_compiling(): return` would drop a frozen embedding's flag, so the
+    post hook may only skip the no-op case (the output already requires grad)."""
+    src = (_ZOO / "peft_utils.py").read_text(encoding = "utf-8")
+    fn = next(
+        n for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.FunctionDef) and n.name == "requires_grad_post_hook"
+    )
+    tests = [
+        ast.dump(n.test) for n in ast.walk(fn)
+        if isinstance(n, ast.If) and "is_compiling" in ast.dump(n.test)
+    ]
+    assert tests, "the post hook no longer checks is_compiling()"
+    assert any("requires_grad" in t for t in tests), tests
+    # and it must not bail out of the whole hook before reaching that check
+    guarded = _guarded_functions(_ZOO / "peft_utils.py", ("requires_grad_post_hook",))
+    assert guarded == {"requires_grad_post_hook" : False}, guarded
 
 
 def test_make_inputs_require_grad_is_NOT_guarded():

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -236,8 +236,13 @@ def test_fullgraph_compiled_module_with_pre_hook_runs():
     model.vision.proj.weight.requires_grad_(True)
     requires_grad_for_gradient_checkpointing(model)
 
+    # aot_eager, like the other compiles in this file. What is under test is
+    # whether Dynamo can trace the hook, not what Inductor emits, and Inductor
+    # needs triton: on Apple Silicon it is stubbed out, so the default backend
+    # fails here with a NotImplementedError that says nothing about the hook.
     compiled = torch.compile(
-        _PreHookModel.forward.__get__(model), fullgraph = True, dynamic = True,
+        _PreHookModel.forward.__get__(model),
+        fullgraph = True, dynamic = True, backend = "aot_eager",
     )
     x = torch.randn(2, 8)
     out = compiled(x)
@@ -253,7 +258,8 @@ def test_fullgraph_compiled_module_with_post_hook_runs():
     requires_grad_for_gradient_checkpointing(model)
 
     compiled = torch.compile(
-        _PostHookModel.forward.__get__(model), fullgraph = True, dynamic = True,
+        _PostHookModel.forward.__get__(model),
+        fullgraph = True, dynamic = True, backend = "aot_eager",
     )
     out = compiled(torch.randn(2, 8))
     assert out.shape == (2, 8)

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -73,6 +73,26 @@ class _PostHookModel(nn.Module):
         return torch.nn.functional.linear(hidden_states, self.head.weight)
 
 
+class _Trunk(nn.Module):
+    """Never called as `self.adapter(`, so `_TupleOutputModel` takes the fallback
+    post-hook path -- onto a module whose output is a tuple, like a decoder layer."""
+    def __init__(self):
+        super().__init__()
+        self.adapter = nn.Linear(8, 8, bias = False)
+
+    def forward(self, hidden_states):
+        return (torch.nn.functional.linear(hidden_states, self.adapter.weight), None)
+
+
+class _TupleOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.trunk = _Trunk()
+
+    def forward(self, hidden_states):
+        return getattr(self, "trunk")(hidden_states)[0]
+
+
 class _Layer(nn.Module):
     def __init__(self):
         super().__init__()
@@ -183,11 +203,39 @@ def test_post_hook_still_flips_a_frozen_output_while_compiling(monkeypatch):
     assert y.requires_grad
 
 
-def test_post_hook_does_not_raise_on_unknown_output_while_compiling(monkeypatch):
-    # Eagerly this output shape raises; under compile it must be skipped.
+def test_post_hook_still_raises_on_unknown_output_while_compiling(monkeypatch):
+    """An output the hook cannot mark must stay a loud error while tracing.
+
+    `is_compiling()` is constant folded into the graph, so a skip here is
+    permanent: the compiled artifact never re-checks the output, and a
+    checkpointed region trains with no adapter gradients at all.
+    """
     hook = _real_post_hook()
     monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
-    hook(None, None, {"not" : "a tensor"})
+    with pytest.raises(RuntimeError, match = "Failed to make output require gradients"):
+        hook(None, None, {"not" : "a tensor"})
+
+
+def test_compiled_tuple_output_still_raises():
+    """End to end: a fallback post-hook target returning a tuple, under compile.
+
+    `requires_grad_for_gradient_checkpointing` itself picks this target, so the
+    shape is one Unsloth produces; the error must survive tracing.
+    """
+    torch._dynamo.reset()
+    model = _TupleOutputModel()
+    model.requires_grad_(False)
+    model.trunk.adapter.weight.requires_grad_(True)
+    requires_grad_for_gradient_checkpointing(model)
+    hooks = list(model.trunk._forward_hooks.values())
+    assert len(hooks) == 1, hooks
+    assert "requires_grad_post_hook" in hooks[0].__qualname__
+
+    x = torch.randn(2, 8)
+    with pytest.raises(RuntimeError, match = "Failed to make output require gradients"):
+        model(x)
+    with pytest.raises(RuntimeError, match = "Failed to make output require gradients"):
+        torch.compile(model, backend = "aot_eager")(x)
 
 
 def test_fullgraph_compiled_module_with_pre_hook_runs():

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -210,11 +210,18 @@ def test_both_gradient_checkpointing_hooks_are_guarded():
     assert all(guarded.values()), guarded
 
 
-def test_make_inputs_require_grad_is_guarded():
+def test_make_inputs_require_grad_is_NOT_guarded():
+    """The peft_utils hooks sit on LoRA modules whose output already requires
+    grad, so skipping them under tracing changes nothing. This one is the only
+    thing making a FROZEN embedding's output require grad, and reentrant
+    gradient checkpointing needs at least one grad-carrying input. Guarding it
+    would leave that tensor detached and silently stop gradients reaching the
+    adapters, which is worse than the graph break it would have avoided.
+    """
     guarded = _guarded_functions(
         _ZOO / "training_utils.py", ("make_inputs_require_grad",),
     )
-    assert guarded == {"make_inputs_require_grad" : True}, guarded
+    assert guarded == {"make_inputs_require_grad" : False}, guarded
 
 
 if __name__ == "__main__":

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -16,18 +16,14 @@
 
 """The gradient-checkpointing hooks must not flip requires_grad while Dynamo traces.
 
-requires_grad_pre_hook / requires_grad_post_hook call `requires_grad_()`, which
-Dynamo rejects when it would change the flag. Outside a fullgraph region that is
-only a graph break, but Gemma 3N compiles a LoRA target with fullgraph = True, so
-it becomes a hard error and trainer.train() dies. torch._dynamo.disable() does not
-rescue it; guarding on `torch.compiler.is_compiling()` does, and is a no-op in eager.
+Dynamo rejects `requires_grad_()` when it would change the flag, and Gemma 3N compiles
+a LoRA target with fullgraph = True, so it is a hard error rather than a graph break.
+torch._dynamo.disable() does not rescue it; `torch.compiler.is_compiling()` does.
 
-The post hook also lands on `get_input_embeddings()`, where it is the only thing
-making a FROZEN embedding's output require grad, so it may skip only the no-op
-case; skipping unconditionally there loses every adapter gradient.
+The post hook also lands on `get_input_embeddings()`, where it is the only thing making
+a FROZEN embedding's output require grad, so it may skip only the no-op case.
 
-Hooks are pulled off a real hooked model, so these break if they are renamed or
-moved. CPU only.
+Hooks are pulled off a real hooked model, so these break on a rename. CPU only.
 """
 
 import ast
@@ -74,8 +70,8 @@ class _PostHookModel(nn.Module):
 
 
 class _Trunk(nn.Module):
-    """Never called as `self.adapter(`, so `_TupleOutputModel` takes the fallback
-    post-hook path -- onto a module whose output is a tuple, like a decoder layer."""
+    """Never called as `self.adapter(`, so the fallback post hook lands here, on a
+    tuple-returning module like a decoder layer."""
     def __init__(self):
         super().__init__()
         self.adapter = nn.Linear(8, 8, bias = False)
@@ -103,8 +99,8 @@ class _Layer(nn.Module):
 
 
 class _LanguageModel(nn.Module):
-    """`for layer in self.layers:` makes this itself the hook target, and it has
-    get_input_embeddings(), so the post hook lands on the FROZEN embedding."""
+    """`for layer in self.layers:` makes this the hook target, and get_input_embeddings()
+    puts the post hook on the FROZEN embedding."""
     def __init__(self):
         super().__init__()
         self.embed_tokens = nn.Embedding(16, 8)
@@ -193,9 +189,8 @@ def test_post_hook_no_ops_while_compiling_when_output_already_requires_grad(monk
 
 
 def test_post_hook_still_flips_a_frozen_output_while_compiling(monkeypatch):
-    """The post hook also lands on `get_input_embeddings()`, where it is the only
-    thing making a FROZEN embedding's output require grad. Skipping it there loses
-    gradients, so only the no-op case may be skipped."""
+    """On `get_input_embeddings()` this is the only thing making a FROZEN embedding's
+    output require grad, so only the no-op case may be skipped."""
     hook = _real_post_hook()
     monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
     y = torch.randn(2, 8)
@@ -204,12 +199,8 @@ def test_post_hook_still_flips_a_frozen_output_while_compiling(monkeypatch):
 
 
 def test_post_hook_still_raises_on_unknown_output_while_compiling(monkeypatch):
-    """An output the hook cannot mark must stay a loud error while tracing.
-
-    `is_compiling()` is constant folded into the graph, so a skip here is
-    permanent: the compiled artifact never re-checks the output, and a
-    checkpointed region trains with no adapter gradients at all.
-    """
+    """An unmarkable output must stay a loud error while tracing: is_compiling() is
+    constant folded, so a skip is permanent and the region trains with no gradients."""
     hook = _real_post_hook()
     monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
     with pytest.raises(RuntimeError, match = "Failed to make output require gradients"):
@@ -218,10 +209,8 @@ def test_post_hook_still_raises_on_unknown_output_while_compiling(monkeypatch):
 
 def test_compiled_tuple_output_still_raises():
     """End to end: a fallback post-hook target returning a tuple, under compile.
-
-    `requires_grad_for_gradient_checkpointing` itself picks this target, so the
-    shape is one Unsloth produces; the error must survive tracing.
-    """
+    requires_grad_for_gradient_checkpointing picks this target itself, so the shape is
+    one Unsloth produces and the error must survive tracing."""
     torch._dynamo.reset()
     model = _TupleOutputModel()
     model.requires_grad_(False)
@@ -271,10 +260,8 @@ def test_fullgraph_compiled_module_with_post_hook_runs():
 
 
 def test_compiled_frozen_embedding_still_carries_gradients():
-    """The end-to-end shape of the post hook on `get_input_embeddings()`: compile the
-    frozen embedding, then feed it to a reentrant-checkpointed trainable layer. If the
-    hook no-ops while tracing, checkpointing sees no grad-carrying input and the
-    adapter gets no gradient at all."""
+    """Compile the frozen embedding, then feed it to a reentrant-checkpointed trainable
+    layer. If the hook no-ops while tracing, the adapter gets no gradient at all."""
     torch._dynamo.reset()
     model = _EmbeddingHookModel()
     model.requires_grad_(False)
@@ -325,8 +312,8 @@ def test_pre_hook_is_guarded():
 
 
 def test_post_hook_guard_is_not_unconditional():
-    """A bare `if is_compiling(): return` would drop a frozen embedding's flag, so the
-    post hook may only skip the no-op case (the output already requires grad)."""
+    """A bare `if is_compiling(): return` would drop a frozen embedding's flag, so only
+    the no-op case (output already requires grad) may be skipped."""
     src = (_ZOO / "peft_utils.py").read_text(encoding = "utf-8")
     fn = next(
         n for n in ast.walk(ast.parse(src))
@@ -344,10 +331,8 @@ def test_post_hook_guard_is_not_unconditional():
 
 
 def test_make_inputs_require_grad_is_NOT_guarded():
-    """Unlike the peft_utils hooks, this is the only thing making a FROZEN
-    embedding's output require grad, which reentrant checkpointing needs.
-    Guarding it would silently stop gradients reaching the adapters.
-    """
+    """Unlike the peft_utils hooks, this is the only thing making a FROZEN embedding's
+    output require grad, so guarding it would silently starve the adapters."""
     guarded = _guarded_functions(
         _ZOO / "training_utils.py", ("make_inputs_require_grad",),
     )

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -343,28 +343,22 @@ def requires_grad_for_gradient_checkpointing(model):
                     # See https://github.com/unslothai/unsloth/issues/5360
                     target = output.last_hidden_state
                 else:
-                    # Raise while tracing too. Skipping here would leave a tuple /
-                    # list / dict output unmarked, and `is_compiling()` is constant
-                    # folded, so the compiled graph would never re-check it: a
-                    # checkpointed region would then train with no adapter
-                    # gradients instead of failing loudly.
+                    # Raise while tracing too: is_compiling() is constant folded, so a skip
+                    # here is permanent and the region trains with no adapter gradients.
                     raise ValueError("Neither loss, logits, nor last_hidden_state are available for grad post hook.")
             except Exception as e:
                 raise RuntimeError(f"Unsloth: Failed to make output require gradients: {e}")
-        # Dynamo rejects requires_grad_() only when it would flip the flag, so skipping a
-        # no-op keeps fullgraph = True working. Flipping is NOT a no-op on the frozen
-        # input embedding this also lands on: skip it there and reentrant checkpointing
-        # loses every gradient, exactly like the training_utils hook this mirrors.
+        # Dynamo rejects requires_grad_() only when it would flip the flag, so skipping the
+        # no-op keeps fullgraph = True working. Skipping a real flip would break the frozen
+        # input embedding this also lands on, losing every checkpointing gradient.
         if torch.compiler.is_compiling() and target.requires_grad: return
         target.requires_grad_(True)
     pass
 
     def requires_grad_pre_hook(module, args, kwargs):
-        # Dynamo cannot trace requires_grad_(), and Gemma 3N compiles a LoRA
-        # target (embed_audio.embedding_projection) with fullgraph = True, making
-        # this a hard error. Safe to skip: the hook only exists to start an
-        # autograd graph, and anything traced here is already downstream of
-        # trainable LoRA weights.
+        # Dynamo cannot trace requires_grad_(), and Gemma 3N compiles a LoRA target
+        # (embed_audio.embedding_projection) with fullgraph = True, so it is a hard error.
+        # Safe to skip: anything traced here is already downstream of trainable LoRA weights.
         if torch.compiler.is_compiling(): return
         # Try positional args first (normal text models)
         if args:

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -289,46 +289,6 @@ def get_lora_layer_modules():
 pass
 
 
-def _run_eagerly_under_compile(fn):
-    """Make `fn` opaque to TorchDynamo, so torch.compile runs it eagerly.
-
-    The gradient-enabling hooks mutate `requires_grad`, which Dynamo cannot
-    trace:
-
-        Unsupported: Unsupported Tensor.requires_grad_() call
-
-    They are autograd bookkeeping rather than compute -- one tensor, once per
-    forward -- so running them eagerly and graph-breaking around them is both
-    correct and cheap.
-
-    Degrades to a no-op decorator on a torch without `_dynamo`, so eager users
-    and older torch builds are unaffected.
-    """
-    try:
-        import torch._dynamo as _torch_dynamo
-    except Exception:
-        return fn
-    disable = getattr(_torch_dynamo, "disable", None)
-    if disable is None:
-        return fn
-    try:
-        wrapped = disable(fn)
-    except Exception:
-        return fn
-    # register_other_hooks() identifies our hooks by matching __name__ /
-    # __qualname__, so the names must survive the wrapper or the hooks stop
-    # being recognised as ours and get re-registered on top of themselves.
-    # torch 2.9 does carry them through disable(), but that is an internal
-    # detail of a private module and this has to hold from torch 2.6 up.
-    for _attr in ("__name__", "__qualname__", "__doc__"):
-        try:
-            setattr(wrapped, _attr, getattr(fn, _attr))
-        except (AttributeError, TypeError):
-            pass
-    return wrapped
-pass
-
-
 def requires_grad_for_gradient_checkpointing(model):
     # All Unsloth Zoo code licensed under LGPLv3
     # Enables requires_grad to make gradient checkpointing work on
@@ -366,8 +326,14 @@ def requires_grad_for_gradient_checkpointing(model):
     pass
 
     # Add post forward hook
-    @_run_eagerly_under_compile
     def requires_grad_post_hook(module, input, output):
+        # Dynamo cannot trace requires_grad_(), so a compiled module carrying
+        # this hook dies with "Unsupported Tensor.requires_grad_() call" (and
+        # torch._dynamo.disable() does not help: under fullgraph = True it just
+        # becomes "Skip calling torch.compiler.disable()d function"). The hook
+        # is autograd bookkeeping, not compute, so skipping it while tracing is
+        # correct -- see the comment on requires_grad_pre_hook below.
+        if torch.compiler.is_compiling(): return
         type_output = type(output)
         if type_output is torch.Tensor:
             output.requires_grad_(True)
@@ -389,8 +355,18 @@ def requires_grad_for_gradient_checkpointing(model):
                 raise RuntimeError(f"Unsloth: Failed to make output require gradients: {e}")
     pass
 
-    @_run_eagerly_under_compile
     def requires_grad_pre_hook(module, args, kwargs):
+        # Do nothing while Dynamo is tracing. Gemma 3N puts a LoRA target
+        # (embed_audio.embedding_projection) inside a forward that we compile
+        # with fullgraph = True, so tracing reaches this hook and rejects the
+        # requires_grad_() call outright. Dynamo only complains when the call
+        # would actually flip the flag, which is why this stayed hidden.
+        #
+        # Skipping it under compile is safe: the hook only exists so that a
+        # frozen input to a gradient-checkpointed block still starts an
+        # autograd graph, and anything Dynamo is tracing here already sits
+        # downstream of trainable LoRA weights.
+        if torch.compiler.is_compiling(): return
         # Try positional args first (normal text models)
         if args:
             first = args[0]

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -327,28 +327,33 @@ def requires_grad_for_gradient_checkpointing(model):
 
     # Add post forward hook
     def requires_grad_post_hook(module, input, output):
-        # Dynamo cannot trace requires_grad_(), and torch._dynamo.disable() does
-        # not help under fullgraph = True. Safe to skip -- see the pre hook below.
-        if torch.compiler.is_compiling(): return
         type_output = type(output)
         if type_output is torch.Tensor:
-            output.requires_grad_(True)
+            target = output
         else:
             try: # For HF dataclass, try loss or logits
                 if hasattr(output, "loss") and output.loss is not None:
-                    output.loss.requires_grad_(True)
+                    target = output.loss
                 elif hasattr(output, "logits") and output.logits is not None: # RL like GRPO has no loss (no labels)
-                    output.logits.requires_grad_(True)
+                    target = output.logits
                 elif hasattr(output, "last_hidden_state") and output.last_hidden_state is not None:
                     # Encoder / decoder-style embedding backbones (e.g. Qwen3-Embedding) return a
                     # BaseModelOutputWithPast with only last_hidden_state (no loss/logits) when called
                     # for sentence embeddings. Make it require grad so gradient checkpointing works.
                     # See https://github.com/unslothai/unsloth/issues/5360
-                    output.last_hidden_state.requires_grad_(True)
+                    target = output.last_hidden_state
                 else:
+                    # Dynamo cannot trace the raise either, so stay quiet while tracing.
+                    if torch.compiler.is_compiling(): return
                     raise ValueError("Neither loss, logits, nor last_hidden_state are available for grad post hook.")
             except Exception as e:
                 raise RuntimeError(f"Unsloth: Failed to make output require gradients: {e}")
+        # Dynamo rejects requires_grad_() only when it would flip the flag, so skipping a
+        # no-op keeps fullgraph = True working. Flipping is NOT a no-op on the frozen
+        # input embedding this also lands on: skip it there and reentrant checkpointing
+        # loses every gradient, exactly like the training_utils hook this mirrors.
+        if torch.compiler.is_compiling() and target.requires_grad: return
+        target.requires_grad_(True)
     pass
 
     def requires_grad_pre_hook(module, args, kwargs):

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -327,12 +327,8 @@ def requires_grad_for_gradient_checkpointing(model):
 
     # Add post forward hook
     def requires_grad_post_hook(module, input, output):
-        # Dynamo cannot trace requires_grad_(), so a compiled module carrying
-        # this hook dies with "Unsupported Tensor.requires_grad_() call" (and
-        # torch._dynamo.disable() does not help: under fullgraph = True it just
-        # becomes "Skip calling torch.compiler.disable()d function"). The hook
-        # is autograd bookkeeping, not compute, so skipping it while tracing is
-        # correct -- see the comment on requires_grad_pre_hook below.
+        # Dynamo cannot trace requires_grad_(), and torch._dynamo.disable() does
+        # not help under fullgraph = True. Safe to skip -- see the pre hook below.
         if torch.compiler.is_compiling(): return
         type_output = type(output)
         if type_output is torch.Tensor:
@@ -356,16 +352,11 @@ def requires_grad_for_gradient_checkpointing(model):
     pass
 
     def requires_grad_pre_hook(module, args, kwargs):
-        # Do nothing while Dynamo is tracing. Gemma 3N puts a LoRA target
-        # (embed_audio.embedding_projection) inside a forward that we compile
-        # with fullgraph = True, so tracing reaches this hook and rejects the
-        # requires_grad_() call outright. Dynamo only complains when the call
-        # would actually flip the flag, which is why this stayed hidden.
-        #
-        # Skipping it under compile is safe: the hook only exists so that a
-        # frozen input to a gradient-checkpointed block still starts an
-        # autograd graph, and anything Dynamo is tracing here already sits
-        # downstream of trainable LoRA weights.
+        # Dynamo cannot trace requires_grad_(), and Gemma 3N compiles a LoRA
+        # target (embed_audio.embedding_projection) with fullgraph = True, making
+        # this a hard error. Safe to skip: the hook only exists to start an
+        # autograd graph, and anything traced here is already downstream of
+        # trainable LoRA weights.
         if torch.compiler.is_compiling(): return
         # Try positional args first (normal text models)
         if args:

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -343,8 +343,11 @@ def requires_grad_for_gradient_checkpointing(model):
                     # See https://github.com/unslothai/unsloth/issues/5360
                     target = output.last_hidden_state
                 else:
-                    # Dynamo cannot trace the raise either, so stay quiet while tracing.
-                    if torch.compiler.is_compiling(): return
+                    # Raise while tracing too. Skipping here would leave a tuple /
+                    # list / dict output unmarked, and `is_compiling()` is constant
+                    # folded, so the compiled graph would never re-check it: a
+                    # checkpointed region would then train with no adapter
+                    # gradients instead of failing loudly.
                     raise ValueError("Neither loss, logits, nor last_hidden_state are available for grad post hook.")
             except Exception as e:
                 raise RuntimeError(f"Unsloth: Failed to make output require gradients: {e}")

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -33,7 +33,7 @@ import logging
 from ..log import logger
 import functools
 UNSLOTH_ENABLE_LOGGING  = os.environ.get("UNSLOTH_ENABLE_LOGGING",  "0") == "1"
-UNSLOTH_COMPILE_DISABLE = os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "1"
+UNSLOTH_COMPILE_DISABLE = os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") in ("1", "partial",)
 # "partial" keeps the source rewrites but turns torch.compile off, like compiler.py does.
 UNSLOTH_COMPILE_DISABLE_PARTIAL = os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "partial"
 

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -481,7 +481,7 @@ def prepare_model_for_training(
         else:
             def make_inputs_require_grad(module, input, output):
                 # Deliberately NOT guarded on is_compiling() like the peft_utils
-                # hooks: this is the only thing making a FROZEN embedding's output
+                # pre hook: this is the only thing making a FROZEN embedding's output
                 # require grad, which reentrant checkpointing needs. Skipping it
                 # would silently stop gradients reaching the adapters.
                 output.requires_grad_(True)

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -480,9 +480,14 @@ def prepare_model_for_training(
             model.enable_input_require_grads()
         else:
             def make_inputs_require_grad(module, input, output):
-                # Dynamo cannot trace requires_grad_(); see the hooks in
-                # peft_utils.requires_grad_for_gradient_checkpointing.
-                if torch.compiler.is_compiling(): return
+                # NOT guarded on torch.compiler.is_compiling(), unlike the
+                # peft_utils hooks. Those sit on LoRA modules whose output
+                # already requires grad, so skipping them changes nothing.
+                # This one is the only thing making a FROZEN embedding's output
+                # require grad, and reentrant checkpointing needs at least one
+                # grad-carrying input. Skipping it under tracing would leave
+                # that tensor detached and silently stop gradients reaching the
+                # adapters, which is worse than a graph break.
                 output.requires_grad_(True)
             model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
     pass

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -480,10 +480,9 @@ def prepare_model_for_training(
             model.enable_input_require_grads()
         else:
             def make_inputs_require_grad(module, input, output):
-                # Deliberately NOT guarded on is_compiling() like the peft_utils
-                # pre hook: this is the only thing making a FROZEN embedding's output
-                # require grad, which reentrant checkpointing needs. Skipping it
-                # would silently stop gradients reaching the adapters.
+                # Deliberately NOT guarded on is_compiling() like the peft_utils pre hook:
+                # this is the only thing making a FROZEN embedding's output require grad,
+                # so skipping it would silently starve the adapters of gradients.
                 output.requires_grad_(True)
             model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
     pass

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -480,6 +480,9 @@ def prepare_model_for_training(
             model.enable_input_require_grads()
         else:
             def make_inputs_require_grad(module, input, output):
+                # Dynamo cannot trace requires_grad_(); see the hooks in
+                # peft_utils.requires_grad_for_gradient_checkpointing.
+                if torch.compiler.is_compiling(): return
                 output.requires_grad_(True)
             model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
     pass

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -480,14 +480,10 @@ def prepare_model_for_training(
             model.enable_input_require_grads()
         else:
             def make_inputs_require_grad(module, input, output):
-                # NOT guarded on torch.compiler.is_compiling(), unlike the
-                # peft_utils hooks. Those sit on LoRA modules whose output
-                # already requires grad, so skipping them changes nothing.
-                # This one is the only thing making a FROZEN embedding's output
-                # require grad, and reentrant checkpointing needs at least one
-                # grad-carrying input. Skipping it under tracing would leave
-                # that tensor detached and silently stop gradients reaching the
-                # adapters, which is worse than a graph break.
+                # Deliberately NOT guarded on is_compiling() like the peft_utils
+                # hooks: this is the only thing making a FROZEN embedding's output
+                # require grad, which reentrant checkpointing needs. Skipping it
+                # would silently stop gradients reaching the adapters.
                 output.requires_grad_(True)
             model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
     pass


### PR DESCRIPTION
### The failure

`Gemma3N_(4B)-Audio.ipynb` cannot keep its multimodal embedder compiled. On the tree before #991 `trainer.train()` died outright:

```
torch._dynamo.exc.Unsupported: Unsupported Tensor.requires_grad_() call

  from user code:
    unsloth_zoo/temporary_patches/gemma3n.py:82   Gemma3nMultimodalEmbedder_forward
                                                  -> self.embedding_projection(emb_norm)
    torch/nn/modules/module.py:1809               inner -> hook(self, args, kwargs)
    unsloth_zoo/peft_utils.py:357                 requires_grad_pre_hook
                                                  -> first.requires_grad_(True)
```

Three things have to line up:

1. #814 (`finetune_audio_layers`) made `embed_audio.embedding_projection` a LoRA target, so `collect_hook_targets()` in `peft_utils.py` picks it up and registers `requires_grad_pre_hook` on it.
2. `temporary_patches/gemma3n.py:88` patches `Gemma3nMultimodalEmbedder.forward` with `fullgraph = True`, and `embedding_projection` is called from inside that forward.
3. Dynamo inlines `nn.Module` forward pre-hooks, so the hook body is traced, and `Tensor.requires_grad_()` is not traceable.

`fullgraph` is the trigger, not the torch version. Without it the same hook is only a graph break, which is why this never showed up on any other model. Dynamo also only objects when the call would actually flip the flag, so a hook whose input already has `requires_grad = True` traces cleanly, which is why it stayed hidden inside a codepath that has been there a while.

Measured on both ends of the supported range, same reduction (`nn.Linear` wrapped in a `fullgraph = True` forward, hook attached):

| case | torch 2.6.0+cu124 | torch 2.9.1+cu128 |
| --- | --- | --- |
| no hook | OK | OK |
| hook, `fullgraph = False` | OK (graph break) | OK (graph break) |
| hook, `fullgraph = True` | `Unsupported: Tensor.requires_grad_` | `Unsupported: Unsupported Tensor.requires_grad_() call` |
| hook wrapped in `torch._dynamo.disable`, `fullgraph = True` | `Unsupported: call torch._dynamo.disable() wrapped function` | `Unsupported: Skip calling` `` `torch.compiler.disable()` ``d function |
| hook guarded on `torch.compiler.is_compiling()`, `fullgraph = True` | OK | OK |
| hook, input already `requires_grad`, `fullgraph = True` | OK | OK |

### Why #991 is not enough

#991 wrapped both hooks in `torch._dynamo.disable`. That fixes the graph-break case, but under `fullgraph = True` the error just changes shape (row 4 above), and the eager-fallback latch added in the same PR then catches it and drops the whole patched forward to eager for the rest of the run:

```
Unsloth: torch.compile hit one of Unsloth's own `torch.compiler.disable`d
gradient-checkpointing hooks inside Gemma3nMultimodalEmbedder.forward;
running it eagerly from here.
```

So today the notebook trains, but the embedder patch is permanently uncompiled. Running the real `Gemma3nMultimodalEmbedder` with the real hook object off a hooked model:

```
### before
forward compiled: True
real hook: requires_grad_for_gradient_checkpointing.<locals>.requires_grad_pre_hook
[WARNING] Unsloth: torch.compile hit one of Unsloth's own `torch.compiler.disable`d
          gradient-checkpointing hooks inside Gemma3nMultimodalEmbedder.forward;
          running it eagerly from here.
OK   | out.requires_grad=True
eager-fallback latched: True

### after
forward compiled: True
real hook: requires_grad_for_gradient_checkpointing.<locals>.requires_grad_pre_hook
OK   | out.requires_grad=True
eager-fallback latched: False
```

### The change

`if torch.compiler.is_compiling(): return` as the first line of `requires_grad_pre_hook` and `requires_grad_post_hook`, replacing the `_run_eagerly_under_compile` wrapper. `is_compiling()` exists from torch 2.0, and branching on it is the documented way to keep something out of a traced graph. In eager it is `False`, so behaviour is byte-identical for every model and every torch we support; under compile it removes both the hard error in a fullgraph region and the graph break everywhere else.

`make_inputs_require_grad` in `training_utils.py` is the same one-liner in the same situation (registered on `get_input_embeddings()` on the `use_reentrant` path) and gets the same guard.

`temporary_patches/gpt_oss.py:2694` deliberately does not. It is `inputs_embeds.requires_grad_(False)` inside `GptOssModel.forward`, which `patch_function(..., match_level = "relaxed")` installs with no `fullgraph` argument, so it is never compiled. It also sits under `if not self.training:` and exists to stop inference building an autograd graph, so the guard would be a behaviour change with nothing to buy.

### Separate one-liner: `UNSLOTH_COMPILE_DISABLE=partial`

`compiler.py:183` reads the flag as `in ("1", "partial")`; `temporary_patches/common.py:36` read it as `== "1"`. So `partial`, which is meant to keep the source rewrites and turn `torch.compile` off, left every `patch_function(fullgraph = ...)` compiling. Measured against the embedder repro:

```
UNSLOTH_COMPILE_DISABLE=0        forward compiled: True    FAIL | Unsupported Tensor.requires_grad_() call
UNSLOTH_COMPILE_DISABLE=1        forward compiled: False   OK
UNSLOTH_COMPILE_DISABLE=partial  forward compiled: True    FAIL | Unsupported Tensor.requires_grad_() call   <- before
UNSLOTH_COMPILE_DISABLE=partial  forward compiled: False   OK                                                <- after
```

The documented escape hatch for a compile-only crash could not actually be used to escape one. `common.py` now reads the flag the same way `compiler.py` does.

### Residual risk

The guard trades a graph break for a silent no-op. If a hook target ever sits inside a compiled region and the `requires_grad_` there is load-bearing, this would quietly stop enabling grad instead of breaking the graph and working.

It is not load-bearing here. The hook exists so a frozen input to a gradient-checkpointed block still starts an autograd graph. Every module Dynamo can reach it through is a LoRA target, which is why `collect_hook_targets()` selected it, so its output already requires grad from the adapter weights: in the repro above `out.requires_grad` is `True` after the fix with the hook doing nothing. Outside compiled regions nothing changes at all.

The cleaner long-term shape is for `collect_hook_targets()` to skip modules that own trainable parameters, since the hook is redundant on those by construction. That is a wider behaviour change and is not in this PR.

Also left alone: `_fall_back_to_eager_on_recompile_limit` still carries the `_is_our_own_disabled_hook` branch from #991. Nothing produces that error any more, but it is cheap and defensive, and its tests still pass.

### Tests

`tests/test_requires_grad_hook_dynamo.py` is rewritten around the real hooks, pulled off a model that `requires_grad_for_gradient_checkpointing()` has actually hooked, rather than an inlined copy: both hooks still fire eagerly (positional and `inputs_embeds` kwargs paths), both no-op while compiling, the post hook stops raising on an output shape it cannot handle while compiling, and a `fullgraph = True` module carrying each hook runs and keeps its grad. Plus AST checks that the guard stays first in all three functions.

`tests/test_compile_disable_partial.py` probes `patch_Gemma3nMultimodalEmbedder_forward()` in a subprocess per flag value (the flag is read at import) and asserts `0` compiles, `1` and `partial` do not.

6 of the 10 tests in `test_requires_grad_hook_dynamo.py` fail on `main`.

```
$ python -m pytest -p no:randomly tests/test_requires_grad_hook_dynamo.py \
    tests/test_compile_disable_partial.py tests/test_disabled_hook_graph_break.py \
    tests/test_eager_fallback_latch.py tests/test_recompile_limit_fallback.py \
    tests/test_peft_regex_audio.py tests/test_training_utils_use_cache.py \
    tests/test_rl_replacements_compile_disable.py \
    tests/test_peft_paramwrapper_layout_drift.py -q
........................................................................ [ 40%]
........................................................................ [ 80%]
................................s.                                       [100%]
177 passed, 1 skipped, 1 warning in 57.26s
```
