### PR TITLE
Stop the MoE LoRA delta reaching torch._grouped_mm without it

### DIFF
--- a/tests/test_moe_grouped_mm_alignment_fallback.py
+++ b/tests/test_moe_grouped_mm_alignment_fallback.py
@@ -1,6 +1,20 @@
 import pytest
 import torch
 
+from unsloth_zoo.temporary_patches import moe_utils as M
+
+
+@pytest.fixture(autouse=True)
+def _pretend_the_kernel_is_supported(monkeypatch):
+    """These tests are about kernel ERROR handling, so the kernel has to be reached.
+
+    `_grouped_mm_with_backward_fix` now returns early when the device has no
+    usable `torch._grouped_mm`, which on CPU-only CI is always. Without this the
+    monkeypatched kernel below is never called: the differentiability test would
+    pass while exercising nothing, and the re-raise test would fail outright.
+    """
+    monkeypatch.setattr(M, "_check_torch_grouped_mm_supported", lambda: True)
+
 
 def test_grouped_mm_alignment_fallback_is_differentiable(monkeypatch):
     from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix

--- a/tests/test_moe_grouped_mm_alignment_fallback.py
+++ b/tests/test_moe_grouped_mm_alignment_fallback.py
@@ -6,13 +6,9 @@ from unsloth_zoo.temporary_patches import moe_utils as M
 
 @pytest.fixture(autouse=True)
 def _pretend_the_kernel_is_supported(monkeypatch):
-    """These tests are about kernel ERROR handling, so the kernel has to be reached.
-
-    `_grouped_mm_with_backward_fix` now returns early when the device has no
-    usable `torch._grouped_mm`, which on CPU-only CI is always. Without this the
-    monkeypatched kernel below is never called: the differentiability test would
-    pass while exercising nothing, and the re-raise test would fail outright.
-    """
+    """These test kernel ERROR handling, so the kernel has to be reached: the new
+    capability early-return in `_grouped_mm_with_backward_fix` always fires on CPU-only
+    CI, so the monkeypatched kernel below would never be called."""
     monkeypatch.setattr(M, "_check_torch_grouped_mm_supported", lambda: True)
 
 

--- a/tests/test_moe_grouped_mm_no_copy.py
+++ b/tests/test_moe_grouped_mm_no_copy.py
@@ -27,6 +27,14 @@ def _grouped_mm_ok():
         return False
 
 
+@pytest.fixture(autouse=True)
+def _pretend_the_kernel_is_supported(monkeypatch):
+    """These pin what happens AT the kernel, so the capability gate in front of
+    it must not answer for a CPU runner and route the call away first."""
+    from unsloth_zoo.temporary_patches import moe_utils
+    monkeypatch.setattr(moe_utils, "_check_torch_grouped_mm_supported", lambda: True)
+
+
 def test_no_forced_copy_on_happy_path(monkeypatch):
     """Probe-safe stack: weight kept as a non-contiguous view in one attempt; unproven: copied."""
     from unsloth_zoo.temporary_patches.moe_utils import (

--- a/tests/test_moe_grouped_mm_no_copy.py
+++ b/tests/test_moe_grouped_mm_no_copy.py
@@ -147,3 +147,57 @@ def test_view_matches_copy_backward():
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main([__file__, "-v", "-s"]))
+
+
+def test_the_routing_signature_sees_a_same_sum_swap():
+    """Summing a row collapses it to a scalar that ignores WHERE its values
+    sit, so `[1, 0]` and `[0, 1]` reduced alike and swapping them across an
+    expert boundary left the signature unchanged. The guard would then accept a
+    replay whose gradients belong to a different routing, which is the one thing
+    it exists to refuse."""
+    from unsloth_zoo.temporary_patches.moe_utils import _routing_signature
+
+    offsets = torch.tensor([2], dtype = torch.int32)
+    rows = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    assert _routing_signature(rows, offsets) != _routing_signature(rows.flip(0), offsets)
+
+
+def test_the_routing_signature_is_stable_for_the_same_rows():
+    """A false positive here turns a healthy step into a hard error."""
+    from unsloth_zoo.temporary_patches.moe_utils import _routing_signature
+
+    offsets = torch.tensor([8], dtype = torch.int32)
+    rows = torch.randn(8, 32)
+    assert _routing_signature(rows, offsets) == _routing_signature(rows.clone(), offsets)
+
+
+def test_the_routing_signature_sees_an_arbitrary_permutation():
+    from unsloth_zoo.temporary_patches.moe_utils import _routing_signature
+
+    offsets = torch.tensor([64], dtype = torch.int32)
+    rows = torch.randn(64, 128)
+    shuffled = rows[torch.randperm(64)]
+    if torch.equal(rows, shuffled):
+        pytest.skip("permutation happened to be the identity")
+    assert _routing_signature(rows, offsets) != _routing_signature(shuffled, offsets)
+
+
+def test_the_routing_signature_does_not_upcast_the_whole_input():
+    """`.float()` on the way in materialised a whole `[routed_tokens, hidden]`
+    transient to produce one number per row: 512MB at 32K by 4096, on exactly
+    the memory-constrained runs this fallback exists for."""
+    import inspect
+
+    from unsloth_zoo.temporary_patches.moe_utils import _routing_signature
+
+    body = inspect.getsource(_routing_signature)
+    assert ".float().sum(" not in body
+    assert ".detach().float()" not in body, "the full-width FP32 copy is back"
+
+
+def test_the_routing_signature_runs_in_half_precision():
+    from unsloth_zoo.temporary_patches.moe_utils import _routing_signature
+
+    offsets = torch.tensor([4], dtype = torch.int32)
+    rows = torch.randn(4, 16).half()
+    assert isinstance(_routing_signature(rows, offsets), list)

--- a/tests/test_moe_grouped_mm_no_copy.py
+++ b/tests/test_moe_grouped_mm_no_copy.py
@@ -150,11 +150,9 @@ if __name__ == "__main__":
 
 
 def test_the_routing_signature_sees_a_same_sum_swap():
-    """Summing a row collapses it to a scalar that ignores WHERE its values
-    sit, so `[1, 0]` and `[0, 1]` reduced alike and swapping them across an
-    expert boundary left the signature unchanged. The guard would then accept a
-    replay whose gradients belong to a different routing, which is the one thing
-    it exists to refuse."""
+    """A sum ignores WHERE a row's values sit, so `[1, 0]` and `[0, 1]` reduced alike
+    and swapping them across an expert boundary left the signature unchanged: the guard
+    would accept a replay whose gradients belong to a different routing."""
     from unsloth_zoo.temporary_patches.moe_utils import _routing_signature
 
     offsets = torch.tensor([2], dtype = torch.int32)
@@ -183,9 +181,9 @@ def test_the_routing_signature_sees_an_arbitrary_permutation():
 
 
 def test_the_routing_signature_does_not_upcast_the_whole_input():
-    """`.float()` on the way in materialised a whole `[routed_tokens, hidden]`
-    transient to produce one number per row: 512MB at 32K by 4096, on exactly
-    the memory-constrained runs this fallback exists for."""
+    """Upcasting on the way in materialised a whole `[routed_tokens, hidden]` transient
+    for one number per row: 512MB at 32K by 4096, on exactly the memory-constrained
+    runs this fallback exists for."""
     import inspect
 
     from unsloth_zoo.temporary_patches.moe_utils import _routing_signature

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -121,3 +121,81 @@ def test_a_supported_device_still_uses_the_kernel(monkeypatch):
     inputs, weight, offsets = _case()
     M._grouped_mm_with_backward_fix(inputs, weight, offsets)
     assert seen.get("called"), "the guard swallowed a device that is supported"
+
+
+# --- what the first live B200 run of Qwen3_5_MoE found ----------------------
+
+def _reference(inputs, weight, offsets):
+    """Plain autograd over per-group matmuls, gradients included."""
+    outs, start = [], 0
+    for g, end in enumerate(offsets.tolist()):
+        if start < end:
+            outs.append(inputs[start:end] @ weight[g])
+        start = end
+    return torch.cat(outs, dim = 0)
+
+
+def test_the_gradients_match_plain_autograd(unsupported):
+    inputs, weight, offsets = _case(dtype = torch.float64)
+    a_in = inputs.clone().requires_grad_(True)
+    a_w = weight.clone().requires_grad_(True)
+    b_in = inputs.clone().requires_grad_(True)
+    b_w = weight.clone().requires_grad_(True)
+    seed = torch.randn(inputs.shape[0], weight.shape[-1], dtype = torch.float64)
+
+    M._grouped_mm_with_backward_fix(a_in, a_w, offsets).backward(seed)
+    _reference(b_in, b_w, offsets).backward(seed)
+
+    torch.testing.assert_close(a_in.grad, b_in.grad)
+    torch.testing.assert_close(a_w.grad, b_w.grad)
+
+
+def test_a_gradient_is_only_produced_where_it_is_wanted(unsupported):
+    """A frozen base stack asks for dX only, and building dW anyway is a
+    full-size allocation per call for nothing."""
+    inputs, weight, offsets = _case()
+    inputs = inputs.requires_grad_(True)
+    M._grouped_mm_with_backward_fix(inputs, weight, offsets).sum().backward()
+    assert inputs.grad is not None
+    assert weight.grad is None
+
+
+def test_an_empty_group_contributes_no_gradient(unsupported):
+    inputs = torch.randn(4, 8, requires_grad = True)
+    weight = torch.randn(3, 8, 6, requires_grad = True)
+    offsets = torch.tensor([0, 4, 4], dtype = torch.int32)
+    M._grouped_mm_with_backward_fix(inputs, weight, offsets).sum().backward()
+    assert torch.count_nonzero(weight.grad[0]) == 0
+    assert torch.count_nonzero(weight.grad[2]) == 0
+    assert torch.count_nonzero(weight.grad[1]) > 0
+
+
+def test_it_saves_only_shape_stable_tensors(unsupported):
+    """The whole point. A per-group slice's shape is the group size, which the
+    router decides, so saving slices made non-reentrant checkpointing compare
+    metadata across two different routings and abort the backward:
+
+        CheckpointError: saved torch.Size([38, 8]) recomputed torch.Size([39, 8])
+
+    Qwen3_5_MoE on a B200 died exactly there once the capability guard let it
+    reach training. Saved shapes must depend on nothing but the inputs.
+    """
+    inputs, weight, offsets = _case()
+    inputs = inputs.requires_grad_(True)
+    out = M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+    saved = out.grad_fn.saved_tensors
+    assert {tuple(t.shape) for t in saved} == {
+        tuple(inputs.shape), tuple(weight.shape), tuple(offsets.shape)}, \
+        [tuple(t.shape) for t in saved]
+
+
+def test_it_survives_non_reentrant_checkpointing(unsupported):
+    """End to end: the same call inside a checkpointed region, backward and all."""
+    from torch.utils.checkpoint import checkpoint
+    inputs, weight, offsets = _case()
+    inputs = inputs.requires_grad_(True)
+    weight = weight.requires_grad_(True)
+    out = checkpoint(lambda x, w: M._grouped_mm_with_backward_fix(x, w, offsets),
+                     inputs, weight, use_reentrant = False)
+    out.sum().backward()
+    assert inputs.grad is not None and torch.isfinite(inputs.grad).all()

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -228,3 +228,80 @@ def test_the_modulelist_stride_fallback_shares_the_same_helper():
     assert {tuple(t.shape) for t in saved} == {
         tuple(inputs.shape), tuple(weight.shape), tuple(offsets.shape)}, \
         [tuple(t.shape) for t in saved]
+
+
+# --- what the first review round found --------------------------------------
+
+def test_a_routing_change_in_the_replay_is_named_not_swallowed(unsupported):
+    """Shape-stable saves are parity with the fused op, not permission to lie.
+
+    Non-reentrant checkpointing replaces the SAVED tensors with the replay's,
+    so a backward that just uses them pairs the original `grad_output` with the
+    replay's partition: a gradient for a routing that never produced the loss.
+    That is worse than the CheckpointError it replaced, so the forward's own
+    boundaries are kept off the tape and compared.
+    """
+    class _Ctx:
+        """What checkpointing hands backward: the REPLAY's saved tensors."""
+        needs_input_grad = (True, True, False)
+        def __init__(self, saved, forward_offsets):
+            self.saved_tensors = saved
+            self.forward_offsets = forward_offsets
+
+    inputs = torch.randn(12, 8)
+    weight = torch.randn(3, 8, 6)
+    replayed = torch.tensor([4, 9, 12], dtype = torch.int32)   # one token over
+    ctx = _Ctx((inputs, weight, replayed), [4, 8, 12])
+
+    with pytest.raises(RuntimeError, match = "assigned tokens differently"):
+        M._ManualGroupedMM.backward(ctx, torch.ones(12, 6))
+
+
+def test_the_real_checkpoint_replay_shape_is_caught(unsupported):
+    """End to end, with a router that really does route differently on replay."""
+    from torch.utils.checkpoint import checkpoint
+    seen = {"n": 0}
+
+    def region(x, w):
+        seen["n"] += 1
+        ends = [4, 8, 12] if seen["n"] == 1 else [4, 9, 12]
+        offsets = torch.tensor(ends, dtype = torch.int32)
+        return M._grouped_mm_with_backward_fix(x, w, offsets)
+
+    inputs = torch.randn(12, 8, requires_grad = True)
+    weight = torch.randn(3, 8, 6, requires_grad = True)
+    out = checkpoint(region, inputs, weight, use_reentrant = False)
+    with pytest.raises(RuntimeError, match = "assigned tokens differently"):
+        out.sum().backward()
+
+
+def test_the_same_routing_twice_is_not_flagged(unsupported):
+    """The check must not fire on the overwhelmingly common case."""
+    inputs, weight, offsets = _case()
+    inputs = inputs.requires_grad_(True)
+    M._grouped_mm_with_backward_fix(inputs, weight, offsets).sum().backward()
+    assert inputs.grad is not None
+
+
+def test_backward_survives_a_reduced_precision_grad_output(unsupported):
+    """`Function.backward` runs OUTSIDE the forward's autocast region, so a
+    forward that autocast fp32 weights to bf16 hands back a bf16 grad_output
+    while the saved tensors are still fp32. Unaligned, the first matmul raises."""
+    inputs = torch.randn(8, 4, dtype = torch.float32, requires_grad = True)
+    weight = torch.randn(2, 4, 6, dtype = torch.float32, requires_grad = True)
+    offsets = torch.tensor([4, 8], dtype = torch.int32)
+
+    out = M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+    out.backward(torch.ones_like(out, dtype = torch.bfloat16))
+
+    assert inputs.grad.dtype == torch.float32
+    assert weight.grad.dtype == torch.float32
+    assert torch.isfinite(inputs.grad).all() and torch.isfinite(weight.grad).all()
+
+
+def test_it_is_marked_as_not_compilable():
+    """A data-dependent group loop cannot be traced; breaking cleanly beats
+    aborting mid-trace, and the tensorized rewrites all cost more than they save."""
+    assert getattr(M._manual_grouped_mm, "_torchdynamo_disable", False) or \
+        "disable" in type(M._manual_grouped_mm).__name__.lower() or \
+        hasattr(M._manual_grouped_mm, "__wrapped__"), M._manual_grouped_mm

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -1,0 +1,119 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""A device without torch._grouped_mm must not reach torch._grouped_mm.
+
+`select_moe_backend` already falls to `unsloth_triton` when the probe says the
+kernel is unsupported, but `forward_triton_grouped_gemm` applied its separated
+LoRA delta through `native_moe_grouped_mm`, which calls the primitive the
+backend was chosen to avoid. Training a LoRA MoE on anything that is not an
+H100 therefore died at the first step:
+
+    RuntimeError: torch._grouped_mm is only supported on CUDA devices with
+    compute capability = 9.0
+
+Found on a B200 running `Qwen3_5_MoE.ipynb` under torch 2.8.0, and reachable on
+an A100 the same way. The guard goes in `_grouped_mm_with_backward_fix`, the one
+choke point every LoRA and base path shares.
+"""
+
+import pytest
+import torch
+
+from unsloth_zoo.temporary_patches import moe_utils as M
+
+
+@pytest.fixture
+def unsupported(monkeypatch):
+    """Report the kernel as unsupported, and make reaching it an error."""
+    monkeypatch.setattr(M, "_check_torch_grouped_mm_supported", lambda: False)
+
+    def _explode(*args, **kwargs):
+        raise RuntimeError(
+            "torch._grouped_mm is only supported on CUDA devices with "
+            "compute capability = 9.0")
+    monkeypatch.setattr(torch, "_grouped_mm", _explode, raising = False)
+
+
+def _case(n_experts = 3, rows_each = 4, k = 8, n = 6, dtype = torch.float32):
+    inputs = torch.randn(n_experts * rows_each, k, dtype = dtype)
+    weight = torch.randn(n_experts, k, n, dtype = dtype)
+    offsets = torch.tensor(
+        [(i + 1) * rows_each for i in range(n_experts)], dtype = torch.int32)
+    return inputs, weight, offsets
+
+
+def test_it_does_not_call_the_kernel_at_all(unsupported):
+    inputs, weight, offsets = _case()
+    out = M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+    assert out.shape == (inputs.shape[0], weight.shape[-1])
+
+
+def test_the_result_matches_a_per_expert_matmul(unsupported):
+    inputs, weight, offsets = _case()
+    out = M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+    expected = torch.cat([
+        inputs[i * 4:(i + 1) * 4] @ weight[i] for i in range(3)], dim = 0)
+    torch.testing.assert_close(out, expected)
+
+
+def test_it_is_still_differentiable(unsupported):
+    """The LoRA delta is trained, so the fallback has to carry gradients."""
+    inputs, weight, offsets = _case()
+    weight = weight.requires_grad_(True)
+    inputs = inputs.requires_grad_(True)
+    M._grouped_mm_with_backward_fix(inputs, weight, offsets).sum().backward()
+    assert inputs.grad is not None and torch.isfinite(inputs.grad).all()
+    assert weight.grad is not None and torch.isfinite(weight.grad).all()
+
+
+def test_an_empty_group_is_skipped(unsupported):
+    """A router can leave an expert with no tokens; offsets then repeat."""
+    inputs = torch.randn(4, 8)
+    weight = torch.randn(3, 8, 6)
+    offsets = torch.tensor([0, 4, 4], dtype = torch.int32)
+    out = M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+    torch.testing.assert_close(out, inputs @ weight[1])
+
+
+def test_the_lora_helper_goes_through_the_same_guard(unsupported):
+    """`_apply_lora_grouped_mm` is the call site that actually failed."""
+    inputs = torch.randn(12, 8)
+    lora_B = torch.randn(3, 8, 2)
+    lora_A = torch.randn(3, 2, 6)
+    offsets = torch.tensor([4, 8, 12], dtype = torch.int32)
+    out = M._apply_lora_grouped_mm(inputs, lora_B, lora_A, offsets, 0.5)
+    expected = torch.cat([
+        ((inputs[i * 4:(i + 1) * 4] @ lora_B[i]) @ lora_A[i]) * 0.5
+        for i in range(3)], dim = 0)
+    torch.testing.assert_close(out, expected)
+
+
+def test_a_supported_device_still_uses_the_kernel(monkeypatch):
+    """The guard must not cost H100 users the kernel they do have."""
+    monkeypatch.setattr(M, "_check_torch_grouped_mm_supported", lambda: True)
+    monkeypatch.setattr(M, "_transposed_view_grouped_mm_is_safe", lambda: True)
+    seen = {}
+
+    def _record(x, w, offs = None):
+        seen["called"] = True
+        return torch.cat([
+            x[i * 4:(i + 1) * 4] @ w[i] for i in range(w.shape[0])], dim = 0)
+    monkeypatch.setattr(torch, "_grouped_mm", _record, raising = False)
+
+    inputs, weight, offsets = _case()
+    M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+    assert seen.get("called"), "the guard swallowed a device that is supported"

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -25,9 +25,13 @@ H100 therefore died at the first step:
     RuntimeError: torch._grouped_mm is only supported on CUDA devices with
     compute capability = 9.0
 
-Found on a B200 running `Qwen3_5_MoE.ipynb` under torch 2.8.0, and reachable on
-an A100 the same way. The guard goes in `_grouped_mm_with_backward_fix`, the one
-choke point every LoRA and base path shares.
+Found on a B200 running `Qwen3_5_MoE.ipynb` under torch 2.8.0, whose check is
+`dprops->major == 9` exactly (Blas.cpp, `sm90_only`), so an A100 is refused the
+same way. torch 2.6 and 2.7 have no `_grouped_mm` at all; 2.9 onwards falls back
+inside torch, which is why only the older pins show this.
+
+The guard goes in `_grouped_mm_with_backward_fix`, the one choke point every
+LoRA and base path shares.
 """
 
 import pytest

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -199,3 +199,32 @@ def test_it_survives_non_reentrant_checkpointing(unsupported):
                      inputs, weight, use_reentrant = False)
     out.sum().backward()
     assert inputs.grad is not None and torch.isfinite(inputs.grad).all()
