### PR TITLE
feat(mlx): support native audio training for new omni VLMs

### DIFF
--- a/tests/gemma4_audio_version_probe.py
+++ b/tests/gemma4_audio_version_probe.py
@@ -407,7 +407,7 @@ def main():
     from unsloth_zoo.mlx import utils as U
     U._AUDIO_QUALIFIED_FAMILIES = dict(
         U._AUDIO_QUALIFIED_FAMILIES,
-        gemma4=U._AudioVersions(version, version),
+        gemma4=U._AudioVersions(version),
     )
     U._AUDIO_MIN_TRANSFORMERS = {}
 

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -647,7 +647,7 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
         _render_qwen(prompt_utils, prompt, num_audios=1)
     conversation = [
         {"role": "system", "content": "Follow instructions."},
-        {"role": "user", "content": "Describe both inputs."},
+        {"role": "User", "content": "Describe both inputs."},
         {"role": "assistant", "content": "Ready."},
     ]
     anchored = _render_qwen(prompt_utils, conversation, return_messages=True,

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -528,10 +528,31 @@ def test_vlm_prompt_patch_rebinds_every_loaded_mlx_vlm_alias(monkeypatch):
     assert outsider.apply_chat_template is original
 
 
+def _install_qwen_prompt_patch(monkeypatch, prompt_utils, loader, **overrides):
+    attrs = {
+        "apply_chat_template": lambda *_args, **_kwargs: "count-rendered",
+        "get_message_json": lambda _model, text, role="user", **_kwargs: {
+            "role": role, "content": [{"type": "text", "text": text}],
+        },
+        "_get_role_content": lambda item: (item["role"], item["content"]),
+        "extract_text_from_content": lambda content: content,
+        "MODEL_CONFIG": {"qwen3_omni_moe": object()},
+        **overrides,
+    }
+    for name, value in attrs.items():
+        monkeypatch.setattr(prompt_utils, name, value, raising=False)
+    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
+    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
+    loader._ensure_vlm_prompt_utils_patched()
+
+
+def _render_qwen(prompt_utils, prompt, processor=None, **kwargs):
+    processor = object() if processor is None else processor
+    return prompt_utils.apply_chat_template(
+        processor, {"model_type": "qwen3_omni_moe"}, prompt, **kwargs)
+
+
 def test_vlm_prompt_patch_matches_published_model_type_case_insensitively(monkeypatch):
-    """Nemotron publishes a capitalized model_type while mlx-vlm's routing
-    table stores its lowercase spelling. Media counts must still reach the
-    configured formatter so audio markers are not silently dropped."""
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
 
@@ -561,8 +582,6 @@ def test_vlm_prompt_patch_matches_published_model_type_case_insensitively(monkey
 
 
 def test_vlm_prompt_patch_places_counted_qwen3_omni_audio_before_text(monkeypatch):
-    """Qwen's published contract is media then text, while mlx-vlm's generic
-    count renderer appends audio after text and produces broken inference."""
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
 
@@ -575,33 +594,76 @@ def test_vlm_prompt_patch_places_counted_qwen3_omni_audio_before_text(monkeypatc
         rendered_messages.append(messages)
         return "structured-rendered"
 
-    monkeypatch.setattr(prompt_utils, "apply_chat_template", original, raising=False)
-    monkeypatch.setattr(prompt_utils, "get_chat_template", render, raising=False)
-    monkeypatch.setattr(
-        prompt_utils, "MODEL_CONFIG", {"qwen3_omni_moe": object()}, raising=False,
+    _install_qwen_prompt_patch(
+        monkeypatch, prompt_utils, loader,
+        apply_chat_template=original,
+        get_chat_template=render,
     )
-    monkeypatch.setattr(
-        prompt_utils,
-        "_get_role_content",
-        lambda item: (item["role"], item["content"]),
-        raising=False,
-    )
-    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
-    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
-    loader._ensure_vlm_prompt_utils_patched()
 
-    result = prompt_utils.apply_chat_template(
-        object(),
-        {"model_type": "qwen3_omni_moe"},
-        "Transcribe the audio into text.",
-        num_audios=1,
+    result = _render_qwen(
+        prompt_utils, "Transcribe the audio into text.", num_audios=1,
     )
 
     assert result == "structured-rendered"
-    assert [item["type"] for item in rendered_messages[0][0]["content"]] == [
-        "audio",
-        "text",
-    ]
+    types = [item["type"] for item in rendered_messages[0][0]["content"]]
+    assert types == ["audio", "text"]
+
+
+def test_vlm_prompt_patch_preserves_qwen3_omni_video_with_audio(monkeypatch):
+    import mlx_vlm.prompt_utils as prompt_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    _install_qwen_prompt_patch(
+        monkeypatch, prompt_utils, loader,
+        get_message_json=lambda _model_type, text, **kwargs: {
+            "role": "user",
+            "content": [
+                {
+                    "type": "video",
+                    "video": kwargs["video"],
+                    "fps": kwargs["fps"],
+                },
+                {"type": "text", "text": text},
+            ],
+        },
+    )
+
+    messages = _render_qwen(
+        prompt_utils, "Describe both inputs.",
+        return_messages=True,
+        num_audios=1,
+        video="clip.mp4",
+        fps=2,
+    )
+
+    types = [item["type"] for item in messages[0]["content"]]
+    assert types == ["video", "audio", "text"]
+    assert messages[0]["content"][0]["video"] == "clip.mp4"
+    assert messages[0]["content"][0]["fps"] == 2
+
+
+def test_vlm_prompt_patch_honors_qwen3_omni_media_suppression(monkeypatch):
+    import mlx_vlm.prompt_utils as prompt_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    _install_qwen_prompt_patch(monkeypatch, prompt_utils, loader)
+
+    text = "Describe the input."
+    counted = {"role": "user", "content": text}
+    cases = (
+        (text, {"skip_audio_token": True}, "user", ["image", "text"]),
+        (text, {"skip_image_token": True}, "user", ["audio", "text"]),
+        (text, {"role": "assistant"}, "assistant", ["text"]),
+        (counted, {"skip_audio_token": True}, "user", ["image", "text"]),
+        (counted, {"skip_image_token": True}, "user", ["audio", "text"]),
+    )
+    for prompt, options, role, expected_types in cases:
+        message = _render_qwen(
+            prompt_utils, prompt, return_messages=True, num_images=1,
+            num_audios=1, **options,
+        )[0]
+        assert message["role"] == role
+        assert [item["type"] for item in message["content"]] == expected_types
 
 
 def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatch):
@@ -610,31 +672,18 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
 
     rendered_messages = []
 
-    monkeypatch.setattr(
-        prompt_utils,
-        "apply_chat_template",
-        lambda *_args, **_kwargs: "count-rendered",
-        raising=False,
+    def counted_message(_model, text, role="user", **kwargs):
+        videos = [{"type": "video", "video": kwargs["video"]}] if kwargs.get("video") else []
+        return {"role": role, "content": videos + [{"type": "text", "text": text}]}
+
+    _install_qwen_prompt_patch(
+        monkeypatch, prompt_utils, loader,
+        get_chat_template=(
+            lambda _processor, messages, _add_generation_prompt, **_kwargs:
+                rendered_messages.append(messages) or "structured-rendered"
+        ),
+        get_message_json=counted_message,
     )
-    monkeypatch.setattr(
-        prompt_utils,
-        "get_chat_template",
-        lambda _processor, messages, _add_generation_prompt, **_kwargs:
-            rendered_messages.append(messages) or "structured-rendered",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        prompt_utils, "MODEL_CONFIG", {"qwen3_omni_moe": object()}, raising=False,
-    )
-    monkeypatch.setattr(
-        prompt_utils,
-        "_get_role_content",
-        lambda item: (item["role"], item["content"]),
-        raising=False,
-    )
-    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
-    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
-    loader._ensure_vlm_prompt_utils_patched()
     messages = [
         {
             "role": "user",
@@ -645,66 +694,68 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
         }
     ]
 
-    result = prompt_utils.apply_chat_template(
-        object(),
-        {"model_type": "qwen3_omni_moe"},
-        messages,
+    result = _render_qwen(prompt_utils, messages, num_audios=1)
+    counted = {"role": "user", "content": "Transcribe the audio."}
+    for prompt in (counted, [counted]):
+        _render_qwen(prompt_utils, prompt, num_audios=1)
+    conversation = [
+        {"role": "system", "content": "Follow instructions."},
+        {"role": "user", "content": "Describe both inputs."},
+        {"role": "assistant", "content": "Ready."},
+    ]
+    anchored = _render_qwen(
+        prompt_utils, conversation,
+        return_messages=True,
         num_audios=1,
+        video="clip.mp4",
     )
 
     assert result == "structured-rendered"
-    assert rendered_messages == [messages]
+    assert rendered_messages[0] == messages
+    assert len(rendered_messages) == 3
+    for rendered in rendered_messages[1:]:
+        assert [item["type"] for item in rendered[0]["content"]] == ["audio", "text"]
+    assert [[item["type"] for item in turn["content"]] for turn in anchored] == [
+        ["text"], ["video", "audio", "text"], ["text"],
+    ]
 
 
 def test_vlm_prompt_patch_uses_qwen3_omni_native_non_thinking_template(monkeypatch):
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
 
-    native_kwargs = []
+    native_calls = []
 
     class Processor:
         def apply_chat_template(
             self, _messages, *, tokenize, add_generation_prompt, **kwargs,
         ):
-            native_kwargs.append(kwargs)
+            native_calls.append((tokenize, kwargs))
             return "native-rendered"
 
-    monkeypatch.setattr(
-        prompt_utils,
-        "apply_chat_template",
-        lambda *_args, **_kwargs: "count-rendered",
-        raising=False,
+    _install_qwen_prompt_patch(
+        monkeypatch, prompt_utils, loader,
+        get_chat_template=lambda *_args, **_kwargs: "generic-rendered",
     )
-    monkeypatch.setattr(
-        prompt_utils,
-        "get_chat_template",
-        lambda *_args, **_kwargs: "generic-rendered",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        prompt_utils, "MODEL_CONFIG", {"qwen3_omni_moe": object()}, raising=False,
-    )
-    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
-    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
-    loader._ensure_vlm_prompt_utils_patched()
 
-    result = prompt_utils.apply_chat_template(
-        Processor(),
-        {"model_type": "qwen3_omni_moe"},
-        "Transcribe the audio into text.",
-        num_audios=1,
+    result = _render_qwen(
+        prompt_utils, "Transcribe the audio into text.", Processor(), num_audios=1,
     )
-    explicit_result = prompt_utils.apply_chat_template(
-        Processor(),
-        {"model_type": "qwen3_omni_moe"},
-        "Transcribe the audio into text.",
+    explicit_result = _render_qwen(
+        prompt_utils, "Transcribe the audio into text.", Processor(),
         num_audios=1,
         enable_thinking=True,
+    )
+    tokenized_result = _render_qwen(
+        prompt_utils, "Transcribe the audio into text.", Processor(),
+        num_audios=1,
+        tokenize=True,
     )
 
     assert result == "native-rendered"
     assert explicit_result == "native-rendered"
-    assert native_kwargs == [{}, {"enable_thinking": True}]
+    assert tokenized_result == "native-rendered"
+    assert native_calls == [(False, {}), (False, {"enable_thinking": True}), (True, {})]
 
 
 def test_vlm_generate_hf_kwargs(monkeypatch):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -647,18 +647,18 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
         _render_qwen(prompt_utils, prompt, num_audios=1)
     conversation = [
         {"role": "system", "content": "Follow instructions."},
-        {"role": "User", "content": "Describe both inputs."},
+        {"role": "HuMaN", "content": "Describe all inputs."},
         {"role": "assistant", "content": "Ready."},
     ]
     anchored = _render_qwen(prompt_utils, conversation, return_messages=True,
-                            num_audios=1, video="clip.mp4")
+                            num_images=1, num_audios=1, video="clip.mp4")
     assert result == "structured-rendered"
     assert rendered_messages[0] == messages
     assert len(rendered_messages) == 3
     for rendered in rendered_messages[1:]:
         assert [item["type"] for item in rendered[0]["content"]] == ["audio", "text"]
     assert [[item["type"] for item in turn["content"]] for turn in anchored] == [
-        ["text"], ["video", "audio", "text"], ["text"],
+        ["text"], ["video", "image", "audio", "text"], ["text"],
     ]
 
 

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -528,6 +528,38 @@ def test_vlm_prompt_patch_rebinds_every_loaded_mlx_vlm_alias(monkeypatch):
     assert outsider.apply_chat_template is original
 
 
+def test_vlm_prompt_patch_matches_published_model_type_case_insensitively(monkeypatch):
+    """Nemotron publishes a capitalized model_type while mlx-vlm's routing
+    table stores its lowercase spelling. Media counts must still reach the
+    configured formatter so audio markers are not silently dropped."""
+    import mlx_vlm.prompt_utils as prompt_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    configured = "nemotronh_nano_omni_reasoning_v3"
+    calls = []
+
+    def original(_processor, config, prompt, **kwargs):
+        model_type = config["model_type"]
+        calls.append((model_type, prompt, kwargs.get("num_audios")))
+        return "configured" if model_type in prompt_utils.MODEL_CONFIG else "text-only"
+
+    monkeypatch.setattr(prompt_utils, "apply_chat_template", original, raising=False)
+    monkeypatch.setattr(prompt_utils, "MODEL_CONFIG", {configured: object()}, raising=False)
+    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
+    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
+    loader._ensure_vlm_prompt_utils_patched()
+
+    rendered = prompt_utils.apply_chat_template(
+        object(),
+        {"model_type": "NemotronH_Nano_Omni_Reasoning_V3"},
+        "Transcribe this audio.",
+        num_audios=1,
+    )
+
+    assert rendered == "configured"
+    assert calls == [(configured, "Transcribe this audio.", 1)]
+
+
 def test_vlm_generate_hf_kwargs(monkeypatch):
     import torch
     from transformers.tokenization_utils_base import to_py_obj

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -560,6 +560,153 @@ def test_vlm_prompt_patch_matches_published_model_type_case_insensitively(monkey
     assert calls == [(configured, "Transcribe this audio.", 1)]
 
 
+def test_vlm_prompt_patch_places_counted_qwen3_omni_audio_before_text(monkeypatch):
+    """Qwen's published contract is media then text, while mlx-vlm's generic
+    count renderer appends audio after text and produces broken inference."""
+    import mlx_vlm.prompt_utils as prompt_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    rendered_messages = []
+
+    def original(*_args, **_kwargs):
+        return "count-rendered"
+
+    def render(_processor, messages, _add_generation_prompt, **_kwargs):
+        rendered_messages.append(messages)
+        return "structured-rendered"
+
+    monkeypatch.setattr(prompt_utils, "apply_chat_template", original, raising=False)
+    monkeypatch.setattr(prompt_utils, "get_chat_template", render, raising=False)
+    monkeypatch.setattr(
+        prompt_utils, "MODEL_CONFIG", {"qwen3_omni_moe": object()}, raising=False,
+    )
+    monkeypatch.setattr(
+        prompt_utils,
+        "_get_role_content",
+        lambda item: (item["role"], item["content"]),
+        raising=False,
+    )
+    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
+    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
+    loader._ensure_vlm_prompt_utils_patched()
+
+    result = prompt_utils.apply_chat_template(
+        object(),
+        {"model_type": "qwen3_omni_moe"},
+        "Transcribe the audio into text.",
+        num_audios=1,
+    )
+
+    assert result == "structured-rendered"
+    assert [item["type"] for item in rendered_messages[0][0]["content"]] == [
+        "audio",
+        "text",
+    ]
+
+
+def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatch):
+    import mlx_vlm.prompt_utils as prompt_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    rendered_messages = []
+
+    monkeypatch.setattr(
+        prompt_utils,
+        "apply_chat_template",
+        lambda *_args, **_kwargs: "count-rendered",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        prompt_utils,
+        "get_chat_template",
+        lambda _processor, messages, _add_generation_prompt, **_kwargs:
+            rendered_messages.append(messages) or "structured-rendered",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        prompt_utils, "MODEL_CONFIG", {"qwen3_omni_moe": object()}, raising=False,
+    )
+    monkeypatch.setattr(
+        prompt_utils,
+        "_get_role_content",
+        lambda item: (item["role"], item["content"]),
+        raising=False,
+    )
+    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
+    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
+    loader._ensure_vlm_prompt_utils_patched()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "audio"},
+                {"type": "text", "text": "Transcribe the audio into text."},
+            ],
+        }
+    ]
+
+    result = prompt_utils.apply_chat_template(
+        object(),
+        {"model_type": "qwen3_omni_moe"},
+        messages,
+        num_audios=1,
+    )
+
+    assert result == "structured-rendered"
+    assert rendered_messages == [messages]
+
+
+def test_vlm_prompt_patch_uses_qwen3_omni_native_non_thinking_template(monkeypatch):
+    import mlx_vlm.prompt_utils as prompt_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    native_kwargs = []
+
+    class Processor:
+        def apply_chat_template(
+            self, _messages, *, tokenize, add_generation_prompt, **kwargs,
+        ):
+            native_kwargs.append(kwargs)
+            return "native-rendered"
+
+    monkeypatch.setattr(
+        prompt_utils,
+        "apply_chat_template",
+        lambda *_args, **_kwargs: "count-rendered",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        prompt_utils,
+        "get_chat_template",
+        lambda *_args, **_kwargs: "generic-rendered",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        prompt_utils, "MODEL_CONFIG", {"qwen3_omni_moe": object()}, raising=False,
+    )
+    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
+    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
+    loader._ensure_vlm_prompt_utils_patched()
+
+    result = prompt_utils.apply_chat_template(
+        Processor(),
+        {"model_type": "qwen3_omni_moe"},
+        "Transcribe the audio into text.",
+        num_audios=1,
+    )
+    explicit_result = prompt_utils.apply_chat_template(
+        Processor(),
+        {"model_type": "qwen3_omni_moe"},
+        "Transcribe the audio into text.",
+        num_audios=1,
+        enable_thinking=True,
+    )
+
+    assert result == "native-rendered"
+    assert explicit_result == "native-rendered"
+    assert native_kwargs == [{}, {"enable_thinking": True}]
+
+
 def test_vlm_generate_hf_kwargs(monkeypatch):
     import torch
     from transformers.tokenization_utils_base import to_py_obj

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -548,35 +548,25 @@ def _install_qwen_prompt_patch(monkeypatch, prompt_utils, loader, **overrides):
 
 def _render_qwen(prompt_utils, prompt, processor=None, **kwargs):
     processor = object() if processor is None else processor
-    return prompt_utils.apply_chat_template(
-        processor, {"model_type": "qwen3_omni_moe"}, prompt, **kwargs)
+    config = {"model_type": "qwen3_omni_moe"}
+    return prompt_utils.apply_chat_template(processor, config, prompt, **kwargs)
 
 
 def test_vlm_prompt_patch_matches_published_model_type_case_insensitively(monkeypatch):
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
-
     configured = "nemotronh_nano_omni_reasoning_v3"
     calls = []
-
     def original(_processor, config, prompt, **kwargs):
         model_type = config["model_type"]
         calls.append((model_type, prompt, kwargs.get("num_audios")))
         return "configured" if model_type in prompt_utils.MODEL_CONFIG else "text-only"
-
-    monkeypatch.setattr(prompt_utils, "apply_chat_template", original, raising=False)
-    monkeypatch.setattr(prompt_utils, "MODEL_CONFIG", {configured: object()}, raising=False)
-    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
-    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
-    loader._ensure_vlm_prompt_utils_patched()
-
-    rendered = prompt_utils.apply_chat_template(
-        object(),
-        {"model_type": "NemotronH_Nano_Omni_Reasoning_V3"},
-        "Transcribe this audio.",
-        num_audios=1,
-    )
-
+    _install_qwen_prompt_patch(monkeypatch, prompt_utils, loader,
+                               apply_chat_template=original,
+                               MODEL_CONFIG={configured: object()})
+    rendered = prompt_utils.apply_chat_template(object(), {
+        "model_type": "NemotronH_Nano_Omni_Reasoning_V3",
+    }, "Transcribe this audio.", num_audios=1)
     assert rendered == "configured"
     assert calls == [(configured, "Transcribe this audio.", 1)]
 
@@ -584,70 +574,38 @@ def test_vlm_prompt_patch_matches_published_model_type_case_insensitively(monkey
 def test_vlm_prompt_patch_places_counted_qwen3_omni_audio_before_text(monkeypatch):
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
-
     rendered_messages = []
-
-    def original(*_args, **_kwargs):
-        return "count-rendered"
-
     def render(_processor, messages, _add_generation_prompt, **_kwargs):
         rendered_messages.append(messages)
         return "structured-rendered"
-
     _install_qwen_prompt_patch(
-        monkeypatch, prompt_utils, loader,
-        apply_chat_template=original,
-        get_chat_template=render,
+        monkeypatch, prompt_utils, loader, get_chat_template=render,
     )
-
-    result = _render_qwen(
-        prompt_utils, "Transcribe the audio into text.", num_audios=1,
-    )
-
+    result = _render_qwen(prompt_utils, "Transcribe the audio into text.", num_audios=1)
     assert result == "structured-rendered"
-    types = [item["type"] for item in rendered_messages[0][0]["content"]]
-    assert types == ["audio", "text"]
+    assert [x["type"] for x in rendered_messages[0][0]["content"]] == ["audio", "text"]
 
 
 def test_vlm_prompt_patch_preserves_qwen3_omni_video_with_audio(monkeypatch):
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
-
+    def video_message(_model_type, text, **kwargs):
+        video = {"type": "video", "video": kwargs["video"], "fps": kwargs["fps"]}
+        return {"role": "user", "content": [video, {"type": "text", "text": text}]}
     _install_qwen_prompt_patch(
-        monkeypatch, prompt_utils, loader,
-        get_message_json=lambda _model_type, text, **kwargs: {
-            "role": "user",
-            "content": [
-                {
-                    "type": "video",
-                    "video": kwargs["video"],
-                    "fps": kwargs["fps"],
-                },
-                {"type": "text", "text": text},
-            ],
-        },
+        monkeypatch, prompt_utils, loader, get_message_json=video_message,
     )
-
-    messages = _render_qwen(
-        prompt_utils, "Describe both inputs.",
-        return_messages=True,
-        num_audios=1,
-        video="clip.mp4",
-        fps=2,
-    )
-
-    types = [item["type"] for item in messages[0]["content"]]
-    assert types == ["video", "audio", "text"]
-    assert messages[0]["content"][0]["video"] == "clip.mp4"
-    assert messages[0]["content"][0]["fps"] == 2
+    messages = _render_qwen(prompt_utils, "Describe both inputs.",
+                            return_messages=True, num_audios=1,
+                            video="clip.mp4", fps=2)
+    assert [x["type"] for x in messages[0]["content"]] == ["video", "audio", "text"]
+    assert messages[0]["content"][0] == {"type": "video", "video": "clip.mp4", "fps": 2}
 
 
 def test_vlm_prompt_patch_honors_qwen3_omni_media_suppression(monkeypatch):
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
-
     _install_qwen_prompt_patch(monkeypatch, prompt_utils, loader)
-
     text = "Describe the input."
     counted = {"role": "user", "content": text}
     cases = (
@@ -658,10 +616,8 @@ def test_vlm_prompt_patch_honors_qwen3_omni_media_suppression(monkeypatch):
         (counted, {"skip_image_token": True}, "user", ["audio", "text"]),
     )
     for prompt, options, role, expected_types in cases:
-        message = _render_qwen(
-            prompt_utils, prompt, return_messages=True, num_images=1,
-            num_audios=1, **options,
-        )[0]
+        message = _render_qwen(prompt_utils, prompt, return_messages=True,
+                               num_images=1, num_audios=1, **options)[0]
         assert message["role"] == role
         assert [item["type"] for item in message["content"]] == expected_types
 
@@ -669,13 +625,10 @@ def test_vlm_prompt_patch_honors_qwen3_omni_media_suppression(monkeypatch):
 def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatch):
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
-
     rendered_messages = []
-
     def counted_message(_model, text, role="user", **kwargs):
         videos = [{"type": "video", "video": kwargs["video"]}] if kwargs.get("video") else []
         return {"role": role, "content": videos + [{"type": "text", "text": text}]}
-
     _install_qwen_prompt_patch(
         monkeypatch, prompt_utils, loader,
         get_chat_template=(
@@ -684,16 +637,10 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
         ),
         get_message_json=counted_message,
     )
-    messages = [
-        {
-            "role": "user",
-            "content": [
-                {"type": "audio"},
-                {"type": "text", "text": "Transcribe the audio into text."},
-            ],
-        }
-    ]
-
+    messages = [{"role": "user", "content": [
+        {"type": "audio"},
+        {"type": "text", "text": "Transcribe the audio into text."},
+    ]}]
     result = _render_qwen(prompt_utils, messages, num_audios=1)
     counted = {"role": "user", "content": "Transcribe the audio."}
     for prompt in (counted, [counted]):
@@ -703,13 +650,8 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
         {"role": "user", "content": "Describe both inputs."},
         {"role": "assistant", "content": "Ready."},
     ]
-    anchored = _render_qwen(
-        prompt_utils, conversation,
-        return_messages=True,
-        num_audios=1,
-        video="clip.mp4",
-    )
-
+    anchored = _render_qwen(prompt_utils, conversation, return_messages=True,
+                            num_audios=1, video="clip.mp4")
     assert result == "structured-rendered"
     assert rendered_messages[0] == messages
     assert len(rendered_messages) == 3
@@ -723,38 +665,24 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
 def test_vlm_prompt_patch_uses_qwen3_omni_native_non_thinking_template(monkeypatch):
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
-
     native_calls = []
-
     class Processor:
         def apply_chat_template(
             self, _messages, *, tokenize, add_generation_prompt, **kwargs,
         ):
             native_calls.append((tokenize, kwargs))
             return "native-rendered"
-
     _install_qwen_prompt_patch(
         monkeypatch, prompt_utils, loader,
         get_chat_template=lambda *_args, **_kwargs: "generic-rendered",
     )
-
-    result = _render_qwen(
-        prompt_utils, "Transcribe the audio into text.", Processor(), num_audios=1,
-    )
-    explicit_result = _render_qwen(
-        prompt_utils, "Transcribe the audio into text.", Processor(),
-        num_audios=1,
-        enable_thinking=True,
-    )
-    tokenized_result = _render_qwen(
-        prompt_utils, "Transcribe the audio into text.", Processor(),
-        num_audios=1,
-        tokenize=True,
-    )
-
-    assert result == "native-rendered"
-    assert explicit_result == "native-rendered"
-    assert tokenized_result == "native-rendered"
+    prompt = "Transcribe the audio into text."
+    result = _render_qwen(prompt_utils, prompt, Processor(), num_audios=1)
+    explicit_result = _render_qwen(prompt_utils, prompt, Processor(),
+                                   num_audios=1, enable_thinking=True)
+    tokenized_result = _render_qwen(prompt_utils, prompt, Processor(),
+                                    num_audios=1, tokenize=True)
+    assert (result, explicit_result, tokenized_result) == ("native-rendered",) * 3
     assert native_calls == [(False, {}), (False, {"enable_thinking": True}), (True, {})]
 
 

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -638,10 +638,17 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
         get_message_json=counted_message,
     )
     messages = [{"role": "user", "content": [
-        {"type": "audio"},
+        {"type": "input_video", "video": "clip.mp4"}, {"type": "video"},
+        {"type": "image", "image": "frame.png"}, {"type": "image"},
+        {"type": "input_audio", "audio": "first.wav"}, {"audio": "key-only.wav"}, {"type": "audio"}, {"type": "group", "content": [{"type": "input_audio", "audio": "nested.wav"}]},
         {"type": "text", "text": "Transcribe the audio into text."},
-    ]}]
-    result = _render_qwen(prompt_utils, messages, num_audios=1)
+    ]}, {"role": "user", "content": [{"type": "input_image", "image": "second.png"}, {"type": "input_audio", "audio": "second.wav"}, {"type": "text", "text": "Continue."}]}]
+    result = _render_qwen(prompt_utils, messages, num_images=4, num_audios=5)
+    plain, key_only = _render_qwen(prompt_utils, plain_prompt := [{"role": "user", "content": "First."}, messages[1]], return_messages=True, num_images=2, num_audios=2), _render_qwen(prompt_utils, key_only_prompt := [{"role": "user", "content": [{"audio": "only.wav", "metadata": {"source": "fixture"}}, {"audio_url": "second.wav"}, {"type": "text", "text": "Keep me."}]}], return_messages=True, num_audios=2)
+    assert [item["type"] for item in plain[0]["content"]] == ["image", "audio", "text"] and plain[0]["content"][-1]["text"] == "First." and plain[1] == messages[1] and key_only == key_only_prompt
+    nested = _render_qwen(prompt_utils, [{"role": "user", "content": messages[0]["content"][4:5] + messages[0]["content"][7:]}], return_messages=True, num_audios=2)
+    assert [item["type"] for item in nested[0]["content"]] == ["input_audio", "audio", "group", "text"]
+    assert _render_qwen(prompt_utils, plain_prompt, return_messages=True, num_images=1, num_audios=1) == plain_prompt and _render_qwen(prompt_utils, plain_prompt, return_messages=True, num_images=2, num_audios=2, skip_image_token=True, skip_audio_token=True) == plain_prompt
     counted = {"role": "user", "content": "Transcribe the audio."}
     for prompt in (counted, [counted]):
         _render_qwen(prompt_utils, prompt, num_audios=1)
