### PR TITLE
Stop the shared RMSNorm kernel from recompiling per norm instance

### DIFF
--- a/tests/test_rmsnorm_recompile_guards.py
+++ b/tests/test_rmsnorm_recompile_guards.py
@@ -1,4 +1,18 @@
-# SPDX-License-Identifier: AGPL-3.0-only
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """One compiled RMSNorm code object is shared by every norm instance in a model.
 
 gemma-4-E2B has 504 of them, so that frame's Dynamo cache holds the *product* of

--- a/tests/test_rmsnorm_recompile_guards.py
+++ b/tests/test_rmsnorm_recompile_guards.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""One compiled RMSNorm code object is shared by every norm instance in a model.
+
+gemma-4-E2B has 504 of them, so that single frame's Dynamo cache holds the
+*product* of every axis its guards can see: parameter width, input rank,
+`self.with_scale`, dtype, grad mode and requires_grad. That reached
+`patch_torch_compile`'s recompile_limit on a T4 and raised
+`FailOnRecompileLimitHit`, which then took activation checkpointing down with it.
+
+Compiling a pure tensor kernel instead of a bound method leaves `self` in eager,
+which removes the parameter-width, rank and with_scale axes. These tests pin
+that: the refactor must not change a single output bit, and it must keep the
+cache small enough that a realistic spread of call shapes never trips the limit.
+"""
+
+import pytest
+import torch
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason = "needs a GPU: these assert on real torch.compile guard behaviour",
+)
+
+# The spread one model actually produces: several norm widths, rank 3 residual
+# norms and rank 4 q/k norms, scaled and unscaled, in each dtype the fp32 patch
+# can see. Deliberately more combinations than the limit below.
+CASES = [
+    ((2, 7, 64),      64,   True),
+    ((2, 7, 768),     768,  True),
+    ((1, 4, 5, 256),  256,  True),
+    ((3, 11, 1536),   1536, True),
+    ((2, 7, 64),      64,   False),
+    ((1, 4, 5, 256),  256,  False),
+]
+DTYPES = (torch.float16, torch.float32, torch.bfloat16)
+_FP16_MAX = float(torch.finfo(torch.float16).max)
+
+
+def _old_body(hidden_states, weight, eps, with_scale):
+    """The pre-fix maths, verbatim, so equivalence is checked against the real thing."""
+    x_fp32 = hidden_states.to(torch.float32)
+    variance = x_fp32.pow(2).mean(-1, keepdim = True)
+    normed = x_fp32 * torch.pow(variance + eps, -0.5)
+    if with_scale:
+        normed = normed * weight.to(torch.float32)
+    return torch.clamp(normed, min = -_FP16_MAX, max = _FP16_MAX).to(torch.float16)
+
+
+class _OldNorm(torch.nn.Module):
+    """A bound method reading `self.weight` / `self.with_scale`, i.e. the old shape."""
+
+    def __init__(self, hidden, with_scale, dtype):
+        super().__init__()
+        self.eps = 1e-6
+        self.with_scale = with_scale
+        if with_scale:
+            self.weight = torch.nn.Parameter(torch.randn(hidden, device = "cuda", dtype = dtype))
+        else:
+            self.weight = None
+
+    def forward(self, hidden_states):
+        return _old_body(hidden_states, self.weight, self.eps, self.with_scale)
+
+
+def _new(hidden_states, weight, eps, with_scale):
+    from unsloth_zoo.temporary_patches.common import (
+        flatten_for_elementwise_norm,
+        unwrap_norm_weight,
+    )
+    from unsloth_zoo.temporary_patches.gemma4_float32 import (
+        _gemma4_rms_norm_scaled,
+        _gemma4_rms_norm_unscaled,
+    )
+    flat, shape = flatten_for_elementwise_norm(hidden_states)
+    if with_scale:
+        out = _gemma4_rms_norm_scaled(flat, unwrap_norm_weight(weight), eps)
+    else:
+        out = _gemma4_rms_norm_unscaled(flat, eps)
+    return out.reshape(shape)
+
+
+def _new_eager(hidden_states, weight, eps, with_scale):
+    """The refactor's data flow without torch.compile.
+
+    Compiled output legitimately differs from eager by Inductor's float
+    reassociation, and the old code was compiled too, so comparing eager-old to
+    compiled-new would measure the compiler rather than this change. Running the
+    same reshape/unwrap path eagerly isolates the refactor itself.
+    """
+    from unsloth_zoo.temporary_patches.common import (
+        flatten_for_elementwise_norm,
+        unwrap_norm_weight,
+    )
+    flat, shape = flatten_for_elementwise_norm(hidden_states)
+    weight = None if weight is None else unwrap_norm_weight(weight)
+    return _old_body(flat, weight, eps, with_scale).reshape(shape)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape, hidden, with_scale", CASES)
+def test_the_refactor_changes_no_output_bit(dtype, shape, hidden, with_scale):
+    torch.manual_seed(0)
+    hidden_states = torch.randn(*shape, device = "cuda", dtype = dtype)
+    weight = torch.nn.Parameter(torch.randn(hidden, device = "cuda", dtype = dtype)) \
+        if with_scale else None
+
+    expected = _old_body(hidden_states, weight, 1e-6, with_scale)
+    actual = _new_eager(hidden_states, weight, 1e-6, with_scale)
+
+    assert torch.equal(expected, actual)
+
+
+@pytest.mark.parametrize("with_scale", (True, False))
+def test_gradients_still_reach_the_parameter_through_the_view(with_scale):
+    # unwrap_norm_weight hands the kernel a *view* of the Parameter. If that view
+    # detached, training would silently stop updating every norm in the model.
+    torch.manual_seed(0)
+    old_x = torch.randn(2, 7, 768, device = "cuda", dtype = torch.float16, requires_grad = True)
+    new_x = old_x.detach().clone().requires_grad_(True)
+    old_w = torch.nn.Parameter(torch.randn(768, device = "cuda", dtype = torch.float16)) \
+        if with_scale else None
+    new_w = torch.nn.Parameter(old_w.detach().clone()) if with_scale else None
+
+    _old_body(old_x, old_w, 1e-6, with_scale).float().sum().backward()
+    _new_eager(new_x, new_w, 1e-6, with_scale).float().sum().backward()
+
+    assert torch.equal(old_x.grad, new_x.grad)
+    if with_scale:
+        assert new_w.grad is not None
+        assert torch.equal(old_w.grad, new_w.grad)
+
+
+def _run_every_case(fn):
+    for dtype in DTYPES:
+        for shape, hidden, with_scale in CASES:
+            torch.manual_seed(0)
+            hidden_states = torch.randn(*shape, device = "cuda", dtype = dtype)
+            weight = torch.nn.Parameter(torch.randn(hidden, device = "cuda", dtype = dtype)) \
+                if with_scale else None
+            fn(hidden_states, weight, with_scale, hidden, dtype)
+
+
+def test_the_old_bound_method_exhausts_a_realistic_recompile_budget():
+    # The regression this fix exists for. A low limit stands in for the real one:
+    # the point is that the old form's cache grows with the product of the axes,
+    # so on a model with hundreds of norms any fixed budget is eventually spent.
+    torch._dynamo.reset()
+    with torch._dynamo.config.patch(
+        recompile_limit = 8,
+        fail_on_recompile_limit_hit = True,
+        # unsloth_zoo sets suppress_errors globally, and Dynamo asserts the two
+        # are never both on, so pin it rather than inherit it.
+        suppress_errors = False,
+    ):
+        compiled = {}
+
+        def call(hidden_states, weight, with_scale, hidden, dtype):
+            key = (hidden, with_scale, dtype)
+            if key not in compiled:
+                module = _OldNorm(hidden, with_scale, dtype).cuda()
+                if with_scale:
+                    module.weight.data = module.weight.data.to(dtype)
+                compiled[key] = torch.compile(module, fullgraph = True)
+            compiled[key](hidden_states)
+
+        with pytest.raises(torch._dynamo.exc.FailOnRecompileLimitHit):
+            _run_every_case(call)
+
+
+def test_the_kernels_survive_the_same_budget():
+    torch._dynamo.reset()
+    with torch._dynamo.config.patch(
+        recompile_limit = 8,
+        fail_on_recompile_limit_hit = True,
+        # unsloth_zoo sets suppress_errors globally, and Dynamo asserts the two
+        # are never both on, so pin it rather than inherit it.
+        suppress_errors = False,
+    ):
+        _run_every_case(
+            lambda hidden_states, weight, with_scale, hidden, dtype:
+                _new(hidden_states, weight, 1e-6, with_scale)
+        )
+
+
+def test_a_parameter_view_is_not_itself_a_parameter():
+    # This is the whole reason the width guard goes away: Dynamo's is_static_input
+    # forces a static shape when `type(t) is torch.nn.Parameter`, and `dynamic=True`
+    # does not override it. A view is a plain Tensor, so it takes dynamic shapes.
+    from unsloth_zoo.temporary_patches.common import unwrap_norm_weight
+
+    weight = torch.nn.Parameter(torch.randn(64))
+    view = unwrap_norm_weight(weight)
+
+    assert type(weight) is torch.nn.Parameter
+    assert type(view) is torch.Tensor
+    assert unwrap_norm_weight(None) is None
+
+
+def test_flatten_round_trips_every_rank():
+    from unsloth_zoo.temporary_patches.common import flatten_for_elementwise_norm
+
+    for shape in ((2, 7, 64), (1, 4, 5, 256), (3, 64), (2, 2, 2, 2, 16)):
+        x = torch.randn(*shape)
+        flat, original = flatten_for_elementwise_norm(x)
+        assert flat.ndim == 2
+        assert flat.shape[-1] == shape[-1]
+        assert tuple(original) == shape
+        assert torch.equal(flat.reshape(original), x)

--- a/tests/test_rmsnorm_recompile_guards.py
+++ b/tests/test_rmsnorm_recompile_guards.py
@@ -287,3 +287,34 @@ def test_the_kernels_fall_back_to_eager_instead_of_aborting():
     assert _gemma4_rms_norm_scaled._unsloth_fallback_state["eager"], (
         "the cache was never actually exhausted, so this asserted nothing"
     )
+
+
+def test_each_kernel_reports_its_own_fallback_state():
+    """Two wrappers sharing a label hide each other in the public diagnostic.
+
+    `eager_fallback_state()` keys by label, so when the scaled kernel latched to
+    eager and the unscaled one had not, the later entry overwrote the earlier and
+    the dict said the active path was still compiled.
+    """
+    from unsloth_zoo.temporary_patches.utils import eager_fallback_state
+    from unsloth_zoo.temporary_patches.gemma4_float32 import (
+        _gemma4_rms_norm_scaled, _gemma4_rms_norm_unscaled,
+    )
+    from unsloth_zoo.temporary_patches.gemma import (
+        _gemma3_rms_norm_float32, _gemma3_rms_norm_generic,
+    )
+
+    labels = [k._unsloth_fallback_label for k in
+              (_gemma4_rms_norm_scaled, _gemma4_rms_norm_unscaled,
+               _gemma3_rms_norm_float32, _gemma3_rms_norm_generic)]
+    assert len(set(labels)) == len(labels), f"labels collide: {labels}"
+
+    # One latched, its neighbour not: the dict must show the latched one.
+    saved = dict(_gemma4_rms_norm_scaled._unsloth_fallback_state)
+    _gemma4_rms_norm_scaled._unsloth_fallback_state["eager"] = True
+    try:
+        state = eager_fallback_state()
+        assert state[_gemma4_rms_norm_scaled._unsloth_fallback_label] is True
+        assert state[_gemma4_rms_norm_unscaled._unsloth_fallback_label] is False
+    finally:
+        _gemma4_rms_norm_scaled._unsloth_fallback_state.update(saved)

--- a/tests/test_rmsnorm_recompile_guards.py
+++ b/tests/test_rmsnorm_recompile_guards.py
@@ -15,10 +15,44 @@ import pytest
 import torch
 
 
