### PR TITLE
MLX VLM: name the config key when a mirrored config.json is incomplete

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -129,11 +129,22 @@ jobs:
         # so a 3.10-only `match` and a module-level `str | Path` both reached main and
         # made the package un-importable on 3.9. It reads the floor from pyproject, so
         # raising requires-python relaxes it rather than making it lie.
+        #
+        # The two test_mlx_incomplete_config files pin the diagnostic that turns a
+        # bare "ModelArgs/ModelConfig.__init__() missing N required positional
+        # arguments" into a message naming the model, the missing keys and
+        # config.json. Several of their assertions read loader.py's source to prove
+        # every mlx-lm / mlx-vlm load entry point is guarded, so a new load path
+        # added without the guard fails here rather than shipping the raw
+        # TypeError. CPU-pure via the MLX simulation shim, no weights, both files
+        # together run in about two tenths of a second.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
             tests/test_mlx_finetune_last_n_layers.py \
             tests/test_mlx_double_quant_reject.py \
+            tests/test_mlx_incomplete_config.py \
+            tests/test_mlx_incomplete_config_vlm.py \
             tests/test_hf_xet_fallback.py \
             tests/test_get_transformers_model_type_empty.py \
             tests/test_train_on_responses_list_labels.py \

--- a/tests/test_mlx_incomplete_config.py
+++ b/tests/test_mlx_incomplete_config.py
@@ -1,0 +1,122 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# A required mlx-lm ModelArgs field absent from config.json raises a bare
+# TypeError naming neither the model nor the file, which reads as missing Apple
+# Silicon support; the guard must name the config as the cause instead.
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+
+    simulate_mlx_on_torch()
+
+
+# Verbatim from mlx-lm 0.31.3 loading unsloth/LFM2.5-230M, whose mirrored
+# config.json lost upstream's "block_ff_dim": 2560 (unslothai/unsloth#7306).
+_LFM2_MSG = (
+    "ModelArgs.__init__() missing 1 required positional argument: 'block_ff_dim'"
+)
+
+
+def test_missing_config_key_raises_actionable_error():
+    from unsloth_zoo.mlx.loader import _raise_if_incomplete_mlx_config
+
+    with pytest.raises(ValueError) as exc:
+        _raise_if_incomplete_mlx_config(
+            "unsloth/LFM2.5-230M", "lfm2", _LFM2_MSG, TypeError(_LFM2_MSG)
+        )
+    msg = str(exc.value)
+    assert "unsloth/LFM2.5-230M" in msg
+    assert "block_ff_dim" in msg
+    assert "config.json" in msg
+    assert "lfm2" in msg
+    # The whole point: stop readers concluding MLX is unsupported.
+    assert "Apple Silicon" in msg
+
+
+def test_multiple_missing_keys_all_named():
+    from unsloth_zoo.mlx.loader import _raise_if_incomplete_mlx_config
+
+    message = (
+        "ModelArgs.__init__() missing 2 required positional arguments: "
+        "'block_ff_dim' and 'block_multiple_of'"
+    )
+    with pytest.raises(ValueError) as exc:
+        _raise_if_incomplete_mlx_config(
+            "unsloth/Example", "lfm2", message, TypeError(message)
+        )
+    msg = str(exc.value)
+    assert "block_ff_dim" in msg and "block_multiple_of" in msg
+    assert "keys" in msg
+
+
+def test_unrelated_type_error_falls_through():
+    # Only the missing-required-argument shape is ours; anything else must keep
+    # its original traceback rather than be relabelled a config problem.
+    from unsloth_zoo.mlx.loader import _raise_if_incomplete_mlx_config
+
+    for message in (
+        "unsupported operand type(s) for +: 'int' and 'str'",
+        "load_model() got an unexpected keyword argument 'strict'",
+    ):
+        _raise_if_incomplete_mlx_config(
+            "unsloth/Example", "lfm2", message, TypeError(message)
+        )
+
+
+def test_mlx_lm_signature_drift_is_not_a_config_problem():
+    # This loader deliberately tolerates mlx-lm changing load_model/_download's
+    # signature between releases (see the bypass comment in
+    # _load_mlx_lm_with_strict_fallback). Those failures have the same
+    # "missing N required positional arguments" wording as a genuinely
+    # incomplete config, so anchoring on __init__ is what keeps them apart:
+    # misreporting one as "config.json is missing 'model_path'" would send a
+    # reader to the wrong repo entirely.
+    from unsloth_zoo.mlx.loader import (
+        _missing_mlx_config_keys,
+        _raise_if_incomplete_mlx_config,
+    )
+
+    for message in (
+        "load_model() missing 1 required positional argument: 'model_path'",
+        "_download() missing 1 required positional argument: 'repo'",
+        "load_tokenizer() missing 2 required positional arguments: 'a' and 'b'",
+    ):
+        assert _missing_mlx_config_keys(message) == []
+        _raise_if_incomplete_mlx_config(
+            "unsloth/Example", "lfm2", message, TypeError(message)
+        )
+
+
+def test_key_extraction_shapes():
+    from unsloth_zoo.mlx.loader import _missing_mlx_config_keys
+
+    assert _missing_mlx_config_keys(_LFM2_MSG) == ["block_ff_dim"]
+    assert _missing_mlx_config_keys(
+        "ModelArgs.__init__() missing 3 required positional arguments: "
+        "'a', 'b', and 'c'"
+    ) == ["a", "b", "c"]
+    # Bare __init__ (no owning class in the message) still counts.
+    assert _missing_mlx_config_keys(
+        "__init__() missing 1 required positional argument: 'block_ff_dim'"
+    ) == ["block_ff_dim"]
+    assert _missing_mlx_config_keys("something else entirely") == []