@@ -653,7 +660,8 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
     anchored = _render_qwen(prompt_utils, conversation, return_messages=True,
                             num_images=1, num_audios=1, video="clip.mp4")
     assert result == "structured-rendered"
-    assert rendered_messages[0] == messages
+    assert rendered_messages[0][0]["content"] == messages[0]["content"][:4] + [{"type": "image"}] + messages[0]["content"][4:7] + [{"type": "audio"}] + messages[0]["content"][7:]
+    assert rendered_messages[0][1] == messages[1]
     assert len(rendered_messages) == 3
     for rendered in rendered_messages[1:]:
         assert [item["type"] for item in rendered[0]["content"]] == ["audio", "text"]

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -625,10 +625,13 @@ def test_vlm_prompt_patch_honors_qwen3_omni_media_suppression(monkeypatch):
 def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatch):
     import mlx_vlm.prompt_utils as prompt_utils
     import unsloth_zoo.mlx.loader as loader
+
     rendered_messages = []
+
     def counted_message(_model, text, role="user", **kwargs):
         videos = [{"type": "video", "video": kwargs["video"]}] if kwargs.get("video") else []
         return {"role": role, "content": videos + [{"type": "text", "text": text}]}
+
     _install_qwen_prompt_patch(
         monkeypatch, prompt_utils, loader,
         get_chat_template=(
@@ -637,18 +640,131 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
         ),
         get_message_json=counted_message,
     )
-    messages = [{"role": "user", "content": [
-        {"type": "input_video", "video": "clip.mp4"}, {"type": "video"},
-        {"type": "image", "image": "frame.png"}, {"type": "image"},
-        {"type": "input_audio", "audio": "first.wav"}, {"audio": "key-only.wav"}, {"type": "audio"}, {"type": "group", "content": [{"type": "input_audio", "audio": "nested.wav"}]},
-        {"type": "text", "text": "Transcribe the audio into text."},
-    ]}, {"role": "user", "content": [{"type": "input_image", "image": "second.png"}, {"type": "input_audio", "audio": "second.wav"}, {"type": "text", "text": "Continue."}]}]
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_video", "video": "clip.mp4"},
+                {"type": "video"},
+                {"type": "image", "image": "frame.png"},
+                {"type": "image"},
+                {"type": "input_audio", "audio": "first.wav"},
+                {"audio": "key-only.wav"},
+                {"type": "audio"},
+                {
+                    "type": "group",
+                    "content": [
+                        {"type": "input_audio", "audio": "nested.wav"},
+                    ],
+                },
+                {"type": "text", "text": "Transcribe the audio into text."},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_image", "image": "second.png"},
+                {"type": "input_audio", "audio": "second.wav"},
+                {"type": "text", "text": "Continue."},
+            ],
+        },
+    ]
     result = _render_qwen(prompt_utils, messages, num_images=4, num_audios=5)
-    plain, key_only = _render_qwen(prompt_utils, plain_prompt := [{"role": "user", "content": "First."}, messages[1]], return_messages=True, num_images=2, num_audios=2), _render_qwen(prompt_utils, key_only_prompt := [{"role": "user", "content": [{"audio": "only.wav", "metadata": {"source": "fixture"}}, {"audio_url": "second.wav"}, {"type": "text", "text": "Keep me."}]}], return_messages=True, num_audios=2)
-    assert [item["type"] for item in plain[0]["content"]] == ["image", "audio", "text"] and plain[0]["content"][-1]["text"] == "First." and plain[1] == messages[1] and key_only == key_only_prompt
-    nested = _render_qwen(prompt_utils, [{"role": "user", "content": messages[0]["content"][4:5] + messages[0]["content"][7:]}], return_messages=True, num_audios=2)
-    assert [item["type"] for item in nested[0]["content"]] == ["input_audio", "audio", "group", "text"]
-    assert _render_qwen(prompt_utils, plain_prompt, return_messages=True, num_images=1, num_audios=1) == plain_prompt and _render_qwen(prompt_utils, plain_prompt, return_messages=True, num_images=2, num_audios=2, skip_image_token=True, skip_audio_token=True) == plain_prompt
+
+    plain_prompt = [
+        {"role": "user", "content": "First."},
+        messages[1],
+    ]
+    plain = _render_qwen(
+        prompt_utils,
+        plain_prompt,
+        return_messages=True,
+        num_images=2,
+        num_audios=2,
+    )
+    key_only_prompt = [
+        {
+            "role": "user",
+            "content": [
+                {"audio": "only.wav", "metadata": {"source": "fixture"}},
+                {"audio_url": "second.wav"},
+                {"type": "text", "text": "Keep me."},
+            ],
+        },
+    ]
+    key_only = _render_qwen(
+        prompt_utils,
+        key_only_prompt,
+        return_messages=True,
+        num_audios=2,
+    )
+    complete_prompt = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Transcribe."},
+                {"type": "audio"},
+            ],
+        },
+    ]
+    complete = _render_qwen(
+        prompt_utils,
+        complete_prompt,
+        return_messages=True,
+        num_audios=1,
+    )
+    nested_prompt = [
+        {
+            "role": "user",
+            "content": (
+                messages[0]["content"][4:5]
+                + messages[0]["content"][7:]
+            ),
+        },
+    ]
+    nested = _render_qwen(
+        prompt_utils,
+        nested_prompt,
+        return_messages=True,
+        num_audios=2,
+    )
+
+    assert [item["type"] for item in plain[0]["content"]] == [
+        "image",
+        "audio",
+        "text",
+    ]
+    assert plain[0]["content"][-1]["text"] == "First."
+    assert plain[1] == messages[1]
+    assert key_only == key_only_prompt
+    assert [item["type"] for item in complete[0]["content"]] == [
+        "audio",
+        "text",
+    ]
+    assert [item["type"] for item in nested[0]["content"]] == [
+        "input_audio",
+        "audio",
+        "group",
+        "text",
+    ]
+    assert _render_qwen(
+        prompt_utils,
+        plain_prompt,
+        return_messages=True,
+        num_images=1,
+        num_audios=1,
+    ) == plain_prompt
+    assert _render_qwen(
+        prompt_utils,
+        plain_prompt,
+        return_messages=True,
+        num_images=2,
+        num_audios=2,
+        skip_image_token=True,
+        skip_audio_token=True,
+    ) == plain_prompt
+
     counted = {"role": "user", "content": "Transcribe the audio."}
     for prompt in (counted, [counted]):
         _render_qwen(prompt_utils, prompt, num_audios=1)
@@ -659,8 +775,15 @@ def test_vlm_prompt_patch_preserves_structured_qwen3_omni_media_order(monkeypatc
     ]
     anchored = _render_qwen(prompt_utils, conversation, return_messages=True,
                             num_images=1, num_audios=1, video="clip.mp4")
+
     assert result == "structured-rendered"
