### PR TITLE
Fix MLX ragged VLM image batches

### DIFF
--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -4004,6 +4004,41 @@ def test_clips_of_unequal_duration_all_reach_the_model():
     assert tuple(stacked.shape) == (2, 80, 300)
 
 
+def test_mixed_aspect_ratio_images_all_reach_the_model():
+    """Gemma 4 keeps differently shaped processed images as a ragged list.
+
+    The generic conversion used to catch the failed stack and retain only the
+    first tensor, so a batch of two OCR examples reached the vision tower as one
+    unbatched 3-D image. Preserve every image and its row order instead.
+    """
+    from unsloth_zoo.mlx.utils import _to_mx_vlm_batch
+
+    source = (
+        np.full((3, 4, 7), 11, dtype=np.float32),
+        np.full((3, 6, 5), 29, dtype=np.float32),
+    )
+    for images in (source, source[::-1]):
+        pixels = _to_mx_vlm_batch({"pixel_values": list(images)})["pixel_values"]
+
+        assert isinstance(pixels, list)
+        assert [tuple(image.shape) for image in pixels] == [tuple(image.shape) for image in images]
+        assert [float(np.asarray(image)[1, -1, -1]) for image in pixels] == [
+            float(image[1, -1, -1]) for image in images
+        ]
+
+
+def test_equal_shape_images_stack_without_data_loss():
+    from unsloth_zoo.mlx.utils import _to_mx_vlm_batch
+
+    dense_source = [
+        np.full((3, 4, 7), 41, dtype=np.float32),
+        np.full((3, 4, 7), 73, dtype=np.float32),
+    ]
+    dense = _to_mx_vlm_batch({"pixel_values": dense_source})["pixel_values"]
+    assert tuple(dense.shape) == (2, *dense_source[0].shape)
+    assert [float(np.asarray(dense)[row, 1, -1, -1]) for row in (0, 1)] == [41.0, 73.0]
+
+
 def test_nested_audio_rows_are_paired_clip_by_clip():
     """A processor that wants ``(samples, rate)`` pairs may also want its audio
     nested per row (MiniCPM-o). Pairing the payload as though its entries were

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6439,6 +6439,11 @@ _AUDIO_FEATURE_PAYLOAD_KEYS = (
     "input_features", "input_audio_embeds", "audio_features",
 )
 
+# Some image processors keep one tensor per image when aspect-ratio-dependent
+# preprocessing produces different spatial shapes. Their vision tower consumes
+# that ragged list directly; collapsing to value[0] silently drops later images.
+_VLM_RAGGED_MEDIA_PAYLOAD_KEYS = (*_AUDIO_FEATURE_PAYLOAD_KEYS, "pixel_values")
+
 
 def _assert_audio_features_present(inputs, expected, processor):
     """Fail when a row carried clips but the processor returned no audio tensors.
@@ -7057,13 +7062,11 @@ def _to_mx_vlm_batch(inputs):
                     for x in value
                 ])
             except Exception:
-                if key in _AUDIO_FEATURE_PAYLOAD_KEYS and len(value) > 1:
-                    # Clips of unequal duration do not stack, and dropping to
-                    # value[0] would leave one clip behind ids, placeholder runs
-                    # and labels for all of them -- the pairing
-                    # `_assert_audio_features_present` just verified. Kept entry
-                    # by entry so the count survives; ragged audio never reaches
-                    # the compiled path, so there is no signature to hold.
+                if key in _VLM_RAGGED_MEDIA_PAYLOAD_KEYS and len(value) > 1:
+                    # Unequal media shapes do not stack, and dropping to value[0]
+                    # would leave one payload behind ids, placeholder runs and
+                    # labels for all of them. Keep every entry so model-specific
+                    # eager paths can apply their own ragged handling.
                     batch[key] = [
                         x if isinstance(x, mx.array) else mx.array(np.asarray(x))
                         for x in value


### PR DESCRIPTION
## Summary

- preserve every `pixel_values` entry when aspect-ratio-dependent VLM preprocessing produces tensors that cannot be stacked
- keep the existing dense stack path for equal-shaped images
- add regression coverage for ragged ordering, reverse ordering, and dense-row data preservation

## Root cause

Gemma 4 can return one processed image tensor per example when a batch contains different aspect ratios. `_to_mx_vlm_batch` attempted to stack those tensors, caught the shape error, and then retained only `value[0]`. The vision tower consequently received a single 3-D image instead of the full batch and failed while unpacking `B, C, H, W`.

## Impact

Mixed-aspect-ratio MLX VLM batches now retain every processed image in order so model-specific eager vision paths can handle the ragged list. Equal-shaped batches remain dense.

## Validation

- `python -m pytest tests/test_mlx_vlm_label_masks.py -q` — 228 passed
- mutation checks independently verified the ragged fallback and dense-row data assertions
- validated with the first two `unsloth/LaTeX_OCR` rows and `mlx-community/gemma-4-E2B-it-qat-4bit`: both `(3, 384, 1584)` and `(3, 480, 1200)` tensors reached the real Gemma 4 input-embedding path
