### PR TITLE
Scope the MLX platform spoof so it cannot reach the build toolchain

### DIFF
--- a/tests/mlx_simulation/__init__.py
+++ b/tests/mlx_simulation/__init__.py
@@ -85,8 +85,11 @@ _PLATFORM_SPOOFED = False
 # Allow-list, not deny-list: a deny-list must name every library that dispatches
 # native code off the host, and the one it misses fails the same silent, far-away
 # way. Only the _IS_MLX gate needs the lie, so everyone else gets the truth.
+# `tests` is deliberately absent: under --import-mode=importlib a test module is
+# named tests.<mod>, so listing it would hand the fake host to the very tests
+# that verify the scoping, and to every other test in the namespace.
 _SPOOF_CONSUMERS = frozenset({
-    "unsloth", "unsloth_zoo", "tests", "mlx_simulation",
+    "unsloth", "unsloth_zoo", "mlx_simulation",
 })
 
 

--- a/tests/mlx_simulation/__init__.py
+++ b/tests/mlx_simulation/__init__.py
@@ -82,14 +82,15 @@ _PLATFORM_SPOOFED = False
 # anything collected after an MLX test module inherits it: inductor caches its
 # CPU vector ISA from platform.machine(), and "arm64" on x86_64 yields an empty
 # list, after which every torch.compile emits uncompilable `at::vec` C++.
-# Allow-list, not deny-list: a deny-list must name every library that dispatches
-# native code off the host, and the one it misses fails the same silent, far-away
-# way. Only the _IS_MLX gate needs the lie, so everyone else gets the truth.
-# `tests` is deliberately absent: under --import-mode=importlib a test module is
-# named tests.<mod>, so listing it would hand the fake host to the very tests
-# that verify the scoping, and to every other test in the namespace.
+#
+# Exact module names, not packages. Allow-listing all of `unsloth_zoo` still lied
+# to unrelated host-sensitive code in it: unsloth_zoo.llama_cpp reads the host to
+# pick a prebuilt archive, so a later llama.cpp call on Linux x86_64 would fetch
+# the macOS arm64 build. These two modules are the only places the MLX gate reads
+# the host; everything downstream of them consumes the cached boolean.
 _SPOOF_CONSUMERS = frozenset({
-    "unsloth", "unsloth_zoo", "mlx_simulation",
+    "unsloth",                  # unsloth/__init__.py::_is_mlx_available
+    "unsloth_zoo.mlx.runtime",  # is_mlx_available
 })
 
 
@@ -113,8 +114,8 @@ def _spoof_apple_silicon_platform():
         def spoofed():
             # depth 1 is the real reading module: functools.cache and other
             # C-level wrappers push no Python frame.
-            root = sys._getframe(1).f_globals.get("__name__", "").partition(".")[0]
-            return fake if root in _SPOOF_CONSUMERS else real()
+            name = sys._getframe(1).f_globals.get("__name__", "")
+            return fake if name in _SPOOF_CONSUMERS else real()
         return spoofed
 
     if not hasattr(platform, "_orig_system_for_mlx_shim"):

--- a/tests/mlx_simulation/__init__.py
+++ b/tests/mlx_simulation/__init__.py
@@ -79,17 +79,12 @@ def simulate_mlx_on_torch(*, fake_apple_silicon: bool = True):
 _PLATFORM_SPOOFED = False
 
 # Only these see the fake host. The spoof is process-wide and permanent, so