+
+
+def test_the_modulelist_stride_fallback_shares_the_same_helper():
+    """`moe_grouped_modulelist._grouped_mm_fix` had its own copy of the loop.
+
+    Two of its callers put the result on the tape, so the same slice-shaped
+    saved tensors were reachable there through the 16-byte stride error.
+    """
+    from unsloth_zoo.temporary_patches import moe_grouped_modulelist as G
+
+    def _stride_error(*args, **kwargs):
+        raise RuntimeError("strides should be multiple of 16 bytes")
+
+    inputs = torch.randn(12, 8, requires_grad = True)
+    weight = torch.randn(3, 8, 6)
+    offsets = torch.tensor([4, 8, 12], dtype = torch.int32)
+
+    real = getattr(torch, "_grouped_mm", None)
+    torch._grouped_mm = _stride_error
+    try:
+        out = G._grouped_mm_fix(inputs, weight, offsets)
+    finally:
+        if real is None: delattr(torch, "_grouped_mm")
+        else: torch._grouped_mm = real
+
+    saved = out.grad_fn.saved_tensors
+    assert {tuple(t.shape) for t in saved} == {
+        tuple(inputs.shape), tuple(weight.shape), tuple(offsets.shape)}, \
+        [tuple(t.shape) for t in saved]

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -464,3 +464,74 @@ def test_the_norm_does_not_materialize_fp32_copies(unsupported):
     body = inspect.getsource(M._routing_signature)
     assert "vector_norm" in body
     assert "inputs.float() * inputs.float()" not in body
+
+
+# --- the fallback's own cost -------------------------------------------------
+
+
+def _backward_matmul_out_usage(out, seed):
+    """Which of `torch.matmul`'s calls during `out.backward(seed)` passed `out=`.
+
+    Only the in-place branch calls `torch.matmul` by name; the casting branch uses
+    the `@` operator, which does not route through this patch. So an empty record
+    means the casting branch ran.
+    """
+    from unittest import mock
+
+    seen = []
+    real = torch.matmul
+
+    def recording_matmul(a, b, *, out = None):
+        seen.append(out is not None)
+        return real(a, b, out = out) if out is not None else real(a, b)
+
+    with mock.patch.object(torch, "matmul", recording_matmul):
+        out.backward(seed)
+    return seen
+
+
+def test_the_backward_writes_each_group_straight_into_its_slice(unsupported):
+    """Assigning a matmul result allocates a temporary and copies it in, twice per
+    group. `out=` does neither, and the loop is 37% cheaper for it on a 128-expert
+    layer. Pinned on the call, since the gradients below are equal either way."""
+    inputs, weight, offsets = _case()
+    out = M._ManualGroupedMM.apply(
+        inputs.requires_grad_(True), weight.requires_grad_(True), offsets)
+
+    seen = _backward_matmul_out_usage(out, torch.ones_like(out))
+    assert seen and all(seen), seen
+
+
+def test_a_cast_still_takes_the_temporary(unsupported):
+    """`out=` cannot cast, so an autocast forward over fp32 saves has to keep the
+    plain path. Left ungated it raises rather than writing."""
+    inputs, weight, offsets = _case(dtype = torch.float32)
+    inputs.requires_grad_(True)
+    weight.requires_grad_(True)
+    with torch.autocast(device_type = "cpu", dtype = torch.bfloat16):
+        out = M._ManualGroupedMM.apply(inputs, weight, offsets)
+    assert out.dtype == torch.bfloat16
+
+    assert _backward_matmul_out_usage(out, torch.ones_like(out)) == []
+    assert inputs.grad.dtype == torch.float32
+    assert weight.grad.dtype == torch.float32
+
+
+def test_writing_in_place_changes_no_gradient(unsupported):
+    """Bit-exact against the per-expert reference, not merely close."""
+    inputs, weight, offsets = _case(n_experts = 4, rows_each = 3, k = 6, n = 5)
+    x = inputs.detach().clone().requires_grad_(True)
+    w = weight.detach().clone().requires_grad_(True)
+    out = M._ManualGroupedMM.apply(x, w, offsets)
+    out.backward(torch.ones_like(out))
+
+    ref_x = torch.zeros_like(inputs)
+    ref_w = torch.zeros_like(weight)
+    start = 0
+    for expert_idx, end in enumerate(offsets.tolist()):
+        g = torch.ones(end - start, weight.shape[-1], dtype = inputs.dtype)
+        ref_x[start:end] = g @ weight[expert_idx].transpose(-2, -1)
+        ref_w[expert_idx] = inputs[start:end].transpose(-2, -1) @ g
+        start = end
+    assert torch.equal(x.grad, ref_x)
+    assert torch.equal(w.grad, ref_w)

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -518,14 +518,15 @@ def test_a_cast_still_takes_the_temporary(unsupported):
 
 
 def test_writing_in_place_changes_no_gradient(unsupported):
-    """Two references, because one of them cannot be exact everywhere.
+    """Every group's gradient lands in ITS OWN slice, against both reference forms.
 
-    Every group's gradient must land in ITS OWN slice: that is the risk in
-    writing through `out=`, and against a reference written the same way it is
-    bit-exact on any BLAS. Against the allocate-and-assign form it is only
-    numerically equal -- `out=` lets the kernel write the destination directly
-    instead of a fresh contiguous buffer, and the two round differently on some
-    BLAS builds (seen on the ubuntu CPU runner, not on this box or a B200).
+    Closeness, not `torch.equal`: bit-exactness is not portable here. The ubuntu
+    CPU runner disagreed in the last bit against BOTH references, the `out=` one
+    included, while this box and a B200 matched exactly -- `out=` lets the kernel
+    write the destination directly rather than a fresh contiguous buffer, and how
+    that rounds is the BLAS build's business. The bug this guards against is a
+    gradient written into the wrong slice, which moves values by whole
+    magnitudes, so tolerance costs nothing here.
     """
     inputs, weight, offsets = _case(n_experts = 4, rows_each = 3, k = 6, n = 5)
     x = inputs.detach().clone().requires_grad_(True)
@@ -546,8 +547,8 @@ def test_writing_in_place_changes_no_gradient(unsupported):
         assign_w[expert_idx] = inputs[start:end].transpose(-2, -1) @ g
         start = end
 
-    assert torch.equal(x.grad, same_form_x)
-    assert torch.equal(w.grad, same_form_w)
+    torch.testing.assert_close(x.grad, same_form_x)
+    torch.testing.assert_close(w.grad, same_form_w)
     torch.testing.assert_close(x.grad, assign_x)
     torch.testing.assert_close(w.grad, assign_w)
 

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -34,6 +34,8 @@ The guard goes in `_grouped_mm_with_backward_fix`, the one choke point every
 LoRA and base path shares.
 """
 
+from unittest import mock
+
 import pytest
 import torch
 
@@ -241,20 +243,59 @@ def test_a_routing_change_in_the_replay_is_named_not_swallowed(unsupported):
     That is worse than the CheckpointError it replaced, so the forward's own
     boundaries are kept off the tape and compared.
     """
-    class _Ctx:
-        """What checkpointing hands backward: the REPLAY's saved tensors."""
-        needs_input_grad = (True, True, False)
-        def __init__(self, saved, forward_offsets):
-            self.saved_tensors = saved
-            self.forward_offsets = forward_offsets
-
     inputs = torch.randn(12, 8)
     weight = torch.randn(3, 8, 6)
     replayed = torch.tensor([4, 9, 12], dtype = torch.int32)   # one token over
-    ctx = _Ctx((inputs, weight, replayed), [4, 8, 12])
+    ctx = _ReplayCtx(
+        (inputs, weight, replayed),
+        M._routing_signature(inputs, torch.tensor([4, 8, 12], dtype = torch.int32)),
+    )
 
     with pytest.raises(RuntimeError, match = "assigned tokens differently"):
         M._ManualGroupedMM.backward(ctx, torch.ones(12, 6))
+
+
+class _ReplayCtx:
+    """What checkpointing hands backward: the REPLAY's saved tensors."""
+    needs_input_grad = (True, True, False)
+    def __init__(self, saved, forward_routing):
+        self.saved_tensors = saved
+        self.forward_routing = forward_routing
+
+
+def test_a_count_preserving_reshuffle_is_caught_too(unsupported):
+    """Offsets are the routing histogram, not the assignment.
+
+    Swap two tokens between experts of the same size and every boundary is
+    where it was, so a check that compares only offsets waves the replay
+    through and pairs the original `grad_output` with reordered input rows.
+    """
+    inputs = torch.randn(12, 8)
+    weight = torch.randn(3, 8, 6)
+    offsets = torch.tensor([4, 8, 12], dtype = torch.int32)
+    forward = M._routing_signature(inputs, offsets)
+
+    reshuffled = inputs.clone()
+    reshuffled[3], reshuffled[4] = inputs[4].clone(), inputs[3].clone()
+    assert M._routing_signature(reshuffled, offsets) != forward
+
+    ctx = _ReplayCtx((reshuffled, weight, offsets), forward)
+    with pytest.raises(RuntimeError, match = "the same experts in a different order"):
+        M._ManualGroupedMM.backward(ctx, torch.ones(12, 6))
+
+
+def test_the_signature_is_one_device_transfer(unsupported):
+    """The group loop already pays a sync; the checksum must not add another."""
+    offsets = torch.tensor([4, 8, 12], dtype = torch.int32)
+    calls = []
+    real = torch.Tensor.cpu
+    def counting_cpu(self, *a, **k):
+        calls.append(tuple(self.shape))
+        return real(self, *a, **k)
+    with mock.patch.object(torch.Tensor, "cpu", counting_cpu):
+        M._routing_signature(torch.randn(12, 8), offsets)
+    assert len(calls) == 1, calls
+    assert calls[0] == (4,)     # 3 offsets + the checksum, packed together
 
 
 def test_the_real_checkpoint_replay_shape_is_caught(unsupported):

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -382,32 +382,47 @@ def test_a_row_orthogonal_to_the_projection_does_not_collide(unsupported):
         M._routing_signature(after, offsets)
 
 
-def test_no_signature_is_taken_under_inference_mode(unsupported):
-    """Nothing is taped and nothing replays it, so the `[T, hidden]` projection
-    is pure cost there. `no_grad` is deliberately NOT this test: an autograd
-    Function's forward always runs with grad off from the inside, which is
-    where a reentrant checkpoint puts the pass that produces the loss."""
+def test_no_signature_is_taken_when_no_backward_can_run(unsupported):
+    """Grad off means `apply` builds no node, so nothing will ever read the
+    signature and the `[T, hidden]` projection is pure cost. The reentrant
+    checkpoint gap this leaves is documented at the call site: it cannot be
+    closed here, and the stash that tried to close it keyed on a weight the
+    LoRA path rebuilds per call, so it both missed the replay AND pinned a
+    fresh GPU tensor on every no-grad decode step."""
     inputs, weight, offsets = _case()
     taken = []
     real = M._routing_signature
     M._routing_signature = lambda *a, **k: (taken.append(1), real(*a, **k))[1]
     try:
-        with torch.inference_mode():
-            out = M._grouped_mm_with_backward_fix(inputs, weight, offsets)
-        assert not taken, "signature taken under inference mode"
-        assert out.shape == (inputs.shape[0], weight.shape[-1])
+        for ctx in (torch.inference_mode(), torch.no_grad()):
+            taken.clear()
+            with ctx:
+                out = M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+            assert not taken, f"signature taken under {type(ctx).__name__}"
+            assert out.shape == (inputs.shape[0], weight.shape[-1])
 
-        with torch.no_grad():
-            M._grouped_mm_with_backward_fix(inputs, weight, offsets)
-        assert taken, "signature skipped with grad off, where reentrant replay needs it"
-
-        taken.clear()
         M._grouped_mm_with_backward_fix(
             inputs.clone().requires_grad_(True), weight, offsets)
         assert taken, "signature skipped with grad ON"
     finally:
         M._routing_signature = real
-        M._REENTRANT_ROUTING.clear()
+
+
+def test_no_grad_decoding_retains_nothing(unsupported):
+    """The stash that was here held a strong reference to each `weight`, and
+    the PEFT extraction path hands over a FRESH contiguous tensor per call, so
+    a long generation accumulated live GPU tensors until a cap it might never
+    reach. Nothing module-level may grow across grad-off calls."""
+    import gc
+
+    inputs, _, offsets = _case()
+    before = sum(1 for o in gc.get_objects() if torch.is_tensor(o))
+    with torch.no_grad():
+        for _ in range(50):
+            M._grouped_mm_with_backward_fix(inputs, torch.randn(3, 8, 6), offsets)
+    gc.collect()
+    after = sum(1 for o in gc.get_objects() if torch.is_tensor(o))
+    assert after - before < 20, f"grad-off calls retained {after - before} tensors"
 
 
 def test_the_signature_carries_a_term_the_projections_cannot_reach(unsupported):