+# Dynamo renamed its cache-limit knobs and its exception in torch 2.7. Everything
+# from 2.6 down carries the cache_size_limit spelling, and `config.patch` raises on
+# a key the installed torch does not define, so select by what is actually there.
+# Same approach as tests/test_recompile_limit_fallback.py.
+_HAS_NEW_NAMES = hasattr(torch._dynamo.config, "recompile_limit")
+_LIMIT_KEY = "recompile_limit" if _HAS_NEW_NAMES else "cache_size_limit"
+_FAIL_KEY = ("fail_on_recompile_limit_hit" if _HAS_NEW_NAMES
+             else "fail_on_cache_limit_hit")
+_LIMIT_ERROR = next(
+    (e for e in (getattr(torch._dynamo.exc, n, None)
+                 for n in ("FailOnRecompileLimitHit", "RecompileLimitExceeded",
+                           "CacheLimitExceeded"))
+     if isinstance(e, type) and issubclass(e, BaseException)),
+    None,
+)
+
+
+def _limit_patch(limit):
+    """`config.patch` kwargs for a hard failure at `limit` recompiles."""
+    return {
+        _LIMIT_KEY: limit,
+        _FAIL_KEY: True,
+        # Pinned: unsloth_zoo sets suppress_errors globally and Dynamo asserts it is
+        # never on together with the fail-on-limit flag.
+        "suppress_errors": False,
+    }
+
+
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason = "needs a GPU: these assert on real torch.compile guard behaviour",
 )
+
+if _LIMIT_ERROR is None or not hasattr(torch._dynamo.config, _FAIL_KEY):
+    pytestmark = [
+        pytestmark,
+        pytest.mark.skip(reason = "this torch exposes no hard recompile-limit failure"),
+    ]
 
 # The spread a real model produces: several norm widths, rank 3 residual norms and
 # rank 4 q/k norms, scaled and unscaled, in every dtype. More combinations than the
@@ -142,13 +176,7 @@ def test_the_old_bound_method_exhausts_a_realistic_recompile_budget():
     # the old form's cache grows with the product of the axes, so any fixed budget
     # is eventually spent on a model with hundreds of norms.
     torch._dynamo.reset()
-    with torch._dynamo.config.patch(
-        recompile_limit = 8,
-        fail_on_recompile_limit_hit = True,
-        # Pinned: unsloth_zoo sets suppress_errors globally and Dynamo asserts it is
-        # never on together with fail_on_recompile_limit_hit.
-        suppress_errors = False,
-    ):
+    with torch._dynamo.config.patch(**_limit_patch(8)):
         compiled = {}
 
         def call(hidden_states, weight, with_scale, hidden, dtype):
@@ -160,19 +188,13 @@ def test_the_old_bound_method_exhausts_a_realistic_recompile_budget():
                 compiled[key] = torch.compile(module, fullgraph = True)
             compiled[key](hidden_states)
 
-        with pytest.raises(torch._dynamo.exc.FailOnRecompileLimitHit):
+        with pytest.raises(_LIMIT_ERROR):
             _run_every_case(call)
 
 
 def test_the_kernels_survive_the_same_budget():
     torch._dynamo.reset()