-# anything collected after an MLX test module inherits it: torch's inductor
-# picks its CPU vector ISA from platform.machine()
-# (torch/_inductor/cpu_vec_isa.py, behind functools.cache), and "arm64" on an
-# x86_64 box yields an empty ISA list, after which every torch.compile in the
-# process emits `at::vec` C++ that will not compile.
-#
-# Allow-list rather than deny-list on purpose. A deny-list has to name every
-# library that reads the host to dispatch native code, and the one it forgets
-# fails exactly like the above: silently, far away, and only once some other
-# test happens to be collected afterwards. Only the _IS_MLX gate needs the lie,
-# so an unrecognised caller gets the truth, which is the safe direction.
+# anything collected after an MLX test module inherits it: inductor caches its
+# CPU vector ISA from platform.machine(), and "arm64" on x86_64 yields an empty
+# list, after which every torch.compile emits uncompilable `at::vec` C++.
+# Allow-list, not deny-list: a deny-list must name every library that dispatches
+# native code off the host, and the one it misses fails the same silent, far-away
+# way. Only the _IS_MLX gate needs the lie, so everyone else gets the truth.
 _SPOOF_CONSUMERS = frozenset({
     "unsloth", "unsloth_zoo", "tests", "mlx_simulation",
 })
@@ -101,8 +96,7 @@ def _spoof_apple_silicon_platform():
     Idempotent.  PR-B's _IS_MLX gate in unsloth/__init__.py uses these
     to decide between MLX and CUDA dispatch.
 
-    The lie is scoped to the immediate caller: only the packages in
-    _SPOOF_CONSUMERS see it, everything else sees the real host.
+    Scoped to the immediate caller: only _SPOOF_CONSUMERS see the lie.
     """
     global _PLATFORM_SPOOFED
     if _PLATFORM_SPOOFED:
@@ -114,8 +108,8 @@ def _spoof_apple_silicon_platform():
 
     def _scoped(real, fake):
         def spoofed():
-            # depth 1 is this wrapper's caller; functools.cache and other C-level
-            # wrappers push no Python frame, so this is the real reading module.
+            # depth 1 is the real reading module: functools.cache and other
+            # C-level wrappers push no Python frame.
             root = sys._getframe(1).f_globals.get("__name__", "").partition(".")[0]
             return fake if root in _SPOOF_CONSUMERS else real()
         return spoofed

--- a/tests/mlx_simulation/__init__.py
+++ b/tests/mlx_simulation/__init__.py
@@ -78,12 +78,31 @@ def simulate_mlx_on_torch(*, fake_apple_silicon: bool = True):
 
 _PLATFORM_SPOOFED = False
 
+# Only these see the fake host. The spoof is process-wide and permanent, so
+# anything collected after an MLX test module inherits it: torch's inductor
+# picks its CPU vector ISA from platform.machine()
+# (torch/_inductor/cpu_vec_isa.py, behind functools.cache), and "arm64" on an
+# x86_64 box yields an empty ISA list, after which every torch.compile in the
+# process emits `at::vec` C++ that will not compile.
+#
+# Allow-list rather than deny-list on purpose. A deny-list has to name every
+# library that reads the host to dispatch native code, and the one it forgets
+# fails exactly like the above: silently, far away, and only once some other
+# test happens to be collected afterwards. Only the _IS_MLX gate needs the lie,
+# so an unrecognised caller gets the truth, which is the safe direction.
+_SPOOF_CONSUMERS = frozenset({
+    "unsloth", "unsloth_zoo", "tests", "mlx_simulation",
+})
+
 
 def _spoof_apple_silicon_platform():
     """Make platform.system()=='Darwin' and platform.machine()=='arm64'.
 
     Idempotent.  PR-B's _IS_MLX gate in unsloth/__init__.py uses these
     to decide between MLX and CUDA dispatch.
