### PR TITLE
MLX: name the config key when a mirrored config.json is incomplete

### DIFF
--- a/tests/test_mlx_incomplete_config.py
+++ b/tests/test_mlx_incomplete_config.py
@@ -1,0 +1,122 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# A required mlx-lm ModelArgs field absent from config.json raises a bare
+# TypeError naming neither the model nor the file, which reads as missing Apple
+# Silicon support; the guard must name the config as the cause instead.
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+
+    simulate_mlx_on_torch()
+
+
+# Verbatim from mlx-lm 0.31.3 loading unsloth/LFM2.5-230M, whose mirrored
+# config.json lost upstream's "block_ff_dim": 2560 (unslothai/unsloth#7306).
+_LFM2_MSG = (
+    "ModelArgs.__init__() missing 1 required positional argument: 'block_ff_dim'"
+)
+
+
+def test_missing_config_key_raises_actionable_error():
+    from unsloth_zoo.mlx.loader import _raise_if_incomplete_mlx_config
+
+    with pytest.raises(ValueError) as exc:
+        _raise_if_incomplete_mlx_config(
+            "unsloth/LFM2.5-230M", "lfm2", _LFM2_MSG, TypeError(_LFM2_MSG)
+        )
+    msg = str(exc.value)
+    assert "unsloth/LFM2.5-230M" in msg
+    assert "block_ff_dim" in msg
+    assert "config.json" in msg
+    assert "lfm2" in msg
+    # The whole point: stop readers concluding MLX is unsupported.
+    assert "Apple Silicon" in msg
+
+
+def test_multiple_missing_keys_all_named():
+    from unsloth_zoo.mlx.loader import _raise_if_incomplete_mlx_config
+
+    message = (
+        "ModelArgs.__init__() missing 2 required positional arguments: "
+        "'block_ff_dim' and 'block_multiple_of'"
+    )
+    with pytest.raises(ValueError) as exc:
+        _raise_if_incomplete_mlx_config(
+            "unsloth/Example", "lfm2", message, TypeError(message)
+        )
+    msg = str(exc.value)
+    assert "block_ff_dim" in msg and "block_multiple_of" in msg
+    assert "keys" in msg
+
+
+def test_unrelated_type_error_falls_through():
+    # Only the missing-required-argument shape is ours; anything else must keep
+    # its original traceback rather than be relabelled a config problem.
+    from unsloth_zoo.mlx.loader import _raise_if_incomplete_mlx_config
+
+    for message in (
+        "unsupported operand type(s) for +: 'int' and 'str'",
+        "load_model() got an unexpected keyword argument 'strict'",
+    ):
+        _raise_if_incomplete_mlx_config(
+            "unsloth/Example", "lfm2", message, TypeError(message)
+        )
+
+
+def test_mlx_lm_signature_drift_is_not_a_config_problem():
+    # This loader deliberately tolerates mlx-lm changing load_model/_download's
+    # signature between releases (see the bypass comment in
+    # _load_mlx_lm_with_strict_fallback). Those failures have the same
+    # "missing N required positional arguments" wording as a genuinely
+    # incomplete config, so anchoring on __init__ is what keeps them apart:
+    # misreporting one as "config.json is missing 'model_path'" would send a
+    # reader to the wrong repo entirely.
+    from unsloth_zoo.mlx.loader import (
+        _missing_mlx_config_keys,
+        _raise_if_incomplete_mlx_config,
+    )
+
+    for message in (
+        "load_model() missing 1 required positional argument: 'model_path'",
+        "_download() missing 1 required positional argument: 'repo'",
+        "load_tokenizer() missing 2 required positional arguments: 'a' and 'b'",
+    ):
+        assert _missing_mlx_config_keys(message) == []
+        _raise_if_incomplete_mlx_config(
+            "unsloth/Example", "lfm2", message, TypeError(message)
+        )
+
+
+def test_key_extraction_shapes():
+    from unsloth_zoo.mlx.loader import _missing_mlx_config_keys
+
+    assert _missing_mlx_config_keys(_LFM2_MSG) == ["block_ff_dim"]
+    assert _missing_mlx_config_keys(
+        "ModelArgs.__init__() missing 3 required positional arguments: "
+        "'a', 'b', and 'c'"
+    ) == ["a", "b", "c"]
+    # Bare __init__ (no owning class in the message) still counts.
+    assert _missing_mlx_config_keys(
+        "__init__() missing 1 required positional argument: 'block_ff_dim'"
+    ) == ["block_ff_dim"]
+    assert _missing_mlx_config_keys("something else entirely") == []

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -443,6 +443,51 @@ def _message_matches_known_fallback(message, rule):
     return any(all(token in message for token in tokens) for tokens in token_sets)
 
 
