### PR TITLE
Follow up on #992: resolved label names, text field stripping, repeated masking calls

### DIFF
--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -3312,3 +3312,170 @@ def test_index_is_not_seeded_into_the_signature():
     assert "index" not in seeded, seeded
     # The columns HF really does always keep are still there.
     assert {"label", "label_ids", "input_ids", "labels"} <= set(seeded)
+
+
+# ── round seventeen: the resolved label names, the text field, repeat calls ──
+
+
+def test_the_resolved_label_names_survive_unused_column_removal():
+    """Trainer resolves `args.label_names` into `self.label_names` in
+    `__init__` and its signature derivation reads the RESOLVED attribute, so a
+    trainer that fills it directly (TRL's `RewardTrainer` does) had its
+    supervision seeded out of `_signature_columns` and stripped from every
+    later `evaluate`/`predict` split before `compute_loss` could read it."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.label_names = ["expert_score", "aux_target"]  # not on `args`
+    assert getattr(trainer.args, "label_names", None) is None
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    seeded = getattr(out, "_signature_columns", None) or []
+    for key in ("expert_score", "aux_target"):
+        assert key in seeded, f"{key} is a resolved label and would be stripped"
+
+
+def test_a_resolved_label_survives_raw_column_removal():
+    """Same divergence one list further on: the keep-list that prunes the split
+    itself asked `args` alone, so the column the trainer resolved was deleted
+    from the dataset even when the signature kept it."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW)] * 2,
+        "attention_mask": [[1] * len(ROW)] * 2,
+        "expert_score": [0.5, 0.25],
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.label_names = ["expert_score"]
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "expert_score" in out.train_dataset.column_names, (
+        f"resolved label dropped from split: {out.train_dataset.column_names}"
+    )
+
+
+def test_a_resolved_label_survives_raw_tokenization():
+    """And one list earlier: `remove_columns` at tokenization deletes it for
+    good, so the two lists above never get the chance to save it."""
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()),
+                          _raw_text_split(my_reward = [0.5, 1.5]))
+    trainer.label_names = ["my_reward"]
+
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+    assert "my_reward" in out.train_dataset.column_names, \
+        "the resolved label was tokenized away"
+
+
+def test_a_retained_text_column_is_stripped_before_the_text_collator():
+    """The keep-list holds the configured text field alive past
+    `remove_unused_columns` so the media path keeps the prompt beside its
+    image. A later `predict(test_dataset = ...)` of pretokenized rows that also
+    kept that raw column then handed the string to `DataCollatorForSeq2Seq`,
+    whose `tokenizer.pad(..., return_tensors = "pt")` tensorizes every key it is
+    given: `ValueError: Unable to create tensor ... Perhaps your features
+    (`text` ...)`."""
+    seen = {}
+
+    class Text:
+        def __call__(self, features):
+            seen["keys"] = sorted(features[0].keys())
+            return {"ok": True}
+
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    dispatcher = out.data_collator
+    assert "text" in (getattr(out, "_signature_columns", None) or []), \
+        "the column never survives removal, so there is nothing to strip"
+    dispatcher.text = Text()
+    dispatcher([{"input_ids": list(ROW), "labels": list(ROW), "text": "hello"}])
+    assert seen["keys"] == ["input_ids", "labels"], seen["keys"]
+
+
+def test_a_configured_text_field_is_stripped_under_its_own_name():
+    """`dataset_text_field` renames the column, and the keep-list keeps
+    whatever it is called, so the strip has to follow the same name."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.dataset_text_field = "body"
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    dispatcher = out.data_collator
+    assert "body" in (getattr(out, "_signature_columns", None) or [])
+    seen = {}
+    dispatcher.text = lambda features: seen.setdefault(
+        "keys", sorted(features[0].keys()))
+    dispatcher([{"input_ids": list(ROW), "body": "hello"}])
+    assert seen["keys"] == ["input_ids"], seen["keys"]
+
+
+def test_the_media_path_still_gets_the_text_field():
+    """Stripped on the text path only: a raw `{"text": ..., "image": ...}` row
+    is exactly why the column is kept, and the vision collator tokenizes it."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    out = train_on_responses_only(
+        StubTrainer(MyVisionCollator(StubProcessor()), rows),
+        INSTRUCTION_PART, RESPONSE_PART)
+
+    seen = {}
+    out.data_collator.media = lambda features: seen.setdefault(
+        "keys", sorted(features[0].keys()))
+    out.data_collator([{"input_ids": list(ROW), "images": [object()],
+                        "text": "describe it"}])
+    assert seen["keys"] == ["images", "input_ids", "text"], seen["keys"]
+
+
+def test_a_tensorizable_text_column_still_reaches_the_text_collator():
+    """The strip is by VALUE, like every other companion: a numeric column that
+    merely shares the configured name is a model input and stays."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    out = train_on_responses_only(
+        StubTrainer(MyVisionCollator(StubProcessor()), rows),
+        INSTRUCTION_PART, RESPONSE_PART)
+
+    seen = {}
+    out.data_collator.text = lambda features: seen.setdefault(
+        "keys", sorted(features[0].keys()))
+    out.data_collator([{"input_ids": list(ROW), "text": [1, 2, 3]}])
+    assert seen["keys"] == ["input_ids", "text"], seen["keys"]
+
+
+def test_a_repeated_masking_call_keeps_the_dispatcher():
+    """Calling `train_on_responses_only` twice met a dispatcher that no guard
+    recognises -- its attributes forward to the TEXT half, so
+    `_is_vision_collator` saw a plain text tokenizer -- and the second call
+    replaced the whole thing with a bare text collator, losing the media
+    fallback a later multimodal `evaluate`/`predict` needs."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    mine = MyVisionCollator(StubProcessor())
+    once = train_on_responses_only(StubTrainer(mine, rows),
+                                   INSTRUCTION_PART, RESPONSE_PART)
+    assert once.data_collator.media is mine
+
+    twice = train_on_responses_only(once, INSTRUCTION_PART, RESPONSE_PART)
+
+    assert hasattr(twice.data_collator, "media"), \
+        "the second call threw the dispatcher away"
+    assert twice.data_collator.media is mine, "the media fallback was replaced"
+    assert twice.data_collator([{"input_ids": list(ROW),
+                                 "images": [object()]}]) == {"mine": True}
+    assert "mine" not in twice.data_collator(
+        [{"input_ids": list(ROW), "labels": list(ROW)}])

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -3418,6 +3418,32 @@ def test_a_configured_text_field_is_stripped_under_its_own_name():
     assert seen["keys"] == ["input_ids"], seen["keys"]
 
 