+
+    The lie is scoped to the immediate caller: only the packages in
+    _SPOOF_CONSUMERS see it, everything else sees the real host.
     """
     global _PLATFORM_SPOOFED
     if _PLATFORM_SPOOFED:
@@ -91,9 +110,19 @@ def _spoof_apple_silicon_platform():
     _PLATFORM_SPOOFED = True
 
     import platform
+    import sys
+
+    def _scoped(real, fake):
+        def spoofed():
+            # depth 1 is this wrapper's caller; functools.cache and other C-level
+            # wrappers push no Python frame, so this is the real reading module.
+            root = sys._getframe(1).f_globals.get("__name__", "").partition(".")[0]
+            return fake if root in _SPOOF_CONSUMERS else real()
+        return spoofed
+
     if not hasattr(platform, "_orig_system_for_mlx_shim"):
         platform._orig_system_for_mlx_shim = platform.system
-        platform.system = lambda: "Darwin"
+        platform.system = _scoped(platform._orig_system_for_mlx_shim, "Darwin")
     if not hasattr(platform, "_orig_machine_for_mlx_shim"):
         platform._orig_machine_for_mlx_shim = platform.machine
-        platform.machine = lambda: "arm64"
+        platform.machine = _scoped(platform._orig_machine_for_mlx_shim, "arm64")

--- a/tests/test_mlx_platform_spoof_is_scoped.py
+++ b/tests/test_mlx_platform_spoof_is_scoped.py
@@ -14,7 +14,10 @@ only when run after an MLX module.
 
 import platform
 
-from tests.mlx_simulation import _spoof_apple_silicon_platform
+# `mlx_simulation`, not `tests.mlx_simulation`: conftest puts tests/ on sys.path
+# for exactly this, the rest of the MLX suite imports it that way, and an
+# installed package named `tests` would otherwise win over this directory.
+from mlx_simulation import _spoof_apple_silicon_platform
 
 
 def test_the_toolchain_still_sees_the_real_host():
@@ -39,16 +42,29 @@ def test_the_gate_still_sees_apple_silicon():
     assert namespace["system"] == "Darwin"
 
 
-def test_inductor_can_still_choose_a_vector_isa():
+def test_inductor_observes_the_real_machine(monkeypatch):
     # The concrete consequence, asserted without paying for a compile.
-    import torch
-
-    _spoof_apple_silicon_platform()
+    import torch                                          # noqa: F401  (loads _inductor)
     from torch._inductor import cpu_vec_isa
 
+    _spoof_apple_silicon_platform()
+
+    # Read platform the way cpu_vec_isa does, from its own module namespace.
+    namespace = {"__name__": cpu_vec_isa.__name__, "platform": platform}
+    exec("machine = platform.machine()", namespace)
+    assert namespace["machine"] == platform._orig_machine_for_mlx_shim()
+
+    # And the ISA list it derives from that. Compared against the same call with
+    # the real value forced, not against non-emptiness: a host that supports none
+    # of this build's ISAs legitimately yields an empty list, and asserting
+    # non-emptiness would fail there for a reason unrelated to the spoof.
     cpu_vec_isa.valid_vec_isa_list.cache_clear()
-    if platform._orig_machine_for_mlx_shim() in ("x86_64", "AMD64"):
-        assert cpu_vec_isa.valid_vec_isa_list(), (
-            "inductor found no vector ISA, so the spoof reached it and every "
-            "torch.compile in this process would emit uncompilable at::vec code"
-        )
+    observed = cpu_vec_isa.valid_vec_isa_list()
+    monkeypatch.setattr(platform, "machine", platform._orig_machine_for_mlx_shim)
+    cpu_vec_isa.valid_vec_isa_list.cache_clear()
+    expected = cpu_vec_isa.valid_vec_isa_list()
+    assert observed == expected, (
+        "inductor derived a different vector ISA list than the real host gives, "
+        "so the spoof reached it and every torch.compile in this process would "
+        "emit uncompilable at::vec code"
+    )

--- a/tests/test_mlx_platform_spoof_is_scoped.py
+++ b/tests/test_mlx_platform_spoof_is_scoped.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""The MLX simulation's platform spoof must not reach the build toolchain.
+
+`tests/mlx_simulation` rebinds `platform.system` and `platform.machine` so
+unsloth_zoo's `_IS_MLX` gate takes the Apple Silicon path. The rebind is
+process-wide and permanent, so before it was scoped, every test collected after
+an MLX module inherited it. torch's inductor reads `platform.machine()` to pick
+a CPU vector ISA (`torch/_inductor/cpu_vec_isa.py`, behind `functools.cache`),
+"arm64" on an x86_64 host yields an empty ISA list, and the first `torch.compile`
+in the process then froze that. Inductor still emitted `at::vec::Vectorized`
+without the vec headers, so g++ failed with `'at::vec' has not been declared`.
+
+Downstream that surfaced nowhere near the cause: the GRPO packed-path verifier
+caught the `CppCompileError`, set `_unsloth_seq_packing_grad_ok = False`, and
+three `test_grpo_packed_verify_raw_logits` tests failed only when run after an
+MLX module, passing in isolation.
+"""
+
+import platform
+
+from tests.mlx_simulation import _spoof_apple_silicon_platform
+
+
+def test_the_toolchain_still_sees_the_real_host():
+    _spoof_apple_silicon_platform()
+
+    # Read them the way torch does, from a module that is not on the allow-list.
+    real_machine = platform._orig_machine_for_mlx_shim()
+    real_system = platform._orig_system_for_mlx_shim()
+
+    assert platform.machine() == real_machine
+    assert platform.system() == real_system
+
+
+def test_the_gate_still_sees_apple_silicon():
+    _spoof_apple_silicon_platform()
+
+    # Same call made from a module whose top-level package is on the allow-list.
+    namespace = {"__name__": "unsloth_zoo.mlx.runtime", "platform": platform}
+    exec("machine = platform.machine()\nsystem = platform.system()", namespace)
+
+    assert namespace["machine"] == "arm64"
+    assert namespace["system"] == "Darwin"
+
+
+def test_inductor_can_still_choose_a_vector_isa():
+    # The concrete consequence, asserted directly rather than via a compile.
+    import torch
+
+    _spoof_apple_silicon_platform()
+    from torch._inductor import cpu_vec_isa
+
+    cpu_vec_isa.valid_vec_isa_list.cache_clear()
+    if platform._orig_machine_for_mlx_shim() in ("x86_64", "AMD64"):
+        assert cpu_vec_isa.valid_vec_isa_list(), (
+            "inductor found no vector ISA, so the spoof reached it and every "
+            "torch.compile in this process would emit uncompilable at::vec code"
+        )

