### PR TITLE
Unwrap an already-compiled callable before handing it back to torch.compile

### DIFF
--- a/tests/test_compile_already_compiled_callable.py
+++ b/tests/test_compile_already_compiled_callable.py
@@ -296,6 +296,27 @@ def test_the_model_keyword_spelling_compiles_the_function():
     """)
 
 
+def test_the_explicit_model_none_decorator_factory_still_compiles():
+    """`torch_compile(model = None, ...)` is the factory spelling of the same
+    signature. Left in `kwargs`, `model = None` collides with the function passed
+    positionally to `torch.compile`, and the eager guard swallows the resulting
+    `TypeError` as "the compiler refused", turning compilation off for good.
+    """
+    _run_with_compile_enabled("""
+        import torch
+        from unsloth_zoo.temporary_patches import common as C
+
+        def eager(x): return x + 1
+
+        for name in ("torch_compile", "_torch_compile"):
+            for kwargs in ({}, {"fullgraph": True, "dynamic": True}):
+                out = getattr(C, name)(model = None, **kwargs)(eager)
+                assert out is not eager, (
+                    f"{name} {kwargs} with an explicit model = None fell back to eager"
+                )
+    """)
+
+
 def test_a_working_compile_is_still_compiled():
     """The fallback must engage only on failure. Silently running eager where
     compile succeeds is a performance regression, not a fix.

