### PR TITLE
Name a half-installed torchvision instead of re-raising its ImportError

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -349,6 +349,7 @@ jobs:
         run: |
           python -m pytest -v --tb=short -rs \
             tests/test_upstream_pinned_symbols_transformers.py \
+            tests/test_torchvision_video_removed_message.py \
             tests/test_upstream_pinned_symbols_trl_vllm.py \
             tests/test_upstream_pinned_symbols_accelerator.py \
             tests/test_zoo_history_regressions_deep.py \

--- a/tests/test_torchvision_video_removed_message.py
+++ b/tests/test_torchvision_video_removed_message.py
@@ -2,11 +2,9 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """torchvision retired `torchvision.io.video`; say so instead of re-raising it.
 
-Found by running the Kaggle notebook variants: `Kaggle-Llama3.2_(11B)-Vision`
-fails where its Colab twin passes, because the Kaggle install cell takes an
-unpinned torchvision off the cu128 index while Colab keeps the preinstalled one.
-The user sees `Exception: No module named 'torchvision.io.video'` raised from
-`import unsloth`, with nothing pointing at the real cause.
+Found by running `Kaggle-Llama3.2_(11B)-Vision`, which fails where its Colab twin
+passes: the Kaggle install cell takes an unpinned torchvision off the cu128 index.
+The user sees a bare `No module named 'torchvision.io.video'` from `import unsloth`.
 """
 from __future__ import annotations
 
@@ -31,7 +29,7 @@ def test_the_removed_video_module_is_recognised():
     body = _handler_body()
     assert "torchvision.io.video" in body, \
         "a torchvision without io.video still falls through to a bare Exception"
-    # Before the named arms is wrong: the catch-all would swallow it first.
+    # Must precede the catch-all, which would otherwise swallow it.
     assert body.index("torchvision.io.video") < body.index('elif "Unpack" not in e')
 
 
@@ -44,7 +42,7 @@ def test_the_message_is_actionable_and_names_the_cause(message):
     arm = _handler_body()
     assert "torchcodec" in arm, "the message does not say where the module went"
     assert "upgrade transformers" in arm, "the message does not say what to run"
-    # The classifier is a substring test, so both spellings must reach the arm.
+    # Substring test, so both spellings must reach the arm.
     assert re.search(r'"torchvision\.io\.video" in e or "torchvision\.io\._video" in e', arm)
     assert message.split("'")[1].rsplit(".", 1)[0] in ("torchvision.io", "torchvision")
 
@@ -60,8 +58,8 @@ def test_every_named_arm_raises_runtime_error():
     """RuntimeError, not Exception: the caller distinguishes a diagnosis it can
     show the user from an error it could not classify."""
     arm = _handler_body()
-    # Sliced to the next branch, not a fixed window: a comment inside an arm
-    # would otherwise push its `raise` out of view and pass the test blind.
+    # Sliced to the next branch, not a fixed window: a comment in an arm would
+    # otherwise push its `raise` out of view and pass the test blind.
     bounds = [m.start() for m in re.finditer(r"\n    (?:elif |raise )", arm)] + [len(arm)]
     for kind in ("numpy._core.umath", "torchvision::nms", "torchvision.io.video", "PIL"):
         i = arm.index(kind)

--- a/tests/test_torchvision_video_removed_message.py
+++ b/tests/test_torchvision_video_removed_message.py
@@ -68,3 +68,39 @@ def test_every_named_arm_raises_runtime_error():
         i = arm.index(kind)
         end = next(b for b in bounds if b > i)
         assert "RuntimeError" in arm[i:end], f"{kind} does not raise RuntimeError"
+
+
+def _fallback_arm():
+    """The `except Exception` arm, which sees what the ImportError arm cannot.
+
+    Anchored after the Unpack handler, since the file has earlier
+    `except Exception` blocks that have nothing to do with this.
+    """
+    anchor = SOURCE.index("    from transformers.processing_utils import Unpack")
+    start = SOURCE.index("except Exception as e:", anchor)
+    return SOURCE[start:SOURCE.index("KWARGS_TYPE", start)]
+
+
+def test_the_nms_break_is_caught_where_it_actually_lands():
+    """A torchvision whose ops do not match torch fails inside
+    `_meta_registrations` at `register_fake("torchvision::nms")`, which raises
+    RuntimeError. The ImportError arm can never see it."""
+    arm = _fallback_arm()
+    assert "torchvision::nms does not exist" in arm, (
+        "the nms check exists only on the ImportError arm, where this error never arrives"
+    )
+    # And it must be diagnosed before the bare re-raise at the end swallows it.
+    assert arm.index("torchvision::nms") < arm.rindex("raise")
+
+
+def test_both_arms_give_the_same_instruction():
+    """One message, so the two arms cannot drift apart."""
+    assert SOURCE.count("_TORCHVISION_BROKE") >= 3, "the shared message is not used by both arms"
+    assert "force-reinstall --no-cache-dir torchvision" in SOURCE
+
+
+def test_an_unrelated_runtime_error_still_surfaces():
+    arm = _fallback_arm()
+    assert "raise" in arm.split("torchvision::nms")[-1], (
+        "unrecognised errors no longer reach the bare re-raise"
+    )