@@ -451,97 +466,6 @@ def test_the_forward_does_not_sync_the_offsets_twice(unsupported):
     with mock.patch.object(torch.Tensor, "cpu", counting_cpu):
         M._ManualGroupedMM.apply(inputs.requires_grad_(True), weight, offsets)
     assert len(calls) == 1, calls
-
-
-# ── the reentrant checkpoint's forward, which no ctx can reach ───────────────
-
-
-@pytest.fixture(autouse = True)
-def _clean_reentrant_stash():
-    M._REENTRANT_ROUTING.clear()
-    M._REENTRANT_SAW_GRAD = False
-    yield
-    M._REENTRANT_ROUTING.clear()
-    M._REENTRANT_SAW_GRAD = False
-
-
-def _reentrant_step(inputs, weight, offsets, replay_offsets):
-    """What `unsloth_checkpoint` does: run the segment with grad OFF for the
-    loss, then re-run it with grad ON inside backward and differentiate that."""
-    with torch.no_grad():
-        M._grouped_mm_with_backward_fix(inputs, weight, offsets)
-    replay_in = inputs.clone().requires_grad_(True)
-    out = M._grouped_mm_with_backward_fix(replay_in, weight, replay_offsets)
-    out.sum().backward()
-    return replay_in.grad
-
-
-def test_a_reentrant_replay_that_reroutes_is_caught(unsupported):
-    """The gap Codex found: grad is off in the pass that produces the loss, so
-    `apply` builds no node and the ctx is discarded. The replay then made a
-    fresh ctx and compared its own routing against itself, which always passed
-    -- and the gradients belonged to a routing that never produced the loss."""
-    inputs, weight, offsets = _case()
-    moved = torch.tensor([5, 8, 12], dtype = torch.int32)  # one row across a boundary
-    with pytest.raises(RuntimeError, match = "assigned tokens differently"):
-        _reentrant_step(inputs, weight, offsets, moved)
-
-
-def test_a_reentrant_replay_that_agrees_is_left_alone(unsupported):
-    """The control: same routing both passes, so nothing is raised and the
-    gradients are the replay's own."""
-    inputs, weight, offsets = _case()
-    grad = _reentrant_step(inputs, weight, offsets, offsets)
-    assert grad is not None and grad.shape == inputs.shape
-
-
-def test_a_weight_used_twice_before_its_replay_disables_the_check(unsupported):
-    """Two records under one key have no unambiguous answer, so the check steps
-    aside rather than compare a replay against the wrong forward and raise on a
-    run that is working."""
-    inputs, weight, offsets = _case()
-    other = torch.tensor([5, 8, 12], dtype = torch.int32)
-    with torch.no_grad():
-        M._grouped_mm_with_backward_fix(inputs, weight, offsets)
-        M._grouped_mm_with_backward_fix(inputs, weight, other)
-    replay_in = inputs.clone().requires_grad_(True)
-    M._grouped_mm_with_backward_fix(replay_in, weight, offsets).sum().backward()
-    assert replay_in.grad is not None
-
-
-def test_an_eval_pass_does_not_poison_the_next_step(unsupported):
-    """Grad-off calls whose backward never came would otherwise sit in the stash
-    and be consumed by a later replay, raising on a healthy run. The first
-    record after any grad-enabled call clears what is left."""
-    inputs, weight, offsets = _case()
-    other = torch.tensor([5, 8, 12], dtype = torch.int32)
-    with torch.no_grad():  # an eval forward, routed differently, never replayed
-        M._grouped_mm_with_backward_fix(inputs, weight, other)
-    # A grad-enabled call: end of that generation.
-    M._grouped_mm_with_backward_fix(
-        inputs.clone().requires_grad_(True), weight, offsets)
-    grad = _reentrant_step(inputs, weight, offsets, offsets)
-    assert grad is not None, "a stale eval routing raised on a matching step"
-
-
-def test_the_stash_does_not_grow_without_bound(unsupported):
-    """One entry per weight, and a ceiling: a long grad-off run with no replay
-    must not accumulate a reference to every weight it ever saw."""
-    inputs, _, offsets = _case()
-    with torch.no_grad():
-        for _ in range(M._REENTRANT_ROUTING_LIMIT + 20):
-            weight = torch.randn(3, 8, 6)
-            M._grouped_mm_with_backward_fix(inputs, weight, offsets)
-    assert len(M._REENTRANT_ROUTING) <= M._REENTRANT_ROUTING_LIMIT
-
-
-def test_inference_mode_records_nothing(unsupported):
-    """Nothing replays an inference forward, so it must not leave an entry for a
-    later training replay to consume."""
-    inputs, weight, offsets = _case()
-    with torch.inference_mode():
-        M._grouped_mm_with_backward_fix(inputs, weight, offsets)
-    assert not M._REENTRANT_ROUTING
 
 
 def test_the_norm_does_not_materialize_fp32_copies(unsupported):

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -382,31 +382,38 @@ def test_a_row_orthogonal_to_the_projection_does_not_collide(unsupported):
         M._routing_signature(after, offsets)
 
 
-def test_no_signature_is_taken_when_no_backward_can_run(unsupported):
-    """Under `no_grad` nothing will ever read it, and the cost is a whole
-    `[T, hidden]` projection plus a SYNCHRONOUS device-to-host copy per call --
-    which for the low-rank LoRA matmuls can outweigh the GEMM it guards."""
+def test_no_signature_is_taken_under_inference_mode(unsupported):
+    """Nothing is taped and nothing replays it, so the `[T, hidden]` projection
+    is pure cost there. `no_grad` is deliberately NOT this test: an autograd
+    Function's forward always runs with grad off from the inside, which is
+    where a reentrant checkpoint puts the pass that produces the loss."""
     inputs, weight, offsets = _case()
     taken = []
     real = M._routing_signature
     M._routing_signature = lambda *a, **k: (taken.append(1), real(*a, **k))[1]
     try:
-        with torch.no_grad():
+        with torch.inference_mode():
             out = M._grouped_mm_with_backward_fix(inputs, weight, offsets)
-        assert not taken, "signature taken with grad off"
+        assert not taken, "signature taken under inference mode"
         assert out.shape == (inputs.shape[0], weight.shape[-1])
 
+        with torch.no_grad():
+            M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+        assert taken, "signature skipped with grad off, where reentrant replay needs it"
+
+        taken.clear()
         M._grouped_mm_with_backward_fix(
             inputs.clone().requires_grad_(True), weight, offsets)
         assert taken, "signature skipped with grad ON"
     finally:
         M._routing_signature = real
+        M._REENTRANT_ROUTING.clear()
 
 
 def test_the_signature_carries_a_term_the_projections_cannot_reach(unsupported):
     """Four projections leave a common null space of dimension `hidden - 4`, so
-    two rows differing by a vector in it project alike. The squared norm is not
-    linear in the row, so it does not share that null space.
+    two rows differing by a vector in it project alike. The norm is not linear
+    in the row, so it does not share that null space.
 
     Asserted structurally rather than by constructing a colliding pair: an exact
     null-space vector is not representable in the float32 the signature uses, so
@@ -444,3 +451,105 @@ def test_the_forward_does_not_sync_the_offsets_twice(unsupported):
     with mock.patch.object(torch.Tensor, "cpu", counting_cpu):
         M._ManualGroupedMM.apply(inputs.requires_grad_(True), weight, offsets)
     assert len(calls) == 1, calls
+
+
+# ── the reentrant checkpoint's forward, which no ctx can reach ───────────────
+
+
+@pytest.fixture(autouse = True)
+def _clean_reentrant_stash():
+    M._REENTRANT_ROUTING.clear()
+    M._REENTRANT_SAW_GRAD = False
+    yield
+    M._REENTRANT_ROUTING.clear()
+    M._REENTRANT_SAW_GRAD = False
+
+
+def _reentrant_step(inputs, weight, offsets, replay_offsets):
+    """What `unsloth_checkpoint` does: run the segment with grad OFF for the
+    loss, then re-run it with grad ON inside backward and differentiate that."""
+    with torch.no_grad():
+        M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+    replay_in = inputs.clone().requires_grad_(True)
+    out = M._grouped_mm_with_backward_fix(replay_in, weight, replay_offsets)
+    out.sum().backward()
+    return replay_in.grad
+
+
+def test_a_reentrant_replay_that_reroutes_is_caught(unsupported):
+    """The gap Codex found: grad is off in the pass that produces the loss, so
+    `apply` builds no node and the ctx is discarded. The replay then made a
+    fresh ctx and compared its own routing against itself, which always passed
+    -- and the gradients belonged to a routing that never produced the loss."""
+    inputs, weight, offsets = _case()
+    moved = torch.tensor([5, 8, 12], dtype = torch.int32)  # one row across a boundary
+    with pytest.raises(RuntimeError, match = "assigned tokens differently"):
+        _reentrant_step(inputs, weight, offsets, moved)
+
+
+def test_a_reentrant_replay_that_agrees_is_left_alone(unsupported):
+    """The control: same routing both passes, so nothing is raised and the
+    gradients are the replay's own."""
+    inputs, weight, offsets = _case()
+    grad = _reentrant_step(inputs, weight, offsets, offsets)
+    assert grad is not None and grad.shape == inputs.shape
+
+
+def test_a_weight_used_twice_before_its_replay_disables_the_check(unsupported):
+    """Two records under one key have no unambiguous answer, so the check steps
+    aside rather than compare a replay against the wrong forward and raise on a
+    run that is working."""
+    inputs, weight, offsets = _case()
+    other = torch.tensor([5, 8, 12], dtype = torch.int32)
+    with torch.no_grad():
+        M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+        M._grouped_mm_with_backward_fix(inputs, weight, other)
+    replay_in = inputs.clone().requires_grad_(True)
+    M._grouped_mm_with_backward_fix(replay_in, weight, offsets).sum().backward()
+    assert replay_in.grad is not None
+
+
+def test_an_eval_pass_does_not_poison_the_next_step(unsupported):
+    """Grad-off calls whose backward never came would otherwise sit in the stash
+    and be consumed by a later replay, raising on a healthy run. The first
+    record after any grad-enabled call clears what is left."""
+    inputs, weight, offsets = _case()
+    other = torch.tensor([5, 8, 12], dtype = torch.int32)
+    with torch.no_grad():  # an eval forward, routed differently, never replayed
+        M._grouped_mm_with_backward_fix(inputs, weight, other)
+    # A grad-enabled call: end of that generation.
+    M._grouped_mm_with_backward_fix(
+        inputs.clone().requires_grad_(True), weight, offsets)
+    grad = _reentrant_step(inputs, weight, offsets, offsets)
+    assert grad is not None, "a stale eval routing raised on a matching step"
+
+
+def test_the_stash_does_not_grow_without_bound(unsupported):
+    """One entry per weight, and a ceiling: a long grad-off run with no replay
+    must not accumulate a reference to every weight it ever saw."""
+    inputs, _, offsets = _case()
+    with torch.no_grad():
+        for _ in range(M._REENTRANT_ROUTING_LIMIT + 20):
+            weight = torch.randn(3, 8, 6)
+            M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+    assert len(M._REENTRANT_ROUTING) <= M._REENTRANT_ROUTING_LIMIT
+
+
+def test_inference_mode_records_nothing(unsupported):
+    """Nothing replays an inference forward, so it must not leave an entry for a
+    later training replay to consume."""
+    inputs, weight, offsets = _case()
+    with torch.inference_mode():
+        M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+    assert not M._REENTRANT_ROUTING
+
+
+def test_the_norm_does_not_materialize_fp32_copies(unsupported):
+    """`(x.float() * x.float()).sum(...)` held two fp32 copies and their product
+    at once. Asserted on the source, since the temporaries are freed before any
+    allocator snapshot a CPU test could take."""
+    import inspect
+
+    body = inspect.getsource(M._routing_signature)
+    assert "vector_norm" in body
+    assert "inputs.float() * inputs.float()" not in body

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -401,3 +401,46 @@ def test_no_signature_is_taken_when_no_backward_can_run(unsupported):
         assert taken, "signature skipped with grad ON"
     finally:
         M._routing_signature = real
+
+
+def test_the_signature_carries_a_term_the_projections_cannot_reach(unsupported):
+    """Four projections leave a common null space of dimension `hidden - 4`, so
+    two rows differing by a vector in it project alike. The squared norm is not
+    linear in the row, so it does not share that null space.
+
+    Asserted structurally rather than by constructing a colliding pair: an exact
+    null-space vector is not representable in the float32 the signature uses, so
+    such a pair separates on rounding noise and the test would pass against a
+    projections-only signature too. What can be checked is that the extra term is
+    there, is the norm, and reaches the packed output.
+    """
+    assert M._SIGNATURE_EXTRA == 1
+    assert M._SIGNATURE_WIDTH == len(M._SIGNATURE_STRIDES) + M._SIGNATURE_EXTRA
+
+    offsets = torch.tensor([2], dtype = torch.int32)
+    hidden = 8
+    # Same direction, different length: the norm separates them on magnitude,
+    # which no linear projection of a single row can be relied on to do once the
+    # row lies in the shared null space.
+    unit = torch.zeros(2, hidden); unit[0, 0] = 1.0; unit[1, 0] = 1.0
+    scaled = unit.clone(); scaled[1, 0] = 4.0
+    assert M._routing_signature(unit, offsets) != \
+        M._routing_signature(scaled, offsets)
+
+    packed = M._routing_signature(unit, offsets)
+    assert len(packed) == 1 + M._SIGNATURE_WIDTH
+
+
+def test_the_forward_does_not_sync_the_offsets_twice(unsupported):
+    """`_routing_signature` packs the offsets into its own single transfer, so
+    re-reading them in the group loop was a second stream synchronization per
+    grouped matmul, multiplied over every layer's base and LoRA projections."""
+    inputs, weight, offsets = _case()
+    calls = []
+    real = torch.Tensor.cpu
+    def counting_cpu(self, *a, **k):
+        calls.append(tuple(self.shape))
+        return real(self, *a, **k)
+    with mock.patch.object(torch.Tensor, "cpu", counting_cpu):
+        M._ManualGroupedMM.apply(inputs.requires_grad_(True), weight, offsets)
+    assert len(calls) == 1, calls

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -16,22 +16,20 @@
 
 """A device without torch._grouped_mm must not reach torch._grouped_mm.
 
-`select_moe_backend` already falls to `unsloth_triton` when the probe says the
-kernel is unsupported, but `forward_triton_grouped_gemm` applied its separated
-LoRA delta through `native_moe_grouped_mm`, which calls the primitive the
-backend was chosen to avoid. Training a LoRA MoE on anything that is not an
-H100 therefore died at the first step:
+`select_moe_backend` already falls to `unsloth_triton` when the probe says the kernel
+is unsupported, but `forward_triton_grouped_gemm` applied its separated LoRA delta
+through `native_moe_grouped_mm`, which calls the primitive the backend was chosen to
+avoid, so a LoRA MoE off an H100 died at the first step:
 
     RuntimeError: torch._grouped_mm is only supported on CUDA devices with
     compute capability = 9.0
 
-Found on a B200 running `Qwen3_5_MoE.ipynb` under torch 2.8.0, whose check is
-`dprops->major == 9` exactly (Blas.cpp, `sm90_only`), so an A100 is refused the
-same way. torch 2.6 and 2.7 have no `_grouped_mm` at all; 2.9 onwards falls back
-inside torch, which is why only the older pins show this.
+Found on a B200 under torch 2.8.0, whose check is `dprops->major == 9` exactly
+(Blas.cpp, `sm90_only`), so an A100 is refused the same way. 2.6/2.7 have no
+`_grouped_mm`; 2.9 falls back inside torch, which is why only older pins show this.
 
-The guard goes in `_grouped_mm_with_backward_fix`, the one choke point every
-LoRA and base path shares.
+The guard goes in `_grouped_mm_with_backward_fix`, the choke point every LoRA and
+base path shares.
 """
 
 from unittest import mock
@@ -173,14 +171,14 @@ def test_an_empty_group_contributes_no_gradient(unsupported):
 
 
 def test_it_saves_only_shape_stable_tensors(unsupported):
-    """The whole point. A per-group slice's shape is the group size, which the
-    router decides, so saving slices made non-reentrant checkpointing compare
-    metadata across two different routings and abort the backward:
+    """The whole point. A slice's shape is the router-decided group size, so saving
+    slices made non-reentrant checkpointing compare metadata across two routings and
+    abort the backward:
 
         CheckpointError: saved torch.Size([38, 8]) recomputed torch.Size([39, 8])
 