--- a/tests/test_compile_already_compiled_callable.py
+++ b/tests/test_compile_already_compiled_callable.py
@@ -1,0 +1,266 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""`torch_compile` on a callable that has already been compiled.
+
+GPT-OSS inference dies at load on torch 2.11 with a bare, message-less
+
+    AssertionError:
+
+out of `patch_GptOssAttention` -> `_compile_or_fall_back` -> `torch.compile`.
+The assert is torch's own:
+
+    torch/_dynamo/eval_frame.py:
+        assert not hasattr(compile_wrapper, "get_compiler_config")
+
+`compile_wrapper` is built with `functools.wraps(fn)`, which copies
+`fn.__dict__`, so the assert says "the function you handed me is already a
+compiled one". Dynamo unwraps its own wrappers first (`innermost_fn`), so this
+can only be reached through a `functools.wraps` copy of a compiled function
+that forwards `get_compiler_config` -- which is exactly what
+`_fall_back_to_eager_on_recompile_limit` returns, on purpose, so that
+"is this compiled?" checks keep answering yes after the fallback is installed.
+
+The chain under GPT-OSS:
+
+  * `pre_compile` writes `unsloth_compiled_cache/unsloth_compiled_module_gpt_oss.py`,
+    whose `apply_rotary_pos_emb` carries
+    `@torch_compile_with_fallback(fullgraph = True, ...)`, and installs it on
+    `transformers.models.gpt_oss.modeling_gpt_oss`.
+  * `post_compile` re-runs `patch_GptOssAttention`, which imports that name and
+    calls `torch_compile(apply_rotary_pos_emb)` -- no `fullgraph`.
+
+Up to torch 2.10 `innermost_fn` followed `_torchdynamo_orig_callable`
+unconditionally, unwrapped the copy to the eager original and recompiled it, so
+none of this showed. torch 2.11 also requires
+`_torchdynamo_wrapper_id == id(fn)`, which a `functools.wraps` copy cannot
+satisfy, and the assert became reachable.
+
+`patch_function` has always hand-unwrapped `get_compiler_config` carriers via
+`__wrapped__` before compiling. The bare `torch_compile` / `_torch_compile`
+decorators never did.
+"""
+
+import functools
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import torch
+
+ZOO = Path(__file__).resolve().parents[1] / "unsloth_zoo"
+
+TORCH_VERSION = tuple(int(x) for x in torch.__version__.split("+")[0].split(".")[:2])
+
+
+def _run_with_compile_enabled(body):
+    """Run `body` in a fresh interpreter with UNSLOTH_COMPILE_DISABLE cleared.
+
+    `torch_compile` and `_torch_compile` are bound at import under a module-level
+    `if UNSLOTH_COMPILE_DISABLE:`, so they are already `noop` by the time a test
+    runs in unsloth's consolidated CI job, which pins the variable to 1 for the
+    whole suite. Rebinding the module attribute afterwards cannot undo that.
+    """
+    env = dict(os.environ)
+    env.pop("UNSLOTH_COMPILE_DISABLE", None)
+    done = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(body)],
+        capture_output = True, text = True, env = env,
+        cwd = str(ZOO.parent),
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+    return done.stdout
+
+
+# ---- the unwrap itself ----------------------------------------------------
+
+def test_unwrap_already_compiled_returns_the_eager_original():
+    from unsloth_zoo.temporary_patches.common import unwrap_already_compiled
+
+    def eager(x): return x + 1
+
+    compiled = torch.compile(eager)
+    assert hasattr(compiled, "get_compiler_config"), \
+        "torch stopped marking its wrappers; this test's premise is gone"
+
+    @functools.wraps(compiled)
+    def fallback_wrapper(*args, **kwargs): return compiled(*args, **kwargs)
+    fallback_wrapper.get_compiler_config = compiled.get_compiler_config
+
+    assert unwrap_already_compiled(fallback_wrapper) is eager
+    assert unwrap_already_compiled(compiled) is eager
+    # A plain function is handed straight back; nothing to unwrap.
+    assert unwrap_already_compiled(eager) is eager
+
+
+def test_unwrap_already_compiled_survives_a_carrier_with_no_wrapped():
+    """An `OptimizedModule`, say. Bail out rather than raise AttributeError.
+
+    `patch_function`'s hand-rolled version does `new_func.__wrapped__`
+    unguarded; the shared helper cannot, because it sees everything.
+    """
+    from unsloth_zoo.temporary_patches.common import unwrap_already_compiled
+
+    def opaque(x): return x
+    opaque.get_compiler_config = lambda: {}
+    assert unwrap_already_compiled(opaque) is opaque
+
+    # And a `__wrapped__` cycle terminates instead of spinning.
+    def a(x): return x
+    def b(x): return x
+    a.get_compiler_config = lambda: {}
+    b.get_compiler_config = lambda: {}
+    a.__wrapped__ = b
+    b.__wrapped__ = a
+    unwrap_already_compiled(a)
+
+
+# ---- the funnel -----------------------------------------------------------
+
+def test_torch_compile_hands_torch_the_eager_function():
+    """Version independent: observe WHICH callable reaches `torch.compile`.
+
+    Before the fix the wrapper itself was passed, which torch 2.11 refuses and
+    torch <= 2.10 silently unwrapped for us. Asserting on the argument fails on
+    every torch, not only the one where the refusal is fatal.
+    """
+    _run_with_compile_enabled("""
+        import functools
+        import torch
+
+        from unsloth_zoo.temporary_patches import common as C
+
+        seen = []
+        real_compile = torch.compile
+
+        def _recording_compile(model = None, **kwargs):
+            if model is not None: seen.append(model)
+            return real_compile(model, **kwargs) if model is not None else real_compile(**kwargs)
+
+        def eager(x): return x + 1
+        compiled = real_compile(eager)
+
+        @functools.wraps(compiled)
+        def fallback_wrapper(*args, **kwargs): return compiled(*args, **kwargs)
+        fallback_wrapper.get_compiler_config = compiled.get_compiler_config
+
+        torch.compile = _recording_compile
+        try:
+            for name in ("torch_compile", "_torch_compile"):
+                seen.clear()
+                out = getattr(C, name)(fallback_wrapper)
+                assert seen, f"{name} never reached torch.compile"
+                assert seen[0] is eager, (
+                    f"{name} handed torch the already-compiled wrapper "
+                    f"({seen[0]!r}), not the eager original"
+                )
+                assert out is not fallback_wrapper
+        finally:
+            torch.compile = real_compile
+    """)
+
+
+@pytest.mark.skipif(
+    TORCH_VERSION < (2, 11),
+    reason = "torch < 2.11 unwraps a functools.wraps copy itself, so the "
+             "assert this reproduces is unreachable",
+)
+def test_the_gpt_oss_load_sequence_does_not_assert():
+    """The real shape of the failure, end to end, on the torch that has it.
+
+    `torch_compile_with_fallback(fullgraph = True)` first, standing in for the
+    decorator in the generated module, then a bare `torch_compile` on its
+    result, standing in for `patch_GptOssAttention`. Unfixed, torch 2.11 raises
+    `AssertionError` with an empty message here.
+    """
+    _run_with_compile_enabled("""
+        import torch
+        from unsloth_zoo.temporary_patches.utils import torch_compile_with_fallback
+        from unsloth_zoo.temporary_patches import common as C
+
+        def apply_rotary_pos_emb(q, k):
+            return q * 2, k * 2
+
+        installed = torch_compile_with_fallback(
+            fullgraph = True, dynamic = True, options = C.torch_compile_options,
+        )(apply_rotary_pos_emb)
+        assert hasattr(installed, "get_compiler_config"), \\
+            "the fallback wrapper stopped advertising itself as compiled"
+
+        # Decoration is the whole failure: unfixed, this line raises before any
+        # tensor exists. Nothing is executed here on purpose, so the test stays
+        # runnable on a CPU-only box with no working inductor backend.
+        recompiled = C.torch_compile(installed)
+        assert callable(recompiled) and recompiled is not installed
+    """)
+
+
+def test_a_refused_decoration_falls_back_to_eager_without_fullgraph():
+    """The non-fullgraph branch used to reach `torch.compile` bare, so anything
+    the compiler refused to decorate took the whole model load with it. It is as
+    protected as the fullgraph branch now: eager, warned about, not raised.
+    """
+    out = _run_with_compile_enabled("""
+        import logging
+        import torch
+
+        logging.basicConfig(level = logging.WARNING)
+
+        # Imported before torch.compile is replaced: unsloth_zoo compiles a few
+        # module-level kernels at import (compile_with_eager_fallback), and a
+        # refusing compiler there is a different failure from the one under test.
+        from unsloth_zoo.temporary_patches import common as C
+
+        real_compile = torch.compile
+        def _refuse(model = None, **kwargs):
+            raise AssertionError
+
+        def eager(x): return x + 1
+
+        torch.compile = _refuse
+        try:
+            for name in ("torch_compile", "_torch_compile"):
+                assert getattr(C, name)(eager) is eager, \\
+                    f"{name} did not fall back to the eager function"
+                assert getattr(C, name)(dynamic = True)(eager) is eager, \\
+                    f"{name} as a decorator factory did not fall back"
+        finally:
+            torch.compile = real_compile
+        print("FELL_BACK")
+    """)
+    assert "FELL_BACK" in out
+
+
+def test_a_working_compile_is_still_compiled():
+    """The fallback must engage only on failure. Silently running eager where
+    compile succeeds is a performance regression, not a fix.
+    """
+    _run_with_compile_enabled("""
+        import torch
+        from unsloth_zoo.temporary_patches import common as C
+
+        def eager(x): return x + 1
+
+        for name in ("torch_compile", "_torch_compile"):
+            out = getattr(C, name)(eager)
+            assert out is not eager, f"{name} returned the eager function"
+            assert hasattr(out, "get_compiler_config"), \\
+                f"{name} returned something torch does not consider compiled"
+
+            out = getattr(C, name)(dynamic = True, fullgraph = True)(eager)
+            assert out is not eager, f"{name} (fullgraph) returned the eager function"
+    """)

--- a/tests/test_compile_already_compiled_callable.py
+++ b/tests/test_compile_already_compiled_callable.py
@@ -129,6 +129,31 @@ def test_unwrap_already_compiled_survives_a_carrier_with_no_wrapped():
     unwrap_already_compiled(a)
 
 
+def test_unwrap_already_compiled_keeps_a_bound_method_bound():
+    """`__wrapped__` on a bound method is the UNBOUND original.
+
+    A bound method forwards attribute lookups to `__func__`, so following
+    `__wrapped__` would hand back a function that still wants `self` and turn the
+    receiver into the first user argument. torch's own `innermost_fn` stops on a
+    bound method for the same reason, so stop here too and let the caller's guard
+    take it from there.
+    """
+    from unsloth_zoo.temporary_patches.common import unwrap_already_compiled
+
+    class Model:
+        def forward(self, x): return x + 1
+
+    model = Model()
+    compiled_forward = torch.compile(Model.forward)
+    Model.forward = compiled_forward
+    bound = model.forward
+
+    assert hasattr(bound, "get_compiler_config"), \
+        "the bound method stopped forwarding the compiled marker"
+    assert bound.__wrapped__ is not bound
+    assert unwrap_already_compiled(bound) is bound
+
+
 # ---- the funnel -----------------------------------------------------------
 
 def test_torch_compile_hands_torch_the_eager_function():
@@ -243,6 +268,32 @@ def test_a_refused_decoration_falls_back_to_eager_without_fullgraph():
         print("FELL_BACK")
     """)
     assert "FELL_BACK" in out