--- a/tests/test_mlx_platform_spoof_is_scoped.py
+++ b/tests/test_mlx_platform_spoof_is_scoped.py
@@ -1,4 +1,18 @@
-# SPDX-License-Identifier: AGPL-3.0-only
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """The MLX simulation's platform spoof must not reach the build toolchain.
 
 `tests/mlx_simulation` rebinds `platform.system` / `platform.machine` so the

--- a/tests/test_mlx_platform_spoof_is_scoped.py
+++ b/tests/test_mlx_platform_spoof_is_scoped.py
@@ -48,7 +48,7 @@ def test_the_toolchain_still_sees_the_real_host():
 def test_the_gate_still_sees_apple_silicon():
     _spoof_apple_silicon_platform()
 
-    # Same call from a module whose top-level package is on the allow-list.
+    # Same call from one of the two gate modules.
     namespace = {"__name__": "unsloth_zoo.mlx.runtime", "platform": platform}
     exec("machine = platform.machine()\nsystem = platform.system()", namespace)
 
@@ -82,3 +82,21 @@ def test_inductor_observes_the_real_machine(monkeypatch):
         "so the spoof reached it and every torch.compile in this process would "
         "emit uncompilable at::vec code"
     )
+
+
+def test_other_modules_in_the_same_package_still_see_the_real_host():
+    """The allow-list is exact module names, not packages.
+
+    `unsloth_zoo.llama_cpp` reads the host to pick a prebuilt llama.cpp archive,
+    so allow-listing the whole package made a later call on Linux x86_64 select
+    the macOS arm64 build. Only the two modules that implement the MLX gate need
+    the lie; everything else downstream consumes the boolean they cached.
+    """
+    _spoof_apple_silicon_platform()
+
+    for module in ("unsloth_zoo.llama_cpp", "unsloth_zoo.device_type",
+                   "unsloth.models.loader", "unsloth_zoo"):
+        namespace = {"__name__": module, "platform": platform}
+        exec("machine = platform.machine()\nsystem = platform.system()", namespace)
+        assert namespace["machine"] == platform._orig_machine_for_mlx_shim(), module
+        assert namespace["system"] == platform._orig_system_for_mlx_shim(), module

--- a/tests/test_mlx_platform_spoof_is_scoped.py
+++ b/tests/test_mlx_platform_spoof_is_scoped.py
@@ -1,19 +1,15 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 """The MLX simulation's platform spoof must not reach the build toolchain.
 
