### PR TITLE
CI: stop main runs cancelling each other

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -15,7 +15,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -14,7 +14,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -17,7 +17,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -24,7 +24,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -23,7 +23,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The event is part of the group so a scheduled run and a push to main cannot
+  # coalesce. Both resolve to refs/heads/main, and the default queue: single keeps
+  # only one pending run, so without this a merge burst silently drops the nightly:
+  # cancel-in-progress protects the running run, never the pending one.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # Latest-only on branches, never on main. Pushes to main land in bursts, so
   # cancelling superseded runs there throws away the run that would have
   # reported a regression, and the run that writes the shared caches.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     - cron: '30 5 * * *' # Runs at 5:30 UTC every day
 
+# Serialize, never cancel. A cancelled run leaves a half-pinged backlog and no
+# record of where it stopped, and two overlapping runs double-ping the same
+# issues.
+concurrency:
+  group: stale-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/studio-export-fix-ci.yml
+++ b/.github/workflows/studio-export-fix-ci.yml
@@ -17,7 +17,10 @@ on:
 
 concurrency:
   group: studio-export-fix-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -19,7 +19,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Latest-only on branches, never on main. Pushes to main land in bursts, so
+  # cancelling superseded runs there throws away the run that would have
+  # reported a regression, and the run that writes the shared caches.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Mirrors unslothai/unsloth#8070 for this repo. Same reasoning, same one-line change.

`group: ${{ github.workflow }}-${{ github.ref }}` resolves to one group for every push to `main`, so a burst of merges cancels its own predecessors and a deterministic failure goes unreported until the burst stops. The same expression puts scheduled runs on `refs/heads/main`, so a push to main cancels the nightly: that is what `mlx-ci.yml` and `security-audit.yml` have been doing to their own crons.

Six workflows move to `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`. PR branches keep cancelling.

Peak concurrency is unchanged, since the group still admits one running run at a time. The cost is job-minutes on main, where the run now finishes instead of being killed early.

`stale.yml` gains a non-cancelling group: a cancelled run leaves a half-pinged backlog with no record of where it stopped, and two overlapping runs double-ping the same issues.

`gemma4-audio-probe.yml` already sets `cancel-in-progress: false` and is untouched. Its inline note is worth reading if you touch concurrency here again, because it documents something GitHub does not:

> concurrency is claimed before the job-level 'if' runs, so an unrelated label would kill a live macOS matrix.


### What this does not fix

`queue: single` is the default and allows exactly one pending run per group, so a burst of three or more merges to `main` keeps the first and the last and discards the middle. `cancel-in-progress: false` governs the running run only and never had anything to say about pending ones.

That limit is deliberate. A per-run group on `main` would preserve every run, but it removes all bounding on the most contended resource here: the account is on the Team plan at 60 concurrent jobs shared across every repo, and a third of queued jobs in one sampled window never received a runner at all. `queue: max` has the same problem one step removed.

So the trade-off is one running plus one pending, and the middle of a burst is still dropped. What changes is that the run which does survive finishes instead of being killed two minutes in.

The scheduled case is different, because a dropped cron is not redundant with a later run. `security-audit.yml` is the only workflow here with both a schedule and a push to `main`, and its group now includes the event so the two cannot coalesce.