-    with torch._dynamo.config.patch(
-        recompile_limit = 8,
-        fail_on_recompile_limit_hit = True,
-        # Pinned: unsloth_zoo sets suppress_errors globally and Dynamo asserts it is
-        # never on together with fail_on_recompile_limit_hit.
-        suppress_errors = False,
-    ):
+    with torch._dynamo.config.patch(**_limit_patch(8)):
         _run_every_case(
             lambda hidden_states, weight, with_scale, hidden, dtype:
                 _new(hidden_states, weight, 1e-6, with_scale)
@@ -203,3 +225,51 @@ def test_flatten_round_trips_every_rank():
         assert flat.shape[-1] == shape[-1]
         assert tuple(original) == shape
         assert torch.equal(flat.reshape(original), x)
+
+
+def test_the_kernels_fall_back_to_eager_instead_of_aborting():
+    """Cache exhaustion must latch to eager, not kill the run.
+
+    `patch_function` wraps anything it compiles with `fullgraph = True` in
+    `_fall_back_to_eager_on_recompile_limit`. Compiling these kernels with a bare
+    decorator skipped that, so the exact failure this file is about, exhausting the
+    cache under fullgraph, became a hard abort instead of a slow-but-correct run.
+    """
+    from unsloth_zoo.temporary_patches.gemma4_float32 import (
+        _gemma4_rms_norm_scaled, _gemma4_rms_norm_unscaled,
+    )
+    from unsloth_zoo.temporary_patches.gemma import (
+        _gemma3_rms_norm_float32, _gemma3_rms_norm_generic,
+    )
+    from unsloth_zoo.temporary_patches.qwen3_moe_float32 import _qwen3_moe_rms_norm
+
+    kernels = (_gemma4_rms_norm_scaled, _gemma4_rms_norm_unscaled,
+               _gemma3_rms_norm_float32, _gemma3_rms_norm_generic,
+               _qwen3_moe_rms_norm)
+    for kernel in kernels:
+        # The wrapper's own marker. `get_compiler_config` is not a usable signal:
+        # the wrapper deliberately re-exposes it so callers cannot tell the two apart.
+        assert hasattr(kernel, "_unsloth_fallback_state"), (
+            f"{kernel.__name__} is a bare compiled function, so cache exhaustion "
+            f"under fullgraph raises instead of falling back to eager"
+        )
+
+    # And it really does run. Note what is NOT set here: `fail_on_recompile_limit_hit`
+    # is the user explicitly asking for a hard stop, and the wrapper re-raises for it
+    # on purpose. Real runs never set it (unsloth_zoo leaves it commented out), so the
+    # limit alone plus `fullgraph = True` is the configuration that matters.
+    # Widths do not exhaust anything under `dynamic = True`; dtype and grad mode do.
+    torch._dynamo.reset()
+    with torch._dynamo.config.patch(**{_LIMIT_KEY: 1, "suppress_errors": False}):
+        for dtype in DTYPES:
+            for grad in (True, False):
+                with torch.set_grad_enabled(grad):
+                    x = torch.randn(4, 128, device = "cuda", dtype = dtype)
+                    w = torch.randn(128, device = "cuda", dtype = dtype)
+                    out = _gemma4_rms_norm_scaled(x, w, 1e-6)
+                    assert out.shape == x.shape
+                    assert torch.isfinite(out).all()
+
+    assert _gemma4_rms_norm_scaled._unsloth_fallback_state["eager"], (
+        "the cache was never actually exhausted, so this asserted nothing"
+    )

--- a/tests/test_rmsnorm_recompile_guards.py
+++ b/tests/test_rmsnorm_recompile_guards.py
@@ -15,24 +15,21 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """One compiled RMSNorm code object is shared by every norm instance in a model.
 
-gemma-4-E2B has 504 of them, so that frame's Dynamo cache holds the *product* of
-every axis its guards see (parameter width, input rank, `self.with_scale`, dtype,
-grad mode, requires_grad), which hit the recompile_limit on a T4 and raised
-`FailOnRecompileLimitHit`, taking activation checkpointing down with it.
-
-Compiling a pure tensor kernel instead of a bound method leaves `self` in eager,
-dropping the width, rank and with_scale axes. These tests pin that: no output bit
-changes, and a realistic spread of call shapes never trips the limit.
+gemma-4-E2B has 504 of them, so that frame's Dynamo cache holds the *product* of every
+axis its guards see (width, rank, `self.with_scale`, dtype, grad mode, requires_grad),
+which hit the recompile_limit on a T4 and raised `FailOnRecompileLimitHit`, taking
+activation checkpointing with it. Compiling a pure tensor kernel instead of a bound
+method leaves `self` in eager, dropping the width, rank and with_scale axes. These
+tests pin that: no output bit changes, and a realistic spread of shapes stays in budget.
 """
 
 import pytest
 import torch
 
 
-# Dynamo renamed its cache-limit knobs and its exception in torch 2.7. Everything
-# from 2.6 down carries the cache_size_limit spelling, and `config.patch` raises on
-# a key the installed torch does not define, so select by what is actually there.
-# Same approach as tests/test_recompile_limit_fallback.py.
+# Dynamo renamed its cache-limit knobs and its exception in torch 2.7, and
+# `config.patch` raises on a key this torch does not define, so select by what is
+# there. Same approach as tests/test_recompile_limit_fallback.py.
 _HAS_NEW_NAMES = hasattr(torch._dynamo.config, "recompile_limit")
 _LIMIT_KEY = "recompile_limit" if _HAS_NEW_NAMES else "cache_size_limit"
 _FAIL_KEY = ("fail_on_recompile_limit_hit" if _HAS_NEW_NAMES
@@ -51,8 +48,8 @@ def _limit_patch(limit):
     return {
         _LIMIT_KEY: limit,
         _FAIL_KEY: True,
-        # Pinned: unsloth_zoo sets suppress_errors globally and Dynamo asserts it is
-        # never on together with the fail-on-limit flag.
+        # unsloth_zoo sets this globally, and Dynamo asserts it is never on together
+        # with the fail-on-limit flag.
         "suppress_errors": False,
     }
 
@@ -68,9 +65,8 @@ if _LIMIT_ERROR is None or not hasattr(torch._dynamo.config, _FAIL_KEY):
         pytest.mark.skip(reason = "this torch exposes no hard recompile-limit failure"),
     ]
 
-# The spread a real model produces: several norm widths, rank 3 residual norms and
-# rank 4 q/k norms, scaled and unscaled, in every dtype. More combinations than the
-# recompile limit used below.
+# The spread a real model produces: several widths, rank 3 residual and rank 4 q/k
+# norms, scaled and unscaled, every dtype. More combinations than the limit below.
 CASES = [
     ((2, 7, 64),      64,   True),
     ((2, 7, 768),     768,  True),
@@ -129,8 +125,8 @@ def _new(hidden_states, weight, eps, with_scale):
 def _new_eager(hidden_states, weight, eps, with_scale):
     """The refactor's data flow without torch.compile.
 
-    Inductor's float reassociation makes compiled output differ from eager, so
-    comparing eager-old to compiled-new would measure the compiler, not this change.
+    Inductor reassociates floats, so comparing eager-old to compiled-new would
+    measure the compiler, not this change.
     """
     from unsloth_zoo.temporary_patches.common import (
         flatten_for_elementwise_norm,
@@ -157,8 +153,7 @@ def test_the_refactor_changes_no_output_bit(dtype, shape, hidden, with_scale):
 
 @pytest.mark.parametrize("with_scale", (True, False))
 def test_gradients_still_reach_the_parameter_through_the_view(with_scale):
-    # If unwrap_norm_weight's view detached, training would silently stop updating
-    # every norm in the model.
+    # A detaching view here would silently stop updating every norm in the model.
     torch.manual_seed(0)
     old_x = torch.randn(2, 7, 768, device = "cuda", dtype = torch.float16, requires_grad = True)
     new_x = old_x.detach().clone().requires_grad_(True)
@@ -187,8 +182,8 @@ def _run_every_case(fn):
 
 def test_the_old_bound_method_exhausts_a_realistic_recompile_budget():
     # The regression this fix exists for. The low limit stands in for the real one:
-    # the old form's cache grows with the product of the axes, so any fixed budget
-    # is eventually spent on a model with hundreds of norms.
+    # the old form's cache grows with the product of the axes, so any fixed budget is
+    # eventually spent on a model with hundreds of norms.
     torch._dynamo.reset()
     with torch._dynamo.config.patch(**_limit_patch(8)):
         compiled = {}
@@ -217,8 +212,8 @@ def test_the_kernels_survive_the_same_budget():
 
 def test_a_parameter_view_is_not_itself_a_parameter():
     # Why the width guard goes away: Dynamo forces a static shape when
-    # `type(t) is torch.nn.Parameter`, even under `dynamic=True`. A view is a
-    # plain Tensor, so it takes dynamic shapes.
+    # `type(t) is torch.nn.Parameter`, even under `dynamic=True`. A view is a plain
+    # Tensor, so it takes dynamic shapes.
     from unsloth_zoo.temporary_patches.common import unwrap_norm_weight
 
     weight = torch.nn.Parameter(torch.randn(64))
@@ -244,10 +239,9 @@ def test_flatten_round_trips_every_rank():
 def test_the_kernels_fall_back_to_eager_instead_of_aborting():
     """Cache exhaustion must latch to eager, not kill the run.
 
-    `patch_function` wraps anything it compiles with `fullgraph = True` in
-    `_fall_back_to_eager_on_recompile_limit`. Compiling these kernels with a bare
-    decorator skipped that, so the exact failure this file is about, exhausting the
-    cache under fullgraph, became a hard abort instead of a slow-but-correct run.
+    `patch_function` wraps whatever it compiles with `fullgraph = True` in
+    `_fall_back_to_eager_on_recompile_limit`; a bare decorator skips it, turning the
+    exact failure this file is about into a hard abort.
     """
     from unsloth_zoo.temporary_patches.gemma4_float32 import (
         _gemma4_rms_norm_scaled, _gemma4_rms_norm_unscaled,
@@ -261,21 +255,19 @@ def test_the_kernels_fall_back_to_eager_instead_of_aborting():
                _gemma3_rms_norm_float32, _gemma3_rms_norm_generic,
                _qwen3_moe_rms_norm)
     for kernel in kernels:
-        # The wrapper's own marker. `get_compiler_config` is not a usable signal:
-        # the wrapper deliberately re-exposes it so callers cannot tell the two apart.
+        # The wrapper's own marker. `get_compiler_config` is no signal: the wrapper
+        # re-exposes it on purpose, so callers cannot tell the two apart.
         assert hasattr(kernel, "_unsloth_fallback_state"), (
             f"{kernel.__name__} is a bare compiled function, so cache exhaustion "
             f"under fullgraph raises instead of falling back to eager"
         )
 
-    # And it really does run. Note what is NOT set here: `fail_on_recompile_limit_hit`
-    # is the user explicitly asking for a hard stop, and the wrapper re-raises for it
-    # on purpose. Real runs never set it (unsloth_zoo leaves it commented out), so the
-    # limit alone plus `fullgraph = True` is the configuration that matters.
-    # Widths do not exhaust anything under `dynamic = True`; dtype and grad mode do.
-    # The latch is module-level and permanent, and torch._dynamo.reset() does not
-    # touch it, so leaving it set would silently hand every later test in this
-    # worker the eager kernel and let compile assertions pass without compiling.
+    # And it really does run. `fail_on_recompile_limit_hit` is deliberately NOT set:
+    # that flag is the user asking for a hard stop and the wrapper re-raises for it,
+    # while real runs leave it off, so limit plus `fullgraph = True` is the case that
+    # matters. Widths cost nothing under `dynamic = True`; dtype and grad mode do.
+    # The latch is module-level, permanent and untouched by reset(), so restore it or
+    # every later test in this worker silently gets the eager kernel.
     saved = {k: dict(k._unsloth_fallback_state) for k in kernels}
     try:
         torch._dynamo.reset()
@@ -302,9 +294,8 @@ def test_the_kernels_fall_back_to_eager_instead_of_aborting():
 def test_each_kernel_reports_its_own_fallback_state():
     """Two wrappers sharing a label hide each other in the public diagnostic.
 
-    `eager_fallback_state()` keys by label, so when the scaled kernel latched to
-    eager and the unscaled one had not, the later entry overwrote the earlier and
-    the dict said the active path was still compiled.
+    `eager_fallback_state()` keys by label, so a later non-latched entry could
+    overwrite a latched one and report the path as still compiled.
     """
     from unsloth_zoo.temporary_patches.utils import eager_fallback_state
     from unsloth_zoo.temporary_patches.gemma4_float32 import (

--- a/tests/test_rmsnorm_recompile_guards.py
+++ b/tests/test_rmsnorm_recompile_guards.py
@@ -273,20 +273,30 @@ def test_the_kernels_fall_back_to_eager_instead_of_aborting():
     # on purpose. Real runs never set it (unsloth_zoo leaves it commented out), so the
     # limit alone plus `fullgraph = True` is the configuration that matters.
     # Widths do not exhaust anything under `dynamic = True`; dtype and grad mode do.
-    torch._dynamo.reset()
-    with torch._dynamo.config.patch(**{_LIMIT_KEY: 1, "suppress_errors": False}):
-        for dtype in DTYPES:
-            for grad in (True, False):
-                with torch.set_grad_enabled(grad):
-                    x = torch.randn(4, 128, device = "cuda", dtype = dtype)
-                    w = torch.randn(128, device = "cuda", dtype = dtype)
-                    out = _gemma4_rms_norm_scaled(x, w, 1e-6)
-                    assert out.shape == x.shape
-                    assert torch.isfinite(out).all()
+    # The latch is module-level and permanent, and torch._dynamo.reset() does not
+    # touch it, so leaving it set would silently hand every later test in this
+    # worker the eager kernel and let compile assertions pass without compiling.
+    saved = {k: dict(k._unsloth_fallback_state) for k in kernels}
+    try:
+        torch._dynamo.reset()
+        with torch._dynamo.config.patch(**{_LIMIT_KEY: 1, "suppress_errors": False}):
+            for dtype in DTYPES:
+                for grad in (True, False):
+                    with torch.set_grad_enabled(grad):
+                        x = torch.randn(4, 128, device = "cuda", dtype = dtype)
+                        w = torch.randn(128, device = "cuda", dtype = dtype)
+                        out = _gemma4_rms_norm_scaled(x, w, 1e-6)
+                        assert out.shape == x.shape
+                        assert torch.isfinite(out).all()
 
-    assert _gemma4_rms_norm_scaled._unsloth_fallback_state["eager"], (
-        "the cache was never actually exhausted, so this asserted nothing"
-    )
+        assert _gemma4_rms_norm_scaled._unsloth_fallback_state["eager"], (
+            "the cache was never actually exhausted, so this asserted nothing"
+        )
+    finally:
+        for kernel, state in saved.items():
+            kernel._unsloth_fallback_state.clear()
+            kernel._unsloth_fallback_state.update(state)
+        torch._dynamo.reset()
 
 
 def test_each_kernel_reports_its_own_fallback_state():

--- a/tests/test_rmsnorm_recompile_guards.py
+++ b/tests/test_rmsnorm_recompile_guards.py
@@ -1,16 +1,14 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 """One compiled RMSNorm code object is shared by every norm instance in a model.
 
-gemma-4-E2B has 504 of them, so that single frame's Dynamo cache holds the
-*product* of every axis its guards can see: parameter width, input rank,
-`self.with_scale`, dtype, grad mode and requires_grad. That reached
-`patch_torch_compile`'s recompile_limit on a T4 and raised
-`FailOnRecompileLimitHit`, which then took activation checkpointing down with it.
+gemma-4-E2B has 504 of them, so that frame's Dynamo cache holds the *product* of
+every axis its guards see (parameter width, input rank, `self.with_scale`, dtype,
+grad mode, requires_grad), which hit the recompile_limit on a T4 and raised
+`FailOnRecompileLimitHit`, taking activation checkpointing down with it.
 
 Compiling a pure tensor kernel instead of a bound method leaves `self` in eager,
-which removes the parameter-width, rank and with_scale axes. These tests pin
-that: the refactor must not change a single output bit, and it must keep the
-cache small enough that a realistic spread of call shapes never trips the limit.
+dropping the width, rank and with_scale axes. These tests pin that: no output bit
+changes, and a realistic spread of call shapes never trips the limit.
 """
 
 import pytest
@@ -22,9 +20,9 @@ pytestmark = pytest.mark.skipif(
     reason = "needs a GPU: these assert on real torch.compile guard behaviour",
 )
 
-# The spread one model actually produces: several norm widths, rank 3 residual
-# norms and rank 4 q/k norms, scaled and unscaled, in each dtype the fp32 patch
-# can see. Deliberately more combinations than the limit below.
+# The spread a real model produces: several norm widths, rank 3 residual norms and
+# rank 4 q/k norms, scaled and unscaled, in every dtype. More combinations than the
+# recompile limit used below.
 CASES = [
     ((2, 7, 64),      64,   True),
     ((2, 7, 768),     768,  True),
@@ -38,7 +36,7 @@ _FP16_MAX = float(torch.finfo(torch.float16).max)
 
 
 def _old_body(hidden_states, weight, eps, with_scale):
-    """The pre-fix maths, verbatim, so equivalence is checked against the real thing."""
+    """The pre-fix maths, verbatim."""
     x_fp32 = hidden_states.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
     normed = x_fp32 * torch.pow(variance + eps, -0.5)
@@ -48,7 +46,7 @@ def _old_body(hidden_states, weight, eps, with_scale):
 
 
 class _OldNorm(torch.nn.Module):
-    """A bound method reading `self.weight` / `self.with_scale`, i.e. the old shape."""
+    """A bound method reading `self.weight` / `self.with_scale`, i.e. the old form."""
 
     def __init__(self, hidden, with_scale, dtype):
         super().__init__()
@@ -83,10 +81,8 @@ def _new(hidden_states, weight, eps, with_scale):
 def _new_eager(hidden_states, weight, eps, with_scale):
     """The refactor's data flow without torch.compile.
 
-    Compiled output legitimately differs from eager by Inductor's float
-    reassociation, and the old code was compiled too, so comparing eager-old to
-    compiled-new would measure the compiler rather than this change. Running the
-    same reshape/unwrap path eagerly isolates the refactor itself.
+    Inductor's float reassociation makes compiled output differ from eager, so
+    comparing eager-old to compiled-new would measure the compiler, not this change.
     """
     from unsloth_zoo.temporary_patches.common import (
         flatten_for_elementwise_norm,
@@ -113,8 +109,8 @@ def test_the_refactor_changes_no_output_bit(dtype, shape, hidden, with_scale):
 
 @pytest.mark.parametrize("with_scale", (True, False))
 def test_gradients_still_reach_the_parameter_through_the_view(with_scale):
-    # unwrap_norm_weight hands the kernel a *view* of the Parameter. If that view
-    # detached, training would silently stop updating every norm in the model.
+    # If unwrap_norm_weight's view detached, training would silently stop updating
+    # every norm in the model.
     torch.manual_seed(0)
     old_x = torch.randn(2, 7, 768, device = "cuda", dtype = torch.float16, requires_grad = True)
     new_x = old_x.detach().clone().requires_grad_(True)
@@ -142,15 +138,15 @@ def _run_every_case(fn):
 
 
 def test_the_old_bound_method_exhausts_a_realistic_recompile_budget():
-    # The regression this fix exists for. A low limit stands in for the real one:
-    # the point is that the old form's cache grows with the product of the axes,
-    # so on a model with hundreds of norms any fixed budget is eventually spent.
+    # The regression this fix exists for. The low limit stands in for the real one:
+    # the old form's cache grows with the product of the axes, so any fixed budget
+    # is eventually spent on a model with hundreds of norms.
     torch._dynamo.reset()
     with torch._dynamo.config.patch(
         recompile_limit = 8,
         fail_on_recompile_limit_hit = True,
-        # unsloth_zoo sets suppress_errors globally, and Dynamo asserts the two
-        # are never both on, so pin it rather than inherit it.
+        # Pinned: unsloth_zoo sets suppress_errors globally and Dynamo asserts it is
+        # never on together with fail_on_recompile_limit_hit.
         suppress_errors = False,
     ):
         compiled = {}
@@ -173,8 +169,8 @@ def test_the_kernels_survive_the_same_budget():
     with torch._dynamo.config.patch(
         recompile_limit = 8,
         fail_on_recompile_limit_hit = True,
-        # unsloth_zoo sets suppress_errors globally, and Dynamo asserts the two
-        # are never both on, so pin it rather than inherit it.
+        # Pinned: unsloth_zoo sets suppress_errors globally and Dynamo asserts it is
+        # never on together with fail_on_recompile_limit_hit.
         suppress_errors = False,
     ):
         _run_every_case(
@@ -184,9 +180,9 @@ def test_the_kernels_survive_the_same_budget():
 
 
 def test_a_parameter_view_is_not_itself_a_parameter():
-    # This is the whole reason the width guard goes away: Dynamo's is_static_input
-    # forces a static shape when `type(t) is torch.nn.Parameter`, and `dynamic=True`
-    # does not override it. A view is a plain Tensor, so it takes dynamic shapes.
+    # Why the width guard goes away: Dynamo forces a static shape when
+    # `type(t) is torch.nn.Parameter`, even under `dynamic=True`. A view is a
+    # plain Tensor, so it takes dynamic shapes.
     from unsloth_zoo.temporary_patches.common import unwrap_norm_weight
 
     weight = torch.nn.Parameter(torch.randn(64))

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -192,11 +192,10 @@ else:
     )
 
 def flatten_for_elementwise_norm(hidden_states):
-    """``(..., H)`` -> ``((N, H), original_shape)`` for a compiled norm kernel.
+    """``(..., H)`` -> ``((N, H), original_shape)``.
 
-    Norms only touch the last dim, so making every caller rank 2 drops the rank
-    and leading-dim guards from the shared kernel's Dynamo cache (Gemma calls the
-    same norm with ``(B, S, H)`` residuals and ``(B, heads, S, D)`` q/k norms).
+    Norms only touch the last dim, so making every caller rank 2 drops the rank and
+    leading-dim guards from the shared kernel's Dynamo cache.
     """
     shape = hidden_states.shape
     return hidden_states.reshape(-1, shape[-1]), shape
@@ -206,11 +205,9 @@ pass
 def unwrap_norm_weight(weight):
     """Hand a norm weight to a compiled kernel as a plain Tensor view.
 
-    Dynamo pins a static shape for anything whose ``type`` is ``nn.Parameter``,
-    even under ``dynamic = True``, so reading ``self.weight`` inside a compiled
-    norm makes every distinct norm width another cache entry. A view is a plain
-    Tensor, so it gets dynamic shapes while autograd still reaches the Parameter,
-    without relaxing parameter shapes globally.
+    Dynamo pins a static shape for anything whose ``type`` is ``nn.Parameter`` even
+    under ``dynamic = True``, so every distinct norm width would be another cache
+    entry. A view takes dynamic shapes, and autograd still reaches the Parameter.
     """
     if weight is None: return None
     return weight.reshape(-1)
@@ -221,17 +218,16 @@ def publish_to_modeling_module(modeling_module, **names):
 
     ``create_standalone_class`` copies the patched forward's source into
     ``unsloth_compiled_cache`` and resolves its free names against the modeling
-    module, so helpers living in unsloth_zoo must be published here or the
-    generated module raises NameError on import.
+    module, so unsloth_zoo helpers must be published here or the generated module
+    raises NameError on import.
     """
     for name, value in names.items():
         try:
             setattr(modeling_module, name, value)
         except Exception as e:
             # Log, never swallow: silence reappears as an unexplained NameError from
-            # generated cache code. `warning`, not `warning_once`: the latter is
-            # monkeypatched on by transformers and may not exist yet, and an
-            # AttributeError here would hide the original failure.
+            # generated cache code. `warning`, not `warning_once`, which transformers
+            # monkeypatches on later and may not exist yet.
             logger.warning(
                 f"Unsloth: could not publish `{name}` to "
                 f"{getattr(modeling_module, '__name__', modeling_module)}: {e}"

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -25,6 +25,9 @@ __all__ = [
     "logger",
     "torch_compile",
     "_torch_compile",
+    "flatten_for_elementwise_norm",
+    "unwrap_norm_weight",
+    "publish_to_modeling_module",
 ]
 
 import os
@@ -187,6 +190,77 @@ else:
     _torch_compile = functools.partial(
         torch.compile,
     )
+
+def flatten_for_elementwise_norm(hidden_states):
+    """``(..., H)`` -> ``((N, H), original_shape)`` for a compiled norm kernel.
+
+    One compiled RMSNorm/LayerNorm kernel is shared by every norm instance in a
+    model, so its Dynamo cache holds the product of every axis its guards see.
+    Rank is one of those axes: Gemma calls the same norm with ``(B, S, H)``
+    residuals and with ``(B, heads, S, D)`` q/k norms, and the guard reads
+
+        tensor 'hidden_states' rank mismatch. expected 4, actual 3
+
+    Normalisation only ever touches the last dimension, so flattening the
+    leading dimensions makes every caller rank 2 and collapses that axis, along
+    with the per-dimension size guards on the leading dims. The reshape is a
+    view for contiguous inputs and is folded away when the kernel is inlined
+    into a larger compiled region.
+    """
+    shape = hidden_states.shape
+    return hidden_states.reshape(-1, shape[-1]), shape
+pass
+
+
+def unwrap_norm_weight(weight):
+    """Hand a norm weight to a compiled kernel as a plain Tensor view.
+
+    ``torch._dynamo.utils.is_static_input`` forces a static shape whenever
+    ``type(tensor) is torch.nn.Parameter`` or the tensor comes from an
+    unspecialized-parameter source, regardless of ``dynamic = True``. Reading
+    ``self.weight`` inside a compiled norm therefore pins the hidden size, and
+    every distinct norm width in the model becomes another cache entry:
+
+        tensor 'self._parameters['weight']' size mismatch at index 0.
+        expected 64, actual 768. Guard failed on a parameter, consider using
+        torch._dynamo.config.force_parameter_static_shapes = False
+
+    A view of a Parameter is a plain Tensor, so it takes the normal dynamic
+    shape treatment while autograd still reaches the Parameter. This is local
+    to the norm kernels; it does not relax parameter shapes globally, which
+    would make Inductor give up its static GEMM specialisations everywhere.
+    """
+    if weight is None: return None
+    return weight.reshape(-1)
+pass
+
+def publish_to_modeling_module(modeling_module, **names):
+    """Make helper names referenced by a patched forward importable from the
+    model's modeling module.
+
+    ``unsloth_zoo.compiler.create_standalone_class`` copies the *source* of
+    whatever ``Cls.forward`` currently is into ``unsloth_compiled_cache`` and
+    resolves that source's free names against ``dir(modeling_file)``, emitting
+    ``from <modeling_file> import (...)``. A patched forward that calls a helper
+    living in unsloth_zoo therefore has to publish it here, or the generated
+    cache module raises NameError on import.
+    """
+    for name, value in names.items():
+        try:
+            setattr(modeling_module, name, value)
+        except Exception as e:
+            # Say so. Swallowing this silently produces the exact failure this
+            # helper exists to prevent, a NameError raised from generated code in
+            # unsloth_compiled_cache, with nothing pointing back to here.
+            # `warning`, not `warning_once`: the latter is monkeypatched onto
+            # logging.Logger by transformers, so it is not guaranteed to exist
+            # yet here, and an AttributeError inside this handler would hide the
+            # original failure. This path is rare and bounded by the name count.
+            logger.warning(
+                f"Unsloth: could not publish `{name}` to "
+                f"{getattr(modeling_module, '__name__', modeling_module)}: {e}"
+            )
+pass
 
 global TEMPORARY_PATCHES
 TEMPORARY_PATCHES = []

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -194,18 +194,9 @@ else:
 def flatten_for_elementwise_norm(hidden_states):
     """``(..., H)`` -> ``((N, H), original_shape)`` for a compiled norm kernel.
 
-    One compiled RMSNorm/LayerNorm kernel is shared by every norm instance in a
-    model, so its Dynamo cache holds the product of every axis its guards see.
-    Rank is one of those axes: Gemma calls the same norm with ``(B, S, H)``
-    residuals and with ``(B, heads, S, D)`` q/k norms, and the guard reads
-
-        tensor 'hidden_states' rank mismatch. expected 4, actual 3
-
-    Normalisation only ever touches the last dimension, so flattening the
-    leading dimensions makes every caller rank 2 and collapses that axis, along
-    with the per-dimension size guards on the leading dims. The reshape is a
-    view for contiguous inputs and is folded away when the kernel is inlined
-    into a larger compiled region.
+    Norms only touch the last dim, so making every caller rank 2 drops the rank
+    and leading-dim guards from the shared kernel's Dynamo cache (Gemma calls the
+    same norm with ``(B, S, H)`` residuals and ``(B, heads, S, D)`` q/k norms).
     """
     shape = hidden_states.shape
     return hidden_states.reshape(-1, shape[-1]), shape
@@ -215,47 +206,32 @@ pass
 def unwrap_norm_weight(weight):
     """Hand a norm weight to a compiled kernel as a plain Tensor view.
 
-    ``torch._dynamo.utils.is_static_input`` forces a static shape whenever
-    ``type(tensor) is torch.nn.Parameter`` or the tensor comes from an
-    unspecialized-parameter source, regardless of ``dynamic = True``. Reading
-    ``self.weight`` inside a compiled norm therefore pins the hidden size, and
-    every distinct norm width in the model becomes another cache entry:
-
-        tensor 'self._parameters['weight']' size mismatch at index 0.
-        expected 64, actual 768. Guard failed on a parameter, consider using
-        torch._dynamo.config.force_parameter_static_shapes = False
-
-    A view of a Parameter is a plain Tensor, so it takes the normal dynamic
-    shape treatment while autograd still reaches the Parameter. This is local
-    to the norm kernels; it does not relax parameter shapes globally, which
-    would make Inductor give up its static GEMM specialisations everywhere.
+    Dynamo pins a static shape for anything whose ``type`` is ``nn.Parameter``,
+    even under ``dynamic = True``, so reading ``self.weight`` inside a compiled
+    norm makes every distinct norm width another cache entry. A view is a plain
+    Tensor, so it gets dynamic shapes while autograd still reaches the Parameter,
+    without relaxing parameter shapes globally.
     """
     if weight is None: return None
     return weight.reshape(-1)
 pass
 
 def publish_to_modeling_module(modeling_module, **names):
-    """Make helper names referenced by a patched forward importable from the
-    model's modeling module.
+    """Make helper names used by a patched forward importable from the modeling module.
 
-    ``unsloth_zoo.compiler.create_standalone_class`` copies the *source* of
-    whatever ``Cls.forward`` currently is into ``unsloth_compiled_cache`` and
-    resolves that source's free names against ``dir(modeling_file)``, emitting
-    ``from <modeling_file> import (...)``. A patched forward that calls a helper
-    living in unsloth_zoo therefore has to publish it here, or the generated
-    cache module raises NameError on import.
+    ``create_standalone_class`` copies the patched forward's source into
+    ``unsloth_compiled_cache`` and resolves its free names against the modeling
+    module, so helpers living in unsloth_zoo must be published here or the
+    generated module raises NameError on import.
     """
     for name, value in names.items():
         try:
             setattr(modeling_module, name, value)
         except Exception as e:
-            # Say so. Swallowing this silently produces the exact failure this
-            # helper exists to prevent, a NameError raised from generated code in
-            # unsloth_compiled_cache, with nothing pointing back to here.
-            # `warning`, not `warning_once`: the latter is monkeypatched onto
-            # logging.Logger by transformers, so it is not guaranteed to exist
-            # yet here, and an AttributeError inside this handler would hide the
-            # original failure. This path is rare and bounded by the name count.
+            # Log, never swallow: silence reappears as an unexplained NameError from
+            # generated cache code. `warning`, not `warning_once`: the latter is
+            # monkeypatched on by transformers and may not exist yet, and an
+            # AttributeError here would hide the original failure.
             logger.warning(
                 f"Unsloth: could not publish `{name}` to "
                 f"{getattr(modeling_module, '__name__', modeling_module)}: {e}"

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -422,15 +422,14 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma3TextScaledWordEmbedding)
 
 
-# Module-level floats so `torch.finfo` stays out of the graph.
+# Module-level so `torch.finfo` stays out of the graph.
 _GEMMA3_FP16_MAX = float(torch.finfo(torch.float16).max)
 _GEMMA3_FP16_MIN = float(torch.finfo(torch.float16).min)
 
 
-# Every Gemma3 RMSNorm instance shares this one kernel, so its Dynamo cache holds
-# the product of every axis its guards see. A plain Tensor weight view keeps the
-# norm width dynamic and a rank 2 input collapses the rank axis, leaving only
-# dtype, grad mode and requires_grad.
+# Every Gemma3 RMSNorm shares this one kernel, so its Dynamo cache holds the product
+# of every axis its guards see. A plain Tensor weight view keeps the width dynamic
+# and a rank 2 input drops the rank axis, leaving dtype, grad mode and requires_grad.
 def _gemma3_rms_norm_float32(hidden_states_2d, weight_1d, eps):
     x_fp32 = hidden_states_2d.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
@@ -438,11 +437,11 @@ def _gemma3_rms_norm_float32(hidden_states_2d, weight_1d, eps):
     # weight may be bf16; cast for the (1.0 + weight) op.
     output_fp32 = hidden_states_fp32 * (1.0 + weight_1d.to(torch.float32))
     clamped_output_fp32 = torch.clamp(output_fp32, min = _GEMMA3_FP16_MIN, max = _GEMMA3_FP16_MAX)
-    return clamped_output_fp32.to(torch.float16) # Output fp16
+    return clamped_output_fp32.to(torch.float16)
 pass
 
-# Compiled here, not via a decorator: `fullgraph = True` makes cache exhaustion
-# raise, and only this wrapper latches to eager instead of aborting training.
+# Not a bare decorator: under `fullgraph = True` cache exhaustion raises, and only
+# this wrapper latches to eager instead of aborting the run.
 _gemma3_rms_norm_float32 = compile_with_eager_fallback(_gemma3_rms_norm_float32, "Gemma3RMSNorm.forward (float32)")
 
 
@@ -477,8 +476,8 @@ def patch_Gemma3RMSNorm():
         out = _gemma3_rms_norm_float32(x_2d, unwrap_norm_weight(self.weight), self.eps)
         return out.reshape(shape)
     pass
-    # Not `fullgraph = True`: the kernel is the compiled unit, and compiling this
-    # wrapper too would put `self` back into the guards.
+    # No `fullgraph`: the kernel is the compiled unit; compiling this wrapper too
+    # would put `self` back into the guards.
     patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3RMSNorm, "forward", forward)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma3RMSNorm)

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -26,6 +26,7 @@ from .common import (
     publish_to_modeling_module,
 )
 from .utils import (
+    compile_with_eager_fallback,
     patch_function,
     process_output_options,
     KWARGS_TYPE,
@@ -430,7 +431,6 @@ _GEMMA3_FP16_MIN = float(torch.finfo(torch.float16).min)
 # the product of every axis its guards see. A plain Tensor weight view keeps the
 # norm width dynamic and a rank 2 input collapses the rank axis, leaving only
 # dtype, grad mode and requires_grad.
-@torch_compile(fullgraph = True, dynamic = True)
 def _gemma3_rms_norm_float32(hidden_states_2d, weight_1d, eps):
     x_fp32 = hidden_states_2d.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
@@ -441,8 +441,11 @@ def _gemma3_rms_norm_float32(hidden_states_2d, weight_1d, eps):
     return clamped_output_fp32.to(torch.float16) # Output fp16
 pass
 
+# Compiled here, not via a decorator: `fullgraph = True` makes cache exhaustion
+# raise, and only this wrapper latches to eager instead of aborting training.
+_gemma3_rms_norm_float32 = compile_with_eager_fallback(_gemma3_rms_norm_float32, "Gemma3RMSNorm.forward")
 
-@torch_compile(fullgraph = True, dynamic = True)
+
 def _gemma3_rms_norm_generic(hidden_states_2d, weight_1d, eps):
     x_fp32 = hidden_states_2d.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
@@ -450,6 +453,8 @@ def _gemma3_rms_norm_generic(hidden_states_2d, weight_1d, eps):
     output_fp32 = hidden_states_fp32 * (1.0 + weight_1d.to(torch.float32))
     return output_fp32.to(hidden_states_2d.dtype)
 pass
+
+_gemma3_rms_norm_generic = compile_with_eager_fallback(_gemma3_rms_norm_generic, "Gemma3RMSNorm.forward")
 
 
 def patch_Gemma3RMSNorm():

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -421,22 +421,21 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma3TextScaledWordEmbedding)
 
 
-# Clamp bounds as module-level floats so `torch.finfo` stays out of the graph.
+# Module-level floats so `torch.finfo` stays out of the graph.
 _GEMMA3_FP16_MAX = float(torch.finfo(torch.float16).max)
 _GEMMA3_FP16_MIN = float(torch.finfo(torch.float16).min)
 
 
-# One compiled kernel is shared by every Gemma3 RMSNorm instance (text norms,
-# q/k norms, vision norms), so its Dynamo cache holds the product of every axis
-# its guards see. Taking the weight as a plain Tensor view keeps the norm width
-# dynamic, and taking the input as rank 2 collapses the (B, S, H) vs
-# (B, heads, S, D) rank axis; only dtype, grad mode and requires_grad remain.
+# Every Gemma3 RMSNorm instance shares this one kernel, so its Dynamo cache holds
+# the product of every axis its guards see. A plain Tensor weight view keeps the
+# norm width dynamic and a rank 2 input collapses the rank axis, leaving only
+# dtype, grad mode and requires_grad.
 @torch_compile(fullgraph = True, dynamic = True)
 def _gemma3_rms_norm_float32(hidden_states_2d, weight_1d, eps):
     x_fp32 = hidden_states_2d.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
     hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + eps)
-    # weight may be bf16; cast to fp32 for the (1.0 + weight) op.
+    # weight may be bf16; cast for the (1.0 + weight) op.
     output_fp32 = hidden_states_fp32 * (1.0 + weight_1d.to(torch.float32))
     clamped_output_fp32 = torch.clamp(output_fp32, min = _GEMMA3_FP16_MIN, max = _GEMMA3_FP16_MAX)
     return clamped_output_fp32.to(torch.float16) # Output fp16
@@ -473,8 +472,8 @@ def patch_Gemma3RMSNorm():
         out = _gemma3_rms_norm_float32(x_2d, unwrap_norm_weight(self.weight), self.eps)
         return out.reshape(shape)
     pass
-    # Not `fullgraph = True`: the kernel above is the compiled unit, and
-    # compiling this wrapper as well would put `self` back into the guards.
+    # Not `fullgraph = True`: the kernel is the compiled unit, and compiling this
+    # wrapper too would put `self` back into the guards.
     patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3RMSNorm, "forward", forward)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma3RMSNorm)

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -18,7 +18,13 @@ from typing import Any, List, Optional, Tuple, Union, Dict, Set, Callable
 import torch
 import torch.nn as nn
 import os
-from .common import TEMPORARY_PATCHES, torch_compile
+from .common import (
+    TEMPORARY_PATCHES,
+    torch_compile,
+    flatten_for_elementwise_norm,
+    unwrap_norm_weight,
+    publish_to_modeling_module,
+)
 from .utils import (
     patch_function,
     process_output_options,
@@ -415,6 +421,38 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma3TextScaledWordEmbedding)
 
 
+# Clamp bounds as module-level floats so `torch.finfo` stays out of the graph.
+_GEMMA3_FP16_MAX = float(torch.finfo(torch.float16).max)
+_GEMMA3_FP16_MIN = float(torch.finfo(torch.float16).min)
+
+
+# One compiled kernel is shared by every Gemma3 RMSNorm instance (text norms,
+# q/k norms, vision norms), so its Dynamo cache holds the product of every axis
+# its guards see. Taking the weight as a plain Tensor view keeps the norm width
+# dynamic, and taking the input as rank 2 collapses the (B, S, H) vs
+# (B, heads, S, D) rank axis; only dtype, grad mode and requires_grad remain.
+@torch_compile(fullgraph = True, dynamic = True)
+def _gemma3_rms_norm_float32(hidden_states_2d, weight_1d, eps):
+    x_fp32 = hidden_states_2d.to(torch.float32)
+    variance = x_fp32.pow(2).mean(-1, keepdim = True)
+    hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + eps)
+    # weight may be bf16; cast to fp32 for the (1.0 + weight) op.
+    output_fp32 = hidden_states_fp32 * (1.0 + weight_1d.to(torch.float32))
+    clamped_output_fp32 = torch.clamp(output_fp32, min = _GEMMA3_FP16_MIN, max = _GEMMA3_FP16_MAX)
+    return clamped_output_fp32.to(torch.float16) # Output fp16
+pass
+
+
+@torch_compile(fullgraph = True, dynamic = True)
+def _gemma3_rms_norm_generic(hidden_states_2d, weight_1d, eps):
+    x_fp32 = hidden_states_2d.to(torch.float32)
+    variance = x_fp32.pow(2).mean(-1, keepdim = True)
+    hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + eps)
+    output_fp32 = hidden_states_fp32 * (1.0 + weight_1d.to(torch.float32))
+    return output_fp32.to(hidden_states_2d.dtype)
+pass
+
+
 def patch_Gemma3RMSNorm():
     if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "0": return
     try:
@@ -423,22 +461,21 @@ def patch_Gemma3RMSNorm():
     except Exception as e:
         return raise_error("Gemma3RMSNorm.forward", e)
 
+    publish_to_modeling_module(
+        transformers.models.gemma3.modeling_gemma3,
+        flatten_for_elementwise_norm = flatten_for_elementwise_norm,
+        unwrap_norm_weight           = unwrap_norm_weight,
+        _gemma3_rms_norm_float32     = _gemma3_rms_norm_float32,
+    )
+
     def forward(self, x): # x can be fp32 (from embeddings) or fp16 (from MLP/Attn)
-        x_fp32 = x.to(torch.float32)
-        variance = x_fp32.pow(2).mean(-1, keepdim=True)
-        hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + self.eps)
-
-        # self.weight may be bf16; cast to fp32 for the (1.0 + weight) op.
-        output_fp32 = hidden_states_fp32 * (1.0 + self.weight.to(torch.float32))
-
-        # Clamp to fp16 range before casting back to fp16
-        fp16_max = torch.finfo(torch.float16).max
-        fp16_min = torch.finfo(torch.float16).min
-        clamped_output_fp32 = torch.clamp(output_fp32, min=fp16_min, max=fp16_max)
-
-        return clamped_output_fp32.to(torch.float16) # Output fp16
+        x_2d, shape = flatten_for_elementwise_norm(x)
+        out = _gemma3_rms_norm_float32(x_2d, unwrap_norm_weight(self.weight), self.eps)
+        return out.reshape(shape)
     pass
-    patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3RMSNorm, "forward", forward, fullgraph = True)
+    # Not `fullgraph = True`: the kernel above is the compiled unit, and
+    # compiling this wrapper as well would put `self` back into the guards.
+    patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3RMSNorm, "forward", forward)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma3RMSNorm)
 
@@ -695,14 +732,19 @@ def patch_Gemma3RMSNorm_generic():
     except Exception as e:
         return raise_error("Gemma3RMSNorm.forward", e)
 
+    publish_to_modeling_module(
+        transformers.models.gemma3.modeling_gemma3,
+        flatten_for_elementwise_norm = flatten_for_elementwise_norm,
+        unwrap_norm_weight           = unwrap_norm_weight,
+        _gemma3_rms_norm_generic     = _gemma3_rms_norm_generic,
+    )
+
     def forward(self, x):
-        x_fp32 = x.to(torch.float32)
-        variance = x_fp32.pow(2).mean(-1, keepdim=True)
-        hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + self.eps)
-        output_fp32 = hidden_states_fp32 * (1.0 + self.weight.to(torch.float32))
-        return output_fp32.to(x.dtype)
+        x_2d, shape = flatten_for_elementwise_norm(x)
+        out = _gemma3_rms_norm_generic(x_2d, unwrap_norm_weight(self.weight), self.eps)
+        return out.reshape(shape)
     pass
-    patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3RMSNorm, "forward", forward, fullgraph = True)
+    patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3RMSNorm, "forward", forward)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma3RMSNorm_generic)
 

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -443,7 +443,7 @@ pass
 
 # Compiled here, not via a decorator: `fullgraph = True` makes cache exhaustion
 # raise, and only this wrapper latches to eager instead of aborting training.
-_gemma3_rms_norm_float32 = compile_with_eager_fallback(_gemma3_rms_norm_float32, "Gemma3RMSNorm.forward")
+_gemma3_rms_norm_float32 = compile_with_eager_fallback(_gemma3_rms_norm_float32, "Gemma3RMSNorm.forward (float32)")
 
 
 def _gemma3_rms_norm_generic(hidden_states_2d, weight_1d, eps):
@@ -454,7 +454,7 @@ def _gemma3_rms_norm_generic(hidden_states_2d, weight_1d, eps):
     return output_fp32.to(hidden_states_2d.dtype)
 pass
 
-_gemma3_rms_norm_generic = compile_with_eager_fallback(_gemma3_rms_norm_generic, "Gemma3RMSNorm.forward")
+_gemma3_rms_norm_generic = compile_with_eager_fallback(_gemma3_rms_norm_generic, "Gemma3RMSNorm.forward (generic)")
 
 
 def patch_Gemma3RMSNorm():

--- a/unsloth_zoo/temporary_patches/gemma4_float32.py
+++ b/unsloth_zoo/temporary_patches/gemma4_float32.py
@@ -304,7 +304,7 @@ pass
 
 # Compiled here, not via a decorator: `fullgraph = True` makes cache exhaustion
 # raise, and only this wrapper latches to eager instead of aborting training.
-_gemma4_rms_norm_scaled = compile_with_eager_fallback(_gemma4_rms_norm_scaled, "Gemma4RMSNorm.forward")
+_gemma4_rms_norm_scaled = compile_with_eager_fallback(_gemma4_rms_norm_scaled, "Gemma4RMSNorm.forward (scaled)")
 
 
 def _gemma4_rms_norm_unscaled(hidden_states_2d, eps):
@@ -314,7 +314,7 @@ def _gemma4_rms_norm_unscaled(hidden_states_2d, eps):
     return torch.clamp(normed_fp32, min = -_GEMMA4_FP16_MAX, max = _GEMMA4_FP16_MAX).to(torch.float16)
 pass
 
-_gemma4_rms_norm_unscaled = compile_with_eager_fallback(_gemma4_rms_norm_unscaled, "Gemma4RMSNorm.forward")
+_gemma4_rms_norm_unscaled = compile_with_eager_fallback(_gemma4_rms_norm_unscaled, "Gemma4RMSNorm.forward (unscaled)")
 
 
 def patch_Gemma4RMSNorm():

--- a/unsloth_zoo/temporary_patches/gemma4_float32.py
+++ b/unsloth_zoo/temporary_patches/gemma4_float32.py
@@ -285,17 +285,15 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma4TextScaledWordEmbedding)
 
 
-# Clamp to the fp16 range before casting back so a large residual never becomes
-# inf. A module-level float keeps `torch.finfo` out of the traced graph.
+# Clamp bound so a large residual never becomes inf on the cast back. Module-level
+# float keeps `torch.finfo` out of the traced graph.
 _GEMMA4_FP16_MAX = float(torch.finfo(torch.float16).max)
 
 
-# gemma-4-E2B has 504 RMSNorm instances that all share this one code object, so
-# its Dynamo cache holds the product of every axis its guards can see. Compiling
-# a pure tensor kernel instead of a bound method removes three of those axes:
-# the Python `with_scale` flag (own kernel), the parameter width (passed as a
-# plain Tensor view) and the input rank (flattened to 2D). What is left is the
-# irreducible set: input dtype, grad mode and requires_grad.
+# gemma-4-E2B has 504 RMSNorm instances sharing this one code object, so its Dynamo
+# cache holds the product of every axis its guards see. A pure tensor kernel instead
+# of a bound method drops three: `with_scale` (own kernel), parameter width (plain
+# Tensor view) and input rank (2D). Only dtype, grad mode and requires_grad remain.
 @torch_compile(fullgraph = True, dynamic = True)
 def _gemma4_rms_norm_scaled(hidden_states_2d, weight_1d, eps):
     x_fp32 = hidden_states_2d.to(torch.float32)
@@ -333,7 +331,7 @@ def patch_Gemma4RMSNorm():
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor: # fp32 (residual) or fp16 (sub-layer)
         # Gemma4 scales by `weight` directly (no 1.0 + weight) and only when with_scale.
-        # `self` is read here, in eager, so none of it reaches the kernel's guards.
+        # `self` is read in eager, so none of it reaches the kernel's guards.
         hidden_states_2d, shape = flatten_for_elementwise_norm(hidden_states)
         if self.with_scale:
             normed = _gemma4_rms_norm_scaled(
@@ -343,9 +341,9 @@ def patch_Gemma4RMSNorm():
             normed = _gemma4_rms_norm_unscaled(hidden_states_2d, self.eps)
         return normed.reshape(shape)
     pass
-    # Deliberately not `fullgraph = True`: the two kernels above are the compiled
-    # units now, and compiling this wrapper as well would put `self` back into the
-    # guards. Dynamo inlines both when a caller is itself compiled.
+    # Not `fullgraph = True`: the kernels are the compiled units, and compiling this
+    # wrapper too would put `self` back into the guards. Dynamo inlines them anyway
+    # when a caller is compiled.
     patch_function(transformers.models.gemma4.modeling_gemma4.Gemma4RMSNorm, "forward", forward, match_level = "relaxed")
 pass
 TEMPORARY_PATCHES.append(patch_Gemma4RMSNorm)

--- a/unsloth_zoo/temporary_patches/gemma4_float32.py
+++ b/unsloth_zoo/temporary_patches/gemma4_float32.py
@@ -42,7 +42,14 @@ import inspect
 import linecache
 import sys
 import torch
-from .common import TEMPORARY_PATCHES, logger
+from .common import (
+    TEMPORARY_PATCHES,
+    logger,
+    torch_compile,
+    flatten_for_elementwise_norm,
+    unwrap_norm_weight,
+    publish_to_modeling_module,
+)
 from .utils import patch_function, raise_error
 
 # Mirrors gemma.py: flex dispatch can be turned off globally.
@@ -278,6 +285,36 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma4TextScaledWordEmbedding)
 
 
+# Clamp to the fp16 range before casting back so a large residual never becomes
+# inf. A module-level float keeps `torch.finfo` out of the traced graph.
+_GEMMA4_FP16_MAX = float(torch.finfo(torch.float16).max)
+
+
+# gemma-4-E2B has 504 RMSNorm instances that all share this one code object, so
+# its Dynamo cache holds the product of every axis its guards can see. Compiling
+# a pure tensor kernel instead of a bound method removes three of those axes:
+# the Python `with_scale` flag (own kernel), the parameter width (passed as a
+# plain Tensor view) and the input rank (flattened to 2D). What is left is the
+# irreducible set: input dtype, grad mode and requires_grad.
+@torch_compile(fullgraph = True, dynamic = True)
+def _gemma4_rms_norm_scaled(hidden_states_2d, weight_1d, eps):
+    x_fp32 = hidden_states_2d.to(torch.float32)
+    variance = x_fp32.pow(2).mean(-1, keepdim = True)
+    normed_fp32 = x_fp32 * torch.pow(variance + eps, -0.5)
+    normed_fp32 = normed_fp32 * weight_1d.to(torch.float32)
+    return torch.clamp(normed_fp32, min = -_GEMMA4_FP16_MAX, max = _GEMMA4_FP16_MAX).to(torch.float16)
+pass
+
+
+@torch_compile(fullgraph = True, dynamic = True)
+def _gemma4_rms_norm_unscaled(hidden_states_2d, eps):
+    x_fp32 = hidden_states_2d.to(torch.float32)
+    variance = x_fp32.pow(2).mean(-1, keepdim = True)
+    normed_fp32 = x_fp32 * torch.pow(variance + eps, -0.5)
+    return torch.clamp(normed_fp32, min = -_GEMMA4_FP16_MAX, max = _GEMMA4_FP16_MAX).to(torch.float16)
+pass
+
+
 def patch_Gemma4RMSNorm():
     if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "0": return
     try:
@@ -286,19 +323,30 @@ def patch_Gemma4RMSNorm():
     except Exception as e:
         return raise_error("Gemma4RMSNorm.forward", e)
 
+    publish_to_modeling_module(
+        transformers.models.gemma4.modeling_gemma4,
+        flatten_for_elementwise_norm  = flatten_for_elementwise_norm,
+        unwrap_norm_weight            = unwrap_norm_weight,
+        _gemma4_rms_norm_scaled       = _gemma4_rms_norm_scaled,
+        _gemma4_rms_norm_unscaled     = _gemma4_rms_norm_unscaled,
+    )
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor: # fp32 (residual) or fp16 (sub-layer)
         # Gemma4 scales by `weight` directly (no 1.0 + weight) and only when with_scale.
-        x_fp32 = hidden_states.to(torch.float32)
-        variance = x_fp32.pow(2).mean(-1, keepdim=True)
-        normed_fp32 = x_fp32 * torch.pow(variance + self.eps, -0.5)
+        # `self` is read here, in eager, so none of it reaches the kernel's guards.
+        hidden_states_2d, shape = flatten_for_elementwise_norm(hidden_states)
         if self.with_scale:
-            normed_fp32 = normed_fp32 * self.weight.to(torch.float32)
-
-        # Clamp to fp16 range before casting back so a large residual never becomes inf.
-        fp16_max = torch.finfo(torch.float16).max
-        return torch.clamp(normed_fp32, min = -fp16_max, max = fp16_max).to(torch.float16)
+            normed = _gemma4_rms_norm_scaled(
+                hidden_states_2d, unwrap_norm_weight(self.weight), self.eps,
+            )
+        else:
+            normed = _gemma4_rms_norm_unscaled(hidden_states_2d, self.eps)
+        return normed.reshape(shape)
     pass
-    patch_function(transformers.models.gemma4.modeling_gemma4.Gemma4RMSNorm, "forward", forward, fullgraph = True, match_level = "relaxed")
+    # Deliberately not `fullgraph = True`: the two kernels above are the compiled
+    # units now, and compiling this wrapper as well would put `self` back into the
+    # guards. Dynamo inlines both when a caller is itself compiled.
+    patch_function(transformers.models.gemma4.modeling_gemma4.Gemma4RMSNorm, "forward", forward, match_level = "relaxed")
 pass
 TEMPORARY_PATCHES.append(patch_Gemma4RMSNorm)
 

--- a/unsloth_zoo/temporary_patches/gemma4_float32.py
+++ b/unsloth_zoo/temporary_patches/gemma4_float32.py
@@ -50,7 +50,7 @@ from .common import (
     unwrap_norm_weight,
     publish_to_modeling_module,
 )
-from .utils import patch_function, raise_error
+from .utils import compile_with_eager_fallback, patch_function, raise_error
 
 # Mirrors gemma.py: flex dispatch can be turned off globally.
 _UNSLOTH_FLEX_ATTENTION_DISABLED = os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0"
@@ -294,7 +294,6 @@ _GEMMA4_FP16_MAX = float(torch.finfo(torch.float16).max)
 # cache holds the product of every axis its guards see. A pure tensor kernel instead
 # of a bound method drops three: `with_scale` (own kernel), parameter width (plain
 # Tensor view) and input rank (2D). Only dtype, grad mode and requires_grad remain.
-@torch_compile(fullgraph = True, dynamic = True)
 def _gemma4_rms_norm_scaled(hidden_states_2d, weight_1d, eps):
     x_fp32 = hidden_states_2d.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
@@ -303,14 +302,19 @@ def _gemma4_rms_norm_scaled(hidden_states_2d, weight_1d, eps):
     return torch.clamp(normed_fp32, min = -_GEMMA4_FP16_MAX, max = _GEMMA4_FP16_MAX).to(torch.float16)
 pass
 
+# Compiled here, not via a decorator: `fullgraph = True` makes cache exhaustion
+# raise, and only this wrapper latches to eager instead of aborting training.
+_gemma4_rms_norm_scaled = compile_with_eager_fallback(_gemma4_rms_norm_scaled, "Gemma4RMSNorm.forward")
 
-@torch_compile(fullgraph = True, dynamic = True)
+
 def _gemma4_rms_norm_unscaled(hidden_states_2d, eps):
     x_fp32 = hidden_states_2d.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
     normed_fp32 = x_fp32 * torch.pow(variance + eps, -0.5)
     return torch.clamp(normed_fp32, min = -_GEMMA4_FP16_MAX, max = _GEMMA4_FP16_MAX).to(torch.float16)
 pass
+
+_gemma4_rms_norm_unscaled = compile_with_eager_fallback(_gemma4_rms_norm_unscaled, "Gemma4RMSNorm.forward")
 
 
 def patch_Gemma4RMSNorm():

--- a/unsloth_zoo/temporary_patches/gemma4_float32.py
+++ b/unsloth_zoo/temporary_patches/gemma4_float32.py
@@ -286,14 +286,13 @@ TEMPORARY_PATCHES.append(patch_Gemma4TextScaledWordEmbedding)
 
 
 # Clamp bound so a large residual never becomes inf on the cast back. Module-level
-# float keeps `torch.finfo` out of the traced graph.
+# keeps `torch.finfo` out of the graph.
 _GEMMA4_FP16_MAX = float(torch.finfo(torch.float16).max)
 
 
-# gemma-4-E2B has 504 RMSNorm instances sharing this one code object, so its Dynamo
-# cache holds the product of every axis its guards see. A pure tensor kernel instead
-# of a bound method drops three: `with_scale` (own kernel), parameter width (plain
-# Tensor view) and input rank (2D). Only dtype, grad mode and requires_grad remain.
+# gemma-4-E2B has 504 RMSNorms sharing this one code object, so its Dynamo cache holds
+# the product of every axis its guards see. A pure tensor kernel instead of a bound
+# method drops three: `with_scale` (own kernel), width (Tensor view) and rank (2D).
 def _gemma4_rms_norm_scaled(hidden_states_2d, weight_1d, eps):
     x_fp32 = hidden_states_2d.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
@@ -302,8 +301,8 @@ def _gemma4_rms_norm_scaled(hidden_states_2d, weight_1d, eps):
     return torch.clamp(normed_fp32, min = -_GEMMA4_FP16_MAX, max = _GEMMA4_FP16_MAX).to(torch.float16)
 pass
 
-# Compiled here, not via a decorator: `fullgraph = True` makes cache exhaustion
-# raise, and only this wrapper latches to eager instead of aborting training.
+# Not a bare decorator: under `fullgraph = True` cache exhaustion raises, and only
+# this wrapper latches to eager instead of aborting the run.
 _gemma4_rms_norm_scaled = compile_with_eager_fallback(_gemma4_rms_norm_scaled, "Gemma4RMSNorm.forward (scaled)")
 
 
@@ -334,8 +333,8 @@ def patch_Gemma4RMSNorm():
     )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor: # fp32 (residual) or fp16 (sub-layer)
-        # Gemma4 scales by `weight` directly (no 1.0 + weight) and only when with_scale.
-        # `self` is read in eager, so none of it reaches the kernel's guards.
+        # Gemma4 scales by `weight` directly (no 1.0 + weight) and only when
+        # with_scale. `self` is read in eager, so it never reaches the kernel's guards.
         hidden_states_2d, shape = flatten_for_elementwise_norm(hidden_states)
         if self.with_scale:
             normed = _gemma4_rms_norm_scaled(
@@ -345,9 +344,9 @@ def patch_Gemma4RMSNorm():
             normed = _gemma4_rms_norm_unscaled(hidden_states_2d, self.eps)
         return normed.reshape(shape)
     pass
-    # Not `fullgraph = True`: the kernels are the compiled units, and compiling this
-    # wrapper too would put `self` back into the guards. Dynamo inlines them anyway
-    # when a caller is compiled.
+    # No `fullgraph`: the kernels are the compiled units; compiling this wrapper too
+    # would put `self` back into the guards. Dynamo inlines it anyway when a caller is
+    # compiled.
     patch_function(transformers.models.gemma4.modeling_gemma4.Gemma4RMSNorm, "forward", forward, match_level = "relaxed")
 pass
 TEMPORARY_PATCHES.append(patch_Gemma4RMSNorm)

--- a/unsloth_zoo/temporary_patches/qwen3_moe_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe_float32.py
@@ -106,13 +106,13 @@ TEMPORARY_PATCHES.append(patch_Qwen3MoeDecoderLayer_float32)
 
 
 # Clamp bound so a large residual never becomes inf on the cast back. Module-level
-# float keeps `torch.finfo` out of the traced graph.
+# keeps `torch.finfo` out of the graph.
 _QWEN3_MOE_FP16_MAX = float(torch.finfo(torch.float16).max)
 
 
-# Every Qwen3-MoE RMSNorm instance shares this one kernel, so its Dynamo cache holds
-# the product of every axis its guards see. A plain Tensor weight view and a rank 2
-# input drop the norm-width and rank axes, leaving dtype, grad mode and requires_grad.
+# Every Qwen3-MoE RMSNorm shares this one kernel, so its Dynamo cache holds the product
+# of every axis its guards see. A plain Tensor weight view and a rank 2 input drop the
+# width and rank axes, leaving dtype, grad mode and requires_grad.
 def _qwen3_moe_rms_norm(hidden_states_2d, weight_1d, variance_epsilon):
     x_fp32 = hidden_states_2d.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
@@ -121,8 +121,8 @@ def _qwen3_moe_rms_norm(hidden_states_2d, weight_1d, variance_epsilon):
     return torch.clamp(normed_fp32, min = -_QWEN3_MOE_FP16_MAX, max = _QWEN3_MOE_FP16_MAX).to(torch.float16)
 pass
 
-# Compiled here, not via a decorator: `fullgraph = True` makes cache exhaustion
-# raise, and only this wrapper latches to eager instead of aborting training.
+# Not a bare decorator: under `fullgraph = True` cache exhaustion raises, and only
+# this wrapper latches to eager instead of aborting the run.
 _qwen3_moe_rms_norm = compile_with_eager_fallback(_qwen3_moe_rms_norm, "Qwen3MoeRMSNorm.forward")
 
 
@@ -143,8 +143,7 @@ def patch_Qwen3MoeRMSNorm_float32():
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor: # fp32 (residual) or fp16 (sub-layer)
         # Qwen3 scales by `weight` directly (no 1.0 + weight) with variance_epsilon.
-        # `self` stays in eager so the kernel's guards never see the norm width,
-        # the input rank or any Python attribute.
+        # `self` stays in eager, so it never reaches the kernel's guards.
         hidden_states_2d, shape = flatten_for_elementwise_norm(hidden_states)
         normed = _qwen3_moe_rms_norm(
             hidden_states_2d, unwrap_norm_weight(self.weight), self.variance_epsilon,

--- a/unsloth_zoo/temporary_patches/qwen3_moe_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe_float32.py
@@ -49,7 +49,7 @@ from .common import (
     unwrap_norm_weight,
     publish_to_modeling_module,
 )
-from .utils import patch_function, raise_error
+from .utils import compile_with_eager_fallback, patch_function, raise_error
 
 # Mirrors gemma.py: flex dispatch can be turned off globally.
 _UNSLOTH_FLEX_ATTENTION_DISABLED = os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0"
@@ -113,7 +113,6 @@ _QWEN3_MOE_FP16_MAX = float(torch.finfo(torch.float16).max)
 # Every Qwen3-MoE RMSNorm instance shares this one kernel, so its Dynamo cache holds
 # the product of every axis its guards see. A plain Tensor weight view and a rank 2
 # input drop the norm-width and rank axes, leaving dtype, grad mode and requires_grad.
-@torch_compile(fullgraph = True, dynamic = True)
 def _qwen3_moe_rms_norm(hidden_states_2d, weight_1d, variance_epsilon):
     x_fp32 = hidden_states_2d.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim = True)
@@ -121,6 +120,10 @@ def _qwen3_moe_rms_norm(hidden_states_2d, weight_1d, variance_epsilon):
     normed_fp32 = normed_fp32 * weight_1d.to(torch.float32)
     return torch.clamp(normed_fp32, min = -_QWEN3_MOE_FP16_MAX, max = _QWEN3_MOE_FP16_MAX).to(torch.float16)
 pass
+
+# Compiled here, not via a decorator: `fullgraph = True` makes cache exhaustion
+# raise, and only this wrapper latches to eager instead of aborting training.
+_qwen3_moe_rms_norm = compile_with_eager_fallback(_qwen3_moe_rms_norm, "Qwen3MoeRMSNorm.forward")
 
 
 def patch_Qwen3MoeRMSNorm_float32():

--- a/unsloth_zoo/temporary_patches/qwen3_moe_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe_float32.py
@@ -42,7 +42,13 @@
 
 import os
 import torch
-from .common import TEMPORARY_PATCHES
+from .common import (
+    TEMPORARY_PATCHES,
+    torch_compile,
+    flatten_for_elementwise_norm,
+    unwrap_norm_weight,
+    publish_to_modeling_module,
+)
 from .utils import patch_function, raise_error
 
 # Mirrors gemma.py: flex dispatch can be turned off globally.
@@ -99,6 +105,25 @@ pass
 TEMPORARY_PATCHES.append(patch_Qwen3MoeDecoderLayer_float32)
 
 
+# Clamp to the fp16 range before casting back so a large residual never becomes
+# inf. A module-level float keeps `torch.finfo` out of the traced graph.
+_QWEN3_MOE_FP16_MAX = float(torch.finfo(torch.float16).max)
+
+
+# One compiled kernel is shared by every Qwen3-MoE RMSNorm instance, so its
+# Dynamo cache holds the product of every axis its guards see. Taking the weight
+# as a plain Tensor view and the input as rank 2 drops the norm-width and rank
+# axes; what remains is dtype, grad mode and requires_grad.
+@torch_compile(fullgraph = True, dynamic = True)
+def _qwen3_moe_rms_norm(hidden_states_2d, weight_1d, variance_epsilon):
+    x_fp32 = hidden_states_2d.to(torch.float32)
+    variance = x_fp32.pow(2).mean(-1, keepdim = True)
+    normed_fp32 = x_fp32 * torch.rsqrt(variance + variance_epsilon)
+    normed_fp32 = normed_fp32 * weight_1d.to(torch.float32)
+    return torch.clamp(normed_fp32, min = -_QWEN3_MOE_FP16_MAX, max = _QWEN3_MOE_FP16_MAX).to(torch.float16)
+pass
+
+
 def patch_Qwen3MoeRMSNorm_float32():
     if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "0": return
     try:
@@ -107,18 +132,24 @@ def patch_Qwen3MoeRMSNorm_float32():
     except Exception as e:
         return raise_error("Qwen3MoeRMSNorm.forward", e)
 
+    publish_to_modeling_module(
+        transformers.models.qwen3_moe.modeling_qwen3_moe,
+        flatten_for_elementwise_norm = flatten_for_elementwise_norm,
+        unwrap_norm_weight           = unwrap_norm_weight,
+        _qwen3_moe_rms_norm          = _qwen3_moe_rms_norm,
+    )
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor: # fp32 (residual) or fp16 (sub-layer)
         # Qwen3 scales by `weight` directly (no 1.0 + weight) with variance_epsilon.
-        x_fp32 = hidden_states.to(torch.float32)
-        variance = x_fp32.pow(2).mean(-1, keepdim = True)
-        normed_fp32 = x_fp32 * torch.rsqrt(variance + self.variance_epsilon)
-        normed_fp32 = normed_fp32 * self.weight.to(torch.float32)
-
-        # Clamp to fp16 range before casting back so a large residual never becomes inf.
-        fp16_max = torch.finfo(torch.float16).max
-        return torch.clamp(normed_fp32, min = -fp16_max, max = fp16_max).to(torch.float16)
+        # `self` stays in eager so the kernel's guards never see the norm width,
+        # the input rank or any Python attribute. See _qwen3_moe_rms_norm below.
+        hidden_states_2d, shape = flatten_for_elementwise_norm(hidden_states)
+        normed = _qwen3_moe_rms_norm(
+            hidden_states_2d, unwrap_norm_weight(self.weight), self.variance_epsilon,
+        )
+        return normed.reshape(shape)
     pass
-    patch_function(transformers.models.qwen3_moe.modeling_qwen3_moe.Qwen3MoeRMSNorm, "forward", forward, fullgraph = True, match_level = "relaxed")
+    patch_function(transformers.models.qwen3_moe.modeling_qwen3_moe.Qwen3MoeRMSNorm, "forward", forward, match_level = "relaxed")
 pass
 TEMPORARY_PATCHES.append(patch_Qwen3MoeRMSNorm_float32)
 

--- a/unsloth_zoo/temporary_patches/qwen3_moe_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe_float32.py
@@ -105,15 +105,14 @@ pass
 TEMPORARY_PATCHES.append(patch_Qwen3MoeDecoderLayer_float32)
 
 
-# Clamp to the fp16 range before casting back so a large residual never becomes
-# inf. A module-level float keeps `torch.finfo` out of the traced graph.
+# Clamp bound so a large residual never becomes inf on the cast back. Module-level
+# float keeps `torch.finfo` out of the traced graph.
 _QWEN3_MOE_FP16_MAX = float(torch.finfo(torch.float16).max)
 
 
-# One compiled kernel is shared by every Qwen3-MoE RMSNorm instance, so its
-# Dynamo cache holds the product of every axis its guards see. Taking the weight
-# as a plain Tensor view and the input as rank 2 drops the norm-width and rank
-# axes; what remains is dtype, grad mode and requires_grad.
+# Every Qwen3-MoE RMSNorm instance shares this one kernel, so its Dynamo cache holds
+# the product of every axis its guards see. A plain Tensor weight view and a rank 2
+# input drop the norm-width and rank axes, leaving dtype, grad mode and requires_grad.
 @torch_compile(fullgraph = True, dynamic = True)
 def _qwen3_moe_rms_norm(hidden_states_2d, weight_1d, variance_epsilon):
     x_fp32 = hidden_states_2d.to(torch.float32)
@@ -142,7 +141,7 @@ def patch_Qwen3MoeRMSNorm_float32():
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor: # fp32 (residual) or fp16 (sub-layer)
         # Qwen3 scales by `weight` directly (no 1.0 + weight) with variance_epsilon.
         # `self` stays in eager so the kernel's guards never see the norm width,
-        # the input rank or any Python attribute. See _qwen3_moe_rms_norm below.
+        # the input rank or any Python attribute.
         hidden_states_2d, shape = flatten_for_elementwise_norm(hidden_states)
         normed = _qwen3_moe_rms_norm(
             hidden_states_2d, unwrap_norm_weight(self.weight), self.variance_epsilon,

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -780,17 +780,16 @@ def _is_our_own_disabled_hook(exc):
 
 
 def compile_with_eager_fallback(func, label, fullgraph = True, dynamic = True):
-    """`torch_compile` the function, keeping the eager fallback `patch_function` gives.
+    """`torch_compile` a standalone kernel, keeping `patch_function`'s eager fallback.
 
-    A bare `@torch_compile(fullgraph = True)` on a module-level kernel skips
-    `_fall_back_to_eager_on_recompile_limit`, which only `patch_function` applies,
-    so cache exhaustion aborts training instead of latching to eager. Use this for
-    any standalone kernel compiled with `fullgraph = True`.
+    A bare `@torch_compile(fullgraph = True)` skips
+    `_fall_back_to_eager_on_recompile_limit` (only `patch_function` applies it), so
+    cache exhaustion aborts training instead of latching to eager.
     """
     from .common import torch_compile
     compiled = torch_compile(fullgraph = fullgraph, dynamic = dynamic)(func)
+    # Without fullgraph Dynamo already falls back by itself.
     if not fullgraph:
-        # Without fullgraph Dynamo already falls back by itself.
         return compiled
     return _fall_back_to_eager_on_recompile_limit(compiled, func, label)
 
@@ -898,9 +897,8 @@ def eager_fallback_state() -> dict[str, bool]:
         w = ref()
         if w is not None:
             label = w._unsloth_fallback_label
-            # OR, not assign: two wrappers can share a label, and plain assignment
-            # lets a later False hide an earlier True, reporting compiled for a
-            # path that is already eager.
+            # OR, not assign: labels can collide, and a later False would hide an
+            # earlier True, reporting compiled for an already-eager path.
             out[label] = out.get(label, False) or bool(w._unsloth_fallback_state["eager"])
     return out
 

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -16,6 +16,7 @@
 
 __all__ = [
     "patch_function",
+    "compile_with_eager_fallback",
     "patch_function_past_key_values",
     "process_return",
     "process_output_options",
@@ -776,6 +777,22 @@ def _is_our_own_disabled_hook(exc):
         all(part in text for part in signature)
         for signature in _DISABLED_HOOK_SIGNATURES
     )
+
+
+def compile_with_eager_fallback(func, label, fullgraph = True, dynamic = True):
+    """`torch_compile` the function, keeping the eager fallback `patch_function` gives.
+
+    A bare `@torch_compile(fullgraph = True)` on a module-level kernel skips
+    `_fall_back_to_eager_on_recompile_limit`, which only `patch_function` applies,
+    so cache exhaustion aborts training instead of latching to eager. Use this for
+    any standalone kernel compiled with `fullgraph = True`.
+    """
+    from .common import torch_compile
+    compiled = torch_compile(fullgraph = fullgraph, dynamic = dynamic)(func)
+    if not fullgraph:
+        # Without fullgraph Dynamo already falls back by itself.
+        return compiled
+    return _fall_back_to_eager_on_recompile_limit(compiled, func, label)
 
 
 def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -897,7 +897,11 @@ def eager_fallback_state() -> dict[str, bool]:
     for ref in _EAGER_FALLBACK_WRAPPERS:
         w = ref()
         if w is not None:
-            out[w._unsloth_fallback_label] = bool(w._unsloth_fallback_state["eager"])
+            label = w._unsloth_fallback_label
+            # OR, not assign: two wrappers can share a label, and plain assignment
+            # lets a later False hide an earlier True, reporting compiled for a
+            # path that is already eager.
+            out[label] = out.get(label, False) or bool(w._unsloth_fallback_state["eager"])
     return out
 
 


### PR DESCRIPTION
### The problem

`Gemma4RMSNorm.forward` is a single compiled code object shared by every RMSNorm instance in the model. `gemma-4-E2B` has 504 of them, so that one frame's Dynamo cache holds the **product** of every axis its guards can see, not the sum.

Measured with `TORCH_LOGS=recompiles,recompiles_verbose` on `unsloth/gemma-4-E2B-it` with `UNSLOTH_FORCE_FLOAT32=1`. Of 25 recompiles across the whole model, 17 are this one frame; every other frame recompiles 1 to 3 times.

| axis | width | guard |
| --- | --- | --- |
| `self._parameters['weight']` size | 8 | `size mismatch at index 0. expected 64, actual 768` |
| input rank | 2 | `rank mismatch. expected 4, actual 3` (residual norms vs q/k norms) |
| `self.with_scale` | 2 | constant baked into the graph |
| input dtype | 3 | intrinsic to the fp32 patch |
| `GLOBAL_STATE: grad_mode` | 2 | gradient checkpointing packs under `no_grad`, recomputes under `enable_grad` |
| `requires_grad` | 2 | same |

That is roughly 384 entries for one frame before per-dimension specialisation from varying image sizes. On a T4 it reached the recompile limit and raised `FailOnRecompileLimitHit`, which then took activation checkpointing down with it.

`dynamic = True` cannot fix this. `torch/_dynamo/utils.py` forces static shapes whenever `type(t) is torch.nn.Parameter`, so reading `self.weight` inside the compiled region pins the hidden size regardless.

### The fix

Compile a pure tensor kernel instead of a bound method, so `self` never reaches the guards:

- the weight goes in as a plain `Tensor` view, which takes normal dynamic-shape treatment while autograd still reaches the `Parameter`. This is local to the norm kernels rather than relaxing `force_parameter_static_shapes` globally, which would cost Inductor its static GEMM specialisations everywhere.
- the input is flattened to rank 2. Normalisation only ever touches the last dimension, so this is a view for contiguous inputs and folds away when the kernel is inlined.
- scaled and unscaled get separate kernels, which removes the `with_scale` axis and the `KeyError` on `self._parameters['weight']` for the unscaled instances.

What remains is the irreducible set: dtype, grad mode and `requires_grad`.

Gemma3 and Qwen3-MoE norms have the same shape of problem and get the same treatment.

`publish_to_modeling_module` is needed because `create_standalone_class` copies the live `forward` source into `unsloth_compiled_cache` and resolves free names against the modeling module; without it the regenerated `unsloth_compiled_module_gemma4.py` raises `NameError` on import.

### Results

| config | RMSNorm recompiles | max cache entries per frame | at `recompile_limit=8` |
| --- | --- | --- | --- |
| before | 17, saturates at step 1 | 17 | `FailOnRecompileLimitHit` |
| `force_parameter_static_shapes=False` alone | 12 | 12 | still fails |
| this PR | 5 | 5 | passes |

### Correctness

Forward and backward are **bitwise identical** to the old body across every shape, dtype and `with_scale` combination tested, and gradients still reach the `Parameter` through the view.

One measurement note worth recording: comparing the old eager body against the new compiled kernel shows deltas up to 4e-3 in bf16. That is Inductor's float reassociation, not this change. The old path was compiled too, so it is not a difference in behaviour. Isolating the refactor by running both paths eagerly gives 0 mismatches in 21 of 21 cases.

### Tests

`tests/test_rmsnorm_recompile_guards.py`, 24 tests. The pair that matters: at `recompile_limit=8` the old bound-method form raises `FailOnRecompileLimitHit` over a realistic spread of call shapes, and the new kernels survive the identical spread.

Full zoo suite: `3 failed, 3856 passed, 162 skipped`. The 3 failures are `test_grpo_packed_verify_raw_logits` and are pre-existing suite pollution, not from this change. A pristine `origin/main` control fails exactly the same 3 in a full run (`3 failed, 3832 passed`, the 24 difference being the tests added here) while passing them in isolation on both branches.

### Caveat

The causal chain from recompile pressure to the checkpoint assert is proven at microbench scale with real `torch.compile` under real `checkpoint(use_reentrant=False)`, and the recompile reduction is measured on the real model. It has not yet been reproduced end to end on real Gemma4 on a T4, which saturates at 17 recompiles on larger cards and so never approaches the limit there.