--- a/tests/test_mlx_incomplete_config_vlm.py
+++ b/tests/test_mlx_incomplete_config_vlm.py
@@ -74,7 +74,7 @@ def test_library_named_in_the_message():
 
 
 def test_default_library_still_mlx_lm():
-    # #1004's three text-side call sites pass no library; changing their message
+    # #1004's two text-side call sites pass no library; changing their message
     # is out of scope for the VLM change.
     from unsloth_zoo.mlx.loader import _raise_if_incomplete_mlx_config
 
@@ -178,10 +178,17 @@ def test_runtime_quant_vlm_path_is_guarded():
     from unsloth_zoo.mlx import loader
 
     source = inspect.getsource(loader)
-    marker = "Pre-quantize load bypasses the extra-weight filter"
-    assert marker in source
-    window = source[source.index(marker) - 1200:source.index(marker)]
+    # Bound the window semantically rather than by a character count: the
+    # runtime-quant VLM branch opens with this print and its QK-norm guard
+    # carries the marker comment, so a guard call between the two is inside
+    # that branch and nowhere else.
+    branch_start = 'via mlx-vlm (VLM, "'
+    branch_end = "Pre-quantize load bypasses the extra-weight filter"
+    assert source.count(branch_start) == 1
+    assert source.count(branch_end) == 1
+    window = source[source.index(branch_start):source.index(branch_end)]
     assert "_raise_if_incomplete_mlx_config" in window
+    assert 'library="mlx-vlm"' in window
 
 
 def test_every_vlm_load_entry_point_is_guarded():

