### PR TITLE
Keep the gated-deltanet fast path on Hopper instead of raising (fla #640)

### DIFF
--- a/tests/test_fla_hopper_tile.py
+++ b/tests/test_fla_hopper_tile.py
@@ -71,7 +71,10 @@ def _load_vendored_fla():
 # ---------------------------------------------------------------------------
 
 
-def _record_bk(chunk_o, K, V, hopper, monkeypatch):
+_KEEP = object()
+
+
+def _record_bk(chunk_o, K, V, hopper, monkeypatch, tensor_hopper=_KEEP):
     """Run chunk_bwd_dqkwg's launcher and capture the BK it selects.
 
     The Triton kernel is swapped for a recorder, so no kernel is compiled or
@@ -90,7 +93,13 @@ def _record_bk(chunk_o, K, V, hopper, monkeypatch):
             return launch
 
     monkeypatch.setattr(chunk_o, "chunk_bwd_kernel_dqkwg", _Recorder())
+    # The guard asks the tensor's device first and only falls back to the global,
+    # so simulating a Hopper host means setting both. `tensor_hopper` lets a test
+    # drive them apart (or pass None for "device could not be inspected"); left
+    # alone, the caller's own patch of _is_hopper_tensor is respected.
     monkeypatch.setattr(chunk_o, "IS_NVIDIA_HOPPER", hopper)
+    if tensor_hopper is not _KEEP:
+        monkeypatch.setattr(chunk_o, "_is_hopper_tensor", lambda x, _h=tensor_hopper: _h)
 
     B, T, H, HV, BT = 1, 128, 2, 2, 64
     dev, dt = "cuda", torch.bfloat16
@@ -119,7 +128,7 @@ def test_bk_64_is_never_selected_on_suspect_hopper(K, monkeypatch):
     if not (chunk_o.TRITON_ABOVE_3_4_0 and not chunk_o.TRITON_ABOVE_3_7_1):
         pytest.skip("host Triton is outside the affected [3.4.0, 3.7.1) range")
 
-    got = _record_bk(chunk_o, K=K, V=128, hopper=True, monkeypatch=monkeypatch)
+    got = _record_bk(chunk_o, K=K, V=128, hopper=True, monkeypatch=monkeypatch, tensor_hopper=True)
     assert got["BK"] != 64, f"K={K} selected the miscompiled BK=64 tile"
 
 
@@ -133,15 +142,15 @@ def test_only_the_bad_tile_is_stepped_down(monkeypatch):
 
     # K=128 is what Qwen3-Next / Qwen3.5 use (linear_key_head_dim). Upstream
     # measured BK=128 clean, so it must be untouched.
-    assert _record_bk(chunk_o, K=128, V=128, hopper=True, monkeypatch=monkeypatch)["BK"] == 128
-    assert _record_bk(chunk_o, K=128, V=128, hopper=False, monkeypatch=monkeypatch)["BK"] == 128
+    assert _record_bk(chunk_o, K=128, V=128, hopper=True, monkeypatch=monkeypatch, tensor_hopper=True)["BK"] == 128
+    assert _record_bk(chunk_o, K=128, V=128, hopper=False, monkeypatch=monkeypatch, tensor_hopper=False)["BK"] == 128
 
     # K=64 is the only shape family that reaches the bad tile, and only on Hopper.
-    assert _record_bk(chunk_o, K=64, V=128, hopper=True, monkeypatch=monkeypatch)["BK"] == 32
-    assert _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch)["BK"] == 64
+    assert _record_bk(chunk_o, K=64, V=128, hopper=True, monkeypatch=monkeypatch, tensor_hopper=True)["BK"] == 32
+    assert _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch, tensor_hopper=False)["BK"] == 64
 
     # BV is not implicated by #640 and must not be narrowed (it would cost speed).
-    hop = _record_bk(chunk_o, K=64, V=128, hopper=True, monkeypatch=monkeypatch)
+    hop = _record_bk(chunk_o, K=64, V=128, hopper=True, monkeypatch=monkeypatch, tensor_hopper=True)
     assert hop["BV"] == 128
 
     # The grid is derived from the *overridden* BK: NK = cdiv(64, 32) = 2.
@@ -196,7 +205,7 @@ def test_hopper_at_a_nonzero_device_index_still_steps_down(monkeypatch):
     # probe built on it would wrongly narrow the tile here.)
     monkeypatch.undo()
     chunk_o._device_is_nvidia_hopper.cache_clear()
-    assert _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch)["BK"] == 64
+    assert _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch, tensor_hopper=False)["BK"] == 64
 
 
 # ---------------------------------------------------------------------------
@@ -1015,3 +1024,63 @@ def test_installed_patch_leaves_non_hopper_tensors_alone(monkeypatch):
     monkeypatch.setattr(fv, "_device_index_is_hopper", lambda index: True)
     chunk_o.chunk_bwd_dqkwg(q=k, k=k, v=k, do=k, h=None, dh=None, g=g)
     assert seen["small_tile"] is True, "a Hopper tensor at K=64 must take the override"
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="needs CUDA")
+def test_vendored_guard_uses_the_tensor_device_not_device_zero(monkeypatch):
+    """The vendored guard must ask the tensor's device, not the import-time global.
+
+    That global is frozen from device 0 and is wrong in BOTH directions on a mixed
+    host: it misses a Hopper at a nonzero index, and it marks a call on an
+    Ada/Blackwell card as affected when device 0 is the Hopper one. Only the
+    unknown case may fall back to it.
+    """
+    chunk_o = _load_vendored_fla()
+    if not (chunk_o.TRITON_ABOVE_3_4_0 and not chunk_o.TRITON_ABOVE_3_7_1):
+        pytest.skip("host Triton is outside the affected [3.4.0, 3.7.1) range")
+
+    # Device 0 reported as Hopper, but this call's tensor is not on Hopper: the
+    # normal tile must survive.
+    monkeypatch.setattr(chunk_o, "IS_NVIDIA_HOPPER", True)
+    monkeypatch.setattr(chunk_o, "_is_hopper_tensor", lambda x: False)
+    assert _record_bk(chunk_o, K=64, V=128, hopper=True, monkeypatch=monkeypatch)["BK"] == 64
+
+    # Tensor on Hopper while the global says otherwise: step down.
+    monkeypatch.setattr(chunk_o, "_is_hopper_tensor", lambda x: True)
+    assert _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch)["BK"] == 32
+
+    # Undeterminable device: fall back to the global rather than fail open.
+    assert _record_bk(
+        chunk_o, K=64, V=128, hopper=True, monkeypatch=monkeypatch, tensor_hopper=None,
+    )["BK"] == 32
+    assert _record_bk(
+        chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch, tensor_hopper=None,
+    )["BK"] == 64
+
+
+def test_hopper_probes_report_unknown_rather_than_no(monkeypatch):
+    """Both probes must distinguish "not Hopper" from "could not tell", so a probe
+    failure never silently drops the workaround."""
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    chunk_o = _load_vendored_fla()
+
+    class _Boom:
+        is_cuda = True
+
+        @property
+        def device(self):
+            raise RuntimeError("cannot inspect")
+
+    assert chunk_o._is_hopper_tensor(_Boom()) is None
+    assert chunk_o._is_hopper_tensor(None) is None
+    # fla_vendor's variant resolves unknown to True, since its wrapper is only
+    # installed when some visible GPU is already known to be Hopper.
+    assert fv._tensor_on_hopper(_Boom()) is True
+    monkeypatch.setattr(fv, "_device_index_is_hopper", lambda index: None)
+
+    class _K:
+        is_cuda = True
+        device = types.SimpleNamespace(index=0)
+
+    assert fv._tensor_on_hopper(_K()) is True

--- a/tests/test_fla_hopper_tile.py
+++ b/tests/test_fla_hopper_tile.py
@@ -914,3 +914,64 @@ def test_optout_does_not_patch_the_kernel_on_the_old_layout(monkeypatch, fake_ga
     fv.patch_vendor_fla()
     for mod in fake_gated_delta_modeling.values():
         assert mod.chunk_gated_delta_rule is None
+
+
+def test_degraded_optout_outranks_disable_vendored(monkeypatch, fake_gated_delta_modeling):
+    """UNSLOTH_DISABLE_VENDORED_FLA is a source preference; the Hopper opt-out is a
+    correctness switch. With both set on the post-#47630 layout, returning at the
+    preference flag would leave the kernel-hub decorator resolving an unpatched
+    BK=64 install, so correctness has to win.
+    """
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    monkeypatch.setenv("UNSLOTH_DISABLE_HOPPER_FLA_BWD", "1")
+    monkeypatch.setenv("UNSLOTH_DISABLE_VENDORED_FLA", "1")
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: True)
+    monkeypatch.setattr(fv, "_transformers_uses_availability_probe", lambda: False)
+    monkeypatch.setattr(fv, "_warn_hopper_optout_degraded", lambda: None)
+    monkeypatch.setattr(fv, "_patch_is_available", lambda probe=None: True)
+    monkeypatch.setattr(fv, "_repair_already_imported_modeling", lambda **kw: None)
+    monkeypatch.setattr(fv, "_vendored_already_injected", lambda: False)
+    monkeypatch.setattr(fv, "_should_defer_to_installed_fla", lambda: False)
+    monkeypatch.setattr(fv, "_torch_triton_cuda_supported", lambda: True)
+
+    reached = []
+    monkeypatch.setattr(
+        fv, "_inject_vendored_fla", lambda: (reached.append(True), (True, False))[1],
+    )
+
+    fv.patch_vendor_fla()
+    assert reached, "disable-vendored must not short-circuit the degraded opt-out"
+
+
+def test_disable_vendored_still_returns_without_the_optout(monkeypatch):
+    """The reverse: with only the source-preference flag set, it still returns and
+    leaves a user's own fla exactly as found."""
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    monkeypatch.setenv("UNSLOTH_DISABLE_VENDORED_FLA", "1")
+    monkeypatch.delenv("UNSLOTH_DISABLE_HOPPER_FLA_BWD", raising=False)
+
+    def fail_inject():
+        raise AssertionError("disable-vendored must still prevent injection")
+
+    monkeypatch.setattr(fv, "_inject_vendored_fla", fail_inject)
+    monkeypatch.setattr(fv, "_vendored_already_injected", lambda: False)
+    fv.patch_vendor_fla()
+
+
+def test_degraded_optout_warning_does_not_promise_pure_torch(monkeypatch, caplog):
+    """Upgrading Triton clears the miscompile but makes the opt-out block skip
+    entirely, so the fast kernels are used. The warning must not advertise it as a
+    route to the pure-PyTorch path."""
+    import logging
+
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    with caplog.at_level(logging.WARNING):
+        fv._warn_hopper_optout_degraded()
+    text = caplog.text
+    assert "triton>=3.7.1" in text, "the remediation should still be offered"
+    assert "neither route gives you the pure-PyTorch path" in text, (
+        "the warning must not claim a Triton upgrade reaches the pure-PyTorch path"
+    )

--- a/tests/test_fla_hopper_tile.py
+++ b/tests/test_fla_hopper_tile.py
@@ -2,16 +2,16 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Hopper gated-deltanet policy (unslothai/unsloth#5276, fla #640).
@@ -146,6 +146,57 @@ def test_only_the_bad_tile_is_stepped_down(monkeypatch):
 
     # The grid is derived from the *overridden* BK: NK = cdiv(64, 32) = 2.
     assert hop["grid"][0] == 2
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="needs CUDA")
+def test_hopper_at_a_nonzero_device_index_still_steps_down(monkeypatch):
+    """A Hopper card the frozen IS_NVIDIA_HOPPER global cannot see must still get
+    the step-down.
+
+    fla/utils/_device.py computes
+        IS_NVIDIA_HOPPER = (IS_NVIDIA and ('NVIDIA H' in torch.cuda.get_device_name(0)
+                                           or torch.cuda.get_device_capability()[0] == 9))
+    once, at import, from device 0 -- while chunk_bwd_dqkwg picks CONST_TILING per
+    tensor via ``k.device.index``. On a mixed host (cuda:0 Ada/Blackwell, cuda:1
+    H100) the global is False for a tensor that really is on Hopper, so without a
+    per-device probe the launcher would keep the miscompiled BK=64 tile and corrupt
+    dk/dg silently. Simulated here by making the tensor's own device report SM90
+    while the module global stays False.
+    """
+    import torch
+
+    chunk_o = _load_vendored_fla()
+    if not (chunk_o.TRITON_ABOVE_3_4_0 and not chunk_o.TRITON_ABOVE_3_7_1):
+        pytest.skip("host Triton is outside the affected [3.4.0, 3.7.1) range")
+
+    real_cap, real_name = torch.cuda.get_device_capability, torch.cuda.get_device_name
+    monkeypatch.setattr(
+        torch.cuda, "get_device_capability",
+        lambda i=None: (9, 0) if i == 0 else real_cap(i),
+    )
+    monkeypatch.setattr(
+        torch.cuda, "get_device_name",
+        lambda i=None: "NVIDIA H100 80GB HBM3" if i == 0 else real_name(i),
+    )
+    chunk_o._device_is_nvidia_hopper.cache_clear()
+    try:
+        # hopper=False -> the module global does NOT report Hopper, exactly as on a
+        # host whose device 0 is not Hopper. The tensor's device does.
+        got = _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch)
+        assert got["BK"] == 32, (
+            "a Hopper device that the import-time global missed still selected the "
+            "miscompiled BK=64 tile"
+        )
+    finally:
+        chunk_o._device_is_nvidia_hopper.cache_clear()
+
+    # And the probe must not mislabel this host: with the simulation undone the real
+    # devices are not Hopper, so nothing is stepped down. (check_shared_mem('hopper')
+    # is NOT a Hopper test -- a Blackwell B200 also reports 232448 bytes -- so a
+    # probe built on it would wrongly narrow the tile here.)
+    monkeypatch.undo()
+    chunk_o._device_is_nvidia_hopper.cache_clear()
+    assert _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch)["BK"] == 64
 
 
 # ---------------------------------------------------------------------------
@@ -384,6 +435,7 @@ def test_in_place_patch_fixes_an_unpatched_tree(monkeypatch):
     with pytest.raises(RuntimeError):
         run()
 
+    pristine_check = chunk_o.check_shared_mem
     assert fv._patch_installed_fla_dqkwg() is True
     try:
         got = run()
@@ -391,14 +443,184 @@ def test_in_place_patch_fixes_an_unpatched_tree(monkeypatch):
             assert torch.isfinite(b).all(), f"{name} not finite after the in-place patch"
             rel = (a - b).norm() / a.norm().clamp_min(1e-12)
             assert rel < 5e-3, f"{name} diverged after the in-place patch (rel L2 {rel:.3e})"
-        # The globals it swaps must be put back after every call.
-        assert chunk_o.IS_NVIDIA_HOPPER is True
-        assert "fla" in str(chunk_o.check_shared_mem.__module__)
-        # Idempotent.
-        assert fv._patch_installed_fla_dqkwg() is False
+        # The patch must NOT save/mutate/restore module globals around each call:
+        # autograd runs one worker thread per device, so two concurrent gated-delta
+        # backwards would interleave those restores. The guard flag is cleared once
+        # and stays cleared, and the tile override rides on a thread-local that is
+        # empty between calls.
+        assert chunk_o.IS_NVIDIA_HOPPER is False
+        assert fv._installed_fla_forcing_small_tile() is False
+        assert chunk_o.check_shared_mem.__wrapped__ is pristine_check
+        # Idempotent, and idempotence reports success: patch_vendor_fla runs twice
+        # (import + TEMPORARY_PATCHES) and a False here would make the second run
+        # shadow the user's fla with the vendored snapshot.
+        assert fv._patch_installed_fla_dqkwg() is True
     finally:
         chunk_o.chunk_bwd_dqkwg = pristine
         gdc.chunk_bwd_dqkwg = pristine
