### PR TITLE
Seed the triton stub's class-valued symbols so torch's isinstance checks work on Apple Silicon

### DIFF
--- a/tests/test_triton_stub_class_symbols.py
+++ b/tests/test_triton_stub_class_symbols.py
@@ -1,0 +1,160 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Class-valued symbols of the Apple Silicon triton stub.
+
+The stub's MetaPathFinder auto-creates any unseeded ``triton.*`` submodule and
+serves unknown attributes as ``_Noop`` instances. An instance is not a type, so
+``isinstance(x, Noop)`` / ``issubclass`` / ``except Noop:`` all raise
+``TypeError: isinstance() arg 2 must be a type``.
+
+torch >= 2.10 does exactly this at import time of ``torch.utils.flop_counter``::
+
+    try:
+        from triton.runtime.jit import JITFunction as _JITFunction
+    except ImportError:
+        _JITFunction = NoneType
+    ...
+    isinstance(target, (torch._ops.OpOverloadPacket, _JITFunction, HigherOrderOperator))
+
+With triton genuinely absent the import fails and torch takes the NoneType
+branch. The stub makes the import succeed, so every name real triton exposes as
+a class has to be seeded as a real class.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+STUB_PATH = REPO_ROOT / "unsloth_zoo" / "stubs" / "triton_stub.py"
+
+
+def _load_stub_module():
+    """Load triton_stub.py standalone, without importing unsloth_zoo itself."""
+    spec = importlib.util.spec_from_file_location("_triton_stub_under_test", STUB_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Real triton's class-valued public surface, per module.
+_TRITON_CLASSES = {
+    "triton.runtime.jit": ["JITFunction", "JITCallable", "KernelInterface",
+                           "KernelParam", "MockTensor", "TensorWrapper"],
+    "triton.runtime.autotuner": ["Autotuner", "Heuristics", "Config",
+                                 "OutOfResources", "PTXASError"],
+    "triton.runtime.errors": ["TritonError", "InterpreterError", "OutOfResources",
+                              "PTXASError", "AutotunerError"],
+    "triton.errors": ["TritonError"],
+    "triton.compiler": ["CompiledKernel", "ASTSource", "IRSource", "LazyDict",
+                        "CompilationError"],
+    "triton.compiler.compiler": ["CompiledKernel", "ASTSource", "IRSource", "LazyDict"],
+    "triton.compiler.errors": ["CompilationError", "CompileTimeAssertionFailure",
+                               "UnsupportedLanguageConstruct"],
+    "triton.backends.compiler": ["GPUTarget", "BaseBackend"],
+    "triton.tools.tensor_descriptor": ["TensorDescriptor"],
+    "triton.language": ["constexpr", "dtype", "tensor", "block_type", "pointer_type"],
+    "triton.language.core": ["constexpr", "dtype", "tensor", "block_type", "pointer_type"],
+}
+
+# Exceptions must be catchable: `except <non-class>` raises TypeError too.
+_TRITON_EXCEPTIONS = ["TritonError", "InterpreterError", "OutOfResources",
+                      "PTXASError", "AutotunerError", "CompilationError"]
+
+
+@pytest.mark.parametrize("module_path,names", sorted(_TRITON_CLASSES.items()))
+def test_seeded_symbols_are_real_classes(module_path, names):
+    stub = _load_stub_module()
+    module = stub
+    for part in module_path.split(".")[1:]:
+        module = getattr(module, part)
+    for name in names:
+        attr = getattr(module, name)
+        assert isinstance(attr, type), f"{module_path}.{name} is {attr!r}, not a class"
+        # The check that actually crashed torch.
+        assert isinstance(object(), attr) is False
+
+
+@pytest.mark.parametrize("name", _TRITON_EXCEPTIONS)
+def test_error_symbols_are_catchable(name):
+    stub = _load_stub_module()
+    error = getattr(stub, name)
+    assert issubclass(error, Exception)
+    with pytest.raises(error):
+        raise error("stub")
+
+
+def test_stub_classes_stay_permissive():
+    """Seeding must not cost the stub its permissive attribute access."""
+    stub = _load_stub_module()
+    assert isinstance(stub.JITFunction.anything_unknown, stub._Noop)
+    assert isinstance(stub.JITFunction().anything_unknown, stub._Noop)
+
+
+_SUBPROCESS = textwrap.dedent(
+    """
+    import importlib.util, sys
+    sys.path.insert(0, {tests!r})
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()          # spoof Darwin/arm64, as on a Mac host
+
+    spec = importlib.util.spec_from_file_location("triton_stub", {stub!r})
+    stub = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = stub
+    spec.loader.exec_module(stub)
+    stub.inject_into_sys_modules()
+
+    from triton.runtime.jit import JITFunction
+    assert isinstance(JITFunction, type), JITFunction
+    import torch.utils.flop_counter          # crashed here pre-fix
+    import torch.utils._runtime_estimation   # the import unsloth.save reaches
+    print("OK")
+    """
+)
+
+
+def _torch_flop_counter_imports_jitfunction() -> bool:
+    spec = importlib.util.find_spec("torch.utils.flop_counter")
+    if spec is None or spec.origin is None:
+        return False
+    # Read the source rather than import it: importing is what used to crash.
+    return "from triton.runtime.jit import JITFunction" in \
+        pathlib.Path(spec.origin).read_text(encoding="utf-8")
+
+
+def test_flop_counter_imports_under_the_stub():
+    """torch.utils.flop_counter must import with the stub installed."""
+    pytest.importorskip("torch")
+    if not _torch_flop_counter_imports_jitfunction():
+        pytest.skip("this torch does not import triton.runtime.jit.JITFunction")
+    code = _SUBPROCESS.format(tests=str(REPO_ROOT / "tests"), stub=str(STUB_PATH))
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                          text=True, cwd=str(REPO_ROOT))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "OK" in proc.stdout
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_triton_stub_class_symbols.py
+++ b/tests/test_triton_stub_class_symbols.py
@@ -16,23 +16,13 @@
 
 """Class-valued symbols of the Apple Silicon triton stub.
 
-The stub's MetaPathFinder auto-creates any unseeded ``triton.*`` submodule and
-serves unknown attributes as ``_Noop`` instances. An instance is not a type, so
-``isinstance(x, Noop)`` / ``issubclass`` / ``except Noop:`` all raise
-``TypeError: isinstance() arg 2 must be a type``.
-
-torch >= 2.10 does exactly this at import time of ``torch.utils.flop_counter``::
-
-    try:
-        from triton.runtime.jit import JITFunction as _JITFunction
-    except ImportError:
-        _JITFunction = NoneType
-    ...
-    isinstance(target, (torch._ops.OpOverloadPacket, _JITFunction, HigherOrderOperator))
-
-With triton genuinely absent the import fails and torch takes the NoneType
-branch. The stub makes the import succeed, so every name real triton exposes as
-a class has to be seeded as a real class.
+Unseeded ``triton.*`` attributes come back as ``_Noop`` instances, and an
+instance is not a type, so ``isinstance`` / ``issubclass`` / ``except`` on one
+raises ``TypeError: isinstance() arg 2 must be a type``. torch >= 2.10 imports
+``triton.runtime.jit.JITFunction`` at import time of ``torch.utils.flop_counter``
+and isinstance()s it: with triton truly absent that import fails and torch falls
+back to NoneType, but the stub makes it succeed, so every name real triton
+exposes as a class has to be seeded as a real class.
 """
 
 from __future__ import annotations