--- a/tests/test_mlx_incomplete_config_vlm.py
+++ b/tests/test_mlx_incomplete_config_vlm.py
@@ -1,0 +1,197 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# The mlx-vlm side of the incomplete-config diagnostic. mlx-vlm's
+# BaseModelConfig.from_dict (mlx_vlm/models/base.py) filters the config on
+# inspect.signature(cls).parameters before constructing, exactly as mlx-lm's
+# from_dict does, so a required field missing from a mirrored config.json fails
+# in ModelConfig.__init__ with a bare TypeError. Without a guard the VLM paths
+# surface that raw error, which reads as missing Apple Silicon support.
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+
+    simulate_mlx_on_torch()
+
+
+# Verbatim from mlx-vlm 0.6.3. 43 of its architectures declare at least one
+# required (no-default) ModelConfig field -- text_config, vision_config,
+# projector_config and model_type are the common ones -- so this is the shape a
+# mirrored VLM config.json produces when transformers drops a key.
+_VLM_MSG = (
+    "ModelConfig.__init__() missing 1 required positional argument: 'text_config'"
+)
+
+
+def test_vlm_message_shape_is_recognized():
+    from unsloth_zoo.mlx.loader import _missing_mlx_config_keys
+
+    assert _missing_mlx_config_keys(_VLM_MSG) == ["text_config"]
+    assert _missing_mlx_config_keys(
+        "ModelConfig.__init__() missing 3 required positional arguments: "
+        "'text_config', 'vision_config', and 'model_type'"
+    ) == ["text_config", "vision_config", "model_type"]
+
+
+def test_library_named_in_the_message():
+    # A reader sent to the wrong project wastes the same time the bare
+    # TypeError did, so the VLM paths must say mlx-vlm, not mlx-lm.
+    from unsloth_zoo.mlx.loader import _raise_if_incomplete_mlx_config
+
+    with pytest.raises(ValueError) as exc:
+        _raise_if_incomplete_mlx_config(
+            "unsloth/Example-VL", "qwen2_5_vl", _VLM_MSG, TypeError(_VLM_MSG),
+            library="mlx-vlm",
+        )
+    msg = str(exc.value)
+    assert "mlx-vlm" in msg
+    assert "mlx-lm" not in msg
+    assert "unsloth/Example-VL" in msg
+    assert "text_config" in msg
+    assert "qwen2_5_vl" in msg
+    assert "Apple Silicon" in msg
+
+
+def test_default_library_still_mlx_lm():
+    # #1004's three text-side call sites pass no library; changing their message
+    # is out of scope for the VLM change.
+    from unsloth_zoo.mlx.loader import _raise_if_incomplete_mlx_config
+
+    with pytest.raises(ValueError) as exc:
+        _raise_if_incomplete_mlx_config(
+            "unsloth/LFM2.5-230M", "lfm2",
+            "ModelArgs.__init__() missing 1 required positional argument: "
+            "'block_ff_dim'",
+            TypeError("x"),
+        )
+    assert "mlx-lm" in str(exc.value)
+
+
+def test_extra_weight_filter_converts_the_type_error():
+    # The real behavioural test: vlm_load is injected, so the whole path runs.
+    from unsloth_zoo.mlx.loader import _load_mlx_vlm_with_extra_weight_filter
+
+    def _vlm_load(model_name, **kwargs):
+        raise TypeError(_VLM_MSG)
+
+    with pytest.raises(ValueError) as exc:
+        _load_mlx_vlm_with_extra_weight_filter(
+            "unsloth/Example-VL", "qwen2_5_vl", _vlm_load, {},
+        )
+    msg = str(exc.value)
+    assert "text_config" in msg
+    assert "mlx-vlm" in msg
+    assert "config.json" in msg
+    # The original TypeError stays reachable for anyone reading the traceback.
+    assert isinstance(exc.value.__cause__, TypeError)
+
+
+def test_extra_weight_filter_passes_through_other_type_errors():
+    # mlx-vlm signature drift at our own call site must keep its traceback,
+    # exactly as on the text side.
+    from unsloth_zoo.mlx.loader import _load_mlx_vlm_with_extra_weight_filter
+
+    drift = "load() got an unexpected keyword argument 'lazy'"
+
+    def _vlm_load(model_name, **kwargs):
+        raise TypeError(drift)
+
+    with pytest.raises(TypeError) as exc:
+        _load_mlx_vlm_with_extra_weight_filter(
+            "unsloth/Example-VL", "qwen2_5_vl", _vlm_load, {},
+        )
+    assert str(exc.value) == drift
+
+
+def test_successful_vlm_load_is_untouched():
+    from unsloth_zoo.mlx.loader import _load_mlx_vlm_with_extra_weight_filter
+
+    def _vlm_load(model_name, **kwargs):
+        return ("model", "processor")
+
+    assert _load_mlx_vlm_with_extra_weight_filter(
+        "unsloth/Example-VL", "qwen2_5_vl", _vlm_load, {},
+    ) == ("model", "processor")
+
+
+def test_retry_path_is_deliberately_not_guarded():
+    # The retry inside the extra-weight filter runs only after a ValueError,
+    # which means ModelConfig already constructed -- a missing-key TypeError
+    # cannot originate there. Guarding it would be dead code, so assert the
+    # first load is the only guarded one.
+    from unsloth_zoo.mlx.loader import _load_mlx_vlm_with_extra_weight_filter
+
+    source = inspect.getsource(_load_mlx_vlm_with_extra_weight_filter)
+    assert source.count("_raise_if_incomplete_mlx_config") == 1
+
+
+def test_distributed_guard_precedes_the_signature_drift_branch():
+    # Ordering is load-bearing in _load_mlx_vlm_distributed: it already owns a
+    # TypeError handler for sharded_load signature drift. The incomplete-config
+    # check has to run first (it is the precise, __init__-anchored test) while
+    # still leaving the drift branch reachable.
+    from unsloth_zoo.mlx.loader import _load_mlx_vlm_distributed
+
+    source = inspect.getsource(_load_mlx_vlm_distributed)
+    assert "_raise_if_incomplete_mlx_config" in source
+    guard_at = source.index("_raise_if_incomplete_mlx_config")
+    drift_at = source.index('"tensor_group" not in message')
+    assert guard_at < drift_at
+    # The drift branch must survive: an __init__-anchored pattern cannot match
+    # "sharded_load() got an unexpected keyword argument 'tensor_group'".
+    from unsloth_zoo.mlx.loader import _missing_mlx_config_keys
+
+    assert _missing_mlx_config_keys(
+        "sharded_load() got an unexpected keyword argument 'tensor_group'"
+    ) == []
+    assert _missing_mlx_config_keys(
+        "sharded_load() missing 1 required positional argument: 'tensor_group'"
+    ) == []
+
+
+def test_runtime_quant_vlm_path_is_guarded():
+    # The runtime-quant branch calls vlm_load directly and so bypasses
+    # _load_mlx_vlm_with_extra_weight_filter -- the same bypass the QK-norm
+    # guard already had to be repeated for. Without its own guard a
+    # load_in_4bit VLM load keeps the bare TypeError.
+    from unsloth_zoo.mlx import loader
+
+    source = inspect.getsource(loader)
+    marker = "Pre-quantize load bypasses the extra-weight filter"
+    assert marker in source
+    window = source[source.index(marker) - 1200:source.index(marker)]
+    assert "_raise_if_incomplete_mlx_config" in window
+
+
+def test_every_vlm_load_entry_point_is_guarded():
+    # Guard against a fourth VLM load path being added later without the
+    # diagnostic. Counts the guard's call sites: three VLM ones plus the two
+    # text-side ones #1004 installed.
+    from unsloth_zoo.mlx import loader
+
+    source = inspect.getsource(loader)
+    calls = source.count("_raise_if_incomplete_mlx_config(")
+    definition = source.count("def _raise_if_incomplete_mlx_config(")
+    assert calls - definition == 5
+    assert source.count('library="mlx-vlm"') == 3

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -443,6 +443,51 @@ def _message_matches_known_fallback(message, rule):
     return any(all(token in message for token in tokens) for tokens in token_sets)
 
 