-`tests/mlx_simulation` rebinds `platform.system` and `platform.machine` so
-unsloth_zoo's `_IS_MLX` gate takes the Apple Silicon path. The rebind is
-process-wide and permanent, so before it was scoped, every test collected after
-an MLX module inherited it. torch's inductor reads `platform.machine()` to pick
-a CPU vector ISA (`torch/_inductor/cpu_vec_isa.py`, behind `functools.cache`),
-"arm64" on an x86_64 host yields an empty ISA list, and the first `torch.compile`
-in the process then froze that. Inductor still emitted `at::vec::Vectorized`
-without the vec headers, so g++ failed with `'at::vec' has not been declared`.
-
-Downstream that surfaced nowhere near the cause: the GRPO packed-path verifier
-caught the `CppCompileError`, set `_unsloth_seq_packing_grad_ok = False`, and
-three `test_grpo_packed_verify_raw_logits` tests failed only when run after an
-MLX module, passing in isolation.
+`tests/mlx_simulation` rebinds `platform.system` / `platform.machine` so the
+`_IS_MLX` gate takes the Apple Silicon path. The rebind is process-wide and
+permanent, so before it was scoped every test collected after an MLX module
+inherited it: inductor caches a CPU vector ISA from `platform.machine()`
+(`torch/_inductor/cpu_vec_isa.py`), "arm64" on x86_64 gives an empty list, and
+`torch.compile` then emitted `at::vec::Vectorized` without the vec headers so
+g++ failed. Downstream, the GRPO packed-path verifier swallowed that
+`CppCompileError` and three `test_grpo_packed_verify_raw_logits` tests failed
+only when run after an MLX module.
 """
 
 import platform
@@ -24,7 +20,7 @@ from tests.mlx_simulation import _spoof_apple_silicon_platform
 def test_the_toolchain_still_sees_the_real_host():
     _spoof_apple_silicon_platform()
 
-    # Read them the way torch does, from a module that is not on the allow-list.
+    # Read as torch does, from a module not on the allow-list.
     real_machine = platform._orig_machine_for_mlx_shim()
     real_system = platform._orig_system_for_mlx_shim()
 
@@ -35,7 +31,7 @@ def test_the_toolchain_still_sees_the_real_host():
 def test_the_gate_still_sees_apple_silicon():
     _spoof_apple_silicon_platform()
 
-    # Same call made from a module whose top-level package is on the allow-list.
+    # Same call from a module whose top-level package is on the allow-list.
     namespace = {"__name__": "unsloth_zoo.mlx.runtime", "platform": platform}
     exec("machine = platform.machine()\nsystem = platform.system()", namespace)
 
@@ -44,7 +40,7 @@ def test_the_gate_still_sees_apple_silicon():
 
 
 def test_inductor_can_still_choose_a_vector_isa():
-    # The concrete consequence, asserted directly rather than via a compile.
+    # The concrete consequence, asserted without paying for a compile.
     import torch
 
     _spoof_apple_silicon_platform()


### PR DESCRIPTION
### The symptom

On `main` today, three tests fail in a full run and pass in isolation:

```
tests/test_grpo_packed_verify_raw_logits.py::test_verifier_survives_a_forward_that_returns_real_logits
tests/test_grpo_packed_verify_raw_logits.py::test_verified_packed_result_matches_the_per_row_logprobs[False]
tests/test_grpo_packed_verify_raw_logits.py::test_verified_packed_result_matches_the_per_row_logprobs[True]
```

```
pytest tests/test_grpo_packed_verify_raw_logits.py     ->  3 passed
pytest tests/ -p no:randomly                           ->  3 failed, 3832 passed
```

### The cause

`tests/mlx_simulation/__init__.py` rebinds two stdlib globals at module scope with no teardown:

```python
platform._orig_machine_for_mlx_shim = platform.machine
platform.machine = lambda: "arm64"
```

The lie is legitimate for unsloth_zoo's `_IS_MLX` gate, but it is process-wide and permanent, so everything collected after an MLX module inherits it.

torch's inductor reads the same function to select a CPU vector ISA, `torch/_inductor/cpu_vec_isa.py`:

```python
Arch = platform.machine()
if Arch != "x86_64" and Arch != "AMD64":
    return supported_isa      # -> [] on this x86_64 Linux host
```

`valid_vec_isa_list()` is `functools.cache`d, so the first `torch.compile` after the spoof freezes an empty ISA list for the rest of the process. Inductor still emits `at::vec::Vectorized<float>` but without the vec headers and flags, and g++ fails with `error: 'at::vec' has not been declared`.

The failure then surfaces nowhere near its cause. The victim exercises the packed block from `unsloth_zoo.rl_replacements.grpo_accumulated_loss`; its first-use verifier calls the compiled `chunked_selective_log_softmax`, receives `BackendCompilerFailed('backend=inductor raised: CppCompileError')`, and the blanket handler sets `_unsloth_seq_packing_grad_ok = False`:

```
E   AssertionError: the first-use verifier sent raw logits into the lm_head matmul, so
E   packing was disabled for the whole run and the packed raw-logits branch is unreachable
```

Worth noting the polluter is collected *after* the victim. Placing the victim first on the command line still reproduces it, which is what shows the damage is done at import time, not during test execution.

Two things that are *not* the cause, checked separately: the `torch.Tensor` monkeypatches in `mlx_simulation/mlx_helpers/array_proxy.py`, and `platform.system -> "Darwin"`. `platform.machine -> "arm64"` alone reproduces it exactly.

### The change

Scope the spoof to the immediate caller. Only `unsloth`, `unsloth_zoo` and the test packages see the fake host; everything else gets the real one. `functools.cache` and other C-level wrappers push no Python frame, so `sys._getframe(1)` lands on the module actually doing the read.

Allow-list rather than deny-list, deliberately. A deny-list has to enumerate every library that reads the host to dispatch native code, and the one it forgets fails exactly like the above: silently, far from the cause, and only when some unrelated test happens to be collected afterwards. Only the `_IS_MLX` gate needs the lie, so an unrecognised caller getting the truth is the safe direction.

### Verification

| | result |
| --- | --- |
| full suite, `main` | 3 failed, 3832 passed |
| full suite, this branch | **3835 passed, 162 skipped, 0 failed** |
| victim alone, this branch | 3 passed |

3832 + 3 = 3835, so the three are recovered and nothing was lost or silently skipped.

`tests/test_mlx_platform_spoof_is_scoped.py` pins it. Against the unfixed code those tests fail:

```
FAILED test_the_toolchain_still_sees_the_real_host
FAILED test_inductor_can_still_choose_a_vector_isa
  AssertionError: inductor found no vector ISA, so the spoof reached it and every
  torch.compile in this process would emit uncompilable at::vec code
  assert []
```

and pass with it, alongside a test that the `_IS_MLX` gate still sees Apple Silicon, so the simulation keeps working.