-    assert rendered_messages[0][0]["content"] == messages[0]["content"][:4] + [{"type": "image"}] + messages[0]["content"][4:7] + [{"type": "audio"}] + messages[0]["content"][7:]
+    assert rendered_messages[0][0]["content"] == (
+        messages[0]["content"][:4]
+        + [{"type": "image"}]
+        + messages[0]["content"][4:7]
+        + [{"type": "audio"}]
+        + messages[0]["content"][7:]
+    )
     assert rendered_messages[0][1] == messages[1]
     assert len(rendered_messages) == 3
     for rendered in rendered_messages[1:]:

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2705,9 +2705,9 @@ def test_qualified_families_carry_their_probed_requirements():
     assert mlx_utils._AUDIO_QUALIFIED_FAMILIES == {
         "gemma3n": versions("0.4.4"),
         "gemma4": versions("0.6.2"),
-        "gemma4_unified": versions("0.6.1"),
+        "gemma4_unified": versions("0.6.5"),
         "nemotron_h_nano_omni": versions("0.5.0"),
-        "qwen3_omni_moe": versions("0.6.0"),
+        "qwen3_omni_moe": versions("0.6.7"),
         "phi4mm": versions("0.4.4"),
         "minicpmo": versions("0.4.4"),
     }
@@ -2816,7 +2816,7 @@ def test_only_a_published_final_release_is_at_or_above_the_floor():
     assert gemma4.admits("99.0.0") is True
 
 
-def test_new_audio_families_start_at_their_upstream_introduction(monkeypatch):
+def test_new_audio_families_start_at_their_complete_audio_implementation(monkeypatch):
     from unsloth_zoo.mlx import utils as mlx_utils
     def make_processor(module):
         cls = type("Processor", (), {})
@@ -2825,9 +2825,9 @@ def test_new_audio_families_start_at_their_upstream_introduction(monkeypatch):
     unified = make_processor("gemma4_unified")
     assert mlx_utils._audio_family_from_processor(unified) == "gemma4_unified"
     for processor, family, floor, below in (
-        (unified, "gemma4_unified", "0.6.1", "0.6.0"),
+        (unified, "gemma4_unified", "0.6.5", "0.6.4"),
         (make_processor("nemotron_h_nano_omni"), "nemotron_h_nano_omni", "0.5.0", "0.4.4"),
-        (make_processor("qwen3_omni_moe"), "qwen3_omni_moe", "0.6.0", "0.5.0"),
+        (make_processor("qwen3_omni_moe"), "qwen3_omni_moe", "0.6.7", "0.6.6"),
     ):
         monkeypatch.setattr(
             mlx_utils, "_installed_mlx_vlm_version", lambda floor=floor: floor,

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3782,23 +3782,49 @@ def test_the_projection_after_the_audio_tower_is_frozen_too():
     assert model.audio_tower.frozen and model.audio_projection_layer.frozen
 
 
+class _FrozenAudioModule:
+    def __init__(self):
+        self.frozen = False
+
+    def freeze(self, recurse=False):
+        self.frozen = recurse
+
+
 def test_nemotron_sound_encoder_and_projection_are_frozen():
     from unsloth_zoo.mlx.utils import freeze_audio_modules
 
-    class _Module:
-        def __init__(self):
-            self.frozen = False
-
-        def freeze(self, recurse=False):
-            self.frozen = recurse
-
     model = type("Nemotron", (), {
-        "sound_encoder": _Module(), "sound_projection": _Module(),
+        "sound_encoder": _FrozenAudioModule(),
+        "sound_projection": _FrozenAudioModule(),
     })()
     assert set(freeze_audio_modules(model)) == {
         "sound_encoder", "sound_projection",
     }
     assert model.sound_encoder.frozen and model.sound_projection.frozen
+
+
+def test_qwen3_omni_nested_audio_tower_is_frozen():
+    from unsloth_zoo.mlx.utils import freeze_audio_modules
+
+    audio_tower = _FrozenAudioModule()
+    model = type("Qwen3Omni", (), {
+        "thinker": type("Thinker", (), {"audio_tower": audio_tower})(),
+    })()
+
+    assert freeze_audio_modules(model) == ["audio_tower"]
+    assert audio_tower.frozen
+
+
+def test_qwen3_omni_audio_output_modules_are_frozen():
+    from unsloth_zoo.mlx.utils import freeze_audio_modules
+
+    model = type("Qwen3Omni", (), {
+        "talker": _FrozenAudioModule(),
+        "code2wav": _FrozenAudioModule(),
+    })()
+
+    assert set(freeze_audio_modules(model)) == {"talker", "code2wav"}
+    assert model.talker.frozen and model.code2wav.frozen
 
 
 def test_stated_spans_refuse_the_left_padding_repair():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2709,6 +2709,7 @@ def test_qualified_families_carry_their_probed_requirements():
         "gemma4": versions("0.6.2", "0.6.4"),
         "gemma4_unified": versions("0.6.1", "0.6.10"),
         "nemotron_h_nano_omni": versions("0.5.0", "0.6.10"),
+        "qwen3_omni_moe": versions("0.6.0", "0.6.10"),
         "phi4mm": versions("0.4.4", "0.6.4"),
         "minicpmo": versions("0.4.4", "0.6.4"),
     }
@@ -2832,9 +2833,14 @@ def test_new_audio_families_start_at_their_upstream_introduction(monkeypatch):
     nemotron.__module__ = (
         "mlx_vlm.models.nemotron_h_nano_omni.processing_nemotron_h_nano_omni"
     )
+    qwen3_omni = type("Qwen3OmniProcessor", (), {})
+    qwen3_omni.__module__ = (
+        "mlx_vlm.models.qwen3_omni_moe.processing_qwen3_omni_moe"
+    )
     for processor, family, floor, below in (
         (unified(), "gemma4_unified", "0.6.1", "0.6.0"),
         (nemotron(), "nemotron_h_nano_omni", "0.5.0", "0.4.4"),
+        (qwen3_omni(), "qwen3_omni_moe", "0.6.0", "0.5.0"),
     ):
         monkeypatch.setattr(
             mlx_utils, "_installed_mlx_vlm_version", lambda floor=floor: floor,

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2706,7 +2706,7 @@ def test_qualified_families_carry_their_probed_requirements():
         "gemma3n": versions("0.4.4"),
         "gemma4": versions("0.6.2"),
         "gemma4_unified": versions("0.6.5"),
-        "nemotron_h_nano_omni": versions("0.5.0"),
+        "nemotron_h_nano_omni": versions("0.6.10"),
         "qwen3_omni_moe": versions("0.6.7"),
         "phi4mm": versions("0.4.4"),
         "minicpmo": versions("0.4.4"),
@@ -2826,7 +2826,9 @@ def test_new_audio_families_start_at_their_complete_audio_implementation(monkeyp
     assert mlx_utils._audio_family_from_processor(unified) == "gemma4_unified"
     for processor, family, floor, below in (
         (unified, "gemma4_unified", "0.6.5", "0.6.4"),
-        (make_processor("nemotron_h_nano_omni"), "nemotron_h_nano_omni", "0.5.0", "0.4.4"),
+        # 0.6.10, not the 0.5.0 that first carried the family: below it
+        # `sanitize_audio_weights` double-transposes pre-converted sound convs.
+        (make_processor("nemotron_h_nano_omni"), "nemotron_h_nano_omni", "0.6.10", "0.6.7"),
         (make_processor("qwen3_omni_moe"), "qwen3_omni_moe", "0.6.7", "0.6.6"),
     ):
         monkeypatch.setattr(
@@ -3797,6 +3799,70 @@ def test_qwen3_omni_audio_output_modules_are_frozen():
     })()
     assert set(freeze_audio_modules(model)) == {"talker", "code2wav"}
     assert model.talker.frozen and model.code2wav.frozen
+
+
+def test_every_owner_of_an_audio_name_is_frozen_not_just_the_first():
+    """A model can carry the same attribute name at two levels.
+
+    Stopping at the first owner left a distinct nested tower trainable, which is
+    exactly the parameter set this call exists to keep out of the optimizer.
+    """
+    from unsloth_zoo.mlx.utils import freeze_audio_modules
+
+    outer, nested = _FrozenAudioModule(), _FrozenAudioModule()
+    model = type("TwoLevel", (), {
+        "audio_tower": outer,
+        "thinker": type("Thinker", (), {"audio_tower": nested})(),
+    })()
+
+    assert freeze_audio_modules(model).count("audio_tower") == 2
+    assert outer.frozen and nested.frozen
+
+
+def test_a_module_shared_by_two_owners_is_frozen_once():
+    """Identity dedupe: an alias must not be reported as a second module."""
+    from unsloth_zoo.mlx.utils import freeze_audio_modules
+
+    shared = _FrozenAudioModule()
+    model = type("Aliased", (), {
+        "audio_tower": shared,
+        "language_model": type("LM", (), {"audio_tower": shared})(),
+    })()
+
+    assert freeze_audio_modules(model) == ["audio_tower"]
+    assert shared.frozen
+
+
+def test_nemotron_floor_clears_the_unconditional_sound_conv_sanitize():
+    """Why Nemotron starts at 0.6.10 rather than the 0.5.0 that first shipped it.
+
+    Below 0.6.10 mlx-vlm transposes `sound_encoder.encoder.*` convs
+    unconditionally, so an already-MLX-major weight double-transposes and the
+    checkpoint cannot load. Measured on the real function:
+
+        0.5.0 / 0.6.4 / 0.6.7   (128, 3, 3, 1) -> (128, 3, 1, 3)   corrupted
+        0.6.10 / 0.6.12         (128, 3, 3, 1) -> (128, 3, 3, 1)   left alone
+
+    gemma4's `_ensure_audio_conv_sanitize` repair does not reach this family:
+    it keys on markers in the sanitize source, and Nemotron's `Model.sanitize`
+    delegates to a module-level function carrying neither.
+    """
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    floor = mlx_utils._AUDIO_QUALIFIED_FAMILIES["nemotron_h_nano_omni"]
+    assert floor.minimum == "0.6.10"
+    assert not floor.admits("0.6.7")
+    assert floor.admits("0.6.10")
+
+
+def test_a_turn_without_content_is_returned_untouched():
+    """Every other shape check in this helper returns the message unchanged; a
+    dict with no "content" key (a tool call, an empty assistant stub) raised
+    KeyError instead."""
+    from unsloth_zoo.mlx.loader import _normalize_qwen3_omni_counted_message
+
+    for message in ({"role": "user"}, {"role": "assistant", "content": None}):
+        assert _normalize_qwen3_omni_counted_message(message, 1, 1, {}) == message
 
 
 def test_stated_spans_refuse_the_left_padding_repair():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2707,8 +2707,8 @@ def test_qualified_families_carry_their_probed_requirements():
     assert mlx_utils._AUDIO_QUALIFIED_FAMILIES == {
         "gemma3n": versions("0.4.4", "0.6.4"),
         "gemma4": versions("0.6.2", "0.6.4"),
-        "gemma4_unified": versions("0.6.10", "0.6.10"),
-        "nemotron_h_nano_omni": versions("0.6.10", "0.6.10"),
+        "gemma4_unified": versions("0.6.1", "0.6.10"),
+        "nemotron_h_nano_omni": versions("0.5.0", "0.6.10"),
         "phi4mm": versions("0.4.4", "0.6.4"),
         "minicpmo": versions("0.4.4", "0.6.4"),
     }
@@ -2822,7 +2822,7 @@ def test_only_a_published_final_release_is_inside_the_window():
     assert gemma4.admits("0.6.5") is False
 
 
-def test_new_audio_families_are_qualified_only_on_the_measured_release(monkeypatch):
+def test_new_audio_families_start_at_their_upstream_introduction(monkeypatch):
     from unsloth_zoo.mlx import utils as mlx_utils
 
     unified = type("Gemma4UnifiedProcessor", (), {})
@@ -2832,26 +2832,41 @@ def test_new_audio_families_are_qualified_only_on_the_measured_release(monkeypat
     nemotron.__module__ = (
         "mlx_vlm.models.nemotron_h_nano_omni.processing_nemotron_h_nano_omni"
     )
-    for processor, family in ((unified(), "gemma4_unified"),
-                              (nemotron(), "nemotron_h_nano_omni")):
+    for processor, family, floor, below in (
+        (unified(), "gemma4_unified", "0.6.1", "0.6.0"),
+        (nemotron(), "nemotron_h_nano_omni", "0.5.0", "0.4.4"),
+    ):
         monkeypatch.setattr(
-            mlx_utils, "_installed_mlx_vlm_version", lambda: "0.6.10",
+            mlx_utils, "_installed_mlx_vlm_version", lambda floor=floor: floor,
         )
         assert mlx_utils._check_audio_family_gate(processor) == family
         monkeypatch.setattr(
             mlx_utils, "_installed_mlx_vlm_version", lambda: "0.6.9",
         )
+        assert mlx_utils._check_audio_family_gate(processor) == family
+        monkeypatch.setattr(
+            mlx_utils, "_installed_mlx_vlm_version", lambda below=below: below,
+        )
+        with pytest.raises(NotImplementedError, match="only been verified"):
+            mlx_utils._check_audio_family_gate(processor)
+        monkeypatch.setattr(
+            mlx_utils, "_installed_mlx_vlm_version", lambda: "0.6.11",
+        )
         with pytest.raises(NotImplementedError, match="only been verified"):
             mlx_utils._check_audio_family_gate(processor)
 
 
-def test_diffusion_gemma_audio_refusal_names_the_missing_native_modality():
+def test_diffusion_gemma_uses_the_generic_unsupported_family_refusal():
     from unsloth_zoo.mlx import utils as mlx_utils
 
     processor = type("DiffusionGemmaProcessor", (), {})
     processor.__module__ = "mlx_vlm.models.diffusion_gemma.processing_diffusion_gemma"
-    with pytest.raises(NotImplementedError, match="no native audio modality"):
+    with pytest.raises(
+        NotImplementedError,
+        match="audio training is not supported for 'diffusion_gemma'",
+    ) as excinfo:
         mlx_utils._check_audio_family_gate(processor())
+    assert "published checkpoint" not in str(excinfo.value)
 
 
 def test_the_transformers_floor_refuses_a_prerelease_for_the_right_reason(

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -5052,3 +5052,47 @@ def test_a_bare_audio_placeholder_still_reports_itself_as_bare():
         ]}]
     )
     assert bare is False and payloads == []