+_MLX_MISSING_ARGS_RE = re.compile(
+    # Anchored on __init__ so mlx-lm signature drift at our own call sites
+    # (e.g. "load_model() missing 1 required positional argument: 'model_path'")
+    # is never mistaken for an incomplete config; this loader deliberately
+    # tolerates that drift and must keep its original traceback.
+    r"\w*\.?__init__\(\) missing \d+ required positional arguments?:(?P<keys>.*)"
+)
+
+
+def _missing_mlx_config_keys(message):
+    """Config keys mlx-lm's ModelArgs required but config.json did not supply.
+
+    mlx-lm builds ModelArgs through ``from_dict``, which filters the config down
+    to fields the dataclass declares. A field with no default that is absent
+    from config.json therefore fails in ``__init__`` with a bare TypeError that
+    names neither the model nor the file. Returns [] for any other TypeError.
+    """
+    match = _MLX_MISSING_ARGS_RE.search(message)
+    if match is None:
+        return []
+    return re.findall(r"'([^']+)'", match.group("keys"))
+
+
+def _raise_if_incomplete_mlx_config(model_name, model_type, message, error):
+    """An incomplete config.json is a model-repo problem, not an MLX one.
+
+    Mirroring a checkpoint through a transformers version that does not model
+    every field can silently drop keys the mlx-lm arch still requires (e.g.
+    lfm2's block_ff_dim). The raw TypeError reads like missing Apple Silicon
+    support, so name the actual cause."""
+    keys = _missing_mlx_config_keys(message)
+    if not keys:
+        return
+    listed = ", ".join(repr(key) for key in keys)
+    plural = "keys" if len(keys) > 1 else "key"
+    raise ValueError(
+        f"Unsloth: {model_name}'s config.json is missing the {plural} {listed}, "
+        f"which mlx-lm's '{model_type or 'unknown'}' architecture requires and "
+        f"cannot default. This is an incomplete config.json in the model repo - "
+        f"MLX and Apple Silicon support are not the problem. Compare the config "
+        f"against the upstream repo this model was mirrored from and add the "
+        f"missing {plural}."
+    ) from error
+
+
 def _raise_if_qk_norm_version_gap(model_type, message, error):
     """A strict load rejecting q_norm / k_norm means mlx-lm / mlx-vlm is too old for
     this QK-norm arch; dropping those weights breaks the model, so raise instead."""
