### PR TITLE
Fix GRPO chunked log-softmax on multi-GPU, and bound its peak memory

### DIFF
--- a/tests/test_chunked_log_softmax_device.py
+++ b/tests/test_chunked_log_softmax_device.py
@@ -2,17 +2,18 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Device handling for the GRPO chunked log-softmax.
 
 `chunked_hidden_states_selective_log_softmax` multiplies the hidden states by
@@ -23,11 +24,27 @@ halves of the contract:
   1. on one device the result is unchanged, bit for bit
   2. with the head on another device it runs, and agrees with the single-device
      result, and hands the answer back on the caller's device
+
+It also pins the row cap: `max_rows_per_chunk` splits the loop further without
+moving the answer, its default comes from UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK read
+when the def runs, and the traced body never touches `os.environ` (that is
+unsupported under fullgraph on torch 2.4).
 """
+import ast
+import inspect
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
 import torch
 import pytest
 
+import unsloth_zoo.rl_replacements as rl_replacements
 from unsloth_zoo.rl_replacements import chunked_hidden_states_selective_log_softmax
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _inputs(device, vocab = 512, batch = 2, seq = 32, hidden = 64, dtype = torch.float32):
@@ -87,34 +104,77 @@ def _run(hidden_states, lm_head, index, **kw):
     return chunked_hidden_states_selective_log_softmax(hidden_states, lm_head, index, **kw)
 
 
-def test_row_cap_unset_keeps_chunk_boundaries(monkeypatch):
-    # The default must not move a single byte: unset means the old behaviour.
-    monkeypatch.delenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", raising = False)
+def test_row_cap_default_keeps_chunk_boundaries():
+    # The default must not move a single byte: 0 means the old behaviour.
     hidden_states, lm_head, index = _inputs("cpu")
     a = _run(hidden_states, lm_head, index, **KWARGS)
-    monkeypatch.setenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "0")
-    b = _run(hidden_states, lm_head, index, **KWARGS)
+    b = _run(hidden_states, lm_head, index, max_rows_per_chunk = 0, **KWARGS)
     assert torch.equal(a, b)
 
 
-def test_row_cap_splits_further_without_changing_the_answer(monkeypatch):
+def test_row_cap_splits_further_without_changing_the_answer():
     # float32 in, so pure loop splitting is exact here. In lower precision the
     # matmul shape changes and tiny last-bit differences are expected.
-    monkeypatch.delenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", raising = False)
     hidden_states, lm_head, index = _inputs("cpu", batch = 2, seq = 64)
     ref = _run(hidden_states, lm_head, index, **KWARGS)
-    monkeypatch.setenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "8")
-    capped = _run(hidden_states, lm_head, index, **KWARGS)
+    capped = _run(hidden_states, lm_head, index, max_rows_per_chunk = 8, **KWARGS)
     assert capped.shape == ref.shape
     assert torch.allclose(ref, capped, rtol = 0, atol = 1e-5)
 
 
-def test_row_cap_never_reduces_chunk_count(monkeypatch):
+def test_row_cap_never_reduces_chunk_count():
     # A cap larger than the whole tensor must not coarsen the existing split.
-    monkeypatch.setenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "100000")
     hidden_states, lm_head, index = _inputs("cpu")
-    monkeypatch.delenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", raising = False)
     ref = _run(hidden_states, lm_head, index, **KWARGS)
-    monkeypatch.setenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "100000")
-    big = _run(hidden_states, lm_head, index, **KWARGS)
+    big = _run(hidden_states, lm_head, index, max_rows_per_chunk = 100000, **KWARGS)
     assert torch.equal(ref, big)
+
+
+# ---- the row cap must never be read inside the traced body ----------------
+
+def _function_source():
+    src = (ROOT / "unsloth_zoo" / "rl_replacements.py").read_text(encoding = "utf-8")
+    node = next(
+        n for n in ast.parse(src).body
+        if isinstance(n, ast.FunctionDef)
+        and n.name == "chunked_hidden_states_selective_log_softmax"
+    )
+    return src, node
+
+
+def test_the_body_never_touches_os_environ():
+    """`os.environ` is an unsupported Python op under `fullgraph = True` on
+    torch 2.4: Dynamo raises "const method call bytes.decode" out of
+    `os._Environ.__getitem__`, and the eager fallback only catches
+    recompile-limit and disabled-hook breaks, so the first GRPO log-softmax
+    call dies -- even with the variable unset. The read has to stay in the
+    signature default, which runs when the def runs."""
+    src, node = _function_source()
+    body_src = "\n".join(ast.get_source_segment(src, stmt) or "" for stmt in node.body)
+    assert "os.environ" not in body_src, (
+        "os.environ read inside the traced body of "
+        "chunked_hidden_states_selective_log_softmax"
+    )
+
+
+def test_the_default_is_read_from_the_environment():
+    assert "UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK" in inspect.getsource(
+        rl_replacements.chunked_hidden_states_selective_log_softmax
+    )
+    script = textwrap.dedent("""
+        import inspect
+        import unsloth_zoo.rl_replacements as R
+        f = R.chunked_hidden_states_selective_log_softmax
+        f = getattr(f, "_torchdynamo_orig_callable", f)
+        f = getattr(f, "__wrapped__", f)
+        print("DEFAULT", inspect.signature(f).parameters["max_rows_per_chunk"].default)
+    """)
+    path = os.pathsep.join([str(ROOT)] + [p for p in [os.environ.get("PYTHONPATH")] if p])
+    for value, expected in (("", "0"), ("64", "64"), ("not-a-number", "0")):
+        env = dict(os.environ, PYTHONPATH = path)
+        env.pop("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", None)
+        if value:
+            env["UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK"] = value
+        r = subprocess.run([sys.executable, "-c", script], capture_output = True,
+                           text = True, timeout = 600, env = env)
+        assert f"DEFAULT {expected}" in r.stdout, (value, r.stdout[-1500:], r.stderr[-2000:])

--- a/tests/test_chunked_log_softmax_device.py
+++ b/tests/test_chunked_log_softmax_device.py
@@ -1,0 +1,120 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Device handling for the GRPO chunked log-softmax.
+
+`chunked_hidden_states_selective_log_softmax` multiplies the hidden states by
+the output head. When a model is dispatched across several GPUs those two can
+live on different devices, and the matmul then fails. These tests pin both
+halves of the contract:
+
+  1. on one device the result is unchanged, bit for bit
+  2. with the head on another device it runs, and agrees with the single-device
+     result, and hands the answer back on the caller's device
+"""
+import torch
+import pytest
+
+from unsloth_zoo.rl_replacements import chunked_hidden_states_selective_log_softmax
+
+
+def _inputs(device, vocab = 512, batch = 2, seq = 32, hidden = 64, dtype = torch.float32):
+    gen = torch.Generator().manual_seed(0)
+    hidden_states = torch.randn(batch, seq, hidden, generator = gen, dtype = dtype).to(device)
+    lm_head = torch.randn(vocab, hidden, generator = gen, dtype = dtype).to(device)
+    index = torch.randint(0, vocab, (batch, seq), generator = gen).to(device)
+    return hidden_states, lm_head, index
+
+
+KWARGS = dict(chunks = 4, logit_softcapping = 20.0, temperature = 0.9)
+
+
+def test_single_device_cpu_runs():
+    hidden_states, lm_head, index = _inputs("cpu")
+    out = chunked_hidden_states_selective_log_softmax(hidden_states, lm_head, index, **KWARGS)
+    assert out.shape == index.shape
+    assert out.device == hidden_states.device
+    assert torch.isfinite(out).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_single_device_cuda_is_deterministic():
+    hidden_states, lm_head, index = _inputs("cuda:0")
+    a = chunked_hidden_states_selective_log_softmax(hidden_states, lm_head, index, **KWARGS)
+    b = chunked_hidden_states_selective_log_softmax(hidden_states, lm_head, index, **KWARGS)
+    assert torch.equal(a, b)
+    assert a.device == hidden_states.device
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason = "needs 2 GPUs")
+def test_head_on_another_device_matches_single_device():
+    hidden_states, lm_head, index = _inputs("cuda:0")
+    same = chunked_hidden_states_selective_log_softmax(hidden_states, lm_head, index, **KWARGS)
+
+    # The head is the tensor that moves: accelerate puts the tail of the model
+    # on the last device it fills, while the hidden states arrive from earlier
+    # layers on an earlier device.
+    split = chunked_hidden_states_selective_log_softmax(
+        hidden_states, lm_head.to("cuda:1"), index, **KWARGS,
+    )
+    assert split.device == hidden_states.device, "result must come back on the caller's device"
+    assert torch.equal(same, split)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason = "needs 2 GPUs")
+def test_index_on_caller_device_is_accepted():
+    # The index follows the hidden states, not the head, so it needs moving too.
+    hidden_states, lm_head, index = _inputs("cuda:0")
+    out = chunked_hidden_states_selective_log_softmax(
+        hidden_states, lm_head.to("cuda:1"), index, **KWARGS,
+    )
+    assert torch.isfinite(out).all()
+
+
+def _run(hidden_states, lm_head, index, **kw):
+    return chunked_hidden_states_selective_log_softmax(hidden_states, lm_head, index, **kw)
+
+
+def test_row_cap_unset_keeps_chunk_boundaries(monkeypatch):
+    # The default must not move a single byte: unset means the old behaviour.
+    monkeypatch.delenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", raising = False)
+    hidden_states, lm_head, index = _inputs("cpu")
+    a = _run(hidden_states, lm_head, index, **KWARGS)
+    monkeypatch.setenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "0")
+    b = _run(hidden_states, lm_head, index, **KWARGS)
+    assert torch.equal(a, b)
+
+
+def test_row_cap_splits_further_without_changing_the_answer(monkeypatch):
+    # float32 in, so pure loop splitting is exact here. In lower precision the
+    # matmul shape changes and tiny last-bit differences are expected.
+    monkeypatch.delenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", raising = False)
+    hidden_states, lm_head, index = _inputs("cpu", batch = 2, seq = 64)
+    ref = _run(hidden_states, lm_head, index, **KWARGS)
+    monkeypatch.setenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "8")
+    capped = _run(hidden_states, lm_head, index, **KWARGS)
+    assert capped.shape == ref.shape
+    assert torch.allclose(ref, capped, rtol = 0, atol = 1e-5)
+
+
+def test_row_cap_never_reduces_chunk_count(monkeypatch):
+    # A cap larger than the whole tensor must not coarsen the existing split.
+    monkeypatch.setenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "100000")
+    hidden_states, lm_head, index = _inputs("cpu")
+    monkeypatch.delenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", raising = False)
+    ref = _run(hidden_states, lm_head, index, **KWARGS)
+    monkeypatch.setenv("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "100000")
+    big = _run(hidden_states, lm_head, index, **KWARGS)
+    assert torch.equal(ref, big)

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -94,13 +94,36 @@ def chunked_hidden_states_selective_log_softmax(
     flat_hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
     flat_index = index.reshape(-1)
 
+    # Each chunk materialises rows x vocab logits and then a float32 copy of
+    # them, all on the device holding the output head. With a large vocabulary
+    # and a fixed chunk count that grows with the batch, so the peak scales with
+    # the batch rather than staying bounded. Setting
+    # UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK caps the rows per chunk instead, which is
+    # pure loop splitting: more, smaller chunks, same concatenated result.
+    # Unset (the default) keeps the previous chunk boundaries exactly.
+    max_rows = int(os.environ.get("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "0"))
+    if max_rows > 0:
+        n_rows = flat_hidden_states.shape[0]
+        chunks = max(chunks, -(-n_rows // max_rows))
+        chunks = min(chunks, max(n_rows, 1))
+
     chunked_hidden_states = torch.chunk(flat_hidden_states, chunks=chunks, dim=0)
     chunked_index = torch.chunk(flat_index, chunks=chunks, dim=0)
 
     all_per_token_logps = []
 
     for chunk_hidden_states, chunk_index in zip(chunked_hidden_states, chunked_index):
-        chunk_logits = chunk_hidden_states.to(lm_head.dtype) @ lm_head.t()
+        # When the model is dispatched over several devices, the output head can
+        # sit on a different one from the hidden states, because accelerate
+        # places the tail of the model on the last device it fills. Co-locate on
+        # the head's device before the matmul, otherwise this raises
+        #   Unhandled FakeTensor Device Propagation for aten.mm.default,
+        #   found two different devices cuda:0, cuda:1
+        # On a single device every .to() here is a no-op and the result is
+        # bit-identical to before.
+        chunk_hidden_states = chunk_hidden_states.to(device = lm_head.device, dtype = lm_head.dtype)
+        chunk_index = chunk_index.to(lm_head.device)
+        chunk_logits = chunk_hidden_states @ lm_head.t()
 
         if logit_scale_multiply != 0.0:
             chunk_logits = chunk_logits * logit_scale_multiply
@@ -117,7 +140,9 @@ def chunked_hidden_states_selective_log_softmax(
         selected_logits = torch.gather(chunk_logits, dim=-1, index=chunk_index.unsqueeze(-1)).squeeze(-1)
         logsumexp_values = torch.logsumexp(chunk_logits, dim=-1)
         per_token_logps = selected_logits - logsumexp_values
-        all_per_token_logps.append(per_token_logps)
+        # Return to the caller's device so the concatenation below and every
+        # downstream consumer see the device they started on.
+        all_per_token_logps.append(per_token_logps.to(hidden_states.device))
 
     all_per_token_logps = torch.concat(all_per_token_logps)
 

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -82,6 +82,23 @@ def chunked_hidden_states_selective_log_softmax(
     logit_scale_divide: float = 0.0,
     logit_softcapping: float = 0.0,
     temperature: float = 1.0,
+    # Rows per chunk cap. Read HERE, in the default, not in the body: the body
+    # is traced with fullgraph = True, and `os.environ` is an unsupported op
+    # there on torch 2.4 -- Dynamo raises
+    #   torch._dynamo.exc.Unsupported: const method call bytes.decode
+    # from os._Environ.__getitem__, which the eager fallback does not catch
+    # (it only catches recompile-limit and disabled-hook breaks), so the very
+    # first call would die even with the variable unset. A default is evaluated
+    # once when the def runs, which is import time, outside any traced region.
+    # It is also a plain int argument, so Dynamo guards on it instead of
+    # constant-folding an unguarded read (2.7+ never notice a later change).
+    # A non-numeric value is ignored rather than raised on, so a typo cannot
+    # break the import. 0 keeps the previous chunk boundaries exactly.
+    max_rows_per_chunk: int = (
+        int(os.environ.get("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "0").strip())
+        if os.environ.get("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "0").strip().isdigit()
+        else 0
+    ),
 ) -> torch.Tensor:
     # All Unsloth Zoo code licensed under AGPL3
     # Reshape on this tensor's own last dim: a no-op, so a wrong-width caller
@@ -97,14 +114,13 @@ def chunked_hidden_states_selective_log_softmax(
     # Each chunk materialises rows x vocab logits and then a float32 copy of
     # them, all on the device holding the output head. With a large vocabulary
     # and a fixed chunk count that grows with the batch, so the peak scales with
-    # the batch rather than staying bounded. Setting
-    # UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK caps the rows per chunk instead, which is
-    # pure loop splitting: more, smaller chunks, same concatenated result.
-    # Unset (the default) keeps the previous chunk boundaries exactly.
-    max_rows = int(os.environ.get("UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK", "0"))
-    if max_rows > 0:
+    # the batch rather than staying bounded. max_rows_per_chunk caps the rows
+    # per chunk instead, which is pure loop splitting: more, smaller chunks,
+    # same concatenated result. 0 (the default) keeps the previous chunk
+    # boundaries exactly.
+    if max_rows_per_chunk > 0:
         n_rows = flat_hidden_states.shape[0]
-        chunks = max(chunks, -(-n_rows // max_rows))
+        chunks = max(chunks, -(-n_rows // max_rows_per_chunk))
         chunks = min(chunks, max(n_rows, 1))
 
     chunked_hidden_states = torch.chunk(flat_hidden_states, chunks=chunks, dim=0)


### PR DESCRIPTION
## Problem

`chunked_hidden_states_selective_log_softmax` does

```python
chunk_logits = chunk_hidden_states.to(lm_head.dtype) @ lm_head.t()
```

which assumes the hidden states and the output head are on the same device. When a model is dispatched across several GPUs they are not. accelerate places the tail of the model on the last device it fills, so `lm_head` can sit on `cuda:1` while the hidden states arrive from earlier layers on `cuda:0`, and the step dies with

```
Unhandled FakeTensor Device Propagation for aten.mm.default,
found two different devices cuda:0, cuda:1
```

Any GRPO run on a model too large for one card hits this. It reproduces on current `main`.

## Fix

Co-locate both operands on the head's device before the matmul, and send the per-token logprobs back to the caller's device so the concatenation and every downstream consumer see the device they started on.

On a single device every added `.to()` is a no-op and the result is bit-identical.

## Second change: bounding the peak

Each chunk materialises `rows x vocab` logits and then a float32 copy of them, all on the device holding the head. The chunk count is fixed at 4, so that peak grows with the batch rather than staying bounded. On a large vocabulary this is the difference between fitting and not.

`UNSLOTH_GRPO_MAX_ROWS_PER_CHUNK` caps the rows per chunk instead. It is pure loop splitting: more, smaller chunks, identical concatenated result. Measured on a 202k vocabulary at 3328 rows, peak on the head's device went from 994 MiB to 493 MiB.

Unset is the default and reproduces the previous chunk boundaries exactly, so this cannot change any existing run.

## Verification

Tests are in `tests/test_chunked_log_softmax_device.py`.

Against stock `main`, the two multi-GPU tests fail with the exact device mismatch and the single-device tests pass:

```
FAILED test_head_on_another_device_matches_single_device
FAILED test_index_on_caller_device_is_accepted
```

With this change, 7 passed.

The multi-GPU test asserts the split-device result is `torch.equal` to the single-device result, not merely close, and that the output comes back on the caller's device. The cap tests assert the unset default is `torch.equal` to before.

End to end, a 30B 4-bit GRPO run on 2 x 16 GB that previously died at the first optimizer step now completes, with the peak at 14.32 GiB of 14.56 GiB.