+_MLX_MISSING_ARGS_RE = re.compile(
+    # Anchored on __init__ so mlx-lm signature drift at our own call sites
+    # (e.g. "load_model() missing 1 required positional argument: 'model_path'")
+    # is never mistaken for an incomplete config; this loader deliberately
+    # tolerates that drift and must keep its original traceback.
+    r"\w*\.?__init__\(\) missing \d+ required positional arguments?:(?P<keys>.*)"
+)
+
+
+def _missing_mlx_config_keys(message):
+    """Config keys mlx-lm's ModelArgs required but config.json did not supply.
+
+    mlx-lm builds ModelArgs through ``from_dict``, which filters the config down
+    to fields the dataclass declares. A field with no default that is absent
+    from config.json therefore fails in ``__init__`` with a bare TypeError that
+    names neither the model nor the file. Returns [] for any other TypeError.
+    """
+    match = _MLX_MISSING_ARGS_RE.search(message)
+    if match is None:
+        return []
+    return re.findall(r"'([^']+)'", match.group("keys"))
+
+
+def _raise_if_incomplete_mlx_config(model_name, model_type, message, error):
+    """An incomplete config.json is a model-repo problem, not an MLX one.
+
+    Mirroring a checkpoint through a transformers version that does not model
+    every field can silently drop keys the mlx-lm arch still requires (e.g.
+    lfm2's block_ff_dim). The raw TypeError reads like missing Apple Silicon
+    support, so name the actual cause."""
+    keys = _missing_mlx_config_keys(message)
+    if not keys:
+        return
+    listed = ", ".join(repr(key) for key in keys)
+    plural = "keys" if len(keys) > 1 else "key"
+    raise ValueError(
+        f"Unsloth: {model_name}'s config.json is missing the {plural} {listed}, "
+        f"which mlx-lm's '{model_type or 'unknown'}' architecture requires and "
+        f"cannot default. This is an incomplete config.json in the model repo - "
+        f"MLX and Apple Silicon support are not the problem. Compare the config "
+        f"against the upstream repo this model was mirrored from and add the "
+        f"missing {plural}."
+    ) from error
+
+
 def _raise_if_qk_norm_version_gap(model_type, message, error):
     """A strict load rejecting q_norm / k_norm means mlx-lm / mlx-vlm is too old for
     this QK-norm arch; dropping those weights breaks the model, so raise instead."""
@@ -809,6 +854,11 @@ def _load_mlx_lm_with_strict_fallback(
             lazy=lazy,
             model_config=model_config,
         )
+    except TypeError as error:
+        # A required ModelArgs field absent from config.json surfaces here, not
+        # as the ValueError the strict fallback below handles.
+        _raise_if_incomplete_mlx_config(model_name, model_type, str(error), error)
+        raise
     except ValueError as error:
         message = str(error)
         # Active-layer QK-norm weights are load-bearing: never strict=False past
@@ -943,12 +993,20 @@ def _load_mlx_lm_distributed(
             allow_patterns=_mlx_lm_metadata_allow_patterns(),
         )
         with _temporary_mlx_lm_snapshot_view(model_path) as metadata_model_path:
-            model, config = load_model(
-                metadata_model_path,
-                lazy=True,
-                strict=False,
-                model_config=model_config,
-            )
+            try:
+                model, config = load_model(
+                    metadata_model_path,
+                    lazy=True,
+                    strict=False,
+                    model_config=model_config,
+                )
+            except TypeError as error:
+                # Same incomplete-config failure as the single-device path;
+                # strict=False does not cover a missing ModelArgs field.
+                _raise_if_incomplete_mlx_config(
+                    model_name, model_type, str(error), error
+                )
+                raise
 
             mode = _mlx_distributed_sharding_mode(
                 model,


### PR DESCRIPTION
## What's wrong

mlx-lm builds `ModelArgs` through `from_dict`, which filters the config down to fields the dataclass declares. A required field with no default that is absent from `config.json` therefore fails in `__init__` with a bare `TypeError` naming neither the model nor the file:

```
TypeError: ModelArgs.__init__() missing 1 required positional argument: 'block_ff_dim'
```

`_load_mlx_lm_with_strict_fallback` catches only `ValueError`, so this propagates uncaught with no Unsloth context. The result reads as missing Apple Silicon support. In unslothai/unsloth#7306 it was diagnosed that way for two weeks — through an `xformers` red herring and a "does MLX support this model?" question — before the real cause surfaced: `unsloth/LFM2.5-230M`'s mirrored `config.json` lost upstream's `"block_ff_dim": 2560`.

## What this does

Catches `TypeError` at both mlx-lm `load_model` call sites (single-device and distributed) and re-raises naming the model, the missing key(s), and `config.json` as the cause:

```
Unsloth: unsloth/LFM2.5-230M's config.json is missing the key 'block_ff_dim',
which mlx-lm's 'lfm2' architecture requires and cannot default. This is an
incomplete config.json in the model repo - MLX and Apple Silicon support are
not the problem. Compare the config against the upstream repo this model was
mirrored from and add the missing key.
```

The original `TypeError` is preserved as `__cause__`.

## Two deliberate choices

**Anchored on `__init__`, not on the "missing N required positional arguments" wording alone.** This loader deliberately tolerates mlx-lm changing `load_model`/`_download`'s signature between releases (see the bypass comment in `_load_mlx_lm_with_strict_fallback`). Those failures carry identical wording, and reporting one as "config.json is missing 'model_path'" would point a reader at the wrong repo entirely. Anything that isn't a constructor failure keeps its original traceback. Covered by `test_mlx_lm_signature_drift_is_not_a_config_problem`.

**No backfill.** Deriving the value would be wrong. `block_ff_dim` is not `intermediate_size` — `LFM2-350M`, `LFM2-700M` and `LFM2-1.2B` omit `intermediate_size` entirely and set `block_auto_adjust_ff_dim: true`. They happen to coincide for LFM2.5-230M, which makes a backfill look safe when it isn't.

This is diagnostics only and does not repair the config. The fix for #7306 itself is adding the key back to the model repo on the Hub.

## Testing

New `tests/test_mlx_incomplete_config.py` (5 tests, follows the `test_mlx_qk_norm_version_gap.py` pattern with the `mlx_simulation` shim).

| Check | Result |
|---|---|
| `tests/test_mlx_incomplete_config.py` | 5 passed |
| `tests/test_mlx_qk_norm_version_gap.py` (sibling guard on the same `try`) | 7 passed |
| `tests/test_mlx_distributed_loader.py` (other patched function) | 7 passed |
| End-to-end: real loader, real `unsloth/LFM2.5-230M`, Apple Silicon M2, mlx-lm 0.31.3 / mlx 0.31.2 | guard fires, `__cause__` preserved |

Refs unslothai/unsloth#7306.