+        chunk_o.check_shared_mem = pristine_check
+
+
+def _fake_installed_fla(monkeypatch, version="0.9.0"):
+    """A stand-in user-installed fla whose chunk_o has the layout the in-place patch
+    recognises, so the real ``_patch_installed_fla_dqkwg`` runs end to end."""
+    real = types.ModuleType("fla")
+    real.__version__ = version
+    chunk_o = types.ModuleType("fla.ops.common.chunk_o")
+    chunk_o.IS_NVIDIA_HOPPER = True
+    chunk_o.check_shared_mem = lambda arch="none", tensor_idx=0: arch != "nope"
+    chunk_o.chunk_bwd_dqkwg = lambda **kw: "original"
+    for name, mod in (
+        ("fla", real),
+        ("fla.ops", types.ModuleType("fla.ops")),
+        ("fla.ops.common", types.ModuleType("fla.ops.common")),
+        ("fla.ops.common.chunk_o", chunk_o),
+    ):
+        monkeypatch.setitem(sys.modules, name, mod)
+    return real, chunk_o
+
+
+def test_second_patch_run_does_not_shadow_the_users_fla(monkeypatch):
+    """patch_vendor_fla runs twice (once at import, once from TEMPORARY_PATCHES).
+
+    The second run must recognise that the installed fla is already patched and
+    stop, not read idempotence as failure and fall through to _inject_vendored_fla,
+    which would purge the user's newer upstream and replace it with the pruned
+    vendored snapshot (dropping every model the snapshot does not cover).
+    """
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    real, _chunk_o = _fake_installed_fla(monkeypatch)
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: True)
+    monkeypatch.setattr(fv, "_torch_triton_cuda_supported", lambda: True)
+    monkeypatch.setattr(fv, "_patch_is_available", lambda probe=None: True)
+    monkeypatch.setattr(fv, "_repair_already_imported_modeling", lambda **kw: None)
+
+    injected = []
+
+    def fake_inject():
+        injected.append(1)
+        sys.modules["fla"] = types.ModuleType("fla")
+        return True, True
+
+    monkeypatch.setattr(fv, "_inject_vendored_fla", fake_inject)
+
+    fv.patch_vendor_fla()
+    assert sys.modules["fla"] is real and not injected
+
+    fv.patch_vendor_fla()
+    assert not injected, "the second run shadowed the user's fla with the snapshot"
+    assert sys.modules["fla"] is real
+
+
+def test_purging_an_installed_fla_unbinds_the_models_we_cannot_rebind(
+    monkeypatch, fake_gated_delta_modeling,
+):
+    """When we shadow a user-installed fla on a suspect Hopper host, every model that
+    was already bound to it must stop using it.
+
+    _repair_already_imported_modeling only visits the three vendor-covered Qwen
+    packages. olmo_hybrid imports symbols the pruned snapshot does not
+    ship, so they cannot be rebound onto the fixed kernels; left alone they keep
+    calling the purged install's unpatched chunk_gated_delta_rule and silently
+    corrupt dk/dg. Before this PR that same host skipped injection entirely and the
+    unpatched kernel raised loudly instead.
+    """
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    real = types.ModuleType("fla")
+    real.__version__ = "0.9.0"
+    monkeypatch.setitem(sys.modules, "fla", real)
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: True)
+    monkeypatch.setattr(fv, "_torch_triton_cuda_supported", lambda: True)
+    monkeypatch.setattr(fv, "_patch_is_available", lambda probe=None: True)
+    monkeypatch.setattr(fv, "_repair_already_imported_modeling", lambda **kw: None)
+    # Their install has an unrecognised layout, so the in-place patch cannot apply.
+    monkeypatch.setattr(fv, "_patch_installed_fla_dqkwg", lambda: False)
+    monkeypatch.setattr(
+        fv, "_inject_vendored_fla",
+        lambda: (sys.modules.__setitem__("fla", types.ModuleType("fla")), (True, True))[1],
+    )
+
+    fv.patch_vendor_fla()
+
+    for pkg in ("olmo_hybrid",):
+        assert fake_gated_delta_modeling[pkg].chunk_gated_delta_rule is None, (
+            f"{pkg} still points at the purged, unpatched fla kernel"
+        )
+    # The vendor-covered models are rebound onto the fixed kernels instead, so they
+    # must NOT be unbound here.
+    for pkg in fv._REPAIR_MODELING:
+        assert fake_gated_delta_modeling[pkg].chunk_gated_delta_rule is not None, pkg
+
+
+def test_in_place_patch_is_thread_safe(monkeypatch):
+    """Two gated-delta backwards can run at once in one process: torch's autograd
+    engine keeps one worker thread per device, so a single ``.backward()`` over a
+    model sharded across two GPUs already executes two Python backward bodies
+    concurrently, and the ATen/Triton calls inside them release the GIL.
+
+    A wrapper that saved, mutated and restored ``IS_NVIDIA_HOPPER`` per call would
+    therefore restore ``True`` while the other call is still inside, resurrecting
+    the blanket RuntimeError mid-backward. The override must not be a module global
+    that gets put back per call.
+    """
+    import threading
+
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    _real, chunk_o = _fake_installed_fla(monkeypatch)
+
+    fast_entered = threading.Event()
+    slow_inside = threading.Event()
+    fast_done = threading.Event()
+    seen = {}
+
+    def original(**kwargs):
+        tag = kwargs["tag"]
+        if tag == "fast":
+            fast_entered.set()
+            slow_inside.wait(5)
+        else:
+            slow_inside.set()
+            fast_done.wait(5)
+        # What the real kernel launcher reads, at exactly this moment.
+        if chunk_o.IS_NVIDIA_HOPPER:
+            raise RuntimeError(f"{tag}: blanket #640 guard fired mid-call")
+        seen[tag] = 128 if chunk_o.check_shared_mem("hopper", 0) else 32
+        return tag
+
+    chunk_o.chunk_bwd_dqkwg = original
+    assert fv._patch_installed_fla_dqkwg() is True
+    patched = chunk_o.chunk_bwd_dqkwg
+
+    class _K:
+        shape = (1, 128, 2, 64)   # head dim 64 -> the tile that must be stepped down
+        device = types.SimpleNamespace(index=0)
+
+    errors = []
+
+    def call(tag):
+        try:
+            patched(g=object(), k=_K(), tag=tag)
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    t_fast = threading.Thread(target=call, args=("fast",))
+    t_fast.start()
+    assert fast_entered.wait(5)
+    t_slow = threading.Thread(target=call, args=("slow",))
+    t_slow.start()
+    t_slow.join(10)
+    fast_done.set()
+    t_fast.join(10)
+
+    assert not errors, errors
+    # Both concurrent calls asked for K=64, so both must get the safe 32-wide tile;
+    # neither may have had its override cancelled by the other's restore.
+    assert seen == {"fast": 32, "slow": 32}, seen
+    # And nothing is left behind on either thread.
+    assert fv._installed_fla_forcing_small_tile() is False
 
 
 # ---------------------------------------------------------------------------
@@ -438,15 +660,21 @@ def test_opt_out_forces_pure_torch(monkeypatch, fake_gated_delta_modeling):
 
 
 def test_opt_out_covers_models_the_vendored_tree_does_not(monkeypatch):
-    """kimi_linear / olmo_hybrid are not vendor-covered, but a user-installed fla
-    still exposes them to the same miscompile, so the opt-out must unbind them."""
+    """olmo_hybrid is not vendor-covered, but a user-installed fla still exposes it
+    to the same miscompile, so the opt-out must unbind it.
+
+    Kimi Linear is deliberately absent: transformers ships no `kimi_linear` model,
+    its weights load via trust_remote_code, and that code calls fla's KDA ops,
+    which never reach chunk_bwd_dqkwg. A name that can never resolve would be dead
+    weight pinned by a test."""
     from unsloth_zoo.temporary_patches.fla_vendor import (
         _GATED_DELTA_MODELING,
         _REPAIR_MODELING,
     )
 
     assert set(_REPAIR_MODELING) < set(_GATED_DELTA_MODELING)
-    assert {"kimi_linear", "olmo_hybrid"} <= set(_GATED_DELTA_MODELING)
+    assert "olmo_hybrid" in _GATED_DELTA_MODELING
+    assert "kimi_linear" not in _GATED_DELTA_MODELING
 
 
 def test_opt_out_outranks_the_source_preference_flags(monkeypatch, fake_gated_delta_modeling):

--- a/tests/test_fla_hopper_tile.py
+++ b/tests/test_fla_hopper_tile.py
@@ -848,12 +848,14 @@ def test_optout_layout_probe_is_not_fooled_by_our_own_patch(monkeypatch):
     assert fv._transformers_uses_availability_probe() is False
 
 
-def test_optout_still_protects_the_kernel_on_the_new_layout(monkeypatch, fake_gated_delta_modeling):
+def test_optout_falls_through_to_protection_on_the_new_layout(monkeypatch, fake_gated_delta_modeling):
     """On a post-#47630 Transformers the opt-out cannot force pure torch, so it must
-    fall back to patching the installed kernel rather than returning unprotected.
+    NOT return early -- it has to fall through to the normal path, which makes the
+    fla the kernel-hub decorator resolves one that carries the tile fix.
 
-    Returning early there would make setting the safety switch WORSE than leaving it
-    unset, since the normal path patches that kernel.
+    Returning there would leave a user's unpatched install serving the BK=64
+    backward, i.e. setting the safety switch would make the host less safe than
+    leaving it unset.
     """
     from unsloth_zoo.temporary_patches import fla_vendor as fv
 