--- a/tests/test_torchvision_video_removed_message.py
+++ b/tests/test_torchvision_video_removed_message.py
@@ -3,12 +3,10 @@
 """Name a half-installed torchvision instead of re-raising its ImportError.
 
 Found by running `Kaggle-Llama3.2_(11B)-Vision`: a venv installed over the base
-image left `/usr/local/.../torchvision` (0.25.0+cu128) partly overwritten, so
-`torchvision/io/__init__.py` still imports a `video` module that is gone. The
-user sees a bare `No module named 'torchvision.io.video'` from `import unsloth`.
-
-Not a version boundary: 0.25 ships `io/video.py`, and 0.26 removed the module
-and its importer together, so no released torchvision raises this by itself.
+image left torchvision 0.25.0+cu128 partly overwritten, so `io/__init__.py`
+still imports a `video` module that is gone and `import unsloth` dies on a bare
+`No module named 'torchvision.io.video'`. Not a version boundary: 0.25 ships
+`io/video.py` and 0.26 removed it with its importer, so no release raises this.
 """
 from __future__ import annotations
 
@@ -60,11 +58,11 @@ def test_an_unrelated_import_error_still_falls_through():
 
 
 def test_every_named_arm_raises_runtime_error():
-    """RuntimeError, not Exception: the caller distinguishes a diagnosis it can
-    show the user from an error it could not classify."""
+    """RuntimeError, not Exception: the caller tells a diagnosis it can show the
+    user from an error it could not classify."""
     arm = _handler_body()
-    # Sliced to the next branch, not a fixed window: a comment in an arm would
-    # otherwise push its `raise` out of view and pass the test blind.
+    # Sliced to the next branch, not a fixed window, or a comment in an arm
+    # pushes its `raise` out of view and the test passes blind.
     bounds = [m.start() for m in re.finditer(r"\n    (?:elif |raise )", arm)] + [len(arm)]
     for kind in ("numpy._core.umath", "torchvision::nms", "torchvision.io.video", "PIL"):
         i = arm.index(kind)

--- a/tests/test_torchvision_video_removed_message.py
+++ b/tests/test_torchvision_video_removed_message.py
@@ -18,8 +18,10 @@ subprocess, and reads back what came out.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -44,7 +46,13 @@ import importlib, json, sys, types
 
 MOD = "unsloth_zoo.temporary_patches.utils"
 cases = json.loads(sys.argv[1])
-importlib.import_module(MOD)          # warm every dependency of the module first
+try:
+    importlib.import_module(MOD)      # warm every dependency of the module first
+except BaseException as e:
+    # This environment cannot import the module at all (no accelerator, no
+    # unsloth installed). Nothing to say about the guard here.
+    sys.stdout.write("<<<WARMFAIL>>>%s: %s" % (type(e).__name__, e))
+    raise SystemExit(0)
 import transformers
 real = sys.modules.get("transformers.processing_utils")
 out = {}
@@ -76,10 +84,20 @@ PIP = "pip install --upgrade --force-reinstall --no-cache-dir torchvision"
 def raised():
     """What each planted failure actually produces, from one warm subprocess."""
     pytest.importorskip("transformers")
+    root = Path(__file__).resolve().parents[1]
+    # The child gets the parent's environment, so it imports the same tree under
+    # the same accelerator settings; only the path to this checkout is added.
+    env = dict(os.environ)
+    env.setdefault("UNSLOTH_ALLOW_CPU", "1")
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(root)] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else []))
     proc = subprocess.run(
         [sys.executable, "-c", _DRIVER, json.dumps(CASES)],
-        capture_output = True, text = True, timeout = 900,
+        capture_output = True, text = True, timeout = 900, cwd = str(root), env = env,
     )