+
+
+def test_the_model_keyword_spelling_compiles_the_function():
+    """`torch.compile(model = fn)` is the signature's own spelling of `(fn)`.
+
+    Left in `kwargs` it is not the positional function, so the funnel handed back
+    the undecorated `decorate` and then, when the caller called that, compiled its
+    first ARGUMENT: `torch_compile(model = fn)(tensor)` returned the tensor.
+    """
+    _run_with_compile_enabled("""
+        import torch
+        from unsloth_zoo.temporary_patches import common as C
+
+        def eager(x): return x + 1
+
+        for name in ("torch_compile", "_torch_compile"):
+            for kwargs in ({}, {"fullgraph": True, "dynamic": True}):
+                out = getattr(C, name)(model = eager, **kwargs)
+                assert out is not eager, f"{name} {kwargs} returned the eager function"
+                assert getattr(out, "__wrapped__", None) is eager \\
+                    or getattr(out, "_torchdynamo_orig_callable", None) is eager, (
+                    f"{name} {kwargs} did not compile the model keyword "
+                    f"(got {out!r})"
+                )
+        print("MODEL_KW_OK")
+    """)
 
 
 def test_a_working_compile_is_still_compiled():

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -213,6 +213,12 @@ def unwrap_already_compiled(function):
     """
     seen = set()
     while callable(function) and hasattr(function, "get_compiler_config"):
+        # A bound method forwards attribute lookups to the function underneath it,
+        # so `__wrapped__` here is the UNBOUND original and following it would drop
+        # the receiver. torch's own `innermost_fn` stops on a bound method for that
+        # exact reason ("id(bound_method) != id(wrapper_function), so we won't
+        # unwrap through __func__ and lose the self binding").
+        if getattr(function, "__self__", None) is not None: break
         inner = getattr(function, "__wrapped__", None)
         # No `__wrapped__` (an OptimizedModule, say) or a cycle: leave it be and
         # let the caller's guard deal with whatever torch makes of it.
@@ -249,6 +255,13 @@ def _compile_or_fall_back(*args, **kwargs):
     Both spellings are in use: `@torch_compile(...)` as a decorator factory, and
     `torch_compile(fn, ...)` applied directly (gemma.py, gpt_oss.py). Imported
     lazily: utils imports this module."""
