### PR TITLE
Gemma3: follow the projection weight dtype at forced-float32 Linear boundaries

### DIFF
--- a/tests/test_gemma3_forced_float32_boundary_dtype.py
+++ b/tests/test_gemma3_forced_float32_boundary_dtype.py
@@ -1,0 +1,292 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""CPU regression tests for the Gemma3 UNSLOTH_FORCE_FLOAT32 Linear boundary dtype fix.
+
+The forced-float32 Gemma3 patches run RMSNorm / SwiGLU / attention reductions in
+float32 and hand a float16 activation to every Linear. That hard-coded float16
+assumed the projection weights were float16 too: true for LoRA / QLoRA, false for
+full finetuning, which upcasts the trainable weights to float32. A float16
+activation then met a float32 weight and the matmul died with
+"expected mat1 and mat2 to have the same dtype, but got: c10::Half != float"
+(the CPU wording is "m1 and m2", same error).
+
+``_linear_boundary_dtype`` reads the dtype off the projections that actually do
+the multiply and ``_to_boundary_dtype`` moves the activation there, so:
+
+  * float32 projections (full finetuning) no longer crash, and stay in float32;
+  * float16 projections (LoRA / QLoRA) hit an identity branch, so the common path
+    keeps bit-for-bit the numerics it had before the fix;
+  * a bitsandbytes 4bit uint8 weight blob is not floating point, so it falls
+    through to the float16 default that path always used.
+
+Everything here is behavioural: the real patched ``Gemma3MLP`` / ``Gemma3Attention``
+forwards are executed on CPU with real transformers modules built from a tiny real
+Gemma3 text config. No test inspects the source text of the patch. dtype-mismatch
+errors raise on CPU, so no GPU is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+try:
+    from transformers.models.gemma3 import modeling_gemma3 as gemma3
+    from transformers.models.gemma3 import Gemma3TextConfig
+    HAS_GEMMA3 = True
+except Exception:  # pragma: no cover - transformers too old for gemma3
+    gemma3 = None
+    Gemma3TextConfig = None
+    HAS_GEMMA3 = False
+
+from unsloth_zoo.temporary_patches import gemma as gemma_patches
+from unsloth_zoo.temporary_patches import utils as patch_utils
+from unsloth_zoo.temporary_patches.gemma import (
+    _linear_boundary_dtype,
+    _to_boundary_dtype,
+)
+
+requires_gemma3 = pytest.mark.skipif(not HAS_GEMMA3, reason="transformers gemma3 not installed")
+
+# Tiny but real Gemma3 text config: head_dim * num_attention_heads == hidden_size.
+HIDDEN_SIZE, INTERMEDIATE_SIZE, HEADS, KV_HEADS, HEAD_DIM = 16, 32, 2, 1, 8
+
+
+def _text_config():
+    return Gemma3TextConfig(
+        vocab_size            = 64,
+        hidden_size           = HIDDEN_SIZE,
+        intermediate_size     = INTERMEDIATE_SIZE,
+        num_hidden_layers     = 1,
+        num_attention_heads   = HEADS,
+        num_key_value_heads   = KV_HEADS,
+        head_dim              = HEAD_DIM,
+    )
+
+
+def _record_input_dtypes(module):
+    """Collect the dtype every call actually hands to ``module``."""
+    seen = []
+    module.register_forward_pre_hook(lambda _module, args: seen.append(args[0].dtype))
+    return seen
+
+
+def _install(monkeypatch, force_float32, patchers):
+    """Run the real zoo patch bodies against transformers, then undo them.
+
+    ``monkeypatch.setattr(cls, "forward", cls.forward)`` records the pre-patch
+    function so teardown restores it: these patches mutate the global transformers
+    classes and must not leak into other test files. torch.compile is switched off
+    so the assertions see the patched Python itself rather than a Dynamo graph
+    (and so the bitwise test compares against eager arithmetic).
+    """
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1" if force_float32 else "0")
+    monkeypatch.setattr(patch_utils, "UNSLOTH_COMPILE_DISABLE", True)
+    monkeypatch.setattr(gemma_patches, "torch_compile", lambda function, *args, **kwargs: function)
+
+    targets = (gemma3.Gemma3MLP, gemma3.Gemma3Attention)
+    for target in targets:
+        monkeypatch.setattr(target, "forward", target.forward)
+    before = {target: target.forward for target in targets}
+
+    for patcher in patchers:
+        patcher()
+
+    # Guard against a vacuous run: patch_function() silently declines to patch when
+    # the upstream signature drifts, and then these tests would exercise stock
+    # transformers and pass no matter what the fix does.
+    patched = {target for target in targets if target.forward is not before[target]}
+    return patched
+
+
+@pytest.fixture
+def forced_float32_patches(monkeypatch):
+    patched = _install(
+        monkeypatch,
+        force_float32 = True,
+        patchers = (gemma_patches.patch_Gemma3MLP, gemma_patches.patch_Gemma3Attention),
+    )
+    assert gemma3.Gemma3MLP in patched, "patch_Gemma3MLP did not install its forward"
+    assert gemma3.Gemma3Attention in patched, "patch_Gemma3Attention did not install its forward"
+    yield
+
+
+@pytest.fixture
+def generic_patches(monkeypatch):
+    patched = _install(
+        monkeypatch,
+        force_float32 = False,
+        patchers = (gemma_patches.patch_Gemma3Attention_generic,),
+    )
+    assert gemma3.Gemma3Attention in patched, "patch_Gemma3Attention_generic did not install its forward"
+    yield
+
+
+@requires_gemma3
+def test_forced_float32_mlp_runs_float16_activation_into_float32_projections(forced_float32_patches):
+    """Full finetuning: fp32 MLP weights fed the fp16 activation RMSNorm emits.
+
+    Before the fix ``self.gate_proj(x)`` raised RuntimeError here.
+    """
+    torch.manual_seed(0)
+    mlp = gemma3.Gemma3MLP(_text_config()).to(torch.float32)
+    gate_seen = _record_input_dtypes(mlp.gate_proj)
+    up_seen = _record_input_dtypes(mlp.up_proj)
+    down_seen = _record_input_dtypes(mlp.down_proj)
+    x = torch.randn(2, 3, HIDDEN_SIZE, dtype = torch.float16)
+
+    out = mlp(x)
+
+    assert out.dtype == torch.float32
+    assert out.shape == (2, 3, HIDDEN_SIZE)
+    assert torch.isfinite(out).all()
+    # Every Linear must have been handed its own weight dtype, not a bare float16.
+    assert gate_seen == [torch.float32]
+    assert up_seen == [torch.float32]
+    assert down_seen == [torch.float32]
+
+
+@requires_gemma3
+def test_forced_float32_mlp_float16_weights_are_bitwise_identical_to_pre_fix(forced_float32_patches):
+    """LoRA / QLoRA path: fp16 weights must reproduce the old algorithm exactly."""
+    torch.manual_seed(0)
+    mlp = gemma3.Gemma3MLP(_text_config()).to(torch.float16)
+    gate_seen = _record_input_dtypes(mlp.gate_proj)
+    down_seen = _record_input_dtypes(mlp.down_proj)
+    x = torch.randn(2, 3, HIDDEN_SIZE, dtype = torch.float16)
+
+    out = mlp(x)
+
+    # Pre-fix algorithm, inline: projections in fp16, upcast, act_fn and product in
+    # fp32, bare .to(torch.float16), down_proj.
+    gate_proj_out = mlp.gate_proj(x)
+    up_proj_out = mlp.up_proj(x)
+    gate_proj_fp32 = gate_proj_out.to(torch.float32)
+    up_proj_fp32 = up_proj_out.to(torch.float32)
+    activated_fp32 = mlp.act_fn(gate_proj_fp32)
+    intermediate_fp32 = activated_fp32 * up_proj_fp32
+    intermediate_fp16 = intermediate_fp32.to(torch.float16)
+    expected = mlp.down_proj(intermediate_fp16)
+
+    assert out.dtype == torch.float16
+    assert expected.dtype == torch.float16
+    # Bitwise, via the raw fp16 bit patterns rather than float comparison.
+    assert torch.equal(out.view(torch.int16), expected.view(torch.int16))
+    assert gate_seen[0] == torch.float16
+    assert down_seen[0] == torch.float16
+
+
+@requires_gemma3
+def test_forced_float32_attention_runs_float16_hidden_states_into_float32_projections(forced_float32_patches):
+    """The exact crash site from the traceback: fp32 q_proj fed fp16 hidden_states."""
+    torch.manual_seed(0)
+    attention = gemma3.Gemma3Attention(_text_config(), layer_idx = 0).to(torch.float32)
+    q_seen = _record_input_dtypes(attention.q_proj)
+    o_seen = _record_input_dtypes(attention.o_proj)
+    hidden_states = torch.randn(1, 4, HIDDEN_SIZE, dtype = torch.float16)
+    cos = torch.randn(1, 4, HEAD_DIM, dtype = torch.float32)
+    sin = torch.randn(1, 4, HEAD_DIM, dtype = torch.float32)
+
+    attn_output, _attn_weights = attention(
+        hidden_states,
+        position_embeddings = (cos, sin),
+        attention_mask = None,
+    )
+
+    assert attn_output.dtype == torch.float32
+    assert attn_output.shape == (1, 4, HIDDEN_SIZE)
+    assert torch.isfinite(attn_output).all()
+    assert q_seen == [torch.float32]
+    assert o_seen == [torch.float32]
+
+
+@requires_gemma3
+def test_generic_attention_runs_float16_hidden_states_into_float32_projections(generic_patches):
+    """The second (non forced-float32) Gemma3Attention forward needs the same fix."""
+    torch.manual_seed(0)
+    attention = gemma3.Gemma3Attention(_text_config(), layer_idx = 0).to(torch.float32)
+    q_seen = _record_input_dtypes(attention.q_proj)
+    hidden_states = torch.randn(1, 4, HIDDEN_SIZE, dtype = torch.float16)
+    cos = torch.randn(1, 4, HEAD_DIM, dtype = torch.float32)
+    sin = torch.randn(1, 4, HEAD_DIM, dtype = torch.float32)
+
+    attn_output, _attn_weights = attention(
+        hidden_states,
+        position_embeddings = (cos, sin),
+        attention_mask = None,
+    )
+
+    assert attn_output.dtype == torch.float32
+    assert attn_output.shape == (1, 4, HIDDEN_SIZE)
+    assert torch.isfinite(attn_output).all()
+    assert q_seen == [torch.float32]
+
+
+class _Projections:
+    """Bare attribute holder: ``_linear_boundary_dtype`` only reads ``.weight``."""
+
+    def __init__(self, **projections):
+        for name, value in projections.items():
+            setattr(self, name, value)
+
+
+def test_linear_boundary_dtype_reads_the_first_floating_point_projection_weight():
+    names = ("q_proj", "k_proj", "v_proj", "o_proj")
+
+    float32_module = _Projections(**{name: torch.nn.Linear(4, 4, bias = False, dtype = torch.float32) for name in names})
+    assert _linear_boundary_dtype(float32_module, *names) == torch.float32
+
+    float16_module = _Projections(**{name: torch.nn.Linear(4, 4, bias = False, dtype = torch.float16) for name in names})
+    assert _linear_boundary_dtype(float16_module, *names) == torch.float16
+
+    bfloat16_module = _Projections(**{name: torch.nn.Linear(4, 4, bias = False, dtype = torch.bfloat16) for name in names})
+    assert _linear_boundary_dtype(bfloat16_module, *names) == torch.bfloat16
+
+    # bitsandbytes 4bit keeps the base weight as a packed uint8 blob, which is not
+    # floating point: fall through to the float16 default this path always used.
+    quantized_module = _Projections(**{name: _Projections(weight = torch.zeros(8, 1, dtype = torch.uint8)) for name in names})
+    assert _linear_boundary_dtype(quantized_module, *names) == torch.float16
+
+    # A uint8 blob must be skipped rather than end the search: the fp32 weight wins.
+    mixed_module = _Projections(
+        q_proj = _Projections(weight = torch.zeros(8, 1, dtype = torch.uint8)),
+        k_proj = torch.nn.Linear(4, 4, bias = False, dtype = torch.float32),
+    )
+    assert _linear_boundary_dtype(mixed_module, *names) == torch.float32
+
+    # No projections at all, and projections explicitly set to None.
+    assert _linear_boundary_dtype(_Projections(), *names) == torch.float16
+    assert _linear_boundary_dtype(_Projections(**{name: None for name in names}), *names) == torch.float16
+
+
+def test_to_boundary_dtype_casts_to_the_weight_dtype_and_is_identity_when_it_matches():
+    float32_activation = torch.randn(2, 3, dtype = torch.float32)
+    float16_activation = torch.randn(2, 3, dtype = torch.float16)
+
+    # Matching dtype: exact same tensor object back, no copy, no numerics change.
+    assert _to_boundary_dtype(float32_activation, torch.float32) is float32_activation
+    assert _to_boundary_dtype(float16_activation, torch.float16) is float16_activation
+
+    # Mismatched dtype: moved onto the Linear's dtype.
+    assert _to_boundary_dtype(float16_activation, torch.float32).dtype == torch.float32
+    assert _to_boundary_dtype(float32_activation, torch.float16).dtype == torch.float16
+    assert torch.equal(
+        _to_boundary_dtype(float16_activation, torch.float32),
+        float16_activation.to(torch.float32),
+    )