-    Qwen3_5_MoE on a B200 died exactly there once the capability guard let it
-    reach training. Saved shapes must depend on nothing but the inputs.
+    Qwen3_5_MoE on a B200 died exactly there once the capability guard let it reach
+    training. Saved shapes must depend on nothing but the inputs.
     """
     inputs, weight, offsets = _case()
     inputs = inputs.requires_grad_(True)
@@ -204,11 +202,9 @@ def test_it_survives_non_reentrant_checkpointing(unsupported):
 
 
 def test_the_modulelist_stride_fallback_shares_the_same_helper():
-    """`moe_grouped_modulelist._grouped_mm_fix` had its own copy of the loop.
-
-    Two of its callers put the result on the tape, so the same slice-shaped
-    saved tensors were reachable there through the 16-byte stride error.
-    """
+    """`moe_grouped_modulelist._grouped_mm_fix` had its own copy of the loop, and two
+    of its callers tape the result, so the same slice-shaped saved tensors were
+    reachable there through the 16-byte stride error."""
     from unsloth_zoo.temporary_patches import moe_grouped_modulelist as G
 
     def _stride_error(*args, **kwargs):
@@ -237,11 +233,11 @@ def test_the_modulelist_stride_fallback_shares_the_same_helper():
 def test_a_routing_change_in_the_replay_is_named_not_swallowed(unsupported):
     """Shape-stable saves are parity with the fused op, not permission to lie.
 
-    Non-reentrant checkpointing replaces the SAVED tensors with the replay's,
-    so a backward that just uses them pairs the original `grad_output` with the
-    replay's partition: a gradient for a routing that never produced the loss.
-    That is worse than the CheckpointError it replaced, so the forward's own
-    boundaries are kept off the tape and compared.
+    Non-reentrant checkpointing replaces the SAVED tensors with the replay's, so a
+    backward that just uses them pairs the original `grad_output` with the replay's
+    partition: a gradient for a routing that never produced the loss, worse than the
+    CheckpointError it replaced. So the forward's own boundaries are kept off the tape
+    and compared.
     """
     inputs = torch.randn(12, 8)
     weight = torch.randn(3, 8, 6)
@@ -264,12 +260,9 @@ class _ReplayCtx:
 
 
 def test_a_count_preserving_reshuffle_is_caught_too(unsupported):
-    """Offsets are the routing histogram, not the assignment.
-
-    Swap two tokens between experts of the same size and every boundary is
-    where it was, so a check that compares only offsets waves the replay
-    through and pairs the original `grad_output` with reordered input rows.
-    """
+    """Offsets are the routing histogram, not the assignment: swap two tokens between
+    equal-sized experts and every boundary is where it was, so an offsets-only check
+    waves the replay through and pairs `grad_output` with reordered input rows."""
     inputs = torch.randn(12, 8)
     weight = torch.randn(3, 8, 6)
     offsets = torch.tensor([4, 8, 12], dtype = torch.int32)
@@ -326,9 +319,8 @@ def test_the_same_routing_twice_is_not_flagged(unsupported):
 
 
 def test_backward_survives_a_reduced_precision_grad_output(unsupported):
-    """`Function.backward` runs OUTSIDE the forward's autocast region, so a
-    forward that autocast fp32 weights to bf16 hands back a bf16 grad_output
-    while the saved tensors are still fp32. Unaligned, the first matmul raises."""
+    """`Function.backward` runs OUTSIDE the forward's autocast, so grad_output can be
+    bf16 while the saved tensors are still fp32. Unaligned, the first matmul raises."""
     inputs = torch.randn(8, 4, dtype = torch.float32, requires_grad = True)
     weight = torch.randn(2, 4, 6, dtype = torch.float32, requires_grad = True)
     offsets = torch.tensor([4, 8], dtype = torch.int32)
@@ -350,11 +342,9 @@ def test_it_is_marked_as_not_compilable():
 
 
 def test_the_signature_ignores_autocast(unsupported):
-    """`mv`/`mm` are on the autocast lower-precision list, and only one of the
-    two calls sees it: the forward runs inside `Function.forward` with the
-    caller's autocast live, the backward runs with autocast disabled. FP32
-    inputs under autocast hashed in bf16 one side and fp32 the other, so every
-    backward raised the routing error on routing that had not changed."""
+    """`mv`/`mm` are on the autocast lower-precision list and only the forward sees it
+    (backward runs with autocast disabled), so FP32 inputs hashed bf16 one side and
+    fp32 the other and every backward raised the routing error on unchanged routing."""
     inputs = torch.randn(12, 8, dtype = torch.float32)
     offsets = torch.tensor([4, 8, 12], dtype = torch.int32)
 
@@ -365,9 +355,9 @@ def test_the_signature_ignores_autocast(unsupported):
 
 
 def test_a_row_orthogonal_to_the_projection_does_not_collide(unsupported):
-    """One dot product per row maps it to a scalar, so every row orthogonal to
-    the projection hashes like the zero row. Swapping such a pair across an
-    expert boundary is a routing change the check has to see."""
+    """One dot product per row maps it to a scalar, so every row orthogonal to the
+    projection hashes like the zero row; swapping such a pair across an expert boundary
+    is a routing change the check has to see."""
     hidden = 8
     ramp = torch.linspace(1.0, 2.0, hidden, dtype = torch.float32)
     p = torch.sin(ramp * M._SIGNATURE_STRIDES[0])
@@ -383,12 +373,11 @@ def test_a_row_orthogonal_to_the_projection_does_not_collide(unsupported):
 
 
 def test_no_signature_is_taken_when_no_backward_can_run(unsupported):
-    """Grad off means `apply` builds no node, so nothing will ever read the
-    signature and the `[T, hidden]` projection is pure cost. The reentrant
-    checkpoint gap this leaves is documented at the call site: it cannot be
-    closed here, and the stash that tried to close it keyed on a weight the
-    LoRA path rebuilds per call, so it both missed the replay AND pinned a
-    fresh GPU tensor on every no-grad decode step."""
+    """Grad off means `apply` builds no node, so nothing will ever read the signature
+    and the `[T, hidden]` projection is pure cost. The reentrant-checkpoint gap this
+    leaves is documented at the call site: the stash that tried to close it keyed on a
+    weight the LoRA path rebuilds per call, so it missed the replay AND pinned a fresh
+    GPU tensor on every no-grad decode step."""
     inputs, weight, offsets = _case()
     taken = []
     real = M._routing_signature
@@ -409,10 +398,9 @@ def test_no_signature_is_taken_when_no_backward_can_run(unsupported):
 
 
 def test_no_grad_decoding_retains_nothing(unsupported):
-    """The stash that was here held a strong reference to each `weight`, and
-    the PEFT extraction path hands over a FRESH contiguous tensor per call, so
-    a long generation accumulated live GPU tensors until a cap it might never
-    reach. Nothing module-level may grow across grad-off calls."""
+    """The stash that was here held a strong reference to each `weight`, and the PEFT
+    extraction path hands over a FRESH contiguous tensor per call, so a long generation
+    accumulated live GPU tensors. Nothing module-level may grow across grad-off calls."""
     import gc
 
     inputs, _, offsets = _case()
@@ -426,24 +414,23 @@ def test_no_grad_decoding_retains_nothing(unsupported):
 
 
 def test_the_signature_carries_a_term_the_projections_cannot_reach(unsupported):
-    """Four projections leave a common null space of dimension `hidden - 4`, so
-    two rows differing by a vector in it project alike. The norm is not linear
-    in the row, so it does not share that null space.
+    """Four projections leave a common `hidden - 4` null space, so two rows differing
+    by a vector in it project alike. The norm is not linear in the row, so it does not
+    share that null space.
 
-    Asserted structurally rather than by constructing a colliding pair: an exact
-    null-space vector is not representable in the float32 the signature uses, so
-    such a pair separates on rounding noise and the test would pass against a
-    projections-only signature too. What can be checked is that the extra term is
-    there, is the norm, and reaches the packed output.
+    Asserted structurally, not by constructing a colliding pair: an exact null-space
+    vector is not representable in the float32 the signature uses, so such a pair
+    separates on rounding noise and the test would pass against a projections-only
+    signature too. What can be checked is that the extra term is there, is the norm,
+    and reaches the packed output.
     """
     assert M._SIGNATURE_EXTRA == 1
     assert M._SIGNATURE_WIDTH == len(M._SIGNATURE_STRIDES) + M._SIGNATURE_EXTRA
 
     offsets = torch.tensor([2], dtype = torch.int32)
     hidden = 8
-    # Same direction, different length: the norm separates them on magnitude,
-    # which no linear projection of a single row can be relied on to do once the
-    # row lies in the shared null space.
+    # Same direction, different length: the norm separates them on magnitude, which no
+    # linear projection can be relied on to do inside the shared null space.
     unit = torch.zeros(2, hidden); unit[0, 0] = 1.0; unit[1, 0] = 1.0
     scaled = unit.clone(); scaled[1, 0] = 4.0
     assert M._routing_signature(unit, offsets) != \
@@ -454,9 +441,9 @@ def test_the_signature_carries_a_term_the_projections_cannot_reach(unsupported):
 
 
 def test_the_forward_does_not_sync_the_offsets_twice(unsupported):
-    """`_routing_signature` packs the offsets into its own single transfer, so
-    re-reading them in the group loop was a second stream synchronization per
-    grouped matmul, multiplied over every layer's base and LoRA projections."""
+    """`_routing_signature` packs the offsets into its own transfer, so re-reading them
+    in the group loop was a second stream sync per grouped matmul, over every layer's
+    base and LoRA projections."""
     inputs, weight, offsets = _case()
     calls = []
     real = torch.Tensor.cpu
@@ -469,9 +456,9 @@ def test_the_forward_does_not_sync_the_offsets_twice(unsupported):
 
 
 def test_the_norm_does_not_materialize_fp32_copies(unsupported):
-    """`(x.float() * x.float()).sum(...)` held two fp32 copies and their product
-    at once. Asserted on the source, since the temporaries are freed before any
-    allocator snapshot a CPU test could take."""
+    """`(x.float() * x.float()).sum(...)` held two fp32 copies and their product at
+    once. Asserted on the source: the temporaries are freed before any allocator
+    snapshot a CPU test could take."""
     import inspect
 
     body = inspect.getsource(M._routing_signature)

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -535,3 +535,39 @@ def test_writing_in_place_changes_no_gradient(unsupported):
         start = end
     assert torch.equal(x.grad, ref_x)
     assert torch.equal(w.grad, ref_w)
+
+
+def test_higher_order_gradients_still_work(unsupported):
+    """`out=` refuses autograd, so the in-place write has to stand down when the
+    backward itself is being differentiated. `torch._grouped_mm` double-backwards
+    on a supported device (checked on a B200, torch 2.9.1), so a fallback that
+    raised there would make the answer depend on the card."""
+    inputs, weight, offsets = _case()
+    x = inputs.detach().clone().requires_grad_(True)
+    w = weight.detach().clone().requires_grad_(True)
+    out = M._ManualGroupedMM.apply(x, w, offsets)
+    (grad_x,) = torch.autograd.grad(out.sum(), x, create_graph = True)
+    (second,) = torch.autograd.grad(grad_x.sum(), w)
+
+    # Same quantity off plain autograd over the per-group loop.
+    rx = inputs.detach().clone().requires_grad_(True)
+    rw = weight.detach().clone().requires_grad_(True)
+    parts, start = [], 0
+    for expert_idx, end in enumerate(offsets.tolist()):
+        parts.append(rx[start:end] @ rw[expert_idx])
+        start = end
+    (ref_grad_x,) = torch.autograd.grad(
+        torch.cat(parts, 0).sum(), rx, create_graph = True)
+    (ref_second,) = torch.autograd.grad(ref_grad_x.sum(), rw)
+    torch.testing.assert_close(second, ref_second)
+
+
+def test_an_ordinary_backward_still_writes_in_place(unsupported):
+    """The guard above must not cost the common case: the engine runs a plain
+    backward with grad mode off, so `out=` still applies."""
+    inputs, weight, offsets = _case()
+    out = M._ManualGroupedMM.apply(
+        inputs.requires_grad_(True), weight.requires_grad_(True), offsets)
+    assert torch.is_grad_enabled()          # the caller's mode is irrelevant
+    seen = _backward_matmul_out_usage(out, torch.ones_like(out))
+    assert seen and all(seen), seen

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -518,23 +518,38 @@ def test_a_cast_still_takes_the_temporary(unsupported):
 
 
 def test_writing_in_place_changes_no_gradient(unsupported):
-    """Bit-exact against the per-expert reference, not merely close."""
+    """Two references, because one of them cannot be exact everywhere.
+
+    Every group's gradient must land in ITS OWN slice: that is the risk in
+    writing through `out=`, and against a reference written the same way it is
+    bit-exact on any BLAS. Against the allocate-and-assign form it is only
+    numerically equal -- `out=` lets the kernel write the destination directly
+    instead of a fresh contiguous buffer, and the two round differently on some
+    BLAS builds (seen on the ubuntu CPU runner, not on this box or a B200).
+    """
     inputs, weight, offsets = _case(n_experts = 4, rows_each = 3, k = 6, n = 5)
     x = inputs.detach().clone().requires_grad_(True)
     w = weight.detach().clone().requires_grad_(True)
     out = M._ManualGroupedMM.apply(x, w, offsets)
     out.backward(torch.ones_like(out))
 
-    ref_x = torch.zeros_like(inputs)
-    ref_w = torch.zeros_like(weight)
+    same_form_x, same_form_w = torch.zeros_like(inputs), torch.zeros_like(weight)
+    assign_x, assign_w = torch.zeros_like(inputs), torch.zeros_like(weight)
     start = 0
     for expert_idx, end in enumerate(offsets.tolist()):
         g = torch.ones(end - start, weight.shape[-1], dtype = inputs.dtype)
-        ref_x[start:end] = g @ weight[expert_idx].transpose(-2, -1)
-        ref_w[expert_idx] = inputs[start:end].transpose(-2, -1) @ g
+        torch.matmul(g, weight[expert_idx].transpose(-2, -1),
+                     out = same_form_x[start:end])
+        torch.matmul(inputs[start:end].transpose(-2, -1), g,
+                     out = same_form_w[expert_idx])
+        assign_x[start:end] = g @ weight[expert_idx].transpose(-2, -1)
+        assign_w[expert_idx] = inputs[start:end].transpose(-2, -1) @ g
         start = end
-    assert torch.equal(x.grad, ref_x)
-    assert torch.equal(w.grad, ref_w)
+
+    assert torch.equal(x.grad, same_form_x)
+    assert torch.equal(w.grad, same_form_w)
+    torch.testing.assert_close(x.grad, assign_x)
+    torch.testing.assert_close(w.grad, assign_w)
 
 
 def test_higher_order_gradients_still_work(unsupported):

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -295,7 +295,8 @@ def test_the_signature_is_one_device_transfer(unsupported):
     with mock.patch.object(torch.Tensor, "cpu", counting_cpu):
         M._routing_signature(torch.randn(12, 8), offsets)
     assert len(calls) == 1, calls
-    assert calls[0] == (4,)     # 3 offsets + the checksum, packed together
+    # 3 offsets + one checksum int per projection, packed into one transfer.
+    assert calls[0] == (3 + M._SIGNATURE_WIDTH,)
 
 
 def test_the_real_checkpoint_replay_shape_is_caught(unsupported):
@@ -346,3 +347,57 @@ def test_it_is_marked_as_not_compilable():
     assert getattr(M._manual_grouped_mm, "_torchdynamo_disable", False) or \
         "disable" in type(M._manual_grouped_mm).__name__.lower() or \
         hasattr(M._manual_grouped_mm, "__wrapped__"), M._manual_grouped_mm
+
+
+def test_the_signature_ignores_autocast(unsupported):
+    """`mv`/`mm` are on the autocast lower-precision list, and only one of the
+    two calls sees it: the forward runs inside `Function.forward` with the
+    caller's autocast live, the backward runs with autocast disabled. FP32
+    inputs under autocast hashed in bf16 one side and fp32 the other, so every
+    backward raised the routing error on routing that had not changed."""
+    inputs = torch.randn(12, 8, dtype = torch.float32)
+    offsets = torch.tensor([4, 8, 12], dtype = torch.int32)
+
+    plain = M._routing_signature(inputs, offsets)
+    with torch.autocast(device_type = "cpu", dtype = torch.bfloat16):
+        under = M._routing_signature(inputs, offsets)
+    assert under == plain
+
+
+def test_a_row_orthogonal_to_the_projection_does_not_collide(unsupported):
+    """One dot product per row maps it to a scalar, so every row orthogonal to
+    the projection hashes like the zero row. Swapping such a pair across an
+    expert boundary is a routing change the check has to see."""
+    hidden = 8
+    ramp = torch.linspace(1.0, 2.0, hidden, dtype = torch.float32)
+    p = torch.sin(ramp * M._SIGNATURE_STRIDES[0])
+    orthogonal = torch.zeros(hidden)
+    orthogonal[0], orthogonal[1] = p[1], -p[0]
+    assert torch.isclose(orthogonal.dot(p), torch.tensor(0.0), atol = 1e-6)
+
+    offsets = torch.tensor([1, 2], dtype = torch.int32)
+    before = torch.stack([orthogonal, torch.zeros(hidden)])
+    after = torch.stack([torch.zeros(hidden), orthogonal])
+    assert M._routing_signature(before, offsets) != \
+        M._routing_signature(after, offsets)
+
+
+def test_no_signature_is_taken_when_no_backward_can_run(unsupported):
+    """Under `no_grad` nothing will ever read it, and the cost is a whole
+    `[T, hidden]` projection plus a SYNCHRONOUS device-to-host copy per call --
+    which for the low-rank LoRA matmuls can outweigh the GEMM it guards."""
+    inputs, weight, offsets = _case()
+    taken = []
+    real = M._routing_signature
+    M._routing_signature = lambda *a, **k: (taken.append(1), real(*a, **k))[1]
+    try:
+        with torch.no_grad():
+            out = M._grouped_mm_with_backward_fix(inputs, weight, offsets)
+        assert not taken, "signature taken with grad off"
+        assert out.shape == (inputs.shape[0], weight.shape[-1])
+
+        M._grouped_mm_with_backward_fix(
+            inputs.clone().requires_grad_(True), weight, offsets)
+        assert taken, "signature skipped with grad ON"
+    finally:
+        M._routing_signature = real

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -88,10 +88,9 @@ def _grouped_mm_fix(x: torch.Tensor, w: torch.Tensor, offs: torch.Tensor) -> tor
     except RuntimeError as e:
         if "strides should be multiple of 16 bytes" not in str(e):
             raise