@@ -809,6 +854,11 @@ def _load_mlx_lm_with_strict_fallback(
             lazy=lazy,
             model_config=model_config,
         )
+    except TypeError as error:
+        # A required ModelArgs field absent from config.json surfaces here, not
+        # as the ValueError the strict fallback below handles.
+        _raise_if_incomplete_mlx_config(model_name, model_type, str(error), error)
+        raise
     except ValueError as error:
         message = str(error)
         # Active-layer QK-norm weights are load-bearing: never strict=False past
@@ -943,12 +993,20 @@ def _load_mlx_lm_distributed(
             allow_patterns=_mlx_lm_metadata_allow_patterns(),
         )
         with _temporary_mlx_lm_snapshot_view(model_path) as metadata_model_path:
-            model, config = load_model(
-                metadata_model_path,
-                lazy=True,
-                strict=False,
-                model_config=model_config,
-            )
+            try:
+                model, config = load_model(
+                    metadata_model_path,
+                    lazy=True,
+                    strict=False,
+                    model_config=model_config,
+                )
+            except TypeError as error:
+                # Same incomplete-config failure as the single-device path;
+                # strict=False does not cover a missing ModelArgs field.
+                _raise_if_incomplete_mlx_config(
+                    model_name, model_type, str(error), error
+                )
+                raise
 
             mode = _mlx_distributed_sharding_mode(
                 model,

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -453,12 +453,18 @@ _MLX_MISSING_ARGS_RE = re.compile(
 
 
 def _missing_mlx_config_keys(message):
-    """Config keys mlx-lm's ModelArgs required but config.json did not supply.
+    """Config keys the arch's config dataclass required but config.json omitted.
 
     mlx-lm builds ModelArgs through ``from_dict``, which filters the config down
     to fields the dataclass declares. A field with no default that is absent
     from config.json therefore fails in ``__init__`` with a bare TypeError that
     names neither the model nor the file. Returns [] for any other TypeError.
+
+    mlx-vlm fails the same way and is matched by the same pattern: its
+    ``BaseModelConfig.from_dict`` (mlx_vlm/models/base.py) filters on
+    ``inspect.signature(cls).parameters`` before constructing, so a missing
+    required field surfaces as e.g. "ModelConfig.__init__() missing 1 required
+    positional argument: 'text_config'".
     """
     match = _MLX_MISSING_ARGS_RE.search(message)
     if match is None:
@@ -466,13 +472,19 @@ def _missing_mlx_config_keys(message):
     return re.findall(r"'([^']+)'", match.group("keys"))
 
 
-def _raise_if_incomplete_mlx_config(model_name, model_type, message, error):
+def _raise_if_incomplete_mlx_config(
+    model_name, model_type, message, error, library="mlx-lm",
+):
     """An incomplete config.json is a model-repo problem, not an MLX one.
 
     Mirroring a checkpoint through a transformers version that does not model
-    every field can silently drop keys the mlx-lm arch still requires (e.g.
-    lfm2's block_ff_dim). The raw TypeError reads like missing Apple Silicon
-    support, so name the actual cause."""
+    every field can silently drop keys the arch still requires (e.g. lfm2's
+    block_ff_dim on the text side, or a VLM's text_config / vision_config). The
+    raw TypeError reads like missing Apple Silicon support, so name the actual
+    cause.
+
+    ``library`` names the loader that rejected the config ("mlx-lm" or
+    "mlx-vlm") so the message points at the right project."""
     keys = _missing_mlx_config_keys(message)
     if not keys:
         return
@@ -480,7 +492,7 @@ def _raise_if_incomplete_mlx_config(model_name, model_type, message, error):
     plural = "keys" if len(keys) > 1 else "key"
     raise ValueError(
         f"Unsloth: {model_name}'s config.json is missing the {plural} {listed}, "
-        f"which mlx-lm's '{model_type or 'unknown'}' architecture requires and "
+        f"which {library}'s '{model_type or 'unknown'}' architecture requires and "
         f"cannot default. This is an incomplete config.json in the model repo - "
         f"MLX and Apple Silicon support are not the problem. Compare the config "
         f"against the upstream repo this model was mirrored from and add the "
@@ -1173,6 +1185,15 @@ def _load_mlx_vlm_with_extra_weight_filter(
     try:
         with _temporary_hf_token_env(hf_token):
             return vlm_load(model_name, **vlm_kwargs)
+    except TypeError as error:
+        # A required config field absent from config.json fails in the arch's
+        # ModelConfig.__init__, not as the ValueError the extra-weight filter
+        # below handles. Only the first load can raise it: the retry runs after
+        # a ValueError, which means the config already constructed.
+        _raise_if_incomplete_mlx_config(
+            model_name, model_type, str(error), error, library="mlx-vlm",
+        )
+        raise
     except ValueError as error:
         message = str(error)
         # QK-norm weights are load-bearing: check before the extra-weight filter.
@@ -1298,6 +1319,14 @@ def _load_mlx_vlm_distributed(
         ) from error
     except TypeError as error:
         message = str(error)
+        # Checked first, and it is the precise test: the incomplete-config
+        # pattern is anchored on __init__, so mlx-vlm signature drift at our own
+        # call site ("sharded_load() got an unexpected keyword argument
+        # 'tensor_group'") can never match it and still reaches the drift
+        # branch below.
+        _raise_if_incomplete_mlx_config(
+            model_name, model_type, message, error, library="mlx-vlm",
+        )
         if "tensor_group" not in message and "pipeline_group" not in message:
             raise
         raise ImportError(
@@ -7476,6 +7505,17 @@ class FastMLXModel:
                             revision=revision,
                             **extra_kwargs,
                         )
+                    except TypeError as error:
+                        # Same bypass as the ValueError below: this load does not
+                        # go through _load_mlx_vlm_with_extra_weight_filter, so
+                        # the incomplete-config diagnostic has to be repeated
+                        # here or a runtime-quant VLM load keeps the bare
+                        # TypeError.
+                        _raise_if_incomplete_mlx_config(
+                            model_name, model_type, str(error), error,
+                            library="mlx-vlm",
+                        )
+                        raise
                     except ValueError as error:
                         # Pre-quantize load bypasses the extra-weight filter, so
                         # surface the QK-norm version gap here too.


### PR DESCRIPTION
> **Stacks on #1004.** That PR adds the diagnostic and the helper this one extends; the diff here shows #1004's commit too until it merges. Review/merge #1004 first, after which this collapses to the VLM-only change.

### The problem

mlx-vlm's `BaseModelConfig.from_dict` (`mlx_vlm/models/base.py`) filters the config on `inspect.signature(cls).parameters` before constructing — exactly as mlx-lm's `from_dict` does. So a required field missing from a mirrored `config.json` fails in `ModelConfig.__init__` with a bare TypeError that names neither the model nor the file:

```
TypeError: ModelConfig.__init__() missing 1 required positional argument: 'text_config'
```

Reproduced against mlx-vlm 0.6.3. That reads as "MLX doesn't support this model", which sends people to the wrong repo — the same failure mode #1004 fixes for the text side (see unslothai/unsloth#7306, where a mirrored LFM2.5 config had lost `block_ff_dim`).

This is not a corner case: **43 of mlx-vlm 0.6.3's architectures declare at least one required no-default `ModelConfig` field**, most commonly `text_config`, `vision_config`, `projector_config` and `model_type`.

### The change

All three VLM load entry points now surface the actionable error:

| Site | Note |
|---|---|
| `_load_mlx_vlm_with_extra_weight_filter` | First load only. The retry is deliberately unguarded — it runs only after a `ValueError`, which means the config already constructed. |
| `_load_mlx_vlm_distributed` | Already owned a `TypeError` handler for `sharded_load` signature drift. The config check runs **first** because it is the precise, `__init__`-anchored test; the drift branch stays reachable since that pattern cannot match `sharded_load() got an unexpected keyword argument 'tensor_group'`. |
| the runtime-quant branch | Calls `vlm_load` directly and so bypasses the extra-weight filter. The QK-norm guard already had to be repeated there for the same reason. |

`_raise_if_incomplete_mlx_config` grows a `library` argument so the message names mlx-vlm rather than mlx-lm. It defaults to `"mlx-lm"`, leaving #1004's text-side call sites byte-identical.

### Tests

`tests/test_mlx_incomplete_config_vlm.py`, 10 tests. **6 fail on the parent commit**; the 4 that pass there assert pre-existing behaviour (message-shape recognition, the mlx-lm default, non-matching TypeErrors passing through, successful loads untouched).

Beyond the behavioural tests, two assertions read `loader.py`'s source so a **fourth** VLM load path added later without the diagnostic fails CI rather than shipping the raw TypeError, and one pins the distributed handler's ordering.

Both incomplete-config test files are registered in the CPU gate — #1004's was not registered either. CPU-pure via the MLX simulation shim, no weights; the two together run in ~0.2s.

### Verification

- `verify_env.py` exit **0** (mlx 0.31.2 / mlx-lm 0.31.3 / mlx-vlm 0.6.3, `unsloth_zoo` resolving from the worktree)
- `tests/test_mlx_incomplete_config_vlm.py` — 10 passed
- `tests/test_mlx_incomplete_config.py` — 5 passed (no regression from the `library` parameter)
- `tests/test_mlx_qk_norm_version_gap.py` — 7 passed
- `tests/test_mlx_distributed_loader.py` — 7 passed
- narrow ruff gate (`--select E9,F63,F7,F82`): 13 findings, **identical to the parent baseline**; YAML parses; `compileall` clean

One invocation per file, per the repo's MLX suite convention.