@@ -138,9 +128,8 @@ _SUBPROCESS = textwrap.dedent(
 
 
 # inductor's two other class-sensitive uses, verbatim from torch main:
-# triton_compat.py imports IntelGPUError under `except ImportError` and
-# triton_heuristics.py catches it; _interpret_args_grid isinstance()s
-# InterpretedFunction. Both names come from modules the finder auto-creates.
+# triton_compat imports IntelGPUError and triton_heuristics catches it;
+# _interpret_args_grid isinstance()s InterpretedFunction.
 _INDUCTOR_SUBPROCESS = textwrap.dedent(
     """
     import importlib.util, sys

--- a/tests/test_triton_stub_class_symbols.py
+++ b/tests/test_triton_stub_class_symbols.py
@@ -66,7 +66,8 @@ _TRITON_CLASSES = {
     "triton.runtime.autotuner": ["Autotuner", "Heuristics", "Config",
                                  "OutOfResources", "PTXASError"],
     "triton.runtime.errors": ["TritonError", "InterpreterError", "OutOfResources",
-                              "PTXASError", "AutotunerError"],
+                              "PTXASError", "AutotunerError", "IntelGPUError"],
+    "triton.runtime.interpreter": ["InterpretedFunction"],
     "triton.errors": ["TritonError"],
     "triton.compiler": ["CompiledKernel", "ASTSource", "IRSource", "LazyDict",
                         "CompilationError"],
@@ -81,7 +82,8 @@ _TRITON_CLASSES = {
 
 # Exceptions must be catchable: `except <non-class>` raises TypeError too.
 _TRITON_EXCEPTIONS = ["TritonError", "InterpreterError", "OutOfResources",
-                      "PTXASError", "AutotunerError", "CompilationError"]
+                      "PTXASError", "AutotunerError", "CompilationError",
+                      "IntelGPUError"]
 
 
 @pytest.mark.parametrize("module_path,names", sorted(_TRITON_CLASSES.items()))
@@ -133,6 +135,46 @@ _SUBPROCESS = textwrap.dedent(
     print("OK")
     """
 )
+
+
+# inductor's two other class-sensitive uses, verbatim from torch main:
+# triton_compat.py imports IntelGPUError under `except ImportError` and
+# triton_heuristics.py catches it; _interpret_args_grid isinstance()s
+# InterpretedFunction. Both names come from modules the finder auto-creates.
+_INDUCTOR_SUBPROCESS = textwrap.dedent(
+    """
+    import importlib.util, sys
+    spec = importlib.util.spec_from_file_location("triton_stub", {stub!r})
+    stub = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = stub
+    spec.loader.exec_module(stub)
+    stub.inject_into_sys_modules()
+
+    try:
+        from triton.runtime.errors import IntelGPUError
+    except ImportError:
+        class IntelGPUError(Exception): pass
+    from triton.runtime.errors import OutOfResources, PTXASError
+    try:
+        raise RuntimeError("compile failed")
+    except (OutOfResources, PTXASError, IntelGPUError):
+        raise AssertionError("stub error classes must not swallow RuntimeError")
+    except RuntimeError:
+        pass
+
+    from triton.runtime.interpreter import InterpretedFunction
+    assert isinstance(object(), InterpretedFunction) is False
+    print("OK")
+    """
+)
+
+
+def test_inductor_error_and_interpreter_symbols():
+    code = _INDUCTOR_SUBPROCESS.format(stub=str(STUB_PATH))
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                          text=True, cwd=str(REPO_ROOT))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "OK" in proc.stdout
 
 
 def _torch_flop_counter_imports_jitfunction() -> bool:

--- a/unsloth_zoo/stubs/triton_stub.py
+++ b/unsloth_zoo/stubs/triton_stub.py
@@ -154,6 +154,68 @@ class Config:
 
 
 # ---------------------------------------------------------------------------
+# Names real triton exposes as CLASSES.
+#
+# A _Noop is an instance, not a type, so `isinstance(x, Noop)`,
+# `issubclass(...)` and `except Noop:` all raise
+# "TypeError: isinstance() arg 2 must be a type". torch does exactly that:
+# `from triton.runtime.jit import JITFunction` then
+# `isinstance(target, (OpOverloadPacket, JITFunction, HigherOrderOperator))`
+# at import time of torch.utils.flop_counter. With triton genuinely absent the
+# import raises ImportError and torch falls back to NoneType; the stub makes
+# the import succeed, so every class-valued name must be a real class.
+# ---------------------------------------------------------------------------
+class _StubMeta(type):
+    """Keeps class-valued stubs permissive: unknown class attrs stay _Noop."""
+    def __getattr__(cls, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return _Noop(f"{cls.__name__}.{name}")
+
+class _StubClass(metaclass=_StubMeta):
+    def __init__(self, *args, **kwargs): pass
+    def __class_getitem__(cls, item): return cls
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return _Noop(f"{type(self).__name__}.{name}")
+
+# triton.errors / triton.runtime.errors / triton.compiler.errors — these are
+# caught with `except`, which also demands a real exception class.
+class TritonError(Exception, metaclass=_StubMeta): pass
+class InterpreterError(TritonError): pass
+class OutOfResources(TritonError): pass
+class PTXASError(TritonError): pass
+class AutotunerError(TritonError): pass
+class CompilationError(TritonError): pass
+class CompileTimeAssertionFailure(CompilationError): pass
+class UnsupportedLanguageConstruct(CompilationError): pass
+
+# triton.runtime.jit
+class KernelInterface(_StubClass): pass
+class JITCallable(_StubClass): pass
+class JITFunction(JITCallable, KernelInterface): pass
+class MockTensor(_StubClass): pass
+class TensorWrapper(_StubClass): pass
+class KernelParam(_StubClass): pass
+
+# triton.runtime.autotuner
+class Autotuner(KernelInterface): pass
+class Heuristics(KernelInterface): pass
+
+# triton.compiler
+class CompiledKernel(_StubClass): pass
+class ASTSource(_StubClass): pass
+class IRSource(_StubClass): pass
+class LazyDict(_StubClass): pass
+
+# triton.backends.compiler / triton.tools.tensor_descriptor
+class GPUTarget(_StubClass): pass
+class BaseBackend(_StubClass): pass
+class TensorDescriptor(_StubClass): pass
+
+
+# ---------------------------------------------------------------------------
 # triton.language — needs constexpr/dtype for kernel annotations
 # ---------------------------------------------------------------------------
 class _ConstExpr:
@@ -163,14 +225,24 @@ class _ConstExpr:
 class dtype:
     def __init__(self, name="void"): self.name = name
 
-language = _make_module("triton.language", {
+# isinstance targets in inductor's codegen
+class tensor(_StubClass): pass
+class block_type(_StubClass): pass
+class pointer_type(_StubClass): pass
+
+_language_attrs = {
     "constexpr": _ConstExpr,
     "dtype": dtype,
+    "tensor": tensor,
+    "block_type": block_type,
+    "pointer_type": pointer_type,
     "float32": "float32", "float16": "float16", "bfloat16": "bfloat16",
     "int32": "int32", "int64": "int64", "int8": "int8",
     "uint8": "uint8", "int1": "int1",
-})
+}
+language = _make_module("triton.language", _language_attrs)
 language.math = language
+language.core = _make_module("triton.language.core", _language_attrs)
 
 # triton.runtime — needs driver.active for target detection
 class _CurrentTarget:
@@ -184,12 +256,55 @@ class _ActiveDriver:
 runtime = _make_module("triton.runtime", {
     "driver": _make_module("triton.runtime.driver", {"active": _ActiveDriver()}),
     "errors": _make_module("triton.runtime.errors", {
-        "OutOfResources": type("OutOfResources", (Exception,), {}),
+        "TritonError": TritonError, "InterpreterError": InterpreterError,
+        "OutOfResources": OutOfResources, "PTXASError": PTXASError,
+        "AutotunerError": AutotunerError,
     }),
+    "jit": _make_module("triton.runtime.jit", {
+        "JITFunction": JITFunction, "JITCallable": JITCallable,
+        "KernelInterface": KernelInterface, "KernelParam": KernelParam,
+        "MockTensor": MockTensor, "TensorWrapper": TensorWrapper, "jit": jit,
+    }),
+    "autotuner": _make_module("triton.runtime.autotuner", {
+        "Autotuner": Autotuner, "Heuristics": Heuristics, "Config": Config,
+        "autotune": autotune, "heuristics": heuristics,
+        "OutOfResources": OutOfResources, "PTXASError": PTXASError,
+    }),
+    # triton.runtime re-exports the above at package level
+    "JITFunction": JITFunction, "KernelInterface": KernelInterface,
+    "MockTensor": MockTensor, "TensorWrapper": TensorWrapper,
+    "Autotuner": Autotuner, "Heuristics": Heuristics, "Config": Config,
+    "autotune": autotune, "heuristics": heuristics,
+    "OutOfResources": OutOfResources, "InterpreterError": InterpreterError,
+})
+
+errors = _make_module("triton.errors", {"TritonError": TritonError})
+
+compiler = _make_module("triton.compiler", {
+    "CompiledKernel": CompiledKernel, "ASTSource": ASTSource,
+    "IRSource": IRSource, "LazyDict": LazyDict,
+    "CompilationError": CompilationError,
+})
+compiler.compiler = _make_module("triton.compiler.compiler", {
+    "CompiledKernel": CompiledKernel, "ASTSource": ASTSource,
+    "IRSource": IRSource, "LazyDict": LazyDict,
+})
+compiler.errors = _make_module("triton.compiler.errors", {
+    "CompilationError": CompilationError,
+    "CompileTimeAssertionFailure": CompileTimeAssertionFailure,
+    "UnsupportedLanguageConstruct": UnsupportedLanguageConstruct,
 })
 
 # triton.backends — needs empty `backends` dict
 backends = _make_module("triton.backends", {"backends": {}})
+backends.compiler = _make_module("triton.backends.compiler", {
+    "GPUTarget": GPUTarget, "BaseBackend": BaseBackend,
+})
+
+tools = _make_module("triton.tools", {})
+tools.tensor_descriptor = _make_module("triton.tools.tensor_descriptor", {
+    "TensorDescriptor": TensorDescriptor,
+})
 
 
 def inject_into_sys_modules():
@@ -199,11 +314,21 @@ def inject_into_sys_modules():
 
     this = sys.modules[__name__]
     sys.modules.update({
-        "triton":                this,
-        "triton.language":       language,
-        "triton.runtime":        runtime,
-        "triton.runtime.driver": runtime.driver,
-        "triton.runtime.errors": runtime.errors,
-        "triton.backends":       backends,
+        "triton":                        this,
+        "triton.errors":                 errors,
+        "triton.language":               language,
+        "triton.language.core":          language.core,
+        "triton.runtime":                runtime,
+        "triton.runtime.driver":         runtime.driver,
+        "triton.runtime.errors":         runtime.errors,
+        "triton.runtime.jit":            runtime.jit,
+        "triton.runtime.autotuner":      runtime.autotuner,
+        "triton.compiler":               compiler,
+        "triton.compiler.compiler":      compiler.compiler,
+        "triton.compiler.errors":        compiler.errors,
+        "triton.backends":               backends,
+        "triton.backends.compiler":      backends.compiler,
+        "triton.tools":                  tools,
+        "triton.tools.tensor_descriptor": tools.tensor_descriptor,
     })
     # Everything else auto-created by _TritonFinder on demand

--- a/unsloth_zoo/stubs/triton_stub.py
+++ b/unsloth_zoo/stubs/triton_stub.py
@@ -154,16 +154,11 @@ class Config:
 
 
 # ---------------------------------------------------------------------------
-# Names real triton exposes as CLASSES.
-#
-# A _Noop is an instance, not a type, so `isinstance(x, Noop)`,
-# `issubclass(...)` and `except Noop:` all raise
-# "TypeError: isinstance() arg 2 must be a type". torch does exactly that:
-# `from triton.runtime.jit import JITFunction` then
-# `isinstance(target, (OpOverloadPacket, JITFunction, HigherOrderOperator))`
-# at import time of torch.utils.flop_counter. With triton genuinely absent the
-# import raises ImportError and torch falls back to NoneType; the stub makes
-# the import succeed, so every class-valued name must be a real class.
+# Names real triton exposes as CLASSES. A _Noop is an instance, not a type, so
+# isinstance/issubclass/except on one raises TypeError. torch.utils.flop_counter
+# imports triton.runtime.jit.JITFunction and isinstance()s it: with triton truly
+# absent that import fails and torch falls back to NoneType, but the stub makes
+# it succeed, so every class-valued name must be a real class.
 # ---------------------------------------------------------------------------
 class _StubMeta(type):
     """Keeps class-valued stubs permissive: unknown class attrs stay _Noop."""
@@ -180,15 +175,13 @@ class _StubClass(metaclass=_StubMeta):
             raise AttributeError(name)
         return _Noop(f"{type(self).__name__}.{name}")
 
-# triton.errors / triton.runtime.errors / triton.compiler.errors — these are
-# caught with `except`, which also demands a real exception class.
+# triton.errors / runtime.errors / compiler.errors: `except` also demands a class.
 class TritonError(Exception, metaclass=_StubMeta): pass
 class InterpreterError(TritonError): pass
 class OutOfResources(TritonError): pass
 class PTXASError(TritonError): pass
 class AutotunerError(TritonError): pass
-# Only Intel's triton declares IntelGPUError; torch imports it under
-# `except ImportError` and then catches it, so the stub must supply a class.
+# Only Intel's triton declares IntelGPUError, but torch still imports and catches it.
 class IntelGPUError(TritonError): pass
 class CompilationError(TritonError): pass
 class CompileTimeAssertionFailure(CompilationError): pass
@@ -206,7 +199,7 @@ class KernelParam(_StubClass): pass
 class Autotuner(KernelInterface): pass
 class Heuristics(KernelInterface): pass
 
-# triton.runtime.interpreter — inductor does isinstance(self.fn, InterpretedFunction)
+# triton.runtime.interpreter: inductor isinstance()s InterpretedFunction
 class InterpretedFunction(KernelInterface): pass
 
 # triton.compiler

--- a/unsloth_zoo/stubs/triton_stub.py
+++ b/unsloth_zoo/stubs/triton_stub.py
@@ -187,6 +187,9 @@ class InterpreterError(TritonError): pass
 class OutOfResources(TritonError): pass
 class PTXASError(TritonError): pass
 class AutotunerError(TritonError): pass
+# Only Intel's triton declares IntelGPUError; torch imports it under
+# `except ImportError` and then catches it, so the stub must supply a class.
+class IntelGPUError(TritonError): pass
 class CompilationError(TritonError): pass
 class CompileTimeAssertionFailure(CompilationError): pass
 class UnsupportedLanguageConstruct(CompilationError): pass
@@ -202,6 +205,9 @@ class KernelParam(_StubClass): pass
 # triton.runtime.autotuner
 class Autotuner(KernelInterface): pass
 class Heuristics(KernelInterface): pass
+
+# triton.runtime.interpreter — inductor does isinstance(self.fn, InterpretedFunction)
+class InterpretedFunction(KernelInterface): pass
 
 # triton.compiler
 class CompiledKernel(_StubClass): pass
@@ -258,7 +264,10 @@ runtime = _make_module("triton.runtime", {
     "errors": _make_module("triton.runtime.errors", {
         "TritonError": TritonError, "InterpreterError": InterpreterError,
         "OutOfResources": OutOfResources, "PTXASError": PTXASError,
-        "AutotunerError": AutotunerError,
+        "AutotunerError": AutotunerError, "IntelGPUError": IntelGPUError,
+    }),
+    "interpreter": _make_module("triton.runtime.interpreter", {
+        "InterpretedFunction": InterpretedFunction,
     }),
     "jit": _make_module("triton.runtime.jit", {
         "JITFunction": JITFunction, "JITCallable": JITCallable,
@@ -323,6 +332,7 @@ def inject_into_sys_modules():
         "triton.runtime.errors":         runtime.errors,
         "triton.runtime.jit":            runtime.jit,
         "triton.runtime.autotuner":      runtime.autotuner,
+        "triton.runtime.interpreter":    runtime.interpreter,
         "triton.compiler":               compiler,
         "triton.compiler.compiler":      compiler.compiler,
         "triton.compiler.errors":        compiler.errors,


### PR DESCRIPTION
On macOS arm64 with MLX installed (no real triton), `import unsloth.save` dies inside torch:

```
tests/test_kaggle_gguf_error_message.py:31: save = pytest.importorskip("unsloth.save")
  ...
torch/utils/_runtime_estimation.py:9:  from .flop_counter import flop_registry
torch/utils/flop_counter.py:753:      _register_flex_attention_flops()
torch/utils/flop_counter.py:630:      @register_flop_formula(flex_attention, get_raw=True)
torch/utils/flop_counter.py:69:       torch.utils._pytree.tree_map_(register, targets)
torch/utils/flop_counter.py:58:       if not (isinstance(target, (torch._ops.OpOverloadPacket, _JITFunction, HigherOrderOperator))):
E   TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

### What was missing

torch 2.10+ (pytorch#169876) does this at import time of `torch.utils.flop_counter`:

```python
try:
    from triton.runtime.jit import JITFunction as _JITFunction
except ImportError:
    _JITFunction = NoneType
```

`unsloth_zoo/stubs/triton_stub.py` seeds `triton.runtime` but not `triton.runtime.jit`, and its `_TritonFinder` auto-creates any unseeded `triton.*` submodule, so the import succeeds and `JITFunction` resolves to a `_Noop` instance. A `_Noop` is an instance, not a type, so the `isinstance` a few lines later raises `TypeError`. With triton genuinely absent the import raises `ImportError` and torch takes the `NoneType` branch, so only the stub makes this reachable.

Same shape of bug for every other triton name that is a class upstream: `except triton.compiler.errors.CompilationError` and `isinstance(kernel, Autotuner)` fail identically. This seeds them all as real classes:

- `triton.runtime.jit`: `JITFunction`, `JITCallable`, `KernelInterface`, `KernelParam`, `MockTensor`, `TensorWrapper`
- `triton.runtime.autotuner`: `Autotuner`, `Heuristics`, `Config`, `OutOfResources`, `PTXASError`
- `triton.errors` / `triton.runtime.errors`: `TritonError`, `InterpreterError`, `OutOfResources`, `PTXASError`, `AutotunerError`
- `triton.compiler` / `.compiler` / `.errors`: `CompiledKernel`, `ASTSource`, `IRSource`, `LazyDict`, `CompilationError`, `CompileTimeAssertionFailure`, `UnsupportedLanguageConstruct`
- `triton.backends.compiler`: `GPUTarget`, `BaseBackend`
- `triton.tools.tensor_descriptor`: `TensorDescriptor`
- `triton.language` / `triton.language.core`: `tensor`, `block_type`, `pointer_type` alongside the existing `constexpr` / `dtype`

Those are exactly the names torch imports from triton (`grep "from triton.* import"` over the installed torch) intersected with what upstream triton defines with `class`. The error names derive from `TritonError` as upstream does, so `except TritonError` catches them. A `_StubMeta` metaclass keeps the classes permissive: unknown attributes on them still return a `_Noop`, so nothing that used to resolve stops resolving.

### Reproduction on Linux

The stub is gated on Darwin + arm64 + MLX, so it was driven directly (torch 2.13.0+cpu, no triton installed):

```
$ python repro.py   # loads triton_stub.py, calls inject_into_sys_modules(), imports torch.utils.flop_counter
```

before:

```
real triton present: False
triton.runtime.jit.JITFunction -> <triton_stub: triton.runtime.jit.JITFunction> | is a type: False
RESULT: TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

after:

```
real triton present: False
triton.runtime.jit.JITFunction -> <class 'triton_stub.JITFunction'> | is a type: True
RESULT: OK, flop_counter imported; _JITFunction = <class 'triton_stub.JITFunction'>
```

Sweeping the torch modules that touch triton, before then after:

```
FAIL torch.utils.flop_counter          TypeError: isinstance() arg 2 must be a type...
FAIL torch.utils._runtime_estimation   TypeError: isinstance() arg 2 must be a type...
FAIL torch._inductor.select_algorithm  TypeError: isinstance() arg 2 must be a type...
OK   torch._higher_order_ops.triton_kernel_wrap, torch._inductor.utils, torch._dynamo, ...
```

```
OK   torch.utils.flop_counter
OK   torch.utils._runtime_estimation
OK   torch._inductor.select_algorithm
OK   torch._higher_order_ops.triton_kernel_wrap, torch._inductor.utils, torch._dynamo, ...
```

Control: with no stub installed at all, `torch.utils.flop_counter` imports fine and `_JITFunction` is `NoneType`, confirming the stub is what made the crash reachable.

### Blast radius

Mac only. The stub is injected solely under the `_SKIP_GPU_INIT` gate in `unsloth_zoo/__init__.py` (Darwin + arm64 + MLX, or the opt-in download-only child). NVIDIA, AMD and Intel hosts never load it and keep the real triton untouched. No gating logic is changed here.

### Tests

`tests/test_triton_stub_class_symbols.py`: 19 checks over the seeded class surface, exception catchability, retained permissive attribute access, and a subprocess that runs `simulate_mlx_on_torch()` then imports `torch.utils.flop_counter` and `torch.utils._runtime_estimation` under the injected stub. All 19 fail on main and pass here. The subprocess check skips on torch older than 2.10, which does not have the `JITFunction` import.

Existing stub and MLX suites still pass (103 passed, 2 skipped), and `ruff check --select E9,F63,F7,F82` is clean.