+    # `torch.compile`'s first parameter is named `model`, so `torch_compile(model = fn)`
+    # is a third legal spelling. Take it out of the compile kwargs, where it would
+    # collide with the function passed positionally, and treat it as that function.
+    function = args[0] if args and callable(args[0]) else None
+    if function is None and callable(kwargs.get("model")):
+        function = kwargs.pop("model")
+
     if kwargs.get("fullgraph"):
         from .utils import torch_compile_with_fallback
         _compile = torch_compile_with_fallback(**kwargs)
@@ -272,8 +285,8 @@ def _compile_or_fall_back(*args, **kwargs):
                     f"from speed. ({type(exception).__name__}: {exception})"
                 )
             return function
-    if args and callable(args[0]):
-        return decorate(args[0])
+    if function is not None:
+        return decorate(function)
     return decorate
 
 

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -258,9 +258,14 @@ def _compile_or_fall_back(*args, **kwargs):
     # `torch.compile`'s first parameter is named `model`, so `torch_compile(model = fn)`
     # is a third legal spelling. Take it out of the compile kwargs, where it would
     # collide with the function passed positionally, and treat it as that function.
+    # Popped whether or not it is callable: `torch_compile(model = None, ...)` is the
+    # decorator-factory spelling, and a `model` left behind collides with the function
+    # `_compile` passes positionally, which the guard below would then swallow as a
+    # refusal to compile.
     function = args[0] if args and callable(args[0]) else None
