### PR TITLE
Stop shipping top-level tests/ and scripts/ in the wheel

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -132,6 +132,8 @@ jobs:
         # so a 3.10-only `match` and a module-level `str | Path` both reached main and
         # made the package un-importable on 3.9. It reads the floor from pyproject, so
         # raising requires-python relaxes it rather than making it lie.
+        # test_wheel_top_level_packages pins that discovery ships unsloth_zoo and
+        # nothing else; collect-only would let the packaging config regress.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
@@ -154,6 +156,7 @@ jobs:
             tests/test_sft_prepare_dataset_double_bos.py \
             tests/test_python39_compatibility.py \
             tests/test_checkpoint_modes.py \
+            tests/test_wheel_top_level_packages.py \
             -v
 
       - name: pytest MLX adapter-filter gate (HARD GATE)

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -67,6 +67,9 @@ jobs:
           print(f"wheel version: {version}")
           with zipfile.ZipFile(w) as z:
               n = z.namelist()
+              # Anything outside these two is a stray tree the wheel must not carry.
+              tops = sorted({s.split("/")[0] for s in n if "/" in s})
+              strays = [t for t in tops if t not in ("unsloth_zoo", f"unsloth_zoo-{version}.dist-info")]
               # Hard checks: must hold for any zoo release wheel.
               hard_checks = {
                 "unsloth_zoo/__init__.py shipped":      any(s == "unsloth_zoo/__init__.py" for s in n),
@@ -76,22 +79,20 @@ jobs:
                 "no .git tree":                         not any(s.startswith(".git/") for s in n),
                 "version is not 0.0.0":                 version is not None and version != "0.0.0",
                 "METADATA present":                     any(s.endswith(".dist-info/METADATA") for s in n),
-              }
-              # Soft checks (warn only). Zoo's pyproject doesn't exclude tests/scripts;
-              # tightening the packaging config is a separate follow-up.
-              soft_checks = {
+                # Hard since the packaging config excludes them. A top-level tests/
+                # or scripts/ in site-packages is shared with every other wheel
+                # using that name, so the last install wins and any uninstall
+                # deletes the survivor's files.
                 "no tests/ shipped":                    not any(s.startswith("tests/") for s in n),
                 "no scripts/ shipped":                  not any(s.startswith("scripts/") for s in n),
+                "no other top-level trees":             not strays,
               }
+              print(f"top-level: {tops}")
+              if strays:
+                  print(f"strays: {strays}")
               print("Hard checks:")
               for k, v in hard_checks.items():
                   print(f"  [{'PASS' if v else 'FAIL'}] {k}")
-              print()
-              print("Soft checks (warnings):")
-              for k, v in soft_checks.items():
-                  status = "PASS" if v else "WARN"
-                  print(f"  [{status}] {k}")
-              # Exit non-zero ONLY if a hard check failed.
               sys.exit(0 if all(hard_checks.values()) else 1)
           PY
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,9 @@ unsloth_zoo = ["diffusion_studio/*.html"]
 [tool.setuptools.packages.find]
 # Explicit include: auto-discovery shipped top-level tests/ and scripts/ into
 # site-packages, where they collide with every other wheel using those names.