+def test_a_mixed_case_text_field_is_stripped_too():
+    """The keep-list holds `Body` alive for the media path with its own casing,
+    but the strip tests `key.lower()` against the companion names, so a
+    `dataset_text_field` carrying an uppercase letter matched nothing: the raw
+    string stayed in the text batch and `DataCollatorForSeq2Seq` raised `Unable
+    to create tensor ... Perhaps your features (`Body` in this case)`. The
+    field is the caller's to name, and Hub datasets do ship capitalised text
+    columns: `ought/raft` has `Sentence`, a StackExchange dump has `Body`."""
+    rows = Dataset.from_dict({
+        "input_ids": [list(ROW), list(ROW)],
+        "attention_mask": [[1] * len(ROW)] * 2,
+    })
+    trainer = StubTrainer(MyVisionCollator(StubProcessor()), rows)
+    trainer.args.dataset_text_field = "Body"
+    out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
+
+    dispatcher = out.data_collator
+    assert "Body" in (getattr(out, "_signature_columns", None) or []), \
+        "the column never survives removal, so there is nothing to strip"
+    seen = {}
+    dispatcher.text = lambda features: seen.setdefault(
+        "keys", sorted(features[0].keys()))
+    dispatcher([{"input_ids": list(ROW), "Body": "hello"}])
+    assert seen["keys"] == ["input_ids"], seen["keys"]
+
+
 def test_the_media_path_still_gets_the_text_field():
     """Stripped on the text path only: a raw `{"text": ..., "image": ...}` row
     is exactly why the column is kept, and the vision collator tokenizes it."""

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -463,6 +463,24 @@ def _case_variants(trainer, keys):
     return found
 
 
