### PR TITLE
CI: drop the macOS leg from studio-export-fix-ci

### DIFF
--- a/.github/workflows/studio-export-fix-ci.yml
+++ b/.github/workflows/studio-export-fix-ci.yml
@@ -31,7 +31,15 @@ jobs:
       # 5-concurrent-Windows-runner limit when this job runs alongside others.
       max-parallel: 3
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        # No macOS leg on purpose. Both test files here are pure Python --
+        # monkeypatched subprocess plus AST parsing of upstream sources, no
+        # torch and no GGUF binary -- and neither contains a single
+        # `sys.platform` / `Darwin` / `arm64` reference, so the macOS row
+        # asserted exactly what the Linux row asserts. Windows stays because
+        # path handling genuinely differs there. macOS concurrency is capped at
+        # 5 jobs account-wide and is shared with unslothai/unsloth, so this was
+        # the one routine per-PR macOS job in this repo and it bought no signal.
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary

GitHub caps **concurrent macOS jobs at 5** per account, and that pool is shared with `unslothai/unsloth`. This was the **only routine per-PR macOS job in this repo**, and it does not need a Mac.

The other two macOS workflows here do not fire on ordinary PRs:

- `gemma4-audio-probe.yml` (7 jobs) requires a `gemma4-probe` label or `workflow_dispatch`
- `mlx-ci.yml` requires an `mlx` label on PRs

So this single leg was the whole routine macOS footprint of `unsloth-zoo`, competing with `unslothai/unsloth` for the same 5 slots.

## Why it does not need a Mac

The job runs two test files: `tests/test_quantize_gguf_q2_k_l.py` and `tests/test_convert_hf_to_gguf_patcher.py`. Both are pure Python -- monkeypatched `subprocess` plus AST parsing of upstream sources, with no torch and no GGUF binary, as the workflow's own install comment already notes.

Across their 925 combined lines there is not one `sys.platform`, `darwin`, `Darwin`, `arm64`, `win32` or `os.name` reference. There is no OS-conditional assertion for the macOS row to exercise that the Linux row does not.

**Windows stays**, since path handling genuinely differs there.

## Test plan

- [x] Workflow parses as valid YAML
- [x] Test-command set unchanged -- this is a matrix-only edit, verified by extracting commands from every `run:` body before and after
- [x] Grepped both test files for platform branching: zero hits
- [ ] CI green on this PR

Paired with unslothai/unsloth#7974, which removes two equivalent legs in the main repo.