+    if "<<<WARMFAIL>>>" in proc.stdout:
+        pytest.skip("cannot import unsloth_zoo here: "
+                    + proc.stdout.split("<<<WARMFAIL>>>", 1)[1][:200])
     if "<<<RESULTS>>>" not in proc.stdout:
         pytest.fail(
             f"driver failed (rc={proc.returncode})\n"

--- a/tests/test_torchvision_video_removed_message.py
+++ b/tests/test_torchvision_video_removed_message.py
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
-"""torchvision retired `torchvision.io.video`; say so instead of re-raising it.
+"""Name a half-installed torchvision instead of re-raising its ImportError.
 
-Found by running `Kaggle-Llama3.2_(11B)-Vision`, which fails where its Colab twin
-passes: the Kaggle install cell takes an unpinned torchvision off the cu128 index.
-The user sees a bare `No module named 'torchvision.io.video'` from `import unsloth`.
+Found by running `Kaggle-Llama3.2_(11B)-Vision`: a venv installed over the base
+image left `/usr/local/.../torchvision` (0.25.0+cu128) partly overwritten, so
+`torchvision/io/__init__.py` still imports a `video` module that is gone. The
+user sees a bare `No module named 'torchvision.io.video'` from `import unsloth`.
+
+Not a version boundary: 0.25 ships `io/video.py`, and 0.26 removed the module
+and its importer together, so no released torchvision raises this by itself.
 """
 from __future__ import annotations
 
@@ -40,8 +44,9 @@ def test_the_removed_video_module_is_recognised():
 def test_the_message_is_actionable_and_names_the_cause(message):
     """A RuntimeError a user can act on, not the original ImportError text."""
     arm = _handler_body()
-    assert "torchcodec" in arm, "the message does not say where the module went"
-    assert "upgrade transformers" in arm, "the message does not say what to run"
+    assert "install is incomplete" in arm, "the message does not name the cause"
+    assert "force-reinstall --no-cache-dir torchvision" in arm, \
+        "the message does not say what to run"
     # Substring test, so both spellings must reach the arm.
     assert re.search(r'"torchvision\.io\.video" in e or "torchvision\.io\._video" in e', arm)
     assert message.split("'")[1].rsplit(".", 1)[0] in ("torchvision.io", "torchvision")

--- a/tests/test_torchvision_video_removed_message.py
+++ b/tests/test_torchvision_video_removed_message.py
@@ -7,100 +7,130 @@ image left torchvision 0.25.0+cu128 partly overwritten, so `io/__init__.py`
 still imports a `video` module that is gone and `import unsloth` dies on a bare
 `No module named 'torchvision.io.video'`. Not a version boundary: 0.25 ships
 `io/video.py` and 0.26 removed it with its importer, so no release raises this.
+
+These tests drive the real guard, they do not read the source. The source-grep
+version of this file passed with the whole feature deleted, because the prose
+explaining an arm contains every string the arm does. So each case plants a
+`transformers.processing_utils` whose `Unpack` raises the exact error a broken
+install raises, re-imports `unsloth_zoo.temporary_patches.utils` in a
+subprocess, and reads back what came out.
 """
 from __future__ import annotations
 
-import inspect
-import re
-from pathlib import Path
+import json
+import subprocess
+import sys
 
 import pytest
 
-SOURCE = (Path(__file__).resolve().parents[1]
-          / "unsloth_zoo" / "temporary_patches" / "utils.py").read_text(encoding = "utf-8")
+# (case name, exception class to raise, message)
+CASES = [
+    ("io_video",      "ImportError",  "No module named 'torchvision.io.video'"),
+    ("io_video_priv", "ImportError",  "No module named 'torchvision.io._video'"),
+    ("nms_import",    "ImportError",  "operator torchvision::nms does not exist"),
+    ("nms_runtime",   "RuntimeError",
+     "Failed to register operator torchvision::nms. operator torchvision::nms does not exist"),
+    ("unrelated_rt",  "RuntimeError", "cuBLAS workspace allocation failed"),
+    ("unrelated_imp", "ImportError",  "No module named 'flash_attn'"),
+    ("unpack_moved",  "ImportError",
+     "cannot import name 'Unpack' from 'transformers.processing_utils'"),
+    ("pillow",        "ImportError",  "cannot import name '_Ink' from 'PIL'"),
+    ("numpy_uv",      "ImportError",  "cannot import name '_center' from 'numpy._core.umath'"),
+    ("numpy_stale",   "RuntimeError", "numpy.core._multiarray_umath failed to import"),
+]
+
+_DRIVER = r'''
+import importlib, json, sys, types
+
+MOD = "unsloth_zoo.temporary_patches.utils"
+cases = json.loads(sys.argv[1])
+importlib.import_module(MOD)          # warm every dependency of the module first
+import transformers
+real = sys.modules.get("transformers.processing_utils")
+out = {}
+for name, kind, message in cases:
+    sys.modules.pop(MOD, None)
+    fake = types.ModuleType("transformers.processing_utils")
+    def _raise(attr, _m = message, _e = {"ImportError": ImportError,
+                                         "RuntimeError": RuntimeError}[kind]):
+        raise _e(_m)
+    fake.__getattr__ = _raise
+    sys.modules["transformers.processing_utils"] = fake
+    transformers.processing_utils = fake
+    try:
+        importlib.import_module(MOD)
+        out[name] = {"type": None, "message": None}
+    except BaseException as e:
+        out[name] = {"type": type(e).__name__, "message": str(e)}
+    finally:
+        if real is not None:
+            sys.modules["transformers.processing_utils"] = real
+            transformers.processing_utils = real
+sys.stdout.write("<<<RESULTS>>>" + json.dumps(out))
+'''
+
+PIP = "pip install --upgrade --force-reinstall --no-cache-dir torchvision"
 
 
-def _handler_body():
-    """The ImportError arm that classifies a failed `Unpack` import."""
-    start = SOURCE.index("    from transformers.processing_utils import Unpack")
-    end = SOURCE.index("except Exception as e:", start)
-    return SOURCE[start:end]
+@pytest.fixture(scope = "module")
+def raised():
+    """What each planted failure actually produces, from one warm subprocess."""
+    pytest.importorskip("transformers")
+    proc = subprocess.run(
+        [sys.executable, "-c", _DRIVER, json.dumps(CASES)],
+        capture_output = True, text = True, timeout = 900,
+    )
+    if "<<<RESULTS>>>" not in proc.stdout:
+        pytest.fail(
+            f"driver failed (rc={proc.returncode})\n"
+            f"{proc.stdout[-2000:]}\n{proc.stderr[-4000:]}"
+        )
+    return json.loads(proc.stdout.split("<<<RESULTS>>>", 1)[1])
 
 
-def test_the_removed_video_module_is_recognised():
-    body = _handler_body()
-    assert "torchvision.io.video" in body, \
-        "a torchvision without io.video still falls through to a bare Exception"
-    # Must precede the catch-all, which would otherwise swallow it.
-    assert body.index("torchvision.io.video") < body.index('elif "Unpack" not in e')
-
-
-@pytest.mark.parametrize("message", [
-    "No module named 'torchvision.io.video'",
-    "No module named 'torchvision.io._video'",
+@pytest.mark.parametrize("case, missing", [
+    ("io_video",      "torchvision.io.video"),
+    ("io_video_priv", "torchvision.io._video"),
 ])
-def test_the_message_is_actionable_and_names_the_cause(message):
-    """A RuntimeError a user can act on, not the original ImportError text."""
-    arm = _handler_body()
-    assert "install is incomplete" in arm, "the message does not name the cause"
-    assert "force-reinstall --no-cache-dir torchvision" in arm, \
-        "the message does not say what to run"
-    # Substring test, so both spellings must reach the arm.
-    assert re.search(r'"torchvision\.io\.video" in e or "torchvision\.io\._video" in e', arm)
-    assert message.split("'")[1].rsplit(".", 1)[0] in ("torchvision.io", "torchvision")
+def test_a_missing_io_video_is_named_as_an_incomplete_install(raised, case, missing):
+    got = raised[case]
+    assert got["type"] == "RuntimeError", got
+    assert "install is incomplete" in got["message"]
+    assert PIP in got["message"]
+    # The original text is kept, so the report still shows what was missing.
+    assert missing in got["message"]
 
 
-def test_an_unrelated_import_error_still_falls_through():
-    """The new arm must not swallow errors it does not explain."""
-    arm = _handler_body()
-    assert 'elif "Unpack" not in e' in arm, "the catch-all arm was removed"
-    assert "raise Exception(e)" in arm, "unrecognised errors no longer surface"
+def test_a_mismatched_torchvision_is_caught_on_the_runtimeerror_arm(raised):
+    """`register_fake("torchvision::nms")` raises RuntimeError, not ImportError,
+    so the ImportError arm could never fire for it."""
+    got = raised["nms_runtime"]
+    assert got["type"] == "RuntimeError", got
+    assert "reinstall torchvision" in got["message"]
+    assert PIP in got["message"]
+    # Not the bare error the user used to see.
+    assert "does not exist" not in got["message"]
 
 
-def test_every_named_arm_raises_runtime_error():
-    """RuntimeError, not Exception: the caller tells a diagnosis it can show the
-    user from an error it could not classify."""
-    arm = _handler_body()
-    # Sliced to the next branch, not a fixed window, or a comment in an arm
-    # pushes its `raise` out of view and the test passes blind.
-    bounds = [m.start() for m in re.finditer(r"\n    (?:elif |raise )", arm)] + [len(arm)]
-    for kind in ("numpy._core.umath", "torchvision::nms", "torchvision.io.video", "PIL"):
-        i = arm.index(kind)
-        end = next(b for b in bounds if b > i)
-        assert "RuntimeError" in arm[i:end], f"{kind} does not raise RuntimeError"
+def test_both_arms_give_the_same_instruction(raised):
+    assert raised["nms_runtime"]["message"] == raised["nms_import"]["message"]
 
 
-def _fallback_arm():
-    """The `except Exception` arm, which sees what the ImportError arm cannot.
-
-    Anchored after the Unpack handler, since the file has earlier
-    `except Exception` blocks that have nothing to do with this.
-    """
-    anchor = SOURCE.index("    from transformers.processing_utils import Unpack")
-    start = SOURCE.index("except Exception as e:", anchor)
-    return SOURCE[start:SOURCE.index("KWARGS_TYPE", start)]
+def test_an_unrelated_runtime_error_is_re_raised_untouched(raised):
+    got = raised["unrelated_rt"]
+    assert got["type"] == "RuntimeError"
+    assert got["message"] == "cuBLAS workspace allocation failed"
 
 
-def test_the_nms_break_is_caught_where_it_actually_lands():
-    """A torchvision whose ops do not match torch fails inside
-    `_meta_registrations` at `register_fake("torchvision::nms")`, which raises
-    RuntimeError. The ImportError arm can never see it."""
-    arm = _fallback_arm()
-    assert "torchvision::nms does not exist" in arm, (
-        "the nms check exists only on the ImportError arm, where this error never arrives"
-    )
-    # And it must be diagnosed before the bare re-raise at the end swallows it.
-    assert arm.index("torchvision::nms") < arm.rindex("raise")
+def test_an_unrelated_import_error_still_falls_through(raised):
+    got = raised["unrelated_imp"]
+    assert got["type"] == "Exception", got
+    assert "flash_attn" in got["message"]
 
 
-def test_both_arms_give_the_same_instruction():
-    """One message, so the two arms cannot drift apart."""
-    assert SOURCE.count("_TORCHVISION_BROKE") >= 3, "the shared message is not used by both arms"
-    assert "force-reinstall --no-cache-dir torchvision" in SOURCE
-
-
-def test_an_unrelated_runtime_error_still_surfaces():
-    arm = _fallback_arm()
-    assert "raise" in arm.split("torchvision::nms")[-1], (
-        "unrecognised errors no longer reach the bare re-raise"
-    )
+def test_the_untouched_arms_still_answer(raised):
+    """The diagnoses that were already here must be unchanged."""
+    assert "Unpack has been moved" in raised["unpack_moved"]["message"]
+    assert "Pillow (PIL) version is incompatible" in raised["pillow"]["message"]
+    assert "they broke numpy" in raised["numpy_uv"]["message"]
+    assert "numpy C extensions cannot be reloaded" in raised["numpy_stale"]["message"]

--- a/tests/test_torchvision_video_removed_message.py
+++ b/tests/test_torchvision_video_removed_message.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""torchvision retired `torchvision.io.video`; say so instead of re-raising it.
+
+Found by running the Kaggle notebook variants: `Kaggle-Llama3.2_(11B)-Vision`
+fails where its Colab twin passes, because the Kaggle install cell takes an
+unpinned torchvision off the cu128 index while Colab keeps the preinstalled one.
+The user sees `Exception: No module named 'torchvision.io.video'` raised from
+`import unsloth`, with nothing pointing at the real cause.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+SOURCE = (Path(__file__).resolve().parents[1]
+          / "unsloth_zoo" / "temporary_patches" / "utils.py").read_text(encoding = "utf-8")
+
+
+def _handler_body():
+    """The ImportError arm that classifies a failed `Unpack` import."""
+    start = SOURCE.index("    from transformers.processing_utils import Unpack")
+    end = SOURCE.index("except Exception as e:", start)
+    return SOURCE[start:end]
+
+
+def test_the_removed_video_module_is_recognised():
+    body = _handler_body()
+    assert "torchvision.io.video" in body, \
+        "a torchvision without io.video still falls through to a bare Exception"
+    # Before the named arms is wrong: the catch-all would swallow it first.
+    assert body.index("torchvision.io.video") < body.index('elif "Unpack" not in e')
+
+
+@pytest.mark.parametrize("message", [
+    "No module named 'torchvision.io.video'",
+    "No module named 'torchvision.io._video'",
+])
+def test_the_message_is_actionable_and_names_the_cause(message):
+    """A RuntimeError a user can act on, not the original ImportError text."""
+    arm = _handler_body()
+    assert "torchcodec" in arm, "the message does not say where the module went"
+    assert "upgrade transformers" in arm, "the message does not say what to run"
+    # The classifier is a substring test, so both spellings must reach the arm.
+    assert re.search(r'"torchvision\.io\.video" in e or "torchvision\.io\._video" in e', arm)
+    assert message.split("'")[1].rsplit(".", 1)[0] in ("torchvision.io", "torchvision")
+
+
+def test_an_unrelated_import_error_still_falls_through():
+    """The new arm must not swallow errors it does not explain."""
+    arm = _handler_body()
+    assert 'elif "Unpack" not in e' in arm, "the catch-all arm was removed"
+    assert "raise Exception(e)" in arm, "unrecognised errors no longer surface"
+
+
+def test_every_named_arm_raises_runtime_error():
+    """RuntimeError, not Exception: the caller distinguishes a diagnosis it can
+    show the user from an error it could not classify."""
+    arm = _handler_body()
+    # Sliced to the next branch, not a fixed window: a comment inside an arm
+    # would otherwise push its `raise` out of view and pass the test blind.
+    bounds = [m.start() for m in re.finditer(r"\n    (?:elif |raise )", arm)] + [len(arm)]
+    for kind in ("numpy._core.umath", "torchvision::nms", "torchvision.io.video", "PIL"):
+        i = arm.index(kind)
+        end = next(b for b in bounds if b > i)
+        assert "RuntimeError" in arm[i:end], f"{kind} does not raise RuntimeError"

--- a/tests/test_torchvision_video_removed_message.py
+++ b/tests/test_torchvision_video_removed_message.py
@@ -17,6 +17,7 @@ subprocess, and reads back what came out.
 """
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import subprocess
@@ -87,10 +88,18 @@ PIP = "pip install --upgrade --force-reinstall --no-cache-dir torchvision"
 def raised():
     """What each planted failure actually produces, from one warm subprocess."""
     pytest.importorskip("transformers")
-    # Skip only where THIS process cannot import it either (no accelerator, no
-    # unsloth installed); the child inherits the environment, so anything the
-    # parent can import the child must too.
-    pytest.importorskip("unsloth_zoo.temporary_patches.utils")
+    # NOT `importorskip` on the module under test: it catches an ImportError
+    # raised while INITIALISING the module too, so a real init regression would
+    # skip all of these and leave the gate this file is listed in green. Skip
+    # only on the two absent-prerequisite guards `unsloth_zoo/__init__.py`
+    # raises; anything else is re-raised and fails.
+    try:
+        importlib.import_module("unsloth_zoo.temporary_patches.utils")
+    except BaseException as exc:
+        text = f"{type(exc).__name__}: {exc}"
+        if "pip install unsloth" in text or "accelerator" in text:
+            pytest.skip("prerequisite absent here -- " + text)
+        raise
     root = Path(__file__).resolve().parents[1]
     # The child gets the parent's environment, so it imports the same tree under
     # the same accelerator settings; only the path to this checkout is added.

--- a/tests/test_torchvision_video_removed_message.py
+++ b/tests/test_torchvision_video_removed_message.py
@@ -39,6 +39,9 @@ CASES = [
     ("pillow",        "ImportError",  "cannot import name '_Ink' from 'PIL'"),
     ("numpy_uv",      "ImportError",  "cannot import name '_center' from 'numpy._core.umath'"),
     ("numpy_stale",   "RuntimeError", "numpy.core._multiarray_umath failed to import"),
+    # Same substring, module present: a missing SYMBOL, which reinstalling does not fix.
+    ("video_symbol",  "ImportError",
+     "cannot import name 'read_video' from 'torchvision.io.video'"),
 ]
 
 _DRIVER = r'''
@@ -84,6 +87,10 @@ PIP = "pip install --upgrade --force-reinstall --no-cache-dir torchvision"
 def raised():
     """What each planted failure actually produces, from one warm subprocess."""
     pytest.importorskip("transformers")
+    # Skip only where THIS process cannot import it either (no accelerator, no
+    # unsloth installed); the child inherits the environment, so anything the
+    # parent can import the child must too.
+    pytest.importorskip("unsloth_zoo.temporary_patches.utils")
     root = Path(__file__).resolve().parents[1]
     # The child gets the parent's environment, so it imports the same tree under
     # the same accelerator settings; only the path to this checkout is added.
@@ -96,8 +103,12 @@ def raised():
         capture_output = True, text = True, timeout = 900, cwd = str(root), env = env,
     )
     if "<<<WARMFAIL>>>" in proc.stdout:
-        pytest.skip("cannot import unsloth_zoo here: "
-                    + proc.stdout.split("<<<WARMFAIL>>>", 1)[1][:200])
+        # A FAILURE, not a skip. The parent just imported the module, so a child
+        # that cannot is a real initialization regression -- and a skip reads as
+        # success to the CI gate this file is listed in, which would leave both
+        # handlers unexercised and every required check green.
+        pytest.fail("the child could not import what this process already did: "
+                    + proc.stdout.split("<<<WARMFAIL>>>", 1)[1][:400])
     if "<<<RESULTS>>>" not in proc.stdout:
         pytest.fail(
             f"driver failed (rc={proc.returncode})\n"
@@ -144,6 +155,16 @@ def test_an_unrelated_import_error_still_falls_through(raised):
     got = raised["unrelated_imp"]
     assert got["type"] == "Exception", got
     assert "flash_attn" in got["message"]
+
+
+def test_a_missing_symbol_is_not_called_an_incomplete_install(raised):
+    """`cannot import name 'read_video' from 'torchvision.io.video'` holds the
+    same substring while the module is right there, so the incomplete-install
+    message would be false and its force-reinstall would not fix it."""
+    got = raised["video_symbol"]
+    assert "install is incomplete" not in (got["message"] or "")
+    assert got["type"] == "Exception", got
+    assert "read_video" in got["message"]
 
 
 def test_the_untouched_arms_still_answer(raised):

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -265,6 +265,11 @@ del _ROCmTorchaoLoader, _ROCmTorchaoFinder
 del _MetaPathFinder, _Loader, _ModuleSpec, _sys_rocm_stub, _types_rocm_stub
 del _is_windows_rocm
 
+_TORCHVISION_BROKE = (
+    "***** Please update and reinstall torchvision - it broke! "
+    "`pip install --upgrade --force-reinstall --no-cache-dir torchvision` *****"
+)
+
 try:
     from transformers.processing_utils import Unpack
     assert \
@@ -277,9 +282,7 @@ except ImportError as e:
             f"***** You might have used uv to install packages, and they broke numpy. Try restarting your runtime. *****"
         )
     elif "torchvision::nms does not exist" in e:
-        raise RuntimeError(
-            f"***** Please update and reinstall torchvision - it broke! `pip install --upgrade --force-reinstall --no-cache-dir torchvision` *****"
-        )
+        raise RuntimeError(_TORCHVISION_BROKE)
     elif "torchvision.io.video" in e or "torchvision.io._video" in e:
         # A HALF-INSTALLED torchvision, same class as the nms arm above. No
         # released version raises this alone: 0.25 ships `io/video.py`, and 0.26
@@ -305,6 +308,13 @@ except ImportError as e:
     )
 except Exception as e:
     e_str = str(e)
+    # Same breakage as the ImportError arm, but it does not arrive as one. A
+    # torchvision whose compiled ops do not match torch fails inside
+    # `_meta_registrations`, at `torch.library.register_fake("torchvision::nms")`,
+    # and that raises RuntimeError. So the arm above could never fire for it and
+    # the user got the bare `operator torchvision::nms does not exist`.
+    if "torchvision::nms does not exist" in e_str:
+        raise RuntimeError(_TORCHVISION_BROKE)
     if "numpy" in e_str and ("_blas" in e_str or "_multiarray" in e_str):
         raise RuntimeError(
             f"***** numpy was likely upgraded mid-session without restarting the kernel. "

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -282,11 +282,10 @@ except ImportError as e:
         )
     elif "torchvision.io.video" in e or "torchvision.io._video" in e:
         # A HALF-INSTALLED torchvision, same class as the nms arm above. No
-        # released torchvision raises this on its own: 0.25 ships `io/video.py`,
-        # and 0.26 dropped the module and the line that imports it together.
-        # Seen when a venv installs over a system torchvision and leaves the
-        # tree partly overwritten, so `io/__init__.py` still imports a `video`
-        # that is gone. Reinstalling is the fix; upgrading anything else is not.
+        # released version raises this alone: 0.25 ships `io/video.py`, and 0.26
+        # dropped the module and its importer together. A venv installing over a
+        # system torchvision leaves the tree partly overwritten, so reinstalling
+        # is the fix and upgrading anything else is not.
         raise RuntimeError(
             f"***** Your torchvision install is incomplete: `torchvision.io` "
             f"imports a `video` module that is not there. Please run "

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -284,11 +284,9 @@ except ImportError as e:
     elif "torchvision::nms does not exist" in e:
         raise RuntimeError(_TORCHVISION_BROKE)
     elif "torchvision.io.video" in e or "torchvision.io._video" in e:
-        # A HALF-INSTALLED torchvision, same class as the nms arm above. No
-        # released version raises this alone: 0.25 ships `io/video.py`, and 0.26
-        # dropped the module and its importer together. A venv installing over a
-        # system torchvision leaves the tree partly overwritten, so reinstalling
-        # is the fix and upgrading anything else is not.
+        # A half-installed torchvision, like the nms arm above. No release raises
+        # this alone (0.25 ships `io/video.py`, 0.26 dropped it with its importer),
+        # so only a tree partly overwritten by a venv install gets here.
         raise RuntimeError(
             f"***** Your torchvision install is incomplete: `torchvision.io` "
             f"imports a `video` module that is not there. Please run "
@@ -308,11 +306,9 @@ except ImportError as e:
     )
 except Exception as e:
     e_str = str(e)
-    # Same breakage as the ImportError arm, but it does not arrive as one. A
+    # The nms arm above, for the case that never arrives as an ImportError: a
     # torchvision whose compiled ops do not match torch fails inside
-    # `_meta_registrations`, at `torch.library.register_fake("torchvision::nms")`,
-    # and that raises RuntimeError. So the arm above could never fire for it and
-    # the user got the bare `operator torchvision::nms does not exist`.
+    # `_meta_registrations` at `register_fake("torchvision::nms")`, a RuntimeError.
     if "torchvision::nms does not exist" in e_str:
         raise RuntimeError(_TORCHVISION_BROKE)
     if "numpy" in e_str and ("_blas" in e_str or "_multiarray" in e_str):

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -283,10 +283,14 @@ except ImportError as e:
         )
     elif "torchvision::nms does not exist" in e:
         raise RuntimeError(_TORCHVISION_BROKE)
-    elif "torchvision.io.video" in e or "torchvision.io._video" in e:
+    elif "No module named 'torchvision.io.video'" in e or \
+         "No module named 'torchvision.io._video'" in e:
         # A half-installed torchvision, like the nms arm above. No release raises
         # this alone (0.25 ships `io/video.py`, 0.26 dropped it with its importer),
         # so only a tree partly overwritten by a venv install gets here.
+        # The MISSING-MODULE form only: `cannot import name 'read_video' from
+        # 'torchvision.io.video'` carries the same substring while the module is
+        # right there, and the message below would then be a lie.
         raise RuntimeError(
             f"***** Your torchvision install is incomplete: `torchvision.io` "
             f"imports a `video` module that is not there. Please run "

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -281,16 +281,17 @@ except ImportError as e:
             f"***** Please update and reinstall torchvision - it broke! `pip install --upgrade --force-reinstall --no-cache-dir torchvision` *****"
         )
     elif "torchvision.io.video" in e or "torchvision.io._video" in e:
-        # torchvision retired video decoding to torchcodec, so an older
-        # transformers dies on `import unsloth` with a bare "No module named
-        # 'torchvision.io.video'". Upgrading transformers is the fix: the newer
-        # ones stopped importing the module.
+        # A HALF-INSTALLED torchvision, same class as the nms arm above. No
+        # released torchvision raises this on its own: 0.25 ships `io/video.py`,
+        # and 0.26 dropped the module and the line that imports it together.
+        # Seen when a venv installs over a system torchvision and leaves the
+        # tree partly overwritten, so `io/__init__.py` still imports a `video`
+        # that is gone. Reinstalling is the fix; upgrading anything else is not.
         raise RuntimeError(
-            f"***** Your torchvision no longer ships `torchvision.io.video` "
-            f"(it moved to torchcodec), but your transformers still imports it. "
-            f"Please run `pip install --upgrade transformers` -- or pin an older "
-            f"torchvision if you need this transformers -- then restart your "
-            f"runtime/kernel. Original error = {e} *****"
+            f"***** Your torchvision install is incomplete: `torchvision.io` "
+            f"imports a `video` module that is not there. Please run "
+            f"`pip install --upgrade --force-reinstall --no-cache-dir torchvision` "
+            f"then restart your runtime/kernel. Original error = {e} *****"
         )
     elif "PIL" in e or "_Ink" in e or "Pillow" in e:
         raise RuntimeError(

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -280,6 +280,21 @@ except ImportError as e:
         raise RuntimeError(
             f"***** Please update and reinstall torchvision - it broke! `pip install --upgrade --force-reinstall --no-cache-dir torchvision` *****"
         )
+    elif "torchvision.io.video" in e or "torchvision.io._video" in e:
+        # torchvision retired its video decoding API in favour of torchcodec, so
+        # a transformers old enough to still import it dies on `import unsloth`
+        # with a bare "No module named 'torchvision.io.video'" and no clue what
+        # to do. Seen on Kaggle, whose install cell takes an unpinned torchvision
+        # off the cu128 index while the Colab twin keeps the preinstalled one --
+        # the same notebook passes there and fails here. UPGRADING is the advice,
+        # not downgrading: newer transformers stopped importing the module.
+        raise RuntimeError(
+            f"***** Your torchvision no longer ships `torchvision.io.video` "
+            f"(it moved to torchcodec), but your transformers still imports it. "
+            f"Please run `pip install --upgrade transformers` -- or pin an older "
+            f"torchvision if you need this transformers -- then restart your "
+            f"runtime/kernel. Original error = {e} *****"
+        )
     elif "PIL" in e or "_Ink" in e or "Pillow" in e:
         raise RuntimeError(
             f"***** Your Pillow (PIL) version is incompatible with torchvision. "

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -281,13 +281,10 @@ except ImportError as e:
             f"***** Please update and reinstall torchvision - it broke! `pip install --upgrade --force-reinstall --no-cache-dir torchvision` *****"
         )
     elif "torchvision.io.video" in e or "torchvision.io._video" in e:
-        # torchvision retired its video decoding API in favour of torchcodec, so
-        # a transformers old enough to still import it dies on `import unsloth`
-        # with a bare "No module named 'torchvision.io.video'" and no clue what
-        # to do. Seen on Kaggle, whose install cell takes an unpinned torchvision
-        # off the cu128 index while the Colab twin keeps the preinstalled one --
-        # the same notebook passes there and fails here. UPGRADING is the advice,
-        # not downgrading: newer transformers stopped importing the module.
+        # torchvision retired video decoding to torchcodec, so an older
+        # transformers dies on `import unsloth` with a bare "No module named
+        # 'torchvision.io.video'". Upgrading transformers is the fix: the newer
+        # ones stopped importing the module.
         raise RuntimeError(
             f"***** Your torchvision no longer ships `torchvision.io.video` "
             f"(it moved to torchcodec), but your transformers still imports it. "


### PR DESCRIPTION
`import unsloth` can die with a bare

```
Exception: No module named 'torchvision.io.video'
```

The handler around `from transformers.processing_utils import Unpack` recognises several torchvision breakages and names each one, but not this one, so it falls through to `raise Exception(e)` and the user gets the raw text with nothing pointing at the cause.

How it turned up

Running the `Kaggle-` notebook variants against the Kaggle install recipe, which nothing had exercised before. `Kaggle-Llama3.2_(11B)-Vision` fails where the same notebook passes on Colab.

What it actually is

I first read this as a version boundary and said so in the original description of this PR. That was wrong, and the driver log shows it. The traceback resolves modules from two different trees:

```
File /kaggle/working/venv_1/lib/python3.12/site-packages/transformers/image_utils.py:60
    from torchvision.transforms import InterpolationMode
File /usr/local/lib/python3.12/dist-packages/torchvision/__init__.py:10
File /usr/local/lib/python3.12/dist-packages/torchvision/io/__init__.py:35
ModuleNotFoundError: No module named 'torchvision.io.video'
```

transformers comes from the venv; torchvision comes from the base image at 0.25.0+cu128, and that copy is half-installed. The same log carries `Failed to load image Python extension: ''` and `'Could not get source, probably due dynamically evaluated source code.'` from the same tree.

Checked against upstream tags rather than assumed:

| torchvision | `io/video.py` | `io/__init__.py` imports it |
| --- | --- | --- |
| 0.24.1 | present | yes |
| 0.25.0 | present | yes |
| 0.26.0 | removed | no |

0.26 removed the module and the line that imports it in the same release, so no released torchvision produces this error on its own. It takes a partially overwritten install, which is what a venv created with `--system-site-packages` on top of a base image can leave behind.

The change

One more arm before the catch-all, raising a `RuntimeError` that names the real condition: `torchvision.io` importing a `video` module that is not there means the install is incomplete. The remedy is the same force-reinstall the adjacent `torchvision::nms` arm already prescribes, since that arm covers the same class of half-installed tree.

Unrecognised import errors still fall through to `raise Exception(e)` untouched.

Scope

This makes the failure legible, not survivable. The environment that produced it is my own test harness, and the fix for that lives in the harness, not here and not in `unslothai/notebooks`. I am not claiming any notebook is fixed by this.

Tests

`tests/test_torchvision_video_removed_message.py`: the arm exists and sits before the catch-all, the message names the cause and the command to run, both `io.video` and `io._video` spellings reach it, every named arm raises `RuntimeError`, and an unrelated import error still falls through. Full zoo suite green apart from the known `test_upstream_pinned_symbols_trl_vllm` PermissionError from my sandbox.