--- a/tests/test_gemma3_forced_float32_boundary_dtype.py
+++ b/tests/test_gemma3_forced_float32_boundary_dtype.py
@@ -494,3 +494,107 @@ def test_to_forced_output_dtype_defaults_to_float16_and_is_not_identity_on_none(
     # Already fp16 with no answer: same tensor back, no pointless copy.
     float16_reduction = torch.randn(2, 3, dtype = torch.float16)
     assert _to_forced_output_dtype(float16_reduction, None) is float16_reduction
+
+
+class _QuantizedWeight(torch.Tensor):
+    """A tensor that carries a `quant_state`, the way `Params4bit` does.
+
+    bitsandbytes only fills `quant_state` in once the parameter has been moved
+    to an accelerator, so a CPU-only test cannot build a real packed weight.
+    What the helper actually reads is just `.dtype` and `.quant_state`, so a
+    tensor subclass carrying both reproduces the case exactly and keeps this
+    test running everywhere. The GPU test below asserts the same thing against
+    a real `Params4bit`.
+    """
+
+    quant_state = None
+
+    @staticmethod
+    def __new__(cls, data, quant_state):
+        instance = torch.Tensor._make_subclass(cls, data, False)
+        instance.quant_state = quant_state
+        return instance
+
+
+_QUANT_STORAGE_DTYPES = [torch.uint8, torch.bfloat16, torch.float16, torch.float32]
+
+
+@pytest.mark.parametrize("storage_dtype", _QUANT_STORAGE_DTYPES,
+                         ids = lambda d: str(d).split(".")[-1])
+def test_a_quantized_weight_never_answers_whatever_its_storage_dtype_is(storage_dtype):
+    """`bnb_4bit_quant_storage` is a public knob, and it is not the compute dtype.
+
+    It defaults to uint8, which is not floating point and so was already
+    skipped. But FSDP can only shard float dtypes, so FSDP-QLoRA users are
+    told to set it to bfloat16, and `vllm_utils` and the bnb MoE loaders plumb
+    the configured value through. Then `Params4bit.weight.dtype` is bfloat16
+    while the tensor is still packed 4bit, and a plain floating-point test
+    reads a storage container as the activation dtype. `Linear4bit` returns
+    the caller's input dtype, so answering here would change QLoRA forward and
+    gradient numerics on a weight that is still quantized.
+    """
+    names = ("q_proj", "k_proj", "v_proj", "o_proj")
+    quantized = _Projections(**{
+        name: _Projections(weight = _QuantizedWeight(
+            torch.zeros(8, 1, dtype = storage_dtype), quant_state = object(),
+        )) for name in names
+    })
+    assert _linear_boundary_dtype(quantized, *names) is None
+
+    # Skipped, not terminal: a real unquantized compute dtype further along wins.
+    mixed = _Projections(
+        q_proj = _Projections(weight = _QuantizedWeight(
+            torch.zeros(8, 1, dtype = storage_dtype), quant_state = object(),
+        )),
+        k_proj = torch.nn.Linear(4, 4, bias = False, dtype = torch.float32),
+    )
+    assert _linear_boundary_dtype(mixed, *names) == torch.float32
+
+
+@pytest.mark.parametrize("weight_dtype", [torch.bfloat16, torch.float16, torch.float32],
+                         ids = lambda d: str(d).split(".")[-1])
+def test_an_unquantized_weight_still_answers_and_the_skip_is_not_blanket(weight_dtype):
+    """The discriminator, asserted from the other side.
+
+    Skipping quantized weights must key off `quant_state`, not off the dtype.
+    A bfloat16 weight with no `quant_state` is an ordinary LoRA / QLoRA base
+    weight or a bf16 full finetune, and it must still answer, or a float32 full
+    finetune goes back to the "expected mat1 and mat2 to have the same dtype"
+    crash this helper exists to fix.
+    """
+    names = ("q_proj", "k_proj", "v_proj", "o_proj")
+    module = _Projections(**{
+        name: torch.nn.Linear(4, 4, bias = False, dtype = weight_dtype) for name in names
+    })
+    assert getattr(module.q_proj.weight, "quant_state", None) is None
+    assert _linear_boundary_dtype(module, *names) == weight_dtype
+
+    # A plain nn.Parameter has no `quant_state` attribute at all: getattr, not
+    # hasattr-then-read, so this stays a no-op on any non-bitsandbytes backend.
+    bare = _Projections(**{name: torch.nn.Parameter(torch.zeros(4, 4, dtype = weight_dtype))
+                           for name in names})
+    assert _linear_boundary_dtype(bare, *names) == weight_dtype
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs an accelerator to quantize")
+@pytest.mark.parametrize("storage_dtype", _QUANT_STORAGE_DTYPES,
+                         ids = lambda d: str(d).split(".")[-1])
+def test_a_real_bitsandbytes_params4bit_never_answers(storage_dtype):
+    """The same assertion against real bitsandbytes, not a stand-in.
+
+    bitsandbytes quantizes on the move to the accelerator, so this is where a
+    genuine packed `Params4bit` exists and where its dtype really does report
+    the storage container.
+    """
+    bnb = pytest.importorskip("bitsandbytes")
+    names = ("q_proj", "k_proj", "v_proj", "o_proj")
+
+    weight = bnb.nn.Params4bit(
+        torch.randn(64, 64, dtype = torch.float16),
+        quant_type = "nf4", quant_storage = storage_dtype, requires_grad = False,
+    ).cuda()
+    assert weight.quant_state is not None, "bitsandbytes did not quantize"
+    assert weight.dtype == storage_dtype, "quant_storage is meant to set the storage dtype"
+
+    module = _Projections(**{name: _Projections(weight = weight) for name in names})
+    assert _linear_boundary_dtype(module, *names) is None

--- a/tests/test_gemma3_forced_float32_boundary_dtype.py
+++ b/tests/test_gemma3_forced_float32_boundary_dtype.py
@@ -60,6 +60,7 @@ from unsloth_zoo.temporary_patches import utils as patch_utils
 from unsloth_zoo.temporary_patches.gemma import (
     _linear_boundary_dtype,
     _to_boundary_dtype,
+    _to_forced_output_dtype,
 )
 
 requires_gemma3 = pytest.mark.skipif(not HAS_GEMMA3, reason="transformers gemma3 not installed")
@@ -339,7 +340,7 @@ def test_every_patch_installing_a_boundary_forward_publishes_the_helpers():
 
     source = pathlib.Path(gemma_patches.__file__).read_text(encoding = "utf-8")
     tree = ast.parse(source)
-    helpers = {"_linear_boundary_dtype", "_to_boundary_dtype"}
+    helpers = {"_linear_boundary_dtype", "_to_boundary_dtype", "_to_forced_output_dtype"}
 
     offenders = []
     for node in tree.body:
@@ -367,7 +368,7 @@ def test_the_publish_check_actually_finds_the_patches():
     import pathlib
 
     tree = ast.parse(pathlib.Path(gemma_patches.__file__).read_text(encoding = "utf-8"))
-    helpers = {"_linear_boundary_dtype", "_to_boundary_dtype"}
+    helpers = {"_linear_boundary_dtype", "_to_boundary_dtype", "_to_forced_output_dtype"}
     using = [
         node.name for node in tree.body
         if isinstance(node, ast.FunctionDef) and node.name.startswith("patch_")
@@ -394,3 +395,102 @@ def test_to_boundary_dtype_casts_to_the_weight_dtype_and_is_identity_when_it_mat
         _to_boundary_dtype(float16_activation, torch.float32),
         float16_activation.to(torch.float32),
     )
+
+
+class _FakeLinear4bit(torch.nn.Module):
+    """A stand-in for bitsandbytes `Linear4bit`, in the two ways that matter here.
+
+    bitsandbytes stores the base weight as a packed `uint8` blob
+    (`Params4bit(quant_storage=torch.uint8)`), so `_linear_boundary_dtype` finds
+    no floating-point weight and answers None. And its forward ends in
+    `bnb.matmul_4bit(...).to(inp_dtype)`, so the result carries the caller's
+    input dtype straight back out. Together those two facts are what turn a
+    float32 activation at a forced output boundary into a float32 `down_proj` /
+    `o_proj` result, and thus into changed QLoRA forward and gradient dtypes.
+    """
+
+    def __init__(self, in_features, out_features):
+        super().__init__()
+        self.register_buffer("weight", torch.zeros(out_features * in_features // 2, 1, dtype = torch.uint8))
+        self.register_buffer("_dequantized", torch.randn(out_features, in_features, dtype = torch.float16))
+
+    def forward(self, x):
+        inp_dtype = x.dtype
+        return (x.to(torch.float16) @ self._dequantized.T).to(inp_dtype)
+
+
+def _quantize_projections(module, names):
+    for name in names:
+        linear = getattr(module, name)
+        setattr(module, name, _FakeLinear4bit(linear.in_features, linear.out_features))
+pass
+
+
+@requires_gemma3
+def test_forced_float32_mlp_downcasts_to_float16_when_4bit_weights_cannot_answer(forced_float32_patches):
+    """4bit QLoRA: no projection weight is floating point, so the boundary dtype
+    is None. The forced output boundary must still fall back to the float16 the
+    bare `.to(torch.float16)` always produced, or `down_proj` receives float32
+    and hands float32 back.
+    """
+    torch.manual_seed(0)
+    mlp = gemma3.Gemma3MLP(_text_config()).to(torch.float16)
+    _quantize_projections(mlp, ("gate_proj", "up_proj", "down_proj"))
+    assert _linear_boundary_dtype(mlp, "gate_proj", "up_proj", "down_proj") is None
+
+    gate_seen = _record_input_dtypes(mlp.gate_proj)
+    down_seen = _record_input_dtypes(mlp.down_proj)
+    x = torch.randn(2, 3, HIDDEN_SIZE, dtype = torch.float16)
+
+    out = mlp(x)
+
+    assert gate_seen == [torch.float16], "the fp16 input boundary must stay fp16"
+    assert down_seen == [torch.float16], "the forced output boundary leaked the fp32 reduction"
+    assert out.dtype == torch.float16, "Linear4bit returns the caller's dtype, so down_proj went fp32"
+
+
+@requires_gemma3
+def test_forced_float32_attention_downcasts_to_float16_when_4bit_weights_cannot_answer(forced_float32_patches):
+    """Same forced output boundary, on `o_proj` at the attention exit."""
+    torch.manual_seed(0)
+    attention = gemma3.Gemma3Attention(_text_config(), layer_idx = 0).to(torch.float16)
+    _quantize_projections(attention, ("q_proj", "k_proj", "v_proj", "o_proj"))
+    assert _linear_boundary_dtype(attention, "q_proj", "k_proj", "v_proj", "o_proj") is None
+
+    q_seen = _record_input_dtypes(attention.q_proj)
+    o_seen = _record_input_dtypes(attention.o_proj)
+    hidden_states = torch.randn(1, 4, HIDDEN_SIZE, dtype = torch.float16)
+    cos = torch.randn(1, 4, HEAD_DIM, dtype = torch.float32)
+    sin = torch.randn(1, 4, HEAD_DIM, dtype = torch.float32)
+
+    attn_output, _attn_weights = attention(
+        hidden_states,
+        position_embeddings = (cos, sin),
+        attention_mask = None,
+    )
+
+    assert q_seen == [torch.float16], "the fp16 input boundary must stay fp16"
+    assert o_seen == [torch.float16], "the forced output boundary leaked the fp32 reduction"
+    assert attn_output.dtype == torch.float16, "Linear4bit returns the caller's dtype, so o_proj went fp32"
+
+
+def test_to_forced_output_dtype_defaults_to_float16_and_is_not_identity_on_none():
+    """The whole distinction between the two helpers, asserted directly."""
+    float32_reduction = torch.randn(2, 3, dtype = torch.float32)
+
+    # No weight answered: the forced output boundary is the old bare fp16 cast...
+    assert _to_forced_output_dtype(float32_reduction, None).dtype == torch.float16
+    assert torch.equal(
+        _to_forced_output_dtype(float32_reduction, None),
+        float32_reduction.to(torch.float16),
+    )
+    # ...while the generic input helper is deliberately identity on None.
+    assert _to_boundary_dtype(float32_reduction, None) is float32_reduction
+
+    # A weight that did answer still wins over the fp16 default.
+    assert _to_forced_output_dtype(float32_reduction, torch.float32) is float32_reduction
+    assert _to_forced_output_dtype(float32_reduction, torch.bfloat16).dtype == torch.bfloat16
+
+    # Already fp16 with no answer: same tensor back, no pointless copy.
+    float16_reduction = torch.randn(2, 3, dtype = torch.float16)
+    assert _to_forced_output_dtype(float16_reduction, None) is float16_reduction

--- a/tests/test_gemma3_forced_float32_boundary_dtype.py
+++ b/tests/test_gemma3_forced_float32_boundary_dtype.py
@@ -259,9 +259,9 @@ def test_linear_boundary_dtype_reads_the_first_floating_point_projection_weight(
     assert _linear_boundary_dtype(bfloat16_module, *names) == torch.bfloat16
 
     # bitsandbytes 4bit keeps the base weight as a packed uint8 blob, which is not
-    # floating point: fall through to the float16 default this path always used.
+    # floating point: no weight answers, so leave the activation alone.
     quantized_module = _Projections(**{name: _Projections(weight = torch.zeros(8, 1, dtype = torch.uint8)) for name in names})
-    assert _linear_boundary_dtype(quantized_module, *names) == torch.float16
+    assert _linear_boundary_dtype(quantized_module, *names) is None
 
     # A uint8 blob must be skipped rather than end the search: the fp32 weight wins.
     mixed_module = _Projections(
@@ -271,8 +271,112 @@ def test_linear_boundary_dtype_reads_the_first_floating_point_projection_weight(
     assert _linear_boundary_dtype(mixed_module, *names) == torch.float32
 
     # No projections at all, and projections explicitly set to None.
-    assert _linear_boundary_dtype(_Projections(), *names) == torch.float16
-    assert _linear_boundary_dtype(_Projections(**{name: None for name in names}), *names) == torch.float16
+    assert _linear_boundary_dtype(_Projections(), *names) is None
+    assert _linear_boundary_dtype(_Projections(**{name: None for name in names}), *names) is None
+
+
+_FLOAT8_DTYPES = [
+    getattr(torch, name) for name in
+    ("float8_e4m3fn", "float8_e4m3fnuz", "float8_e5m2", "float8_e5m2fnuz")
+    if hasattr(torch, name)
+]
+
+
+@pytest.mark.parametrize("float8_dtype", _FLOAT8_DTYPES, ids = lambda d: str(d).split(".")[-1])
+def test_a_float8_storage_weight_is_not_read_as_an_activation_dtype(float8_dtype):
+    """`torch.float8_e4m3fn.is_floating_point` is True, so a plain floating-point
+    test hands back float8 and the caller casts the hidden states straight to it.
+
+    transformers' FP8Linear / FbgemmFp8Linear take bfloat16 or float16 in and do
+    their own scaled quantization, so an unscaled cast loses values before the
+    scaling meant to preserve them, and the Q/K norm and SDPA downstream get a
+    dtype they do not support.
+    """
+    names = ("q_proj", "k_proj", "v_proj", "o_proj")
+    fp8_module = _Projections(**{
+        name: _Projections(weight = torch.zeros(8, 8).to(float8_dtype)) for name in names
+    })
+    assert float8_dtype.is_floating_point, "the decoy must look like a float to the old test"
+    assert _linear_boundary_dtype(fp8_module, *names) is None
+
+    # It is skipped, not treated as terminal: a real compute dtype further along wins.
+    mixed = _Projections(
+        q_proj = _Projections(weight = torch.zeros(8, 8).to(float8_dtype)),
+        k_proj = torch.nn.Linear(4, 4, bias = False, dtype = torch.bfloat16),
+    )
+    assert _linear_boundary_dtype(mixed, *names) == torch.bfloat16
+
+
+def test_a_bfloat16_activation_survives_a_4bit_model():
+    """The generic (non-forced) path installs on 4bit QLoRA with bfloat16
+    activations. Every projection is a uint8 blob there, so nothing answers, and
+    a float16 fallback would narrow bfloat16 to float16 on a forward the
+    unpatched model passed through untouched, costing exactly the exponent range
+    bfloat16 is chosen for.
+    """
+    names = ("q_proj", "k_proj", "v_proj", "o_proj")
+    quantized = _Projections(**{
+        name: _Projections(weight = torch.zeros(8, 1, dtype = torch.uint8)) for name in names
+    })
+    hidden_states = torch.randn(2, 3, dtype = torch.bfloat16)
+    boundary = _linear_boundary_dtype(quantized, *names)
+    out = _to_boundary_dtype(hidden_states, boundary)
+    assert out is hidden_states, "the activation was copied or narrowed"
+    assert out.dtype == torch.bfloat16
+
+
+def test_every_patch_installing_a_boundary_forward_publishes_the_helpers():
+    """The auto-compiler serializes these forwards into unsloth_compiled_cache and
+    resolves their free names by importing from the modeling module. A helper that
+    lives only in the patch module is not importable there, so the generated
+    forward dies with NameError on its first call.
+
+    Read off the source rather than asserted by name, so adding a fourth patch
+    that uses the helpers without publishing them fails here.
+    """
+    import ast
+    import pathlib
+
+    source = pathlib.Path(gemma_patches.__file__).read_text(encoding = "utf-8")
+    tree = ast.parse(source)
+    helpers = {"_linear_boundary_dtype", "_to_boundary_dtype"}
+
+    offenders = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("patch_"):
+            continue
+        called = {
+            n.func.id for n in ast.walk(node)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        }
+        if not (helpers & called):
+            continue
+        if "_publish_boundary_helpers" not in called:
+            offenders.append(node.name)
+
+    assert not offenders, (
+        f"{offenders} install a forward calling {sorted(helpers)} without calling "
+        f"_publish_boundary_helpers, so the compiled copy raises NameError"
+    )
+
+
+def test_the_publish_check_actually_finds_the_patches():
+    """Guard the guard: if the AST walk stopped matching, the test above would
+    pass with an empty offender list and prove nothing."""
+    import ast
+    import pathlib
+
+    tree = ast.parse(pathlib.Path(gemma_patches.__file__).read_text(encoding = "utf-8"))
+    helpers = {"_linear_boundary_dtype", "_to_boundary_dtype"}
+    using = [
+        node.name for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("patch_")
+        and (helpers & {
+            n.func.id for n in ast.walk(node)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        })
+    ]
+    assert len(using) >= 3, f"expected the MLP and both attention patches, found {using}"
 
 
 def test_to_boundary_dtype_casts_to_the_weight_dtype_and_is_identity_when_it_matches():

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -47,6 +47,45 @@ import inspect
 _UNSLOTH_FLEX_ATTENTION_DISABLED = os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0"
 
 
+def _linear_boundary_dtype(module, *attr_names):
+    """Dtype of the activations that the given projections expect.
+
+    The UNSLOTH_FORCE_FLOAT32 Gemma3 patches run the heavy reductions (RMSNorm
+    variance, SwiGLU, attention) in float32 for fp16 overflow safety and hand a
+    float16 activation to every Linear. That hard-coded float16 silently assumes
+    the projection weights are float16 too. They are for LoRA / QLoRA, where the
+    base weights stay float16, but full finetuning upcasts the trainable weights
+    to float32, and then a float16 activation meets a float32 weight and the
+    matmul dies with "expected mat1 and mat2 to have the same dtype".
+
+    So read the dtype off the weights that will actually do the multiply. The
+    first floating-point weight wins; bitsandbytes stores a 4bit base weight as
+    a uint8 blob, which is not floating point and is therefore skipped, leaving
+    the float16 default that path already used.
+    """
+    for name in attr_names:
+        module_or_param = getattr(module, name, None)
+        if module_or_param is None: continue
+        weight = getattr(module_or_param, "weight", module_or_param)
+        dtype = getattr(weight, "dtype", None)
+        if dtype is not None and dtype.is_floating_point:
+            return dtype
+    return torch.float16
+pass
+
+
+def _to_boundary_dtype(x, dtype):
+    """Move an activation onto a Linear's dtype, skipping the cast when it already matches.
+
+    float16 weights (LoRA / QLoRA) hit the identity branch on every call, so the
+    common path keeps exactly the casts it had before and its numerics are
+    unchanged. Only the float32 full-finetuning mismatch actually converts.
+    """
+    if x.dtype == dtype: return x
+    return x.to(dtype)
+pass
+
+
 def _prepare_gemma3_sdpa_attention_mask(attention_mask, query_states, key_states, sliding_window=None):
     if attention_mask is None or attention_mask.dim() != 2:
         return attention_mask
@@ -491,7 +530,11 @@ def patch_Gemma3MLP():
     except Exception as e:
         return raise_error("Gemma3MLP.forward", e)
 
-    def forward(self, x): # x is fp16 from RMSNorm
+    def forward(self, x): # x is fp16 from RMSNorm, or fp32 once full finetuning upcasts
+        # RMSNorm always emits fp16. That matches fp16 projection weights (LoRA),
+        # but full finetuning upcasts these Linears to fp32, so meet them there.
+        boundary_dtype = _linear_boundary_dtype(self, "gate_proj", "up_proj", "down_proj")
+        x = _to_boundary_dtype(x, boundary_dtype)
         gate_proj_out = self.gate_proj(x)
         up_proj_out = self.up_proj(x)
 
@@ -501,9 +544,9 @@ def patch_Gemma3MLP():
         activated_fp32 = self.act_fn(gate_proj_fp32) # Activation in fp32
         intermediate_fp32 = activated_fp32 * up_proj_fp32 # Product in fp32
 
-        # Downcast and down_proj
-        intermediate_fp16 = intermediate_fp32.to(torch.float16)
-        down_proj_out = self.down_proj(intermediate_fp16)
+        # Downcast and down_proj. fp16 weights take the same bare cast as before.
+        intermediate = _to_boundary_dtype(intermediate_fp32, boundary_dtype)
+        down_proj_out = self.down_proj(intermediate)
         return down_proj_out
     pass
     patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3MLP, "forward", forward, fullgraph = False)
@@ -596,7 +639,11 @@ def patch_Gemma3Attention():
         query_hidden_shape = (bsz, q_len, num_heads, head_dim)
         kv_hidden_shape    = (bsz, q_len, num_key_value_heads, head_dim)
 
-        # 1. Projections (q, k, v) in fp16
+        # 1. Projections (q, k, v). RMSNorm hands us fp16, which matches fp16
+        # projection weights (LoRA); full finetuning upcasts them to fp32, so
+        # move the activation onto whatever dtype the weights actually are.
+        boundary_dtype = _linear_boundary_dtype(self, "q_proj", "k_proj", "v_proj", "o_proj")
+        hidden_states = _to_boundary_dtype(hidden_states, boundary_dtype)
         query_states_fp16 = self.q_proj(hidden_states) # output fp16
         key_states_fp16   = self.k_proj(hidden_states) # output fp16
         value_states_fp16 = self.v_proj(hidden_states) # output fp16
@@ -709,7 +756,9 @@ def patch_Gemma3Attention():
 
         attn_output_fp32 = attn_output_fp32.reshape(bsz, q_len, -1)
 
-        attn_output_fp16 = attn_output_fp32.to(torch.float16)
+        # fp16 weights keep the exact bare cast this line always did; fp32
+        # full-finetuning weights leave it in fp32 rather than crashing o_proj.
+        attn_output_fp16 = _to_boundary_dtype(attn_output_fp32, boundary_dtype)
 
         # 8. Output Projection (o_proj) in fp16
         attn_output_projected = self.o_proj(attn_output_fp16) # fp16 output
@@ -837,7 +886,11 @@ def patch_Gemma3Attention_generic():
         query_hidden_shape = (bsz, q_len, num_heads, head_dim)
         kv_hidden_shape    = (bsz, q_len, num_key_value_heads, head_dim)
 
-        # 1. Projections (q, k, v) in fp16
+        # 1. Projections (q, k, v). RMSNorm hands us fp16, which matches fp16
+        # projection weights (LoRA); full finetuning upcasts them to fp32, so
+        # move the activation onto whatever dtype the weights actually are.
+        boundary_dtype = _linear_boundary_dtype(self, "q_proj", "k_proj", "v_proj", "o_proj")
+        hidden_states = _to_boundary_dtype(hidden_states, boundary_dtype)
         query_states_fp16 = self.q_proj(hidden_states) # output fp16
         key_states_fp16   = self.k_proj(hidden_states) # output fp16
         value_states_fp16 = self.v_proj(hidden_states) # output fp16

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -47,8 +47,33 @@ import inspect
 _UNSLOTH_FLEX_ATTENTION_DISABLED = os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0"
 
 
+def _storage_only_float_dtypes():
+    """float8 dtypes, which are a storage format rather than a compute dtype.
+
+    `torch.float8_e4m3fn.is_floating_point` is True, so a plain floating-point
+    test reads an FP8 checkpoint's stored weight as the dtype its Linear wants
+    its activations in. It is not: transformers' `FP8Linear` / `FbgemmFp8Linear`
+    take bfloat16 or float16 in, do their own scaled quantization, and hand back
+    the input dtype. Casting the hidden states straight to unscaled float8 would
+    throw away range before the scaling that exists to preserve it, and leave
+    the Q/K norm and SDPA downstream holding a dtype they do not support.
+
+    Built by lookup rather than hard-coded, so a torch that predates one of
+    these (or adds another) neither raises nor silently stops excluding it.
+    """
+    names = ("float8_e4m3fn", "float8_e4m3fnuz", "float8_e5m2", "float8_e5m2fnuz",
+             "float8_e8m0fnu")
+    return frozenset(
+        dtype for dtype in (getattr(torch, name, None) for name in names)
+        if dtype is not None
+    )
+pass
+
+_STORAGE_ONLY_FLOAT_DTYPES = _storage_only_float_dtypes()
+
+
 def _linear_boundary_dtype(module, *attr_names):
-    """Dtype of the activations that the given projections expect.
+    """Dtype of the activations that the given projections expect, or None.
 
     The UNSLOTH_FORCE_FLOAT32 Gemma3 patches run the heavy reductions (RMSNorm
     variance, SwiGLU, attention) in float32 for fp16 overflow safety and hand a
@@ -59,18 +84,26 @@ def _linear_boundary_dtype(module, *attr_names):
     matmul dies with "expected mat1 and mat2 to have the same dtype".
 
     So read the dtype off the weights that will actually do the multiply. The
-    first floating-point weight wins; bitsandbytes stores a 4bit base weight as
-    a uint8 blob, which is not floating point and is therefore skipped, leaving
-    the float16 default that path already used.
+    first ordinary floating-point weight wins.
+
+    None means "no weight answered, so leave the activation alone". It is not
+    float16. bitsandbytes stores a 4bit base weight as a uint8 blob, so on a
+    4bit model every projection is skipped, and a float16 default would narrow
+    a bfloat16 QLoRA activation on the generic (non-forced) path that the
+    unpatched forward passed through untouched -- costing exactly the exponent
+    range bfloat16 is chosen for. Under UNSLOTH_FORCE_FLOAT32 the activation
+    reaching here is already float16 out of RMSNorm, so "leave it alone" and
+    the old float16 default are the same value on that path.
     """
     for name in attr_names:
         module_or_param = getattr(module, name, None)
         if module_or_param is None: continue
         weight = getattr(module_or_param, "weight", module_or_param)
         dtype = getattr(weight, "dtype", None)
-        if dtype is not None and dtype.is_floating_point:
-            return dtype
-    return torch.float16
+        if dtype is None or not dtype.is_floating_point: continue
+        if dtype in _STORAGE_ONLY_FLOAT_DTYPES: continue
+        return dtype
+    return None
 pass
 
 
@@ -80,9 +113,29 @@ def _to_boundary_dtype(x, dtype):
     float16 weights (LoRA / QLoRA) hit the identity branch on every call, so the
     common path keeps exactly the casts it had before and its numerics are
     unchanged. Only the float32 full-finetuning mismatch actually converts.
+    A None dtype is the "no weight answered" case and is also identity.
     """
-    if x.dtype == dtype: return x
+    if dtype is None or x.dtype == dtype: return x
     return x.to(dtype)
+pass
+
+
+def _publish_boundary_helpers(modeling_module):
+    """Make the two boundary helpers importable from the modeling module.
+
+    The auto-compiler serializes a patched forward into unsloth_compiled_cache
+    as source text, and `create_new_function` resolves the free names it finds
+    by importing them from `transformers.models.gemma3.modeling_gemma3`. A
+    helper that lives only in this patch module is not there, so the generated
+    forward raises NameError the first time it runs and compiled Gemma3
+    training dies. The RMSNorm helpers are published for exactly this reason;
+    every forward below references these two, so they need it too.
+    """
+    publish_to_modeling_module(
+        modeling_module,
+        _linear_boundary_dtype = _linear_boundary_dtype,
+        _to_boundary_dtype     = _to_boundary_dtype,
+    )
 pass
 
 
@@ -530,6 +583,8 @@ def patch_Gemma3MLP():
     except Exception as e:
         return raise_error("Gemma3MLP.forward", e)
 
+    _publish_boundary_helpers(transformers.models.gemma3.modeling_gemma3)
+
     def forward(self, x): # x is fp16 from RMSNorm, or fp32 once full finetuning upcasts
         # RMSNorm always emits fp16. That matches fp16 projection weights (LoRA),
         # but full finetuning upcasts these Linears to fp32, so meet them there.
@@ -562,6 +617,8 @@ def patch_Gemma3Attention():
         from transformers.models.gemma3.modeling_gemma3 import apply_rotary_pos_emb, ALL_ATTENTION_FUNCTIONS, eager_attention_forward
     except Exception as e:
         return raise_error("Gemma3Attention.forward", e)
+
+    _publish_boundary_helpers(transformers.models.gemma3.modeling_gemma3)
     scaled_dot_product_attention = torch.nn.functional.scaled_dot_product_attention
     scaled_dot_product_attention = torch.compiler.disable(scaled_dot_product_attention, recursive = True)
     torch_jit_is_tracing = torch.jit.is_tracing
@@ -810,6 +867,8 @@ def patch_Gemma3Attention_generic():
         from transformers.models.gemma3.modeling_gemma3 import apply_rotary_pos_emb, ALL_ATTENTION_FUNCTIONS, eager_attention_forward
     except Exception as e:
         return raise_error("Gemma3Attention.forward", e)
+
+    _publish_boundary_helpers(transformers.models.gemma3.modeling_gemma3)
     scaled_dot_product_attention = torch.nn.functional.scaled_dot_product_attention
     scaled_dot_product_attention = torch.compiler.disable(scaled_dot_product_attention, recursive = True)
     torch_jit_is_tracing = torch.jit.is_tracing

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -86,19 +86,35 @@ def _linear_boundary_dtype(module, *attr_names):
     So read the dtype off the weights that will actually do the multiply. The
     first ordinary floating-point weight wins.
 
+    A weight carrying a `quant_state` is quantized and never answers, whatever
+    its dtype says. bitsandbytes packs a 4bit weight into a blob of
+    `bnb_4bit_quant_storage`, which defaults to uint8 but is a public knob:
+    FSDP can only shard float dtypes, so FSDP-QLoRA setups are told to set it
+    to bfloat16, and `vllm_utils` / the bnb MoE loaders plumb the configured
+    value straight through. That makes `Params4bit.weight.dtype` bfloat16 while
+    the tensor is still packed 4bit, so a plain floating-point test reads a
+    storage container as the activation dtype. `Linear4bit` dequantizes to its
+    own compute dtype and hands back the caller's input dtype, so answering
+    here would cast activations and forced outputs to the storage dtype and
+    change QLoRA forward and gradient numerics. `quant_state` is the only
+    reliable discriminator, and is read with getattr so a plain `nn.Parameter`
+    or a non-bitsandbytes backend is unaffected.
+
     None means "no weight answered, so leave the activation alone". It is not
-    float16. bitsandbytes stores a 4bit base weight as a uint8 blob, so on a
-    4bit model every projection is skipped, and a float16 default would narrow
-    a bfloat16 QLoRA activation on the generic (non-forced) path that the
-    unpatched forward passed through untouched -- costing exactly the exponent
-    range bfloat16 is chosen for. Under UNSLOTH_FORCE_FLOAT32 the activation
-    reaching here is already float16 out of RMSNorm, so "leave it alone" and
-    the old float16 default are the same value on that path.
+    float16. On a 4bit model every projection is skipped, and a float16 default
+    would narrow a bfloat16 QLoRA activation on the generic (non-forced) path
+    that the unpatched forward passed through untouched -- costing exactly the
+    exponent range bfloat16 is chosen for. Under UNSLOTH_FORCE_FLOAT32 the
+    activation reaching here is already float16 out of RMSNorm, so "leave it
+    alone" and the old float16 default are the same value on that path.
     """
     for name in attr_names:
         module_or_param = getattr(module, name, None)
         if module_or_param is None: continue
         weight = getattr(module_or_param, "weight", module_or_param)
+        # Quantized weights describe storage, not the activation dtype. Must be
+        # tested before the dtype checks, which a float quant_storage passes.
+        if getattr(weight, "quant_state", None) is not None: continue
         dtype = getattr(weight, "dtype", None)
         if dtype is None or not dtype.is_floating_point: continue
         if dtype in _STORAGE_ONLY_FLOAT_DTYPES: continue
@@ -133,7 +149,7 @@ def _to_forced_output_dtype(x, dtype):
     incoming activation is the explicitly upcast float32 SwiGLU / attention
     reduction rather than a float16 RMSNorm output. Those lines used to be a
     bare `.to(torch.float16)`, so "no weight answered" must still mean float16,
-    not identity: on 4bit QLoRA every projection weight is a packed uint8 blob
+    not identity: on 4bit QLoRA every projection weight is a packed 4bit blob
     and nothing answers, and bitsandbytes `Linear4bit` returns its caller's
     input dtype, so an identity here would make `down_proj` / `o_proj` hand back
     float32 and change the forward and gradient dtypes of the common QLoRA path.

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -108,20 +108,47 @@ pass
 
 
 def _to_boundary_dtype(x, dtype):
-    """Move an activation onto a Linear's dtype, skipping the cast when it already matches.
+    """Move an *already correctly typed* activation onto a Linear's dtype.
 
+    For the input boundaries only, where x arrives as float16 out of RMSNorm.
     float16 weights (LoRA / QLoRA) hit the identity branch on every call, so the
     common path keeps exactly the casts it had before and its numerics are
     unchanged. Only the float32 full-finetuning mismatch actually converts.
-    A None dtype is the "no weight answered" case and is also identity.
+
+    A None dtype means "no weight answered" and is identity, which is safe here
+    precisely because x is already the float16 these lines used to hard-code.
+    Do NOT use this at a forced output boundary, where x is a deliberately
+    upcast float32 reduction and identity would leak that float32 into the
+    projection -- use `_to_forced_output_dtype` there.
     """
     if dtype is None or x.dtype == dtype: return x
     return x.to(dtype)
 pass
 
 
+def _to_forced_output_dtype(x, dtype):
+    """Downcast a forced-float32 reduction before its output projection.
+
+    The counterpart of `_to_boundary_dtype` for the two boundaries where the
+    incoming activation is the explicitly upcast float32 SwiGLU / attention
+    reduction rather than a float16 RMSNorm output. Those lines used to be a
+    bare `.to(torch.float16)`, so "no weight answered" must still mean float16,
+    not identity: on 4bit QLoRA every projection weight is a packed uint8 blob
+    and nothing answers, and bitsandbytes `Linear4bit` returns its caller's
+    input dtype, so an identity here would make `down_proj` / `o_proj` hand back
+    float32 and change the forward and gradient dtypes of the common QLoRA path.
+
+    Kept as a separate name, rather than a default argument on the helper above,
+    so the two kinds of boundary cannot be confused at the call site.
+    """
+    if dtype is None: dtype = torch.float16
+    if x.dtype == dtype: return x
+    return x.to(dtype)
+pass
+
+
 def _publish_boundary_helpers(modeling_module):
-    """Make the two boundary helpers importable from the modeling module.
+    """Make the three boundary helpers importable from the modeling module.
 
     The auto-compiler serializes a patched forward into unsloth_compiled_cache
     as source text, and `create_new_function` resolves the free names it finds
@@ -133,8 +160,9 @@ def _publish_boundary_helpers(modeling_module):
     """
     publish_to_modeling_module(
         modeling_module,
-        _linear_boundary_dtype = _linear_boundary_dtype,
-        _to_boundary_dtype     = _to_boundary_dtype,
+        _linear_boundary_dtype  = _linear_boundary_dtype,
+        _to_boundary_dtype      = _to_boundary_dtype,
+        _to_forced_output_dtype = _to_forced_output_dtype,
     )
 pass
 
@@ -599,8 +627,9 @@ def patch_Gemma3MLP():
         activated_fp32 = self.act_fn(gate_proj_fp32) # Activation in fp32
         intermediate_fp32 = activated_fp32 * up_proj_fp32 # Product in fp32
 
-        # Downcast and down_proj. fp16 weights take the same bare cast as before.
-        intermediate = _to_boundary_dtype(intermediate_fp32, boundary_dtype)
+        # Downcast and down_proj. Forced output boundary: intermediate_fp32 is the
+        # upcast reduction, so a weight that does not answer still means fp16.
+        intermediate = _to_forced_output_dtype(intermediate_fp32, boundary_dtype)
         down_proj_out = self.down_proj(intermediate)
         return down_proj_out
     pass
@@ -813,9 +842,10 @@ def patch_Gemma3Attention():
 
         attn_output_fp32 = attn_output_fp32.reshape(bsz, q_len, -1)
 
-        # fp16 weights keep the exact bare cast this line always did; fp32
-        # full-finetuning weights leave it in fp32 rather than crashing o_proj.
-        attn_output_fp16 = _to_boundary_dtype(attn_output_fp32, boundary_dtype)
+        # Forced output boundary: fp16 (and a 4bit weight that cannot answer)
+        # keep the exact bare cast this line always did; fp32 full-finetuning
+        # weights leave it in fp32 rather than crashing o_proj.
+        attn_output_fp16 = _to_forced_output_dtype(attn_output_fp32, boundary_dtype)
 
         # 8. Output Projection (o_proj) in fp16
         attn_output_projected = self.o_proj(attn_output_fp16) # fp16 output


### PR DESCRIPTION
## What broke

Full finetuning any Gemma3 model on a GPU without bfloat16 (T4, V100) died in the first forward pass:

```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::Half != float
  unsloth_zoo/temporary_patches/gemma.py:600 in patch_Gemma3Attention.<locals>.forward_function
      query_states_fp16 = self.q_proj(hidden_states)
```

`gemma3` is in `FORCE_FLOAT32`, so a float16 request loads float32 weights and sets `UNSLOTH_FORCE_FLOAT32=1`. The forced patches (`patch_Gemma3RMSNorm`, `patch_Gemma3MLP`, `patch_Gemma3Attention`) run the heavy reductions in float32 for fp16 overflow safety, then narrow the activation back to a hard-coded `torch.float16` at every Linear boundary.

That hard-coded float16 assumes the projection weights are float16. They are for LoRA and QLoRA, where the base weights stay float16. Full finetuning upcasts the trainable weights to float32, so a float16 activation met a float32 weight.

Nothing reconciled the two dtypes because there was no autocast to do it. That is precisely the situation on a no-bfloat16 GPU: unsloth reports `Switching to float32 training since model cannot work with float16` and trains with neither `fp16` nor `bf16` set.

Two things worth flagging, because the original report had them the other way round:

- **This is not specific to QAT.** It was found through `Gemma3_(270M)_Phone_Deployment.ipynb`, which uses `qat_scheme = "int4"`, but plain `full_finetuning = True` with no `qat_scheme` fails identically. torchao's fake quantizer restores the weight dtype (`fq.view(w.shape).to(w.dtype)` in both 0.15.0 and 0.17.0), so `FakeQuantizedLinear` is not what makes the weight float32. The whole model is float32.
- **The projection call is the symptom, not the cause.** `input_layernorm` receives float32 and emits float16, because `_gemma3_rms_norm_float32` ends in `.to(torch.float16)`. The projection is simply the first Linear that float16 reaches.

## What happens after

The boundary dtype is read off the weights that actually do the multiply, rather than hard-coded, in `Gemma3MLP` and in both `Gemma3Attention` forwards. Two small helpers:

- `_linear_boundary_dtype(module, *attr_names)` returns the dtype of the first floating-point projection weight. A bitsandbytes 4bit base weight is a `uint8` blob and is not floating point, so it is skipped and that path keeps the float16 default it already used.
- `_to_boundary_dtype(x, dtype)` returns `x` unchanged when the dtype already matches.

RMSNorm is deliberately left alone. Its own weight is float32 even under LoRA, because `UNSLOTH_HIGH_PRECISION_LAYERNORM=1` upcasts the norms, so deriving the boundary from the norm weight would upcast the common path too. Deriving it from the projections is what distinguishes the two regimes.

## Blast radius

float16 weights hit the identity branch of `_to_boundary_dtype` on every call, so LoRA and QLoRA keep exactly the casts they had and add one dtype comparison per boundary. Measured on `gemma-3-270m-it`, bfloat16 hidden at import to emulate a T4:

| path | before | after |
| --- | --- | --- |
| full finetuning, no bf16 | `RuntimeError: Half != float` | trains, loss 1.5520 |
| full finetuning + `qat_scheme="int4"`, no bf16 | `RuntimeError: Half != float` | trains, loss 1.3969 |
| LoRA 16bit | 24.680545806884766 | 24.680545806884766 |
| QLoRA 4bit | 19.022239685058594 | 19.022239685058594 |

On a bfloat16 GPU, where the forced patches do not engage, full finetuning is unchanged as well: 1.8550999959309895 without QAT and 1.8105351130167644 with it, identical before and after. The LoRA numbers are bitwise stable across reruns, so the equality is meaningful rather than noise.

No change to the AMD, Intel or MLX paths, and no device specific calls: only `tensor.dtype` and `tensor.to(dtype)`.

## Test evidence

`tests/test_gemma3_forced_float32_boundary_dtype.py`, 6 tests, CPU only, no network:

```
6 passed in 0.07s
```

Full suite, `pytest tests/ -q --ignore=tests/test_upstream_pinned_symbols_trl_vllm.py` (that file has a hard-coded absolute path and raises `PermissionError` at collection on `main`):

```
4380 passed, 162 skipped in 401s
```

Every test is behavioural. None of them match against the source text of `gemma.py`.

Each test was proved discriminating by reverting the matching source arm and confirming that specific test fails:

| test | A: `_to_boundary_dtype` always fp16 | B: `_linear_boundary_dtype` always fp16 | C: MLP arm reverted | D: attention arm reverted | E: generic attention arm reverted | F: MLP fp32 reduction dropped |
| --- | --- | --- | --- | --- | --- | --- |
| mlp float32 projections | FAIL | FAIL | FAIL | pass | pass | pass |
| mlp float16 bitwise identical | pass | pass | pass | pass | pass | FAIL |
| attention float32 projections | FAIL | FAIL | pass | FAIL | pass | pass |
| generic attention float32 projections | FAIL | FAIL | pass | pass | FAIL | pass |
| `_linear_boundary_dtype` unit | pass | FAIL | pass | pass | pass | pass |
| `_to_boundary_dtype` unit | FAIL | pass | pass | pass | pass | pass |

C, D and E show each of the three wired call sites is pinned by exactly one distinct test. Under sabotage C the failure is the original error, `expected m1 and m2 to have the same dtype, but got: c10::Half != float` (CPU wording; CUDA says `mat1 and mat2`).

The bitwise test is a regression guard for the common path rather than a test of the fix, so it passes with and without the fix by design. It is pinned by sabotage F, which drops the float32 reduction.

## Relationship to #706

#706 targets the same crash. It is 367 commits behind `main` and no longer applies: `main` has since moved the RMSNorm into the module-level compiled `_gemma3_rms_norm_float32`, and merging conflicts.

It also derives the RMSNorm boundary from that norm's own weight. Because `UNSLOTH_HIGH_PRECISION_LAYERNORM=1` makes the norms float32 even under LoRA, that upcasts the LoRA path too. On its own branch it changes the LoRA forward from 24.680545806884766 to 24.725526809692383 and QLoRA from 19.022239685058594 to 19.043985366821290, which its description states is bit-identical. This PR keeps those two numbers exactly. Happy to close #706 in favour of this, or to fold anything wanted from it, including its `Gemma3MultiModalProjector` patch, which is not carried here.

## Same assumption elsewhere, not fixed here

Kept scoped to Gemma3, but the identical hard-coded float16 boundary exists in:

- `temporary_patches/qwen3_moe_float32.py` lines 121 and 264-265 (`attn_output.to(torch.float16)` straight into `self.o_proj`)
- `temporary_patches/gemma4_float32.py` lines 301, 313 and 495-496
- `temporary_patches/misc.py` lines 1643 and 1652

#978 addresses the Qwen3.5 equivalent.