-include = ["unsloth_zoo*"]
+# Dotted rather than "unsloth_zoo*", which also matches a sibling like
+# unsloth_zoo_cache/ and would ship it as another top-level package.
+include = ["unsloth_zoo", "unsloth_zoo.*"]
 exclude = ["images*", "tests*", "scripts*"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,10 @@ include-package-data = false
 unsloth_zoo = ["diffusion_studio/*.html"]
 
 [tool.setuptools.packages.find]
-exclude = ["images*"]
+# Explicit include: auto-discovery shipped top-level tests/ and scripts/ into
+# site-packages, where they collide with every other wheel using those names.
+include = ["unsloth_zoo*"]
+exclude = ["images*", "tests*", "scripts*"]
 
 [project.optional-dependencies]
 mlx = [

--- a/tests/test_wheel_top_level_packages.py
+++ b/tests/test_wheel_top_level_packages.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """The wheel must ship unsloth_zoo and nothing else at the top level.
 
 setuptools auto-discovery used to package the repo's tests/ and scripts/ trees,
@@ -43,9 +59,27 @@ def _discover(config):
 
 def test_config_excludes_the_shared_trees():
     config = _find_config()
-    assert config.get("include") == ["unsloth_zoo*"]
+    assert config.get("include") == ["unsloth_zoo", "unsloth_zoo.*"]
     for name in ("tests*", "scripts*"):
         assert name in config.get("exclude", []), f"{name} must stay excluded"
+
+
+def test_a_sibling_of_the_package_is_not_discovered(tmp_path):
+    # "unsloth_zoo*" would match unsloth_zoo_cache/ and ship it as its own
+    # top-level package, which is the shape this whole change exists to stop.
+    from setuptools.discovery import PEP420PackageFinder
+
+    (tmp_path / "unsloth_zoo").mkdir()
+    (tmp_path / "unsloth_zoo" / "__init__.py").touch()
+    (tmp_path / "unsloth_zoo_cache").mkdir()
+    (tmp_path / "unsloth_zoo_cache" / "blob.py").touch()
+    config = _find_config()
+    found = PEP420PackageFinder.find(
+        where = str(tmp_path),
+        include = tuple(config["include"]),
+        exclude = tuple(config["exclude"]),
+    )
+    assert sorted(found) == ["unsloth_zoo"]
 
 
 def test_only_unsloth_zoo_is_discovered():

--- a/tests/test_wheel_top_level_packages.py
+++ b/tests/test_wheel_top_level_packages.py
@@ -1,0 +1,73 @@
+"""The wheel must ship unsloth_zoo and nothing else at the top level.
+
+setuptools auto-discovery used to package the repo's tests/ and scripts/ trees,
+which land in site-packages as top-level `tests` and `scripts`. Those names are
+shared with other wheels, so the last install wins and any uninstall deletes the
+survivor's files, leaving a RECORD that points at a file nothing recreates.
+Studio's post-update integrity check then reports the tree as damaged and
+refuses to start. These CPU-only tests pin the pyproject config that fixes it.
+"""
+import os
+import sys
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Names other wheels also write into, so unsloth_zoo must never claim them.
+_SHARED_TOP_LEVEL = ("test", "tests", "doc", "docs", "example", "examples", "scripts")
+
+
+def _find_config():
+    if sys.version_info < (3, 11):
+        pytest.skip("tomllib needs Python 3.11+")
+    import tomllib
+
+    with open(os.path.join(_REPO_ROOT, "pyproject.toml"), "rb") as f:
+        data = tomllib.load(f)
+    return data["tool"]["setuptools"]["packages"]["find"]
+
+
+def _discover(config):
+    # PEP420PackageFinder is what auto-discovery ran, so a directory without
+    # __init__.py (tests/, scripts/) still counts as a package here.
+    from setuptools.discovery import PEP420PackageFinder
+
+    found = PEP420PackageFinder.find(
+        where = _REPO_ROOT,
+        include = tuple(config.get("include", ("*",))),
+        exclude = tuple(config.get("exclude", ())),
+    )
+    return sorted(p for p in found if "." not in p)
+
+
+def test_config_excludes_the_shared_trees():
+    config = _find_config()
+    assert config.get("include") == ["unsloth_zoo*"]
+    for name in ("tests*", "scripts*"):
+        assert name in config.get("exclude", []), f"{name} must stay excluded"
+
+
+def test_only_unsloth_zoo_is_discovered():
+    top_level = _discover(_find_config())
+    assert top_level == ["unsloth_zoo"], f"unexpected top-level packages: {top_level}"
+
+
+def test_shared_names_are_never_discovered():
+    top_level = set(_discover(_find_config()))
+    assert not top_level.intersection(_SHARED_TOP_LEVEL)
+
+
+def test_package_payload_is_untouched():
+    # The exclusion must not thin out unsloth_zoo itself.
+    from setuptools.discovery import PEP420PackageFinder
+
+    config = _find_config()
+    found = PEP420PackageFinder.find(
+        where = _REPO_ROOT,
+        include = tuple(config["include"]),
+        exclude = tuple(config["exclude"]),
+    )
+    assert "unsloth_zoo" in found
+    assert "unsloth_zoo._vendored" in found
+    assert len(found) > 10, f"only found {len(found)} packages, discovery is wrong"


### PR DESCRIPTION
## Summary

Stop packaging the repo's `tests/` and `scripts/` trees into the wheel. They install as top-level `tests` and `scripts` in site-packages, where they collide with other distributions and break Studio's post-update integrity check on Windows.

## Motivation

`[tool.setuptools.packages.find]` only excluded `images*`, so auto-discovery picked up every other top-level directory. Every release since 2026.5.2 has shipped them:

```
2026.5.1  unsloth_zoo
2026.5.2  scripts, tests, unsloth_zoo   <- regression starts here
2026.8.5  scripts, tests, unsloth_zoo
```

`site-packages/tests/` is not ours to own. Several wheels write into it, so whichever installs last wins and any uninstall deletes the survivor's files. The result is a RECORD entry pointing at a file that no longer matches, or no longer exists, and pip will not repair it because the package metadata is intact.

That is what users hit on the Windows desktop app. `unsloth studio update` runs an integrity scan over every RECORD row and exits 1 when a file has shrunk or disappeared:

```
Update finished, but some installed files are damaged:
  unsloth_zoo: tests/conftest.py is 8107 bytes, expected 11429
```

11429 bytes is exactly `tests/conftest.py` in the 2026.8.5 wheel, so the recorded size is ours and the file on disk is not. The update then fails on every attempt, and the printed remedy (reinstalling over the top) cannot help because nothing is actually damaged.

unsloth already gets this right with an explicit `include` list. This brings unsloth_zoo in line.

## Changes

- `pyproject.toml`: add `include = ["unsloth_zoo*"]` and extend `exclude` with `tests*` and `scripts*`.
- Add `tests/test_wheel_top_level_packages.py` covering the config, the discovery result, the shared names, and that the `unsloth_zoo` payload itself is untouched.

## Verification

Wheels built before and after the change carry an identical `unsloth_zoo/` payload (144 files, including the `diffusion_studio/*.html` package data). Only the two stray trees are gone:

```
before  TOP-LEVEL: ['scripts', 'tests', 'unsloth_zoo', 'unsloth_zoo-2026.8.5.dist-info']
after   TOP-LEVEL: ['unsloth_zoo', 'unsloth_zoo-2026.8.5.dist-info']
        top_level.txt: ['unsloth_zoo']
        missing from new wheel: []
```

The explicit `include` also stops a stray directory in a working tree from being packaged. Running the suite locally creates `unsloth_compiled_cache/`, which the old config discovered as a package; unsloth 2026.8.7 shipped exactly that by accident.

Test runs are unaffected: `pythonpath = ["."]` in `[tool.pytest.ini_options]` keeps `from scripts import scan_packages` working from a checkout.

```bash
python -m pytest tests/test_wheel_top_level_packages.py tests/test_vendored_license_shipped.py tests/test_pypi_version_sync.py tests/test_python39_compatibility.py -q
```

14 passed.

## Review follow-up (d9c8fb7d)

- `include` narrowed from `unsloth_zoo*` to `["unsloth_zoo", "unsloth_zoo.*"]`. The prefix glob also matches a sibling top-level package, which is the shape this change exists to stop: with a `unsloth_zoo_generated/` in the tree, discovery returned `['unsloth_zoo', 'unsloth_zoo_generated']`. Both forms find the same 20 real subpackages.
- `wheel-smoke.yml` carried `no tests/ shipped` and `no scripts/ shipped` as soft checks, with a comment deferring the packaging fix to a follow-up. This is that follow-up, so both are now hard checks, joined by a `no other top-level trees` check, and the stale comment is gone. The promoted check fails on a wheel built from main and passes on this head.
- `tests/test_wheel_top_level_packages.py` now runs in the `pytest behavioral gates (HARD GATE)` step of `repo-tests-cpu`, not only in the collect-only matrix, which is `continue-on-error: true`.
