### PR TITLE
Test the compile-disable switch instead of working around it

### DIFF
--- a/tests/test_compiler_dynamic_exec.py
+++ b/tests/test_compiler_dynamic_exec.py
@@ -35,12 +35,25 @@ import textwrap
 import pytest
 
 
-# Disable torch.compile so we only exercise the source rewrite + ast.parse.
-os.environ.setdefault("UNSLOTH_COMPILE_DISABLE", "1")
-
-
 transformers = pytest.importorskip("transformers")
 compiler = pytest.importorskip("unsloth_zoo.compiler")
+
+
+@pytest.fixture(autouse = True)
+def _compile_disabled(monkeypatch):
+    """Disable torch.compile so we only exercise the source rewrite + ast.parse.
+
+    A fixture rather than the `os.environ.setdefault` this used to do at module
+    scope. That ran during collection, in every xdist worker, and wrote through
+    to the real process environment for the rest of the session: every module
+    collected after this one, and every subprocess any of them spawn, inherited
+    a compile-disabled environment they never asked for. What saved the suite
+    was that `conftest.py` imports unsloth first, so
+    `temporary_patches/common.py` had already latched the variable's real value
+    at import; if that import ever fails, collection order decides the result
+    instead. Scoped and undone here, the setting reaches only this module.
+    """
+    monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "1")
 
 
 # Model types the zoo compiler drives end-to-end (from

--- a/tests/test_generated_fullgraph_fallback.py
+++ b/tests/test_generated_fullgraph_fallback.py
@@ -52,25 +52,50 @@ FULLGRAPH_SITES = (COMPILER, ZOO / "rl_replacements.py",
                    ZOO / "temporary_patches" / "common.py")
 
 
-def _run_with_compile_enabled(body):
-    """Run `body` in a fresh interpreter with UNSLOTH_COMPILE_DISABLE cleared.
+def _run_in_fresh_interpreter(body, compile_disable):
+    """Run `body` in a new interpreter with UNSLOTH_COMPILE_DISABLE pinned.
 