-        # Shared with moe_utils rather than looped here: a loop puts every
-        # per-group SLICE on the tape, and a slice's shape is the group size, so
-        # non-reentrant checkpointing compares two routings and aborts the
-        # backward. Two callers are on the tape, so the hazard is reachable.
+        # Shared with moe_utils, not looped here: a loop tapes every per-group SLICE,
+        # whose shape is the router-decided group size, so non-reentrant checkpointing
+        # aborts the backward. Two callers tape this, so the hazard is reachable.
         try:
             from .moe_utils import _manual_grouped_mm
         except Exception:

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -88,12 +88,10 @@ def _grouped_mm_fix(x: torch.Tensor, w: torch.Tensor, offs: torch.Tensor) -> tor
     except RuntimeError as e:
         if "strides should be multiple of 16 bytes" not in str(e):
             raise
-        # Shared with moe_utils rather than looped here: the loop puts every
-        # per-group SLICE on the tape, and a slice's shape is the group size,
-        # so non-reentrant checkpointing compares two routings and aborts the
-        # backward. Two of this function's callers are on the tape
-        # (`_grouped_expert_gemm` without recompute, and the cached path), so
-        # the hazard is reachable. The shared one saves what the fused op saves.
+        # Shared with moe_utils rather than looped here: a loop puts every
+        # per-group SLICE on the tape, and a slice's shape is the group size, so
+        # non-reentrant checkpointing compares two routings and aborts the
+        # backward. Two callers are on the tape, so the hazard is reachable.
         try:
             from .moe_utils import _manual_grouped_mm
         except Exception:

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -88,12 +88,22 @@ def _grouped_mm_fix(x: torch.Tensor, w: torch.Tensor, offs: torch.Tensor) -> tor
     except RuntimeError as e:
         if "strides should be multiple of 16 bytes" not in str(e):
             raise
-        outs, start = [], 0
-        for i, end in enumerate(offs.detach().cpu().tolist()):
-            if start < end:
-                outs.append(torch.matmul(x[start:end], w[i]))
-            start = end
-        return torch.cat(outs, 0) if outs else x.new_empty((0, w.shape[-1]))
+        # Shared with moe_utils rather than looped here: the loop puts every
+        # per-group SLICE on the tape, and a slice's shape is the group size,
+        # so non-reentrant checkpointing compares two routings and aborts the
+        # backward. Two of this function's callers are on the tape
+        # (`_grouped_expert_gemm` without recompute, and the cached path), so
+        # the hazard is reachable. The shared one saves what the fused op saves.
+        try:
+            from .moe_utils import _manual_grouped_mm
+        except Exception:
+            outs, start = [], 0
+            for i, end in enumerate(offs.detach().cpu().tolist()):
+                if start < end:
+                    outs.append(torch.matmul(x[start:end], w[i]))
+                start = end
+            return torch.cat(outs, 0) if outs else x.new_empty((0, w.shape[-1]))
+        return _manual_grouped_mm(x, w, offs)
 
 
 def _expert_weight(lin, dtype):

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -126,10 +126,18 @@ def _grouped_mm_with_backward_fix(
     ~57% of MoE GPU time) every step. torch._grouped_mm takes the non-contiguous view directly,
     but some CUDA builds silently miscompute it (pytorch/pytorch#186365), so we only skip the
     copy when a one-time probe proves the view path matches the contiguous one; else we keep the
-    always-correct copy. Falls back to a per-group matmul on the 16-byte stride error. Bit-exact
-    vs the always-contiguous path in forward and backward.
+    always-correct copy. Falls back to a per-group matmul when the device has no torch._grouped_mm
+    at all, and on the 16-byte stride error. Bit-exact vs the always-contiguous path in forward
+    and backward.
     """
     inputs = inputs.contiguous()
+    # Devices without torch._grouped_mm never reach the kernel. The Triton backend
+    # is picked precisely when the probe says no, and its separated-LoRA delta
+    # still routed through here, so a LoRA MoE raised "torch._grouped_mm is only
+    # supported on CUDA devices with compute capability = 9.0" on every card that
+    # is not an H100. The probe is cached, so this costs one global read.
+    if not _check_torch_grouped_mm_supported():
+        return _manual_grouped_mm(inputs, weight, offsets)
     if not _transposed_view_grouped_mm_is_safe():
         weight = weight.contiguous()   # #186365: view path unproven on this build -> safe copy
     try:

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -132,10 +132,11 @@ def _grouped_mm_with_backward_fix(
     """
     inputs = inputs.contiguous()
     # Devices without torch._grouped_mm never reach the kernel. The Triton backend
-    # is picked precisely when the probe says no, and its separated-LoRA delta
-    # still routed through here, so a LoRA MoE raised "torch._grouped_mm is only
-    # supported on CUDA devices with compute capability = 9.0" on every card that
-    # is not an H100. The probe is cached, so this costs one global read.
+    # is picked precisely when the probe says no, but its separated-LoRA delta
+    # still routed through here. torch 2.8 hard-raises unless `dprops->major == 9`
+    # (Blas.cpp, sm90_only), and 2.6/2.7 have no `_grouped_mm` at all, so a LoRA
+    # MoE died on every card but an H100. 2.9 onwards falls back internally, which
+    # is why this only shows up on the older pins. Probe is cached: one global read.
     if not _check_torch_grouped_mm_supported():
         return _manual_grouped_mm(inputs, weight, offsets)
     if not _transposed_view_grouped_mm_is_safe():

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -190,6 +190,11 @@ class _ManualGroupedMM(torch.autograd.Function):
     """
     @staticmethod
     def forward(ctx, inputs, weight, offsets):
+        # A plain list, NOT a tensor: non-reentrant checkpointing replaces the
+        # saved TENSORS with the replay's, so a saved `offsets` tells us what
+        # the replay routed, never what the forward routed. This copy survives,
+        # and backward uses it to tell the two apart.
+        ctx.forward_offsets = offsets.detach().cpu().tolist()
         ctx.save_for_backward(inputs, weight, offsets)
         with torch.no_grad():
             return _grouped_matmul_loop(inputs, weight, offsets)
@@ -197,18 +202,44 @@ class _ManualGroupedMM(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         inputs, weight, offsets = ctx.saved_tensors
+        bounds = offsets.detach().cpu().tolist()
+        if bounds != ctx.forward_offsets:
+            # Shape-stable saves would otherwise let this through silently, and
+            # pairing the original `grad_output` with the replay's partition is
+            # a gradient for a routing that never produced the loss. Louder than
+            # CheckpointError and pointed at the actual cause.
+            raise RuntimeError(
+                "Unsloth: the MoE router assigned tokens differently in the "
+                "activation-checkpoint replay than in the forward "
+                f"(expert ends {ctx.forward_offsets} then {bounds}), so the "
+                "gradients would belong to a routing that never produced the "
+                "loss. Turn gradient checkpointing off for this run, or make "
+                "the router deterministic."
+            )
         need_x, need_w, _ = ctx.needs_input_grad
+        grad_output = grad_output.contiguous()
+        # `backward` runs OUTSIDE the forward's autocast region, so a forward
+        # that autocast fp32 weights to bf16 hands back a bf16 `grad_output`
+        # while the saved tensors are still fp32, and the first matmul raises.
+        # Aligned by hand rather than with `torch.amp.custom_fwd/custom_bwd`,
+        # whose `device_type` is fixed at class definition: this fallback also
+        # runs on CPU and XPU.
+        compute_dtype = grad_output.dtype
         grad_inputs = torch.zeros_like(inputs) if need_x else None
         grad_weight = torch.zeros_like(weight) if need_w else None
-        grad_output = grad_output.contiguous()
         start = 0
-        for expert_idx, end in enumerate(offsets.detach().cpu().tolist()):
+        for expert_idx, end in enumerate(bounds):
             if start < end:
                 g = grad_output[start:end]
                 if need_x:
-                    grad_inputs[start:end] = g @ weight[expert_idx].transpose(-2, -1)
+                    w = weight[expert_idx]
+                    grad_inputs[start:end] = (
+                        g @ w.to(compute_dtype).transpose(-2, -1)
+                    ).to(inputs.dtype)
                 if need_w:
-                    grad_weight[expert_idx] = inputs[start:end].transpose(-2, -1) @ g
+                    x = inputs[start:end].to(compute_dtype)
+                    grad_weight[expert_idx] = (
+                        x.transpose(-2, -1) @ g).to(weight.dtype)
             start = end
         return grad_inputs, grad_weight, None
 
@@ -216,8 +247,22 @@ class _ManualGroupedMM(torch.autograd.Function):
 def _manual_grouped_mm(
     inputs: torch.Tensor, weight: torch.Tensor, offsets: torch.Tensor
 ) -> torch.Tensor:
-    """Differentiable grouped matmul fallback for torch._grouped_mm alignment gaps."""
+    """Differentiable grouped matmul fallback for torch._grouped_mm alignment gaps.
+
+    Not compilable, and marked so. Group boundaries come off a tensor, so
+    `start < end` is a data-dependent branch Dynamo cannot guard, and a
+    tensorized rewrite is worse than the problem: gathering `weight[expert_id]`
+    per row materializes `[T, K, N]`, and masking runs every expert over every
+    row. `torch.compiler.disable` makes a compiled caller break cleanly here
+    rather than abort mid-trace; under `fullgraph = True` a break is still
+    fatal, which is what the eager fallback in `temporary_patches/utils.py` is
+    for.
+    """
     return _ManualGroupedMM.apply(inputs, weight, offsets)
+
+
+if hasattr(torch, "compiler") and hasattr(torch.compiler, "disable"):
+    _manual_grouped_mm = torch.compiler.disable(_manual_grouped_mm)
 
 
 # Recompute-in-backward for the frozen base expert GEMM: the dequantized bf16 stack

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -155,10 +155,8 @@ def _grouped_mm_with_backward_fix(
         return _manual_grouped_mm(inputs, weight, offsets)
 
 
-def _manual_grouped_mm(
-    inputs: torch.Tensor, weight: torch.Tensor, offsets: torch.Tensor
-) -> torch.Tensor:
-    """Differentiable grouped matmul fallback for torch._grouped_mm alignment gaps."""
+def _grouped_matmul_loop(inputs, weight, offsets):
+    """out[s:e] = inputs[s:e] @ weight[g], group by group. No autograd."""
     outputs = []
     start = 0
     for expert_idx, end in enumerate(offsets.detach().cpu().tolist()):
@@ -168,6 +166,58 @@ def _manual_grouped_mm(
     if outputs:
         return torch.cat(outputs, dim=0)
     return inputs.new_empty((0, weight.shape[-1]))
+
+
+class _ManualGroupedMM(torch.autograd.Function):
+    """The loop above, saving what torch._grouped_mm saves and nothing else.
+
+    Written as a Function rather than left to autograd because the naive loop
+    puts every per-group SLICE on the tape, and a slice's shape is the group
+    size, which the router decides. Non-reentrant activation checkpointing
+    replays the forward and compares saved metadata, so any routing difference
+    between the two passes surfaces as
+
+        CheckpointError: Recomputed values ... have different metadata
+        saved: torch.Size([38, 8])  recomputed: torch.Size([39, 8])
+
+    one row apart, in a hundred groups at once. `torch._grouped_mm` never shows
+    that because it is one op saving the whole `[T, K]` input, so a fallback
+    that means to be a drop-in has to save the same shape-stable set: inputs,
+    weight, offsets. The slices are rebuilt in backward.
+
+    This does not make routing deterministic, and does not pretend to: it
+    restores the numerics the fused path already has on an H100.
+    """
+    @staticmethod
+    def forward(ctx, inputs, weight, offsets):
+        ctx.save_for_backward(inputs, weight, offsets)
+        with torch.no_grad():
+            return _grouped_matmul_loop(inputs, weight, offsets)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        inputs, weight, offsets = ctx.saved_tensors
+        need_x, need_w, _ = ctx.needs_input_grad
+        grad_inputs = torch.zeros_like(inputs) if need_x else None
+        grad_weight = torch.zeros_like(weight) if need_w else None
+        grad_output = grad_output.contiguous()
+        start = 0
+        for expert_idx, end in enumerate(offsets.detach().cpu().tolist()):
+            if start < end:
+                g = grad_output[start:end]
+                if need_x:
+                    grad_inputs[start:end] = g @ weight[expert_idx].transpose(-2, -1)
+                if need_w:
+                    grad_weight[expert_idx] = inputs[start:end].transpose(-2, -1) @ g
+            start = end
+        return grad_inputs, grad_weight, None
+
+
+def _manual_grouped_mm(
+    inputs: torch.Tensor, weight: torch.Tensor, offsets: torch.Tensor
+) -> torch.Tensor:
+    """Differentiable grouped matmul fallback for torch._grouped_mm alignment gaps."""
+    return _ManualGroupedMM.apply(inputs, weight, offsets)
 
 
 # Recompute-in-backward for the frozen base expert GEMM: the dequantized bf16 stack

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -304,19 +304,37 @@ class _ManualGroupedMM(torch.autograd.Function):
         compute_dtype = grad_output.dtype
         grad_inputs = torch.zeros_like(inputs) if need_x else None
         grad_weight = torch.zeros_like(weight) if need_w else None
+        # Write each group straight into its slice when no cast is due. The assignment
+        # below allocates a temporary and copies it in; `out=` does neither, and there
+        # are two per group -- 256 on a 128-expert layer, 37% of this loop measured.
+        # A cast needs the temporary anyway, and a non-contiguous destination would put
+        # the copy back, so both keep the plain path.
+        direct = (
+            inputs.dtype == weight.dtype == compute_dtype
+            and (grad_inputs is None or grad_inputs.is_contiguous())
+            and (grad_weight is None or grad_weight.is_contiguous())
+        )
         start = 0
         for expert_idx, end in enumerate(bounds):
             if start < end:
                 g = grad_output[start:end]
                 if need_x:
                     w = weight[expert_idx]
-                    grad_inputs[start:end] = (
-                        g @ w.to(compute_dtype).transpose(-2, -1)
-                    ).to(inputs.dtype)
+                    if direct:
+                        torch.matmul(g, w.transpose(-2, -1),
+                                     out = grad_inputs[start:end])
+                    else:
+                        grad_inputs[start:end] = (
+                            g @ w.to(compute_dtype).transpose(-2, -1)
+                        ).to(inputs.dtype)
                 if need_w:
-                    x = inputs[start:end].to(compute_dtype)
-                    grad_weight[expert_idx] = (
-                        x.transpose(-2, -1) @ g).to(weight.dtype)
+                    if direct:
+                        torch.matmul(inputs[start:end].transpose(-2, -1), g,
+                                     out = grad_weight[expert_idx])
+                    else:
+                        x = inputs[start:end].to(compute_dtype)
+                        grad_weight[expert_idx] = (
+                            x.transpose(-2, -1) @ g).to(weight.dtype)
             start = end
         return grad_inputs, grad_weight, None
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -176,8 +176,30 @@ def _routing_signature(inputs, offsets):
     holds a different sequence. The checksum moves with the rows, so the swap
     is visible. Bit-cast into the offsets vector, exactly, so the whole thing
     is one device sync -- the same one the group loop already pays.
+
+    Each row is reduced through a fixed pseudo-random projection, not a plain
+    sum. Summing collapses a row to a scalar that ignores WHERE its values sit,
+    so `[1, 0]` and `[0, 1]` reduce alike and swapping them across an expert
+    boundary left the whole signature unchanged -- the guard would accept a
+    replay whose gradients belong to a different routing. The projection is
+    derived from the hidden size alone, so forward and recompute build the same
+    one without carrying state.
+
+    The matvec also runs in the input's own dtype rather than on an FP32 copy.
+    `.float()` on the way in materialised a whole `[routed_tokens, hidden]`
+    transient -- 512MB at 32K rows by 4096 features -- to produce one number per
+    row, which is a real risk of OOM on exactly the memory-constrained runs this
+    fallback exists for. cuBLAS accumulates a half-precision gemv in FP32
+    internally, and only the small result is upcast.
     """
-    rows = inputs.detach().float().sum(dim = -1)
+    inputs = inputs.detach()
+    hidden = inputs.shape[-1]
+    weights = torch.linspace(
+        1.0, 2.0, hidden, device = inputs.device, dtype = torch.float32)
+    # Irrational stride: a linear ramp alone still sums to the same value under
+    # a reversal, which is the collision this replaces.
+    weights = torch.sin(weights * 12.9898).to(inputs.dtype)
+    rows = inputs.mv(weights).float()
     ramp = torch.arange(1, rows.numel() + 1, device = rows.device, dtype = rows.dtype)
     checksum = torch.dot(rows, ramp).reshape(1)
     packed = torch.cat((

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -184,7 +184,7 @@ def _grouped_matmul_loop(inputs, weight, offsets, bounds = None):
 # every term, so a swap escapes only by matching ALL of these AND the norm below.
 _SIGNATURE_STRIDES = (12.9898, 78.233, 43.7585, 96.4271)
 
-# Squared row norm, carried beside the projections. Not linear in the row, so the
+# Row 2-norm, carried beside the projections. Not linear in the row, so the
 # null-space argument above does not reach it: rows differing within that space
 # must also have equal norms to swap unseen.
 _SIGNATURE_EXTRA = 1

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -245,10 +245,18 @@ def _routing_signature(inputs, offsets):
         # `[p[1], -p[0], 0, ...]` and zeros both give exactly 0 -- and swapping
         # those two across an expert boundary survived the check.
         rows = (inputs @ weights).float()
-        # Plus the squared norm, which is not linear in the row, so the null
-        # space shared by the projections does not carry over to it.
-        rows = torch.cat(
-            (rows, (inputs.float() * inputs.float()).sum(-1, keepdim = True)), -1)
+        # Plus the norm, which is not linear in the row, so the null space
+        # shared by the projections does not carry over to it. `vector_norm`
+        # accumulates in fp32 from the input's own dtype: `(x.float() *
+        # x.float()).sum(...)` held two fp32 copies AND their product at once,
+        # three concurrent 512MB temporaries at the 32K-by-4096 shape this
+        # fallback targets, which is memory the run does not have.
+        # Promoted, not pinned to fp32: `vector_norm` refuses a dtype that
+        # narrows its input, so a float64 split would raise outright.
+        norm = torch.linalg.vector_norm(
+            inputs, dim = -1, keepdim = True,
+            dtype = torch.promote_types(inputs.dtype, torch.float32))
+        rows = torch.cat((rows, norm.to(rows.dtype)), -1)
         ramp = torch.arange(
             1, rows.shape[0] + 1, device = rows.device, dtype = rows.dtype)
         checksum = (rows * ramp.unsqueeze(1)).sum(0)
@@ -257,6 +265,49 @@ def _routing_signature(inputs, offsets):
         checksum.view(torch.int32).to(torch.int64),
     ))
     return packed.cpu().tolist()
+
+
+# Routing recorded by a REENTRANT checkpoint's forward, so its replay can be
+# compared against the pass that actually produced the loss.
+#
+# `ctx` cannot carry it there. `unsloth_checkpoint` forces the reentrant
+# implementation, whose loss-producing forward runs with grad DISABLED, so
+# `apply` builds no autograd node and the ctx is thrown away. The replay inside
+# `CheckpointFunction.backward` then makes a fresh ctx and compares the replay
+# against itself, which always passes. The non-reentrant path has no such gap:
+# its forward runs with grad on, so the forward's own ctx survives and only its
+# SAVED TENSORS are swapped for the replay's.
+#
+# Keyed on the weight, the one object both passes share: inputs are recomputed
+# and offsets re-derived, but the parameter is the same object. Two records for
+# one weight before its replay is ambiguous and disables the check rather than
+# risk a false alarm on a working run.
+_REENTRANT_ROUTING = {}
+_REENTRANT_SAW_GRAD = False
+_REENTRANT_ROUTING_LIMIT = 512
+
+
+def _record_reentrant_routing(weight, routing):
+    global _REENTRANT_SAW_GRAD
+    if _REENTRANT_SAW_GRAD:
+        # A grad-enabled call ran since the last record, so anything still here
+        # belongs to a forward whose backward has already been and gone. Drop
+        # it: a stale routing consumed by a later replay is a false alarm, and
+        # this is what keeps an eval pass from poisoning the next step.
+        _REENTRANT_ROUTING.clear()
+        _REENTRANT_SAW_GRAD = False
+    if len(_REENTRANT_ROUTING) >= _REENTRANT_ROUTING_LIMIT: return
+    key = id(weight)
+    # The weight is held so its `id()` cannot be reused by a later object.
+    _REENTRANT_ROUTING[key] = (weight, None if key in _REENTRANT_ROUTING else routing)
+
+
+def _take_reentrant_routing(weight):
+    """The forward's routing for this weight, once. None when there is none."""
+    global _REENTRANT_SAW_GRAD
+    _REENTRANT_SAW_GRAD = True
+    entry = _REENTRANT_ROUTING.pop(id(weight), None)
+    return None if entry is None else entry[1]
 
 
 class _ManualGroupedMM(torch.autograd.Function):
@@ -285,13 +336,16 @@ class _ManualGroupedMM(torch.autograd.Function):
         # saved TENSORS with the replay's, so a saved `offsets` tells us what
         # the replay routed, never what the forward routed. This copy survives,
         # and backward uses it to tell the two apart.
-        ctx.forward_routing = _routing_signature(inputs, offsets)
+        routing = _routing_signature(inputs, offsets)
+        # A reentrant checkpoint's forward left its routing on the side, and
+        # THAT is what produced the loss: this call is the replay. The bounds
+        # below still come from `routing`, since they are this pass's own math.
+        stashed = _take_reentrant_routing(weight)
+        ctx.forward_routing = routing if stashed is None else stashed
         ctx.save_for_backward(inputs, weight, offsets)
         with torch.no_grad():
             return _grouped_matmul_loop(
-                inputs, weight, offsets,
-                ctx.forward_routing[:-_SIGNATURE_WIDTH],
-            )
+                inputs, weight, offsets, routing[:-_SIGNATURE_WIDTH])
 
     @staticmethod
     def backward(ctx, grad_output):