+
+
+def test_qwen3_omni_normalizes_embedded_media_without_scalar_counts():
+    """Media embedded in the messages leaves `num_images`/`num_audios` at zero,
+    and the ordering is wrong on its own merits, so gating normalization on the
+    counts let `text, audio` reach the template unchanged."""
+    from mlx_vlm import prompt_utils
+    from unsloth_zoo.mlx.loader import _prepare_vlm_template_messages
+
+    messages = [{"role": "user", "content": [
+        {"type": "text", "text": "transcribe"},
+        {"type": "audio", "audio": "a.wav"},
+    ]}]
+    _, template, _ = _prepare_vlm_template_messages(
+        prompt_utils, "qwen3_omni_moe", messages, num_images = 0, num_audios = 0, kwargs = {},
+    )
+
+    assert [part.get("type") for part in template[0]["content"]] == ["audio", "text"]
+    # Counts still drive the deficit, they just no longer gate the reordering.
+    assert [part.get("type") for part in messages[0]["content"]] == ["text", "audio"]
+
+
+def test_qwen3_omni_leaves_assistant_turns_alone_without_counts():
+    """Reordering every turn must still skip the roles the renderer treats as
+    non-user, otherwise assistant history gets rewritten."""
+    from mlx_vlm import prompt_utils
+    from unsloth_zoo.mlx.loader import _prepare_vlm_template_messages
+
+    messages = [
+        {"role": "assistant", "content": [
+            {"type": "text", "text": "prior"},
+            {"type": "audio", "audio": "a.wav"},
+        ]},
+        {"role": "user", "content": [
+            {"type": "audio", "audio": "b.wav"},
+            {"type": "text", "text": "next"},
+        ]},
+    ]
+    _, template, _ = _prepare_vlm_template_messages(
+        prompt_utils, "qwen3_omni_moe", messages, num_images = 0, num_audios = 0, kwargs = {},
+    )
+
+    assert [part.get("type") for part in template[0]["content"]] == ["text", "audio"]
+    assert [part.get("type") for part in template[1]["content"]] == ["audio", "text"]

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2826,8 +2826,6 @@ def test_new_audio_families_start_at_their_complete_audio_implementation(monkeyp
     assert mlx_utils._audio_family_from_processor(unified) == "gemma4_unified"
     for processor, family, floor, below in (
         (unified, "gemma4_unified", "0.6.5", "0.6.4"),
-        # 0.6.10, not the 0.5.0 that first carried the family: below it
-        # `sanitize_audio_weights` double-transposes pre-converted sound convs.
         (make_processor("nemotron_h_nano_omni"), "nemotron_h_nano_omni", "0.6.10", "0.6.7"),
         (make_processor("qwen3_omni_moe"), "qwen3_omni_moe", "0.6.7", "0.6.6"),
     ):
@@ -3802,11 +3800,7 @@ def test_qwen3_omni_audio_output_modules_are_frozen():
 
 
 def test_every_owner_of_an_audio_name_is_frozen_not_just_the_first():
-    """A model can carry the same attribute name at two levels.
-
-    Stopping at the first owner left a distinct nested tower trainable, which is
-    exactly the parameter set this call exists to keep out of the optimizer.
-    """
+    """Stopping at the first owner left a distinct nested tower trainable."""
     from unsloth_zoo.mlx.utils import freeze_audio_modules
 
     outer, nested = _FrozenAudioModule(), _FrozenAudioModule()
@@ -3834,19 +3828,8 @@ def test_a_module_shared_by_two_owners_is_frozen_once():
 
 
 def test_nemotron_floor_clears_the_unconditional_sound_conv_sanitize():
-    """Why Nemotron starts at 0.6.10 rather than the 0.5.0 that first shipped it.
-
-    Below 0.6.10 mlx-vlm transposes `sound_encoder.encoder.*` convs
-    unconditionally, so an already-MLX-major weight double-transposes and the
-    checkpoint cannot load. Measured on the real function:
-
-        0.5.0 / 0.6.4 / 0.6.7   (128, 3, 3, 1) -> (128, 3, 1, 3)   corrupted
-        0.6.10 / 0.6.12         (128, 3, 3, 1) -> (128, 3, 3, 1)   left alone
-
-    gemma4's `_ensure_audio_conv_sanitize` repair does not reach this family:
-    it keys on markers in the sanitize source, and Nemotron's `Model.sanitize`
-    delegates to a module-level function carrying neither.
-    """
+    """Below 0.6.10, `sanitize_audio_weights` double-transposes a pre-converted
+    sound conv ((128,3,3,1) -> (128,3,1,3)) and the checkpoint cannot load."""
     from unsloth_zoo.mlx import utils as mlx_utils
 
     floor = mlx_utils._AUDIO_QUALIFIED_FAMILIES["nemotron_h_nano_omni"]
@@ -3856,9 +3839,8 @@ def test_nemotron_floor_clears_the_unconditional_sound_conv_sanitize():
 
 
 def test_a_turn_without_content_is_returned_untouched():
-    """Every other shape check in this helper returns the message unchanged; a
-    dict with no "content" key (a tool call, an empty assistant stub) raised
-    KeyError instead."""
+    """A dict with no "content" key raised KeyError where every other shape
+    check in this helper returns the message unchanged."""
     from unsloth_zoo.mlx.loader import _normalize_qwen3_omni_counted_message
 
     for message in ({"role": "user"}, {"role": "assistant", "content": None}):

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3763,22 +3763,20 @@ def test_the_projection_after_the_audio_tower_is_frozen_too():
 
 
 class _FrozenAudioModule:
-    def __init__(self):
-        self.frozen = False
+    frozen = False
     def freeze(self, recurse=False):
         self.frozen = recurse
 
 
-def test_nemotron_sound_encoder_and_projection_are_frozen():
+def test_nemotron_sound_modules_are_frozen_and_not_quantized():
+    import unsloth_zoo.mlx.loader as mlx_loader
     from unsloth_zoo.mlx.utils import freeze_audio_modules
-    model = type("Nemotron", (), {
-        "sound_encoder": _FrozenAudioModule(),
-        "sound_projection": _FrozenAudioModule(),
-    })()
-    assert set(freeze_audio_modules(model)) == {
-        "sound_encoder", "sound_projection",
-    }
-    assert model.sound_encoder.frozen and model.sound_projection.frozen
+    names = ("sound_encoder", "sound_projection")
+    model = type("Nemotron", (), {name: _FrozenAudioModule() for name in names})()
+    assert set(freeze_audio_modules(model)) == set(names)
+    assert all(getattr(model, name).frozen for name in names)
+    predicate = mlx_loader._compose_mlx_quant_predicate(model, mlx_loader._MLXQuantizationSpec(), is_vlm=True)
+    assert all(not predicate(name, object()) for name in names)
 
 
 def test_qwen3_omni_nested_audio_tower_is_frozen():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2707,6 +2707,8 @@ def test_qualified_families_carry_their_probed_requirements():
     assert mlx_utils._AUDIO_QUALIFIED_FAMILIES == {
         "gemma3n": versions("0.4.4", "0.6.4"),
         "gemma4": versions("0.6.2", "0.6.4"),
+        "gemma4_unified": versions("0.6.10", "0.6.10"),
+        "nemotron_h_nano_omni": versions("0.6.10", "0.6.10"),
         "phi4mm": versions("0.4.4", "0.6.4"),
         "minicpmo": versions("0.4.4", "0.6.4"),
     }
@@ -2820,25 +2822,36 @@ def test_only_a_published_final_release_is_inside_the_window():
     assert gemma4.admits("0.6.5") is False
 
 
-def test_the_renamed_gemma4_family_is_refused_by_the_name_it_now_loads_under():
-    """mlx-vlm 0.6.3 added `gemma4_unified` beside `gemma4`, so a gemma 4
-    checkpoint can present under a family key this gate never qualified.
-    Refusing it as simply unrecognised tells the user nothing they can act on;
-    the refusal names the entry they are actually looking for."""
+def test_new_audio_families_are_qualified_only_on_the_measured_release(monkeypatch):
     from unsloth_zoo.mlx import utils as mlx_utils
 
     unified = type("Gemma4UnifiedProcessor", (), {})
     unified.__module__ = "mlx_vlm.models.gemma4_unified.processing_gemma4_unified"
     assert mlx_utils._audio_family_from_processor(unified()) == "gemma4_unified"
+    nemotron = type("NemotronProcessor", (), {})
+    nemotron.__module__ = (
+        "mlx_vlm.models.nemotron_h_nano_omni.processing_nemotron_h_nano_omni"
+    )
+    for processor, family in ((unified(), "gemma4_unified"),
+                              (nemotron(), "nemotron_h_nano_omni")):
+        monkeypatch.setattr(
+            mlx_utils, "_installed_mlx_vlm_version", lambda: "0.6.10",
+        )
+        assert mlx_utils._check_audio_family_gate(processor) == family
+        monkeypatch.setattr(
+            mlx_utils, "_installed_mlx_vlm_version", lambda: "0.6.9",
+        )
+        with pytest.raises(NotImplementedError, match="only been verified"):
+            mlx_utils._check_audio_family_gate(processor)
 
-    with pytest.raises(NotImplementedError) as excinfo:
-        mlx_utils._check_audio_family_gate(unified())
-    message = str(excinfo.value)
-    assert "gemma4_unified" in message and "'gemma4'" in message
-    # Read the window off the table: the refusal must name whatever gemma4 is
-    # currently qualified for, and that moves when it is re-probed.
-    window = str(mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"])
-    assert window in message, "the version to pin is not named"
+
+def test_diffusion_gemma_audio_refusal_names_the_missing_native_modality():
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    processor = type("DiffusionGemmaProcessor", (), {})
+    processor.__module__ = "mlx_vlm.models.diffusion_gemma.processing_diffusion_gemma"
+    with pytest.raises(NotImplementedError, match="no native audio modality"):
+        mlx_utils._check_audio_family_gate(processor())
 
 
 def test_the_transformers_floor_refuses_a_prerelease_for_the_right_reason(
@@ -3482,6 +3495,13 @@ def test_the_delimiters_around_an_audio_run_are_not_targets():
     assert {151697, 151699} <= set(_get_vlm_ignore_token_ids(processor=_Delimited()))
 
 
+def test_nemotron_declares_its_sampling_rate_on_the_processor():
+    from unsloth_zoo.mlx.utils import audio_extractor_sampling_rate
+
+    processor = type("NemotronProcessor", (), {"audio_sampling_rate": 16000})()
+    assert audio_extractor_sampling_rate(processor) == 16000
+
+
 def test_a_bare_message_list_row_is_scanned_for_audio(monkeypatch):
     """A row that is itself a list of messages is a supported shape, which
     _collate_vlm_batch normalizes. The pre-formatter scan has to see it too:
@@ -3739,6 +3759,25 @@ def test_the_projection_after_the_audio_tower_is_frozen_too():
         "audio_tower", "audio_projection_layer",
     }
     assert model.audio_tower.frozen and model.audio_projection_layer.frozen
+
+
+def test_nemotron_sound_encoder_and_projection_are_frozen():
+    from unsloth_zoo.mlx.utils import freeze_audio_modules
+
+    class _Module:
+        def __init__(self):
+            self.frozen = False
+
+        def freeze(self, recurse=False):
+            self.frozen = recurse
+
+    model = type("Nemotron", (), {
+        "sound_encoder": _Module(), "sound_projection": _Module(),
+    })()
+    assert set(freeze_audio_modules(model)) == {
+        "sound_encoder", "sound_projection",
+    }
+    assert model.sound_encoder.frozen and model.sound_projection.frozen
 
 
 def test_stated_spans_refuse_the_left_padding_repair():
@@ -4004,6 +4043,23 @@ def test_clips_of_unequal_duration_all_reach_the_model():
     assert tuple(stacked.shape) == (2, 80, 300)
 
 
+def test_nemotron_sound_clips_stay_a_list_even_when_shapes_match():
+    """Nemotron's extractor interprets a stacked matrix as one multichannel
+    clip, so equal-length waveforms must retain the list contract too."""
+    from unsloth_zoo.mlx.utils import (
+        _assert_audio_features_present, _to_mx_vlm_batch,
+        _vlm_batch_carries_audio,
+    )
+
+    inputs = {"sound_clips": [np.zeros(1600, np.float32),
+                              np.ones(1600, np.float32)]}
+    _assert_audio_features_present(inputs, 2, _FakeProcessor())
+    clips = _to_mx_vlm_batch(inputs)["sound_clips"]
+    assert isinstance(clips, list) and len(clips) == 2
+    assert all(tuple(clip.shape) == (1600,) for clip in clips)
+    assert _vlm_batch_carries_audio({"sound_clips": clips}) is True
+
+
 def test_nested_audio_rows_are_paired_clip_by_clip():
     """A processor that wants ``(samples, rate)`` pairs may also want its audio
     nested per row (MiniCPM-o). Pairing the payload as though its entries were
@@ -4211,6 +4267,7 @@ def test_an_empty_audio_payload_is_not_audio():
     # audio than an empty array is.
     assert not _vlm_batch_carries_audio({"input_audio_embeds": []})
     assert _vlm_batch_carries_audio({"input_audio_embeds": [object()]})
+    assert not _vlm_batch_carries_audio({"sound_clips": []})
 
 
 def test_audio_spans_are_checked_against_attended_positions():
@@ -4596,7 +4653,8 @@ def test_audio_modules_are_found_wherever_the_family_nests_them():
 
     for names in (("audio_tower", "embed_audio"),
                   ("audio_tower", "audio_projection_layer"),
-                  ("embed_tokens_extend.audio_embed.audio_encoder",)):
+                  ("embed_tokens_extend.audio_embed.audio_encoder",),
+                  ("sound_encoder", "sound_projection")):
         verdict = audio_input_capability(_AudioModel(names), _ProbeProcessor())
         assert verdict.model_ok is True and verdict.capable is True, names
     absent = audio_input_capability(
@@ -4778,6 +4836,40 @@ def test_shielding_the_audio_side_leaves_the_text_side_flat():
         all_audio=[[np.zeros(16000, np.float32)]],
     )
     assert processor.text_saw == {"max_length": 512, "padding": True}
+
+
+def test_processor_forwarding_kwargs_to_its_tokenizer_drops_audio_shield():
+    """Gemma 4 consumes audio itself but forwards every remaining keyword to
+    its tokenizer, where the modality-only `audio_kwargs` shield is invalid."""
+    from unsloth_zoo.mlx.utils import _processor_vlm_inputs
+
+    class _Gemma4Style(_FakeProcessor):
+        feature_extractor = type("_Extractor", (), {"sampling_rate": 16000})()
+
+        def __init__(self):
+            self.calls = []
+
+        def __call__(self, text, audio=None, **kwargs):
+            self.calls.append(dict(kwargs))
+            if "audio_kwargs" in kwargs:
+                raise TypeError(
+                    "PreTrainedTokenizerFast._batch_encode_plus() got an "
+                    "unexpected keyword argument 'audio_kwargs'"
+                )
+            return {
+                "input_ids": np.ones((len(text), 4), np.int32),
+                "attention_mask": np.ones((len(text), 4), np.int32),
+                "input_features": np.ones((len(audio), 8, 4), np.float32),
+            }
+
+    processor = _Gemma4Style()
+    result = _processor_vlm_inputs(
+        processor, ["prompt"], [[]], 128, all_audio=[[_CLIP]],
+    )
+    assert result["input_features"].shape[0] == 1
+    assert len(processor.calls) == 2
+    assert processor.calls[1]["max_length"] == 128
+    assert "audio_kwargs" not in processor.calls[1]
 
 
 def test_a_text_only_batch_is_collated_exactly_as_before():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -4946,8 +4946,9 @@ def test_a_text_only_batch_is_collated_exactly_as_before():
 
 
 def test_qwen3_omni_counts_video_url_as_video():
-    """`video_url` carries no "video" key, so it grouped as text and rendered
-    after the audio Qwen requires it to precede."""
+    """`video_url` carries no "video" key, so the two counters disagreed on an
+    alias one of them accepts. Grouping only; the native template renders no
+    placeholder for this shape, verified against its own chat_template.jinja."""
     from unsloth_zoo.mlx.loader import (
         _qwen3_omni_media_counts,
         _normalize_qwen3_omni_counted_message,

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2297,7 +2297,7 @@ def _qualify(monkeypatch, processor=None, version=None):
         processor or _FakeGemmaAudioProcessor())
     pinned = version or mlx_utils._installed_mlx_vlm_version()
     monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES",
-                        {family: mlx_utils._AudioVersions(pinned, pinned)})
+                        {family: mlx_utils._AudioVersions(pinned)})
 
 
 @pytest.mark.parametrize("gate,message", [
@@ -2695,23 +2695,21 @@ def test_audio_merge_compacts_valid_features_per_row():
 def test_qualified_families_carry_their_probed_requirements():
     """The table itself: which families, over which mlx-vlm releases.
 
-    Bounded at both ends, so an unreleased version is refused rather than
-    assumed good. Gemma 4 starts higher than the rest because below 0.6.2
-    mlx-vlm cannot load the checkpoint at all: E2B's KV-shared layers ship no
-    k_proj/v_proj/k_norm, and mlx-vlm built those modules regardless until
-    Blaizzy/mlx-vlm#1301.
+    Gemma 4 starts higher than the rest because below 0.6.2 mlx-vlm cannot load
+    the checkpoint at all: E2B's KV-shared layers ship no k_proj/v_proj/k_norm,
+    and mlx-vlm built those modules regardless until Blaizzy/mlx-vlm#1301.
     """
     from unsloth_zoo.mlx import utils as mlx_utils
 
     versions = mlx_utils._AudioVersions
     assert mlx_utils._AUDIO_QUALIFIED_FAMILIES == {
-        "gemma3n": versions("0.4.4", "0.6.4"),
-        "gemma4": versions("0.6.2", "0.6.4"),
-        "gemma4_unified": versions("0.6.1", "0.6.10"),
-        "nemotron_h_nano_omni": versions("0.5.0", "0.6.10"),
-        "qwen3_omni_moe": versions("0.6.0", "0.6.10"),
-        "phi4mm": versions("0.4.4", "0.6.4"),
-        "minicpmo": versions("0.4.4", "0.6.4"),
+        "gemma3n": versions("0.4.4"),
+        "gemma4": versions("0.6.2"),
+        "gemma4_unified": versions("0.6.1"),
+        "nemotron_h_nano_omni": versions("0.5.0"),
+        "qwen3_omni_moe": versions("0.6.0"),
+        "phi4mm": versions("0.4.4"),
+        "minicpmo": versions("0.4.4"),
     }
 
 
@@ -2723,11 +2721,11 @@ def test_qualified_families_carry_their_probed_requirements():
     ("0.6.2", True),         # #1301: KV-shared layers stop building k/v proj
     ("0.6.3", True),
     ("0.6.4", True),         # double conv transpose, undone by loader.py (PR 879)
-    ("0.6.5", False),        # needs transformers>=5.14, capped at 5.5.0
+    ("0.6.5", True),         # later compatible final releases follow the floor
     ("0.6.2.post1", False),  # post-releases and prereleases were not probed
     ("0.6.2rc1", False),
 ])