-    `common.py` reads that variable once at import and collapses both
-    `torch_compile` and `_maybe_compile` to a no-op when it is set, so the two
-    routing assertions below cannot hold in-process under it. unsloth's
-    consolidated CI runs this whole suite with `UNSLOTH_COMPILE_DISABLE=1` at
-    the job level, which is what made them fail there and pass locally. A
-    subprocess, not `importlib.reload`, because reloading the module mid-session
-    rebinds objects other tests in the same run already hold.
+    `None` clears the variable, a string sets it. unsloth's consolidated CI runs
+    this whole suite with `UNSLOTH_COMPILE_DISABLE=1` at the job level, so a test
+    that needs the other setting cannot get it from the ambient environment.
+
+    `common.py` reacts to that variable in two different ways, and only one of
+    them needs this:
+
+    * **Bound at import.** `torch_compile`, `_torch_compile` and
+      `_raw_torch_compile` are assigned under a module-level
+      `if UNSLOTH_COMPILE_DISABLE:` and are already `noop` function objects by
+      the time any test runs. Rebinding `common.UNSLOTH_COMPILE_DISABLE`
+      afterwards cannot undo that, so asserting on these three needs a fresh
+      interpreter.
+    * **Read per call.** `_maybe_compile` reads `UNSLOTH_COMPILE_DISABLE` and
+      `UNSLOTH_COMPILE_DISABLE_PARTIAL` in its own body on every call.
+      `monkeypatch.setattr` on the module attributes is enough there, and is
+      what the `_maybe_compile` tests below use; a subprocess would only buy a
+      five second package import per assertion.
+
+    A subprocess, not `importlib.reload`, because reloading the module
+    mid-session rebinds objects other tests in the same run already hold.
     """
     env = dict(os.environ)
-    env.pop("UNSLOTH_COMPILE_DISABLE", None)
+    if compile_disable is None:
+        env.pop("UNSLOTH_COMPILE_DISABLE", None)
+    else:
+        env["UNSLOTH_COMPILE_DISABLE"] = compile_disable
     done = subprocess.run(
         [sys.executable, "-c", textwrap.dedent(body)],
         capture_output = True, text = True, env = env,
         cwd = str(ZOO.parent),
     )
     assert done.returncode == 0, done.stdout + done.stderr
+
+
+def _run_with_compile_enabled(body):
+    _run_in_fresh_interpreter(body, None)
+
+
+def _run_with_compile_disabled(body):
+    _run_in_fresh_interpreter(body, "1")
 
 
 # ---- what the compiler emits ---------------------------------------------
@@ -106,7 +131,7 @@ def test_the_grpo_loss_regions_are_wrapped():
         "accumulate_chunk is still compiled bare"
 
 
-def test_maybe_compile_routes_fullgraph_through_the_fallback():
+def test_maybe_compile_routes_fullgraph_through_the_fallback(monkeypatch):
     """Three more fullgraph regions go through this one helper, so wiring it
     covers them without touching each decorator."""
     from unsloth_zoo.temporary_patches import common
@@ -116,15 +141,56 @@ def test_maybe_compile_routes_fullgraph_through_the_fallback():
     # Without fullgraph Dynamo already falls back by itself, so leave it alone.
     assert 'if not kwargs.get("fullgraph"):' in body
 
-    _run_with_compile_enabled("""
+    # In process, unlike the alias below: `_maybe_compile` reads both switches
+    # in its own body on every call, so pinning the module attributes is exact
+    # and the assertion then holds in every configuration the suite runs under.
+    monkeypatch.setattr(common, "UNSLOTH_COMPILE_DISABLE", False)
+    monkeypatch.setattr(common, "UNSLOTH_COMPILE_DISABLE_PARTIAL", False)
+
+    def f(x):
+        return x
+    wrapped = common._maybe_compile(fullgraph = True, dynamic = True)(f)
+    assert hasattr(wrapped, "_unsloth_fallback_state")
+    plain = common._maybe_compile(dynamic = True)(f)
+    assert not hasattr(plain, "_unsloth_fallback_state")
+
+
+@pytest.mark.parametrize("flag", ["UNSLOTH_COMPILE_DISABLE",
+                                  "UNSLOTH_COMPILE_DISABLE_PARTIAL"])
+def test_maybe_compile_is_a_no_op_when_compilation_is_switched_off(monkeypatch, flag):
+    """The other half of the switch. Turning compilation off has to drop the
+    fallback wrapper as well, or torch is still handed a fullgraph region by the
+    one helper three of them go through.
+
+    Monkeypatch, again because the read is per call: setting the variable in the
+    environment instead would do nothing to an already imported module, and a
+    subprocess would be spelling `False -> True` the long way round."""
+    from unsloth_zoo.temporary_patches import common
+
+    monkeypatch.setattr(common, "UNSLOTH_COMPILE_DISABLE", False)
+    monkeypatch.setattr(common, "UNSLOTH_COMPILE_DISABLE_PARTIAL", False)
+    monkeypatch.setattr(common, flag, True)
+
+    def f(x):
+        return x
+    assert common._maybe_compile(fullgraph = True, dynamic = True)(f) is f, \
+        f"{flag} did not switch the fullgraph wrapper off"
+
+
+def test_the_alias_is_the_no_op_when_compilation_is_switched_off():
+    """The same half of the switch for the import-bound side.
+
+    Nothing else pins this: the source scan below only recognises the enabled
+    spelling, `functools.partial(...)`, so a disabled branch that bound bare
+    `torch.compile` would pass every other test in this file while handing
+    unsloth's CPU CI job the fullgraph regions it asked not to have. Needs a
+    fresh interpreter for the reason in `_run_in_fresh_interpreter`: these three
+    names are bound once, at import."""
+    _run_with_compile_disabled("""
         from unsloth_zoo.temporary_patches import common
 
-        def f(x):
-            return x
-        wrapped = common._maybe_compile(fullgraph = True, dynamic = True)(f)
-        assert hasattr(wrapped, "_unsloth_fallback_state")
-        plain = common._maybe_compile(dynamic = True)(f)
-        assert not hasattr(plain, "_unsloth_fallback_state")
+        for name in ("torch_compile", "_torch_compile", "_raw_torch_compile"):
+            assert getattr(common, name) is common.noop, name
     """)
 
 