@@ -862,25 +864,31 @@ def test_optout_still_protects_the_kernel_on_the_new_layout(monkeypatch, fake_ga
     monkeypatch.setattr(fv, "_FLA_DISABLED_REASON", None)
     monkeypatch.setattr(fv, "_transformers_uses_availability_probe", lambda: False)
     monkeypatch.setattr(fv, "_patch_is_available", lambda probe=None: True)
+    monkeypatch.setattr(fv, "_repair_already_imported_modeling", lambda **kw: None)
+    monkeypatch.setattr(fv, "_should_defer_to_installed_fla", lambda: False)
+    monkeypatch.setattr(fv, "_torch_triton_cuda_supported", lambda: True)
+    # A previous test in this process may already have injected the vendored tree,
+    # which legitimately short-circuits the injection decision. Force the
+    # not-yet-injected state so the fall-through is what is under test.
+    monkeypatch.setattr(fv, "_vendored_already_injected", lambda: False)
 
-    called = {}
+    warned = []
+    monkeypatch.setattr(fv, "_warn_hopper_optout_degraded", lambda: warned.append(True))
+
+    reached = []
     monkeypatch.setattr(
-        fv, "_patch_installed_fla_dqkwg", lambda: called.setdefault("patched", True),
+        fv, "_inject_vendored_fla", lambda: (reached.append(True), (True, False))[1],
     )
-    warned = {}
-    monkeypatch.setattr(fv, "_warn_hopper_optout_degraded", lambda ok: warned.setdefault("ok", ok))
-
-    def fail_inject():
-        raise AssertionError("the opt-out must not inject the vendored tree")
-
-    monkeypatch.setattr(fv, "_inject_vendored_fla", fail_inject)
 
     fv.patch_vendor_fla()
 
-    assert called.get("patched") is True, (
-        "the installed kernel must still be patched when pure torch is unreachable"
+    assert warned, "the user must be told the opt-out could not force pure torch"
+    assert reached, (
+        "the opt-out must fall through to the normal protection path, not return "
+        "and leave the decorator resolving an unpatched fla"
     )
-    assert warned.get("ok") is True, "the user must be told the opt-out was degraded"
+    # fla is not actually disabled on this path, so the loader must not be told it was.
+    assert fv.fla_unavailable_reason() is None
 
 
 def test_optout_does_not_patch_the_kernel_on_the_old_layout(monkeypatch, fake_gated_delta_modeling):

--- a/tests/test_fla_hopper_tile.py
+++ b/tests/test_fla_hopper_tile.py
@@ -1,0 +1,485 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Hopper gated-deltanet policy (unslothai/unsloth#5276, fla #640).
+
+fla's gated ``chunk_bwd_dqkwg`` is miscompiled by Triton in [3.4.0, 3.7.1) on
+Hopper. Upstream's own bisection pinned the trigger to a single block width --
+BK 32 and BK 128 measure clean, BK 64 gives a dk max error of 14.65 -- and
+explicitly ruled out the autotune config space. The vendored kernel therefore
+steps 64 down to 32 and keeps the Triton fast path instead of raising.
+
+``IS_NVIDIA_HOPPER`` is read at *call* time inside ``chunk_bwd_dqkwg``, so the
+whole policy is exercisable on non-Hopper hardware by flipping that flag. That is
+what lets these tests cover the fix without an H100.
+"""
+
+import os
+import sys
+import types
+
+import pytest
+
+os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
+os.environ.setdefault("UNSLOTH_VENDORED_FLA_NO_AUTORUN", "1")
+
+try:
+    import unsloth_zoo  # noqa: F401
+except ImportError as _e:
+    pytest.skip(f"unsloth_zoo unavailable: {_e}", allow_module_level=True)
+
+
+def _cuda_available() -> bool:
+    try:
+        import torch
+        return bool(torch.cuda.is_available())
+    except Exception:
+        return False
+
+
+def _load_vendored_fla():
+    """Inject the vendored tree into this interpreter, or skip."""
+    from unsloth_zoo.temporary_patches.fla_vendor import (
+        _inject_vendored_fla,
+        _vendored_injection_supported,
+    )
+
+    if not _vendored_injection_supported():
+        pytest.skip("vendored fla kernels need CUDA + torch>=2.7 + triton>=3.3")
+    injected, _ = _inject_vendored_fla()
+    if not injected:
+        pytest.skip("vendored fla injection failed on this host")
+    import fla.ops.common.chunk_o as chunk_o
+    return chunk_o
+
+
+# ---------------------------------------------------------------------------
+# 1. Tile selection: BK must never land on 64 in the affected range
+# ---------------------------------------------------------------------------
+
+
+def _record_bk(chunk_o, K, V, hopper, monkeypatch):
+    """Run chunk_bwd_dqkwg's launcher and capture the BK it selects.
+
+    The Triton kernel is swapped for a recorder, so no kernel is compiled or
+    launched; only the block-size arithmetic under test runs.
+    """
+    import torch
+
+    seen = {}
+
+    class _Recorder:
+        def __getitem__(self, grid):
+            def launch(**kwargs):
+                seen["BK"] = kwargs["BK"]
+                seen["BV"] = kwargs["BV"]
+                seen["grid"] = grid
+            return launch
+
+    monkeypatch.setattr(chunk_o, "chunk_bwd_kernel_dqkwg", _Recorder())
+    monkeypatch.setattr(chunk_o, "IS_NVIDIA_HOPPER", hopper)
+
+    B, T, H, HV, BT = 1, 128, 2, 2, 64
+    dev, dt = "cuda", torch.bfloat16
+    q = torch.randn(B, T, H, K, device=dev, dtype=dt)
+    k = torch.randn(B, T, H, K, device=dev, dtype=dt)
+    v = torch.randn(B, T, HV, V, device=dev, dtype=dt)
+    do = torch.randn(B, T, HV, V, device=dev, dtype=dt)
+    NT = T // BT
+    h = torch.randn(B, NT, HV, K, V, device=dev, dtype=dt)
+    dh = torch.randn(B, NT, HV, K, V, device=dev, dtype=dt)
+    g = torch.randn(B, T, HV, device=dev, dtype=torch.float32)
+
+    # chunk_bwd_dqkwg is wrapped by @dispatch('common'); call the undecorated
+    # implementation so no backend can pre-empt the block-size arithmetic.
+    impl = getattr(chunk_o.chunk_bwd_dqkwg, "__wrapped__", chunk_o.chunk_bwd_dqkwg)
+    impl(q=q, k=k, v=v, do=do, h=h, dh=dh, g=g, scale=K ** -0.5, chunk_size=BT)
+    return seen
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="needs CUDA")
+@pytest.mark.parametrize("K", [16, 32, 60, 64, 65, 100, 128, 256])
+def test_bk_64_is_never_selected_on_suspect_hopper(K, monkeypatch):
+    """The whole fix in one assertion: on a Hopper host in the bad Triton range the
+    launcher must not pick the miscompiled tile, for any head dim."""
+    chunk_o = _load_vendored_fla()
+    if not (chunk_o.TRITON_ABOVE_3_4_0 and not chunk_o.TRITON_ABOVE_3_7_1):
+        pytest.skip("host Triton is outside the affected [3.4.0, 3.7.1) range")
+
+    got = _record_bk(chunk_o, K=K, V=128, hopper=True, monkeypatch=monkeypatch)
+    assert got["BK"] != 64, f"K={K} selected the miscompiled BK=64 tile"
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="needs CUDA")
+def test_only_the_bad_tile_is_stepped_down(monkeypatch):
+    """The override must be surgical: head dims that already choose a clean tile
+    keep it, so Qwen3-Next (K=128 -> BK=128) is completely unaffected."""
+    chunk_o = _load_vendored_fla()
+    if not (chunk_o.TRITON_ABOVE_3_4_0 and not chunk_o.TRITON_ABOVE_3_7_1):
+        pytest.skip("host Triton is outside the affected [3.4.0, 3.7.1) range")
+
+    # K=128 is what Qwen3-Next / Qwen3.5 use (linear_key_head_dim). Upstream
+    # measured BK=128 clean, so it must be untouched.
+    assert _record_bk(chunk_o, K=128, V=128, hopper=True, monkeypatch=monkeypatch)["BK"] == 128
+    assert _record_bk(chunk_o, K=128, V=128, hopper=False, monkeypatch=monkeypatch)["BK"] == 128
+
+    # K=64 is the only shape family that reaches the bad tile, and only on Hopper.
+    assert _record_bk(chunk_o, K=64, V=128, hopper=True, monkeypatch=monkeypatch)["BK"] == 32
+    assert _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch)["BK"] == 64
+
+    # BV is not implicated by #640 and must not be narrowed (it would cost speed).
+    hop = _record_bk(chunk_o, K=64, V=128, hopper=True, monkeypatch=monkeypatch)
+    assert hop["BV"] == 128
+
+    # The grid is derived from the *overridden* BK: NK = cdiv(64, 32) = 2.
+    assert hop["grid"][0] == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. The override is a tiling change, not an algebra change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="needs CUDA")
+def test_bk_override_does_not_change_gradients(monkeypatch):
+    """Run the real gated-delta backward at BK=64 and at the stepped-down BK=32 on
+    hardware where both tiles are known good, and assert the gradients agree.
+
+    This is the strongest statement available without a Hopper GPU: it shows the
+    override only repartitions the reduction, so the correctness of BK=32 on SM90
+    (measured upstream) carries over to the same kernel invocation we now issue.
+    """
+    import torch
+
+    chunk_o = _load_vendored_fla()
+    if not (chunk_o.TRITON_ABOVE_3_4_0 and not chunk_o.TRITON_ABOVE_3_7_1):
+        pytest.skip("host Triton is outside the affected [3.4.0, 3.7.1) range")
+    if chunk_o.IS_NVIDIA_HOPPER:
+        pytest.skip("on real Hopper BK=64 is the miscompiled tile; nothing to compare")
+
+    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+
+    B, T, H, D = 2, 256, 4, 64      # D=64 -> BK would be 64 without the override
+
+    def run(hopper):
+        torch.manual_seed(0)
+        dev, dt = "cuda", torch.bfloat16
+        q = torch.randn(B, T, H, D, device=dev, dtype=dt, requires_grad=True)
+        k = torch.randn(B, T, H, D, device=dev, dtype=dt, requires_grad=True)
+        v = torch.randn(B, T, H, D, device=dev, dtype=dt, requires_grad=True)
+        beta = torch.rand(B, T, H, device=dev, dtype=dt).requires_grad_(True)
+        g = torch.nn.functional.logsigmoid(
+            torch.rand(B, T, H, device=dev, dtype=torch.float32)
+        ).requires_grad_(True)
+
+        monkeypatch.setattr(chunk_o, "IS_NVIDIA_HOPPER", hopper)
+        try:
+            # Mirror Qwen3-Next's configuration: without the in-kernel q/k L2norm
+            # and beta sigmoid the delta recurrence diverges to NaN over T steps on
+            # random inputs, which would test the inputs rather than the tiling.
+            o, _ = chunk_gated_delta_rule(
+                q=q, k=k, v=v, g=g, beta=beta, scale=D ** -0.5,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=True,
+                use_beta_sigmoid_in_kernel=True,
+            )
+            o.sum().backward()
+        finally:
+            monkeypatch.undo()
+        grads = [t.grad.detach().float() for t in (q, k, v, beta, g)]
+        for name, t in zip(("dq", "dk", "dv", "dbeta", "dg"), grads):
+            assert torch.isfinite(t).all(), f"{name} is not finite (hopper={hopper})"
+        return grads
+
+    baseline = run(hopper=False)   # BK = 64
+    stepped = run(hopper=True)     # BK = 32
+
+    names = ("dq", "dk", "dv", "dbeta", "dg")
+    for name, a, b in zip(names, baseline, stepped):
+        denom = a.norm().clamp_min(1e-12)
+        rel = (a - b).norm() / denom
+        assert rel < 5e-3, f"{name}: BK=32 diverged from BK=64 (rel L2 {rel:.3e})"
+
+
+# ---------------------------------------------------------------------------
+# 3. No fla is left bound unpatched on a suspect host (the #5276 crash path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_gated_delta_modeling(monkeypatch):
+    """Stand-in transformers gated-delta modeling modules with live fla globals."""
+    from unsloth_zoo.temporary_patches.fla_vendor import _GATED_DELTA_MODELING
+
+    made = {}
+    for pkg in _GATED_DELTA_MODELING:
+        name = f"transformers.models.{pkg}.modeling_{pkg}"
+        mod = types.ModuleType(name)
+        mod.chunk_gated_delta_rule = lambda *a, **k: None
+        mod.fused_recurrent_gated_delta_rule = lambda *a, **k: None
+        mod.FusedRMSNormGated = object
+        monkeypatch.setitem(sys.modules, name, mod)
+        made[pkg] = mod
+    return made
+
+
+@pytest.mark.parametrize(
+    "version", ["0.9.0", "0.5.0", None], ids=["newer", "older", "unversioned"],
+)
+def test_installed_fla_never_stays_bound_on_suspect_hopper(
+    version, monkeypatch, fake_gated_delta_modeling,
+):
+    """Regression test for unslothai/unsloth#5276.
+
+    A pip-installed fla-core carries the #640 miscompile whatever its version, and
+    every version reached the RuntimeError before this fix: a *newer* install won
+    the deferral check (which runs before the hardware gate), while an *older* one
+    lost the deferral but then bailed at the hardware gate, leaving the installed
+    fla importable so transformers' own probe still answered True. Neither may
+    leave an unpatched fla serving the gated-delta backward.
+    """
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    real = types.ModuleType("fla")
+    if version is not None:
+        real.__version__ = version
+    monkeypatch.setitem(sys.modules, "fla", real)
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: True)
+
+    injected = {}
+
+    def fake_inject():
+        injected["yes"] = True
+        monkeypatch.setitem(sys.modules, "fla", types.ModuleType("fla"))
+        return True, True
+
+    monkeypatch.setattr(fv, "_inject_vendored_fla", fake_inject)
+    monkeypatch.setattr(fv, "_torch_triton_cuda_supported", lambda: True)
+    monkeypatch.setattr(fv, "_patch_is_available", lambda probe=None: True)
+    monkeypatch.setattr(fv, "_repair_already_imported_modeling", lambda **kw: None)
+
+    fv.patch_vendor_fla()
+
+    assert injected.get("yes"), (
+        "a suspect Hopper host must inject the vendored copy, which carries the "
+        "BK tile fix, rather than defer to an unpatched user install"
+    )
+
+
+def test_installed_fla_still_wins_on_a_healthy_host(monkeypatch):
+    """The Hopper override must not hijack normal hosts: a newer user install is
+    still preferred everywhere else."""
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    real = types.ModuleType("fla")
+    real.__version__ = "0.9.0"
+    monkeypatch.setitem(sys.modules, "fla", real)
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: False)
+
+    def fail_inject():
+        raise AssertionError("must defer to the newer install, not inject")
+
+    monkeypatch.setattr(fv, "_inject_vendored_fla", fail_inject)
+    fv.patch_vendor_fla()
+    assert sys.modules["fla"] is real
+
+
+# ---------------------------------------------------------------------------
+# 4. The opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_opt_out_forces_pure_torch(monkeypatch, fake_gated_delta_modeling):
+    """UNSLOTH_DISABLE_HOPPER_FLA_BWD=1 must make transformers take its pure-torch
+    gated-delta path, which needs both a False availability probe and the module
+    global unbound (the layer reads ``chunk_gated_delta_rule or torch_...``)."""
+    import transformers.utils.import_utils as iu
+
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    monkeypatch.setenv("UNSLOTH_DISABLE_HOPPER_FLA_BWD", "1")
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: True)
+    monkeypatch.setattr(fv, "_FLA_DISABLED_REASON", None)
+    monkeypatch.setattr(iu, "is_flash_linear_attention_available", lambda: True, raising=False)
+
+    def fail_inject():
+        raise AssertionError("the opt-out must not inject the vendored tree")
+
+    monkeypatch.setattr(fv, "_inject_vendored_fla", fail_inject)
+
+    fv.patch_vendor_fla()
+
+    assert iu.is_flash_linear_attention_available() is False
+    reason = fv.fla_unavailable_reason()
+    assert reason and "triton>=3.7.1" in reason
+
+    for pkg, mod in fake_gated_delta_modeling.items():
+        assert mod.chunk_gated_delta_rule is None, pkg
+        # #640 is a chunked-backward bug; decode and the norm stay on fast kernels.
+        assert mod.fused_recurrent_gated_delta_rule is not None, pkg
+        assert mod.FusedRMSNormGated is not None, pkg
+
+
+def test_opt_out_covers_models_the_vendored_tree_does_not(monkeypatch):
+    """kimi_linear / olmo_hybrid are not vendor-covered, but a user-installed fla
+    still exposes them to the same miscompile, so the opt-out must unbind them."""
+    from unsloth_zoo.temporary_patches.fla_vendor import (
+        _GATED_DELTA_MODELING,
+        _REPAIR_MODELING,
+    )
+
+    assert set(_REPAIR_MODELING) < set(_GATED_DELTA_MODELING)
+    assert {"kimi_linear", "olmo_hybrid"} <= set(_GATED_DELTA_MODELING)
+
+
+def test_opt_out_outranks_the_source_preference_flags(monkeypatch, fake_gated_delta_modeling):
+    """The other two flags choose *which* fla to use; this one is a correctness
+    switch, so it has to win over both."""
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: True)
+
+    def fail_inject():
+        raise AssertionError("the opt-out must not inject the vendored tree")
+
+    monkeypatch.setattr(fv, "_inject_vendored_fla", fail_inject)
+
+    for other in ("UNSLOTH_DISABLE_VENDORED_FLA", "UNSLOTH_FORCE_VENDORED_FLA"):
+        monkeypatch.setenv("UNSLOTH_DISABLE_HOPPER_FLA_BWD", "1")
+        monkeypatch.setenv(other, "1")
+        for mod in fake_gated_delta_modeling.values():
+            mod.chunk_gated_delta_rule = lambda *a, **k: None
+        fv.patch_vendor_fla()
+        for pkg, mod in fake_gated_delta_modeling.items():
+            assert mod.chunk_gated_delta_rule is None, f"{other} defeated the opt-out for {pkg}"
+        monkeypatch.delenv(other)
+
+
+def test_opt_out_is_inert_off_hopper(monkeypatch, fake_gated_delta_modeling):
+    """Setting the flag on a non-suspect host must change nothing at all."""
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    monkeypatch.setenv("UNSLOTH_DISABLE_HOPPER_FLA_BWD", "1")
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: False)
+    monkeypatch.setattr(fv, "_FLA_DISABLED_REASON", None)
+    monkeypatch.setattr(fv, "_should_defer_to_installed_fla", lambda: False)
+    monkeypatch.setattr(fv, "_torch_triton_cuda_supported", lambda: False)
+
+    fv.patch_vendor_fla()
+
+    assert fv.fla_unavailable_reason() is None
+    for mod in fake_gated_delta_modeling.values():
+        assert mod.chunk_gated_delta_rule is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. End to end: a real gated-deltanet model trains on a simulated Hopper
+# ---------------------------------------------------------------------------
+
+
+def _has_qwen3_next() -> bool:
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec("transformers.models.qwen3_next") is not None
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="needs CUDA")
+@pytest.mark.skipif(not _has_qwen3_next(), reason="transformers lacks qwen3_next")
+def test_qwen3_next_trains_with_simulated_hopper_tile(monkeypatch):
+    """The payoff, end to end: with the Hopper flag forced on, a real Qwen3-Next
+    gated-deltanet model must take the fla Triton path (not the pure-torch
+    fallback) and produce finite gradients, where it previously raised."""
+    import torch
+
+    chunk_o = _load_vendored_fla()
+    if not (chunk_o.TRITON_ABOVE_3_4_0 and not chunk_o.TRITON_ABOVE_3_7_1):
+        pytest.skip("host Triton is outside the affected [3.4.0, 3.7.1) range")
+
+    from unsloth_zoo.temporary_patches.fla_vendor import _patch_is_available
+    _patch_is_available()
+
+    from transformers import Qwen3NextConfig
+    from transformers.models.qwen3_next import modeling_qwen3_next as mod
+
+    if getattr(mod, "chunk_gated_delta_rule", None) is None:
+        pytest.skip("modeling module was imported before injection; rebinding is "
+                    "covered by the force-rebind subprocess test")
+
+    monkeypatch.setattr(chunk_o, "IS_NVIDIA_HOPPER", True)
+
+    cfg = Qwen3NextConfig(
+        hidden_size=128, intermediate_size=256, num_hidden_layers=4,
+        num_attention_heads=4, num_key_value_heads=2, vocab_size=256,
+        linear_num_key_heads=2, linear_num_value_heads=4,
+        linear_key_head_dim=64, linear_value_head_dim=64,   # 64 -> the bad tile
+        num_experts=2, num_experts_per_tok=1, shared_expert_intermediate_size=64,
+    )
+    # Qwen3NextGatedDeltaNet falls back to torch.get_current_dtype() when the config
+    # carries no dtype, which does not exist on every supported torch. Set it so the
+    # test exercises the kernels rather than that version mismatch.
+    cfg.dtype = torch.bfloat16
+    try:
+        model = mod.Qwen3NextForCausalLM(cfg).cuda().to(torch.bfloat16)
+    except AttributeError as e:
+        pytest.skip(f"transformers/torch mismatch building Qwen3-Next: {e}")
+
+    # The layer binds the kernel per-instance; confirm Triton is actually serving
+    # this, otherwise a silent fallback would make the test vacuous.
+    linear_layers = [
+        getattr(layer, "linear_attn", None) for layer in model.model.layers
+    ]
+    linear_layers = [layer for layer in linear_layers if layer is not None]
+    assert linear_layers, "no gated-deltanet layers in this config"
+    assert all(
+        layer.chunk_gated_delta_rule is not mod.torch_chunk_gated_delta_rule
+        for layer in linear_layers
+    ), "fell back to the pure-torch path; the Triton kernels were not exercised"
+
+    ids = torch.randint(0, cfg.vocab_size, (1, 256), device="cuda")
+    out = model(input_ids=ids, labels=ids)
+    out.loss.backward()
+
+    assert torch.isfinite(out.loss), "loss is not finite"
+    grads = [p.grad for p in model.parameters() if p.grad is not None]
+    assert grads, "no gradients were produced"
+    assert all(torch.isfinite(g).all() for g in grads), "non-finite gradients"
+
+
+# ---------------------------------------------------------------------------
+# 6. Non-Hopper hosts are untouched
+# ---------------------------------------------------------------------------
+
+
+def test_this_blackwell_host_is_not_suspect():
+    """This host runs Triton 3.5.1, which *is* inside the affected version range,
+    so only the architecture check keeps it off the Hopper path. Guards against a
+    predicate change that would slow down every Blackwell user."""
+    try:
+        import torch
+        import triton  # noqa: F401
+    except Exception:
+        pytest.skip("torch/triton unavailable")
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+    if torch.cuda.get_device_capability(0)[0] == 9:
+        pytest.skip("this host really is Hopper")
+
+    from unsloth_zoo.temporary_patches.fla_vendor import _hopper_dqkwg_suspect_here
+
+    assert _hopper_dqkwg_suspect_here() is False

--- a/tests/test_fla_hopper_tile.py
+++ b/tests/test_fla_hopper_tile.py
@@ -815,3 +815,94 @@ def test_this_blackwell_host_is_not_suspect():
     from unsloth_zoo.temporary_patches.fla_vendor import _hopper_dqkwg_suspect_here
 
     assert _hopper_dqkwg_suspect_here() is False
+
+
+def test_optout_layout_probe_is_not_fooled_by_our_own_patch(monkeypatch):
+    """`_transformers_uses_availability_probe` must key on the NEW mechanism.
+
+    Two traps make the obvious `hasattr(iu, "is_flash_linear_attention_available")`
+    check wrong: transformers keeps defining that name after #47630 (it is merely
+    unused by the modeling files), and `_patch_is_available` assigns the attribute
+    unconditionally, so once it has run every Transformers looks like the old one.
+    """
+    import transformers.utils.import_utils as iu
+
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    hub = pytest.importorskip("transformers.integrations.hub_kernels")
+
+    # Old layout: no kernel-hub fallback decorator -> the probe still steers things.
+    monkeypatch.delattr(hub, "use_kernel_func_from_hub_with_fallback", raising=False)
+    assert fv._transformers_uses_availability_probe() is True
+
+    # New layout: the decorator exists, so the probe no longer steers anything --
+    # even though the old name is still defined on import_utils, and even after our
+    # own _patch_is_available has re-added it.
+    monkeypatch.setattr(
+        hub, "use_kernel_func_from_hub_with_fallback", lambda *a, **k: (lambda f: f),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        iu, "is_flash_linear_attention_available", lambda: True, raising=False,
+    )
+    assert fv._transformers_uses_availability_probe() is False
+
+
+def test_optout_still_protects_the_kernel_on_the_new_layout(monkeypatch, fake_gated_delta_modeling):
+    """On a post-#47630 Transformers the opt-out cannot force pure torch, so it must
+    fall back to patching the installed kernel rather than returning unprotected.
+
+    Returning early there would make setting the safety switch WORSE than leaving it
+    unset, since the normal path patches that kernel.
+    """
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    monkeypatch.setenv("UNSLOTH_DISABLE_HOPPER_FLA_BWD", "1")
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: True)
+    monkeypatch.setattr(fv, "_FLA_DISABLED_REASON", None)
+    monkeypatch.setattr(fv, "_transformers_uses_availability_probe", lambda: False)
+    monkeypatch.setattr(fv, "_patch_is_available", lambda probe=None: True)
+
+    called = {}
+    monkeypatch.setattr(
+        fv, "_patch_installed_fla_dqkwg", lambda: called.setdefault("patched", True),
+    )
+    warned = {}
+    monkeypatch.setattr(fv, "_warn_hopper_optout_degraded", lambda ok: warned.setdefault("ok", ok))
+
+    def fail_inject():
+        raise AssertionError("the opt-out must not inject the vendored tree")
+
+    monkeypatch.setattr(fv, "_inject_vendored_fla", fail_inject)
+
+    fv.patch_vendor_fla()
+
+    assert called.get("patched") is True, (
+        "the installed kernel must still be patched when pure torch is unreachable"
+    )
+    assert warned.get("ok") is True, "the user must be told the opt-out was degraded"
+
+
+def test_optout_does_not_patch_the_kernel_on_the_old_layout(monkeypatch, fake_gated_delta_modeling):
+    """The reverse: where the probe does steer selection, the opt-out reaches pure
+    torch and must not touch the installed kernel or warn."""
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    monkeypatch.setenv("UNSLOTH_DISABLE_HOPPER_FLA_BWD", "1")
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: True)
+    monkeypatch.setattr(fv, "_FLA_DISABLED_REASON", None)
+    monkeypatch.setattr(fv, "_transformers_uses_availability_probe", lambda: True)
+    monkeypatch.setattr(fv, "_patch_is_available", lambda probe=None: True)
+
+    def fail_patch():
+        raise AssertionError("pure torch is reachable; do not touch the kernel")
+
+    def fail_warn(ok):
+        raise AssertionError("nothing degraded; do not warn")
+
+    monkeypatch.setattr(fv, "_patch_installed_fla_dqkwg", fail_patch)
+    monkeypatch.setattr(fv, "_warn_hopper_optout_degraded", fail_warn)
+
+    fv.patch_vendor_fla()
+    for mod in fake_gated_delta_modeling.values():
+        assert mod.chunk_gated_delta_rule is None

--- a/tests/test_fla_hopper_tile.py
+++ b/tests/test_fla_hopper_tile.py
@@ -570,6 +570,10 @@ def test_in_place_patch_is_thread_safe(monkeypatch):
     from unsloth_zoo.temporary_patches import fla_vendor as fv
 
     _real, chunk_o = _fake_installed_fla(monkeypatch)
+    # The wrapper only overrides the tile for tensors that are actually on Hopper,
+    # so declare the fake tensors' device to be one. Without this the concurrency
+    # path under test is never entered on a non-Hopper CI host.
+    monkeypatch.setattr(fv, "_device_index_is_hopper", lambda index: True)
 
     fast_entered = threading.Event()
     slow_inside = threading.Event()
@@ -597,6 +601,7 @@ def test_in_place_patch_is_thread_safe(monkeypatch):
     class _K:
         shape = (1, 128, 2, 64)   # head dim 64 -> the tile that must be stepped down
         device = types.SimpleNamespace(index=0)
+        is_cuda = True            # the wrapper skips non-CUDA tensors outright
 
     errors = []
 
@@ -975,3 +980,38 @@ def test_degraded_optout_warning_does_not_promise_pure_torch(monkeypatch, caplog
     assert "neither route gives you the pure-PyTorch path" in text, (
         "the warning must not claim a Triton upgrade reaches the pure-PyTorch path"
     )
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="needs CUDA")
+def test_installed_patch_leaves_non_hopper_tensors_alone(monkeypatch):
+    """The installed-fla wrapper is installed process-wide when ANY visible GPU is
+    Hopper, but fla #640 is Hopper-only. A call whose tensors live on an
+    Ada/Ampere/Blackwell card in the same box must keep its normal tiling, or
+    K=33..64 pays a narrowed BK and BV on every backward for nothing.
+    """
+    import torch
+
+    chunk_o = _load_vendored_fla()
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    seen = {}
+
+    def fake_original(**kwargs):
+        seen["small_tile"] = fv._installed_fla_forcing_small_tile()
+        return None
+
+    monkeypatch.setattr(chunk_o, "chunk_bwd_dqkwg", fake_original)
+    monkeypatch.setattr(fv, "_device_index_is_hopper", lambda index: False)
+    assert fv._patch_installed_fla_dqkwg() is True
+
+    k = torch.zeros(1, 8, 1, 64, device="cuda", dtype=torch.bfloat16)
+    g = torch.zeros(1, 8, 1, device="cuda", dtype=torch.float32)
+    chunk_o.chunk_bwd_dqkwg(q=k, k=k, v=k, do=k, h=None, dh=None, g=g)
+    assert seen["small_tile"] is False, (
+        "a non-Hopper tensor must not be forced onto the narrow tile"
+    )
+
+    # Same call on a device reported as Hopper does take the override.
+    monkeypatch.setattr(fv, "_device_index_is_hopper", lambda index: True)
+    chunk_o.chunk_bwd_dqkwg(q=k, k=k, v=k, do=k, h=None, dh=None, g=g)
+    assert seen["small_tile"] is True, "a Hopper tensor at K=64 must take the override"

--- a/tests/test_fla_hopper_tile.py
+++ b/tests/test_fla_hopper_tile.py
@@ -270,13 +270,44 @@ def test_installed_fla_never_stays_bound_on_suspect_hopper(
     monkeypatch.setattr(fv, "_torch_triton_cuda_supported", lambda: True)
     monkeypatch.setattr(fv, "_patch_is_available", lambda probe=None: True)
     monkeypatch.setattr(fv, "_repair_already_imported_modeling", lambda **kw: None)
+    # Their install cannot be patched in place (it is a bare stub module here), so
+    # the vendored snapshot, which has the fix compiled in, must take over.
+    monkeypatch.setattr(fv, "_patch_installed_fla_dqkwg", lambda: False)
 
     fv.patch_vendor_fla()
 
     assert injected.get("yes"), (
-        "a suspect Hopper host must inject the vendored copy, which carries the "
-        "BK tile fix, rather than defer to an unpatched user install"
+        "a suspect Hopper host must fall back to the vendored copy, which carries "
+        "the BK tile fix, rather than leave an unpatched user install in charge"
     )
+
+
+def test_installed_fla_is_patched_in_place_when_possible(monkeypatch):
+    """Preferred outcome on a suspect host: keep the user's own fla and patch only
+    the miscompiled kernel, instead of shadowing their deliberate install."""
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+
+    real = types.ModuleType("fla")
+    real.__version__ = "0.9.0"
+    monkeypatch.setitem(sys.modules, "fla", real)
+    monkeypatch.setattr(fv, "_hopper_dqkwg_suspect_here", lambda: True)
+    monkeypatch.setattr(fv, "_patch_installed_fla_dqkwg", lambda: True)
+
+    def fail_inject():
+        raise AssertionError("must patch the install in place, not shadow it")
+
+    monkeypatch.setattr(fv, "_inject_vendored_fla", fail_inject)
+
+    def fail_probe(probe=None):
+        raise AssertionError(
+            "must not repoint transformers' probe at the vendored answer when the "
+            "user's own fla is the one in use"
+        )
+
+    monkeypatch.setattr(fv, "_patch_is_available", fail_probe)
+
+    fv.patch_vendor_fla()
+    assert sys.modules["fla"] is real
 
 
 def test_installed_fla_still_wins_on_a_healthy_host(monkeypatch):
@@ -295,6 +326,79 @@ def test_installed_fla_still_wins_on_a_healthy_host(monkeypatch):
     monkeypatch.setattr(fv, "_inject_vendored_fla", fail_inject)
     fv.patch_vendor_fla()
     assert sys.modules["fla"] is real
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="needs CUDA")
+def test_in_place_patch_fixes_an_unpatched_tree(monkeypatch):
+    """_patch_installed_fla_dqkwg must make an fla that still has the blanket guard
+    both run and produce correct gradients.
+
+    Exercised against the vendored tree with its source-level fix neutralised, so
+    it stands in for a user-installed fla-core that has the guard and no tile fix.
+    """
+    import torch
+
+    chunk_o = _load_vendored_fla()
+    if not (chunk_o.TRITON_ABOVE_3_4_0 and not chunk_o.TRITON_ABOVE_3_7_1):
+        pytest.skip("host Triton is outside the affected [3.4.0, 3.7.1) range")
+    if chunk_o.IS_NVIDIA_HOPPER:
+        pytest.skip("needs a non-Hopper host to hold a trustworthy reference")
+
+    from unsloth_zoo.temporary_patches import fla_vendor as fv
+    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+    import fla.ops.gated_delta_rule.chunk as gdc
+
+    B, T, H, D = 1, 128, 2, 64      # D=64 is the head dim that reaches the bad tile
+
+    def run():
+        torch.manual_seed(0)
+        dev, dt = "cuda", torch.bfloat16
+        mk = lambda: torch.randn(B, T, H, D, device=dev, dtype=dt, requires_grad=True)
+        q, k, v = mk(), mk(), mk()
+        beta = torch.rand(B, T, H, device=dev, dtype=dt, requires_grad=True)
+        g = torch.nn.functional.logsigmoid(
+            torch.rand(B, T, H, device=dev, dtype=torch.float32)).requires_grad_(True)
+        o, _ = chunk_gated_delta_rule(
+            q=q, k=k, v=v, g=g, beta=beta, scale=D ** -0.5,
+            use_qk_l2norm_in_kernel=True, use_beta_sigmoid_in_kernel=True,
+        )
+        o.sum().backward()
+        return [t.grad.detach().float() for t in (q, k, v, beta, g)]
+
+    reference = run()
+
+    # Stand in for an unpatched install: restore the old blanket guard, which
+    # refuses every gated call on Hopper regardless of the tile.
+    pristine = chunk_o.chunk_bwd_dqkwg
+
+    def blanket_guard(*args, **kwargs):
+        if (kwargs.get("g") is not None and chunk_o.IS_NVIDIA_HOPPER
+                and chunk_o.TRITON_ABOVE_3_4_0 and not chunk_o.TRITON_ABOVE_3_7_1):
+            raise RuntimeError("Triton >= 3.4.0 and < 3.7.1 on Hopper GPUs ...")
+        return pristine(*args, **kwargs)
+
+    monkeypatch.setattr(chunk_o, "chunk_bwd_dqkwg", blanket_guard)
+    monkeypatch.setattr(gdc, "chunk_bwd_dqkwg", blanket_guard)
+    monkeypatch.setattr(chunk_o, "IS_NVIDIA_HOPPER", True)
+
+    with pytest.raises(RuntimeError):
+        run()
+
+    assert fv._patch_installed_fla_dqkwg() is True
+    try:
+        got = run()
+        for name, a, b in zip(("dq", "dk", "dv", "dbeta", "dg"), reference, got):
+            assert torch.isfinite(b).all(), f"{name} not finite after the in-place patch"
+            rel = (a - b).norm() / a.norm().clamp_min(1e-12)
+            assert rel < 5e-3, f"{name} diverged after the in-place patch (rel L2 {rel:.3e})"
+        # The globals it swaps must be put back after every call.
+        assert chunk_o.IS_NVIDIA_HOPPER is True
+        assert "fla" in str(chunk_o.check_shared_mem.__module__)
+        # Idempotent.
+        assert fv._patch_installed_fla_dqkwg() is False
+    finally:
+        chunk_o.chunk_bwd_dqkwg = pristine
+        gdc.chunk_bwd_dqkwg = pristine
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vendor_fla.py
+++ b/tests/test_vendor_fla.py
@@ -193,7 +193,16 @@ def test_backported_blackwell_hopper_fixes_present():
     assert "for num_warps in [2, 4, 8]" in wy
 
     co = (VENDORED / "ops" / "common" / "chunk_o.py").read_text()
-    assert "IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0 and not TRITON_ABOVE_3_7_1" in co
+    # Upstream's guard window, kept intact: [3.4.0, 3.7.1) only.
+    assert "and TRITON_ABOVE_3_4_0\n        and not TRITON_ABOVE_3_7_1" in co
+    # Hopper is detected by BOTH signals. IS_NVIDIA_HOPPER alone is frozen at import
+    # from device 0, so on a mixed host it misses a Hopper card at a nonzero index
+    # while CONST_TILING is chosen from k.device.index.
+    assert "and (IS_NVIDIA_HOPPER or _is_hopper_tensor(k))" in co
+    assert "def _device_is_nvidia_hopper(index):" in co
+    # Capability, not shared memory: check_shared_mem('hopper') is a >=232448-byte
+    # tier test that Blackwell B200 also passes, so it cannot detect Hopper.
+    assert "torch.cuda.get_device_capability(index)[0] == 9" in co
     # fla #640's root cause is BK == 64 on Hopper, so we step the tile down instead
     # of refusing to run. Pin both halves so a re-vendor cannot silently drop them.
     assert "if HOPPER_DQKWG_BROKEN and BK == 64:\n        BK = 32" in co

--- a/tests/test_vendor_fla.py
+++ b/tests/test_vendor_fla.py
@@ -195,10 +195,13 @@ def test_backported_blackwell_hopper_fixes_present():
     co = (VENDORED / "ops" / "common" / "chunk_o.py").read_text()
     # Upstream's guard window, kept intact: [3.4.0, 3.7.1) only.
     assert "and TRITON_ABOVE_3_4_0\n        and not TRITON_ABOVE_3_7_1" in co
-    # Hopper is detected by BOTH signals. IS_NVIDIA_HOPPER alone is frozen at import
-    # from device 0, so on a mixed host it misses a Hopper card at a nonzero index
-    # while CONST_TILING is chosen from k.device.index.
-    assert "and (IS_NVIDIA_HOPPER or _is_hopper_tensor(k))" in co
+    # Hopper is decided per tensor, not from the import-time global. That global is
+    # frozen from device 0 and is wrong in both directions on a mixed host: it misses
+    # a Hopper card at a nonzero index, and it marks a call on an Ada/Blackwell card
+    # as affected when device 0 is the Hopper one. It survives only as the fallback
+    # for when the probe cannot tell, so a probe failure never fails open.
+    assert "_on_hopper = _is_hopper_tensor(k)" in co
+    assert "if _on_hopper is None:\n        _on_hopper = IS_NVIDIA_HOPPER" in co
     assert "def _device_is_nvidia_hopper(index):" in co
     # Capability, not shared memory: check_shared_mem('hopper') is a >=232448-byte
     # tier test that Blackwell B200 also passes, so it cannot detect Hopper.

--- a/tests/test_vendor_fla.py
+++ b/tests/test_vendor_fla.py
@@ -60,9 +60,8 @@ VENDORED = ZOO_ROOT / "unsloth_zoo" / "_vendored" / "fla"
 
 def _injection_supported() -> bool:
     # Mirror the production support gate exactly (Python>=3.10, torch/triton
-    # minimums, CUDA, and the Hopper/Triton range that needs the pruned TileLang
-    # backend). A looser check would run the subprocess tests on hosts where the
-    # patch intentionally skips injection, so they would fail instead of skip.
+    # minimums, CUDA). A looser check would run the subprocess tests on hosts where
+    # the patch intentionally skips injection, so they would fail instead of skip.
     try:
         from unsloth_zoo.temporary_patches.fla_vendor import (
             _vendored_injection_supported,
@@ -195,6 +194,16 @@ def test_backported_blackwell_hopper_fixes_present():
 
     co = (VENDORED / "ops" / "common" / "chunk_o.py").read_text()
     assert "IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0 and not TRITON_ABOVE_3_7_1" in co
+    # fla #640's root cause is BK == 64 on Hopper, so we step the tile down instead
+    # of refusing to run. Pin both halves so a re-vendor cannot silently drop them.
+    assert "if HOPPER_DQKWG_BROKEN and BK == 64:\n        BK = 32" in co
+    assert co.index("BK = 32") < co.index("NK = triton.cdiv(K, BK)"), (
+        "the BK override must run before NK / the dg scratch / the grid are derived"
+    )
+    # The dead remediation must not come back: the TileLang kernels are pruned and
+    # _inject_vendored_fla force-sets FLA_TILELANG=0, so installing it cannot help.
+    assert "install tilelang: `pip install tilelang`" not in co
+    assert 'pip install -U "triton>=3.7.1"' in co
 
     compat = (VENDORED / "utils" / "_compat.py").read_text()
     assert "TRITON_ABOVE_3_7_1 = " in compat
@@ -384,12 +393,14 @@ def test_python_39_skips_injection(monkeypatch):
     assert fla_vendor._torch_triton_cuda_supported() is False
 
 
-def test_hopper_bad_triton_range_skips_injection():
-    # Upstream chunk_bwd_dqkwg raises on Hopper + triton [3.4.0, 3.7.1) and
-    # points at the pruned TileLang backend, so injection must bail there.
+def test_hopper_bad_triton_range_is_suspect_but_still_supported():
+    # Hopper + triton [3.4.0, 3.7.1) is the fla #640 miscompile range. It used to
+    # skip injection entirely; the vendored chunk_bwd_dqkwg now steps around the
+    # bad BK=64 tile, so such a host is flagged *suspect* (prefer our copy over an
+    # installed fla) while remaining *supported* (keep the Triton fast path).
     import types
 
-    from unsloth_zoo.temporary_patches.fla_vendor import _hopper_triton_needs_tilelang
+    from unsloth_zoo.temporary_patches.fla_vendor import _hopper_dqkwg_suspect
 
     def fake_torch(name, major, count=1):
         cuda = types.SimpleNamespace(
@@ -410,8 +421,20 @@ def test_hopper_bad_triton_range_skips_injection():
         ("3.8.0", False),
     ):
         tri = types.SimpleNamespace(__version__=ver)
-        assert _hopper_triton_needs_tilelang(hopper, tri) is want_on_hopper, ver
-        assert _hopper_triton_needs_tilelang(blackwell, tri) is False, ver
+        assert _hopper_dqkwg_suspect(hopper, tri) is want_on_hopper, ver
+        assert _hopper_dqkwg_suspect(blackwell, tri) is False, ver
+
+    # The key inversion: being suspect no longer disables injection. The support
+    # gate must not consult the Hopper predicate at all any more.
+    import inspect
+
+    from unsloth_zoo.temporary_patches.fla_vendor import _torch_triton_cuda_supported
+
+    src = inspect.getsource(_torch_triton_cuda_supported)
+    assert "_hopper_dqkwg_suspect(" not in src, (
+        "the support gate must not disable fla on Hopper; the vendored kernel "
+        "avoids the miscompiled tile instead"
+    )
 
 
 def test_rocm_major9_device_not_treated_as_hopper():
@@ -420,7 +443,7 @@ def test_rocm_major9_device_not_treated_as_hopper():
     # Hopper guard, or AMD users lose the vendored path on triton [3.4.0, 3.7.1).
     import types
 
-    from unsloth_zoo.temporary_patches.fla_vendor import _hopper_triton_needs_tilelang
+    from unsloth_zoo.temporary_patches.fla_vendor import _hopper_dqkwg_suspect
 
     def fake_torch(name, major, hip):
         cuda = types.SimpleNamespace(
@@ -433,12 +456,12 @@ def test_rocm_major9_device_not_treated_as_hopper():
     bad = types.SimpleNamespace(__version__="3.6.0")  # in [3.4.0, 3.7.1)
     # AMD Instinct on a ROCm build: major 9 but not Hopper -> keep the fast path.
     amd = fake_torch("AMD Instinct MI300X", 9, "6.0.32830")
-    assert _hopper_triton_needs_tilelang(amd, bad) is False
+    assert _hopper_dqkwg_suspect(amd, bad) is False
     # A real Hopper on a CUDA build (hip=None) still trips, by name and by major.
     nvidia_named = fake_torch("NVIDIA H100 80GB HBM3", 9, None)
     nvidia_unnamed = fake_torch("", 9, None)
-    assert _hopper_triton_needs_tilelang(nvidia_named, bad) is True
-    assert _hopper_triton_needs_tilelang(nvidia_unnamed, bad) is True
+    assert _hopper_dqkwg_suspect(nvidia_named, bad) is True
+    assert _hopper_dqkwg_suspect(nvidia_unnamed, bad) is True
 
 
 def test_hopper_at_nonzero_device_index_trips_guard():
@@ -446,7 +469,7 @@ def test_hopper_at_nonzero_device_index_trips_guard():
     # different architecture; the guard must scan every visible device, not just 0.
     import types
 
-    from unsloth_zoo.temporary_patches.fla_vendor import _hopper_triton_needs_tilelang
+    from unsloth_zoo.temporary_patches.fla_vendor import _hopper_dqkwg_suspect
 
     def mixed_torch(caps, names):
         cuda = types.SimpleNamespace(
@@ -471,11 +494,11 @@ def test_hopper_at_nonzero_device_index_trips_guard():
     ok = types.SimpleNamespace(__version__="3.7.1")    # patched Triton
 
     # A Hopper card at cuda:1 must trip the guard in the bad Triton range.
-    assert _hopper_triton_needs_tilelang(ada_then_hopper, bad) is True
+    assert _hopper_dqkwg_suspect(ada_then_hopper, bad) is True
     # Same host, patched Triton: no skip.
-    assert _hopper_triton_needs_tilelang(ada_then_hopper, ok) is False
+    assert _hopper_dqkwg_suspect(ada_then_hopper, ok) is False
     # No Hopper on any index: never skip.
-    assert _hopper_triton_needs_tilelang(ada_only, bad) is False
+    assert _hopper_dqkwg_suspect(ada_only, bad) is False
 
 
 def test_blackwell_import_device_scans_visible_devices():

--- a/unsloth_zoo/_vendored/_licenses.py
+++ b/unsloth_zoo/_vendored/_licenses.py
@@ -132,6 +132,14 @@ modifications =
           `pip install tilelang`, which cannot work here because the TileLang
           kernels are pruned (below) and _inject_vendored_fla force-sets
           FLA_TILELANG=0.
+          The Hopper test is also widened from upstream's ``IS_NVIDIA_HOPPER``
+          alone, which fla/utils/_device.py freezes at import from device 0, to
+          that OR a probe of ``k.device`` (``_device_is_nvidia_hopper``): the
+          launcher already picks CONST_TILING from ``k.device.index``, so on a
+          mixed host a Hopper card at a nonzero index would otherwise keep the
+          miscompiled tile. The probe uses compute capability 9, not
+          ``check_shared_mem('hopper')``, which is a >=232448-byte shared-memory
+          tier test that Blackwell B200 also passes.
     - Dropped fla/ops/gated_delta_rule/naive.py (the only einops dependency; the
       reference implementation is unused on the fast path).
     - Dropped the three heavy tilelang kernel files

--- a/unsloth_zoo/_vendored/_licenses.py
+++ b/unsloth_zoo/_vendored/_licenses.py
@@ -121,6 +121,17 @@ modifications =
         * PR #983 (issue #640) in ops/common/chunk_o.py (+ TRITON_ABOVE_3_7_1 in
           utils/_compat.py and utils/__init__.py): narrow the Hopper gated
           chunk_bwd_dqkwg guard to Triton [3.4.0, 3.7.1); 3.7.1 fixes the bug.
+          Unsloth goes one step further than upstream here and does not merely
+          narrow the guard, it removes the need for it. Issue #640's own root-cause
+          bisection pins the miscompile to BK == 64 on Hopper (BK 32 and BK 128 both
+          measured clean; the autotune config space was explicitly ruled out), and
+          Hopper's CONST_TILING of 128 only reaches BK 64 for head dims 33..64. So
+          chunk_bwd_dqkwg steps those down to BK 32 and keeps the Triton fast path,
+          and the RuntimeError is retained only as an unreachable fence. Its
+          remediation text was also rewritten: upstream points at
+          `pip install tilelang`, which cannot work here because the TileLang
+          kernels are pruned (below) and _inject_vendored_fla force-sets
+          FLA_TILELANG=0.
     - Dropped fla/ops/gated_delta_rule/naive.py (the only einops dependency; the
       reference implementation is unused on the fast path).
     - Dropped the three heavy tilelang kernel files

--- a/unsloth_zoo/_vendored/fla/MANIFEST
+++ b/unsloth_zoo/_vendored/fla/MANIFEST
@@ -35,6 +35,17 @@ modifications =
         * PR #983 (issue #640) in ops/common/chunk_o.py (+ TRITON_ABOVE_3_7_1 in
           utils/_compat.py and utils/__init__.py): narrow the Hopper gated
           chunk_bwd_dqkwg guard to Triton [3.4.0, 3.7.1); 3.7.1 fixes the bug.
+          Unsloth goes one step further than upstream here and does not merely
+          narrow the guard, it removes the need for it. Issue #640's own root-cause
+          bisection pins the miscompile to BK == 64 on Hopper (BK 32 and BK 128 both
+          measured clean; the autotune config space was explicitly ruled out), and
+          Hopper's CONST_TILING of 128 only reaches BK 64 for head dims 33..64. So
+          chunk_bwd_dqkwg steps those down to BK 32 and keeps the Triton fast path,
+          and the RuntimeError is retained only as an unreachable fence. Its
+          remediation text was also rewritten: upstream points at
+          `pip install tilelang`, which cannot work here because the TileLang
+          kernels are pruned (below) and _inject_vendored_fla force-sets
+          FLA_TILELANG=0.
     - Dropped fla/ops/gated_delta_rule/naive.py (the only einops dependency; the
       reference implementation is unused on the fast path).
     - Dropped the three heavy tilelang kernel files

--- a/unsloth_zoo/_vendored/fla/MANIFEST
+++ b/unsloth_zoo/_vendored/fla/MANIFEST
@@ -46,6 +46,14 @@ modifications =
           `pip install tilelang`, which cannot work here because the TileLang
           kernels are pruned (below) and _inject_vendored_fla force-sets
           FLA_TILELANG=0.
+          The Hopper test is also widened from upstream's ``IS_NVIDIA_HOPPER``
+          alone, which fla/utils/_device.py freezes at import from device 0, to
+          that OR a probe of ``k.device`` (``_device_is_nvidia_hopper``): the
+          launcher already picks CONST_TILING from ``k.device.index``, so on a
+          mixed host a Hopper card at a nonzero index would otherwise keep the
+          miscompiled tile. The probe uses compute capability 9, not
+          ``check_shared_mem('hopper')``, which is a >=232448-byte shared-memory
+          tier test that Blackwell B200 also passes.
     - Dropped fla/ops/gated_delta_rule/naive.py (the only einops dependency; the
       reference implementation is unused on the fast path).
     - Dropped the three heavy tilelang kernel files

--- a/unsloth_zoo/_vendored/fla/ops/common/chunk_o.py
+++ b/unsloth_zoo/_vendored/fla/ops/common/chunk_o.py
@@ -60,16 +60,23 @@ def _device_is_nvidia_hopper(index):
             return True
         return 'NVIDIA H' in torch.cuda.get_device_name(index)
     except Exception:
-        return False
+        return None  # unknown, not "no": see _is_hopper_tensor
 
 
 def _is_hopper_tensor(x):
+    """True / False for a CUDA tensor whose device we could inspect, else None.
+
+    The tri-state matters. ``None`` means "could not tell", and the caller then
+    falls back to the import-time global, so an unexpected probe failure on a real
+    Hopper still gets the step-down. Collapsing that into ``False`` would fail open
+    into the miscompile, which is the one direction this must never take.
+    """
     try:
         if x is None or not x.is_cuda:
-            return False
+            return None
         return _device_is_nvidia_hopper(x.device.index)
     except Exception:
-        return False
+        return None
 
 
 @triton.heuristics({
@@ -755,12 +762,20 @@ def chunk_bwd_dqkwg(
     # upstream guard. Triton >= 3.7.1 fixes the miscompile, so nothing is stepped
     # down there.
     #
-    # ``IS_NVIDIA_HOPPER`` is frozen at import from device 0, so it misses a Hopper
-    # card at a nonzero index on a mixed host; OR in a probe of the tensor's own
-    # device (see _device_is_nvidia_hopper above). Either signal is enough.
+    # Whether *this* call runs on Hopper is a per-tensor question, so ask the
+    # tensor's own device first. ``IS_NVIDIA_HOPPER`` is frozen at import from
+    # device 0 and is wrong in both directions on a mixed host: it misses a Hopper
+    # card at a nonzero index, and it also marks a call on an Ada / Ampere /
+    # Blackwell card as affected when device 0 happens to be the Hopper one, which
+    # would narrow BK for a miscompile that cannot occur there. The global is used
+    # only as the fallback for when the probe cannot tell (``None``), so an
+    # unexpected probe failure on a real Hopper still gets the step-down.
+    _on_hopper = _is_hopper_tensor(k)
+    if _on_hopper is None:
+        _on_hopper = IS_NVIDIA_HOPPER
     HOPPER_DQKWG_BROKEN = (
         g is not None
-        and (IS_NVIDIA_HOPPER or _is_hopper_tensor(k))
+        and _on_hopper
         and TRITON_ABOVE_3_4_0
         and not TRITON_ABOVE_3_7_1
     )

--- a/unsloth_zoo/_vendored/fla/ops/common/chunk_o.py
+++ b/unsloth_zoo/_vendored/fla/ops/common/chunk_o.py
@@ -5,6 +5,8 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+import functools
+
 import torch
 import triton
 import triton.language as tl
@@ -14,6 +16,7 @@ from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
 from fla.utils import (
+    IS_NVIDIA,
     IS_NVIDIA_HOPPER,
     TRITON_ABOVE_3_4_0,
     TRITON_ABOVE_3_7_1,
@@ -23,6 +26,50 @@ from fla.utils import (
 
 BKV_LIST = [64, 128] if check_shared_mem() else ([32, 64] if check_shared_mem('ada') else [32])
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
+
+
+# Unsloth: per-device Hopper probe for the fla #640 tile workaround below.
+#
+# ``IS_NVIDIA_HOPPER`` (fla/utils/_device.py) is a module constant frozen at import
+# time from device 0 only:
+#     IS_NVIDIA_HOPPER = (IS_NVIDIA and ('NVIDIA H' in torch.cuda.get_device_name(0)
+#                                        or torch.cuda.get_device_capability()[0] == 9))
+# while chunk_bwd_dqkwg picks CONST_TILING per tensor via ``k.device.index``. On a
+# mixed host (cuda:0 Ada/Blackwell, cuda:1 H100) the global is False even though the
+# tensor lives on Hopper, so the BK=64 step-down would not fire and the miscompiled
+# tile would silently corrupt dk/dg. Probe the tensor's own device instead.
+#
+# Only ever ORed with the global, never used to clear it, so this can add a
+# step-down but never remove one.
+#
+# Capability, not shared memory: ``check_shared_mem('hopper', idx)`` is a
+# shared-memory *tier* test (>= 232448 bytes) that Blackwell B200 also passes, so it
+# is not a Hopper detector. SM90 == Hopper. HIP is excluded because an AMD Instinct
+# reports capability major 9 on a ROCm build without being Hopper, matching how
+# fla_vendor._hopper_dqkwg_suspect gates the bare major==9 signal.
+@functools.lru_cache(maxsize=None)
+def _device_is_nvidia_hopper(index):
+    if not IS_NVIDIA:
+        return False
+    try:
+        if getattr(torch.version, 'hip', None) is not None:
+            return False
+        if index is None:
+            index = torch.cuda.current_device()
+        if torch.cuda.get_device_capability(index)[0] == 9:
+            return True
+        return 'NVIDIA H' in torch.cuda.get_device_name(index)
+    except Exception:
+        return False
+
+
+def _is_hopper_tensor(x):
+    try:
+        if x is None or not x.is_cuda:
+            return False
+        return _device_is_nvidia_hopper(x.device.index)
+    except Exception:
+        return False
 
 
 @triton.heuristics({
@@ -707,8 +754,15 @@ def chunk_bwd_dqkwg(
     # pure-torch layer. Scoped to the gated path (g is not None), matching the
     # upstream guard. Triton >= 3.7.1 fixes the miscompile, so nothing is stepped
     # down there.
+    #
+    # ``IS_NVIDIA_HOPPER`` is frozen at import from device 0, so it misses a Hopper
+    # card at a nonzero index on a mixed host; OR in a probe of the tensor's own
+    # device (see _device_is_nvidia_hopper above). Either signal is enough.
     HOPPER_DQKWG_BROKEN = (
-        g is not None and IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0 and not TRITON_ABOVE_3_7_1
+        g is not None
+        and (IS_NVIDIA_HOPPER or _is_hopper_tensor(k))
+        and TRITON_ABOVE_3_4_0
+        and not TRITON_ABOVE_3_7_1
     )
     if HOPPER_DQKWG_BROKEN and BK == 64:
         BK = 32

--- a/unsloth_zoo/_vendored/fla/ops/common/chunk_o.py
+++ b/unsloth_zoo/_vendored/fla/ops/common/chunk_o.py
@@ -680,15 +680,6 @@ def chunk_bwd_dqkwg(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    # Unsloth: backported from fla PR #983 (issue #640). Triton 3.7.1 fixes the
-    # precision bug, so only block the affected [3.4.0, 3.7.1) range on Hopper.
-    if g is not None and IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0 and not TRITON_ABOVE_3_7_1:
-        raise RuntimeError(
-            "Triton >= 3.4.0 and < 3.7.1 on Hopper GPUs produces incorrect results for "
-            "gated chunk_bwd_dqkwg (see #640). Please upgrade Triton to >= 3.7.1 or "
-            "install tilelang: `pip install tilelang`"
-        )
-
     B, T, H, K, V, HV = *k.shape, v.shape[-1], v.shape[2]
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
@@ -703,6 +694,38 @@ def chunk_bwd_dqkwg(
         CONST_TILING = 32
     BK = min(max(triton.next_power_of_2(K), 16), CONST_TILING)
     BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
+
+    # Unsloth: extends the fla PR #983 (issue #640) backport. Upstream narrowed the
+    # Hopper guard to Triton [3.4.0, 3.7.1) but still refused to run at all. The
+    # root cause reported in #640 is narrower than that: a Triton codegen bug that
+    # only corrupts dk (and, through it, dg and dbeta) at BK == 64 on Hopper. The
+    # upstream CONST_TILING sweep measured BK 32 and BK 128 clean (< 0.02) and only
+    # BK 64 broken (dk max error 14.65, dg 5.47), and explicitly ruled out the
+    # autotune config space as the trigger. Hopper's CONST_TILING of 128 means the
+    # bad tile is reachable only for head dims 33 <= K <= 64, so step those down to
+    # the measured-clean 32 and keep the fast kernels instead of falling back to a
+    # pure-torch layer. Scoped to the gated path (g is not None), matching the
+    # upstream guard. Triton >= 3.7.1 fixes the miscompile, so nothing is stepped
+    # down there.
+    HOPPER_DQKWG_BROKEN = (
+        g is not None and IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0 and not TRITON_ABOVE_3_7_1
+    )
+    if HOPPER_DQKWG_BROKEN and BK == 64:
+        BK = 32
+
+    # Unreachable fence: BK can no longer be 64 in the affected range. Kept so a
+    # future edit that reintroduces the bad tile fails loudly instead of silently
+    # training on corrupted gradients.
+    if HOPPER_DQKWG_BROKEN and BK == 64:
+        raise RuntimeError(
+            "Triton >= 3.4.0 and < 3.7.1 on Hopper GPUs produces incorrect results for "
+            "gated chunk_bwd_dqkwg at BK=64 (see fla issue #640). Fix this with: "
+            'pip install -U "triton>=3.7.1"\n'
+            "Note: upstream also suggests `pip install tilelang`, which cannot help "
+            "here because this vendored snapshot prunes the TileLang kernels. To take "
+            "the slower pure-PyTorch path instead, set UNSLOTH_DISABLE_HOPPER_FLA_BWD=1."
+        )
+
     NK = triton.cdiv(K, BK)
     dq = q.new_empty(B, T, HV, K)
     dk = k.new_empty(B, T, HV, K)

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -244,6 +244,37 @@ def _hopper_dqkwg_suspect_here():
     return _hopper_dqkwg_suspect(torch, triton)
 
 
+@functools.lru_cache(maxsize=None)
+def _device_index_is_hopper(index):
+    """Whether one CUDA device index is an NVIDIA Hopper (SM90).
+
+    ``_hopper_dqkwg_suspect_here`` deliberately answers for the whole process (any
+    visible Hopper counts), which is right for deciding *whether to install* the
+    workaround. Deciding whether a given call needs it is a per-tensor question:
+    fla #640 is Hopper-only, so narrowing the tile for a tensor on an Ada or
+    Blackwell card in the same box would cost speed for nothing. HIP excluded, as
+    an AMD Instinct reports capability major 9 without being Hopper.
+    """
+    try:
+        import torch
+        if getattr(getattr(torch, "version", None), "hip", None) is not None:
+            return False
+        if index is None:
+            index = torch.cuda.current_device()
+        if torch.cuda.get_device_capability(index)[0] == 9:
+            return True
+        return "NVIDIA H" in torch.cuda.get_device_name(index)
+    except Exception:
+        return False
+
+
+def _tensor_on_hopper(x):
+    try:
+        return bool(x is not None and x.is_cuda and _device_index_is_hopper(x.device.index))
+    except Exception:
+        return False
+
+
 # Set once when UNSLOTH_DISABLE_HOPPER_FLA_BWD turns the fast kernels off, so
 # unsloth's loader can explain *why* the slow path was chosen instead of blaming
 # "no CUDA / torch < 2.7 / triton < 3.3", none of which is true on an H100.
@@ -788,6 +819,12 @@ def _patch_installed_fla_dqkwg():
         k = _arg("k", _k_pos, args, kwargs, _MISSING)
         if g is None:
             return original(*args, **kwargs)  # ungated: the miscompile cannot fire
+        if not _tensor_on_hopper(k):
+            # The wrapper is installed process-wide because *some* visible GPU is
+            # Hopper, but #640 is Hopper-only. A call on an Ada / Ampere / Blackwell
+            # card in the same box must keep its normal tiling, or K=33..64 would
+            # narrow both BK and BV on every backward for no reason.
+            return original(*args, **kwargs)
         try:
             idx = k.device.index
             if real_check_shared_mem('hopper', idx):

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -254,6 +254,9 @@ def _device_index_is_hopper(index):
     fla #640 is Hopper-only, so narrowing the tile for a tensor on an Ada or
     Blackwell card in the same box would cost speed for nothing. HIP excluded, as
     an AMD Instinct reports capability major 9 without being Hopper.
+
+    Returns None when the device cannot be inspected, so callers can fall back to
+    the process-wide answer rather than fail open into the miscompile.
     """
     try:
         import torch
@@ -265,14 +268,24 @@ def _device_index_is_hopper(index):
             return True
         return "NVIDIA H" in torch.cuda.get_device_name(index)
     except Exception:
-        return False
+        return None
 
 
 def _tensor_on_hopper(x):
+    """Whether a call on this tensor needs the #640 workaround.
+
+    Unknown devices fall back to True: the wrapper is only installed at all when
+    ``_hopper_dqkwg_suspect_here()`` already said some visible GPU is Hopper, so on
+    a host we cannot inspect the safe answer is to keep the narrower tile. Being
+    wrong that way costs speed; being wrong the other way corrupts gradients.
+    """
     try:
-        return bool(x is not None and x.is_cuda and _device_index_is_hopper(x.device.index))
+        if x is None or not x.is_cuda:
+            return True
+        answer = _device_index_is_hopper(x.device.index)
+        return True if answer is None else bool(answer)
     except Exception:
-        return False
+        return True
 
 
 # Set once when UNSLOTH_DISABLE_HOPPER_FLA_BWD turns the fast kernels off, so

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -49,6 +49,7 @@ __all__ = [
 
 import os
 import sys
+import functools
 import importlib
 import importlib.util
 
@@ -650,6 +651,103 @@ def _disable_already_imported_gated_delta():
             )
 
 
+_INSTALLED_FLA_PATCH_MARK = "_unsloth_hopper_dqkwg_patched"
+
+
+def _patch_installed_fla_dqkwg():
+    """Apply the BK=64 workaround to a *user-installed* fla, in place.
+
+    When a deliberate fla-core install is present on an affected Hopper host we
+    would otherwise have to shadow it with the vendored snapshot to get the tile
+    fix, silently downgrading whatever newer upstream the user chose. Patching
+    their copy instead keeps their kernels and fixes only the miscompiled tile.
+
+    Mechanism, chosen so it does not depend on the installed fla's source layout
+    (which differs across versions): wrap ``chunk_bwd_dqkwg`` and, for the
+    duration of a gated call, flip two module globals it reads.
+
+      * ``IS_NVIDIA_HOPPER = False`` disables the blanket guard. Inside this
+        function that global is read *only* by the guard; the Hopper autotune
+        restrictions were frozen at import, so nothing else moves.
+      * ``check_shared_mem`` reporting the smallest tier makes the function's own
+        arithmetic pick ``CONST_TILING = 32``, hence ``BK = 32``. Applied only
+        when the unmodified arithmetic would have landed on 64.
+
+    ``BV`` drops to 32 alongside ``BK`` on that path, because both derive from the
+    same ``CONST_TILING``. That costs some speed for head dims 33..64 only, and
+    the vendored copy (which edits the source directly) keeps the wider ``BV``.
+
+    Returns True if a patch was installed. Best effort: any failure leaves the
+    installed fla untouched and the caller falls back to shadowing it.
+    """
+    try:
+        import triton
+        import fla.ops.common.chunk_o as chunk_o
+    except Exception:
+        return False
+
+    fn = getattr(chunk_o, "chunk_bwd_dqkwg", None)
+    if fn is None or getattr(fn, _INSTALLED_FLA_PATCH_MARK, False):
+        return False
+    if not all(hasattr(chunk_o, a) for a in ("IS_NVIDIA_HOPPER", "check_shared_mem")):
+        return False  # unrecognised layout; do not guess
+
+    original = fn
+
+    @functools.wraps(original)
+    def _patched(*args, **kwargs):
+        g = kwargs.get("g")
+        k = kwargs.get("k")
+        if g is None or k is None:
+            return original(*args, **kwargs)
+        saved_hopper = chunk_o.IS_NVIDIA_HOPPER
+        saved_check = chunk_o.check_shared_mem
+        chunk_o.IS_NVIDIA_HOPPER = False
+        try:
+            try:
+                idx = k.device.index
+                if chunk_o.check_shared_mem('hopper', idx):
+                    const_tiling = 128
+                elif chunk_o.check_shared_mem('ada', idx):
+                    const_tiling = 64
+                else:
+                    const_tiling = 32
+                bad_tile = min(max(triton.next_power_of_2(k.shape[-1]), 16), const_tiling) == 64
+            except Exception:
+                bad_tile = True  # unknown shape: take the safe tile
+            if bad_tile:
+                chunk_o.check_shared_mem = lambda arch="none", tensor_idx=0: False
+            return original(*args, **kwargs)
+        finally:
+            chunk_o.IS_NVIDIA_HOPPER = saved_hopper
+            chunk_o.check_shared_mem = saved_check
+
+    setattr(_patched, _INSTALLED_FLA_PATCH_MARK, True)
+    chunk_o.chunk_bwd_dqkwg = _patched
+
+    # fla/ops/gated_delta_rule/chunk.py does `from fla.ops.common.chunk_o import
+    # chunk_bwd_dqkwg` at import, so that module global still holds the original.
+    # Rebind every fla module pointing at it, the same way _patch_is_available
+    # rebinds transformers' probe.
+    for name, mod in list(sys.modules.items()):
+        if mod is None or not (name == "fla" or name.startswith("fla.")):
+            continue
+        mod_dict = getattr(mod, "__dict__", None)
+        if not isinstance(mod_dict, dict):
+            continue
+        if mod_dict.get("chunk_bwd_dqkwg") is original:
+            try:
+                setattr(mod, "chunk_bwd_dqkwg", _patched)
+            except Exception:
+                pass
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info(
+            "Unsloth: patched the installed fla's chunk_bwd_dqkwg for the Hopper "
+            "BK=64 miscompile (fla #640); keeping your fla install."
+        )
+    return True
+
+
 def _mark_fla_disabled_hopper():
     global _FLA_DISABLED_REASON
     if _FLA_DISABLED_REASON is not None:
@@ -698,15 +796,25 @@ def patch_vendor_fla(phase=None):
 
     replaced_real = False
     if not _vendored_already_injected():
-        # On a host where fla's gated chunk_bwd_dqkwg is miscompiled, prefer the
-        # vendored copy over any user install regardless of version: only ours
-        # carries the BK=64 tile workaround for fla #640. Deferring there is what
-        # left a pip-installed fla-core raising mid-backward on H100s
-        # (unslothai/unsloth#5276).
-        force = _flag("UNSLOTH_FORCE_VENDORED_FLA") or _hopper_dqkwg_suspect_here()
+        force = _flag("UNSLOTH_FORCE_VENDORED_FLA")
         if not force and _should_defer_to_installed_fla():
             # A newer (or unversioned deliberate) user install is present; use it.
-            return
+            # On an affected Hopper host it carries the #640 miscompile, which is
+            # what left a pip-installed fla-core raising mid-backward
+            # (unslothai/unsloth#5276). Patch their copy in place rather than
+            # shadowing it, so they keep the upstream they deliberately chose. If
+            # the patch cannot be applied, fall through to the vendored snapshot,
+            # which has the fix compiled in.
+            if not _hopper_dqkwg_suspect_here():
+                return
+            if _patch_installed_fla_dqkwg():
+                # Deliberately no _patch_is_available() here: their fla is a real
+                # install, so transformers' native probe already finds it, and our
+                # vendored probe would wrongly narrow it to the vendor-covered
+                # models. Rebinding chunk_bwd_dqkwg on the fla modules is enough,
+                # because chunk_gated_delta_rule looks it up as a module global at
+                # call time, so modeling modules imported earlier pick it up too.
+                return
         if not _torch_triton_cuda_supported():
             # Cannot run the Triton kernels here; leave the pure-torch fallback.
             return

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -860,40 +860,54 @@ def _transformers_uses_availability_probe():
     ``is_flash_linear_attention_available()`` probe + module globals.
 
     Transformers PR #47630 ("[Kernels] Refactor all linear attn models & native
-    kernels fallback", merged after v5.14.1) drops that probe entirely: the
-    modeling files now carry
+    kernels fallback", merged after v5.14.1) stops using that probe: the modeling
+    files now carry
     ``@use_kernel_func_from_hub_with_fallback("chunk_gated_delta_rule", "fla")``,
     which resolves the implementation with ``importlib.import_module`` at
     decoration time and freezes it into a closure. There is then no probe to answer
     False and no module global to unbind.
+
+    Detected by the *presence of the new mechanism*, not the absence of the old
+    name. Two traps make the obvious check wrong:
+
+      * ``is_flash_linear_attention_available`` still exists in
+        ``transformers/utils/import_utils.py`` after #47630 (it is merely unused by
+        the modeling files), so ``hasattr`` on it is True in both layouts.
+      * ``_patch_is_available`` assigns the attribute unconditionally, so once it
+        has run the old name is present even on a Transformers that never had it.
+        Any caller must therefore evaluate this BEFORE ``_patch_is_available``.
     """
     try:
-        import transformers.utils.import_utils as iu
+        from transformers.integrations import hub_kernels
     except Exception:
         return True  # cannot tell; assume the old layout and stay quiet
-    return hasattr(iu, "is_flash_linear_attention_available")
+    return not hasattr(hub_kernels, "use_kernel_func_from_hub_with_fallback")
 
 
-def _warn_if_hopper_optout_cannot_engage():
-    """Say so loudly when UNSLOTH_DISABLE_HOPPER_FLA_BWD cannot actually take hold.
+def _warn_hopper_optout_degraded(patched_installed):
+    """Say so loudly when UNSLOTH_DISABLE_HOPPER_FLA_BWD cannot force pure torch.
 
     Silence would be the dangerous outcome: the user set a *correctness* switch and
     would reasonably believe gated-delta training had moved off the miscompiled
     kernel. On a post-#47630 Transformers neither lever we pull exists, so the
-    switch is inert. Their training is still protected -- the vendored
-    chunk_bwd_dqkwg steps around the bad tile and the installed-fla patch does the
-    same one layer down -- but they should know the escape hatch did nothing.
+    switch cannot do what it says.
     """
-    if _transformers_uses_availability_probe():
-        return
+    protection = (
+        "Unsloth patched the installed fla's chunk_bwd_dqkwg instead, so the\n"
+        "miscompiled block size is still avoided and your gradients are correct."
+        if patched_installed else
+        "The gated-delta kernels Unsloth ships already avoid the miscompiled block\n"
+        "size, so your gradients are correct."
+    )
     logger.warning(
-        "Unsloth: UNSLOTH_DISABLE_HOPPER_FLA_BWD=1 could not be applied. This\n"
-        "Transformers selects gated-deltanet kernels through the kernel-hub\n"
-        "decorator (transformers#47630) rather than is_flash_linear_attention_available,\n"
-        "so there is no availability probe to disable and no module global to unbind.\n"
-        "Training is still protected: Unsloth's gated chunk_bwd_dqkwg avoids the\n"
-        "miscompiled block size (fla #640) on Hopper. For the pure-PyTorch path,\n"
-        'install a Triton with the upstream fix instead: pip install -U "triton>=3.7.1"'
+        "Unsloth: UNSLOTH_DISABLE_HOPPER_FLA_BWD=1 could not force the pure-PyTorch\n"
+        "path. This Transformers selects gated-deltanet kernels through the\n"
+        "kernel-hub decorator (transformers#47630) rather than\n"
+        "is_flash_linear_attention_available, so there is no availability probe to\n"
+        "disable and no module global to unbind.\n"
+        f"{protection}\n"
+        "To actually reach the pure-PyTorch path, install a Triton carrying the\n"
+        'upstream fix instead: pip install -U "triton>=3.7.1"'
     )
 
 
@@ -910,10 +924,22 @@ def patch_vendor_fla(phase=None):
     # installed fla stays importable, so transformers' own availability probe would
     # answer True and bind the unpatched kernels (unslothai/unsloth#5276).
     if _flag("UNSLOTH_DISABLE_HOPPER_FLA_BWD") and _hopper_dqkwg_suspect_here():
+        # Sample the layout BEFORE _patch_is_available, which assigns the probe
+        # attribute unconditionally and would otherwise make every Transformers
+        # look like the old one.
+        can_force_pure_torch = _transformers_uses_availability_probe()
         _mark_fla_disabled_hopper()
         _patch_is_available(_unavailable_probe)
         _disable_already_imported_gated_delta()
-        _warn_if_hopper_optout_cannot_engage()
+        if not can_force_pure_torch:
+            # The opt-out cannot do what it says here: the kernel-hub decorator
+            # froze the implementation at decoration time, so neither the probe nor
+            # the module globals steer anything. Returning now would leave a
+            # user-installed fla's unpatched BK=64 kernel live -- i.e. setting the
+            # safety switch would make this host LESS safe than not setting it,
+            # since the normal path patches that kernel. Patch it here too, then
+            # say plainly that the pure-torch path was not reachable.
+            _warn_hopper_optout_degraded(_patch_installed_fla_dqkwg())
         return
 
     if _flag("UNSLOTH_DISABLE_VENDORED_FLA"):

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -884,28 +884,28 @@ def _transformers_uses_availability_probe():
     return not hasattr(hub_kernels, "use_kernel_func_from_hub_with_fallback")
 
 
-def _warn_hopper_optout_degraded(patched_installed):
+def _warn_hopper_optout_degraded():
     """Say so loudly when UNSLOTH_DISABLE_HOPPER_FLA_BWD cannot force pure torch.
 
     Silence would be the dangerous outcome: the user set a *correctness* switch and
     would reasonably believe gated-delta training had moved off the miscompiled
-    kernel. On a post-#47630 Transformers neither lever we pull exists, so the
-    switch cannot do what it says.
+    kernel. On a post-#47630 Transformers neither lever we pull steers kernel
+    selection, so the switch cannot do what it says.
+
+    Deliberately makes no claim about the resulting gradients. The caller falls
+    through to the normal path, which patches or shadows fla so the kernel the
+    decorator resolves carries the tile fix, but whether that succeeds depends on
+    the install it finds -- and asserting "your gradients are correct" here would
+    be exactly the wrong thing to say if it did not.
     """
-    protection = (
-        "Unsloth patched the installed fla's chunk_bwd_dqkwg instead, so the\n"
-        "miscompiled block size is still avoided and your gradients are correct."
-        if patched_installed else
-        "The gated-delta kernels Unsloth ships already avoid the miscompiled block\n"
-        "size, so your gradients are correct."
-    )
     logger.warning(
         "Unsloth: UNSLOTH_DISABLE_HOPPER_FLA_BWD=1 could not force the pure-PyTorch\n"
         "path. This Transformers selects gated-deltanet kernels through the\n"
         "kernel-hub decorator (transformers#47630) rather than\n"
         "is_flash_linear_attention_available, so there is no availability probe to\n"
         "disable and no module global to unbind.\n"
-        f"{protection}\n"
+        "Unsloth is instead making the fla that decorator resolves one that avoids\n"
+        "the miscompiled block size (fla #640).\n"
         "To actually reach the pure-PyTorch path, install a Triton carrying the\n"
         'upstream fix instead: pip install -U "triton>=3.7.1"'
     )
@@ -927,20 +927,23 @@ def patch_vendor_fla(phase=None):
         # Sample the layout BEFORE _patch_is_available, which assigns the probe
         # attribute unconditionally and would otherwise make every Transformers
         # look like the old one.
-        can_force_pure_torch = _transformers_uses_availability_probe()
-        _mark_fla_disabled_hopper()
-        _patch_is_available(_unavailable_probe)
-        _disable_already_imported_gated_delta()
-        if not can_force_pure_torch:
-            # The opt-out cannot do what it says here: the kernel-hub decorator
-            # froze the implementation at decoration time, so neither the probe nor
-            # the module globals steer anything. Returning now would leave a
-            # user-installed fla's unpatched BK=64 kernel live -- i.e. setting the
-            # safety switch would make this host LESS safe than not setting it,
-            # since the normal path patches that kernel. Patch it here too, then
-            # say plainly that the pure-torch path was not reachable.
-            _warn_hopper_optout_degraded(_patch_installed_fla_dqkwg())
-        return
+        if _transformers_uses_availability_probe():
+            _mark_fla_disabled_hopper()
+            _patch_is_available(_unavailable_probe)
+            _disable_already_imported_gated_delta()
+            return
+        # Post-#47630 Transformers: the kernel-hub decorator resolves fla with
+        # importlib at decoration time, so neither the availability probe nor the
+        # module globals steer kernel selection and the opt-out cannot reach the
+        # pure-PyTorch path. Do NOT return here. Returning would leave whatever fla
+        # the decorator resolves -- a user's unpatched install -- serving the BK=64
+        # backward, making the safety switch worse than not setting it. Fall
+        # through to the normal path instead: it patches an installed fla in place
+        # and otherwise injects the vendored snapshot, either of which guarantees
+        # the fla the decorator resolves carries the tile fix. Deliberately no
+        # _mark_fla_disabled_hopper() -- fla is not disabled on this path, and
+        # claiming otherwise would mislead unsloth's loader message.
+        _warn_hopper_optout_degraded()
 
     if _flag("UNSLOTH_DISABLE_VENDORED_FLA"):
         # Scope is the vendored injection only: a user's own fla install is left as

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -50,6 +50,8 @@ __all__ = [
 import os
 import sys
 import functools
+import inspect
+import threading
 import importlib
 import importlib.util
 
@@ -77,11 +79,27 @@ _REPAIR_MODELING = ("qwen3_5", "qwen3_5_moe", "qwen3_next")
 # False (keep the pure-torch path) or its modeling module crashes on import.
 _VENDOR_COVERED_MODELS = frozenset(_REPAIR_MODELING)
 
-# Every gated-deltanet consumer, not just the vendor-covered ones. Used only by the
-# UNSLOTH_DISABLE_HOPPER_FLA_BWD path: those extra models never bind the *vendored*
-# kernels, but they do bind a user-installed fla's, which carries the same #640
-# miscompile, so they must be unbound too.
-_GATED_DELTA_MODELING = _REPAIR_MODELING + ("kimi_linear", "olmo_hybrid")
+# Every gated-deltanet consumer, not just the vendor-covered ones. Used by the
+# UNSLOTH_DISABLE_HOPPER_FLA_BWD path and the purge path below: the extra models
+# never bind the *vendored* kernels, but they do bind a user-installed fla's, which
+# carries the same #640 miscompile, so they must be unbound too.
+#
+# olmo_hybrid (transformers >= 5.3) is the only one: it imports
+# chunk_gated_delta_rule alongside ShortConvolution. Kimi Linear deliberately is
+# NOT here -- transformers ships no `kimi_linear` model (only `kimi_k25`), the
+# weights run through trust_remote_code as `transformers_modules...modeling_kimi`,
+# and that code calls fla's KDA ops (chunk_kda / fused_recurrent_kda), which have
+# their own kernels and never reach chunk_bwd_dqkwg. Listing it would be a name
+# that can never resolve.
+_GATED_DELTA_MODELING = _REPAIR_MODELING + ("olmo_hybrid",)
+
+# The gated-deltanet consumers the vendored snapshot cannot serve, so
+# _repair_already_imported_modeling can never rebind them onto the fixed kernels.
+# If one of them was imported while a user-installed fla was live and we then purge
+# that install, its module global still points at the unpatched kernel.
+_UNCOVERED_GATED_DELTA = tuple(
+    pkg for pkg in _GATED_DELTA_MODELING if pkg not in _VENDOR_COVERED_MODELS
+)
 
 # Minimum versions declared by fla-core 0.5.1.
 _MIN_TORCH = "2.7"
@@ -618,7 +636,7 @@ def _repair_already_imported_modeling(force_rebind=False):
             logger.info(f"Unsloth: rebound vendored fla kernels onto {modname}.")
 
 
-def _disable_already_imported_gated_delta():
+def _disable_already_imported_gated_delta(packages=_GATED_DELTA_MODELING, why="UNSLOTH_DISABLE_HOPPER_FLA_BWD"):
     """Unbind the miscompiled chunk kernel on gated-delta modeling modules that were
     imported before this ran.
 
@@ -633,7 +651,7 @@ def _disable_already_imported_gated_delta():
     backward-pass bug in the chunked kernel; ``fused_recurrent_gated_delta_rule``
     (decode) and ``FusedRMSNormGated`` are unaffected and stay fast.
     """
-    for pkg in _GATED_DELTA_MODELING:
+    for pkg in packages:
         modname = f"transformers.models.{pkg}.modeling_{pkg}"
         mod = sys.modules.get(modname)
         if mod is None:
@@ -646,12 +664,31 @@ def _disable_already_imported_gated_delta():
             continue
         if UNSLOTH_ENABLE_LOGGING:
             logger.info(
-                f"Unsloth: unbound fla chunk_gated_delta_rule on {modname} "
-                "(UNSLOTH_DISABLE_HOPPER_FLA_BWD)."
+                f"Unsloth: unbound fla chunk_gated_delta_rule on {modname} ({why})."
             )
 
 
 _INSTALLED_FLA_PATCH_MARK = "_unsloth_hopper_dqkwg_patched"
+
+# Per-thread override for the installed-fla patch below. NOT a module global that
+# gets saved/mutated/restored around the call: torch's autograd engine runs one
+# worker thread per device ("The engine operates by having a single worker thread
+# per work queue, and every work queue is pinned to a specific device",
+# torch/csrc/autograd/engine.cpp), so a single ``.backward()`` over a model sharded
+# across two GPUs already executes two Python backward bodies concurrently, and
+# every ATen op / Triton launch inside them drops the GIL
+# (``pybind11::gil_scoped_release`` in the generated bindings,
+# ``Py_BEGIN_ALLOW_THREADS`` in Triton's launcher). A save/restore of a module
+# global therefore genuinely interleaves: one call restores the guard flag to True
+# while the other is still inside, which resurrects the RuntimeError mid-backward,
+# or leaves the tile override stuck on for the rest of the process. A
+# threading.local carries the override on the calling thread only, so no lock is
+# needed and multi-GPU backward stays parallel.
+_installed_fla_tls = threading.local()
+
+
+def _installed_fla_forcing_small_tile():
+    return getattr(_installed_fla_tls, "force_small_tile", False)
 
 
 def _patch_installed_fla_dqkwg():
@@ -663,21 +700,32 @@ def _patch_installed_fla_dqkwg():
     their copy instead keeps their kernels and fixes only the miscompiled tile.
 
     Mechanism, chosen so it does not depend on the installed fla's source layout
-    (which differs across versions): wrap ``chunk_bwd_dqkwg`` and, for the
-    duration of a gated call, flip two module globals it reads.
+    (which differs across versions): wrap ``chunk_bwd_dqkwg`` and steer the two
+    module globals it reads. Both are plain ``LOAD_GLOBAL`` reads out of
+    ``fla.ops.common.chunk_o.__dict__`` on every call, so rebinding the module
+    attribute is enough.
 
-      * ``IS_NVIDIA_HOPPER = False`` disables the blanket guard. Inside this
-        function that global is read *only* by the guard; the Hopper autotune
-        restrictions were frozen at import, so nothing else moves.
-      * ``check_shared_mem`` reporting the smallest tier makes the function's own
-        arithmetic pick ``CONST_TILING = 32``, hence ``BK = 32``. Applied only
-        when the unmodified arithmetic would have landed on 64.
+      * ``IS_NVIDIA_HOPPER`` is set to False *once and permanently*. Inside
+        ``chunk_bwd_dqkwg`` that global is read only by the blanket guard; the
+        Hopper autotune restriction (``NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER
+        else ...``) is a module constant frozen into the kernel's config list at
+        import, so a later rebind cannot move it. Setting it permanently rather
+        than per call is what makes this wrapper thread safe (see
+        ``_installed_fla_tls``).
+      * ``check_shared_mem`` is replaced *once and permanently* by a shim that
+        answers False while the calling thread has the small-tile override set,
+        and delegates to fla's real (``@cache``d) implementation otherwise. That
+        makes the function's own arithmetic pick ``CONST_TILING = 32``, hence
+        ``BK = 32``, only for the calls that would otherwise land on 64.
 
     ``BV`` drops to 32 alongside ``BK`` on that path, because both derive from the
     same ``CONST_TILING``. That costs some speed for head dims 33..64 only, and
     the vendored copy (which edits the source directly) keeps the wider ``BV``.
 
-    Returns True if a patch was installed. Best effort: any failure leaves the
+    Returns True if the installed fla is patched, including when a previous call
+    already patched it: this runs once at import and again from TEMPORARY_PATCHES,
+    and reporting idempotence as failure would make the second call shadow the
+    user's fla with the vendored snapshot. Best effort: any real failure leaves the
     installed fla untouched and the caller falls back to shadowing it.
     """
     try:
@@ -687,40 +735,76 @@ def _patch_installed_fla_dqkwg():
         return False
 
     fn = getattr(chunk_o, "chunk_bwd_dqkwg", None)
-    if fn is None or getattr(fn, _INSTALLED_FLA_PATCH_MARK, False):
+    if fn is None:
         return False
+    if getattr(fn, _INSTALLED_FLA_PATCH_MARK, False):
+        return True  # already patched by an earlier call; idempotent success
     if not all(hasattr(chunk_o, a) for a in ("IS_NVIDIA_HOPPER", "check_shared_mem")):
         return False  # unrecognised layout; do not guess
 
     original = fn
 
+    # Every in-tree fla caller passes `g=` / `k=` by keyword, but the signature is
+    # (q, k, v, do, h, dh, w=None, g=None, ...), so a positional caller is possible.
+    # Resolve the positions once; if the signature cannot be read, treat every call
+    # as potentially gated and take the safe tile (costs speed, never correctness).
+    try:
+        _params = list(inspect.signature(original).parameters)
+        _k_pos, _g_pos = _params.index("k"), _params.index("g")
+    except Exception:
+        _k_pos = _g_pos = None
+
+    def _arg(name, pos, args, kwargs, missing):
+        if name in kwargs:
+            return kwargs[name]
+        if pos is not None and len(args) > pos:
+            return args[pos]
+        return missing
+
+    _MISSING = object()
+
+    real_check_shared_mem = chunk_o.check_shared_mem
+    if not getattr(real_check_shared_mem, _INSTALLED_FLA_PATCH_MARK, False):
+        def _check_shared_mem_shim(arch="none", tensor_idx=0):
+            if _installed_fla_forcing_small_tile():
+                return False
+            return real_check_shared_mem(arch, tensor_idx)
+
+        setattr(_check_shared_mem_shim, _INSTALLED_FLA_PATCH_MARK, True)
+        _check_shared_mem_shim.__wrapped__ = real_check_shared_mem
+        chunk_o.check_shared_mem = _check_shared_mem_shim
+    else:
+        real_check_shared_mem = getattr(
+            real_check_shared_mem, "__wrapped__", real_check_shared_mem,
+        )
+
+    # Permanent: the guard is the only runtime reader of this global inside
+    # chunk_bwd_dqkwg, and on this host it would only ever refuse to run.
+    chunk_o.IS_NVIDIA_HOPPER = False
+
     @functools.wraps(original)
     def _patched(*args, **kwargs):
-        g = kwargs.get("g")
-        k = kwargs.get("k")
-        if g is None or k is None:
-            return original(*args, **kwargs)
-        saved_hopper = chunk_o.IS_NVIDIA_HOPPER
-        saved_check = chunk_o.check_shared_mem
-        chunk_o.IS_NVIDIA_HOPPER = False
+        g = _arg("g", _g_pos, args, kwargs, _MISSING)
+        k = _arg("k", _k_pos, args, kwargs, _MISSING)
+        if g is None:
+            return original(*args, **kwargs)  # ungated: the miscompile cannot fire
         try:
-            try:
-                idx = k.device.index
-                if chunk_o.check_shared_mem('hopper', idx):
-                    const_tiling = 128
-                elif chunk_o.check_shared_mem('ada', idx):
-                    const_tiling = 64
-                else:
-                    const_tiling = 32
-                bad_tile = min(max(triton.next_power_of_2(k.shape[-1]), 16), const_tiling) == 64
-            except Exception:
-                bad_tile = True  # unknown shape: take the safe tile
-            if bad_tile:
-                chunk_o.check_shared_mem = lambda arch="none", tensor_idx=0: False
+            idx = k.device.index
+            if real_check_shared_mem('hopper', idx):
+                const_tiling = 128
+            elif real_check_shared_mem('ada', idx):
+                const_tiling = 64
+            else:
+                const_tiling = 32
+            bad_tile = min(max(triton.next_power_of_2(k.shape[-1]), 16), const_tiling) == 64
+        except Exception:
+            bad_tile = True  # unknown shape/args: take the safe tile
+        previous = _installed_fla_forcing_small_tile()
+        _installed_fla_tls.force_small_tile = bad_tile or previous
+        try:
             return original(*args, **kwargs)
         finally:
-            chunk_o.IS_NVIDIA_HOPPER = saved_hopper
-            chunk_o.check_shared_mem = saved_check
+            _installed_fla_tls.force_small_tile = previous
 
     setattr(_patched, _INSTALLED_FLA_PATCH_MARK, True)
     chunk_o.chunk_bwd_dqkwg = _patched
@@ -771,6 +855,48 @@ def _mark_fla_disabled_hopper():
         logger.warning(_FLA_DISABLED_REASON)
 
 
+def _transformers_uses_availability_probe():
+    """Whether this Transformers still selects gated-delta kernels via the
+    ``is_flash_linear_attention_available()`` probe + module globals.
+
+    Transformers PR #47630 ("[Kernels] Refactor all linear attn models & native
+    kernels fallback", merged after v5.14.1) drops that probe entirely: the
+    modeling files now carry
+    ``@use_kernel_func_from_hub_with_fallback("chunk_gated_delta_rule", "fla")``,
+    which resolves the implementation with ``importlib.import_module`` at
+    decoration time and freezes it into a closure. There is then no probe to answer
+    False and no module global to unbind.
+    """
+    try:
+        import transformers.utils.import_utils as iu
+    except Exception:
+        return True  # cannot tell; assume the old layout and stay quiet
+    return hasattr(iu, "is_flash_linear_attention_available")
+
+
+def _warn_if_hopper_optout_cannot_engage():
+    """Say so loudly when UNSLOTH_DISABLE_HOPPER_FLA_BWD cannot actually take hold.
+
+    Silence would be the dangerous outcome: the user set a *correctness* switch and
+    would reasonably believe gated-delta training had moved off the miscompiled
+    kernel. On a post-#47630 Transformers neither lever we pull exists, so the
+    switch is inert. Their training is still protected -- the vendored
+    chunk_bwd_dqkwg steps around the bad tile and the installed-fla patch does the
+    same one layer down -- but they should know the escape hatch did nothing.
+    """
+    if _transformers_uses_availability_probe():
+        return
+    logger.warning(
+        "Unsloth: UNSLOTH_DISABLE_HOPPER_FLA_BWD=1 could not be applied. This\n"
+        "Transformers selects gated-deltanet kernels through the kernel-hub\n"
+        "decorator (transformers#47630) rather than is_flash_linear_attention_available,\n"
+        "so there is no availability probe to disable and no module global to unbind.\n"
+        "Training is still protected: Unsloth's gated chunk_bwd_dqkwg avoids the\n"
+        "miscompiled block size (fla #640) on Hopper. For the pure-PyTorch path,\n"
+        'install a Triton with the upstream fix instead: pip install -U "triton>=3.7.1"'
+    )
+
+
 def patch_vendor_fla(phase=None):
     """Register the bundled fla kernels and advertise availability.
 
@@ -787,6 +913,7 @@ def patch_vendor_fla(phase=None):
         _mark_fla_disabled_hopper()
         _patch_is_available(_unavailable_probe)
         _disable_already_imported_gated_delta()
+        _warn_if_hopper_optout_cannot_engage()
         return
 
     if _flag("UNSLOTH_DISABLE_VENDORED_FLA"):
@@ -821,6 +948,18 @@ def patch_vendor_fla(phase=None):
         injected, replaced_real = _inject_vendored_fla()
         if not injected:
             return
+        if replaced_real and _hopper_dqkwg_suspect_here():
+            # A real fla install was just purged on a host where its
+            # chunk_bwd_dqkwg carries the #640 miscompile.
+            # _repair_already_imported_modeling rebinds the vendor-covered Qwen
+            # packages onto the fixed vendored kernels, but the snapshot cannot
+            # serve olmo_hybrid (it prunes ShortConvolution), so a
+            # module of theirs imported before this ran would keep calling the
+            # purged install's unpatched kernel and silently corrupt dk/dg. Unbind
+            # it and let them take transformers' pure-torch gated-delta path.
+            _disable_already_imported_gated_delta(
+                packages=_UNCOVERED_GATED_DELTA, why="fla #640; vendored tree cannot serve this model",
+            )
 
     _patch_is_available()
     _repair_already_imported_modeling(force_rebind=replaced_real)

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -897,6 +897,13 @@ def _warn_hopper_optout_degraded():
     decorator resolves carries the tile fix, but whether that succeeds depends on
     the install it finds -- and asserting "your gradients are correct" here would
     be exactly the wrong thing to say if it did not.
+
+    Note it must not advertise ``triton>=3.7.1`` as a way to reach the pure-PyTorch
+    path either. Upgrading Triton makes ``_hopper_dqkwg_suspect_here()`` False, so
+    this whole block is skipped and the fast kernels are used -- correct gradients,
+    but still not the fallback the user asked for. On this layout there is no lever
+    on our side that forces pure torch; only the absence of an importable ``fla``
+    does that, since the decorator falls back when its import fails.
     """
     logger.warning(
         "Unsloth: UNSLOTH_DISABLE_HOPPER_FLA_BWD=1 could not force the pure-PyTorch\n"
@@ -905,9 +912,12 @@ def _warn_hopper_optout_degraded():
         "is_flash_linear_attention_available, so there is no availability probe to\n"
         "disable and no module global to unbind.\n"
         "Unsloth is instead making the fla that decorator resolves one that avoids\n"
-        "the miscompiled block size (fla #640).\n"
-        "To actually reach the pure-PyTorch path, install a Triton carrying the\n"
-        'upstream fix instead: pip install -U "triton>=3.7.1"'
+        "the miscompiled block size (fla #640), which is what the opt-out was\n"
+        "protecting you from.\n"
+        'Installing a fixed Triton (pip install -U "triton>=3.7.1") also removes the\n'
+        "miscompile, but note neither route gives you the pure-PyTorch path on this\n"
+        "Transformers: that decorator only falls back when fla cannot be imported\n"
+        "at all."
     )
 
 
@@ -923,6 +933,7 @@ def patch_vendor_fla(phase=None):
     # gated-delta path. Bailing out of injection is not enough on its own: an
     # installed fla stays importable, so transformers' own availability probe would
     # answer True and bind the unpatched kernels (unslothai/unsloth#5276).
+    optout_degraded = False
     if _flag("UNSLOTH_DISABLE_HOPPER_FLA_BWD") and _hopper_dqkwg_suspect_here():
         # Sample the layout BEFORE _patch_is_available, which assigns the probe
         # attribute unconditionally and would otherwise make every Transformers
@@ -944,10 +955,17 @@ def patch_vendor_fla(phase=None):
         # _mark_fla_disabled_hopper() -- fla is not disabled on this path, and
         # claiming otherwise would mislead unsloth's loader message.
         _warn_hopper_optout_degraded()
+        optout_degraded = True
 
-    if _flag("UNSLOTH_DISABLE_VENDORED_FLA"):
+    if _flag("UNSLOTH_DISABLE_VENDORED_FLA") and not optout_degraded:
         # Scope is the vendored injection only: a user's own fla install is left as
         # found so Transformers' native availability probe still governs it.
+        #
+        # Skipped when the Hopper opt-out landed in its degraded mode: that flag is
+        # a source *preference* ("prefer your fla over ours"), while
+        # UNSLOTH_DISABLE_HOPPER_FLA_BWD is a *correctness* switch, and returning
+        # here would leave the kernel-hub decorator resolving an unpatched BK=64
+        # install. Correctness outranks the preference, so the protection path runs.
         return
 
     replaced_real = False

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -34,10 +34,17 @@ Precedence / escape hatches:
   * Only injects when torch >= 2.7, triton >= 3.3 and CUDA are available (the
     requirements of the vendored fla-core 0.5.1 kernels); otherwise the
     pure-torch fallback is left untouched.
+  * ``UNSLOTH_DISABLE_HOPPER_FLA_BWD=1`` -> on Hopper with Triton in
+    [3.4.0, 3.7.1), disable fla entirely (vendored *and* installed) and force the
+    pure-torch gated-delta path. This is a correctness switch, not a source
+    preference, so it is checked before the two flags above. The vendored
+    chunk_bwd_dqkwg already steps around the miscompiled BK=64 tile (fla #640), so
+    this is only for users who want the belt-and-braces fallback.
 """
 
 __all__ = [
     "patch_vendor_fla",
+    "fla_unavailable_reason",
 ]
 
 import os
@@ -68,6 +75,12 @@ _REPAIR_MODELING = ("qwen3_5", "qwen3_5_moe", "qwen3_next")
 # also imports ShortConvolution, which is not vendored, so its probe must answer
 # False (keep the pure-torch path) or its modeling module crashes on import.
 _VENDOR_COVERED_MODELS = frozenset(_REPAIR_MODELING)
+
+# Every gated-deltanet consumer, not just the vendor-covered ones. Used only by the
+# UNSLOTH_DISABLE_HOPPER_FLA_BWD path: those extra models never bind the *vendored*
+# kernels, but they do bind a user-installed fla's, which carries the same #640
+# miscompile, so they must be unbound too.
+_GATED_DELTA_MODELING = _REPAIR_MODELING + ("kimi_linear", "olmo_hybrid")
 
 # Minimum versions declared by fla-core 0.5.1.
 _MIN_TORCH = "2.7"
@@ -123,28 +136,30 @@ def _version_strictly_after(value, threshold):
         return False
 
 
-def _hopper_triton_needs_tilelang(torch_mod, triton_mod):
-    """True on Hopper with triton in [3.4.0, 3.7.1), where the vendored tree
-    cannot serve gated-delta training.
+def _hopper_dqkwg_suspect(torch_mod, triton_mod):
+    """True on Hopper with triton in [3.4.0, 3.7.1), the range in which fla's gated
+    ``chunk_bwd_dqkwg`` is miscompiled (fla #640).
 
-    Upstream chunk_bwd_dqkwg raises on that combination (Triton precision bug,
-    fla #640) and points at its TileLang backend, which this snapshot prunes,
-    so injection must be skipped there to keep the pure-torch fallback.
+    This no longer gates injection. The vendored kernel steps the block width away
+    from the miscompiled BK=64 tile (see ops/common/chunk_o.py), so the vendored
+    tree is safe to use on these hosts and does so by default. The predicate now
+    answers two narrower questions: whether to prefer the vendored copy over a
+    user-installed fla (only ours carries the tile fix), and whether
+    ``UNSLOTH_DISABLE_HOPPER_FLA_BWD=1`` should force the pure-torch path.
     Mirrors upstream's exact constants (full version parse, not base_version).
 
     Every visible CUDA device is probed, not just device 0: on a mixed host a
     model can be placed on a nonzero Hopper card (e.g. cuda:0 Ada, cuda:1 H100),
-    and a device-0-only check would report that setup as safe and inject kernels
-    that crash mid-backward on the Hopper card. If any visible GPU would hit the
-    bug we conservatively skip injection for the whole process.
+    and a device-0-only check would report that setup as safe. If any visible GPU
+    would hit the bug we answer True for the whole process.
     """
     try:
         from packaging import version
         v = version.parse(str(triton_mod.__version__).split("+")[0])
         if not (version.parse("3.4.0") <= v < version.parse("3.7.1")):
             return False
-        # The Hopper TileLang workaround is NVIDIA-specific. On a ROCm build a card
-        # can report capability major 9 (e.g. AMD Instinct) without being Hopper, so
+        # The Hopper miscompile is NVIDIA-specific. On a ROCm build a card can
+        # report capability major 9 (e.g. AMD Instinct) without being Hopper, so
         # only the bare major==9 signal is gated on a CUDA (non-HIP) build; a name
         # that literally says "NVIDIA H" is unambiguous either way.
         is_nvidia = getattr(getattr(torch_mod, "version", None), "hip", None) is None
@@ -189,18 +204,47 @@ def _torch_triton_cuda_supported():
             return False
     except Exception:
         return False
-    if _hopper_triton_needs_tilelang(torch, triton):
-        return False
+    # Hopper with triton in [3.4.0, 3.7.1) used to be excluded here, because fla's
+    # gated chunk_bwd_dqkwg raised outright on that combination (fla #640) and the
+    # whole model had to fall back to transformers' pure-torch gated-delta path.
+    # The vendored kernel now avoids the miscompiled BK=64 tile instead of refusing
+    # to run, so those hosts keep the Triton fast path. Users who want the old
+    # conservative behaviour set UNSLOTH_DISABLE_HOPPER_FLA_BWD=1, which is handled
+    # in patch_vendor_fla (it must also disable a user-installed fla, which this
+    # boolean cannot express).
     return True
+
+
+def _hopper_dqkwg_suspect_here():
+    """``_hopper_dqkwg_suspect`` for the live interpreter, or False if unknowable."""
+    try:
+        import torch
+        import triton
+    except Exception:
+        return False
+    return _hopper_dqkwg_suspect(torch, triton)
+
+
+# Set once when UNSLOTH_DISABLE_HOPPER_FLA_BWD turns the fast kernels off, so
+# unsloth's loader can explain *why* the slow path was chosen instead of blaming
+# "no CUDA / torch < 2.7 / triton < 3.3", none of which is true on an H100.
+_FLA_DISABLED_REASON = None
+
+
+def fla_unavailable_reason():
+    """A user-facing explanation of why Unsloth disabled fla's gated-delta kernels,
+    or ``None`` when they were not disabled. Read by unsloth's model loader."""
+    return _FLA_DISABLED_REASON
 
 
 def _vendored_injection_supported():
     """Whether ``patch_vendor_fla`` would actually inject the vendored kernels.
 
     Exposed so tests can gate their subprocess assertions on the exact same
-    production support check (Python >= 3.10, torch/triton minimums, CUDA, and
-    the Hopper/Triton range that needs the pruned TileLang backend) instead of a
-    looser mirror that would fail rather than skip on unsupported hosts.
+    production support check (Python >= 3.10, torch/triton minimums, CUDA)
+    instead of a looser mirror that would fail rather than skip on unsupported
+    hosts. Hopper in the fla #640 Triton range is no longer excluded: the vendored
+    chunk_bwd_dqkwg steps around the miscompiled tile, so it injects there too.
     """
     return _torch_triton_cuda_supported()
 
@@ -462,13 +506,28 @@ def _vendored_availability_probe():
     return True
 
 
-def _patch_is_available():
+def _unavailable_probe():
+    """Availability answer when fla must not be used on this host at all.
+
+    Unlike ``_vendored_availability_probe`` this is deliberately not caller-aware:
+    the #640 miscompile hits every gated-deltanet model, so every caller has to see
+    False and take its pure-torch fallback.
+    """
+    return False
+
+
+def _patch_is_available(probe=None):
     """Replace transformers' cached availability probe.
 
     The probe is @lru_cache and keys on dist metadata that a vendored package
     lacks, so we clear the cache and replace the callable outright. Modeling
     modules bind the name lazily (after this runs), so replacement is enough.
+
+    ``probe`` defaults to the vendored answer; the Hopper opt-out passes
+    ``_unavailable_probe`` to force the pure-torch path instead.
     """
+    if probe is None:
+        probe = _vendored_availability_probe
     try:
         import transformers.utils.import_utils as iu
     except Exception:
@@ -478,7 +537,7 @@ def _patch_is_available():
         iu.is_flash_linear_attention_available.cache_clear()
     except Exception:
         pass
-    iu.is_flash_linear_attention_available = _vendored_availability_probe
+    iu.is_flash_linear_attention_available = probe
     # Re-exporting namespaces (e.g. ``transformers.utils`` on versions that alias
     # it, or any transformers.* module that did ``from ...import_utils import
     # is_flash_linear_attention_available`` before this ran) still hold the
@@ -497,7 +556,7 @@ def _patch_is_available():
                 continue
             if mod_dict.get("is_flash_linear_attention_available") is original:
                 try:
-                    setattr(mod, "is_flash_linear_attention_available", _vendored_availability_probe)
+                    setattr(mod, "is_flash_linear_attention_available", probe)
                 except Exception:
                     pass
     return True
@@ -558,11 +617,80 @@ def _repair_already_imported_modeling(force_rebind=False):
             logger.info(f"Unsloth: rebound vendored fla kernels onto {modname}.")
 
 
+def _disable_already_imported_gated_delta():
+    """Unbind the miscompiled chunk kernel on gated-delta modeling modules that were
+    imported before this ran.
+
+    Mirror image of ``_repair_already_imported_modeling``. A modeling module
+    imported while some fla was available holds a live ``chunk_gated_delta_rule``,
+    and ``Qwen3NextGatedDeltaNet.__init__`` reads it as ``chunk_gated_delta_rule or
+    torch_chunk_gated_delta_rule``, so forcing the availability probe False is not
+    enough on its own. Setting the global to ``None`` makes every layer built after
+    this point pick the pure-torch path.
+
+    Deliberately narrow: only ``chunk_gated_delta_rule`` is unbound. fla #640 is a
+    backward-pass bug in the chunked kernel; ``fused_recurrent_gated_delta_rule``
+    (decode) and ``FusedRMSNormGated`` are unaffected and stay fast.
+    """
+    for pkg in _GATED_DELTA_MODELING:
+        modname = f"transformers.models.{pkg}.modeling_{pkg}"
+        mod = sys.modules.get(modname)
+        if mod is None:
+            continue
+        if getattr(mod, "chunk_gated_delta_rule", None) is None:
+            continue
+        try:
+            setattr(mod, "chunk_gated_delta_rule", None)
+        except Exception:
+            continue
+        if UNSLOTH_ENABLE_LOGGING:
+            logger.info(
+                f"Unsloth: unbound fla chunk_gated_delta_rule on {modname} "
+                "(UNSLOTH_DISABLE_HOPPER_FLA_BWD)."
+            )
+
+
+def _mark_fla_disabled_hopper():
+    global _FLA_DISABLED_REASON
+    if _FLA_DISABLED_REASON is not None:
+        return
+    try:
+        import triton
+        triton_version = triton.__version__
+    except Exception:
+        triton_version = "?"
+    _FLA_DISABLED_REASON = (
+        "Unsloth: gated-deltanet (linear attention) fast kernels are DISABLED on this GPU\n"
+        "because UNSLOTH_DISABLE_HOPPER_FLA_BWD=1 is set. Triton "
+        f"{triton_version} on Hopper\n"
+        "(H100 / H200 / H20) miscompiles flash-linear-attention's gated-delta backward\n"
+        "pass (fla issue #640), so training falls back to the slower pure-PyTorch path.\n"
+        '  To use the fast kernels with a Triton that has the fix: pip install -U "triton>=3.7.1"\n'
+        "  To use them on this Triton: unset UNSLOTH_DISABLE_HOPPER_FLA_BWD. Unsloth's\n"
+        "  bundled kernels already step around the miscompiled block size."
+    )
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.warning(_FLA_DISABLED_REASON)
+
+
 def patch_vendor_fla(phase=None):
     """Register the bundled fla kernels and advertise availability.
 
     Idempotent; safe to call at import time and again from TEMPORARY_PATCHES.
     """
+    # Correctness switch, checked before the source-preference flags below. On
+    # Hopper + Triton [3.4.0, 3.7.1) *every* fla on the host has the #640 backward
+    # miscompile except our vendored copy, which steps around it. A user who does
+    # not want to rely on that opts out here and gets transformers' pure-torch
+    # gated-delta path. Bailing out of injection is not enough on its own: an
+    # installed fla stays importable, so transformers' own availability probe would
+    # answer True and bind the unpatched kernels (unslothai/unsloth#5276).
+    if _flag("UNSLOTH_DISABLE_HOPPER_FLA_BWD") and _hopper_dqkwg_suspect_here():
+        _mark_fla_disabled_hopper()
+        _patch_is_available(_unavailable_probe)
+        _disable_already_imported_gated_delta()
+        return
+
     if _flag("UNSLOTH_DISABLE_VENDORED_FLA"):
         # Scope is the vendored injection only: a user's own fla install is left as
         # found so Transformers' native availability probe still governs it.
@@ -570,7 +698,12 @@ def patch_vendor_fla(phase=None):
 
     replaced_real = False
     if not _vendored_already_injected():
-        force = _flag("UNSLOTH_FORCE_VENDORED_FLA")
+        # On a host where fla's gated chunk_bwd_dqkwg is miscompiled, prefer the
+        # vendored copy over any user install regardless of version: only ours
+        # carries the BK=64 tile workaround for fla #640. Deferring there is what
+        # left a pip-installed fla-core raising mid-backward on H100s
+        # (unslothai/unsloth#5276).
+        force = _flag("UNSLOTH_FORCE_VENDORED_FLA") or _hopper_dqkwg_suspect_here()
         if not force and _should_defer_to_installed_fla():
             # A newer (or unversioned deliberate) user install is present; use it.
             return


### PR DESCRIPTION
Fixes the H100 report in unslothai/unsloth#5276.

## The problem

On Hopper with Triton in `[3.4.0, 3.7.1)`, fla's gated `chunk_bwd_dqkwg` raised outright, and `fla_vendor` responded by skipping vendored injection entirely. Net effect for H100 users of Qwen3-Next / Qwen3.5: every fast gated-deltanet kernel was lost, not just the affected one, and training fell back to transformers' pure-torch path. Users who had also `pip install`ed `fla-core` got the RuntimeError itself, because `_should_defer_to_installed_fla()` is checked before the hardware gate.

## The guard was much broader than the bug

Issue #640's own root-cause bisection pins the miscompile to a single block width. Sweeping `CONST_TILING` on Hopper ([comment](https://github.com/fla-org/flash-linear-attention/issues/640#issuecomment-4236520788)):

| CONST_TILING | BK | dk max err | dg max err | Status |
|---|---|---|---|---|
| 32 | 32 | < 0.02 | < 0.02 | PASS |
| 64 | 64 | 14.65 | 5.47 | FAIL |
| 128 | 128 | < 0.02 | < 0.02 | PASS |

The same reporter [ruled out the autotune config space](https://github.com/fla-org/flash-linear-attention/issues/640#issuecomment-4210397084), so the `num_warps`-pin pattern from #953 / #1000 / #988 does not apply here. Upstream never narrowed the guard because their H100 CI runs Triton 3.7.1, where it is already off.

Hopper takes `CONST_TILING = 128`, so `BK = min(max(next_pow2(K), 16), 128)` only lands on 64 for head dims `33 <= K <= 64`. Qwen3-Next and Qwen3.5 use `linear_key_head_dim = 128`, giving `BK = 128`, the tile upstream measured as clean. Those users were blocked by a tile they never pick.

## Changes

- `ops/common/chunk_o.py`: step `BK` 64 down to the measured-clean 32 on Hopper in the affected range, and keep the RuntimeError only as an unreachable fence so a future edit that reintroduces the bad tile fails loudly. The override sits after `BK`/`BV` and before `NK`, the `dg` scratch and the grid, all of which derive from it. `BK` is already in the autotune key, so cache identity is preserved. `BV` is untouched; #640 implicates only `BK`.
- The remediation text no longer suggests `pip install tilelang`. That cannot work in this snapshot: the TileLang kernels are pruned and `_inject_vendored_fla` force-sets `FLA_TILELANG=0` and overrides `TileLangBackend.is_available` to False. @oobabooga already pointed this out on the issue.
- `fla_vendor.py`: drop the Hopper exclusion from `_torch_triton_cuda_supported`, and prefer the vendored copy over an installed fla on those hosts, since only ours carries the tile fix.
- `fla_vendor.py`: `UNSLOTH_DISABLE_HOPPER_FLA_BWD=1` restores the old conservative behaviour. It forces transformers' availability probe False and unbinds `chunk_gated_delta_rule` on every gated-delta modeling module, including `kimi_linear` and `olmo_hybrid`, which the vendored exports do not cover but an installed fla does. Bailing out of injection alone was never enough, since an installed fla stays importable and transformers' own probe still answers True.
- `fla_unavailable_reason()` lets unsloth's loader say why the slow path was chosen. The current message blames CUDA / torch >= 2.7 / triton >= 3.3, all of which are satisfied on an affected H100. Companion PR in `unslothai/unsloth`.

## Verification

`chunk_bwd_dqkwg` reads `IS_NVIDIA_HOPPER` at call time, so the whole policy is exercisable by flipping that flag. Run on 1x B200, torch 2.9.1+cu128, triton 3.5.1, which is itself inside the affected version range:

- `BK` never lands on 64 on a simulated Hopper for K in {16, 32, 60, 64, 65, 100, 128, 256}; K=128 still gets BK=128 untouched; K=64 steps to 32 and the grid picks up `NK = 2`.
- Gradients at the stepped-down BK=32 match BK=64 to under 5e-3 relative L2 on hardware where both tiles are known good, so the override only repartitions the reduction.
- A Qwen3-Next with a 64-wide linear key head trains with finite loss and gradients on the Triton path where the old guard raised.
- Regression tests for the #5276 crash path with a fake installed fla at a newer, older and unversioned version.
- The opt-out forces pure torch, outranks both existing flags, and is inert off Hopper.

Before and after on a simulated Hopper, showing the old guard also blocked the unaffected K=128 shape:

```
triton 3.5.1 in affected range: True
AFTER the fix (simulated Hopper):
    K= 64: ran, finite grads = True
    K=128: ran, finite grads = True
BEFORE the fix (old unconditional guard restored):
    K= 64: RAISED Triton >= 3.4.0 and < 3.7.1 on Hopper GPUs produces incorr
    K=128: RAISED Triton >= 3.4.0 and < 3.7.1 on Hopper GPUs produces incorr
```

Suite: 83 passed, 1 skipped across `test_fla_hopper_tile.py`, `test_vendor_fla.py`, `test_python39_compatibility.py`, `test_temporary_patches_imports.py`, `test_vendored_license_shipped.py`. Baseline before the change was 24 passed, 1 skipped on the two pre-existing files.

## What still needs a Hopper runner

I do not have an H100. The claim that BK 32 and BK 128 are correct on SM90 comes from upstream's H20 bisection, which ran against a tree predating two kernel-body changes now in the 0.5.1 snapshot (#823 `b_dg`, #867 exp2). The B200 test shows the override is algebraically neutral, which is supporting evidence, not proof for SM90. Worth an H100 CI run, or confirmation from the #5276 reporter, before treating the narrowing as proven. `UNSLOTH_DISABLE_HOPPER_FLA_BWD=1` is the escape hatch in the meantime and is worth naming in the release notes.