+def _configured_label_names(trainer):
+    """Every supervision column the trainer itself will look for.
+
+    Trainer resolves `args.label_names` once in `__init__` (defaulting to
+    `find_labels(model)`) and every later derivation reads the RESOLVED
+    `self.label_names`, so a trainer that fills or extends the attribute
+    directly -- TRL's `RewardTrainer` sets it, and a custom `compute_loss`
+    declares its targets there -- must be honoured too, or the keep-lists below
+    drop a column the loss needs.
+    """
+    names = set()
+    for source in (getattr(getattr(trainer, "args", None), "label_names", None),
+                   getattr(trainer, "label_names", None)):
+        try: names.update(n for n in source or () if isinstance(n, str))
+        except TypeError: pass
+    return names
+
+
 def _keep_media_columns(trainer, keys):
     """Stop `remove_unused_columns` stripping media before the collator sees it.
 
@@ -489,8 +507,10 @@ def _keep_media_columns(trainer, keys):
             # Trainer's own derivation does `+= list(set(["label", "label_ids"]
             # + self.label_names))`, so a custom trainer whose supervision is
             # consumed by `compute_loss` rather than declared by `forward` had
-            # it dropped here and on every later split.
-            declared |= set(getattr(getattr(trainer, "args", None), "label_names", None) or ())
+            # it dropped here and on every later split. It reads the RESOLVED
+            # attribute, so seeding from `args.label_names` alone still lost a
+            # trainer that fills `self.label_names` itself.
+            declared |= _configured_label_names(trainer)
             trainer._signature_columns = sorted(set(names) | declared | {
                 "label", "label_ids", "input_ids", "attention_mask",
                 "labels", "completion_mask", "assistant_masks", "token_type_ids",
@@ -935,12 +955,11 @@ def train_on_responses_only(
         _raw_columns = getattr(dataset, "column_names", None) or list(sample.keys())
         if not isinstance(_raw_columns, dict):
             _keep = _model_forward_parameter_names(getattr(trainer, "model", None))
-            # `args.label_names` too, as the keep-lists further down already do:
+            # The label names too, as the keep-lists further down already do:
             # supervision consumed by a custom `compute_loss` is not declared by
             # `forward`, and `remove_columns` here deletes it for good, so those
             # later lists never get the chance to save it.
-            _keep |= set(
-                getattr(getattr(trainer, "args", None), "label_names", None) or ())
+            _keep |= _configured_label_names(trainer)
             # `labels` only when it really is token-level. A raw split can carry
             # a SCALAR `labels` (a class id), and keeping that as supervision
             # sent an int into `_train_on_responses_only`, which calls
@@ -1191,6 +1210,17 @@ def train_on_responses_only(
         names -= set(getattr(tokenizer, "model_input_names", None) or ())
         return frozenset(names - _TEXT_COLUMNS)
     pass
+
+    # A previous call already swapped in the dispatcher, so unwrap it back to
+    # the collator the caller actually built. Nothing below recognises the
+    # wrapper: its attributes forward to the TEXT half, so `_is_vision_collator`
+    # sees a plain text tokenizer and the swap at the end replaces the whole
+    # dispatcher with a bare text collator -- and a later multimodal
+    # `evaluate`/`predict` loses the media fallback. Restoring the original
+    # instead makes a repeated call reproduce the first one. Before
+    # `_derive_multimodal_columns` runs, which reads the collator's processor.
+    if isinstance(getattr(trainer, "data_collator", None), _MediaAwareCollator):
+        trainer.data_collator = trainer.data_collator.media
 
     try:
         _MULTIMODAL_COLUMNS = _MULTIMODAL_COLUMNS | _derive_multimodal_columns()
@@ -2064,8 +2094,16 @@ def train_on_responses_only(
         # repair exists to remove. The bypass flag is the case where the
         # displaced collator is a working vision collator.
         _media_capable = _bypassed_vision_collator and not _processor_backed
-        # The training text column is NOT a companion to strip: it is what the
-        # text collator is there to read.
+        # The training text column is kept for the MEDIA path -- a raw
+        # `{"text": ..., "image": ...}` row needs its prompt -- and stripped on
+        # the text path with the other companions: the text collator is a
+        # `DataCollatorForSeq2Seq`, which pads through `tokenizer.pad` and never
+        # tokenizes, so a retained string kills the batch ("Unable to create
+        # tensor ... Perhaps your features (`text` ...)"). The keep-list below
+        # is what holds the column alive past `remove_unused_columns` for a
+        # pretokenized split handed to a later `predict`/`evaluate`. Stripped by
+        # VALUE like every other companion, so a tensorizable column that merely
+        # shares the name stays.
         _text_field = getattr(getattr(trainer, "args", None),
                               "dataset_text_field", None) or "text"
         # Every media form the initial-split guard recognises, not just the two
@@ -2081,7 +2119,7 @@ def train_on_responses_only(
             # `_MULTIMODAL_COLUMNS`, so a processed `predict` batch matched
             # nothing and went to the text collator that cannot tensorize it.
             _text_collator, _collator, _dispatch_keys, _AMBIGUOUS_MEDIA_COLUMNS,
-            _RAW_TEXT_COMPANION_COLUMNS - {_text_field},
+            _RAW_TEXT_COMPANION_COLUMNS | {_text_field},
         ) if _media_capable else _text_collator
         if _media_capable:
             # And the keys have to survive `remove_unused_columns`, which is on
@@ -2127,11 +2165,11 @@ def train_on_responses_only(
                 except Exception: pass
             # Unwrap PEFT/compile wrappers: their own forward hides pixel_values.
             names.update(_model_forward_parameter_names(getattr(trainer, "model", None)))
-            # `args.label_names` too, exactly as `_keep_media_columns` does and
+            # The label names too, exactly as `_keep_media_columns` does and
             # as Trainer's own signature derivation does. Supervision consumed
             # by a custom `compute_loss` is not declared by `forward`, so the
             # signature kept it while THIS list deleted it from the split.
-            names.update(getattr(getattr(trainer, "args", None), "label_names", None) or ())
+            names.update(_configured_label_names(trainer))
             names.discard("self")
             # Same reason as the tokenizing strip above: a `forward` declaring
             # `text` must not keep a raw string column no collator can tensorize.

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -593,7 +593,12 @@ class _MediaAwareCollator:
         self.media = media
         # Kept so the media collator can read the prompt beside its image, and
         # stripped again on the text path, which cannot tensorize a raw string.
-        self.companion_keys = frozenset(companion_keys)
+        # Lowercased: `_keep` below tests `key.lower()`, and unlike the other two
+        # sets this one carries the caller's own `dataset_text_field`. A
+        # mixed-case one (`Body`) never matched, so the raw string it names
+        # survived into a text batch and `DataCollatorForSeq2Seq` died on it.
+        self.companion_keys = frozenset(
+            k.lower() if isinstance(k, str) else k for k in companion_keys)
         # Split, not merged: an ambiguous name is decided by its value below,
         # and folding the two would match `url` on the name alone.
         self.ambiguous_keys = frozenset(ambiguous_keys)


### PR DESCRIPTION
#992 merged with three review items open. All three reproduce against main; this is the fix for each, with a regression test that goes red when the change is reverted.

**Honor the trainer's resolved label names.** Trainer sets `self.label_names` in `__init__` (`default_label_names if self.args.label_names is None else self.args.label_names`) and `_set_signature_columns_if_needed` builds the whitelist with `+= list(set(["label", "label_ids"] + self.label_names))`, on 4.57.6 and on transformers main alike. Seeding `_signature_columns` from `args.label_names` alone therefore dropped a column a trainer resolved for itself: with `args.label_names = None` and `trainer.label_names = ["expert_score"]` the seeded signature came back without it, and `_drop_raw_columns` then deleted it from the split. A shared `_configured_label_names(trainer)` now feeds three keep lists, not two: the `remove_columns` at tokenization deletes the column for good, so the later two never get the chance to save it.

**Strip the configured text field on the text path.** The keep-list holds that column alive past `remove_unused_columns` so the media route keeps the prompt beside its image. A pretokenized `predict(test_dataset = ...)` that still carried it then handed the raw string to `DataCollatorForSeq2Seq`, and `tokenizer.pad(..., return_tensors = "pt")` raises `ValueError: Unable to create tensor ... Perhaps your features`. The field now joins the companion set instead of being subtracted from it, so it is stripped on the text route only and by value: the media route still receives it, and a tensorizable column that merely shares the name still reaches the collator.

**Preserve the dispatcher across repeated masking calls.** `_MediaAwareCollator.__getattr__` forwards to the TEXT half, so `.processor` is absent and `.tokenizer` is the plain text tokenizer: `_is_vision_collator` and `_pads_through_a_processor` both return False and the last arm of the swap condition fires. A second `train_on_responses_only` turned the dispatcher into a bare `DataCollatorForSeq2Seq` and a later multimodal `evaluate`/`predict` lost the media fallback. The call now unwraps an installed dispatcher back to the caller's own collator before any classification, and before `_derive_multimodal_columns` reads the collator's processor, so a repeated call reproduces the first one.

Tests: 8 new cases in `tests/test_pretokenized_bypass_collator.py`. Full suite on this branch: 4382 passed, 162 skipped (`tests/test_upstream_pinned_symbols_trl_vllm.py` ignored, it aborts collection with a PermissionError on a path outside this machine's workspace).