--- a/tests/test_generated_fullgraph_fallback.py
+++ b/tests/test_generated_fullgraph_fallback.py
@@ -151,8 +151,28 @@ def test_maybe_compile_routes_fullgraph_through_the_fallback(monkeypatch):
         return x
     wrapped = common._maybe_compile(fullgraph = True, dynamic = True)(f)
     assert hasattr(wrapped, "_unsloth_fallback_state")
-    plain = common._maybe_compile(dynamic = True)(f)
-    assert not hasattr(plain, "_unsloth_fallback_state")
+
+    # The other direction needs a second observable. `_unsloth_fallback_state`
+    # is stamped on only under fullgraph (utils.py returns the plain compiled
+    # object before it), so its absence cannot tell a non-fullgraph compile that
+    # wrongly went through the helper from one that did not. Record the call
+    # instead: `_maybe_compile` resolves the name off `utils` at call time, so
+    # rebinding the attribute is enough. Verified by replacing the guard's body
+    # with `pass`, which the `hasattr` form did not notice in any switch
+    # position and this does.
+    import unsloth_zoo.temporary_patches.utils as U
+    calls = []
+
+    def _record(**kwargs):
+        calls.append(kwargs)
+        return lambda fn: fn
+
+    monkeypatch.setattr(U, "torch_compile_with_fallback", _record)
+    common._maybe_compile(fullgraph = True, dynamic = True)(f)
+    assert calls, "the recorder never saw the fullgraph compile, so it proves nothing"
+    calls.clear()
+    common._maybe_compile(dynamic = True)(f)
+    assert not calls, f"a non-fullgraph compile was wrapped: {calls}"
 
 
 @pytest.mark.parametrize("flag", ["UNSLOTH_COMPILE_DISABLE",
@@ -363,20 +383,55 @@ def test_the_alias_still_accepts_a_function_positionally():
     assert wrapped(3) == 6
 
 
-def test_a_non_fullgraph_compile_is_left_alone(monkeypatch):
+def test_a_non_fullgraph_compile_is_left_alone():
     """Dynamo already falls back by itself without fullgraph, so wrapping there
-    would add a layer that can never fire."""
-    from unsloth_zoo.temporary_patches import common as C
-    called = {"n": 0}
+    would add a layer that can never fire.
 
-    def _boom(**kwargs):
-        called["n"] += 1
-        return lambda fn: fn
+    In a fresh interpreter, because in process this asserted nothing whenever
+    the switch was off, which is the position unsloth's Core job runs the whole
+    suite in: the alias is `noop` there, so the helper is unreachable and the
+    recorder stays at zero however the routing is written. Removing the
+    `if not kwargs.get("fullgraph")` guard from `_compile_or_fall_back` left the
+    in-process form green under `UNSLOTH_COMPILE_DISABLE=1` and `partial`.
 
-    monkeypatch.setattr("unsloth_zoo.temporary_patches.utils."
-                        "torch_compile_with_fallback", _boom)
+    `_torch_compile` comes along for free here; nothing else ran it. A positive
+    control first, or every assertion below passes the moment the recorder
+    stops recording."""
+    _run_with_compile_enabled("""
+        import unsloth_zoo.temporary_patches.utils as U
+        calls = []
 
-    @C.torch_compile(dynamic = True)
-    def _f(x): return x
+        def _record(**kwargs):
+            calls.append(kwargs)
+            return lambda fn: fn
 
-    assert called["n"] == 0
+        # Both aliases import the helper lazily inside the call, so rebinding
+        # the attribute on utils before the decorator runs is enough.
+        U.torch_compile_with_fallback = _record
+
+        from unsloth_zoo.temporary_patches import common as C
+
+        def _f(x): return x
+
+        for name in ("torch_compile", "_torch_compile"):
+            calls.clear()
+            getattr(C, name)(dynamic = True, fullgraph = True)(_f)
+            assert calls, f"the recorder never saw {name} under fullgraph"
+            calls.clear()
+            # `is _f` because the recorder's decorator is the identity: reaching
+            # the helper is not enough, the function has to be handed to it
+            # rather than the undecorated decorator returned to the caller.
+            assert getattr(C, name)(_f, dynamic = True, fullgraph = True) is _f, \
+                f"positional {name} did not apply the decorator"
+            assert calls, f"the recorder never saw positional {name}"
+            calls.clear()
+            getattr(C, name)(dynamic = True)(_f)
+            assert not calls, f"{name} wrapped a non-fullgraph compile: {calls}"
+
+        # `_raw_torch_compile` is excluded on purpose: its one caller,
+        # compile_with_eager_fallback, applies the wrapper itself, and wrapping a
+        # wrapper leaves the inner one swallowing the exhaustion.
+        calls.clear()
+        C._raw_torch_compile(_f, fullgraph = True)
+        assert not calls, calls
+    """)

--- a/tests/test_rmsnorm_recompile_guards.py
+++ b/tests/test_rmsnorm_recompile_guards.py
@@ -262,6 +262,18 @@ def test_the_kernels_fall_back_to_eager_instead_of_aborting():
             f"under fullgraph raises instead of falling back to eager"
         )
 
+    # The half above holds in any configuration; the half below cannot. These
+    # kernels are built by `compile_with_eager_fallback`, which compiles through
+    # `_raw_torch_compile`, and that name is bound to `noop` at import when
+    # `UNSLOTH_COMPILE_DISABLE` is set. The wrapper is still there, so the marker
+    # assertions above still mean something, but nothing underneath it ever
+    # compiles, so the cache cannot be exhausted and the latch cannot fire. Not
+    # rebindable in process, for the reason set out in
+    # tests/test_generated_fullgraph_fallback.py::_run_in_fresh_interpreter.
+    from unsloth_zoo.temporary_patches import common
+    if common.UNSLOTH_COMPILE_DISABLE:
+        pytest.skip("compilation is off, so there is no cache left to exhaust")
+
     # And it really does run. `fail_on_recompile_limit_hit` is deliberately NOT set:
     # that flag is the user asking for a hard stop and the wrapper re-raises for it,
     # while real runs leave it off, so limit plus `fullgraph = True` is the case that


### PR DESCRIPTION
Follow-up to #1022, now rebased onto `main` at 94b8860 (which carries #1022, #1017, #1019 and #1020).
No source changes; three test files. The rebase was clean: none of the three merges touch these files.

#1022 established the right thing: the two fullgraph routing assertions have to run with compilation enabled, because unsloth's consolidated CI runs this whole suite with a job-level `UNSLOTH_COMPILE_DISABLE=1`. It ran both of them in a fresh interpreter. Only one of them needs that, and neither half of the switch was covered at all.

## The rule, corrected

`common.py` reacts to `UNSLOTH_COMPILE_DISABLE` in two different ways, and the distinction decides which tool a test should use.

| | how the flag is read | to test it |
| --- | --- | --- |
| `torch_compile`, `_torch_compile`, `_raw_torch_compile` | assigned under a module-level `if UNSLOTH_COMPILE_DISABLE:` (common.py lines 201, 216) | fresh interpreter: they are already `noop` function objects before any test runs, and rebinding `common.UNSLOTH_COMPILE_DISABLE` afterwards cannot undo that |
| `_maybe_compile` | reads `UNSLOTH_COMPILE_DISABLE` and `UNSLOTH_COMPILE_DISABLE_PARTIAL` in its own body, line 278, on every call | `monkeypatch.setattr` on the module attributes |

`_run_with_compile_enabled`'s docstring says the first row is true of both, naming `_maybe_compile` explicitly. It is not, and that is the sentence most likely to send the next test down the wrong route, so it now states the rule and names which functions fall on which side.

## What changed

**`_maybe_compile`'s routing assertion moves back in process.** A subprocess buys nothing here: the read is per call, so pinning the two module attributes is exact. It buys immunity to someone later moving that read to import time, but that change would make this test go red rather than quietly pass, which is the failure mode you want. Against that, the subprocess re-imports the whole package per assertion. Verified rather than assumed:

- with the routing removed from `_maybe_compile` (the `torch_compile_with_fallback` import left in place, so the source-text scan cannot be what catches it), the in-process test is the only one that fails, `1 failed, 17 passed`, both without the variable and with `UNSLOTH_COMPILE_DISABLE=1` exported.
- the file goes from `15 passed in 11.09s` to 18 tests in 6s of work plus one remaining subprocess.

**The other half of the switch, for both sides.** Turning compilation off has to remove the fallback wrapper as well, or the switch does not switch anything and torch is still handed a fullgraph region.

- `_maybe_compile`: parametrised over both spellings of the flag, in process.
- the alias: nothing pinned this at all. The source scan only recognises the enabled spelling, `functools.partial(...)`, so a disabled branch binding bare `torch.compile` passed every other test in the file. Confirmed: with `torch_compile = torch.compile` in the disabled branch, this new test is the only failure.

## Two suite-level fixes of the same kind

**`test_compiler_dynamic_exec.py` leaked a process-global.** It set `UNSLOTH_COMPILE_DISABLE` with `os.environ.setdefault` at module scope. That runs during collection, in every xdist worker, and writes through to the real process environment for the rest of the session, so every module collected after it and every subprocess any of them spawn inherited a compile-disabled environment. What hides it today is that `conftest.py` imports unsloth before collection, latching the real value in `common.py` first; if that import ever fails, collection order decides the result instead. Now an autouse fixture, scoped and undone. The two tests that actually needed the variable already set it with `monkeypatch.setenv`.

```
$ python3 -c 'import os,sys; os.environ.pop("UNSLOTH_COMPILE_DISABLE",None); sys.path.insert(0,"tests"); import test_compiler_dynamic_exec; print(os.environ.get("UNSLOTH_COMPILE_DISABLE"))'
main    -> 1
here    -> None
```

**`test_rmsnorm_recompile_guards.py` fails on main under the flag.** Those kernels come from `compile_with_eager_fallback`, which compiles through `_raw_torch_compile`; with the flag set that is `noop`, so the wrapper is present but nothing under it compiles, the cache cannot be exhausted and the latch cannot fire. `AssertionError: the cache was never actually exhausted, so this asserted nothing`, reproducible standalone on a GPU box. The file is GPU-gated so unsloth's CPU job skips it, but "run the zoo suite with the variable set" is red on main today. Split: the wrapper-presence half keeps running in every configuration, only the exhaustion half stands down.

## Mutations

Each deletes one behaviour an assertion claims to guard. Run in both configurations, tree restored and re-run green after each.

| mutation | red under normal | red under `UNSLOTH_COMPILE_DISABLE=1` |
| --- | --- | --- |
| `_maybe_compile` stops routing fullgraph through the fallback | `test_maybe_compile_routes_fullgraph_through_the_fallback` | same |
| `_maybe_compile` ignores the compile-disable switch | `test_maybe_compile_is_a_no_op_when_compilation_is_switched_off` (both params) | same |
| the disabled branch binds `functools.partial(torch.compile)` | `test_the_alias_is_the_no_op_...`, `test_the_alias_sites_exist_...` | same |
| the disabled branch binds bare `torch.compile` | `test_the_alias_is_the_no_op_...` only | same |
| `_compile_or_fall_back` stops routing fullgraph through the fallback | `test_the_alias_routes_a_fullgraph_compile_through_the_fallback` | same |
| `compile_with_eager_fallback` drops the eager wrapper | `test_the_kernels_fall_back_to_eager_...`, `test_each_kernel_reports_its_own_fallback_state` | same, so the skip above is not a coverage hole |

Every sabotage exited 1, every restore exited 0.

## Runs

`tests/test_generated_fullgraph_fallback.py`: 18 passed unset, 18 passed with `UNSLOTH_COMPILE_DISABLE=1`, 18 passed with `=partial`.

Full suite, `pytest tests/ -q -n 8`, this branch against `origin/main` on the same box, two runs each way:

| | this branch | main |
| --- | --- | --- |
| normal | 1 failed, 4381 passed / 2 failed, 4380 passed | 1 failed, 4382 passed |
| `UNSLOTH_COMPILE_DISABLE=1` | 2 failed, 4383 passed / 1 failed, 4384 passed | 3 failed, 4376 passed |

One stable failure, `test_moe_lora_grouped_mm_capability.py::test_no_grad_decoding_retains_nothing`, on this branch and on main alike, pre-existing and unrelated. The rest are pre-existing `-n 8` flakes that rotate between runs and pass when run on their own: `test_upstream_pinned_symbols_accelerator.py::test_collect_all_linear_target_names_finds_qkv_and_moe` (skips standalone) and `test_recompile_limit_fallback.py::test_a_different_call_site_is_not_dragged_along` (80 passed standalone, on this branch and on main). Main's third failure under the flag is `test_rmsnorm_recompile_guards.py`, which this branch fixes. The 8 collection errors are a local `PermissionError` in `test_upstream_pinned_symbols_trl_vllm.py`, identical on both sides.



## Rebase onto 94b8860, and what #1021 leaves behind

Rebased with no conflicts. Both fixes below were re-confirmed against the new `main` rather than assumed to
still be needed:

```
env-leak probe, tests/test_compiler_dynamic_exec.py + a probe asserting the variable is absent
  main 94b8860   1 failed, 83 passed   EXIT=1
  this branch    84 passed             EXIT=0

three test files, main 94b8860
  unset    124 passed, 2 skipped  EXIT=0
  =1       1 failed (test_rmsnorm_recompile_guards::test_the_kernels_fall_back_to_eager_instead_of_aborting)  EXIT=1
  =partial 1 failed (same)        EXIT=1
```

#1021 attacked the same red as #1022 and #1022 landed first, so its subject is gone: on `main` today every test in
`tests/test_generated_fullgraph_fallback.py` passes under `UNSLOTH_COMPILE_DISABLE=1` and `=partial`. Closing it
rather than resolving the conflict. Two of its assertions were not redundant though, and both are the kind that
passes on a broken tree, so they are carried here instead:

| assertion | why it could not fail | now |
| --- | --- | --- |
| `_maybe_compile`'s non-fullgraph case | asserted `_unsloth_fallback_state` is absent, but the helper stamps that marker only under fullgraph, so it is absent either way | records the call on `utils.torch_compile_with_fallback`, with a positive control |
| `test_a_non_fullgraph_compile_is_left_alone` | ran in process, where the alias is `noop` whenever the switch is off, so the recorder cannot fire however the routing is written -- and that is the position unsloth's Core job runs in | moved into the compile-enabled interpreter, extended to `_torch_compile`, the positional spelling and `_raw_torch_compile` |

Mutations, each with `__pycache__` cleared and `python3 -B`:

| mutation | before | now |
| --- | --- | --- |
| `_maybe_compile`'s `if not kwargs.get("fullgraph"):` body replaced with `pass` (source text kept, so the scan still passes) | green unset, `=1`, `=partial` | red in all three |
| the same short circuit removed from `_compile_or_fall_back` | red unset only; green `=1`, `=partial` | red in all three |
| `_compile_or_fall_back` stops applying the decorator positionally | red unset only | red in both |

## Runs after the rebase

`tests/test_generated_fullgraph_fallback.py`: 18 passed unset, 18 with `=1`, 18 with `=partial`.

Three affected files: 127 passed / 2 skipped unset, 126 / 3 with `=1`, 126 / 3 with `=partial`. EXIT=0 each.

Full suite serially (`pytest tests/ -q -p no:randomly`, one collection error ignored on both sides: a local
`PermissionError` in `test_upstream_pinned_symbols_trl_vllm.py` reaching outside the checkout), this branch against
a clean `origin/main` worktree on the same box:

| | main 94b8860 | this branch |
| --- | --- | --- |
| normal | 4416 passed, 162 skipped, EXIT=0 | 4419 passed, 162 skipped, EXIT=0 |
| `UNSLOTH_COMPILE_DISABLE=1` | 1 failed, 4415 passed, 162 skipped, EXIT=1 | 4418 passed, 163 skipped, EXIT=0 |

Main's one failure is `test_rmsnorm_recompile_guards.py::test_the_kernels_fall_back_to_eager_instead_of_aborting`,
which this branch fixes. Serially there is nothing else red on either side: the `-n 8` flakes reported above, and
`test_moe_lora_grouped_mm_capability.py::test_no_grad_decoding_retains_nothing`, did not reproduce in this run on
either tree.