@@ -356,13 +410,21 @@ def _manual_grouped_mm(
     fatal, which is what the eager fallback in `temporary_patches/utils.py` is
     for.
     """
-    # No tape, no replay, so nothing will ever read the signature: skip the
-    # Function entirely rather than pay a `[T, hidden]` projection and a
-    # SYNCHRONOUS device-to-host copy per call on the inference path. That copy
-    # is the expensive half -- it serializes the stream -- and for the low-rank
-    # LoRA matmuls it can outweigh the GEMM it guards.
-    if not torch.is_grad_enabled():
+    # Nothing is taped and nothing replays it, so skip the Function entirely
+    # rather than pay a `[T, hidden]` projection per call on the inference path.
+    if torch.is_inference_mode_enabled():
         return _grouped_matmul_loop(inputs, weight, offsets)
+    if not torch.is_grad_enabled():
+        # Grad off but not inference. `apply` would build no node here, so the
+        # Function's own ctx cannot reach any backward -- and this is exactly
+        # where a REENTRANT checkpoint runs its loss-producing forward, so the
+        # routing has to be kept on the side for the replay to be checked
+        # against. Grad off is NOT a reason to skip: it is what an autograd
+        # Function's forward always looks like from the inside.
+        routing = _routing_signature(inputs, offsets)
+        _record_reentrant_routing(weight, routing)
+        return _grouped_matmul_loop(
+            inputs, weight, offsets, routing[:-_SIGNATURE_WIDTH])
     return _ManualGroupedMM.apply(inputs, weight, offsets)
 
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -267,49 +267,6 @@ def _routing_signature(inputs, offsets):
     return packed.cpu().tolist()
 
 
-# Routing recorded by a REENTRANT checkpoint's forward, so its replay can be
-# compared against the pass that actually produced the loss.
-#
-# `ctx` cannot carry it there. `unsloth_checkpoint` forces the reentrant
-# implementation, whose loss-producing forward runs with grad DISABLED, so
-# `apply` builds no autograd node and the ctx is thrown away. The replay inside
-# `CheckpointFunction.backward` then makes a fresh ctx and compares the replay
-# against itself, which always passes. The non-reentrant path has no such gap:
-# its forward runs with grad on, so the forward's own ctx survives and only its
-# SAVED TENSORS are swapped for the replay's.
-#
-# Keyed on the weight, the one object both passes share: inputs are recomputed
-# and offsets re-derived, but the parameter is the same object. Two records for
-# one weight before its replay is ambiguous and disables the check rather than
-# risk a false alarm on a working run.
-_REENTRANT_ROUTING = {}
-_REENTRANT_SAW_GRAD = False
-_REENTRANT_ROUTING_LIMIT = 512
-
-
-def _record_reentrant_routing(weight, routing):
-    global _REENTRANT_SAW_GRAD
-    if _REENTRANT_SAW_GRAD:
-        # A grad-enabled call ran since the last record, so anything still here
-        # belongs to a forward whose backward has already been and gone. Drop
-        # it: a stale routing consumed by a later replay is a false alarm, and
-        # this is what keeps an eval pass from poisoning the next step.
-        _REENTRANT_ROUTING.clear()
-        _REENTRANT_SAW_GRAD = False
-    if len(_REENTRANT_ROUTING) >= _REENTRANT_ROUTING_LIMIT: return
-    key = id(weight)
-    # The weight is held so its `id()` cannot be reused by a later object.
-    _REENTRANT_ROUTING[key] = (weight, None if key in _REENTRANT_ROUTING else routing)
-
-
-def _take_reentrant_routing(weight):
-    """The forward's routing for this weight, once. None when there is none."""
-    global _REENTRANT_SAW_GRAD
-    _REENTRANT_SAW_GRAD = True
-    entry = _REENTRANT_ROUTING.pop(id(weight), None)
-    return None if entry is None else entry[1]
-
-
 class _ManualGroupedMM(torch.autograd.Function):
     """The loop above, saving what torch._grouped_mm saves and nothing else.
 
@@ -336,12 +293,7 @@ class _ManualGroupedMM(torch.autograd.Function):
         # saved TENSORS with the replay's, so a saved `offsets` tells us what
         # the replay routed, never what the forward routed. This copy survives,
         # and backward uses it to tell the two apart.
-        routing = _routing_signature(inputs, offsets)
-        # A reentrant checkpoint's forward left its routing on the side, and
-        # THAT is what produced the loss: this call is the replay. The bounds
-        # below still come from `routing`, since they are this pass's own math.
-        stashed = _take_reentrant_routing(weight)
-        ctx.forward_routing = routing if stashed is None else stashed
+        ctx.forward_routing = routing = _routing_signature(inputs, offsets)
         ctx.save_for_backward(inputs, weight, offsets)
         with torch.no_grad():
             return _grouped_matmul_loop(
@@ -410,21 +362,23 @@ def _manual_grouped_mm(
     fatal, which is what the eager fallback in `temporary_patches/utils.py` is
     for.
     """
-    # Nothing is taped and nothing replays it, so skip the Function entirely
-    # rather than pay a `[T, hidden]` projection per call on the inference path.
-    if torch.is_inference_mode_enabled():
-        return _grouped_matmul_loop(inputs, weight, offsets)
+    # Grad off means `apply` builds no autograd node, so nothing will ever read
+    # the signature: skip the Function rather than pay a `[T, hidden]`
+    # projection per call. Covers `inference_mode` and `no_grad` alike.
+    #
+    # KNOWN GAP, deliberately not closed here. A REENTRANT checkpoint runs its
+    # loss-producing forward with grad off too, and its replay runs with grad
+    # ON, so the replay builds a fresh ctx and compares its own routing against
+    # itself -- a reroute between the two passes goes through silently. This is
+    # NOT fixable from inside this function: `ctx` cannot cross a reentrant
+    # boundary, and the obvious side channel keyed on the weight does not work
+    # either, because `_canonical_lora_weights_for_grouped_mm` rebuilds a
+    # contiguous tensor on every call, so forward and replay never share one.
+    # It needs `unsloth_checkpoint` to announce its region and its call order.
+    # The non-reentrant path is unaffected: its forward runs with grad on, so
+    # the forward ctx survives and only its SAVED TENSORS are swapped.
     if not torch.is_grad_enabled():
-        # Grad off but not inference. `apply` would build no node here, so the
-        # Function's own ctx cannot reach any backward -- and this is exactly
-        # where a REENTRANT checkpoint runs its loss-producing forward, so the
-        # routing has to be kept on the side for the replay to be checked
-        # against. Grad off is NOT a reason to skip: it is what an autograd
-        # Function's forward always looks like from the inside.
-        routing = _routing_signature(inputs, offsets)
-        _record_reentrant_routing(weight, routing)
-        return _grouped_matmul_loop(
-            inputs, weight, offsets, routing[:-_SIGNATURE_WIDTH])
+        return _grouped_matmul_loop(inputs, weight, offsets)
     return _ManualGroupedMM.apply(inputs, weight, offsets)
 
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -309,8 +309,13 @@ class _ManualGroupedMM(torch.autograd.Function):
         # are two per group -- 256 on a 128-expert layer, 37% of this loop measured.
         # A cast needs the temporary anyway, and a non-contiguous destination would put
         # the copy back, so both keep the plain path.
+        # Grad mode first: it is off for an ordinary backward and ON only under
+        # `create_graph = True`, where `out=` raises "functions with out=... arguments
+        # don't support automatic differentiation". The fused path double-backwards
+        # fine, so the fallback has to as well; the plain branch is differentiable.
         direct = (
-            inputs.dtype == weight.dtype == compute_dtype
+            not torch.is_grad_enabled()
+            and inputs.dtype == weight.dtype == compute_dtype
             and (grad_inputs is None or grad_inputs.is_contiguous())
             and (grad_weight is None or grad_weight.is_contiguous())
         )

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -155,11 +155,19 @@ def _grouped_mm_with_backward_fix(
         return _manual_grouped_mm(inputs, weight, offsets)
 
 
-def _grouped_matmul_loop(inputs, weight, offsets):
-    """out[s:e] = inputs[s:e] @ weight[g], group by group. No autograd."""
+def _grouped_matmul_loop(inputs, weight, offsets, bounds = None):
+    """out[s:e] = inputs[s:e] @ weight[g], group by group. No autograd.
+
+    `bounds` is the already-decoded group ends. The signature packs the offsets
+    into its own single transfer, so on the grad path they have been on the CPU
+    since before this call and re-reading them here was a second stream
+    synchronization per grouped matmul -- multiplied over the base and LoRA
+    projections of every layer.
+    """
     outputs = []
     start = 0
-    for expert_idx, end in enumerate(offsets.detach().cpu().tolist()):
+    if bounds is None: bounds = offsets.detach().cpu().tolist()
+    for expert_idx, end in enumerate(bounds):
         if start < end:
             outputs.append(torch.matmul(inputs[start:end], weight[expert_idx]))
         start = end
@@ -168,15 +176,27 @@ def _grouped_matmul_loop(inputs, weight, offsets):
     return inputs.new_empty((0, weight.shape[-1]))
 
 
-# Projection strides for the routing signature. Four, so a row has to be
-# orthogonal to four independent directions to collide; the cost is four columns
-# of a `[T, hidden]` matmul against the grouped GEMM it guards.
+# Projection strides for the routing signature. This is a CHECKSUM, not an
+# identity: any fixed-width digest of a `hidden`-wide row is lossy, and four
+# projections leave a common null space of dimension `hidden - 4`, so two rows
+# differing by a vector in it project alike. An exact identity is not affordable
+# here -- it would need a Python-side copy of the whole `[T, hidden]` input,
+# which is the 512MB transient this file exists to avoid -- so what is bought is
+# a smaller false-negative set, not a proof. The row index weights every term
+# (see the ramp below), so a swap is caught unless the two rows agree on ALL of
+# these AND on the norm below.
 _SIGNATURE_STRIDES = (12.9898, 78.233, 43.7585, 96.4271)
+
+# Squared row norm, carried beside the projections. It is not linear in the row,
+# so the null-space argument that bounds the projections does not reach it: two
+# rows whose difference lies in their common null space still have to have equal
+# norms to swap unseen.
+_SIGNATURE_EXTRA = 1
 
 # How many trailing entries of a packed signature are checksum rather than group
 # boundary. Named, because the offsets are read back by slicing it off and a bare
 # `[:-1]` silently read three checksums as three more experts.
-_SIGNATURE_WIDTH = len(_SIGNATURE_STRIDES)
+_SIGNATURE_WIDTH = len(_SIGNATURE_STRIDES) + _SIGNATURE_EXTRA
 
 
 def _routing_signature(inputs, offsets):
@@ -223,10 +243,12 @@ def _routing_signature(inputs, offsets):
         # Several projections, not one. A single dot maps each row to one
         # scalar, so every row orthogonal to it hashes like the zero row --
         # `[p[1], -p[0], 0, ...]` and zeros both give exactly 0 -- and swapping
-        # those two across an expert boundary survived the check. Independent
-        # directions have no shared null space, so a row has to be orthogonal to
-        # all of them at once.
+        # those two across an expert boundary survived the check.
         rows = (inputs @ weights).float()
+        # Plus the squared norm, which is not linear in the row, so the null
+        # space shared by the projections does not carry over to it.
+        rows = torch.cat(
+            (rows, (inputs.float() * inputs.float()).sum(-1, keepdim = True)), -1)
         ramp = torch.arange(
             1, rows.shape[0] + 1, device = rows.device, dtype = rows.dtype)
         checksum = (rows * ramp.unsqueeze(1)).sum(0)
@@ -266,7 +288,10 @@ class _ManualGroupedMM(torch.autograd.Function):
         ctx.forward_routing = _routing_signature(inputs, offsets)
         ctx.save_for_backward(inputs, weight, offsets)
         with torch.no_grad():
-            return _grouped_matmul_loop(inputs, weight, offsets)
+            return _grouped_matmul_loop(
+                inputs, weight, offsets,
+                ctx.forward_routing[:-_SIGNATURE_WIDTH],
+            )
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -126,17 +126,15 @@ def _grouped_mm_with_backward_fix(
     ~57% of MoE GPU time) every step. torch._grouped_mm takes the non-contiguous view directly,
     but some CUDA builds silently miscompute it (pytorch/pytorch#186365), so we only skip the
     copy when a one-time probe proves the view path matches the contiguous one; else we keep the
-    always-correct copy. Falls back to a per-group matmul when the device has no torch._grouped_mm
-    at all, and on the 16-byte stride error. Bit-exact vs the always-contiguous path in forward
-    and backward.
+    always-correct copy. Falls back to a per-group matmul when the device has no
+    torch._grouped_mm, and on the 16-byte stride error. Bit-exact vs the always-contiguous
+    path in forward and backward.
     """
     inputs = inputs.contiguous()
-    # The Triton backend is picked precisely when the probe says no, yet its
-    # separated-LoRA delta still routed here. torch 2.8 hard-raises unless
-    # `dprops->major == 9` (Blas.cpp, sm90_only) and 2.6/2.7 have no
-    # `_grouped_mm` at all, so a LoRA MoE died on every card but an H100; 2.9
-    # falls back internally, which is why only the older pins show it. Probe is
-    # cached, so this is one global read.
+    # The Triton backend is picked precisely when the probe says no, yet its separated
+    # LoRA delta still routed here. torch 2.8 hard-raises unless `dprops->major == 9`
+    # (Blas.cpp, sm90_only) and 2.6/2.7 have no `_grouped_mm`, so a LoRA MoE died on
+    # every card but an H100; 2.9 falls back internally. Probe is cached: one read.
     if not _check_torch_grouped_mm_supported():
         return _manual_grouped_mm(inputs, weight, offsets)
     if not _transposed_view_grouped_mm_is_safe():
@@ -158,11 +156,9 @@ def _grouped_mm_with_backward_fix(
 def _grouped_matmul_loop(inputs, weight, offsets, bounds = None):
     """out[s:e] = inputs[s:e] @ weight[g], group by group. No autograd.
 
-    `bounds` is the already-decoded group ends. The signature packs the offsets
-    into its own single transfer, so on the grad path they have been on the CPU
-    since before this call and re-reading them here was a second stream
-    synchronization per grouped matmul -- multiplied over the base and LoRA
-    projections of every layer.
+    `bounds` is the already-decoded group ends: the signature packs the offsets into
+    its own transfer, so re-reading them here was a second stream synchronization per
+    grouped matmul, over every layer's base and LoRA projections.
     """
     outputs = []
     start = 0
@@ -177,77 +173,65 @@ def _grouped_matmul_loop(inputs, weight, offsets, bounds = None):
 
 
 # Projection strides for the routing signature. A CHECKSUM, not an identity: four
-# projections of a `hidden`-wide row leave a null space of dimension `hidden - 4`,
-# so rows differing within it project alike. An exact identity would need a copy
-# of the whole `[T, hidden]` input, the 512MB transient this file exists to avoid,
-# so this buys a smaller false-negative set, not a proof. The row index weights
-# every term, so a swap escapes only by matching ALL of these AND the norm below.
+# projections leave a `hidden - 4` null space, so rows differing within it project
+# alike; an exact identity means copying the whole `[T, hidden]` input, the 512MB
+# transient this file avoids. A swap escapes only by matching ALL of these AND the
+# norm below, each term weighted by the row index.
 _SIGNATURE_STRIDES = (12.9898, 78.233, 43.7585, 96.4271)
 
-# Row 2-norm, carried beside the projections. Not linear in the row, so the
-# null-space argument above does not reach it: rows differing within that space
-# must also have equal norms to swap unseen.
+# Row 2-norm, carried beside the projections. Not linear in the row, so that null
+# space does not reach it: rows differing within it must also match norms to swap unseen.
 _SIGNATURE_EXTRA = 1
 
-# Trailing entries of a packed signature that are checksum, not group boundary.
-# Named because the offsets are read back by slicing it off, and a bare `[:-1]`
-# silently read three checksums as three more experts.
+# Trailing checksum entries of a packed signature, not group boundaries. Named because
+# offsets are read back by slicing it off, and a bare `[:-1]` read checksums as experts.
 _SIGNATURE_WIDTH = len(_SIGNATURE_STRIDES) + _SIGNATURE_EXTRA
 
 
 def _routing_signature(inputs, offsets):
     """Offsets plus an order-sensitive checksum of the expert-sorted rows.
 
-    The offsets are only the routing histogram, so a replay that swaps two
-    tokens between experts of equal size leaves them identical while `inputs`
-    holds a different sequence. The checksum moves with the rows, so the swap
-    is visible. Bit-cast into the offsets vector, exactly, so the whole thing
-    is one device sync -- the same one the group loop already pays.
+    Offsets are only the routing histogram, so a replay swapping two tokens between
+    equal-sized experts leaves them identical while `inputs` holds a different
+    sequence; the checksum moves with the rows, so the swap is visible. Bit-cast into
+    the offsets vector so the whole thing is one device sync, the one the group loop
+    already pays.
 
-    Each row is reduced through a fixed pseudo-random projection, not a plain
-    sum. Summing collapses a row to a scalar that ignores WHERE its values sit,
-    so `[1, 0]` and `[0, 1]` reduce alike and swapping them across an expert
-    boundary left the whole signature unchanged -- the guard would accept a
-    replay whose gradients belong to a different routing. The projection is
-    derived from the hidden size alone, so forward and recompute build the same
-    one without carrying state.
+    Rows reduce through a fixed pseudo-random projection, not a sum: a sum ignores
+    WHERE a row's values sit, so `[1, 0]` and `[0, 1]` reduced alike and a swap across
+    an expert boundary went unseen, letting the guard accept gradients from a different
+    routing. The projection derives from the hidden size alone, so forward and
+    recompute build the same one without carrying state.
 
-    The matvec also runs in the input's own dtype rather than on an FP32 copy.
-    `.float()` on the way in materialised a whole `[routed_tokens, hidden]`
-    transient -- 512MB at 32K rows by 4096 features -- to produce one number per
-    row, which is a real risk of OOM on exactly the memory-constrained runs this
-    fallback exists for. cuBLAS accumulates a half-precision gemv in FP32
-    internally, and only the small result is upcast.
+    The matvec runs in the input's own dtype, not an FP32 copy: upcasting on the way in
+    materialised a whole `[routed_tokens, hidden]` transient, 512MB at 32K by 4096, to
+    produce one number per row -- an OOM risk on exactly the memory-constrained runs
+    this fallback exists for. cuBLAS accumulates a half-precision gemv in FP32 anyway.
     """
     inputs = inputs.detach()
     hidden = inputs.shape[-1]
-    # Autocast off, explicitly. `mv`/`mm` are on the autocast lower-precision list
-    # and only ONE of the two calls sees it: the forward runs with the caller's
-    # autocast live, the backward with it disabled. FP32 inputs therefore hashed
-    # in bf16 one side and fp32 the other, and every backward raised the routing
-    # error below on routing that had not changed.
+    # Autocast off, explicitly: `mv`/`mm` are on the autocast lower-precision list and
+    # only ONE of the two calls sees it (forward with the caller's autocast live,
+    # backward with it disabled), so FP32 inputs hashed bf16 one side and fp32 the
+    # other and every backward raised the routing error below on unchanged routing.
     with torch.autocast(device_type = inputs.device.type, enabled = False):
         weights = torch.linspace(
             1.0, 2.0, hidden, device = inputs.device, dtype = torch.float32)
-        # Irrational stride: a linear ramp alone still sums to the same value
-        # under a reversal, which is the collision this replaces.
+        # Irrational stride: a linear ramp alone sums the same under a reversal.
         strides = torch.tensor(
             _SIGNATURE_STRIDES, device = inputs.device, dtype = torch.float32)
         weights = torch.sin(
             weights.unsqueeze(1) * strides).to(inputs.dtype)
-        # Several projections, not one. A single dot maps each row to one
-        # scalar, so every row orthogonal to it hashes like the zero row --
-        # `[p[1], -p[0], 0, ...]` and zeros both give exactly 0 -- and swapping
-        # those two across an expert boundary survived the check.
+        # Several projections, not one: a single dot maps each row to one scalar, so
+        # rows orthogonal to it hash like the zero row (`[p[1], -p[0], 0, ...]` and
+        # zeros both give exactly 0) and swapping that pair across an expert boundary
+        # survived the check.
         rows = (inputs @ weights).float()
-        # Plus the norm, which is not linear in the row, so the null space
-        # shared by the projections does not carry over to it. `vector_norm`
-        # accumulates in fp32 from the input's own dtype: `(x.float() *
-        # x.float()).sum(...)` held two fp32 copies AND their product at once,
-        # three concurrent 512MB temporaries at the 32K-by-4096 shape this
-        # fallback targets, which is memory the run does not have.
-        # Promoted, not pinned to fp32: `vector_norm` refuses a dtype that
-        # narrows its input, so a float64 split would raise outright.
+        # Plus the norm, not linear in the row, so the projections' shared null space
+        # does not reach it. `vector_norm` accumulates in fp32 from the input's own
+        # dtype; `(x.float() * x.float()).sum(...)` held three concurrent 512MB
+        # temporaries at the 32K-by-4096 shape this fallback targets. Promoted, not
+        # pinned to fp32: `vector_norm` refuses a dtype that narrows its input.
         norm = torch.linalg.vector_norm(
             inputs, dim = -1, keepdim = True,
             dtype = torch.promote_types(inputs.dtype, torch.float32))
@@ -265,29 +249,26 @@ def _routing_signature(inputs, offsets):
 class _ManualGroupedMM(torch.autograd.Function):
     """The loop above, saving what torch._grouped_mm saves and nothing else.
 
-    Written as a Function rather than left to autograd because the naive loop
-    puts every per-group SLICE on the tape, and a slice's shape is the group
-    size, which the router decides. Non-reentrant activation checkpointing
-    replays the forward and compares saved metadata, so any routing difference
-    between the two passes surfaces as
+    A Function rather than plain autograd because the naive loop tapes every per-group
+    SLICE, whose shape is the group size the router decides. Non-reentrant checkpointing
+    replays the forward and compares saved metadata, so any routing difference between
+    the two passes surfaces as
 
         CheckpointError: Recomputed values ... have different metadata
         saved: torch.Size([38, 8])  recomputed: torch.Size([39, 8])
 
-    one row apart, in a hundred groups at once. `torch._grouped_mm` never shows
-    that because it is one op saving the whole `[T, K]` input, so a fallback
-    that means to be a drop-in has to save the same shape-stable set: inputs,
-    weight, offsets. The slices are rebuilt in backward.
+    one row apart, in a hundred groups at once. `torch._grouped_mm` never shows that:
+    it is one op saving the whole `[T, K]` input, so a drop-in has to save the same
+    shape-stable set (inputs, weight, offsets) and rebuild the slices in backward.
 
-    This does not make routing deterministic, and does not pretend to: it
-    restores the numerics the fused path already has on an H100.
+    This does not make routing deterministic, and does not pretend to: it restores the
+    numerics the fused path already has on an H100.
     """
     @staticmethod
     def forward(ctx, inputs, weight, offsets):
-        # A plain list, NOT a tensor: non-reentrant checkpointing replaces the
-        # saved TENSORS with the replay's, so a saved `offsets` tells us what
-        # the replay routed, never what the forward routed. This copy survives,
-        # and backward uses it to tell the two apart.
+        # A plain list, NOT a tensor: non-reentrant checkpointing swaps the saved
+        # TENSORS for the replay's, so a saved `offsets` reports the replay's routing,
+        # never the forward's. This copy survives, and backward compares the two.
         ctx.forward_routing = routing = _routing_signature(inputs, offsets)
         ctx.save_for_backward(inputs, weight, offsets)
         with torch.no_grad():
@@ -299,10 +280,9 @@ class _ManualGroupedMM(torch.autograd.Function):
         inputs, weight, offsets = ctx.saved_tensors
         routing = _routing_signature(inputs, offsets)
         if routing != ctx.forward_routing:
-            # Shape-stable saves would otherwise let this through silently, and
-            # pairing the original `grad_output` with the replay's partition is
-            # a gradient for a routing that never produced the loss. Louder than
-            # CheckpointError and pointed at the actual cause.
+            # Shape-stable saves would let this through silently, and pairing the
+            # original `grad_output` with the replay's partition is a gradient for a
+            # routing that never produced the loss. Louder than CheckpointError.
             were = ctx.forward_routing[:-_SIGNATURE_WIDTH]
             now = routing[:-_SIGNATURE_WIDTH]
             how = ("the same experts in a different order"
@@ -317,12 +297,10 @@ class _ManualGroupedMM(torch.autograd.Function):
         bounds = routing[:-_SIGNATURE_WIDTH]
         need_x, need_w, _ = ctx.needs_input_grad
         grad_output = grad_output.contiguous()
-        # `backward` runs OUTSIDE the forward's autocast region, so a forward
-        # that autocast fp32 weights to bf16 hands back a bf16 `grad_output`
-        # while the saved tensors are still fp32, and the first matmul raises.
-        # Aligned by hand rather than with `torch.amp.custom_fwd/custom_bwd`,
-        # whose `device_type` is fixed at class definition: this fallback also
-        # runs on CPU and XPU.
+        # `backward` runs OUTSIDE the forward's autocast, so `grad_output` can be bf16
+        # while the saved tensors are still fp32 and the first matmul raises. Aligned
+        # by hand, not with `torch.amp.custom_fwd/custom_bwd`, whose `device_type` is
+        # fixed at class definition: this fallback also runs on CPU and XPU.
         compute_dtype = grad_output.dtype
         grad_inputs = torch.zeros_like(inputs) if need_x else None
         grad_weight = torch.zeros_like(weight) if need_w else None
@@ -348,30 +326,26 @@ def _manual_grouped_mm(
 ) -> torch.Tensor:
     """Differentiable grouped matmul fallback for torch._grouped_mm alignment gaps.
 
-    Not compilable, and marked so. Group boundaries come off a tensor, so
-    `start < end` is a data-dependent branch Dynamo cannot guard, and a
-    tensorized rewrite is worse than the problem: gathering `weight[expert_id]`
-    per row materializes `[T, K, N]`, and masking runs every expert over every
-    row. `torch.compiler.disable` makes a compiled caller break cleanly here
-    rather than abort mid-trace; under `fullgraph = True` a break is still
-    fatal, which is what the eager fallback in `temporary_patches/utils.py` is
-    for.
+    Not compilable, and marked so: group boundaries come off a tensor, so `start < end`
+    is a data-dependent branch Dynamo cannot guard, and a tensorized rewrite is worse
+    (gathering `weight[expert_id]` per row materializes `[T, K, N]`; masking runs every
+    expert over every row). `torch.compiler.disable` makes a compiled caller break
+    cleanly here rather than abort mid-trace; under `fullgraph = True` a break is still
+    fatal, which is what the eager fallback in `temporary_patches/utils.py` is for.
     """
-    # Grad off means `apply` builds no autograd node, so nothing will ever read
-    # the signature: skip the Function rather than pay a `[T, hidden]`
-    # projection per call. Covers `inference_mode` and `no_grad` alike.
+    # Grad off means `apply` builds no autograd node, so nothing will ever read the
+    # signature: skip the Function rather than pay a `[T, hidden]` projection per call.
+    # Covers `inference_mode` and `no_grad` alike.
     #
-    # KNOWN GAP, deliberately not closed here. A REENTRANT checkpoint runs its
-    # loss-producing forward with grad off too, and its replay runs with grad
-    # ON, so the replay builds a fresh ctx and compares its own routing against
-    # itself -- a reroute between the two passes goes through silently. This is
-    # NOT fixable from inside this function: `ctx` cannot cross a reentrant
-    # boundary, and the obvious side channel keyed on the weight does not work
-    # either, because `_canonical_lora_weights_for_grouped_mm` rebuilds a
-    # contiguous tensor on every call, so forward and replay never share one.
-    # It needs `unsloth_checkpoint` to announce its region and its call order.
-    # The non-reentrant path is unaffected: its forward runs with grad on, so
-    # the forward ctx survives and only its SAVED TENSORS are swapped.
+    # KNOWN GAP, deliberately not closed here. A REENTRANT checkpoint also runs its
+    # loss-producing forward with grad off and its replay with grad ON, so the replay
+    # compares its own routing against itself and a reroute passes silently. Not
+    # fixable from inside this function: `ctx` cannot cross a reentrant boundary, and a
+    # side channel keyed on the weight fails too because
+    # `_canonical_lora_weights_for_grouped_mm` rebuilds a contiguous tensor per call.
+    # It needs `unsloth_checkpoint` to announce its region and call order. The
+    # non-reentrant path is unaffected: its forward runs with grad on, so the forward
+    # ctx survives and only its SAVED TENSORS are swapped.
     if not torch.is_grad_enabled():
         return _grouped_matmul_loop(inputs, weight, offsets)
     return _ManualGroupedMM.apply(inputs, weight, offsets)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -131,12 +131,12 @@ def _grouped_mm_with_backward_fix(
     and backward.
     """
     inputs = inputs.contiguous()
-    # Devices without torch._grouped_mm never reach the kernel. The Triton backend
-    # is picked precisely when the probe says no, but its separated-LoRA delta
-    # still routed through here. torch 2.8 hard-raises unless `dprops->major == 9`
-    # (Blas.cpp, sm90_only), and 2.6/2.7 have no `_grouped_mm` at all, so a LoRA
-    # MoE died on every card but an H100. 2.9 onwards falls back internally, which
-    # is why this only shows up on the older pins. Probe is cached: one global read.
+    # The Triton backend is picked precisely when the probe says no, yet its
+    # separated-LoRA delta still routed here. torch 2.8 hard-raises unless
+    # `dprops->major == 9` (Blas.cpp, sm90_only) and 2.6/2.7 have no
+    # `_grouped_mm` at all, so a LoRA MoE died on every card but an H100; 2.9
+    # falls back internally, which is why only the older pins show it. Probe is
+    # cached, so this is one global read.
     if not _check_torch_grouped_mm_supported():
         return _manual_grouped_mm(inputs, weight, offsets)
     if not _transposed_view_grouped_mm_is_safe():
@@ -176,26 +176,22 @@ def _grouped_matmul_loop(inputs, weight, offsets, bounds = None):
     return inputs.new_empty((0, weight.shape[-1]))
 
 
-# Projection strides for the routing signature. This is a CHECKSUM, not an
-# identity: any fixed-width digest of a `hidden`-wide row is lossy, and four
-# projections leave a common null space of dimension `hidden - 4`, so two rows
-# differing by a vector in it project alike. An exact identity is not affordable
-# here -- it would need a Python-side copy of the whole `[T, hidden]` input,
-# which is the 512MB transient this file exists to avoid -- so what is bought is
-# a smaller false-negative set, not a proof. The row index weights every term
-# (see the ramp below), so a swap is caught unless the two rows agree on ALL of
-# these AND on the norm below.
+# Projection strides for the routing signature. A CHECKSUM, not an identity: four
+# projections of a `hidden`-wide row leave a null space of dimension `hidden - 4`,
+# so rows differing within it project alike. An exact identity would need a copy
+# of the whole `[T, hidden]` input, the 512MB transient this file exists to avoid,
+# so this buys a smaller false-negative set, not a proof. The row index weights
+# every term, so a swap escapes only by matching ALL of these AND the norm below.
 _SIGNATURE_STRIDES = (12.9898, 78.233, 43.7585, 96.4271)
 
-# Squared row norm, carried beside the projections. It is not linear in the row,
-# so the null-space argument that bounds the projections does not reach it: two
-# rows whose difference lies in their common null space still have to have equal
-# norms to swap unseen.
+# Squared row norm, carried beside the projections. Not linear in the row, so the
+# null-space argument above does not reach it: rows differing within that space
+# must also have equal norms to swap unseen.
 _SIGNATURE_EXTRA = 1
 
-# How many trailing entries of a packed signature are checksum rather than group
-# boundary. Named, because the offsets are read back by slicing it off and a bare
-# `[:-1]` silently read three checksums as three more experts.
+# Trailing entries of a packed signature that are checksum, not group boundary.
+# Named because the offsets are read back by slicing it off, and a bare `[:-1]`
+# silently read three checksums as three more experts.
 _SIGNATURE_WIDTH = len(_SIGNATURE_STRIDES) + _SIGNATURE_EXTRA
 
 
@@ -225,12 +221,11 @@ def _routing_signature(inputs, offsets):
     """
     inputs = inputs.detach()
     hidden = inputs.shape[-1]
-    # Autocast off, explicitly. `mv`/`mm` are on the autocast lower-precision
-    # list, and only ONE of the two calls sees it: the forward runs inside
-    # `Function.forward` with the caller's autocast live, the backward runs with
-    # autocast disabled. FP32 inputs under autocast therefore hashed in bf16 one
-    # side and fp32 the other, and every backward raised the routing error below
-    # on routing that had not changed at all.
+    # Autocast off, explicitly. `mv`/`mm` are on the autocast lower-precision list
+    # and only ONE of the two calls sees it: the forward runs with the caller's
+    # autocast live, the backward with it disabled. FP32 inputs therefore hashed
+    # in bf16 one side and fp32 the other, and every backward raised the routing
+    # error below on routing that had not changed.
     with torch.autocast(device_type = inputs.device.type, enabled = False):
         weights = torch.linspace(
             1.0, 2.0, hidden, device = inputs.device, dtype = torch.float32)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -168,6 +168,25 @@ def _grouped_matmul_loop(inputs, weight, offsets):
     return inputs.new_empty((0, weight.shape[-1]))
 
 
+def _routing_signature(inputs, offsets):
+    """Offsets plus an order-sensitive checksum of the expert-sorted rows.
+
+    The offsets are only the routing histogram, so a replay that swaps two
+    tokens between experts of equal size leaves them identical while `inputs`
+    holds a different sequence. The checksum moves with the rows, so the swap
+    is visible. Bit-cast into the offsets vector, exactly, so the whole thing
+    is one device sync -- the same one the group loop already pays.
+    """
+    rows = inputs.detach().float().sum(dim = -1)
+    ramp = torch.arange(1, rows.numel() + 1, device = rows.device, dtype = rows.dtype)
+    checksum = torch.dot(rows, ramp).reshape(1)
+    packed = torch.cat((
+        offsets.detach().reshape(-1).to(torch.int64),
+        checksum.view(torch.int32).to(torch.int64),
+    ))
+    return packed.cpu().tolist()
+
+
 class _ManualGroupedMM(torch.autograd.Function):
     """The loop above, saving what torch._grouped_mm saves and nothing else.
 
@@ -194,7 +213,7 @@ class _ManualGroupedMM(torch.autograd.Function):
         # saved TENSORS with the replay's, so a saved `offsets` tells us what
         # the replay routed, never what the forward routed. This copy survives,
         # and backward uses it to tell the two apart.
-        ctx.forward_offsets = offsets.detach().cpu().tolist()
+        ctx.forward_routing = _routing_signature(inputs, offsets)
         ctx.save_for_backward(inputs, weight, offsets)
         with torch.no_grad():
             return _grouped_matmul_loop(inputs, weight, offsets)
@@ -202,20 +221,23 @@ class _ManualGroupedMM(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         inputs, weight, offsets = ctx.saved_tensors
-        bounds = offsets.detach().cpu().tolist()
-        if bounds != ctx.forward_offsets:
+        routing = _routing_signature(inputs, offsets)
+        if routing != ctx.forward_routing:
             # Shape-stable saves would otherwise let this through silently, and
             # pairing the original `grad_output` with the replay's partition is
             # a gradient for a routing that never produced the loss. Louder than
             # CheckpointError and pointed at the actual cause.
+            were, now = ctx.forward_routing[:-1], routing[:-1]
+            how = ("the same experts in a different order"
+                   if were == now else f"expert ends {were} then {now}")
             raise RuntimeError(
                 "Unsloth: the MoE router assigned tokens differently in the "
-                "activation-checkpoint replay than in the forward "
-                f"(expert ends {ctx.forward_offsets} then {bounds}), so the "
-                "gradients would belong to a routing that never produced the "
-                "loss. Turn gradient checkpointing off for this run, or make "
-                "the router deterministic."
+                f"activation-checkpoint replay than in the forward ({how}), so "
+                "the gradients would belong to a routing that never produced "
+                "the loss. Turn gradient checkpointing off for this run, or "
+                "make the router deterministic."
             )
+        bounds = routing[:-1]
         need_x, need_w, _ = ctx.needs_input_grad
         grad_output = grad_output.contiguous()
         # `backward` runs OUTSIDE the forward's autocast region, so a forward

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -168,6 +168,17 @@ def _grouped_matmul_loop(inputs, weight, offsets):
     return inputs.new_empty((0, weight.shape[-1]))
 
 
+# Projection strides for the routing signature. Four, so a row has to be
+# orthogonal to four independent directions to collide; the cost is four columns
+# of a `[T, hidden]` matmul against the grouped GEMM it guards.
+_SIGNATURE_STRIDES = (12.9898, 78.233, 43.7585, 96.4271)
+
+# How many trailing entries of a packed signature are checksum rather than group
+# boundary. Named, because the offsets are read back by slicing it off and a bare
+# `[:-1]` silently read three checksums as three more experts.
+_SIGNATURE_WIDTH = len(_SIGNATURE_STRIDES)
+
+
 def _routing_signature(inputs, offsets):
     """Offsets plus an order-sensitive checksum of the expert-sorted rows.
 
@@ -194,14 +205,31 @@ def _routing_signature(inputs, offsets):
     """
     inputs = inputs.detach()
     hidden = inputs.shape[-1]
-    weights = torch.linspace(
-        1.0, 2.0, hidden, device = inputs.device, dtype = torch.float32)
-    # Irrational stride: a linear ramp alone still sums to the same value under
-    # a reversal, which is the collision this replaces.
-    weights = torch.sin(weights * 12.9898).to(inputs.dtype)
-    rows = inputs.mv(weights).float()
-    ramp = torch.arange(1, rows.numel() + 1, device = rows.device, dtype = rows.dtype)
-    checksum = torch.dot(rows, ramp).reshape(1)
+    # Autocast off, explicitly. `mv`/`mm` are on the autocast lower-precision
+    # list, and only ONE of the two calls sees it: the forward runs inside
+    # `Function.forward` with the caller's autocast live, the backward runs with
+    # autocast disabled. FP32 inputs under autocast therefore hashed in bf16 one
+    # side and fp32 the other, and every backward raised the routing error below
+    # on routing that had not changed at all.
+    with torch.autocast(device_type = inputs.device.type, enabled = False):
+        weights = torch.linspace(
+            1.0, 2.0, hidden, device = inputs.device, dtype = torch.float32)
+        # Irrational stride: a linear ramp alone still sums to the same value
+        # under a reversal, which is the collision this replaces.
+        strides = torch.tensor(
+            _SIGNATURE_STRIDES, device = inputs.device, dtype = torch.float32)
+        weights = torch.sin(
+            weights.unsqueeze(1) * strides).to(inputs.dtype)
+        # Several projections, not one. A single dot maps each row to one
+        # scalar, so every row orthogonal to it hashes like the zero row --
+        # `[p[1], -p[0], 0, ...]` and zeros both give exactly 0 -- and swapping
+        # those two across an expert boundary survived the check. Independent
+        # directions have no shared null space, so a row has to be orthogonal to
+        # all of them at once.
+        rows = (inputs @ weights).float()
+        ramp = torch.arange(
+            1, rows.shape[0] + 1, device = rows.device, dtype = rows.dtype)
+        checksum = (rows * ramp.unsqueeze(1)).sum(0)
     packed = torch.cat((
         offsets.detach().reshape(-1).to(torch.int64),
         checksum.view(torch.int32).to(torch.int64),
@@ -249,7 +277,8 @@ class _ManualGroupedMM(torch.autograd.Function):
             # pairing the original `grad_output` with the replay's partition is
             # a gradient for a routing that never produced the loss. Louder than
             # CheckpointError and pointed at the actual cause.
-            were, now = ctx.forward_routing[:-1], routing[:-1]
+            were = ctx.forward_routing[:-_SIGNATURE_WIDTH]
+            now = routing[:-_SIGNATURE_WIDTH]
             how = ("the same experts in a different order"
                    if were == now else f"expert ends {were} then {now}")
             raise RuntimeError(
@@ -259,7 +288,7 @@ class _ManualGroupedMM(torch.autograd.Function):
                 "the loss. Turn gradient checkpointing off for this run, or "
                 "make the router deterministic."
             )
-        bounds = routing[:-1]
+        bounds = routing[:-_SIGNATURE_WIDTH]
         need_x, need_w, _ = ctx.needs_input_grad
         grad_output = grad_output.contiguous()
         # `backward` runs OUTSIDE the forward's autocast region, so a forward
@@ -302,6 +331,13 @@ def _manual_grouped_mm(
     fatal, which is what the eager fallback in `temporary_patches/utils.py` is
     for.
     """
+    # No tape, no replay, so nothing will ever read the signature: skip the
+    # Function entirely rather than pay a `[T, hidden]` projection and a
+    # SYNCHRONOUS device-to-host copy per call on the inference path. That copy
+    # is the expensive half -- it serializes the stream -- and for the low-rank
+    # LoRA matmuls it can outweigh the GEMM it guards.
+    if not torch.is_grad_enabled():
+        return _grouped_matmul_loop(inputs, weight, offsets)
     return _ManualGroupedMM.apply(inputs, weight, offsets)
 
 


### PR DESCRIPTION
## What breaks

`select_moe_backend` runs a real probe and falls back to `unsloth_triton` when the device has no usable `torch._grouped_mm`. That part works. But `forward_triton_grouped_gemm` applies its separated LoRA delta through `native_moe_grouped_mm`, hardcoded at both call sites, and that calls the very primitive the backend was selected to avoid.

The chain is `forward_moe_backend` to `forward_triton_grouped_gemm` to `_apply_lora_grouped_mm` to `native_moe_grouped_mm` to `_grouped_mm_with_backward_fix` to `torch._grouped_mm`, and it ends at:

```
RuntimeError: torch._grouped_mm is only supported on CUDA devices with compute capability = 9.0
```

Found running `Qwen3_5_MoE.ipynb` unedited on a B200 under torch 2.8.0. I checked the probe is not the thing at fault, on that exact torch and card:

```
torch 2.8.0+cu128 cc (10, 0)
fp16 dim8 (the exact probe zoo runs): RuntimeError: torch._grouped_mm is only supported on ...
bf16 dim8 : same
bf16 real : same
```

So the probe correctly returns False and `unsloth_triton` really was selected. The LoRA delta ignored that.

## Which torch versions this bites, exactly

Worth being precise, because the blast radius is version-shaped rather than card-shaped:

| torch | `torch._grouped_mm` | LoRA MoE off an H100 |
| --- | --- | --- |
| 2.6, 2.7 | not present at all | broken |
| 2.8.x | `TORCH_CHECK(dprops->major == 9)`, `sm90_only` in `Blas.cpp` | broken, A100 and B200 alike |
| 2.9+ | `_scaled_mm_allowed_device(sm90_only, sm100_only)` selects a fast path, falls back internally otherwise | fine |

`= 9.0`, not `>= 9.0`. On 2.8 an A100 is refused for being major 8, a B200 for being major 10. `Qwen3_MoE.ipynb` passed on the same B200 in the same sweep precisely because it installs torch 2.11.

## The fix

One guard in `_grouped_mm_with_backward_fix`, which is the single choke point every LoRA and base path shares, handing the call to the `_manual_grouped_mm` fallback that is already there for the 16-byte stride case. At the choke point rather than at the two LoRA call sites, so a new caller cannot miss it, and so the missing-symbol case on 2.6/2.7 is covered by the same line.

The probe result is cached in a module global, so a supported device pays one read and still gets the kernel. `test_a_supported_device_still_uses_the_kernel` pins that.

`moe_grouped_modulelist.py` needed nothing. It has the same primitive, but `_grouped_mm_supported()` gates the whole patch entry point, so nothing is ever patched without support.

## Tests

`tests/test_moe_lora_grouped_mm_capability.py`, 6 cases: the kernel is not called at all, the result matches a per-expert matmul, gradients still flow (the LoRA delta is trained), an empty expert group is skipped, `_apply_lora_grouped_mm` goes through the same guard, and a supported device is untouched. 5 fail on main; the sixth is the no-regression guard that must pass both ways.

Full suite: 3906 passed, 162 skipped.

A B200 re-run of `Qwen3_5_MoE.ipynb` unedited against this branch is queued and I will post the result here.