-    if function is None and callable(kwargs.get("model")):
-        function = kwargs.pop("model")
+    if function is None and "model" in kwargs:
+        model = kwargs.pop("model")
+        if callable(model): function = model
 
     if kwargs.get("fullgraph"):
         from .utils import torch_compile_with_fallback

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -26,6 +26,7 @@ __all__ = [
     "torch_compile",
     "_torch_compile",
     "_raw_torch_compile",
+    "unwrap_already_compiled",
     "flatten_for_elementwise_norm",
     "unwrap_norm_weight",
     "publish_to_modeling_module",
@@ -177,6 +178,57 @@ def noop(*args: Any, **kwargs: Any):
     return _decorator
 pass
 
+def unwrap_already_compiled(function):
+    """Hand `torch.compile` the eager original when given an already-compiled one.
+
+    `torch.compile` builds its wrapper with `functools.wraps(fn)`, which copies
+    `fn.__dict__`, and then asserts the copy did not bring `get_compiler_config`
+    along:
+
+        torch/_dynamo/eval_frame.py: assert not hasattr(compile_wrapper, "get_compiler_config")
+
+    a bare assert, so it surfaces as `AssertionError:` with no message at all.
+    Dynamo unwraps its OWN wrappers before that point (`innermost_fn`), so the
+    assert can only be reached through a wrapper that carries
+    `get_compiler_config` without being a Dynamo wrapper. That is exactly what
+    `_fall_back_to_eager_on_recompile_limit` returns: it forwards
+    `get_compiler_config` and `_torchdynamo_orig_callable` on purpose, so that
+    "is this compiled?" checks keep answering yes after the fallback is
+    installed.
+
+    Up to torch 2.10 `innermost_fn` followed `_torchdynamo_orig_callable`
+    unconditionally and unwrapped those too, so recompiling one was harmless.
+    torch 2.11 additionally requires `_torchdynamo_wrapper_id == id(fn)`,
+    which a `functools.wraps` copy cannot satisfy by construction, and the
+    assert became reachable. Under GPT-OSS it is: the generated
+    `unsloth_compiled_module_gpt_oss.py` installs a fullgraph-fallback
+    `apply_rotary_pos_emb` onto the modeling module during `pre_compile`, and
+    `patch_GptOssAttention` re-compiles that same name during `post_compile`.
+
+    `patch_function` has always done this unwrap by hand before compiling.
+    Doing it in the shared funnel covers the bare decorators too. `__wrapped__`
+    is what `functools.wraps` sets, and it is the eager original for both the
+    fallback wrapper and a plain `torch.compile` result, so compiling it
+    reproduces the pre-2.11 outcome exactly rather than degrading to eager.
+    """
+    seen = set()
+    while callable(function) and hasattr(function, "get_compiler_config"):
+        inner = getattr(function, "__wrapped__", None)
+        # No `__wrapped__` (an OptimizedModule, say) or a cycle: leave it be and
+        # let the caller's guard deal with whatever torch makes of it.
+        if not callable(inner) or id(inner) in seen: break
+        seen.add(id(function))
+        function = inner
+    return function
+pass
+
+
+# Warn once per call site, not once per compile attempt: the temporary patches
+# re-run at every phase and for every model, so an unwarned repeat would print
+# the same line several times per load.
+_UNCOMPILED_CALL_SITES: set = set()
+
+
 def _compile_or_fall_back(*args, **kwargs):
     """`torch.compile`, routed through the eager fallback under fullgraph.
 
@@ -186,13 +238,40 @@ def _compile_or_fall_back(*args, **kwargs):
     exhaustion there stayed fatal while `patch_function`'s did not. Fixed here
     rather than per call site so a new one cannot miss it.
 
+    The same goes for the compile call itself. `fullgraph = False` used to go
+    straight to `torch.compile` with nothing around it, so a compiler that
+    refuses to decorate at all (see `unwrap_already_compiled`) took the whole
+    model load down. Decorating is the only thing guarded here: it either hands
+    back the compiled callable it always did, or, if torch declines to build
+    one, the eager function. Compilation itself still happens on the first
+    call, so a setup where compile works keeps working, at the same speed.
+
     Both spellings are in use: `@torch_compile(...)` as a decorator factory, and
     `torch_compile(fn, ...)` applied directly (gemma.py, gpt_oss.py). Imported
     lazily: utils imports this module."""
-    if not kwargs.get("fullgraph"):
-        return torch.compile(*args, **kwargs)
-    from .utils import torch_compile_with_fallback
-    decorate = torch_compile_with_fallback(**kwargs)
+    if kwargs.get("fullgraph"):
+        from .utils import torch_compile_with_fallback
+        _compile = torch_compile_with_fallback(**kwargs)
+    else:
+        def _compile(function):
+            return torch.compile(function, **kwargs)
+
+    def decorate(function):
+        function = unwrap_already_compiled(function)
+        try:
+            return _compile(function)
+        except Exception as exception:
+            # Never fatal: a temporary patch that cannot be compiled is a
+            # performance problem, and the uncompiled function is still correct.
+            label = getattr(function, "__qualname__", None) or repr(function)
+            if label not in _UNCOMPILED_CALL_SITES:
+                _UNCOMPILED_CALL_SITES.add(label)
+                logger.warning(
+                    f"Unsloth: torch.compile refused to wrap {label}; running "
+                    f"it eagerly. Training and inference are unaffected apart "
+                    f"from speed. ({type(exception).__name__}: {exception})"
+                )
+            return function
     if args and callable(args[0]):
         return decorate(args[0])
     return decorate

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1251,7 +1251,12 @@ def compile_with_eager_fallback(func, label, fullgraph = True, dynamic = True):
     # fallback itself, so wrapping its result again would leave the inner
     # wrapper swallowing the exhaustion under a label nobody looks up, and the
     # outer one returned here never latching.
-    from .common import _raw_torch_compile
+    from .common import _raw_torch_compile, unwrap_already_compiled
+    # No-op for the plain module-level functions every caller passes today, and
+    # the thing that keeps torch 2.11's bare
+    # `assert not hasattr(compile_wrapper, "get_compiler_config")` out of reach
+    # if one ever passes a callable that has already been through here.
+    func = unwrap_already_compiled(func)
     compiled = _raw_torch_compile(fullgraph = fullgraph, dynamic = dynamic)(func)
     # Without fullgraph Dynamo already falls back by itself.
     if not fullgraph:


### PR DESCRIPTION
### Symptom

`GPT_OSS_MXFP4_(20B)-Inference.ipynb` and `GPT_OSS_BNB_(20B)-Inference.ipynb` both die at model load on Colab A100/T4 VMs running torch 2.11.0+cu128 with transformers 4.56.2. The error is a bare `AssertionError:` with no message:

```
unsloth/models/_utils.py       in _run_temporary_patches(phase)
unsloth_zoo/.../gpt_oss.py     in patch_GptOssAttention()
unsloth_zoo/.../common.py      in _compile_or_fall_back(*args, **kwargs)
torch/__init__.py              in compile(...)
torch/_dynamo/eval_frame.py    in __call__(self, fn)
AssertionError:
```

Reproduced locally, off Colab, on an identical stack (torch 2.11.0+cu128, transformers 4.56.2, B200), with the exact same frame list:

```
_utils.py:3446 unsloth_compile_transformers -> _run_temporary_patches("post_compile")
gpt_oss.py:2214 apply_rotary_pos_emb = torch_compile(apply_rotary_pos_emb)
common.py:193   return torch.compile(*args, **kwargs)
eval_frame.py:1073 assert not hasattr(compile_wrapper, "get_compiler_config")
```

### Root cause

The assert is torch's own, and it means "the callable you handed me is already a compiled one". `torch.compile` builds its wrapper with `functools.wraps(fn)`, which copies `fn.__dict__`, then checks the copy did not bring `get_compiler_config` along. Dynamo unwraps its own wrappers before that point (`innermost_fn`), so the assert is only reachable through a `functools.wraps` copy of a compiled function that forwards `get_compiler_config` without being a Dynamo wrapper.

That is exactly what `_fall_back_to_eager_on_recompile_limit` returns. It forwards `get_compiler_config` and `_torchdynamo_orig_callable` deliberately, so that "is this compiled?" checks keep answering yes once the eager fallback is installed.

The GPT-OSS chain:

1. `pre_compile` writes `unsloth_compiled_cache/unsloth_compiled_module_gpt_oss.py`, whose `apply_rotary_pos_emb` carries `@torch_compile_with_fallback(fullgraph = True, ...)`, and installs it on `transformers.models.gpt_oss.modeling_gpt_oss`.
2. `post_compile` re-runs `patch_GptOssAttention`, which imports that name and calls `torch_compile(apply_rotary_pos_emb)`.

Up to torch 2.10 `innermost_fn` followed `_torchdynamo_orig_callable` unconditionally, unwrapped the copy to the eager original and recompiled it, so none of this showed. torch 2.11 added an id check:

```python
while (hasattr(unaltered_fn, "_torchdynamo_orig_callable")
       and getattr(unaltered_fn, "_torchdynamo_wrapper_id", None) == id(unaltered_fn)):
```

whose docstring names the case directly: "When functools.wraps copies `_torchdynamo_orig_callable` from a wrapped function, the copied `_torchdynamo_wrapper_id` won't match the outer wrapper's id." So the wrapper is no longer unwrapped, the copied `get_compiler_config` survives into `compile_wrapper.__dict__`, and the assert fires.

`patch_function` has always hand-unwrapped `get_compiler_config` carriers via `__wrapped__` before compiling (`utils.py:1789`). The bare `torch_compile` / `_torch_compile` decorators never got that unwrap, and `_compile_or_fall_back`'s non-fullgraph branch reached `torch.compile` with nothing around it, so the failure was fatal rather than a lost optimisation.

### Fix

`unsloth_zoo/temporary_patches/common.py`

* New `unwrap_already_compiled(function)`: follow `__wrapped__` while the callable advertises `get_compiler_config`. Unlike `patch_function`'s inline version it tolerates a carrier with no `__wrapped__` (an `OptimizedModule`) and terminates on a `__wrapped__` cycle, because the shared funnel sees everything.
* `_compile_or_fall_back` now builds the decorator for either branch and applies it inside one `decorate()` that unwraps first and catches a refusal to decorate, returning the eager function with a one-per-call-site warning.

Only **decoration** is guarded. Compilation still happens on the first call exactly as before, so a setup where compile succeeds keeps its compiled kernel at the same speed; the fallback engages only when torch declines to build a wrapper at all.

`unsloth_zoo/temporary_patches/utils.py`

* `compile_with_eager_fallback` applies the same unwrap before `_raw_torch_compile`. A no-op for every current caller (they all pass module-level plain functions), and it keeps the hazard out of reach if one ever passes a callable that has been through here already.

### Audit of every compile entry point

`_compile_or_fall_back` has no callers outside `common.py` (it is only reached through the two aliases). `torch_compile` and `_torch_compile` cover 15 call sites; the ones that omit `fullgraph`, and so took the unprotected branch, are `gpt_oss.py:2214`, `gpt_oss.py:2451-2452`, `gpt_oss.py:2528`, `gpt_oss.py:2583`, `misc.py:607/610`, `flex_attention/utils.py:77` and `patch_torch_functions.py:131`. Nothing depends on the unprotected behaviour. `patch_torch_functions.py:131` already guards itself with `if not hasattr(qat_class.forward, "get_compiler_config")`, which is the same hazard spotted once and fixed locally. `_raw_torch_compile` keeps its `functools.partial(torch.compile, ...)` form: its one caller applies the fallback itself, and `test_generated_fullgraph_fallback.py` asserts on that shape.

### Tests

New `tests/test_compile_already_compiled_callable.py`, six tests:

* the unwrap returns the eager original, and survives a carrier with no `__wrapped__` and a `__wrapped__` cycle
* `torch_compile` and `_torch_compile` hand **the eager function** to `torch.compile`, observed by recording the argument, so it fails on every torch rather than only the one where the refusal is fatal
* the GPT-OSS `pre_compile` then `post_compile` sequence does not assert (gated on torch >= 2.11, where the assert exists)
* a refused decoration falls back to eager instead of raising
* a working compile is still compiled, which is the control against turning the fix into a silent performance regression

Compatibility, running the new file on both this branch and 566aa2b2:

| torch | 566aa2b2 | this branch |
| --- | --- | --- |
| 2.6.0+cu124 | 4 failed | 5 passed, 1 skipped |
| 2.7.1+cpu | 4 failed | 5 passed, 1 skipped |
| 2.8.0+cu128 | 4 failed | 5 passed, 1 skipped |
| 2.9.1+cu128 | 4 failed | 5 passed, 1 skipped |
| 2.10.0+cpu | 4 failed | 5 passed, 1 skipped |
| 2.11.0+cu128 | 5 failed | 6 passed |
| 2.12.0+cu130 | 5 failed | 6 passed |
| 2.13.0+cpu | 5 failed | 6 passed |

The extra failure and the missing skip from 2.11 onward are the GPT-OSS sequence test, which only runs where the assert exists.

Existing suites, unchanged: `test_generated_fullgraph_fallback`, `test_recompile_limit_fallback`, `test_eager_fallback_latch`, `test_disabled_hook_graph_break`, `test_rmsnorm_recompile_guards`, `test_compile_disable_partial`, `test_rl_replacements_compile_disable`, `test_checkpoint_compile_mix`, `test_compiler_decorated_forward`, `test_unreadable_modeling_source`. 193 passed 1 skipped on torch 2.11, 239 passed on torch 2.9.

### End to end on a real model

torch 2.11.0+cu128, transformers 4.56.2, one B200, unsloth 2026.8.5:

* `unsloth/gpt-oss-20b-unsloth-bnb-4bit` loads and generates ("What is 2+2?" -> 4). Dies at load on 566aa2b2.
* `unsloth/gpt-oss-20b` loads and generates. Dies at load on 566aa2b2.
* 3 LoRA steps on the BNB model, loss 2.5276 -> 2.4472.

### Not verified

* Not run on Colab. Everything above is a local reproduction of the same stack; the Colab VMs were left alone.
* `triton_kernels` is not installed here, so the MXFP4 repo took the 16-bit LoRA path rather than the true MXFP4 kernel path. The patch sequence that fails is the same either way, but the MXFP4 kernels themselves were not exercised.
* No T4. The Colab reports include a G4 VM; only B200 (and CPU-only venvs for the version matrix) were available.
* No throughput measurement. The claim that a working compile stays compiled rests on the returned object still being a `torch.compile` wrapper, asserted in `test_a_working_compile_is_still_compiled`, not on a timed run.
* torch 2.6 and 2.7 were exercised through the new test file only, not through a GPT-OSS load.