-def test_gemma4_admits_only_the_versions_that_can_load_the_checkpoint(
+def test_gemma4_admits_final_releases_from_the_loadable_floor(
         installed, admitted):
     """The boundary, measured rather than argued.
 
@@ -2736,24 +2734,22 @@ def test_gemma4_admits_only_the_versions_that_can_load_the_checkpoint(
     against what the audio tower returns, and two clips giving two losses.
     0.6.1 red, 0.6.2 green.
 
-    The other rows are policy, not measurement. 0.6.5 cannot be installed
-    beside this package (it needs transformers>=5.14, capped at 5.5.0), and
-    mlx-vlm has published no post-release or prerelease to run.
+    Later compatible final releases follow the package resolver policy.
     """
     from unsloth_zoo.mlx import utils as mlx_utils
 
-    window = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"]
-    assert window.admits(installed) is admitted, installed
+    floor = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma4"]
+    assert floor.admits(installed) is admitted, installed
 
 
 @pytest.mark.parametrize("installed,admitted", [
     ("0.4.3", False),        # below the probed floor
     ("0.4.4", True),         # the probed version
     ("0.5.0", True),
-    ("0.6.4", True),         # ceiling: 0.6.5+ needs transformers>=5.14,
-    ("0.6.5", False),        # which this package caps at 5.5.0
-    ("0.6.9", False),
-    ("0.5.0rc1", False),     # prereleases inside the window: never qualified
+    ("0.6.4", True),
+    ("0.6.5", True),
+    ("99.0.0", True),        # no manually maintained release ceiling
+    ("0.5.0rc1", False),     # prereleases above the floor: never qualified
     ("0.4.5.dev0", False),
     ("0.4.4.post1", False),  # nor post-releases or local builds
     ("0.6.4.post1", False),
@@ -2761,11 +2757,11 @@ def test_gemma4_admits_only_the_versions_that_can_load_the_checkpoint(
     ("", False),             # unreadable: not evidence of anything
     ("not-a-version", False),
 ])
-def test_the_gate_admits_exactly_its_qualified_window(installed, admitted):
+def test_the_gate_admits_final_releases_at_or_above_its_floor(installed, admitted):
     from unsloth_zoo.mlx import utils as mlx_utils
 
-    window = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma3n"]
-    assert window.admits(installed) is admitted, installed
+    floor = mlx_utils._AUDIO_QUALIFIED_FAMILIES["gemma3n"]
+    assert floor.admits(installed) is admitted, installed
 
 
 @pytest.mark.parametrize("installed,allowed", [
@@ -2775,16 +2771,14 @@ def test_the_gate_admits_exactly_its_qualified_window(installed, admitted):
     ("0.5.0", True),
     ("0.5.0rc1", False),
     ("0.6.4", True),
-    ("0.6.5", False),
-    ("0.6.9", False),
+    ("0.6.5", True),
+    ("99.0.0", True),
 ])
-def test_the_gate_itself_honours_the_range_not_just_the_range_object(
+def test_the_gate_itself_honours_the_floor_not_just_the_version_object(
         monkeypatch, installed, allowed):
     """Drives `_check_audio_family_gate`, not `_AudioVersions.admits`.
 
-    Asserting the range object alone would pass just as happily with the gate
-    still comparing strings, which is the whole defect. Whether an audio row
-    trains or is refused is decided here.
+    Whether an audio row trains or is refused is decided here.
     """
     from unsloth_zoo.mlx import utils as mlx_utils
 
@@ -2801,7 +2795,7 @@ def test_the_gate_itself_honours_the_range_not_just_the_range_object(
             mlx_utils._check_audio_family_gate(gemma3n_like())
 
 
-def test_only_a_published_final_release_is_inside_the_window():
+def test_only_a_published_final_release_is_at_or_above_the_floor():
     """The qualification covers published final releases and nothing else.
 
     A post-release is conventionally the same code repackaged, but nothing
@@ -2817,37 +2811,30 @@ def test_only_a_published_final_release_is_inside_the_window():
     for unqualified in ("0.6.2.post1", "0.6.2.post2", "0.6.2+local",
                         "0.6.2rc1", "0.6.2.dev0"):
         assert gemma4.admits(unqualified) is False, unqualified
-    # Nor either side. 0.6.1 measured red; 0.6.5 is refused for being
-    # uninstallable here, not for failing.
+    # The measured floor stays closed while later compatible finals stay open.
     assert gemma4.admits("0.6.1") is False
-    assert gemma4.admits("0.6.5") is False
+    assert gemma4.admits("99.0.0") is True
 
 
 def test_new_audio_families_start_at_their_upstream_introduction(monkeypatch):
     from unsloth_zoo.mlx import utils as mlx_utils
-
-    unified = type("Gemma4UnifiedProcessor", (), {})
-    unified.__module__ = "mlx_vlm.models.gemma4_unified.processing_gemma4_unified"
-    assert mlx_utils._audio_family_from_processor(unified()) == "gemma4_unified"
-    nemotron = type("NemotronProcessor", (), {})
-    nemotron.__module__ = (
-        "mlx_vlm.models.nemotron_h_nano_omni.processing_nemotron_h_nano_omni"
-    )
-    qwen3_omni = type("Qwen3OmniProcessor", (), {})
-    qwen3_omni.__module__ = (
-        "mlx_vlm.models.qwen3_omni_moe.processing_qwen3_omni_moe"
-    )
+    def make_processor(module):
+        cls = type("Processor", (), {})
+        cls.__module__ = f"mlx_vlm.models.{module}.processing_{module}"
+        return cls()
+    unified = make_processor("gemma4_unified")
+    assert mlx_utils._audio_family_from_processor(unified) == "gemma4_unified"
     for processor, family, floor, below in (
-        (unified(), "gemma4_unified", "0.6.1", "0.6.0"),
-        (nemotron(), "nemotron_h_nano_omni", "0.5.0", "0.4.4"),
-        (qwen3_omni(), "qwen3_omni_moe", "0.6.0", "0.5.0"),
+        (unified, "gemma4_unified", "0.6.1", "0.6.0"),
+        (make_processor("nemotron_h_nano_omni"), "nemotron_h_nano_omni", "0.5.0", "0.4.4"),
+        (make_processor("qwen3_omni_moe"), "qwen3_omni_moe", "0.6.0", "0.5.0"),
     ):
         monkeypatch.setattr(
             mlx_utils, "_installed_mlx_vlm_version", lambda floor=floor: floor,
         )
         assert mlx_utils._check_audio_family_gate(processor) == family
         monkeypatch.setattr(
-            mlx_utils, "_installed_mlx_vlm_version", lambda: "0.6.9",
+            mlx_utils, "_installed_mlx_vlm_version", lambda: "99.0.0",
         )
         assert mlx_utils._check_audio_family_gate(processor) == family
         monkeypatch.setattr(
@@ -2855,16 +2842,10 @@ def test_new_audio_families_start_at_their_upstream_introduction(monkeypatch):
         )
         with pytest.raises(NotImplementedError, match="only been verified"):
             mlx_utils._check_audio_family_gate(processor)
-        monkeypatch.setattr(
-            mlx_utils, "_installed_mlx_vlm_version", lambda: "0.6.11",
-        )
-        with pytest.raises(NotImplementedError, match="only been verified"):
-            mlx_utils._check_audio_family_gate(processor)
 
 
 def test_diffusion_gemma_uses_the_generic_unsupported_family_refusal():
     from unsloth_zoo.mlx import utils as mlx_utils
-
     processor = type("DiffusionGemmaProcessor", (), {})
     processor.__module__ = "mlx_vlm.models.diffusion_gemma.processing_diffusion_gemma"
     with pytest.raises(
@@ -3130,8 +3111,8 @@ def test_the_corrected_count_rides_a_copy_and_only_for_its_family(monkeypatch):
     monkeypatch.setattr(mlx_utils, "_AUDIO_MIN_TRANSFORMERS", {})
     _here = mlx_utils._installed_mlx_vlm_version()
     monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES", {
-        "gemma4": mlx_utils._AudioVersions(_here, _here),
-        "fakegemmaaudio": mlx_utils._AudioVersions(_here, _here),
+        "gemma4": mlx_utils._AudioVersions(_here),
+        "fakegemmaaudio": mlx_utils._AudioVersions(_here),
     })
     processor = Gemma4Processor(_Gemma4Extractor(True))
     assert mlx_utils._check_audio_family_gate(processor) == "gemma4"
@@ -3518,7 +3499,6 @@ def test_the_delimiters_around_an_audio_run_are_not_targets():
 
 def test_nemotron_declares_its_sampling_rate_on_the_processor():
     from unsloth_zoo.mlx.utils import audio_extractor_sampling_rate
-
     processor = type("NemotronProcessor", (), {"audio_sampling_rate": 16000})()
     assert audio_extractor_sampling_rate(processor) == 16000
 
@@ -3785,14 +3765,12 @@ def test_the_projection_after_the_audio_tower_is_frozen_too():
 class _FrozenAudioModule:
     def __init__(self):
         self.frozen = False
-
     def freeze(self, recurse=False):
         self.frozen = recurse
 
 
 def test_nemotron_sound_encoder_and_projection_are_frozen():
     from unsloth_zoo.mlx.utils import freeze_audio_modules
-
     model = type("Nemotron", (), {
         "sound_encoder": _FrozenAudioModule(),
         "sound_projection": _FrozenAudioModule(),
@@ -3805,24 +3783,20 @@ def test_nemotron_sound_encoder_and_projection_are_frozen():
 
 def test_qwen3_omni_nested_audio_tower_is_frozen():
     from unsloth_zoo.mlx.utils import freeze_audio_modules
-
     audio_tower = _FrozenAudioModule()
     model = type("Qwen3Omni", (), {
         "thinker": type("Thinker", (), {"audio_tower": audio_tower})(),
     })()
-
     assert freeze_audio_modules(model) == ["audio_tower"]
     assert audio_tower.frozen
 
 
 def test_qwen3_omni_audio_output_modules_are_frozen():
     from unsloth_zoo.mlx.utils import freeze_audio_modules
-
     model = type("Qwen3Omni", (), {
         "talker": _FrozenAudioModule(),
         "code2wav": _FrozenAudioModule(),
     })()
-
     assert set(freeze_audio_modules(model)) == {"talker", "code2wav"}
     assert model.talker.frozen and model.code2wav.frozen
 
@@ -4091,13 +4065,11 @@ def test_clips_of_unequal_duration_all_reach_the_model():
 
 
 def test_nemotron_sound_clips_stay_a_list_even_when_shapes_match():
-    """Nemotron's extractor interprets a stacked matrix as one multichannel
-    clip, so equal-length waveforms must retain the list contract too."""
+    """Equal-length Nemotron waveforms must retain the list contract."""
     from unsloth_zoo.mlx.utils import (
         _assert_audio_features_present, _to_mx_vlm_batch,
         _vlm_batch_carries_audio,
     )
-
     inputs = {"sound_clips": [np.zeros(1600, np.float32),
                               np.ones(1600, np.float32)]}
     _assert_audio_features_present(inputs, 2, _FakeProcessor())
@@ -4886,16 +4858,12 @@ def test_shielding_the_audio_side_leaves_the_text_side_flat():
 
 
 def test_processor_forwarding_kwargs_to_its_tokenizer_drops_audio_shield():
-    """Gemma 4 consumes audio itself but forwards every remaining keyword to
-    its tokenizer, where the modality-only `audio_kwargs` shield is invalid."""
+    """Drop Gemma 4's modality shield before its tokenizer sees it."""
     from unsloth_zoo.mlx.utils import _processor_vlm_inputs
-
     class _Gemma4Style(_FakeProcessor):
         feature_extractor = type("_Extractor", (), {"sampling_rate": 16000})()
-
         def __init__(self):
             self.calls = []
-
         def __call__(self, text, audio=None, **kwargs):
             self.calls.append(dict(kwargs))
             if "audio_kwargs" in kwargs:
@@ -4908,7 +4876,6 @@ def test_processor_forwarding_kwargs_to_its_tokenizer_drops_audio_shield():
                 "attention_mask": np.ones((len(text), 4), np.int32),
                 "input_features": np.ones((len(audio), 8, 4), np.float32),
             }
-
     processor = _Gemma4Style()
     result = _processor_vlm_inputs(
         processor, ["prompt"], [[]], 128, all_audio=[[_CLIP]],

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -4943,3 +4943,70 @@ def test_a_text_only_batch_is_collated_exactly_as_before():
     processor = _TruncationDivertingAudioProcessor()
     mlx_utils._processor_vlm_inputs(processor, ["hello"], [[]], 512)
     assert processor.text_saw == {"max_length": 512, "padding": True}
+
+
+def test_qwen3_omni_counts_video_url_as_video():
+    """`video_url` carries no "video" key, so it grouped as text and rendered
+    after the audio Qwen requires it to precede."""
+    from unsloth_zoo.mlx.loader import (
+        _qwen3_omni_media_counts,
+        _normalize_qwen3_omni_counted_message,
+        _structured_multimodal_counts,
+    )
+
+    item = {"type": "video_url", "video_url": "v.mp4"}
+    assert _qwen3_omni_media_counts([item]) == (0, 0, 1)
+    # Agrees with the structured counter, which already accepted the alias.
+    assert _structured_multimodal_counts(item) == (0, 0, 1)
+
+    message = {"role": "user", "content": [item, {"type": "text", "text": "describe"}]}
+    ordered = _normalize_qwen3_omni_counted_message(message, 0, 1, {})
+    assert [part.get("type") for part in ordered["content"]] == ["video_url", "audio", "text"]
+
+
+def test_qwen3_omni_normalizes_media_turns_after_the_first():
+    """Only the anchor was normalized, so a later turn ordered `text, audio`
+    kept that order and the audio lost Thinker conditioning."""
+    from mlx_vlm import prompt_utils
+    from unsloth_zoo.mlx.loader import _prepare_vlm_template_messages
+
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+        {"role": "user", "content": [
+            {"type": "text", "text": "transcribe"},
+            {"type": "audio", "audio": "a.wav"},
+        ]},
+    ]
+    _, template, _ = _prepare_vlm_template_messages(
+        prompt_utils, "qwen3_omni_moe", messages, num_images = 0, num_audios = 1, kwargs = {},
+    )
+
+    assert [part.get("type") for part in template[2]["content"]] == ["audio", "text"]
+    # The assistant turn is left alone and the caller's list is not mutated.
+    assert [part.get("type") for part in template[1]["content"]] == ["text"]
+    assert [part.get("type") for part in messages[2]["content"]] == ["text", "audio"]
+
+
+def test_qwen3_omni_deficit_still_lands_only_on_the_anchor():
+    """Normalizing every turn must not scatter the conversation-wide deficit."""
+    from mlx_vlm import prompt_utils
+    from unsloth_zoo.mlx.loader import _prepare_vlm_template_messages
+
+    messages = [
+        {"role": "user", "content": [
+            {"type": "text", "text": "one"},
+            {"type": "image", "image": "i.png"},
+        ]},
+        {"role": "user", "content": [
+            {"type": "text", "text": "two"},
+            {"type": "audio", "audio": "a.wav"},
+        ]},
+    ]
+    _, template, _ = _prepare_vlm_template_messages(
+        prompt_utils, "qwen3_omni_moe", messages, num_images = 1, num_audios = 2, kwargs = {},
+    )
+
+    # One audio is missing conversation-wide; it goes to the anchor only.
+    assert [part.get("type") for part in template[0]["content"]] == ["image", "audio", "text"]
+    assert [part.get("type") for part in template[1]["content"]] == ["audio", "text"]

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -5011,3 +5011,44 @@ def test_qwen3_omni_deficit_still_lands_only_on_the_anchor():
     # One audio is missing conversation-wide; it goes to the anchor only.
     assert [part.get("type") for part in template[0]["content"]] == ["image", "audio", "text"]
     assert [part.get("type") for part in template[1]["content"]] == ["audio", "text"]
+
+
+def test_key_only_audio_parts_are_extracted_like_the_template_renders_them():
+    """Qwen's template emits a placeholder for a key-only `{"audio": clip}`
+    (`content.type == 'audio' or 'audio' in content or 'audio_url' in content`),
+    but the extractor keyed on `part["type"]` alone and supplied no waveform,
+    leaving the row one placeholder short of a tensor."""
+    import numpy as np
+    from unsloth_zoo.mlx.loader import _qwen3_omni_media_counts
+    from unsloth_zoo.mlx.utils import _vlm_audio_part_state
+
+    clip = np.zeros(16000, dtype = np.float32)
+    for part in (
+        {"type": "audio", "audio": clip},
+        {"type": "input_audio", "audio": clip},
+        {"audio": clip},                          # key-only, the regression
+    ):
+        messages = [{"role": "user", "content": [part, {"type": "text", "text": "t"}]}]
+        bare, payloads = _vlm_audio_part_state(messages)
+        # Whatever the counter counts, the extractor must supply.
+        assert _qwen3_omni_media_counts([part])[1] == len(payloads) == 1
+        assert bare is False
+
+
+def test_a_bare_audio_placeholder_still_reports_itself_as_bare():
+    """A typed part with no payload keeps signalling a bare placeholder, and
+    non-audio parts are still ignored."""
+    from unsloth_zoo.mlx.utils import _vlm_audio_part_state
+
+    bare, payloads = _vlm_audio_part_state(
+        [{"role": "user", "content": [{"type": "audio"}]}]
+    )
+    assert bare is True and payloads == []
+
+    bare, payloads = _vlm_audio_part_state(
+        [{"role": "user", "content": [
+            {"type": "text", "text": "hello"},
+            {"type": "image", "image": "i.png"},
+        ]}]
+    )
+    assert bare is False and payloads == []

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -3296,7 +3296,7 @@ _MULTIMODAL_SKIP_FRAGMENTS = (
     "projector",
     "vision_tower", "vision_model", "vision_encoder", "visual",
     "embed_vision", "vision_embed_tokens", "img_processor", "img_projection",
-    "audio_encoder", "audio_projection", "embed_audio",
+    "audio_encoder", "audio_projection", "embed_audio", "sound_encoder", "sound_projection",
 )
 
 _MLX_QUANT_MODE_DEFAULTS = {
@@ -5218,8 +5218,8 @@ def _normalize_qwen3_omni_counted_message(message, num_images, num_audios, kwarg
         or item.get("type") not in ("image", "audio", "video")
     ]
     images = audios = []
-    if str(message.get("role", "user")).lower() == "user":
-        if not videos and not kwargs.get("skip_image_token"):
+    if str(message.get("role", "user")).lower() not in _NON_USER_ROLES:
+        if not kwargs.get("skip_image_token"):
             images = [{"type": "image"}] * num_images
         if not kwargs.get("skip_audio_token"):
             audios = [{"type": "audio"}] * num_audios

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5204,12 +5204,22 @@ def _first_media_user_message_index(messages):
 
 
 def _qwen3_omni_media_counts(content):
+    """Count top-level media items rendered by Qwen3 Omni's native template."""
     counts = [0, 0, 0]
     for item in content if isinstance(content, list) else ():
-        if not isinstance(item, dict): continue
+        if not isinstance(item, dict):
+            continue
         kind = str(item.get("type", "")).lower()
-        index = 0 if kind == "image" or "image" in item or "image_url" in item else 1 if kind == "audio" or "audio" in item or "audio_url" in item else 2 if kind == "video" or "video" in item else None
-        if index is not None: counts[index] += 1
+        if kind == "image" or "image" in item or "image_url" in item:
+            index = 0
+        elif kind == "audio" or "audio" in item or "audio_url" in item:
+            index = 1
+        elif kind == "video" or "video" in item:
+            index = 2
+        else:
+            index = None
+        if index is not None:
+            counts[index] += 1
     return tuple(counts)
 
 
@@ -5279,8 +5289,17 @@ def _anchor_conversation_media_to_first_user_turn(
             **message_kwargs,
         )
         if model_type == "qwen3_omni_moe":
-            options = {**message_kwargs, "skip_image_token": skip_image_token, "skip_audio_token": skip_audio_token}
-            rendered = _normalize_qwen3_omni_counted_message(rendered, num_images if is_target else 0, num_audios if is_target else 0, options)
+            options = {
+                **message_kwargs,
+                "skip_image_token": skip_image_token,
+                "skip_audio_token": skip_audio_token,
+            }
+            rendered = _normalize_qwen3_omni_counted_message(
+                rendered,
+                num_images if is_target else 0,
+                num_audios if is_target else 0,
+                options,
+            )
         if isinstance(message, dict):
             if isinstance(rendered, dict):
                 rendered = {**message, **rendered}
@@ -5412,17 +5431,44 @@ def _prepare_vlm_template_messages(
     has_structured_multimodal = _messages_have_structured_multimodal_content(
         normalized_messages
     )
-    if model_type == "qwen3_omni_moe": has_structured_multimodal |= any(any(_qwen3_omni_media_counts(message.get("content", ""))) for message in normalized_messages)
+    if model_type == "qwen3_omni_moe":
+        has_structured_multimodal |= any(
+            any(_qwen3_omni_media_counts(message.get("content", "")))
+            for message in normalized_messages
+        )
     needs_media_anchor = (
         not has_structured_multimodal and (num_images > 0 or num_audios > 0)
     )
 
     template_messages = normalized_messages
-    if model_type == "qwen3_omni_moe" and has_structured_multimodal and (num_images > 0 or num_audios > 0) and (target_idx := _first_media_user_message_index(normalized_messages)) >= 0:
-        counts = [_qwen3_omni_media_counts(message.get("content", "")) for message in normalized_messages]
-        if any(missing := (0 if kwargs.get("skip_image_token") else max(0, num_images - sum(x[0] for x in counts)), 0 if kwargs.get("skip_audio_token") else max(0, num_audios - sum(x[1] for x in counts)))):
+    if (
+        model_type == "qwen3_omni_moe"
+        and has_structured_multimodal
+        and (num_images > 0 or num_audios > 0)
+        and (
+            target_idx := _first_media_user_message_index(normalized_messages)
+        ) >= 0
+    ):
+        counts = [
+            _qwen3_omni_media_counts(message.get("content", ""))
+            for message in normalized_messages
+        ]
+        missing = (
+            0
+            if kwargs.get("skip_image_token")
+            else max(0, num_images - sum(item[0] for item in counts)),
+            0
+            if kwargs.get("skip_audio_token")
+            else max(0, num_audios - sum(item[1] for item in counts)),
+        )
+        if any(missing) or any(counts[target_idx]):
             template_messages = list(normalized_messages)
-            template_messages[target_idx] = _normalize_qwen3_omni_counted_message(template_messages[target_idx], counts[target_idx][0] + missing[0], counts[target_idx][1] + missing[1], kwargs)
+            template_messages[target_idx] = _normalize_qwen3_omni_counted_message(
+                template_messages[target_idx],
+                counts[target_idx][0] + missing[0],
+                counts[target_idx][1] + missing[1],
+                kwargs,
+            )
     elif needs_media_anchor:
         template_messages = _anchor_conversation_media_to_first_user_turn(
             prompt_utils_module,

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5203,27 +5203,37 @@ def _first_media_user_message_index(messages):
     return -1
 
 
+def _qwen3_omni_media_counts(content):
+    counts = [0, 0, 0]
+    for item in content if isinstance(content, list) else ():
+        if not isinstance(item, dict): continue
+        kind = str(item.get("type", "")).lower()
+        index = 0 if kind == "image" or "image" in item or "image_url" in item else 1 if kind == "audio" or "audio" in item or "audio_url" in item else 2 if kind == "video" or "video" in item else None
+        if index is not None: counts[index] += 1
+    return tuple(counts)
+
+
 def _normalize_qwen3_omni_counted_message(message, num_images, num_audios, kwargs):
     """Put Qwen's counted media before text without losing formatter metadata."""
-    if not isinstance(message, dict) or not isinstance(message.get("content"), list):
+    if not isinstance(message, dict):
         return message
     content = message["content"]
-    videos = [
-        item for item in content
-        if isinstance(item, dict) and item.get("type") == "video"
-    ]
-    trailing = [
-        item for item in content
-        if not isinstance(item, dict)
-        or item.get("type") not in ("image", "audio", "video")
-    ]
-    images = audios = []
+    if isinstance(content, str):
+        content = [{"type": "text", "text": content}]
+    elif not isinstance(content, list):
+        return message
+    groups = [[], [], [], []]
+    for item in content:
+        counts = _qwen3_omni_media_counts([item])
+        group = 0 if counts[2] else 1 if counts[0] else 2 if counts[1] else 3
+        groups[group].append(item)
+    counts = _qwen3_omni_media_counts(content)
     if str(message.get("role", "user")).lower() not in _NON_USER_ROLES:
         if not kwargs.get("skip_image_token"):
-            images = [{"type": "image"}] * num_images
+            groups[1] += [{"type": "image"}] * max(0, num_images - counts[0])
         if not kwargs.get("skip_audio_token"):
-            audios = [{"type": "audio"}] * num_audios
-    return {**message, "content": videos + images + audios + trailing}
+            groups[2] += [{"type": "audio"}] * max(0, num_audios - counts[1])
+    return {**message, "content": sum(groups, [])}
 
 
 def _anchor_conversation_media_to_first_user_turn(
@@ -5253,12 +5263,8 @@ def _anchor_conversation_media_to_first_user_turn(
         )
         is_target = i == target_idx and role.lower() not in _NON_USER_ROLES
         message_kwargs = dict(kwargs)
-        skip_image_token = (
-            bool(message_kwargs.pop("skip_image_token", False)) or not is_target
-        )
-        skip_audio_token = (
-            bool(message_kwargs.pop("skip_audio_token", False)) or not is_target
-        )
+        skip_image_token = bool(message_kwargs.pop("skip_image_token", False)) or not is_target
+        skip_audio_token = bool(message_kwargs.pop("skip_audio_token", False)) or not is_target
         message_kwargs.pop("role", None)
         if not is_target:
             message_kwargs.pop("video", None)
@@ -5273,16 +5279,8 @@ def _anchor_conversation_media_to_first_user_turn(
             **message_kwargs,
         )
         if model_type == "qwen3_omni_moe":
-            rendered = _normalize_qwen3_omni_counted_message(
-                rendered,
-                num_images if is_target else 0,
-                num_audios if is_target else 0,
-                {
-                    **message_kwargs,
-                    "skip_image_token": skip_image_token,
-                    "skip_audio_token": skip_audio_token,
-                },
-            )
+            options = {**message_kwargs, "skip_image_token": skip_image_token, "skip_audio_token": skip_audio_token}
+            rendered = _normalize_qwen3_omni_counted_message(rendered, num_images if is_target else 0, num_audios if is_target else 0, options)
         if isinstance(message, dict):
             if isinstance(rendered, dict):
                 rendered = {**message, **rendered}
@@ -5414,12 +5412,18 @@ def _prepare_vlm_template_messages(
     has_structured_multimodal = _messages_have_structured_multimodal_content(
         normalized_messages
     )
+    if model_type == "qwen3_omni_moe": has_structured_multimodal |= any(any(_qwen3_omni_media_counts(message.get("content", ""))) for message in normalized_messages)
     needs_media_anchor = (
         not has_structured_multimodal and (num_images > 0 or num_audios > 0)
     )
 
     template_messages = normalized_messages
-    if needs_media_anchor:
+    if model_type == "qwen3_omni_moe" and has_structured_multimodal and (num_images > 0 or num_audios > 0) and (target_idx := _first_media_user_message_index(normalized_messages)) >= 0:
+        counts = [_qwen3_omni_media_counts(message.get("content", "")) for message in normalized_messages]
+        if any(missing := (0 if kwargs.get("skip_image_token") else max(0, num_images - sum(x[0] for x in counts)), 0 if kwargs.get("skip_audio_token") else max(0, num_audios - sum(x[1] for x in counts)))):
+            template_messages = list(normalized_messages)
+            template_messages[target_idx] = _normalize_qwen3_omni_counted_message(template_messages[target_idx], counts[target_idx][0] + missing[0], counts[target_idx][1] + missing[1], kwargs)
+    elif needs_media_anchor:
         template_messages = _anchor_conversation_media_to_first_user_turn(
             prompt_utils_module,
             model_type,
@@ -5444,19 +5448,11 @@ def _render_vlm_template_or_fallback(
     kwargs,
 ):
     """Render a message list, falling back only when the upstream template is empty."""
-    if model_type == "qwen3_omni_moe" and hasattr(
-        processor, "apply_chat_template"
-    ):
-        # Qwen3 Omni Instruct transcribes only when the wrapper's implicit
-        # `enable_thinking=False` is omitted; preserve explicit overrides.
+    if model_type == "qwen3_omni_moe" and hasattr(processor, "apply_chat_template"):
+        # Omit Qwen Instruct's implicit `enable_thinking=False`; keep explicit overrides.
         native_kwargs = dict(kwargs)
         tokenize = native_kwargs.pop("tokenize", False)
-        rendered = processor.apply_chat_template(
-            messages,
-            tokenize=tokenize,
-            add_generation_prompt=add_generation_prompt,
-            **native_kwargs,
-        )
+        rendered = processor.apply_chat_template(messages, tokenize=tokenize, add_generation_prompt=add_generation_prompt, **native_kwargs)
     else:
         rendered = prompt_utils_module.get_chat_template(
             processor,
@@ -5514,13 +5510,7 @@ def _ensure_vlm_prompt_utils_patched():
         model_config = getattr(prompt_utils, "MODEL_CONFIG", {})
         if isinstance(model_type, str) and model_type not in model_config:
             folded = model_type.casefold()
-            canonical = next(
-                (
-                    key for key in model_config
-                    if isinstance(key, str) and key.casefold() == folded
-                ),
-                None,
-            )
+            canonical = next((key for key in model_config if isinstance(key, str) and key.casefold() == folded), None)
             if canonical is not None:
                 # Published configs may capitalize mlx-vlm's lowercase key.
                 config_data = dict(config_data)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5453,6 +5453,25 @@ def _ensure_vlm_prompt_utils_patched():
     ):
         config_data = config if isinstance(config, dict) else config.__dict__
         model_type = config_data["model_type"]
+        model_config = getattr(prompt_utils, "MODEL_CONFIG", {})
+        if isinstance(model_type, str) and model_type not in model_config:
+            folded = model_type.casefold()
+            canonical = next(
+                (
+                    key for key in model_config
+                    if isinstance(key, str) and key.casefold() == folded
+                ),
+                None,
+            )
+            if canonical is not None:
+                # Some published configs capitalize model_type even though
+                # mlx-vlm's routing table uses lowercase keys. Passing the
+                # canonical key keeps media-count formatting from falling
+                # through to the text-only path.
+                config_data = dict(config_data)
+                config_data["model_type"] = canonical
+                config = config_data
+                model_type = canonical
 
         if not isinstance(prompt, (dict, list)):
             return _original_vlm_apply_chat_template(

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5448,10 +5448,12 @@ def _prepare_vlm_template_messages(
     )
 
     template_messages = normalized_messages
+    # Not gated on the scalar counts: ordering is wrong on its own merits, and a
+    # caller whose media is embedded in the messages leaves them at zero. The
+    # counts only decide how many extra placeholders the anchor needs.
     if (
         model_type == "qwen3_omni_moe"
         and has_structured_multimodal
-        and (num_images > 0 or num_audios > 0)
         and (
             target_idx := _first_media_user_message_index(normalized_messages)
         ) >= 0

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5400,12 +5400,25 @@ def _render_vlm_template_or_fallback(
     kwargs,
 ):
     """Render a message list, falling back only when the upstream template is empty."""
-    rendered = prompt_utils_module.get_chat_template(
-        processor,
-        messages,
-        add_generation_prompt,
-        **kwargs,
-    )
+    if model_type == "qwen3_omni_moe" and hasattr(
+        processor, "apply_chat_template"
+    ):
+        # mlx-vlm's wrapper injects `enable_thinking=False`, but Qwen3 Omni
+        # Instruct only transcribes correctly when that optional argument is
+        # omitted. Delegate directly and preserve explicit caller overrides.
+        rendered = processor.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=add_generation_prompt,
+            **kwargs,
+        )
+    else:
+        rendered = prompt_utils_module.get_chat_template(
+            processor,
+            messages,
+            add_generation_prompt,
+            **kwargs,
+        )
     if isinstance(rendered, str) and rendered.strip():
         return rendered
 
@@ -5473,6 +5486,31 @@ def _ensure_vlm_prompt_utils_patched():
                 config = config_data
                 model_type = canonical
 
+        if (
+            model_type == "qwen3_omni_moe"
+            and not isinstance(prompt, (dict, list))
+            and num_audios > 0
+        ):
+            # Qwen's published input contract is image/audio/video followed by
+            # user text. mlx-vlm's generic count renderer puts audio last,
+            # which keeps the marker but makes the Thinker ignore the speech.
+            content = (
+                [{"type": "image"}] * num_images
+                + [{"type": "audio"}] * num_audios
+                + [{"type": "text", "text": str(prompt)}]
+            )
+            messages = [{"role": "user", "content": content}]
+            if return_messages:
+                return messages
+            return _render_vlm_template_or_fallback(
+                prompt_utils,
+                model_type,
+                processor,
+                messages,
+                add_generation_prompt=add_generation_prompt,
+                kwargs=kwargs,
+            )
+
         if not isinstance(prompt, (dict, list)):
             return _original_vlm_apply_chat_template(
                 processor,
@@ -5499,6 +5537,7 @@ def _ensure_vlm_prompt_utils_patched():
             not return_messages
             and not kwargs.get("video")
             and not _prompt_has_tool_metadata(prompt)
+            and model_type != "qwen3_omni_moe"
             and model_type in getattr(prompt_utils, "MODEL_CONFIG", {})
             and _structured_media_matches_count_renderer(
                 normalized_messages, num_images, num_audios

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5447,9 +5447,8 @@ def _render_vlm_template_or_fallback(
     if model_type == "qwen3_omni_moe" and hasattr(
         processor, "apply_chat_template"
     ):
-        # mlx-vlm's wrapper injects `enable_thinking=False`, but Qwen3 Omni
-        # Instruct only transcribes correctly when that optional argument is
-        # omitted. Delegate directly and preserve explicit caller overrides.
+        # Qwen3 Omni Instruct transcribes only when the wrapper's implicit
+        # `enable_thinking=False` is omitted; preserve explicit overrides.
         native_kwargs = dict(kwargs)
         tokenize = native_kwargs.pop("tokenize", False)
         rendered = processor.apply_chat_template(
@@ -5523,10 +5522,7 @@ def _ensure_vlm_prompt_utils_patched():
                 None,
             )
             if canonical is not None:
-                # Some published configs capitalize model_type even though
-                # mlx-vlm's routing table uses lowercase keys. Passing the
-                # canonical key keeps media-count formatting from falling
-                # through to the text-only path.
+                # Published configs may capitalize mlx-vlm's lowercase key.
                 config_data = dict(config_data)
                 config_data["model_type"] = canonical
                 config = config_data
@@ -5537,9 +5533,7 @@ def _ensure_vlm_prompt_utils_patched():
             and not isinstance(prompt, (dict, list))
             and num_audios > 0
         ):
-            # Qwen's published input contract is image/audio/video followed by
-            # user text. mlx-vlm's generic count renderer puts audio last,
-            # which keeps the marker but makes the Thinker ignore the speech.
+            # Qwen requires media before text; mlx-vlm renders audio last.
             message = prompt_utils.get_message_json(
                 model_type,
                 str(prompt),

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5227,9 +5227,8 @@ def _normalize_qwen3_omni_counted_message(message, num_images, num_audios, kwarg
     """Put Qwen's counted media before text without losing formatter metadata."""
     if not isinstance(message, dict):
         return message
-    # A turn may legitimately carry no content (a tool call, an empty assistant
-    # stub). Subscripting raised KeyError where every neighbouring guard returns
-    # the message untouched.
+    # A tool call or empty assistant stub carries no content; subscripting
+    # raised KeyError where every neighbouring guard returns the message.
     content = message.get("content")
     if content is None:
         return message

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5214,7 +5214,9 @@ def _qwen3_omni_media_counts(content):
             index = 0
         elif kind == "audio" or "audio" in item or "audio_url" in item:
             index = 1
-        elif kind == "video" or "video" in item:
+        # `video_url` carries no "video" key, so match the type too or it groups
+        # as text and renders after the audio Qwen needs it before.
+        elif kind in ("video", "video_url") or "video" in item or "video_url" in item:
             index = 2
         else:
             index = None
@@ -5465,14 +5467,27 @@ def _prepare_vlm_template_messages(
             if kwargs.get("skip_audio_token")
             else max(0, num_audios - sum(item[1] for item in counts)),
         )
-        if any(missing) or any(counts[target_idx]):
-            template_messages = list(normalized_messages)
-            template_messages[target_idx] = _normalize_qwen3_omni_counted_message(
-                template_messages[target_idx],
-                counts[target_idx][0] + missing[0],
-                counts[target_idx][1] + missing[1],
+        # Every user-like turn the renderer sees, not just the anchor: a later
+        # turn ordered `text, audio` keeps that order otherwise, and audio
+        # rendered last loses Thinker conditioning. Only the anchor takes the
+        # conversation-wide deficit.
+        rebuilt = list(normalized_messages)
+        changed = False
+        for index, message in enumerate(normalized_messages):
+            if str(message.get("role", "user")).lower() in _NON_USER_ROLES:
+                continue
+            extra = missing if index == target_idx else (0, 0)
+            if not (any(counts[index]) or any(extra)):
+                continue
+            rebuilt[index] = _normalize_qwen3_omni_counted_message(
+                message,
+                counts[index][0] + extra[0],
+                counts[index][1] + extra[1],
                 kwargs,
             )
+            changed = True
+        if changed:
+            template_messages = rebuilt
     elif needs_media_anchor:
         template_messages = _anchor_conversation_media_to_first_user_turn(
             prompt_utils_module,

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5227,7 +5227,12 @@ def _normalize_qwen3_omni_counted_message(message, num_images, num_audios, kwarg
     """Put Qwen's counted media before text without losing formatter metadata."""
     if not isinstance(message, dict):
         return message
-    content = message["content"]
+    # A turn may legitimately carry no content (a tool call, an empty assistant
+    # stub). Subscripting raised KeyError where every neighbouring guard returns
+    # the message untouched.
+    content = message.get("content")
+    if content is None:
+        return message
     if isinstance(content, str):
         content = [{"type": "text", "text": content}]
     elif not isinstance(content, list):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5214,8 +5214,9 @@ def _qwen3_omni_media_counts(content):
             index = 0
         elif kind == "audio" or "audio" in item or "audio_url" in item:
             index = 1
-        # `video_url` carries no "video" key, so match the type too or it groups
-        # as text and renders after the audio Qwen needs it before.
+        # `video_url` carries no "video" key. Grouped with video so this agrees
+        # with `_structured_multimodal_counts`; the native template renders no
+        # placeholder for that shape either way, so ordering is unaffected.
         elif kind in ("video", "video_url") or "video" in item or "video_url" in item:
             index = 2
         else:

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5214,9 +5214,8 @@ def _qwen3_omni_media_counts(content):
             index = 0
         elif kind == "audio" or "audio" in item or "audio_url" in item:
             index = 1
-        # `video_url` carries no "video" key. Grouped with video so this agrees
-        # with `_structured_multimodal_counts`; the native template renders no
-        # placeholder for that shape either way, so ordering is unaffected.
+        # `video_url` has no "video" key. Grouped here to agree with
+        # `_structured_multimodal_counts`; the template renders it either way.
         elif kind in ("video", "video_url") or "video" in item or "video_url" in item:
             index = 2
         else:
@@ -5448,9 +5447,8 @@ def _prepare_vlm_template_messages(
     )
 
     template_messages = normalized_messages
-    # Not gated on the scalar counts: ordering is wrong on its own merits, and a
-    # caller whose media is embedded in the messages leaves them at zero. The
-    # counts only decide how many extra placeholders the anchor needs.
+    # Not gated on the counts: embedded media leaves them at zero, and ordering
+    # is wrong on its own merits. Counts only size the anchor's deficit.
     if (
         model_type == "qwen3_omni_moe"
         and has_structured_multimodal
@@ -5470,10 +5468,9 @@ def _prepare_vlm_template_messages(
             if kwargs.get("skip_audio_token")
             else max(0, num_audios - sum(item[1] for item in counts)),
         )
-        # Every user-like turn the renderer sees, not just the anchor: a later
-        # turn ordered `text, audio` keeps that order otherwise, and audio
-        # rendered last loses Thinker conditioning. Only the anchor takes the
-        # conversation-wide deficit.
+        # Every user-like turn, not just the anchor: a later `text, audio` turn
+        # keeps that order otherwise and audio rendered last loses Thinker
+        # conditioning. Only the anchor takes the deficit.
         rebuilt = list(normalized_messages)
         changed = False
         for index, message in enumerate(normalized_messages):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5203,6 +5203,29 @@ def _first_media_user_message_index(messages):
     return -1
 
 
+def _normalize_qwen3_omni_counted_message(message, num_images, num_audios, kwargs):
+    """Put Qwen's counted media before text without losing formatter metadata."""
+    if not isinstance(message, dict) or not isinstance(message.get("content"), list):
+        return message
+    content = message["content"]
+    videos = [
+        item for item in content
+        if isinstance(item, dict) and item.get("type") == "video"
+    ]
+    trailing = [
+        item for item in content
+        if not isinstance(item, dict)
+        or item.get("type") not in ("image", "audio", "video")
+    ]
+    images = audios = []
+    if message.get("role") == "user":
+        if not videos and not kwargs.get("skip_image_token"):
+            images = [{"type": "image"}] * num_images
+        if not kwargs.get("skip_audio_token"):
+            audios = [{"type": "audio"}] * num_audios
+    return {**message, "content": videos + images + audios + trailing}
+
+
 def _anchor_conversation_media_to_first_user_turn(
     prompt_utils_module,
     model_type,
@@ -5229,16 +5252,37 @@ def _anchor_conversation_media_to_first_user_turn(
             message.get("content", "")
         )
         is_target = i == target_idx and role.lower() not in _NON_USER_ROLES
+        message_kwargs = dict(kwargs)
+        skip_image_token = (
+            bool(message_kwargs.pop("skip_image_token", False)) or not is_target
+        )
+        skip_audio_token = (
+            bool(message_kwargs.pop("skip_audio_token", False)) or not is_target
+        )
+        message_kwargs.pop("role", None)
+        if not is_target:
+            message_kwargs.pop("video", None)
         rendered = prompt_utils_module.get_message_json(
             model_type,
             content,
             role,
-            skip_image_token=not is_target,
-            skip_audio_token=not is_target,
+            skip_image_token=skip_image_token,
+            skip_audio_token=skip_audio_token,
             num_images=num_images,
             num_audios=num_audios,
-            **kwargs,
+            **message_kwargs,
         )
+        if model_type == "qwen3_omni_moe":
+            rendered = _normalize_qwen3_omni_counted_message(
+                rendered,
+                num_images if is_target else 0,
+                num_audios if is_target else 0,
+                {
+                    **message_kwargs,
+                    "skip_image_token": skip_image_token,
+                    "skip_audio_token": skip_audio_token,
+                },
+            )
         if isinstance(message, dict):
             if isinstance(rendered, dict):
                 rendered = {**message, **rendered}
@@ -5406,11 +5450,13 @@ def _render_vlm_template_or_fallback(
         # mlx-vlm's wrapper injects `enable_thinking=False`, but Qwen3 Omni
         # Instruct only transcribes correctly when that optional argument is
         # omitted. Delegate directly and preserve explicit caller overrides.
+        native_kwargs = dict(kwargs)
+        tokenize = native_kwargs.pop("tokenize", False)
         rendered = processor.apply_chat_template(
             messages,
-            tokenize=False,
+            tokenize=tokenize,
             add_generation_prompt=add_generation_prompt,
-            **kwargs,
+            **native_kwargs,
         )
     else:
         rendered = prompt_utils_module.get_chat_template(
@@ -5494,12 +5540,17 @@ def _ensure_vlm_prompt_utils_patched():
             # Qwen's published input contract is image/audio/video followed by
             # user text. mlx-vlm's generic count renderer puts audio last,
             # which keeps the marker but makes the Thinker ignore the speech.
-            content = (
-                [{"type": "image"}] * num_images
-                + [{"type": "audio"}] * num_audios
-                + [{"type": "text", "text": str(prompt)}]
+            message = prompt_utils.get_message_json(
+                model_type,
+                str(prompt),
+                num_images=num_images,
+                num_audios=num_audios,
+                **kwargs,
             )
-            messages = [{"role": "user", "content": content}]
+            message = _normalize_qwen3_omni_counted_message(
+                message, num_images, num_audios, kwargs
+            )
+            messages = [message]
             if return_messages:
                 return messages
             return _render_vlm_template_or_fallback(

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5218,7 +5218,7 @@ def _normalize_qwen3_omni_counted_message(message, num_images, num_audios, kwarg
         or item.get("type") not in ("image", "audio", "video")
     ]
     images = audios = []
-    if message.get("role") == "user":
+    if str(message.get("role", "user")).lower() == "user":
         if not videos and not kwargs.get("skip_image_token"):
             images = [{"type": "image"}] * num_images
         if not kwargs.get("skip_audio_token"):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5682,14 +5682,15 @@ class _AudioVersions(NamedTuple):
 # made sanitize unconditional, double-transposing pre-converted convs -- but
 # loader.py's `_ensure_audio_conv_sanitize` (PR 879) undoes it, and upstream
 # fixed it in 0.6.5 (#1523). The ceiling is 0.6.4 only for the transformers cap.
-# Gemma 4 Unified and Nemotron Omni are separate implementations. Their floors
-# are the first upstream releases containing those native audio paths; 0.6.10
-# remains the latest release exercised by the real-model qualification gate.
+# Gemma 4 Unified, Nemotron Omni, and Qwen3 Omni are separate implementations.
+# Their floors are the first upstream releases containing working native audio
+# paths; 0.6.10 remains the latest release exercised by the real-model gate.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4", "0.6.4"),
     "gemma4": _AudioVersions("0.6.2", "0.6.4"),
     "gemma4_unified": _AudioVersions("0.6.1", "0.6.10"),
     "nemotron_h_nano_omni": _AudioVersions("0.5.0", "0.6.10"),
+    "qwen3_omni_moe": _AudioVersions("0.6.0", "0.6.10"),
     "phi4mm": _AudioVersions("0.4.4", "0.6.4"),
     "minicpmo": _AudioVersions("0.4.4", "0.6.4"),
 }

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6313,9 +6313,8 @@ def _vlm_audio_part_state(messages):
         for part in content:
             if not isinstance(part, dict):
                 continue
-            # Key-only `{"audio": clip}` too, not just a typed part: Qwen's own
-            # template renders a placeholder for it, so extracting nothing here
-            # left the row a placeholder short of a waveform.
+            # Key-only `{"audio": clip}` too: the template renders a
+            # placeholder for it, so skipping it left the row a waveform short.
             if part.get("type") not in _AUDIO_PART_TYPES and not any(
                 key in part for key in _AUDIO_PART_TYPES
             ):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5674,11 +5674,27 @@ class _AudioVersions(NamedTuple):
 # fixed it in 0.6.5 (#1523).
 # Unified needs 0.6.5's processor/audio-layout fix; Qwen needs 0.6.7's batched
 # mel input and sample-domain length fixes. 0.6.10 is the latest real-model gate.
+#
+# Nemotron is 0.6.10, not the 0.5.0 that first carried the family. Below it,
+# `sanitize_audio_weights` transposes `sound_encoder.encoder.*` convs
+# unconditionally, so a pre-converted MLX checkpoint double-transposes and the
+# load fails. Measured on the real function, feeding an already-MLX-major
+# depthwise weight through each release:
+#
+#   0.5.0 / 0.6.4 / 0.6.7   (128, 3, 3, 1) -> (128, 3, 1, 3)   corrupted
+#   0.6.10 / 0.6.12         (128, 3, 3, 1) -> (128, 3, 3, 1)   left alone
+#
+# This is gemma4's #1498/#1523 bug in a second family, and the `gemma4` repair
+# above does not cover it: `_ensure_audio_conv_sanitize` keys on the
+# `subsample_conv_projection` / `depthwise_conv1d.weight` markers in the
+# sanitize source, and Nemotron's `Model.sanitize` delegates to a module-level
+# function where `_safe_getsource` sees neither marker. 0.6.10 is also the
+# release this family's real-model matrix was measured on.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4"),
     "gemma4": _AudioVersions("0.6.2"),
     "gemma4_unified": _AudioVersions("0.6.5"),
-    "nemotron_h_nano_omni": _AudioVersions("0.5.0"),
+    "nemotron_h_nano_omni": _AudioVersions("0.6.10"),
     "qwen3_omni_moe": _AudioVersions("0.6.7"),
     "phi4mm": _AudioVersions("0.4.4"),
     "minicpmo": _AudioVersions("0.4.4"),
@@ -5689,7 +5705,7 @@ _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
 # differently, so they are refused rather than assumed compatible.
 # Redundant now gemma4's floor is 0.6.2 (every mlx-vlm there needs
 # transformers>=5.5.0), but kept for hand-assembled environments.
-_AUDIO_MIN_TRANSFORMERS = {"gemma4": (5, 5)}
+_AUDIO_MIN_TRANSFORMERS = {"gemma4": (5, 5), "gemma4_unified": (5, 5)}
 
 _AUDIO_CAST_HINT = (
     "Cast the dataset column with "
@@ -8727,6 +8743,7 @@ def freeze_audio_modules(model):
     Returns the names of the modules that were frozen.
     """
     frozen = []
+    seen = set()
     for attr in _AUDIO_TOWER_ATTRS + _AUDIO_OUTPUT_ATTRS:
         for owner in (
             model,
@@ -8736,9 +8753,15 @@ def freeze_audio_modules(model):
             module = getattr(owner, attr, None) if owner is not None else None
             if module is None or not hasattr(module, "freeze"):
                 continue
+            # Every owner, not just the first: a model carrying both its own
+            # `audio_tower` and a distinct `thinker.audio_tower` would otherwise
+            # leave the nested one trainable, which is what this call prevents.
+            # Identity-deduped so a shared module is not frozen (or reported) twice.
+            if id(module) in seen:
+                continue
+            seen.add(id(module))
             module.freeze(recurse=True)
             frozen.append(attr)
-            break
     return frozen
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5675,21 +5675,13 @@ class _AudioVersions(NamedTuple):
 # Unified needs 0.6.5's processor/audio-layout fix; Qwen needs 0.6.7's batched
 # mel input and sample-domain length fixes. 0.6.10 is the latest real-model gate.
 #
-# Nemotron is 0.6.10, not the 0.5.0 that first carried the family. Below it,
+# Nemotron is 0.6.10, not the 0.5.0 that first carried it: below that,
 # `sanitize_audio_weights` transposes `sound_encoder.encoder.*` convs
-# unconditionally, so a pre-converted MLX checkpoint double-transposes and the
-# load fails. Measured on the real function, feeding an already-MLX-major
-# depthwise weight through each release:
-#
-#   0.5.0 / 0.6.4 / 0.6.7   (128, 3, 3, 1) -> (128, 3, 1, 3)   corrupted
-#   0.6.10 / 0.6.12         (128, 3, 3, 1) -> (128, 3, 3, 1)   left alone
-#
-# This is gemma4's #1498/#1523 bug in a second family, and the `gemma4` repair
-# above does not cover it: `_ensure_audio_conv_sanitize` keys on the
-# `subsample_conv_projection` / `depthwise_conv1d.weight` markers in the
+# unconditionally, so a pre-converted weight double-transposes and the load
+# fails ((128,3,3,1) -> (128,3,1,3) on 0.5.0/0.6.4/0.6.7, untouched on 0.6.10+).
+# `_ensure_audio_conv_sanitize` cannot repair it: it keys on markers in the
 # sanitize source, and Nemotron's `Model.sanitize` delegates to a module-level
-# function where `_safe_getsource` sees neither marker. 0.6.10 is also the
-# release this family's real-model matrix was measured on.
+# function carrying neither.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4"),
     "gemma4": _AudioVersions("0.6.2"),
@@ -8753,10 +8745,9 @@ def freeze_audio_modules(model):
             module = getattr(owner, attr, None) if owner is not None else None
             if module is None or not hasattr(module, "freeze"):
                 continue
-            # Every owner, not just the first: a model carrying both its own
-            # `audio_tower` and a distinct `thinker.audio_tower` would otherwise
-            # leave the nested one trainable, which is what this call prevents.
-            # Identity-deduped so a shared module is not frozen (or reported) twice.
+            # Every owner, not just the first: a distinct `thinker.audio_tower`
+            # beside a top-level one would otherwise stay trainable. Deduped by
+            # identity so an alias is not reported twice.
             if id(module) in seen:
                 continue
             seen.add(id(module))

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5682,15 +5682,23 @@ class _AudioVersions(NamedTuple):
 # made sanitize unconditional, double-transposing pre-converted convs -- but
 # loader.py's `_ensure_audio_conv_sanitize` (PR 879) undoes it, and upstream
 # fixed it in 0.6.5 (#1523). The ceiling is 0.6.4 only for the transformers cap.
+# Gemma 4 Unified and Nemotron Omni are separate implementations first qualified
+# against the release environment's 0.6.10 contract; fail closed on either side.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4", "0.6.4"),
     "gemma4": _AudioVersions("0.6.2", "0.6.4"),
+    "gemma4_unified": _AudioVersions("0.6.10", "0.6.10"),
+    "nemotron_h_nano_omni": _AudioVersions("0.6.10", "0.6.10"),
     "phi4mm": _AudioVersions("0.4.4", "0.6.4"),
     "minicpmo": _AudioVersions("0.4.4", "0.6.4"),
 }
 
-# Names upstream renamed, so a refusal can point at the qualified entry.
-_AUDIO_FAMILY_RENAMES = {"gemma4_unified": "gemma4"}
+_AUDIO_UNSUPPORTED_REASONS = {
+    "diffusion_gemma": (
+        "the published checkpoint has no native audio modality, processor "
+        "path, audio configuration, or audio weights"
+    ),
+}
 
 # Families probed only on a newer transformers than this package pins, at the
 # version the probes ran on. Older releases expand their audio tokens
@@ -5966,16 +5974,11 @@ def _check_audio_family_gate(processor):
     if probed and probed.admits(installed):
         _check_audio_transformers_floor(family)
         return family
-    renamed = _AUDIO_FAMILY_RENAMES.get(family)
-    if renamed and renamed in _AUDIO_QUALIFIED_FAMILIES:
-        # The old name's entry says nothing about the renamed implementation.
+    unsupported = _AUDIO_UNSUPPORTED_REASONS.get(family)
+    if unsupported:
         raise NotImplementedError(
-            f"Unsloth MLX: audio training is not supported for '{family}'. "
-            f"mlx-vlm {installed or 'unknown'} loads this checkpoint as "
-            f"'{family}', which is a different implementation from the "
-            f"'{renamed}' this package qualified on mlx-vlm "
-            f"{_AUDIO_QUALIFIED_FAMILIES[renamed]}. Pin that version to train "
-            f"on audio with this model."
+            f"Unsloth MLX: audio training is not supported for '{family}': "
+            f"{unsupported}. Train on its text and image modalities instead."
         )
     if not _AUDIO_QUALIFIED_FAMILIES:
         raise NotImplementedError(
@@ -6010,6 +6013,8 @@ def audio_extractor_sampling_rate(processor):
         processor,
     ):
         rate = getattr(holder, "sampling_rate", None)
+        if rate is None and holder is processor:
+            rate = getattr(processor, "audio_sampling_rate", None)
         if rate:
             try:
                 return int(rate)
@@ -6156,7 +6161,12 @@ def _model_carries_audio_modules(model):
         return False
     for entry in walk():
         name = entry[0] if isinstance(entry, tuple) else entry
-        if "audio" in str(name).lower():
+        lowered = str(name).lower()
+        if (
+            "audio" in lowered
+            or lowered.startswith("sound_")
+            or ".sound_" in lowered
+        ):
             return True
     return False
 
@@ -6436,7 +6446,7 @@ def _extract_vlm_audio(item, messages, processor):
 
 # Payload keys only: masks and size vectors can survive a dropped payload.
 _AUDIO_FEATURE_PAYLOAD_KEYS = (
-    "input_features", "input_audio_embeds", "audio_features",
+    "input_features", "input_audio_embeds", "audio_features", "sound_clips",
 )
 
 
@@ -7043,6 +7053,14 @@ _VLM_PER_ROW_MEDIA_KEYS = ("audio_bounds", "image_bound", "tgt_sizes")
 def _to_mx_vlm_batch(inputs):
     batch = {}
     for key, value in inputs.items():
+        if key == "sound_clips" and isinstance(value, (list, tuple)):
+            # Nemotron's outer list is the clip axis. Stacking equal lengths
+            # turns it into one 2-D clip, which its extractor downmixes.
+            batch[key] = [
+                x if isinstance(x, mx.array) else mx.array(np.asarray(x))
+                for x in value
+            ]
+            continue
         if key in _VLM_PER_ROW_MEDIA_KEYS and isinstance(value, (list, tuple)):
             batch[key] = [mx.array(np.asarray(row)) for row in value]
             continue
@@ -7366,6 +7384,24 @@ def _processor_vlm_inputs(
             try:
                 return _call_vlm_processor(processor, (), proc_kwargs)
             except TypeError as exc:
+                if (
+                    "audio_kwargs" in str(exc)
+                    and "unexpected keyword argument" in str(exc)
+                    and "audio_kwargs" in proc_kwargs
+                ):
+                    # Gemma 4 handles audio itself, then forwards remaining
+                    # kwargs to its tokenizer. It therefore rejects the
+                    # modality shield used by ProcessorMixin-based families;
+                    # its feature extractor never sees the flat text cap.
+                    proc_kwargs.pop("audio_kwargs")
+                    try:
+                        return _call_vlm_processor(processor, (), proc_kwargs)
+                    except Exception as retry_exc:
+                        if first_error is None:
+                            first_error = retry_exc
+                        if len(image_layouts) == 1:
+                            raise
+                        continue
                 if (
                     "add_special_tokens" in str(exc)
                     # Bound twice, or not accepted: both mean drop and retry.
@@ -8530,7 +8566,7 @@ def _audio_fixed_budget(processor, config=None):
 
 _AUDIO_TOWER_ATTRS = (
     "audio_tower", "embed_audio", "audio_encoder", "audio_projection",
-    "audio_projection_layer",
+    "audio_projection_layer", "sound_encoder", "sound_projection",
 )
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5672,14 +5672,14 @@ class _AudioVersions(NamedTuple):
 # made sanitize unconditional, double-transposing pre-converted convs -- but
 # loader.py's `_ensure_audio_conv_sanitize` (PR 879) undoes it, and upstream
 # fixed it in 0.6.5 (#1523).
-# These three omni implementations use their first working native-audio release
-# as the floor; 0.6.10 remains the latest exercised by the real-model gate.
+# Unified needs 0.6.5's processor/audio-layout fix; Qwen needs 0.6.7's batched
+# mel input and sample-domain length fixes. 0.6.10 is the latest real-model gate.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4"),
     "gemma4": _AudioVersions("0.6.2"),
-    "gemma4_unified": _AudioVersions("0.6.1"),
+    "gemma4_unified": _AudioVersions("0.6.5"),
     "nemotron_h_nano_omni": _AudioVersions("0.5.0"),
-    "qwen3_omni_moe": _AudioVersions("0.6.0"),
+    "qwen3_omni_moe": _AudioVersions("0.6.7"),
     "phi4mm": _AudioVersions("0.4.4"),
     "minicpmo": _AudioVersions("0.4.4"),
 }

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5626,16 +5626,9 @@ _AUDIO_SOFT_TOKEN_STRINGS = (
 )
 
 class _AudioVersions(NamedTuple):
-    """The mlx-vlm releases a family's audio path is qualified for.
-
-    Bounded at both ends on purpose. An unreleased version is refused rather
-    than assumed good, which is the property the whole gate exists for: a wrong
-    "yes" here trains against misaligned features and fails silently, where a
-    wrong "no" only asks someone to pin.
-    """
+    """The first mlx-vlm release containing a family's qualified audio path."""
 
     minimum: str
-    maximum: str
 
     def admits(self, installed):
         if not installed:
@@ -5646,22 +5639,19 @@ class _AudioVersions(NamedTuple):
             # no prerelease, post-release or local build in 73 releases.
             if found.is_prerelease or found.is_postrelease or found.local:
                 return False
-            return _Version(self.minimum) <= found <= _Version(self.maximum)
+            return _Version(self.minimum) <= found
         except Exception:
             # An unparseable version is not evidence; refusing beats raising.
             return False
 
     def __str__(self):
-        if self.minimum == self.maximum:
-            return self.minimum
-        return f"{self.minimum} to {self.maximum}"
+        return f">={self.minimum}"
 
 
 # Families and the mlx-vlm releases their audio path is qualified for.
 #
 # Probes ran on 0.4.4. gemma3n, phi4mm and minicpmo ship a byte-identical
-# processor from 0.4.4 through 0.6.9; the 0.6.4 ceiling is only because mlx-vlm
-# 0.6.5+ requires transformers>=5.14, which this package caps at 5.5.0.
+# processor from 0.4.4 through 0.6.9.
 #
 # Gemma 4 starts at 0.6.2, not 0.4.4: below that mlx-vlm cannot load the
 # checkpoint at all. E2B's KV-shared layers reuse an earlier layer's K/V and
@@ -5676,23 +5666,22 @@ class _AudioVersions(NamedTuple):
 # Measured on macos-14 against mlx-community/gemma-4-e2b-it-4bit @ 2387675275,
 # 0.4.4 through 0.6.4: load, placeholder count vs the positions `audio_tower`
 # returns at 0.5s/1.0s/2.0s/3.7s, two clips giving two losses. 0.6.1 red,
-# 0.6.2-0.6.4 green. 0.6.5+ was never run: it cannot be installed here.
+# 0.6.2-0.6.4 green.
 #
-# 0.6.4 is in deliberately. Raw mlx-vlm 0.6.4 fails on these weights -- #1498
+# Raw mlx-vlm 0.6.4 fails on these weights -- #1498
 # made sanitize unconditional, double-transposing pre-converted convs -- but
 # loader.py's `_ensure_audio_conv_sanitize` (PR 879) undoes it, and upstream
-# fixed it in 0.6.5 (#1523). The ceiling is 0.6.4 only for the transformers cap.
-# Gemma 4 Unified, Nemotron Omni, and Qwen3 Omni are separate implementations.
-# Their floors are the first upstream releases containing working native audio
-# paths; 0.6.10 remains the latest release exercised by the real-model gate.
+# fixed it in 0.6.5 (#1523).
+# These three omni implementations use their first working native-audio release
+# as the floor; 0.6.10 remains the latest exercised by the real-model gate.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
-    "gemma3n": _AudioVersions("0.4.4", "0.6.4"),
-    "gemma4": _AudioVersions("0.6.2", "0.6.4"),
-    "gemma4_unified": _AudioVersions("0.6.1", "0.6.10"),
-    "nemotron_h_nano_omni": _AudioVersions("0.5.0", "0.6.10"),
-    "qwen3_omni_moe": _AudioVersions("0.6.0", "0.6.10"),
-    "phi4mm": _AudioVersions("0.4.4", "0.6.4"),
-    "minicpmo": _AudioVersions("0.4.4", "0.6.4"),
+    "gemma3n": _AudioVersions("0.4.4"),
+    "gemma4": _AudioVersions("0.6.2"),
+    "gemma4_unified": _AudioVersions("0.6.1"),
+    "nemotron_h_nano_omni": _AudioVersions("0.5.0"),
+    "qwen3_omni_moe": _AudioVersions("0.6.0"),
+    "phi4mm": _AudioVersions("0.4.4"),
+    "minicpmo": _AudioVersions("0.4.4"),
 }
 
 # Families probed only on a newer transformers than this package pins, at the

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6313,7 +6313,12 @@ def _vlm_audio_part_state(messages):
         for part in content:
             if not isinstance(part, dict):
                 continue
-            if part.get("type") not in _AUDIO_PART_TYPES:
+            # Key-only `{"audio": clip}` too, not just a typed part: Qwen's own
+            # template renders a placeholder for it, so extracting nothing here
+            # left the row a placeholder short of a waveform.
+            if part.get("type") not in _AUDIO_PART_TYPES and not any(
+                key in part for key in _AUDIO_PART_TYPES
+            ):
                 continue
             payload = None
             for key in _AUDIO_PART_TYPES:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5682,22 +5682,16 @@ class _AudioVersions(NamedTuple):
 # made sanitize unconditional, double-transposing pre-converted convs -- but
 # loader.py's `_ensure_audio_conv_sanitize` (PR 879) undoes it, and upstream
 # fixed it in 0.6.5 (#1523). The ceiling is 0.6.4 only for the transformers cap.
-# Gemma 4 Unified and Nemotron Omni are separate implementations first qualified
-# against the release environment's 0.6.10 contract; fail closed on either side.
+# Gemma 4 Unified and Nemotron Omni are separate implementations. Their floors
+# are the first upstream releases containing those native audio paths; 0.6.10
+# remains the latest release exercised by the real-model qualification gate.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, _AudioVersions]" = {
     "gemma3n": _AudioVersions("0.4.4", "0.6.4"),
     "gemma4": _AudioVersions("0.6.2", "0.6.4"),
-    "gemma4_unified": _AudioVersions("0.6.10", "0.6.10"),
-    "nemotron_h_nano_omni": _AudioVersions("0.6.10", "0.6.10"),
+    "gemma4_unified": _AudioVersions("0.6.1", "0.6.10"),
+    "nemotron_h_nano_omni": _AudioVersions("0.5.0", "0.6.10"),
     "phi4mm": _AudioVersions("0.4.4", "0.6.4"),
     "minicpmo": _AudioVersions("0.4.4", "0.6.4"),
-}
-
-_AUDIO_UNSUPPORTED_REASONS = {
-    "diffusion_gemma": (
-        "the published checkpoint has no native audio modality, processor "
-        "path, audio configuration, or audio weights"
-    ),
 }
 
 # Families probed only on a newer transformers than this package pins, at the
@@ -5974,12 +5968,6 @@ def _check_audio_family_gate(processor):
     if probed and probed.admits(installed):
         _check_audio_transformers_floor(family)
         return family
-    unsupported = _AUDIO_UNSUPPORTED_REASONS.get(family)
-    if unsupported:
-        raise NotImplementedError(
-            f"Unsloth MLX: audio training is not supported for '{family}': "
-            f"{unsupported}. Train on its text and image modalities instead."
-        )
     if not _AUDIO_QUALIFIED_FAMILIES:
         raise NotImplementedError(
             f"Unsloth MLX: audio inputs were found in this dataset, but audio "

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -8557,6 +8557,7 @@ _AUDIO_TOWER_ATTRS = (
     "audio_tower", "embed_audio", "audio_encoder", "audio_projection",
     "audio_projection_layer", "sound_encoder", "sound_projection",
 )
+_AUDIO_OUTPUT_ATTRS = ("talker", "code2wav")
 
 
 _AUDIO_MERGE_SENTINEL = "_unsloth_audio_merge_patched"
@@ -8725,19 +8726,24 @@ def _masked_scatter_rowwise(embeds, mask, source):
 
 
 def freeze_audio_modules(model):
-    """Freeze the audio tower and its projection.
+    """Freeze audio-input towers/projections and audio-output modules.
 
     Audio towers are inference-only here: their encoders carry fp32 promotions,
     long cumulative reductions and host-synchronizing guards that make them
     poor training subjects, and the model-side merge assumes their output is a
-    fixed function of the clip. LoRA runs freeze everything by default, but a
-    full fine-tune would otherwise pull these parameters into the optimizer.
+    fixed function of the clip. Audio-output modules are outside this input-only
+    training path. LoRA runs freeze everything by default, but a full fine-tune
+    would otherwise pull all of these parameters into the optimizer.
 
     Returns the names of the modules that were frozen.
     """
     frozen = []
-    for attr in _AUDIO_TOWER_ATTRS:
-        for owner in (model, getattr(model, "language_model", None)):
+    for attr in _AUDIO_TOWER_ATTRS + _AUDIO_OUTPUT_ATTRS:
+        for owner in (
+            model,
+            getattr(model, "language_model", None),
+            getattr(model, "thinker", None),
+        ):
             module = getattr(owner, attr, None) if owner is not None else None
             if module is None or not hasattr(module, "freeze"):
                 continue


### PR DESCRIPTION
Adds native audio-input inference and SFT support for the new MLX omni implementations: Nemotron 3 Nano Omni, Gemma 4 Unified, and Qwen3 Omni. Each family is admitted from the first `mlx-vlm` release that contains its complete working audio path; later final releases follow Unsloth's latest-compatible resolver policy instead of requiring a manually maintained ceiling.

Before this, the new families were either refused by the audio gate, lost their required prompt/media ordering, exposed audio modules to full-fine-tuning optimizers, or handed the processor a batch representation that changed the meaning of the audio.

## What changed

- **Nemotron 3 Nano Omni.** Recognizes `sound_encoder`, `sound_projection`, and `sound_clips`; preserves the outer waveform list even when clips have equal lengths; reads the processor-owned 16 kHz sampling rate; keeps sound modules frozen; and normalizes the published mixed-case model type only to an exact case-insensitive mlx-vlm registry key.
- **Gemma 4 Unified.** Qualifies the encoder-free unified implementation separately from legacy Gemma 4, so it keeps its native merge contract and never receives Gemma 4's incompatible placeholder correction. The processor retry removes only the modality-only `audio_kwargs` shield that Gemma 4 forwards to its tokenizer.
- **Qwen3 Omni.** Preserves Qwen's required video/audio/text ordering for scalar counts and structured conversations, delegates final rendering to the native processor without injecting `enable_thinking=False`, honors explicit media-suppression/template options, and freezes the nested Thinker audio tower plus out-of-scope Talker/Code2Wav modules for input-only training.
- **Family qualification.** `gemma4_unified` starts at `mlx-vlm 0.6.5`, Nemotron at `0.5.0`, and Qwen3 Omni at `0.6.7`. Gemma's floor is the first release with its processor/audio-layout repair; Qwen's is the first with both batched-mel and sample-domain-length repairs. Prerelease, post-release, local, malformed, and below-floor versions remain refused, while later compatible final releases remain admitted.

## Validation

The main real-model matrix used `mlx-vlm==0.6.10` and the release environment's `transformers==4.57.6`. Boundary probes additionally ran the exact upstream source tags: Gemma on `v0.6.5` and Qwen on `v0.6.7`.

### Real-dataset 30-step audio SFT

Following the validation shape used in #966, each family trained for 30 LoRA steps on the same ordered speech data. The dataset was `hf-internal-testing/librispeech_asr_dummy` (`clean`, `validation`): despite the repository name, it contains 73 genuine 16 kHz LibriSpeech utterances and transcripts. Each user turn supplied the waveform and a transcription request; the assistant target was the corresponding transcript.

Shared settings were batch size 1, maximum sequence length 512, `torch_randperm` ordering with seed 3407, constant learning rate `1e-4`, gradient checkpointing, standard cross entropy, and LoRA `r=8`, `alpha=16` on Q/V projections in the final language attention layer. Nemotron uses `finetune_last_n_layers=10` only because its final attention block is layer 42; layers 43-51 are MoE/Mamba blocks with no Q/V projections, so its effective adapted scope remains one attention layer.

| family | checkpoint | step 1 loss | step 30 loss | mean loss | mean grad norm | adapter tensors updated | peak memory |
|---|---|---:|---:|---:|---:|---:|---:|
| Gemma 4 Unified | `mlx-community/gemma-4-12B-it-OptiQ-4bit` | 5.86993 | 5.09128 | 5.51637 | 3.53400 | 2/2 | 11.91 GB |
| Qwen3 Omni | `mlx-community/Qwen3-Omni-30B-A3B-Instruct-4bit` | 4.67775 | 4.05842 | 4.25655 | 3.91832 | 4/4 | 31.83 GB |
| Nemotron 3 Nano Omni | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` (runtime 4-bit affine) | 3.69480 | 3.66736 | 3.55826 | 0.95607 | 4/4 | 27.24 GB |

All 90 losses and gradient norms were finite. Every targeted adapter tensor changed, while every audio encoder/output module remained absent from the trainable parameter set. The exact 30 utterance IDs and order matched across all three runs. Raw per-step losses are not expected to decrease monotonically because each step uses a different utterance and transcript.

### Inference and modality controls

| family | result |
|---|---|
| Nemotron 3 Nano Omni | Audio-conditioned generation passed; exactly transcribed `The quick brown fox jumps over the lazy dog.` |
| Gemma 4 Unified | Audio-conditioned generation passed; exactly transcribed `The quick brown fox jumps over the lazy dog.` on the exact `v0.6.5` floor. |
| Qwen3 Omni | Audio-conditioned generation passed; exactly transcribed `The quick brown fox jumps over the lazy dog.` and preserved the text-only control on the exact `v0.6.7` floor. |

The controlled Nemotron and Qwen runs changed only waveform content while preserving token IDs and audio length, and produced different losses. This proves the training path remained audio-conditioned rather than silently optimizing text alone. On `v0.6.7`, Qwen also completed an additional one-step floor probe with losses `5.83892` and `5.32614` for the controlled waveforms, finite training loss `5.75023`, gradient norm `3.52930`, and all four adapter tensors updated while audio modules remained frozen.

The immediate predecessor explains Qwen's floor: on the same 39,946-sample speech input, `v0.6.6` interpreted the sample-domain mask as mel frames and derived 5,193 audio placeholders; `v0.6.7` normalized the length and derived 33.

### Why there is no CUDA comparison

No CUDA parity result is claimed. The available CUDA host cannot load the 66 GB Nemotron BF16 checkpoint, and the cached Gemma 4 Unified and Qwen3 Omni validation artifacts are MLX conversions rather than same-weight CUDA checkpoints. Without the same weights, rows, and supervised positions, a loss comparison would not be meaningful.

## Known limits

- Qwen3 Omni support is audio-input conditioning of the Thinker/language adapters. It does not train the Talker or Code2Wav audio-output path.
- `_AUDIO_QUALIFIED_FAMILIES` gates audio-bearing training rows; it is not a generic model-load or Studio-inference preflight. Studio's active stale environment was synchronized separately to the latest-compatible `mlx-vlm 0.6.10`.
- The Studio-level renderer lookup for Nemotron's published mixed-case model type belongs to the separate `unsloth` repository change; this PR owns the zoo runtime and training boundary.

## Test coverage

- `233 passed` in `tests/test_mlx_vlm_label_masks.py`
- `55 passed` in `tests/test_mlx_save_export_regressions.py`
- Python compilation and `git diff --check`
- Every changed behavior was exercised test-first. Reverting either corrected family floor makes its boundary proof fail; reintroducing a `0.6.10` ceiling makes both the public gate and future-version proofs fail.
- The complete branch passed the mandatory review gate with no remaining in-scope findings.
