### PR TITLE
Add a head-aware multi-GPU device map planner

### DIFF
--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -885,3 +885,86 @@ def test_the_plan_reports_the_reserve_each_device_kept():
         head_extra = plan.headroom_bytes if device == plan.head_device else 0
         assert plan.weight_bytes[device] + kept + head_extra <= plan.raw_budgets[device]
     assert "1.000 GiB" in plan.describe()
+
+
+class _SharedLayerStack(nn.Module):
+    """The same block object registered under several names."""
+
+    def __init__(self, hidden = 64, vocab = 512):
+        super().__init__()
+        block = _Block(hidden)
+        self.embed_tokens = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList([block] * 4)
+        self.lm_head = nn.Linear(hidden, vocab, bias = False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_repeated_module_registrations_are_planned():
+    """`named_children()` drops repeated registrations of the same object, so
+    the aliases never became placement units while the coverage check still
+    enumerated them, and a model that fits was reported as an internal error."""
+    with torch.device("meta"):
+        model = _SharedLayerStack()
+    assert len(model.layers) == 4
+    plan = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"})
+    for name, _ in model.named_parameters(remove_duplicate = False):
+        assert any(name == k or name.startswith(k + ".") for k in plan.device_map), name
+    # One shared object, so every alias has to land on the same device.
+    assert len({plan.device_map[f"layers.{i}"] for i in range(4)}) == 1
+
+
+def test_infeasible_reports_each_devices_reserve():
+    """The message promises exact numbers, so a per-device mapping cannot be
+    collapsed to its maximum and multiplied by the device count: 1 GiB and
+    3 GiB reserved is 4 GiB, not 6 GiB."""
+    model = _meta(hidden = 256, vocab = 4096, layers = 16)
+    with pytest.raises(DeviceMapInfeasible) as excinfo:
+        plan_device_map(
+            model,
+            max_memory = {0: "2GiB", 1: "2GiB"},
+            headroom_bytes = 8 * _GiB,
+            activation_reserve_bytes = {0: 1 * _GiB, 1: 3 * _GiB},
+        )
+    message = str(excinfo.value)
+    assert "cuda:0=1.000 GiB, cuda:1=3.000 GiB" in message
+    assert "(4.000 GiB total)" in message
+
+
+def test_head_max_fills_the_other_cards_before_a_low_index_head():
+    """`head_max` exists to push weight off the head's card. Walking plain
+    device order filled the head's own card first whenever the head was not the
+    last device."""
+    model = _meta(layers = 8)
+    plan = plan_device_map(
+        model,
+        max_memory = {0: "8GiB", 1: "8GiB"},
+        free_space_policy = "head_max",
+        prefer_head_device = 0,
+    )
+    assert plan.head_device == 0
+    assert plan.weight_bytes[1] > 0
+    assert plan.weight_bytes[1] >= plan.weight_bytes[0]
+
+
+def test_fp32_loader_exceptions_apply_without_a_quantizer():
+    """An fp16 checkpoint whose class declares `_keep_in_fp32_modules` (the T5
+    family keeps `wo` that way) has those tensors loaded as float32, while the
+    meta model still holds them in the config dtype."""
+    pytest.importorskip("accelerate")
+
+    class Cfg:
+        dtype = torch.float16
+
+    with torch.device("meta"):
+        model = _Tiny(hidden = 64, vocab = 512, layers = 4)
+    model.half()
+    model.config = Cfg()
+    plain = _compute_module_sizes(model)
+    model._keep_in_fp32_modules = ["norm"]
+    upcast = _compute_module_sizes(model)
+    # The norm doubles from float16 to float32; nothing else moves.
+    assert upcast["norm"] == plain["norm"] * 2
+    assert upcast["layers"] == plain["layers"]
+    assert upcast[""] == plain[""] + plain["norm"]

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1,0 +1,125 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Head-aware device map planner: introspection and arithmetic.
+
+These tests use meta-device models only, so they need no GPU and no weights.
+They pin the parts that must stay model agnostic: finding the output head,
+finding the decoder block class, honouring tied embeddings, the headroom
+arithmetic, and refusing rather than silently spilling when a request cannot
+fit.
+"""
+import pytest
+import torch
+import torch.nn as nn
+
+from unsloth_zoo.device_map_planner import (
+    DeviceMapInfeasible,
+    logit_headroom_bytes,
+    plan_device_map,
+    resolve_head_width,
+    resolve_no_split_classes,
+    resolve_output_head,
+)
+
+_GiB = 1024 ** 3
+
+
+class _Block(nn.Module):
+    def __init__(self, hidden):
+        super().__init__()
+        self.mlp = nn.Linear(hidden, hidden, bias = False)
+
+
+class _Tiny(nn.Module):
+    _no_split_modules = ["_Block"]
+
+    def __init__(self, hidden = 64, vocab = 512, layers = 8, tie = False):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList([_Block(hidden) for _ in range(layers)])
+        self.norm = nn.LayerNorm(hidden)
+        self.lm_head = nn.Linear(hidden, vocab, bias = False)
+        if tie:
+            self.lm_head.weight = self.embed_tokens.weight
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+
+def _meta(**kw):
+    with torch.device("meta"):
+        return _Tiny(**kw)
+
+
+def test_finds_head_and_block_class():
+    model = _meta()
+    name, head = resolve_output_head(model)
+    assert name == "lm_head"
+    assert head is model.lm_head
+    assert resolve_head_width(model, head) == 512
+    assert "_Block" in resolve_no_split_classes(model)
+
+
+def test_headroom_grows_with_rows_and_vocab():
+    small = logit_headroom_bytes(1000, 128, softcapped = False)
+    wide = logit_headroom_bytes(200000, 128, softcapped = False)
+    assert wide > small
+    more_rows = logit_headroom_bytes(200000, 256, softcapped = False)
+    assert more_rows > wide
+
+
+def test_headroom_retained_term_scales_with_total_rows():
+    # The retained term is what makes the backward pass expensive: it depends on
+    # the total number of rows, not on the chunk size, so chunking alone cannot
+    # bound it.
+    a = logit_headroom_bytes(200000, 128, retained_rows = 1024)
+    b = logit_headroom_bytes(200000, 128, retained_rows = 4096)
+    assert b > a
+
+
+def test_single_device_returns_none_shaped_plan():
+    model = _meta()
+    plan = plan_device_map(model, max_memory = {0: "8GiB"})
+    assert plan is None or set(plan.device_map.values()) == {0}
+
+
+def test_two_devices_place_every_module_on_a_gpu():
+    model = _meta(layers = 8)
+    plan = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"})
+    assert plan is not None
+    assert set(plan.device_map.values()) <= {0, 1}
+    assert all(isinstance(v, int) for v in plan.device_map.values()), "no cpu or disk spill"
+    assert plan.head_device in (0, 1)
+
+
+def test_tied_embedding_lands_with_the_head():
+    model = _meta(tie = True)
+    plan = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"})
+    assert plan is not None
+    assert plan.device_map["embed_tokens"] == plan.head_device
+
+
+def test_refuses_instead_of_spilling_when_it_cannot_fit():
+    model = _meta(hidden = 256, vocab = 4096, layers = 16)
+    with pytest.raises(DeviceMapInfeasible):
+        plan_device_map(
+            model,
+            max_memory = {0: "1MiB", 1: "1MiB"},
+            headroom_bytes = 8 * _GiB,
+        )

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -765,3 +765,60 @@ def test_keep_in_fp32_modules_mirror_the_loader():
     assert _keep_in_fp32_modules(model, Bnb()) == ["norm", "lm_head"]
     assert _keep_in_fp32_modules(model, Other()) == ["lm_head"]
     assert _keep_in_fp32_modules(model, None) == ["lm_head"]
+
+
+def test_seq2seq_checkpoints_get_their_conditional_generation_class():
+    """T5 and mT5 are registered only under `AutoModelForSeq2SeqLM`, so the walk
+    fell through to the bare `AutoModel`: a meta model with no output head, an
+    undercounted weight total and the headroom reserved around some unrelated
+    linear."""
+    transformers = pytest.importorskip("transformers")
+    cfg = transformers.T5Config(vocab_size = 32, d_model = 8, num_layers = 1,
+                                num_heads = 1, d_ff = 16)
+    assert _auto_class_for(cfg) is transformers.AutoModelForSeq2SeqLM
+
+    # A config in two mappings is decided by the checkpoint's `architectures`.
+    bart = transformers.BartConfig(vocab_size = 32, d_model = 8,
+                                   encoder_layers = 1, decoder_layers = 1,
+                                   encoder_attention_heads = 1,
+                                   decoder_attention_heads = 1)
+    assert _auto_class_for(bart) is transformers.AutoModelForCausalLM
+    bart.architectures = ["BartForConditionalGeneration"]
+    assert _auto_class_for(bart) is transformers.AutoModelForSeq2SeqLM
+
+
+def test_model_declaring_an_empty_no_split_list_is_believed():
+    """`[]` is the model saying nothing is atomic, which camembert, colpali,
+    colqwen2, efficientnet and fuyu all do. Only `None` means "not declared"."""
+    model = _meta()
+    model._no_split_modules = []
+    assert resolve_no_split_classes(model) == []
+    model._no_split_modules = None
+    assert "_Block" in resolve_no_split_classes(model)
+
+
+def test_a_failed_dynamic_resolution_keeps_the_hub_restrictions(monkeypatch):
+    """Retrying through `from_config` after a failed lookup would go to the
+    network under `local_files_only`, drop the token, or take a different code
+    revision, so the failure has to surface instead."""
+    import transformers.dynamic_module_utils as dyn
+
+    def boom(class_reference, repo, **kwargs):
+        raise OSError("not found in the local cache")
+
+    monkeypatch.setattr(dyn, "get_class_from_dynamic_module", boom)
+
+    class Cfg:
+        auto_map = {"AutoModelForCausalLM": "org/repo--modeling_x.XForCausalLM"}
+        _name_or_path = "org/repo"
+
+    class AutoModelForCausalLM:
+        @staticmethod
+        def from_config(config, **kwargs):
+            raise AssertionError("must not retry without the Hub options")
+
+    with pytest.raises(OSError, match = "local cache"):
+        _from_config_remote_aware(
+            AutoModelForCausalLM, Cfg(),
+            {"trust_remote_code": True, "local_files_only": True},
+        )

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -22,6 +22,8 @@ finding the decoder block class, honouring tied embeddings, the headroom
 arithmetic, and refusing rather than silently spilling when a request cannot
 fit.
 """
+import sys
+
 import pytest
 import torch
 import torch.nn as nn
@@ -142,12 +144,28 @@ def test_quantised_sizes_use_the_storage_dtype():
     from accelerate.utils import CustomDtype
 
     class Q:
+        """Both quantiser protocols at once.
+
+        transformers' own `compute_module_sizes` asks for `param_element_size`;
+        accelerate's has no quantiser argument and takes a storage dtype plus the
+        not-converted modules. Which one the planner reaches depends on the
+        installed transformers, so the double implements both and the test pins
+        the same answer either way."""
         modules_to_not_convert = ["lm_head"]
+
+        def _skipped(self, name):
+            return any(m in name for m in self.modules_to_not_convert)
+
+        # transformers >= the release that added hf_quantizer support
+        def param_element_size(self, model, name, param):
+            return 2 if self._skipped(name) else 0.5
+
+        # accelerate
         def adjust_target_dtype(self, dtype):
             return CustomDtype.INT4
+
         def get_special_dtypes_update(self, model, dtype):
-            return {n: dtype for n, _ in model.named_parameters()
-                    if any(m in n for m in self.modules_to_not_convert)}
+            return {n: dtype for n, _ in model.named_parameters() if self._skipped(n)}
 
     class Cfg:
         dtype = torch.bfloat16
@@ -376,3 +394,49 @@ def test_an_unusable_prefer_head_device_says_so():
     model = _meta()
     with pytest.raises(ValueError, match = "prefer_head_device"):
         plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"}, prefer_head_device = 7)
+
+
+def test_each_backend_is_called_with_the_arguments_it_accepts(monkeypatch):
+    """transformers' `compute_module_sizes(model, hf_quantizer=...)` and
+    accelerate's `compute_module_sizes(model, dtype=..., special_dtypes=...)`
+    do not accept each other's arguments, and the wrong pair does not fail
+    loudly: it falls through to the plain walk, which measures a 4-bit
+    checkpoint at several times its real size. So dispatch on the signature."""
+    import types
+
+    seen = {}
+
+    def transformers_style(model, hf_quantizer = None, buffers_only = False, only_modules = True):
+        seen["transformers"] = hf_quantizer
+        return {"": 1234}, {}
+
+    def accelerate_style(model, dtype = None, special_dtypes = None, buffers_only = False):
+        seen["accelerate"] = (dtype, special_dtypes)
+        return {"": 5678}
+
+    class Q:
+        modules_to_not_convert = ["lm_head"]
+        def adjust_target_dtype(self, dtype):
+            return torch.int8
+        def get_special_dtypes_update(self, model, dtype):
+            return {}
+
+    class Cfg:
+        dtype = torch.bfloat16
+
+    model = _meta()
+    model.config = Cfg()
+
+    fake = types.ModuleType("transformers.integrations.accelerate")
+    fake.compute_module_sizes = transformers_style
+    monkeypatch.setitem(sys.modules, "transformers.integrations.accelerate", fake)
+    assert _compute_module_sizes(model, Q())[""] == 1234
+    assert isinstance(seen["transformers"], Q)
+
+    # Same call with only accelerate's older signature available.
+    seen.clear()
+    fake2 = types.ModuleType("transformers.integrations.accelerate")
+    fake2.compute_module_sizes = accelerate_style
+    monkeypatch.setitem(sys.modules, "transformers.integrations.accelerate", fake2)
+    assert _compute_module_sizes(model, Q())[""] == 5678
+    assert seen["accelerate"][0] is torch.int8

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -2,17 +2,18 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Head-aware device map planner: introspection and arithmetic.
 
 These tests use meta-device models only, so they need no GPU and no weights.
@@ -27,6 +28,8 @@ import torch.nn as nn
 
 from unsloth_zoo.device_map_planner import (
     DeviceMapInfeasible,
+    _auto_class_for,
+    _compute_module_sizes,
     logit_headroom_bytes,
     plan_device_map,
     resolve_head_width,
@@ -123,3 +126,219 @@ def test_refuses_instead_of_spilling_when_it_cannot_fit():
             max_memory = {0: "1MiB", 1: "1MiB"},
             headroom_bytes = 8 * _GiB,
         )
+
+
+# --------------------------------------------------------------------------- #
+# quantised sizing
+# --------------------------------------------------------------------------- #
+def test_quantised_sizes_use_the_storage_dtype():
+    """`preprocess_model` leaves a meta `Params4bit` at the full unpacked shape
+    in float32, so measuring the modules directly reports a 4-bit checkpoint at
+    several times its real size and the planner refuses the very models it
+    exists for. The quantiser turns the load dtype into the storage dtype the
+    loader will really allocate; this is what transformers does before it calls
+    `infer_auto_device_map`."""
+    pytest.importorskip("accelerate")
+    from accelerate.utils import CustomDtype
+
+    class Q:
+        modules_to_not_convert = ["lm_head"]
+        def adjust_target_dtype(self, dtype):
+            return CustomDtype.INT4
+        def get_special_dtypes_update(self, model, dtype):
+            return {n: dtype for n, _ in model.named_parameters()
+                    if any(m in n for m in self.modules_to_not_convert)}
+
+    class Cfg:
+        dtype = torch.bfloat16
+
+    model = _meta(hidden = 64, vocab = 512, layers = 8)
+    model.config = Cfg()
+    plain = _compute_module_sizes(model)[""]
+    quant = _compute_module_sizes(model, Q())[""]
+    assert quant < plain, (quant, plain)
+    # lm_head is not converted, so it keeps the load dtype rather than shrinking
+    # with everything else.
+    assert _compute_module_sizes(model, Q())["lm_head"] == 512 * 64 * 2
+
+
+def test_no_quantizer_leaves_sizes_untouched():
+    model = _meta()
+    assert _compute_module_sizes(model, None) == _compute_module_sizes(model)
+
+
+# --------------------------------------------------------------------------- #
+# placement units
+# --------------------------------------------------------------------------- #
+class _RootState(nn.Module):
+    _no_split_modules = ["_Block"]
+
+    def __init__(self):
+        super().__init__()
+        self.scale = nn.Parameter(torch.zeros(8))
+        self.register_buffer("shift", torch.zeros(8))
+        self.embed_tokens = nn.Embedding(64, 16)
+        self.layers = nn.ModuleList([_Block(16) for _ in range(4)])
+        self.lm_head = nn.Linear(16, 64, bias = False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+
+def test_state_owned_by_the_root_module_is_placed():
+    """A parameter or buffer registered on the root has no module name to hang
+    it on, and accelerate reads "" as a catch-all default, so each tensor gets
+    its own entry. Without one the coverage check called it unplaced and raised
+    an internal error even with memory to spare."""
+    with torch.device("meta"):
+        model = _RootState()
+    plan = plan_device_map(model, max_memory = {0: "1GiB", 1: "1GiB"})
+    assert plan.device_map["scale"] in (0, 1)
+    assert plan.device_map["shift"] in (0, 1)
+
+
+class _CompositeHead(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(16, 64, bias = False)
+
+
+class _CompositeHeadModel(nn.Module):
+    _no_split_modules = ["_Block"]
+
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(64, 16)
+        self.layers = nn.ModuleList([_Block(16) for _ in range(4)])
+        self.lm_head = _CompositeHead()
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+
+def test_a_composite_head_is_pinned_whole():
+    """`_split_units` descends into a head that has children, so the head's own
+    name never appears as a unit and an exact-name filter dropped it from the
+    pinned list. The greedy walk was then free to place it away from
+    `head_device`, leaving the logit headroom reserved on the wrong card."""
+    with torch.device("meta"):
+        model = _CompositeHeadModel()
+    plan = plan_device_map(model, max_memory = {0: "1GiB", 1: "1GiB"})
+    assert plan.device_map["lm_head.proj"] == plan.head_device
+
+
+# --------------------------------------------------------------------------- #
+# packing
+# --------------------------------------------------------------------------- #
+class _Sized(nn.Module):
+    def __init__(self, n):
+        super().__init__()
+        self.w = nn.Parameter(torch.zeros(n))
+
+
+class _Bins(nn.Module):
+    _no_split_modules = ["_Sized"]
+
+    def __init__(self, sizes):
+        super().__init__()
+        self.parts = nn.ModuleList([_Sized(n) for n in sizes])
+        self.lm_head = nn.Linear(1, 1, bias = False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_differently_sized_units_still_find_a_packing():
+    """Next-fit with a first-fit rescue builds loads of 9 and 9 out of
+    7, 6, 3, 2, 2 into capacities 10 and 10 and then rejects the last unit,
+    although 7+3 and 6+2+2 both fit. float32 makes each unit 4 bytes wide, and
+    the 4-byte head is pinned, so device 1 gets 4 bytes more."""
+    with torch.device("meta"):
+        model = _Bins([7, 6, 3, 2, 2])
+    plan = plan_device_map(
+        model,
+        max_memory = {0: 4 * 10, 1: 4 * 10 + 4},
+        headroom_bytes = 0,
+        activation_reserve_bytes = 0,
+        prefer_head_device = 1,
+    )
+    assert plan.weight_bytes == {0: 40, 1: 44}
+    assert plan.device_map["lm_head"] == 1
+
+
+def test_in_order_layout_is_kept_when_it_fits():
+    """The repack is a last resort. As long as the in-order walk succeeds the
+    layout must stay in definition order, which keeps consecutive layers on one
+    card and costs fewer cross-device hops."""
+    model = _meta(layers = 8)
+    plan = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"})
+    layers = [plan.device_map[f"layers.{i}"] for i in range(8)]
+    assert layers == sorted(layers), layers
+
+
+# --------------------------------------------------------------------------- #
+# reserves
+# --------------------------------------------------------------------------- #
+def test_an_explicit_reserve_is_a_hard_constraint():
+    """The relaxation loop walks the non-head reserve down to zero. Doing that
+    to a reserve the caller measured is how a run OOMs on a card the plan still
+    reports as having that reserve free, so an explicit reserve now either fits
+    or the plan is refused."""
+    model = _meta(hidden = 16, vocab = 64, layers = 8)
+    total = _compute_module_sizes(model)[""]
+    reserve = 4096
+    with pytest.raises(DeviceMapInfeasible):
+        plan_device_map(
+            model,
+            max_memory = {0: total // 2 + reserve // 2, 1: total // 2 + reserve},
+            headroom_bytes = 0,
+            activation_reserve_bytes = {0: reserve, 1: reserve},
+        )
+
+
+def test_the_auto_reserve_is_still_relaxable():
+    """The default reserve is a guess, so it may shrink to make a placement fit;
+    only that keeps a model that only just fits from being refused."""
+    model = _meta(hidden = 16, vocab = 64, layers = 8)
+    total = _compute_module_sizes(model)[""]
+    plan = plan_device_map(
+        model,
+        max_memory = {0: total // 2 + 4096, 1: total // 2 + 4096},
+        headroom_bytes = 0,
+    )
+    assert set(plan.device_map.values()) <= {0, 1}
+
+
+# --------------------------------------------------------------------------- #
+# remote code
+# --------------------------------------------------------------------------- #
+def test_remote_code_config_picks_the_auto_class_the_repo_registered():
+    """A dynamic config is in no `_model_mapping`, so the mapping walk falls
+    through to AutoModel and `from_config` then fails instead of honouring the
+    `trust_remote_code` the caller passed. The repo says which Auto class it
+    registered; `from_config` looks the model class up under exactly that name."""
+    transformers = pytest.importorskip("transformers")
+
+    class RemoteConfig:
+        architectures = ["MyRemoteForCausalLM"]
+        auto_map = {"AutoConfig": "x--MyConfig",
+                    "AutoModelForCausalLM": "x--MyRemoteForCausalLM"}
+
+    cfg = RemoteConfig()
+    assert _auto_class_for(cfg, trust_remote_code = True) is transformers.AutoModelForCausalLM
+    # Without permission nothing changes: the old fall-through is preserved.
+    assert _auto_class_for(cfg) is transformers.AutoModel
+
+
+def test_a_normal_config_is_unaffected_by_the_auto_map_branch():
+    transformers = pytest.importorskip("transformers")
+    cfg = transformers.AutoConfig.for_model("llama", vocab_size = 32, hidden_size = 8,
+                                            num_hidden_layers = 1, num_attention_heads = 1)
+    assert _auto_class_for(cfg) is transformers.AutoModelForCausalLM
+    assert _auto_class_for(cfg, trust_remote_code = True) is transformers.AutoModelForCausalLM

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -32,6 +32,8 @@ from unsloth_zoo.device_map_planner import (
     DeviceMapInfeasible,
     _auto_class_for,
     _compute_module_sizes,
+    _from_config_remote_aware,
+    _split_units,
     logit_headroom_bytes,
     plan_device_map,
     resolve_head_width,
@@ -579,3 +581,98 @@ def test_every_shared_parameter_is_co_located():
         activation_reserve_bytes = 0,
     )
     assert plan.device_map["projA"] == plan.device_map["projB"]
+
+
+def test_reported_budgets_cover_the_pinned_head_weights():
+    """`budgets` means "budget available to weights after every reserve", and
+    `weight_bytes` counts the pinned head units, so the head device must not be
+    reported holding more weight than its own budget allows."""
+    model = _meta(tie = True)
+    plan = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"})
+    for device, budget in plan.budgets.items():
+        assert plan.weight_bytes[device] <= budget, (device, plan.describe())
+    assert plan.budgets[plan.head_device] <= plan.raw_budgets[plan.head_device]
+
+
+class _OwnStateBlock(nn.Module):
+    def __init__(self, hidden):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(hidden))
+        self.mlp = nn.Linear(hidden, hidden, bias = False)
+
+
+class _OwnState(nn.Module):
+    _no_split_modules = []
+
+    def __init__(self, hidden = 64, vocab = 512):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList([_OwnStateBlock(hidden) for _ in range(4)])
+        self.lm_head = nn.Linear(hidden, vocab, bias = False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_directly_owned_tensors_use_the_quantizer_aware_sizes():
+    """A composite module's own parameters were measured with the live tensor's
+    `element_size()`, which is exactly the number the quantiser-aware table
+    exists to replace: the units then stop summing to the total and the planner
+    refuses a model that fits (or overcommits one that does not)."""
+    with torch.device("meta"):
+        model = _OwnState()
+    # A quantiser that halves every parameter, the shape of a 4-bit checkpoint
+    # whose meta tensors still report the unpacked float32 size.
+    sizes = {k: v // 2 for k, v in _compute_module_sizes(model).items()}
+    units = _split_units(model, [], sizes)
+    assert sum(size for _, size in units) == sizes[""]
+    own = dict(units)["layers.0"]
+    assert own == sizes["layers.0"] - sizes["layers.0.mlp"]
+
+
+def test_remote_code_construction_gets_the_hub_options(monkeypatch):
+    """Resolving a dynamic model class is a second Hub lookup. Handing the Hub
+    options to `from_config` is not an option -- it forwards leftovers to
+    `cls(config, **kwargs)`, so `token=...` is a TypeError on every ordinary
+    checkpoint -- so the class is resolved explicitly instead."""
+    import transformers.dynamic_module_utils as dyn
+
+    seen = {}
+
+    class _Remote:
+        @classmethod
+        def _from_config(cls, config):
+            return "remote-model"
+
+    def fake_get_class(class_reference, repo, **kwargs):
+        seen["ref"] = (class_reference, repo)
+        seen["kwargs"] = kwargs
+        return _Remote
+
+    monkeypatch.setattr(dyn, "get_class_from_dynamic_module", fake_get_class)
+
+    class Cfg:
+        auto_map = {"AutoModelForCausalLM": "org/repo--modeling_x.XForCausalLM"}
+        _name_or_path = "org/repo"
+
+    class AutoModelForCausalLM:
+        @staticmethod
+        def from_config(config, **kwargs):
+            seen["fallback"] = kwargs
+            return "auto-model"
+
+    out = _from_config_remote_aware(
+        AutoModelForCausalLM, Cfg(),
+        {"trust_remote_code": True, "token": "t", "code_revision": "abc", "dtype": "bfloat16"},
+    )
+    assert out == "remote-model"
+    assert seen["ref"] == ("modeling_x.XForCausalLM", "org/repo")
+    assert seen["kwargs"] == {"token": "t", "code_revision": "abc"}
+    assert "fallback" not in seen
+
+    # No auto_map entry, or no Hub options to carry: plain from_config.
+    class Plain:
+        auto_map = {}
+
+    assert _from_config_remote_aware(AutoModelForCausalLM, Plain(), {"token": "t"}) == "auto-model"
+    assert seen["fallback"] == {"trust_remote_code": True}

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -34,6 +34,7 @@ from unsloth_zoo.device_map_planner import (
     _compute_module_sizes,
     _from_config_remote_aware,
     _split_units,
+    _keep_in_fp32_modules,
     logit_headroom_bytes,
     plan_device_map,
     resolve_head_width,
@@ -676,3 +677,91 @@ def test_remote_code_construction_gets_the_hub_options(monkeypatch):
 
     assert _from_config_remote_aware(AutoModelForCausalLM, Plain(), {"token": "t"}) == "auto-model"
     assert seen["fallback"] == {"trust_remote_code": True}
+
+
+class _Composite(nn.Module):
+    def __init__(self, hidden):
+        super().__init__()
+        self.inner = nn.Linear(hidden, hidden, bias = False)
+
+
+class _TiedDirectState(nn.Module):
+    """A composite module whose own parameter is tied to one counted earlier."""
+
+    def __init__(self, hidden = 16, vocab = 64):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab, hidden)
+        self.trunk = _Composite(hidden)
+        self.lm_head = nn.Linear(hidden, vocab, bias = False)
+        # Registered after `embed_tokens`, so sizing counts the tensor there and
+        # this module's own share of the size table is zero.
+        self.trunk.shadow = self.embed_tokens.weight
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+
+def test_zero_byte_direct_state_still_gets_a_unit():
+    """Sizing counts a shared tensor once, so a direct parameter tied to one
+    counted elsewhere weighs nothing. Its unit still has to exist or the
+    parameter is uncovered and the coverage check raises."""
+    with torch.device("meta"):
+        model = _TiedDirectState()
+    assert _compute_module_sizes(model)["trunk"] == 16 * 16 * 4
+    assert ("trunk", 0) in _split_units(model, [], _compute_module_sizes(model))
+    plan = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"})
+    # accelerate's own `check_device_map` walks `state_dict()`, which lists a
+    # tied tensor under every name it has, so the map has to cover those too.
+    for name in model.state_dict():
+        assert any(name == k or name.startswith(k + ".") for k in plan.device_map), name
+
+
+def test_recurrentgemma_softcap_alias_is_detected():
+    """`logits_soft_cap` is the same knob under a different name, and the
+    repository's own `_detect_logit_softcap` already treats them as aliases.
+    Missing it drops the tanh temporary and the retained soft-cap buffer, so the
+    head's card is under-reserved."""
+    class Cfg:
+        logits_soft_cap = 30.0
+
+    model = _meta()
+    model.config = Cfg()
+    capped = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"},
+                             retained_rows = 256)
+    uncapped = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"},
+                               retained_rows = 256, softcapped = False)
+    assert capped.headroom_bytes > uncapped.headroom_bytes
+
+
+def test_keep_in_fp32_modules_mirror_the_loader():
+    """`from_pretrained` hands this list to `preprocess_model`; passing `[]`
+    quantises modules the loader keeps in float32 and undercounts the weights."""
+    model = _meta()
+
+    class Cfg:
+        dtype = torch.bfloat16
+
+    model.config = Cfg()
+    model._keep_in_fp32_modules = ["norm"]
+    model._keep_in_fp32_modules_strict = ["lm_head"]
+
+    class Bnb:
+        use_keep_in_fp32_modules = True
+
+        def update_dtype(self, dtype):
+            return dtype
+
+    class Other:
+        use_keep_in_fp32_modules = False
+
+        def update_dtype(self, dtype):
+            return dtype
+
+    # bfloat16: the strict list always applies, the plain one only because the
+    # quantiser asks for it.
+    assert _keep_in_fp32_modules(model, Bnb()) == ["norm", "lm_head"]
+    assert _keep_in_fp32_modules(model, Other()) == ["lm_head"]
+    assert _keep_in_fp32_modules(model, None) == ["lm_head"]

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -440,3 +440,142 @@ def test_each_backend_is_called_with_the_arguments_it_accepts(monkeypatch):
     monkeypatch.setitem(sys.modules, "transformers.integrations.accelerate", fake2)
     assert _compute_module_sizes(model, Q())[""] == 5678
     assert seen["accelerate"][0] is torch.int8
+
+
+# --------------------------------------------------------------------------- #
+# budgets, packing and shared parameters
+# --------------------------------------------------------------------------- #
+_MiB = 1024 ** 2
+
+
+def test_quantizer_budget_haircut_is_applied():
+    """`transformers.modeling_utils._get_device_map` runs
+    `hf_quantizer.adjust_max_memory(...)` before it infers a device map, and the
+    bitsandbytes quantisers hold 10% of every budget back for the buffers they
+    allocate while quantising. An explicit map skips that path, so without this
+    the planner hands out memory the loader still needs."""
+
+    class Q:
+        def adjust_max_memory(self, max_memory):
+            return {k: v * 0.90 for k, v in max_memory.items()}
+
+    model = _meta()
+    plan = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"}, hf_quantizer = Q())
+    assert plan.raw_budgets[0] == int(8 * _GiB * 0.90)
+    assert plan.raw_budgets[1] == int(8 * _GiB * 0.90)
+    assert any("adjust_max_memory" in n for n in plan.notes)
+
+    # A quantiser that asks for more must not talk the planner into overcommitting.
+    class Greedy:
+        def adjust_max_memory(self, max_memory):
+            return {k: v * 4 for k, v in max_memory.items()}
+
+    plan = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"}, hf_quantizer = Greedy())
+    assert plan.raw_budgets == {0: 8 * _GiB, 1: 8 * _GiB}
+
+
+class _Uneven(nn.Module):
+    """Unit sizes 2, 2, 2, 3, 5, 6 MiB plus a 20 MiB head."""
+
+    def __init__(self):
+        super().__init__()
+        self.u1 = nn.Linear(256, 2048, bias = False)
+        self.u2 = nn.Linear(256, 2048, bias = False)
+        self.u3 = nn.Linear(256, 2048, bias = False)
+        self.u4 = nn.Linear(256, 3072, bias = False)
+        self.u5 = nn.Linear(256, 5120, bias = False)
+        self.u6 = nn.Linear(256, 6144, bias = False)
+        self.lm_head = nn.Linear(256, 20480, bias = False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_heterogeneous_units_are_packed_exactly():
+    """Both heuristics reject this one: the in-order walk builds 2+2+2+3 then
+    stalls, and best-fit packs 6+3 and 5+2+2 before rejecting the last 2, even
+    though 6+2+2 and 5+3+2 fill both cards exactly."""
+    with torch.device("meta"):
+        model = _Uneven()
+    plan = plan_device_map(
+        model,
+        max_memory = {0: 10 * _MiB, 1: 10 * _MiB, 2: 20 * _MiB},
+        headroom_bytes = 0,
+        activation_reserve_bytes = 0,
+    )
+    assert plan.device_map["lm_head"] == 2
+    for device, budget in plan.raw_budgets.items():
+        assert plan.weight_bytes[device] <= budget
+    for name, _ in model.named_parameters():
+        assert any(name == k or name.startswith(k + ".") for k in plan.device_map), name
+
+
+class _FatBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = nn.Linear(256, 6144, bias = False)   # 6 MiB
+        self.b = nn.Linear(256, 6144, bias = False)   # 6 MiB
+
+
+class _FatBlockModel(nn.Module):
+    _no_split_modules = ["_FatBlock"]
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList([_FatBlock()])
+        self.lm_head = nn.Linear(256, 1024, bias = False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_empty_no_split_override_is_honoured():
+    """`[]` means "nothing is atomic, split anywhere" and is not the same
+    request as `None` ("detect the block classes"). A truthiness test threw the
+    override away, so a model whose whole block is larger than any single card
+    was reported infeasible even though its children fit."""
+    with torch.device("meta"):
+        model = _FatBlockModel()
+    budgets = {0: 7 * _MiB, 1: 7 * _MiB}
+    with pytest.raises(DeviceMapInfeasible):
+        plan_device_map(model, max_memory = budgets, headroom_bytes = 0,
+                        activation_reserve_bytes = 0)
+    plan = plan_device_map(model, max_memory = budgets, headroom_bytes = 0,
+                           activation_reserve_bytes = 0,
+                           no_split_module_classes = [])
+    assert plan.no_split_module_classes == []
+    assert plan.device_map["layers.0.a"] != plan.device_map["layers.0.b"]
+
+
+class _SharedProj(nn.Module):
+    """A parameter shared by two modules outside the embedding pair."""
+
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(1024, 256)
+        self.projA = nn.Linear(256, 4096, bias = False)
+        self.filler = nn.Linear(256, 4096, bias = False)
+        self.projB = nn.Linear(256, 4096, bias = False)
+        self.projB.weight = self.projA.weight
+        self.lm_head = nn.Linear(256, 1024, bias = False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+
+def test_every_shared_parameter_is_co_located():
+    """Module sizing counts a shared tensor once, so splitting its owners across
+    devices makes accelerate materialise a copy that `weight_bytes` never
+    accounted for and a "feasible" plan OOMs during dispatch."""
+    with torch.device("meta"):
+        model = _SharedProj()
+    plan = plan_device_map(
+        model,
+        max_memory = {0: 8 * _MiB, 1: 8 * _MiB},
+        headroom_bytes = 0,
+        activation_reserve_bytes = 0,
+    )
+    assert plan.device_map["projA"] == plan.device_map["projB"]

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -852,3 +852,36 @@ def test_an_atomic_ancestor_of_the_head_is_pinned():
     )
     assert plan.head_module == "language_model.lm_head"
     assert plan.device_map["language_model"] == plan.head_device
+
+
+def test_logit_scaling_adds_one_chunk_buffer():
+    """`chunk_logits * logit_scale_multiply` and `/ logit_scale_divide` are both
+    out of place, so one more buffer of the chunk shape in the logit dtype is
+    live before the float32 copy."""
+    plain = logit_headroom_bytes(200000, 128, softcapped = False, safety_bytes = 0)
+    scaled = logit_headroom_bytes(200000, 128, softcapped = False, logit_scaled = True,
+                                  safety_bytes = 0)
+    s = torch.empty((), dtype = torch.bfloat16).element_size()
+    assert scaled - plain == 128 * 200000 * s
+
+    model = _meta()
+    budgets = {0: "8GiB", 1: "8GiB"}
+    assert (plan_device_map(model, max_memory = budgets, logit_scaled = True).headroom_bytes >
+            plan_device_map(model, max_memory = budgets).headroom_bytes)
+
+
+def test_the_plan_reports_the_reserve_each_device_kept():
+    """A per-device mapping is not one number, and the auto reserve is relaxed on
+    the non-head cards, so a single scalar promised headroom the accepted
+    packing had not kept."""
+    model = _meta()
+    plan = plan_device_map(
+        model,
+        max_memory = {0: "8GiB", 1: "8GiB"},
+        activation_reserve_bytes = {0: 1 * _GiB, 1: 3 * _GiB},
+    )
+    assert plan.activation_reserve_by_device == {0: 1 * _GiB, 1: 3 * _GiB}
+    for device, kept in plan.activation_reserve_by_device.items():
+        head_extra = plan.headroom_bytes if device == plan.head_device else 0
+        assert plan.weight_bytes[device] + kept + head_extra <= plan.raw_budgets[device]
+    assert "1.000 GiB" in plan.describe()

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -342,3 +342,37 @@ def test_a_normal_config_is_unaffected_by_the_auto_map_branch():
                                             num_hidden_layers = 1, num_attention_heads = 1)
     assert _auto_class_for(cfg) is transformers.AutoModelForCausalLM
     assert _auto_class_for(cfg, trust_remote_code = True) is transformers.AutoModelForCausalLM
+
+
+class _BigHead(nn.Module):
+    """Four small blocks and an output head larger than half the weights."""
+    _no_split_modules = ["_Block"]
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList([_Block(32) for _ in range(4)])
+        self.output = nn.Linear(32, 256, bias = False)
+
+
+def test_a_model_that_trivially_fits_is_not_refused():
+    """The auto reserve is capped by the smallest budget less the headroom and
+    less the weight the head's device has to hold. Using only an average share
+    of the weights understates that whenever the pinned units are bigger than
+    the share, and since `attempt` relaxes the reserve on the OTHER cards only,
+    the head's budget stays negative and every step fails. Four 4 KiB blocks and
+    a 32 KiB head (share 24 KiB) were refused on 2 x 8 GiB."""
+    with torch.device("meta"):
+        model = _BigHead()
+    plan = plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"})
+    assert set(plan.device_map.values()) <= {0, 1}
+    assert plan.device_map["output"] == plan.head_device
+    for name, _ in list(model.named_parameters()) + list(model.named_buffers()):
+        assert any(name == k or name.startswith(k + ".") for k in plan.device_map), name
+
+
+def test_an_unusable_prefer_head_device_says_so():
+    """It used to fall through the candidate loop and report a memory
+    shortfall, which points at entirely the wrong problem."""
+    model = _meta()
+    with pytest.raises(ValueError, match = "prefer_head_device"):
+        plan_device_map(model, max_memory = {0: "8GiB", 1: "8GiB"}, prefer_head_device = 7)

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -667,7 +667,7 @@ def test_remote_code_construction_gets_the_hub_options(monkeypatch):
         {"trust_remote_code": True, "token": "t", "code_revision": "abc", "dtype": "bfloat16"},
     )
     assert out == "remote-model"
-    assert seen["ref"] == ("modeling_x.XForCausalLM", "org/repo")
+    assert seen["ref"] == ("org/repo--modeling_x.XForCausalLM", "org/repo")
     assert seen["kwargs"] == {"token": "t", "code_revision": "abc"}
     assert "fallback" not in seen
 
@@ -822,3 +822,33 @@ def test_a_failed_dynamic_resolution_keeps_the_hub_restrictions(monkeypatch):
             AutoModelForCausalLM, Cfg(),
             {"trust_remote_code": True, "local_files_only": True},
         )
+
+
+class _Wrapped(nn.Module):
+    """The head lives inside a module the caller declares atomic."""
+
+    def __init__(self, hidden = 64, vocab = 512):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList([_Block(hidden) for _ in range(4)])
+        self.language_model = nn.Module()
+        self.language_model.norm = nn.LayerNorm(hidden)
+        self.language_model.lm_head = nn.Linear(hidden, vocab, bias = False)
+
+    def get_output_embeddings(self):
+        return self.language_model.lm_head
+
+
+def test_an_atomic_ancestor_of_the_head_is_pinned():
+    """`_split_units` emits the atomic ancestor, not the nested head name, so a
+    descendants-only filter left `pinned` empty and the logit headroom was
+    reserved on a card that need not hold the head at all."""
+    with torch.device("meta"):
+        model = _Wrapped()
+    plan = plan_device_map(
+        model,
+        max_memory = {0: "8GiB", 1: "8GiB"},
+        no_split_module_classes = ["Module", "_Block"],
+    )
+    assert plan.head_module == "language_model.lm_head"
+    assert plan.device_map["language_model"] == plan.head_device

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -121,7 +121,9 @@ Nothing here is specific to one architecture:
 * the head comes from ``model.get_output_embeddings()`` resolved back to its
   module name by identity,
 * tied embeddings are detected from the config *and* by parameter identity, and
-  the tied input embedding is pinned to the head's device,
+  the tied input embedding is pinned to the head's device; any other group of
+  modules sharing a parameter is placed as one unit, since the size table counts
+  a shared tensor once,
 * vision towers / multimodal projectors / final norms are just ordinary split
   units and are placed by the same greedy walk.
 """
@@ -129,9 +131,8 @@ Nothing here is specific to one architecture:
 from __future__ import annotations
 
 import inspect
-import math
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Mapping, Sequence
 
 import torch
 import torch.nn as nn
@@ -222,7 +223,7 @@ class DeviceMapPlan:
     budgets: dict[int, int]
     """Per-device budget actually available to weights (after every reserve)."""
     raw_budgets: dict[int, int]
-    """Per-device budget as requested by the caller, before any reserve."""
+    """Per-device budget before any reserve, after the quantiser's own haircut."""
     weight_bytes: dict[int, int]
     activation_reserve_bytes: int
     total_weight_bytes: int
@@ -587,7 +588,18 @@ def _split_units(
         # to travel with the module itself, so keep them as their own unit.
         own_tensors = list(module.named_parameters(recurse=False)) + \
                       list(module.named_buffers(recurse=False))
-        own = sum(t.numel() * t.element_size() for _, t in own_tensors)
+        # Size direct state from the same quantiser-aware table as everything
+        # else, by subtracting the children from the subtree. `element_size()` on
+        # the live tensor is the number this module exists to avoid: a
+        # preprocessed meta `Params4bit` reports the full unpacked shape in
+        # float32, so the units would stop summing to `total_weight_bytes` and
+        # the planner would refuse a model that fits (or overcommit one that
+        # does not).
+        child_bytes = sum(
+            sizes.get(f"{prefix}.{child_name}" if prefix else child_name, 0)
+            for child_name, _ in children
+        )
+        own = max(0, size - child_bytes) if own_tensors else 0
         if own and prefix:
             units.append((prefix, own))
         elif own:
@@ -602,7 +614,9 @@ def _split_units(
             # raises, so a model with a root-level scale or bias could not be
             # planned at all.
             for tensor_name, tensor in own_tensors:
-                units.append((tensor_name, tensor.numel() * tensor.element_size()))
+                units.append((tensor_name, sizes.get(
+                    tensor_name, tensor.numel() * tensor.element_size()
+                )))
         for child_name, child in children:
             walk(f"{prefix}.{child_name}" if prefix else child_name, child)
 
@@ -932,7 +946,14 @@ def plan_device_map(
             assign[p] = head_device
             used[head_device] += unit_size[p]
         weight_bytes = {d: used[d] for d in devices}
-        return assign, weight_bytes, {d: budget[d] for d in devices}
+        # `budget` is the *remaining* capacity the packing walks were allowed to
+        # use, so the head device has already paid for the pinned units. The
+        # public field means "budget available to weights after every reserve"
+        # and `weight_bytes` counts those same pinned units, so hand the pinned
+        # bytes back or the head device reports weights above its own budget.
+        public_budgets = {d: budget[d] for d in devices}
+        public_budgets[head_device] += pinned_bytes
+        return assign, weight_bytes, public_budgets
 
     def _walk_in_order(free, budget):
         used = dict.fromkeys(devices, 0)
@@ -1116,8 +1137,8 @@ def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
         # the same Hub repo and `from_config` only fetches it when it is allowed
         # to, so without this a remote-code checkpoint raises instead of
         # honouring the option the caller already passed.
-        model = auto_cls.from_config(config, trust_remote_code=True) if trust_remote_code \
-            else auto_cls.from_config(config)
+        model = _from_config_remote_aware(auto_cls, config, from_pretrained_kwargs) \
+            if trust_remote_code else auto_cls.from_config(config)
     model.eval()
     if hf_quantizer is not None:
         # Swap in the quantised Linear classes so the size table matches the
@@ -1127,6 +1148,44 @@ def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
         except Exception:
             pass
     return model, hf_quantizer, config
+
+
+_HUB_KWARGS = (
+    "cache_dir", "force_download", "proxies", "token", "revision",
+    "local_files_only", "code_revision", "repo_type",
+)
+
+
+def _from_config_remote_aware(auto_cls: Any, config: Any, from_pretrained_kwargs: Mapping[str, Any]):
+    """``from_config`` for a remote-code checkpoint, with the Hub options applied.
+
+    Resolving a dynamic model class is a second Hub lookup, and the config's own
+    options do not travel with it: a private repo then fails to authenticate,
+    ``code_revision`` is ignored and ``local_files_only`` is violated.
+
+    They cannot simply be handed to ``from_config``. It forwards its leftover
+    kwargs to ``_from_config``, which passes them straight to ``cls(config,
+    **kwargs)``, and a model ``__init__`` takes the config alone -- so
+    ``token=...`` there is a ``TypeError`` on every ordinary checkpoint. Resolve
+    the class explicitly instead, and fall back to plain ``from_config`` for
+    anything that is not a dynamic class.
+    """
+    hub_kwargs = {k: from_pretrained_kwargs[k] for k in _HUB_KWARGS
+                  if k in from_pretrained_kwargs}
+    auto_map = getattr(config, "auto_map", None)
+    class_ref = auto_map.get(auto_cls.__name__) if isinstance(auto_map, Mapping) else None
+    if class_ref and hub_kwargs:
+        try:
+            from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+            repo_id, _, ref = class_ref.rpartition("--")
+            model_cls = get_class_from_dynamic_module(
+                ref, repo_id or config._name_or_path, **hub_kwargs
+            )
+            return model_cls._from_config(config)
+        except Exception:
+            pass
+    return auto_cls.from_config(config, trust_remote_code=True)
 
 
 def _auto_class_for(config: Any, trust_remote_code: bool = False):

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -65,6 +65,7 @@ per-device mapping built from measurements instead of trusting the equal split.
 Formula (see :func:`logit_headroom_bytes`), with ``s = logit dtype itemsize``::
 
     per_chunk = rows_per_chunk * vocab * (s + 4)          # logits + float32 copy
+              + rows_per_chunk * vocab * s   if logit_scaled      # scaled copy
               + rows_per_chunk * vocab * s   if softcapped        # tanh temporary
               + rows_per_chunk * vocab * 4   if temperature != 1  # 2nd fp32 buffer
               + rows_per_chunk * vocab * 4   if retained_rows      # backward grad buffer
@@ -74,6 +75,8 @@ Formula (see :func:`logit_headroom_bytes`), with ``s = logit dtype itemsize``::
 * ``rows_per_chunk * vocab * s`` is ``chunk_hidden @ lm_head.T``.
 * ``+ 4`` bytes/element is the ``chunk_logits.to(torch.float32)`` copy, which is
   live at the same time as the low-precision tensor it was copied from.
+* the scaling term is the out-of-place ``chunk_logits * logit_scale_multiply``
+  (or ``/ logit_scale_divide``), which is live alongside the tensor it reads.
 * the softcap term is the ``logit_softcapping * tanh(x / logit_softcapping)``
   temporary, which is also the tensor autograd saves for the tanh backward.
 * ``retained_rows`` is the autograd case: when the log-softmax is
@@ -167,6 +170,7 @@ def logit_headroom_bytes(
     logit_dtype: torch.dtype = torch.bfloat16,
     retained_rows: int = 0,
     softcapped: bool = True,
+    logit_scaled: bool = False,
     temperature_scaled: bool = False,
     safety_bytes: int = 256 * 1024 ** 2,
 ) -> int:
@@ -184,6 +188,9 @@ def logit_headroom_bytes(
             differentiated, because autograd keeps every chunk's saved tensors.
         softcapped: the caller passes a non-zero ``logit_softcapping``, adding a
             ``tanh`` temporary of the chunk shape (also saved for backward).
+        logit_scaled: the caller passes a non-zero ``logit_scale_multiply`` or
+            ``logit_scale_divide``. Both are out-of-place, so one more buffer of
+            the chunk shape in the logit dtype is live before the float32 copy.
         temperature_scaled: the caller passes ``temperature != 1``, adding one
             more float32 buffer of the chunk shape.
         safety_bytes: allocator fragmentation / cuBLAS workspace slack. The
@@ -197,6 +204,8 @@ def logit_headroom_bytes(
         return int(safety_bytes)
     s = torch.empty((), dtype=logit_dtype).element_size()
     per_chunk = rows_per_chunk * vocab_size * (s + 4)
+    if logit_scaled:
+        per_chunk += rows_per_chunk * vocab_size * s
     if softcapped:
         per_chunk += rows_per_chunk * vocab_size * s
     if temperature_scaled:
@@ -226,8 +235,13 @@ class DeviceMapPlan:
     """Per-device budget before any reserve, after the quantiser's own haircut."""
     weight_bytes: dict[int, int]
     activation_reserve_bytes: int
+    """Largest reserve asked for. See ``activation_reserve_by_device`` for what
+    the accepted packing actually kept, which is smaller wherever a per-device
+    mapping was passed or an auto-derived reserve had to be relaxed."""
     total_weight_bytes: int
     no_split_module_classes: list[str]
+    activation_reserve_by_device: dict[int, int] = field(default_factory=dict)
+    """Reserve the accepted packing really kept free, per device."""
     tied_to_head: list[str] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
 
@@ -242,16 +256,18 @@ class DeviceMapPlan:
             f"no_split classes   : {sorted(self.no_split_module_classes)}",
             f"output head        : {self.head_module} -> cuda:{self.head_device}",
             f"head headroom      : {self.headroom_bytes / _GiB:.3f} GiB",
-            f"activation reserve : {self.activation_reserve_bytes / _GiB:.3f} GiB per device",
+            f"activation reserve : {self.activation_reserve_bytes / _GiB:.3f} GiB requested",
         ]
         if self.tied_to_head:
             lines.append(f"tied to head       : {self.tied_to_head}")
         for d in sorted(self.raw_budgets):
             w = self.weight_bytes.get(d, 0)
+            kept = self.activation_reserve_by_device.get(d)
             lines.append(
                 f"  cuda:{d}  budget {self.raw_budgets[d] / _GiB:6.2f} GiB"
                 f"  weights {w / _GiB:6.3f} GiB"
                 f"  free {(self.raw_budgets[d] - w) / _GiB:6.3f} GiB"
+                + (f"  reserve {kept / _GiB:6.3f} GiB" if kept is not None else "")
                 + ("   <- output head" if d == self.head_device else "")
             )
         lines.extend(f"note: {n}" for n in self.notes)
@@ -685,6 +701,7 @@ def plan_device_map(
     vocab_size: int | None = None,
     logit_dtype: torch.dtype | None = None,
     softcapped: bool | None = None,
+    logit_scaled: bool = False,
     temperature_scaled: bool = False,
     headroom_bytes: int | None = None,
     safety_bytes: int = 256 * 1024 ** 2,
@@ -706,7 +723,10 @@ def plan_device_map(
         vocab_size: override the detected head width.
         logit_dtype: dtype of the logits; defaults to the head's dtype.
         softcapped: whether a non-zero ``logit_softcapping`` is in play.
-            ``None`` (default) reads ``final_logit_softcapping`` off the config.
+            ``None`` (default) reads ``final_logit_softcapping`` (or its
+            RecurrentGemma alias ``logits_soft_cap``) off the config.
+        logit_scaled: whether the caller passes a non-zero
+            ``logit_scale_multiply`` or ``logit_scale_divide``.
         temperature_scaled: whether the caller divides by a temperature != 1.
         headroom_bytes: bypass the formula entirely.
         safety_bytes: slack added to the headroom.
@@ -793,6 +813,7 @@ def plan_device_map(
             logit_dtype=logit_dtype,
             retained_rows=retained_rows,
             softcapped=softcapped,
+            logit_scaled=logit_scaled,
             temperature_scaled=temperature_scaled,
             safety_bytes=safety_bytes,
         )
@@ -963,9 +984,14 @@ def plan_device_map(
         return None
 
     def _fill(head_device: int, other_reserve: int):
+        # What this attempt really keeps free per device, which is what the plan
+        # reports: a per-device mapping is not one number, and `attempt` relaxes
+        # the reserve on the non-head cards, so a single scalar would promise
+        # headroom the accepted packing did not keep.
+        kept = {d: reserve[d] if d == head_device else min(reserve[d], other_reserve)
+                for d in devices}
         budget = {
-            d: raw_budgets[d] - (reserve[d] + headroom if d == head_device
-                                 else min(reserve[d], other_reserve))
+            d: raw_budgets[d] - (kept[d] + headroom if d == head_device else kept[d])
             for d in devices
         }
         budget[head_device] -= pinned_bytes
@@ -1004,7 +1030,7 @@ def plan_device_map(
         # bytes back or the head device reports weights above its own budget.
         public_budgets = {d: budget[d] for d in devices}
         public_budgets[head_device] += pinned_bytes
-        return assign, weight_bytes, public_budgets
+        return assign, weight_bytes, public_budgets, kept
 
     def _walk_in_order(free, budget):
         used = dict.fromkeys(devices, 0)
@@ -1133,7 +1159,7 @@ def plan_device_map(
             "to CPU/disk: bitsandbytes cannot load a partially offloaded 4-bit model."
         )
 
-    assign, weight_bytes, budgets = result
+    assign, weight_bytes, budgets, reserve_kept = result
     # Sanity: the map must cover every parameter and buffer.
     # `remove_duplicate=False`, because accelerate's own `check_device_map`
     # walks `state_dict()`, which lists a tied tensor under every name it has.
@@ -1161,6 +1187,7 @@ def plan_device_map(
         activation_reserve_bytes=activation_reserve_bytes,
         total_weight_bytes=total,
         no_split_module_classes=no_split,
+        activation_reserve_by_device=reserve_kept,
         tied_to_head=tied_to_head,
         notes=notes,
     )
@@ -1314,6 +1341,7 @@ def plan_device_map_for_pretrained(
     retained_rows: int = 0,
     vocab_size: int | None = None,
     softcapped: bool | None = None,
+    logit_scaled: bool = False,
     temperature_scaled: bool = False,
     headroom_bytes: int | None = None,
     safety_bytes: int = 256 * 1024 ** 2,
@@ -1340,6 +1368,7 @@ def plan_device_map_for_pretrained(
         retained_rows=retained_rows,
         vocab_size=vocab_size,
         softcapped=softcapped,
+        logit_scaled=logit_scaled,
         temperature_scaled=temperature_scaled,
         headroom_bytes=headroom_bytes,
         safety_bytes=safety_bytes,

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -2,17 +2,18 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Head-aware multi-GPU device map planner.
 
 Why this exists
@@ -149,6 +150,10 @@ _GiB = 1024 ** 3
 
 class DeviceMapInfeasible(RuntimeError):
     """The model plus the requested head headroom does not fit on the GPUs."""
+
+
+class _SearchExhausted(Exception):
+    """Internal: the bounded exact-packing search hit its node budget."""
 
 
 # --------------------------------------------------------------------------- #
@@ -489,6 +494,71 @@ def _compute_module_sizes(model: nn.Module, hf_quantizer: Any = None) -> dict[st
     return sizes
 
 
+def _adjust_budgets_for_quantizer(
+    raw_budgets: Mapping[int, int], hf_quantizer: Any
+) -> tuple[dict[int, int], str | None]:
+    """Apply the quantiser's own budget haircut, exactly as transformers does.
+
+    ``transformers.modeling_utils._get_device_map`` runs
+    ``hf_quantizer.adjust_max_memory(max_memory)`` before it infers a device map,
+    and the bitsandbytes quantisers hold back 10% of every budget for the buffers
+    they allocate while quantising. An explicit device map skips that whole path,
+    so without this the planner hands out memory the loader still needs and a plan
+    that measured as feasible OOMs while the checkpoint loads.
+
+    Only ever lowers a budget: a quantiser that hands back more than was asked for
+    cannot talk the planner into overcommitting a card.
+    """
+    budgets = dict(raw_budgets)
+    adjust = getattr(hf_quantizer, "adjust_max_memory", None)
+    if not callable(adjust):
+        return budgets, None
+    try:
+        adjusted = adjust(dict(raw_budgets))
+    except Exception:
+        return budgets, None
+    if not isinstance(adjusted, Mapping):
+        return budgets, None
+    lowered: list[int] = []
+    for d in raw_budgets:
+        if d not in adjusted:
+            continue
+        try:
+            value = _parse_size(adjusted[d])
+        except (TypeError, ValueError):
+            continue
+        value = min(int(value), raw_budgets[d])
+        if value < budgets[d]:
+            budgets[d] = value
+            lowered.append(d)
+    if not lowered:
+        return budgets, None
+    note = (
+        f"{type(hf_quantizer).__name__}.adjust_max_memory lowered the budget on "
+        + ", ".join(
+            f"cuda:{d} {raw_budgets[d] / _GiB:.3f} -> {budgets[d] / _GiB:.3f} GiB"
+            for d in sorted(lowered)
+        )
+        + " (memory the quantiser keeps for its own load-time buffers)"
+    )
+    return budgets, note
+
+
+def _tied_parameter_groups(model: nn.Module) -> list[list[str]]:
+    """Names of every tensor that is one shared object under several names.
+
+    ``compute_module_sizes`` counts a shared tensor once, so two modules that
+    share a parameter are only correctly sized when they land on the same device.
+    Grouping by object identity (rather than ``data_ptr``) is what makes this work
+    on a meta model, where every tensor reports the same null pointer.
+    """
+    by_object: dict[int, list[str]] = {}
+    for name, tensor in list(model.named_parameters(remove_duplicate=False)) + \
+                        list(model.named_buffers(remove_duplicate=False)):
+        by_object.setdefault(id(tensor), []).append(name)
+    return [names for names in by_object.values() if len(names) > 1]
+
+
 def _split_units(
     model: nn.Module,
     no_split_classes: Sequence[str],
@@ -605,7 +675,9 @@ def plan_device_map(
             which maximises head free space but can starve GPU 0.
         hf_quantizer: pass the model's ``HfQuantizer`` so quantised sizes are
             exact.
-        no_split_module_classes: override the detected block classes.
+        no_split_module_classes: override the detected block classes. ``[]``
+            removes every no-split constraint, so blocks may be split at their
+            children; ``None`` (default) detects the classes from the model.
         prefer_head_device: force the head onto this device index.
 
     Returns:
@@ -619,6 +691,8 @@ def plan_device_map(
     if len(devices) < 2:
         return None
 
+    notes: list[str] = []
+
     raw_budgets: dict[int, int] = {}
     for d in devices:
         if max_memory is not None:
@@ -627,8 +701,16 @@ def plan_device_map(
         else:
             free, _total = torch.cuda.mem_get_info(d)
             raw_budgets[d] = int(free)
+    raw_budgets, quantizer_note = _adjust_budgets_for_quantizer(raw_budgets, hf_quantizer)
+    if quantizer_note is not None:
+        notes.append(quantizer_note)
 
-    no_split = list(no_split_module_classes) if no_split_module_classes else resolve_no_split_classes(model)
+    # `[]` is a real override -- "split anywhere, no block is atomic" -- and is
+    # not the same request as `None`, which means "detect the block classes".
+    no_split = (
+        list(no_split_module_classes) if no_split_module_classes is not None
+        else resolve_no_split_classes(model)
+    )
     sizes = _compute_module_sizes(model, hf_quantizer)
     units = _split_units(model, no_split, sizes)
     total = sizes.get("", sum(s for _, s in units))
@@ -661,8 +743,6 @@ def plan_device_map(
     if free_space_policy not in ("balanced", "head_max"):
         raise ValueError(f"free_space_policy must be 'balanced' or 'head_max', got {free_space_policy!r}")
 
-    notes: list[str] = []
-
     # Units that must travel with the head. Resolved BEFORE the reserve is
     # derived: the head's device pays for them on top of the headroom, so the
     # reserve cap below cannot be computed without knowing how big they are.
@@ -693,7 +773,67 @@ def plan_device_map(
     pinned = list(dict.fromkeys(
         u for p in pinned for u, _ in units if u == p or u.startswith(p + ".")
     ))
+
+    # Co-locate every group of units that shares a parameter, not just the
+    # input/output embedding pair. `compute_module_sizes` counts a shared tensor
+    # once, so splitting its owners across devices makes accelerate materialise a
+    # second copy that `weight_bytes` never accounted for, and a plan that
+    # measured as feasible OOMs during dispatch. Encoder/decoder models that tie
+    # `shared` to both embedding tables are the common case.
+    unit_names = [u for u, _ in units]
+    parent = {u: u for u in unit_names}
+
+    def _root(u: str) -> str:
+        while parent[u] != u:
+            parent[u] = parent[parent[u]]
+            u = parent[u]
+        return u
+
+    def _owning_unit(param_name: str) -> str | None:
+        best = None
+        for u in unit_names:
+            if (param_name == u or param_name.startswith(u + ".")) and \
+               (best is None or len(u) > len(best)):
+                best = u
+        return best
+
+    for shared_names in _tied_parameter_groups(model):
+        owners = list(dict.fromkeys(
+            u for u in (_owning_unit(n) for n in shared_names) if u is not None
+        ))
+        for other in owners[1:]:
+            a, b = _root(owners[0]), _root(other)
+            if a != b:
+                parent[a] = b
+
+    # A tied group that touches the head travels with the head; the rest just
+    # have to stay together.
+    pinned_roots = {_root(p) for p in pinned}
+    tied_with_head = [u for u in unit_names if u not in pinned and _root(u) in pinned_roots]
+    if tied_with_head:
+        pinned.extend(tied_with_head)
+        tied_to_head.extend(u for u in tied_with_head if u not in tied_to_head)
+        notes.append(
+            "tied parameters: " + ", ".join(tied_with_head) +
+            " share storage with the head's group and are pinned to its device"
+        )
     pinned_bytes = sum(unit_size[p] for p in pinned)
+
+    # Placement items: one per co-location group, in first-appearance order, so
+    # the walks below cannot separate units that share a tensor.
+    free_groups: list[tuple[tuple[str, ...], int]] = []
+    _group_index: dict[str, int] = {}
+    for name, size in units:
+        if name in pinned:
+            continue
+        root = _root(name)
+        if root in _group_index:
+            at = _group_index[root]
+            names, total_size = free_groups[at]
+            free_groups[at] = (names + (name,), total_size + size)
+        else:
+            _group_index[root] = len(free_groups)
+            free_groups.append(((name,), size))
 
     # A reserve the caller measured is a constraint; a reserve we guessed is a
     # heuristic. Only the guess may be relaxed to make a placement fit (see
@@ -766,8 +906,7 @@ def plan_device_map(
         budget[head_device] -= pinned_bytes
         if any(b < 0 for b in budget.values()):
             return None
-        free = [(name, size) for name, size in units if name not in pinned]
-        used, assign = _walk_in_order(free, budget)
+        used, assign = _walk_in_order(free_groups, budget)
         if used is None:
             # The in-order walk is next-fit with a first-fit rescue, and neither
             # backtracks, so it can run out of room while a valid assignment
@@ -780,7 +919,13 @@ def plan_device_map(
             # failed, so a plan that already worked is never rewritten: layout
             # in definition order keeps consecutive layers together, which
             # costs fewer cross-device hops than a size-sorted one.
-            used, assign = _best_fit(free, budget)
+            used, assign = _best_fit(free_groups, budget)
+        if used is None:
+            # Best-fit is not exact either: capacities 10 and 10 with units
+            # 6, 5, 3, 2, 2, 2 pack 6+3 and 5+2+2 and then reject the last 2,
+            # although 6+2+2 and 5+3+2 both fit. Last resort before refusing a
+            # model that demonstrably fits.
+            used, assign = _exact_fit(free_groups, budget)
         if used is None:
             return None
         for p in pinned:
@@ -793,12 +938,12 @@ def plan_device_map(
         used = dict.fromkeys(devices, 0)
         assign: dict[str, int] = {}
         cursor = 0
-        for name, size in free:
+        for names, size in free:
             placed = False
             while cursor < len(devices):
                 d = devices[cursor]
                 if used[d] + size <= budget[d]:
-                    assign[name] = d
+                    assign.update(dict.fromkeys(names, d))
                     used[d] += size
                     placed = True
                     break
@@ -808,7 +953,7 @@ def plan_device_map(
                 # has room rather than falling off to CPU.
                 for d in devices:
                     if used[d] + size <= budget[d]:
-                        assign[name] = d
+                        assign.update(dict.fromkeys(names, d))
                         used[d] += size
                         placed = True
                         break
@@ -820,15 +965,66 @@ def plan_device_map(
         """Largest unit first into the device it leaves least room on."""
         used = dict.fromkeys(devices, 0)
         assign: dict[str, int] = {}
-        for name, size in sorted(free, key=lambda item: -item[1]):
+        for names, size in sorted(free, key=lambda item: -item[1]):
             room = [(budget[d] - used[d] - size, d) for d in devices
                     if used[d] + size <= budget[d]]
             if not room:
                 return None, None
             _, d = min(room)
-            assign[name] = d
+            assign.update(dict.fromkeys(names, d))
             used[d] += size
         return used, assign
+
+    def _exact_fit(free, budget, node_budget=20000, max_units=512):
+        """Bounded depth-first packing, largest unit first.
+
+        Runs only after both heuristics have failed, so it can turn a refusal
+        into a plan and can never rewrite one that already worked. Two prunes
+        keep it cheap: at each depth a device whose remaining capacity was
+        already tried is skipped (interchangeable), and the whole search gives up
+        after ``node_budget`` placements rather than exploring an exponential
+        tree. Deep unit lists (a fine-grained ``no_split_module_classes = []``)
+        are left to the heuristics, which handle uniform units well.
+        """
+        order = sorted(free, key=lambda item: -item[1])
+        if not order or len(order) > max_units:
+            return None, None
+        if sum(size for _, size in order) > sum(budget[d] for d in devices):
+            return None, None
+        remaining = {d: budget[d] for d in devices}
+        assign: dict[str, int] = {}
+        visited = 0
+
+        def place(i: int) -> bool:
+            nonlocal visited
+            if i == len(order):
+                return True
+            visited += 1
+            if visited > node_budget:
+                raise _SearchExhausted
+            names, size = order[i]
+            tried: set[int] = set()
+            for d in devices:
+                room = remaining[d]
+                if size > room or room in tried:
+                    continue
+                tried.add(room)
+                remaining[d] -= size
+                assign.update(dict.fromkeys(names, d))
+                if place(i + 1):
+                    return True
+                remaining[d] += size
+                for n in names:
+                    assign.pop(n, None)
+            return False
+
+        try:
+            fitted = place(0)
+        except (_SearchExhausted, RecursionError):
+            return None, None
+        if not fitted:
+            return None, None
+        return {d: budget[d] - remaining[d] for d in devices}, assign
 
     if prefer_head_device is not None and prefer_head_device not in devices:
         # Otherwise the candidate loop below skips every option and the failure

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -371,29 +371,81 @@ def head_is_tied(model: nn.Module, head: nn.Module | None) -> bool:
     return hw is not None and iw is not None and hw is iw
 
 
+def _model_dtype(model: nn.Module) -> Any:
+    """The dtype the checkpoint will be loaded in, as the config declares it."""
+    cfg = getattr(model, "config", None)
+    for holder in (cfg, getattr(cfg, "text_config", None)):
+        for attr in ("dtype", "torch_dtype"):
+            d = getattr(holder, attr, None)
+            if isinstance(d, torch.dtype):
+                return d
+    for t in model.parameters():
+        if t.dtype.is_floating_point:
+            return t.dtype
+    return None
+
+
+def _quantized_size_kwargs(model: nn.Module, hf_quantizer: Any) -> dict[str, Any]:
+    """`dtype` / `special_dtypes` for `compute_module_sizes`, quantiser-aware.
+
+    Mirrors what ``transformers.modeling_utils._get_device_map`` does before it
+    calls ``infer_auto_device_map``: the quantiser turns the load dtype into the
+    storage dtype it will really allocate (``CustomDtype.INT4`` for bnb-4bit,
+    half a byte per element), and names the modules it will NOT convert so those
+    keep the load dtype.
+
+    This matters a lot. ``preprocess_model`` leaves a meta ``Params4bit`` at the
+    full unpacked shape in float32, so measuring the modules directly reports a
+    4-bit checkpoint at roughly four times its real size, and the planner then
+    refuses or badly partitions exactly the quantised models it exists for.
+    """
+    if hf_quantizer is None:
+        return {}
+    dtype = _model_dtype(model)
+    if dtype is None:
+        return {}
+    kwargs: dict[str, Any] = {}
+    adjust = getattr(hf_quantizer, "adjust_target_dtype", None)
+    if callable(adjust):
+        try:
+            target = adjust(dtype)
+        except Exception:
+            target = None
+        if target is not None:
+            kwargs["dtype"] = target
+    special = getattr(hf_quantizer, "get_special_dtypes_update", None)
+    if callable(special) and getattr(hf_quantizer, "modules_to_not_convert", None):
+        try:
+            kwargs["special_dtypes"] = dict(special(model, dtype))
+        except Exception:
+            pass
+    return kwargs
+
+
 def _compute_module_sizes(model: nn.Module, hf_quantizer: Any = None) -> dict[str, int]:
     """Bytes per module subtree. Uses transformers'/accelerate's version when
     available so quantised (bnb / Params4bit) sizes match what the loader will
     actually allocate; otherwise falls back to a plain walk."""
+    size_kwargs = _quantized_size_kwargs(model, hf_quantizer)
     for mod_path in ("transformers.integrations.accelerate", "accelerate.utils.modeling"):
         try:
             module = __import__(mod_path, fromlist=["compute_module_sizes"])
             fn = getattr(module, "compute_module_sizes")
         except Exception:
             continue
-        try:
-            out = fn(model, hf_quantizer) if hf_quantizer is not None else fn(model)
-        except TypeError:
+        # Drop the extras one at a time rather than all at once: an older
+        # accelerate without `special_dtypes` still gets the storage dtype,
+        # which is the term that actually moves the number.
+        for kwargs in ([size_kwargs] if size_kwargs else []) + \
+                      ([{"dtype": size_kwargs["dtype"]}] if "special_dtypes" in size_kwargs else []) + [{}]:
             try:
-                out = fn(model)
+                out = fn(model, **kwargs)
             except Exception:
                 continue
-        except Exception:
-            continue
-        if isinstance(out, tuple):
-            out = out[0]
-        if isinstance(out, Mapping) and "" in out:
-            return {k: int(v) for k, v in out.items()}
+            if isinstance(out, tuple):
+                out = out[0]
+            if isinstance(out, Mapping) and "" in out:
+                return {k: int(v) for k, v in out.items()}
     sizes: dict[str, int] = {}
     for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
         nbytes = tensor.numel() * tensor.element_size()
@@ -430,12 +482,24 @@ def _split_units(
             return
         # Direct parameters/buffers owned by this module (not by a child) have
         # to travel with the module itself, so keep them as their own unit.
-        own = sum(
-            t.numel() * t.element_size()
-            for t in list(module.parameters(recurse=False)) + list(module.buffers(recurse=False))
-        )
+        own_tensors = list(module.named_parameters(recurse=False)) + \
+                      list(module.named_buffers(recurse=False))
+        own = sum(t.numel() * t.element_size() for _, t in own_tensors)
         if own and prefix:
             units.append((prefix, own))
+        elif own:
+            # State registered directly on the ROOT module. There is no module
+            # name to hang it on -- the prefix is "" -- and accelerate reads ""
+            # as a catch-all default for everything unlisted, which would fight
+            # the explicit entries this planner exists to produce. So name each
+            # tensor instead: accelerate's lookup walks a parameter name up to
+            # its longest present prefix and tries the full name first, so an
+            # exact key matches immediately. Without this the coverage check at
+            # the end of plan_device_map reports the state as unplaced and
+            # raises, so a model with a root-level scale or bias could not be
+            # planned at all.
+            for tensor_name, tensor in own_tensors:
+                units.append((tensor_name, tensor.numel() * tensor.element_size()))
         for child_name, child in children:
             walk(f"{prefix}.{child_name}" if prefix else child_name, child)
 
@@ -494,7 +558,11 @@ def plan_device_map(
             sets it per device, which is what you want when one card also holds
             a vision tower or the generation KV cache. Kept free on *every* device for ordinary
             activations, on top of the head headroom on the head's device.
-            Defaults follow ``free_space_policy``.
+            Defaults follow ``free_space_policy``. A value you pass is a **hard
+            constraint**: if the model cannot be placed while keeping it free,
+            :class:`DeviceMapInfeasible` is raised rather than a plan that
+            quietly leaves less room than you asked for. Only the default,
+            auto-derived reserve is relaxed to make a placement fit.
         free_space_policy: how the leftover memory is shared.
             ``"balanced"`` (default) gives every device an equal activation
             budget ``(total_slack - headroom) / n_devices`` and hands the head's
@@ -561,6 +629,13 @@ def plan_device_map(
         raise ValueError(f"free_space_policy must be 'balanced' or 'head_max', got {free_space_policy!r}")
 
     notes: list[str] = []
+    # A reserve the caller measured is a constraint; a reserve we guessed is a
+    # heuristic. Only the guess may be relaxed to make a placement fit (see
+    # `attempt`), otherwise a per-device mapping built from measurements -- the
+    # documented answer to the asymmetric-activation caveat above -- could be
+    # quietly reduced to zero and the run would OOM on a card the plan still
+    # claimed had the reserve free.
+    reserve_is_explicit = activation_reserve_bytes is not None
     if activation_reserve_bytes is None:
         if free_space_policy == "balanced":
             # Give every device the same activation budget, then hand the head's
@@ -610,7 +685,16 @@ def plan_device_map(
             )
 
     unit_size = dict(units)
-    pinned = [p for p in pinned if p in unit_size]
+    # Expand each pinned module to every placement unit at or below it. A head
+    # that is a plain nn.Linear is a leaf and is its own unit, so this is a
+    # no-op there; a composite head is split by `_split_units` into descendants
+    # like `lm_head.proj` and the head's own name never appears as a unit, so an
+    # exact-name filter dropped it from `pinned` entirely and the greedy walk was
+    # free to put it on a card that is not `head_device` -- leaving the logit
+    # headroom reserved on the wrong GPU.
+    pinned = list(dict.fromkeys(
+        u for p in pinned for u, _ in units if u == p or u.startswith(p + ".")
+    ))
     pinned_bytes = sum(unit_size[p] for p in pinned)
 
     def attempt(head_device: int):
@@ -619,8 +703,12 @@ def plan_device_map(
         The head device always keeps ``activation_reserve + headroom`` free; when
         block granularity makes the ideal split infeasible we take the slack out
         of the *other* cards, never out of the head's logit headroom.
+
+        Only an auto-derived reserve is relaxed. A caller-supplied one is a hard
+        constraint, so an explicit reserve either fits or the plan is refused.
         """
-        for step in range(21):
+        steps = 1 if reserve_is_explicit else 21
+        for step in range(steps):
             r = _fill(head_device, max(reserve.values()) * (20 - step) // 20)
             if r is not None:
                 return r
@@ -635,12 +723,34 @@ def plan_device_map(
         budget[head_device] -= pinned_bytes
         if any(b < 0 for b in budget.values()):
             return None
+        free = [(name, size) for name, size in units if name not in pinned]
+        used, assign = _walk_in_order(free, budget)
+        if used is None:
+            # The in-order walk is next-fit with a first-fit rescue, and neither
+            # backtracks, so it can run out of room while a valid assignment
+            # exists: capacities 10 and 10 with units 7, 6, 3, 2, 2 build loads
+            # of 9 and 9 and then reject the last unit, although 7+3 and 6+2+2
+            # both fit. Differently sized units -- a vision tower, a projector
+            # and decoder blocks in one model -- produce exactly that shape. So
+            # before giving up, repack largest-first into the tightest device
+            # that still fits. This runs ONLY after the in-order walk has
+            # failed, so a plan that already worked is never rewritten: layout
+            # in definition order keeps consecutive layers together, which
+            # costs fewer cross-device hops than a size-sorted one.
+            used, assign = _best_fit(free, budget)
+        if used is None:
+            return None
+        for p in pinned:
+            assign[p] = head_device
+            used[head_device] += unit_size[p]
+        weight_bytes = {d: used[d] for d in devices}
+        return assign, weight_bytes, {d: budget[d] for d in devices}
+
+    def _walk_in_order(free, budget):
         used = dict.fromkeys(devices, 0)
         assign: dict[str, int] = {}
         cursor = 0
-        for name, size in units:
-            if name in pinned:
-                continue
+        for name, size in free:
             placed = False
             while cursor < len(devices):
                 d = devices[cursor]
@@ -660,12 +770,22 @@ def plan_device_map(
                         placed = True
                         break
             if not placed:
-                return None
-        for p in pinned:
-            assign[p] = head_device
-            used[head_device] += unit_size[p]
-        weight_bytes = {d: used[d] for d in devices}
-        return assign, weight_bytes, {d: budget[d] for d in devices}
+                return None, None
+        return used, assign
+
+    def _best_fit(free, budget):
+        """Largest unit first into the device it leaves least room on."""
+        used = dict.fromkeys(devices, 0)
+        assign: dict[str, int] = {}
+        for name, size in sorted(free, key=lambda item: -item[1]):
+            room = [(budget[d] - used[d] - size, d) for d in devices
+                    if used[d] + size <= budget[d]]
+            if not room:
+                return None, None
+            _, d = min(room)
+            assign[name] = d
+            used[d] += size
+        return used, assign
 
     order = [prefer_head_device] if prefer_head_device is not None else list(reversed(devices))
     result = None
@@ -735,7 +855,8 @@ def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
     from transformers import AutoConfig
 
     config = AutoConfig.from_pretrained(model_name_or_path, **from_pretrained_kwargs)
-    auto_cls = _auto_class_for(config)
+    trust_remote_code = bool(from_pretrained_kwargs.get("trust_remote_code", False))
+    auto_cls = _auto_class_for(config, trust_remote_code=trust_remote_code)
     hf_quantizer = None
     qcfg = getattr(config, "quantization_config", None)
     if qcfg is not None:
@@ -743,7 +864,13 @@ def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
 
         hf_quantizer = AutoHfQuantizer.from_config(qcfg)
     with init_empty_weights():
-        model = auto_cls.from_config(config)
+        # `trust_remote_code` has to travel to `from_config` too. AutoConfig can
+        # resolve a dynamic config on its own, but the model class then lives in
+        # the same Hub repo and `from_config` only fetches it when it is allowed
+        # to, so without this a remote-code checkpoint raises instead of
+        # honouring the option the caller already passed.
+        model = auto_cls.from_config(config, trust_remote_code=True) if trust_remote_code \
+            else auto_cls.from_config(config)
     model.eval()
     if hf_quantizer is not None:
         # Swap in the quantised Linear classes so the size table matches the
@@ -755,7 +882,7 @@ def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
     return model, hf_quantizer, config
 
 
-def _auto_class_for(config: Any):
+def _auto_class_for(config: Any, trust_remote_code: bool = False):
     """Pick the right Auto* class without hardcoding an architecture."""
     from transformers import (
         AutoModelForCausalLM,
@@ -764,6 +891,15 @@ def _auto_class_for(config: Any):
     )
 
     archs = list(getattr(config, "architectures", None) or [])
+    # A dynamic (remote-code) config is not in any `_model_mapping`, so the
+    # mapping walk below always falls through to AutoModel and construction
+    # fails. The repo says which Auto class it registered for; `from_config`
+    # looks the model class up under exactly that name, so pick the matching one.
+    auto_map = getattr(config, "auto_map", None)
+    if trust_remote_code and isinstance(auto_map, Mapping):
+        for auto_cls in (AutoModelForImageTextToText, AutoModelForCausalLM, AutoModel):
+            if auto_cls.__name__ in auto_map:
+                return auto_cls
     for auto_cls in (AutoModelForImageTextToText, AutoModelForCausalLM):
         mapping = getattr(auto_cls, "_model_mapping", None)
         if mapping is None:

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -85,7 +85,7 @@ Formula (see :func:`logit_headroom_bytes`), with ``s = logit dtype itemsize``::
 
 Usage
 -----
-    from device_map_planner import plan_device_map_for_pretrained
+    from unsloth_zoo.device_map_planner import plan_device_map_for_pretrained
 
     plan = plan_device_map_for_pretrained(
         "unsloth/Qwen3-14B-unsloth-bnb-4bit",
@@ -829,8 +829,14 @@ def plan_device_map(
     # exact-name filter dropped it from `pinned` entirely and the greedy walk was
     # free to put it on a card that is not `head_device` -- leaving the logit
     # headroom reserved on the wrong GPU.
+    # ... and up as well as down. When the head sits inside a module whose class
+    # is in `no_split_module_classes`, the unit is that atomic ANCESTOR and the
+    # head's own name never appears, so a descendants-only filter emptied
+    # `pinned` and the greedy walk was free to put the head's card's contents
+    # anywhere -- headroom reserved on a GPU that does not hold the head.
     pinned = list(dict.fromkeys(
-        u for p in pinned for u, _ in units if u == p or u.startswith(p + ".")
+        u for p in pinned for u, _ in units
+        if u == p or u.startswith(p + ".") or p.startswith(u + ".")
     ))
 
     # Co-locate every group of units that shares a parameter, not just the
@@ -1237,11 +1243,17 @@ def _from_config_remote_aware(auto_cls: Any, config: Any, from_pretrained_kwargs
             from transformers.dynamic_module_utils import get_class_from_dynamic_module
         except ImportError:
             get_class_from_dynamic_module = None
-        repo_id, _, ref = class_ref.rpartition("--")
-        repo_id = repo_id or getattr(config, "_name_or_path", None) \
-            or getattr(config, "name_or_path", None)
-        if get_class_from_dynamic_module is not None and repo_id:
-            model_cls = get_class_from_dynamic_module(ref, repo_id, **hub_kwargs)
+        # Hand over the reference UNSPLIT, with the model's own path. The
+        # `repo--module.Class` form names a separate code repository, and
+        # `get_class_from_dynamic_module` compares the two before deciding
+        # anything: `if code_revision is None and pretrained_model_name_or_path
+        # == repo_id: code_revision = revision`. Splitting it here and passing
+        # the code repo as the path makes those two always equal, so a model
+        # `revision` would be looked for as a branch of the unrelated code repo.
+        model_path = getattr(config, "_name_or_path", None) \
+            or getattr(config, "name_or_path", None) or ""
+        if get_class_from_dynamic_module is not None and (model_path or "--" in class_ref):
+            model_cls = get_class_from_dynamic_module(class_ref, model_path, **hub_kwargs)
             return model_cls._from_config(config)
     return auto_cls.from_config(config, trust_remote_code=True)
 

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -127,6 +127,7 @@ Nothing here is specific to one architecture:
 
 from __future__ import annotations
 
+import inspect
 import math
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Mapping, Sequence
@@ -425,19 +426,51 @@ def _quantized_size_kwargs(model: nn.Module, hf_quantizer: Any) -> dict[str, Any
 def _compute_module_sizes(model: nn.Module, hf_quantizer: Any = None) -> dict[str, int]:
     """Bytes per module subtree. Uses transformers'/accelerate's version when
     available so quantised (bnb / Params4bit) sizes match what the loader will
-    actually allocate; otherwise falls back to a plain walk."""
+    actually allocate; otherwise falls back to a plain walk.
+
+    The two available implementations take the quantiser differently and neither
+    tolerates the other's arguments, so dispatch on the signature:
+
+    * ``transformers.integrations.accelerate.compute_module_sizes(model,
+      hf_quantizer=...)`` asks the quantiser for the element size of each
+      parameter, which is exact. It returns a 2-tuple.
+    * ``accelerate.utils.modeling.compute_module_sizes(model, dtype=...,
+      special_dtypes=...)`` has no quantiser argument, so it gets the storage
+      dtype and the not-converted modules instead (see
+      :func:`_quantized_size_kwargs`).
+
+    Passing the wrong pair is not a near miss. ``hf_quantizer`` in accelerate's
+    second positional slot is read as a dtype and raises, and a ``dtype`` keyword
+    on the transformers version is unexpected, so either mistake ends in the
+    plain walk below -- which measures a preprocessed meta ``Params4bit`` at the
+    full unpacked shape in float32, several times the real size of a 4-bit
+    checkpoint.
+    """
     size_kwargs = _quantized_size_kwargs(model, hf_quantizer)
     for mod_path in ("transformers.integrations.accelerate", "accelerate.utils.modeling"):
         try:
             module = __import__(mod_path, fromlist=["compute_module_sizes"])
             fn = getattr(module, "compute_module_sizes")
+            accepted = inspect.signature(fn).parameters
         except Exception:
             continue
-        # Drop the extras one at a time rather than all at once: an older
-        # accelerate without `special_dtypes` still gets the storage dtype,
-        # which is the term that actually moves the number.
-        for kwargs in ([size_kwargs] if size_kwargs else []) + \
-                      ([{"dtype": size_kwargs["dtype"]}] if "special_dtypes" in size_kwargs else []) + [{}]:
+        attempts: list[dict[str, Any]] = []
+        if hf_quantizer is not None and "hf_quantizer" in accepted:
+            attempts.append({"hf_quantizer": hf_quantizer})
+        elif size_kwargs:
+            supported = {k: v for k, v in size_kwargs.items() if k in accepted}
+            # Drop the extras one at a time rather than all at once: an older
+            # accelerate without `special_dtypes` still gets the storage dtype,
+            # which is the term that actually moves the number.
+            if supported:
+                attempts.append(supported)
+            if "dtype" in supported and len(supported) > 1:
+                attempts.append({"dtype": supported["dtype"]})
+        # Last resort. Correct for an unquantised model, an over-estimate for a
+        # quantised one -- which refuses rather than OOMs, so it is the safe way
+        # to be wrong.
+        attempts.append({})
+        for kwargs in attempts:
             try:
                 out = fn(model, **kwargs)
             except Exception:

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -629,45 +629,10 @@ def plan_device_map(
         raise ValueError(f"free_space_policy must be 'balanced' or 'head_max', got {free_space_policy!r}")
 
     notes: list[str] = []
-    # A reserve the caller measured is a constraint; a reserve we guessed is a
-    # heuristic. Only the guess may be relaxed to make a placement fit (see
-    # `attempt`), otherwise a per-device mapping built from measurements -- the
-    # documented answer to the asymmetric-activation caveat above -- could be
-    # quietly reduced to zero and the run would OOM on a card the plan still
-    # claimed had the reserve free.
-    reserve_is_explicit = activation_reserve_bytes is not None
-    if activation_reserve_bytes is None:
-        if free_space_policy == "balanced":
-            # Give every device the same activation budget, then hand the head's
-            # device the logit headroom on top.
-            #
-            # This equal split is a heuristic and it is only right when the
-            # per-device activation demand is symmetric. It is NOT symmetric for
-            # a vision-LM whose GPU 0 also carries the vision tower, the input
-            # embedding and the generation KV cache: a measured GRPO step
-            # (4 x 640 completion tokens, a 30B 4-bit model, 2 x 14.56 GiB) OOMs on
-            # GPU 0 under the equal split while succeeding under accelerate's
-            # own layout. Pass a per-device mapping when you have measurements.
-            slack = sum(raw_budgets.values()) - total
-            activation_reserve_bytes = int(max(0, (slack - headroom) // len(devices)))
-            # The head's device pays the headroom on top of its share, so an
-            # equal split of the global slack can exceed that one device's own
-            # budget even when the totals fit. Cap by the smallest budget less
-            # the headroom and less that device's expected share of the weights,
-            # otherwise a model that trivially fits is refused.
-            share = -(-total // len(devices))
-            per_device_cap = min(raw_budgets.values()) - headroom - share
-            activation_reserve_bytes = int(max(0, min(activation_reserve_bytes, per_device_cap)))
-        else:
-            # Mirror accelerate: reserve the largest single placement unit.
-            activation_reserve_bytes = max((s for _, s in units), default=0)
-    if isinstance(activation_reserve_bytes, Mapping):
-        reserve = {d: _parse_size(activation_reserve_bytes.get(d, 0)) for d in devices}
-    else:
-        reserve = dict.fromkeys(devices, int(activation_reserve_bytes))
-    activation_reserve_bytes = max(reserve.values()) if reserve else 0
 
-    # Units that must travel with the head.
+    # Units that must travel with the head. Resolved BEFORE the reserve is
+    # derived: the head's device pays for them on top of the headroom, so the
+    # reserve cap below cannot be computed without knowing how big they are.
     pinned: list[str] = []
     if head_name is not None:
         pinned.append(head_name)
@@ -696,6 +661,51 @@ def plan_device_map(
         u for p in pinned for u, _ in units if u == p or u.startswith(p + ".")
     ))
     pinned_bytes = sum(unit_size[p] for p in pinned)
+
+    # A reserve the caller measured is a constraint; a reserve we guessed is a
+    # heuristic. Only the guess may be relaxed to make a placement fit (see
+    # `attempt`), otherwise a per-device mapping built from measurements -- the
+    # documented answer to the asymmetric-activation caveat above -- could be
+    # quietly reduced to zero and the run would OOM on a card the plan still
+    # claimed had the reserve free.
+    reserve_is_explicit = activation_reserve_bytes is not None
+    if activation_reserve_bytes is None:
+        if free_space_policy == "balanced":
+            # Give every device the same activation budget, then hand the head's
+            # device the logit headroom on top.
+            #
+            # This equal split is a heuristic and it is only right when the
+            # per-device activation demand is symmetric. It is NOT symmetric for
+            # a vision-LM whose GPU 0 also carries the vision tower, the input
+            # embedding and the generation KV cache: a measured GRPO step
+            # (4 x 640 completion tokens, a 30B 4-bit model, 2 x 14.56 GiB) OOMs on
+            # GPU 0 under the equal split while succeeding under accelerate's
+            # own layout. Pass a per-device mapping when you have measurements.
+            slack = sum(raw_budgets.values()) - total
+            activation_reserve_bytes = int(max(0, (slack - headroom) // len(devices)))
+            # The head's device pays the headroom on top of its share, so an
+            # equal split of the global slack can exceed that one device's own
+            # budget even when the totals fit. Cap by the smallest budget less
+            # the headroom and less the weight that device has to hold,
+            # otherwise a model that trivially fits is refused.
+            #
+            # That weight is at least the pinned units, which the head's device
+            # takes whole. An average share alone is not enough: `attempt` only
+            # relaxes the reserve on the OTHER cards, so once the head's budget
+            # goes negative every step fails and the plan is refused. A four-layer
+            # model whose head is larger than half the weights (share 24 KiB,
+            # head 32 KiB) was rejected on 2 x 8 GiB for exactly that reason.
+            share = max(-(-total // len(devices)), pinned_bytes)
+            per_device_cap = min(raw_budgets.values()) - headroom - share
+            activation_reserve_bytes = int(max(0, min(activation_reserve_bytes, per_device_cap)))
+        else:
+            # Mirror accelerate: reserve the largest single placement unit.
+            activation_reserve_bytes = max((s for _, s in units), default=0)
+    if isinstance(activation_reserve_bytes, Mapping):
+        reserve = {d: _parse_size(activation_reserve_bytes.get(d, 0)) for d in devices}
+    else:
+        reserve = dict.fromkeys(devices, int(activation_reserve_bytes))
+    activation_reserve_bytes = max(reserve.values()) if reserve else 0
 
     def attempt(head_device: int):
         """Try progressively smaller activation reserves on the non-head devices.
@@ -787,6 +797,14 @@ def plan_device_map(
             used[d] += size
         return used, assign
 
+    if prefer_head_device is not None and prefer_head_device not in devices:
+        # Otherwise the candidate loop below skips every option and the failure
+        # is reported as a memory shortfall, which sends the caller looking in
+        # entirely the wrong place.
+        raise ValueError(
+            f"prefer_head_device={prefer_head_device} is not one of the usable "
+            f"devices {devices}"
+        )
     order = [prefer_head_device] if prefer_head_device is not None else list(reversed(devices))
     result = None
     chosen = None

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -392,6 +392,39 @@ def _model_dtype(model: nn.Module) -> Any:
     return None
 
 
+def _keep_in_fp32_modules(model: nn.Module, hf_quantizer: Any = None) -> list[str]:
+    """Modules the loader will leave in float32, mirroring transformers.
+
+    ``from_pretrained`` hands this list to ``preprocess_model`` so the quantiser
+    skips those modules and they keep the load dtype. Passing ``[]`` instead
+    sizes them at the quantised width while the loader keeps them wide, which
+    undercounts the weights of a tight plan and OOMs during loading. Both
+    bitsandbytes quantisers set ``use_keep_in_fp32_modules``, and real
+    checkpoints do declare the list (gpt-oss keeps its layer norms, the T5
+    family keeps `wo`), so this is not a rare path.
+
+    The gate is the same as ``modeling_utils``: the plain list applies under
+    float16 or when the quantiser asks for it, the strict list under float16 or
+    bfloat16, both against the dtype the quantiser resolved.
+    """
+    dtype = _model_dtype(model)
+    update = getattr(hf_quantizer, "update_dtype", None)
+    if callable(update):
+        try:
+            dtype = update(dtype)
+        except Exception:
+            pass
+    keep: list[str] = []
+    plain = getattr(model, "_keep_in_fp32_modules", None)
+    if plain and (dtype == torch.float16 or
+                  getattr(hf_quantizer, "use_keep_in_fp32_modules", False)):
+        keep.extend(plain)
+    strict = getattr(model, "_keep_in_fp32_modules_strict", None)
+    if strict and dtype in (torch.float16, torch.bfloat16):
+        keep.extend(strict)
+    return list(dict.fromkeys(keep))
+
+
 def _quantized_size_kwargs(model: nn.Module, hf_quantizer: Any) -> dict[str, Any]:
     """`dtype` / `special_dtypes` for `compute_module_sizes`, quantiser-aware.
 
@@ -599,10 +632,14 @@ def _split_units(
             sizes.get(f"{prefix}.{child_name}" if prefix else child_name, 0)
             for child_name, _ in children
         )
+        # Emit the unit whenever direct state exists, even at zero bytes: a
+        # tensor tied to one counted elsewhere weighs nothing here, and dropping
+        # its unit would leave the parameter uncovered and fail the coverage
+        # check at the end of `plan_device_map`.
         own = max(0, size - child_bytes) if own_tensors else 0
-        if own and prefix:
+        if own_tensors and prefix:
             units.append((prefix, own))
-        elif own:
+        elif own_tensors:
             # State registered directly on the ROOT module. There is no module
             # name to hang it on -- the prefix is "" -- and accelerate reads ""
             # as a catch-all default for everything unlisted, which would fight
@@ -737,9 +774,14 @@ def plan_device_map(
 
     if softcapped is None:
         cfg = getattr(model, "config", None)
+        # `logits_soft_cap` is the RecurrentGemma spelling of the same knob, and
+        # the repository's own `_detect_logit_softcap` already treats them as
+        # aliases. Missing it drops the tanh temporary and the retained soft-cap
+        # buffer from the headroom, so the head's card is under-reserved.
         softcapped = any(
-            bool(getattr(h, "final_logit_softcapping", None))
+            bool(getattr(h, name, None))
             for h in (cfg, getattr(cfg, "text_config", None))
+            for name in ("final_logit_softcapping", "logits_soft_cap")
         )
 
     if headroom_bytes is None:
@@ -1084,8 +1126,13 @@ def plan_device_map(
 
     assign, weight_bytes, budgets = result
     # Sanity: the map must cover every parameter and buffer.
+    # `remove_duplicate=False`, because accelerate's own `check_device_map`
+    # walks `state_dict()`, which lists a tied tensor under every name it has.
+    # Covering only the deduplicated names lets a map through that accelerate
+    # then rejects with "does not give any device for the following parameters".
     uncovered = []
-    for pname, _ in list(model.named_parameters()) + list(model.named_buffers()):
+    for pname, _ in list(model.named_parameters(remove_duplicate=False)) + \
+                    list(model.named_buffers(remove_duplicate=False)):
         if not any(pname == k or pname.startswith(k + ".") for k in assign):
             uncovered.append(pname)
     if uncovered:
@@ -1144,7 +1191,10 @@ def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
         # Swap in the quantised Linear classes so the size table matches the
         # bytes the loader will really allocate.
         try:
-            hf_quantizer.preprocess_model(model=model, device_map=None, keep_in_fp32_modules=[])
+            hf_quantizer.preprocess_model(
+                model=model, device_map=None,
+                keep_in_fp32_modules=_keep_in_fp32_modules(model, hf_quantizer),
+            )
         except Exception:
             pass
     return model, hf_quantizer, config

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -296,7 +296,10 @@ def _name_of_module(model: nn.Module, target: nn.Module) -> str | None:
 def resolve_no_split_classes(model: nn.Module) -> list[str]:
     """Decoder / encoder block classes that must not be split across devices."""
     classes = getattr(model, "_no_split_modules", None)
-    if classes:
+    # `[]` is the model declaring that nothing is atomic, which several
+    # transformers models do (camembert, colpali, colqwen2, efficientnet, fuyu).
+    # Only `None`, the base-class default, means "not declared, go and detect".
+    if classes is not None:
         return sorted(str(c) for c in classes)
     # Fallback: every distinct child class of every nn.ModuleList that holds
     # more than one entry. That is where repeated transformer blocks live.
@@ -1219,6 +1222,11 @@ def _from_config_remote_aware(auto_cls: Any, config: Any, from_pretrained_kwargs
     ``token=...`` there is a ``TypeError`` on every ordinary checkpoint. Resolve
     the class explicitly instead, and fall back to plain ``from_config`` for
     anything that is not a dynamic class.
+
+    The fallback is chosen before the lookup, never after it: retrying a *failed*
+    resolution without the options would go to the network under
+    ``local_files_only``, drop the token, or take a different ``code_revision``
+    than the caller asked for, so a genuine Hub failure is raised as is.
     """
     hub_kwargs = {k: from_pretrained_kwargs[k] for k in _HUB_KWARGS
                   if k in from_pretrained_kwargs}
@@ -1227,14 +1235,14 @@ def _from_config_remote_aware(auto_cls: Any, config: Any, from_pretrained_kwargs
     if class_ref and hub_kwargs:
         try:
             from transformers.dynamic_module_utils import get_class_from_dynamic_module
-
-            repo_id, _, ref = class_ref.rpartition("--")
-            model_cls = get_class_from_dynamic_module(
-                ref, repo_id or config._name_or_path, **hub_kwargs
-            )
+        except ImportError:
+            get_class_from_dynamic_module = None
+        repo_id, _, ref = class_ref.rpartition("--")
+        repo_id = repo_id or getattr(config, "_name_or_path", None) \
+            or getattr(config, "name_or_path", None)
+        if get_class_from_dynamic_module is not None and repo_id:
+            model_cls = get_class_from_dynamic_module(ref, repo_id, **hub_kwargs)
             return model_cls._from_config(config)
-        except Exception:
-            pass
     return auto_cls.from_config(config, trust_remote_code=True)
 
 
@@ -1243,6 +1251,7 @@ def _auto_class_for(config: Any, trust_remote_code: bool = False):
     from transformers import (
         AutoModelForCausalLM,
         AutoModelForImageTextToText,
+        AutoModelForSeq2SeqLM,
         AutoModel,
     )
 
@@ -1253,10 +1262,18 @@ def _auto_class_for(config: Any, trust_remote_code: bool = False):
     # looks the model class up under exactly that name, so pick the matching one.
     auto_map = getattr(config, "auto_map", None)
     if trust_remote_code and isinstance(auto_map, Mapping):
-        for auto_cls in (AutoModelForImageTextToText, AutoModelForCausalLM, AutoModel):
+        for auto_cls in (AutoModelForImageTextToText, AutoModelForCausalLM,
+                         AutoModelForSeq2SeqLM, AutoModel):
             if auto_cls.__name__ in auto_map:
                 return auto_cls
-    for auto_cls in (AutoModelForImageTextToText, AutoModelForCausalLM):
+    # Seq2Seq is in the walk because an encoder-decoder checkpoint (T5, mT5) is
+    # registered ONLY under `AutoModelForSeq2SeqLM`; without it the walk fell
+    # through to the bare `AutoModel`, whose meta model has no output head at
+    # all, so the plan reserved the logit headroom around some unrelated linear
+    # and undercounted the weights the loader would really place.
+    first_hit = None
+    for auto_cls in (AutoModelForImageTextToText, AutoModelForCausalLM,
+                     AutoModelForSeq2SeqLM):
         mapping = getattr(auto_cls, "_model_mapping", None)
         if mapping is None:
             continue
@@ -1267,10 +1284,14 @@ def _auto_class_for(config: Any, trust_remote_code: bool = False):
         names = {model_cls.__name__} if not isinstance(model_cls, (list, tuple)) else {
             c.__name__ for c in model_cls
         }
-        if not archs or names & set(archs):
+        # A config can appear in two mappings -- BART is both `BartForCausalLM`
+        # and `BartForConditionalGeneration` -- so let the checkpoint's own
+        # `architectures` break the tie, and keep the first hit otherwise.
+        if archs and names & set(archs):
             return auto_cls
-        return auto_cls
-    return AutoModel
+        if first_hit is None:
+            first_hit = auto_cls
+    return first_hit if first_hit is not None else AutoModel
 
 
 def plan_device_map_for_pretrained(

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -1,0 +1,825 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Head-aware multi-GPU device map planner.
+
+Why this exists
+---------------
+When a quantised causal LM or vision-LM is split over several GPUs, the tail of
+the model (final norm + output head) lands on the *last* card that the layout
+walk touches. Anything that materialises a full-vocabulary logit tensor then has
+to allocate `rows x vocab` on that same card:
+
+* TRL / Unsloth GRPO calls
+  `unsloth_zoo.rl_replacements.chunked_hidden_states_selective_log_softmax`,
+  which builds `chunk_rows x vocab` logits in the compute dtype and then a
+  float32 copy of them.
+* On a 200k-token vocabulary that is hundreds of MB per chunk, on top of the
+  weights already resident on that card.
+
+`device_map="auto"` / `"balanced"` splits the weights *evenly*, so the head's
+card ends up with the same weight load as every other card and no room for the
+logits. `device_map="sequential"` fills greedily, but accelerate only reserves
+`max_layer_size` on GPU 0 (`main_devices = [gpus[0], "cpu"]`), never on the card
+that actually holds the head.
+
+Capping the head's card with `max_memory` does not work either: accelerate's
+allocator never backtracks to an earlier device, so once the capped card is
+full the remaining modules (the head itself, typically) are pushed to `"cpu"` /
+`"disk"`, and bitsandbytes then refuses to load with
+
+    ValueError: Some modules are dispatched on the CPU or the disk.
+
+This module therefore builds an **explicit** `device_map` dict: every split unit
+of the model is named and pinned to a GPU, so accelerate has no freedom to spill.
+
+Core idea
+---------
+Reserve headroom on whichever device holds the output head, sized from the real
+vocabulary width and the real per-chunk row count, and hand out the rest of the
+slack as an activation budget for every device (``free_space_policy="balanced"``,
+the default). ``free_space_policy="head_max"`` instead fills the non-head cards as
+far as they go, which maximises head free space but can starve GPU 0.
+
+Caveat, measured: activations follow layers. Moving decoder layers off the head's
+card raises the other card's peak by more than the weight it gained (about
+0.55 GiB per layer for a 4 x 640-token GRPO step on a 30B 4-bit model, against
+about 0.27 GiB saved
+on the head card). On a vision-LM whose GPU 0 also holds the vision tower, the input
+embedding and the generation KV cache, pass ``activation_reserve_bytes`` as a
+per-device mapping built from measurements instead of trusting the equal split.
+
+Formula (see :func:`logit_headroom_bytes`), with ``s = logit dtype itemsize``::
+
+    per_chunk = rows_per_chunk * vocab * (s + 4)          # logits + float32 copy
+              + rows_per_chunk * vocab * s   if softcapped        # tanh temporary
+              + rows_per_chunk * vocab * 4   if temperature != 1  # 2nd fp32 buffer
+              + rows_per_chunk * vocab * 4   if retained_rows      # backward grad buffer
+    retained  = retained_rows  * vocab * (4 + (s if softcapped else 0))
+    headroom  = per_chunk + retained + safety_bytes
+
+* ``rows_per_chunk * vocab * s`` is ``chunk_hidden @ lm_head.T``.
+* ``+ 4`` bytes/element is the ``chunk_logits.to(torch.float32)`` copy, which is
+  live at the same time as the low-precision tensor it was copied from.
+* the softcap term is the ``logit_softcapping * tanh(x / logit_softcapping)``
+  temporary, which is also the tensor autograd saves for the tanh backward.
+* ``retained_rows`` is the autograd case: when the log-softmax is
+  differentiated, the float32 logits of *every* chunk (plus the saved tanh
+  output when softcapping is on) stay alive until backward, so the retained
+  term scales with ``total_rows``, not with ``rows_per_chunk``. Chunking does
+  not help there. Pass ``retained_rows=0`` for a ``torch.no_grad()`` /
+  reference-model pass.
+
+Usage
+-----
+    from device_map_planner import plan_device_map_for_pretrained
+
+    plan = plan_device_map_for_pretrained(
+        "unsloth/Qwen3-14B-unsloth-bnb-4bit",
+        max_memory     = {0: "14GiB", 1: "14GiB"},
+        vocab_size     = None,          # read from the config
+        rows_per_chunk = 128,
+        retained_rows  = 0,
+    )
+    if plan is None:                    # single GPU, nothing to plan
+        device_map = "sequential"
+    else:
+        device_map = plan.device_map
+        print(plan.describe())
+
+    model, tok = FastModel.from_pretrained(..., device_map = device_map)
+
+Degradation contract
+--------------------
+* 0 or 1 usable GPU  -> returns ``None``; the caller keeps its current
+  behaviour (``"auto"`` / ``"sequential"`` / single device).
+* enough memory      -> a plan that is a strict superset of what
+  ``"sequential"`` would have done, with the head's card deliberately
+  under-filled.
+* not enough memory  -> raises :class:`DeviceMapInfeasible` with the exact
+  numbers. It never silently offloads to CPU or disk.
+
+Model agnostic
+--------------
+Nothing here is specific to one architecture:
+
+* split granularity comes from ``model._no_split_modules`` (falling back to a
+  scan of ``nn.ModuleList`` children),
+* the head comes from ``model.get_output_embeddings()`` resolved back to its
+  module name by identity,
+* tied embeddings are detected from the config *and* by parameter identity, and
+  the tied input embedding is pinned to the head's device,
+* vision towers / multimodal projectors / final norms are just ordinary split
+  units and are placed by the same greedy walk.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+import torch
+import torch.nn as nn
+
+__all__ = [
+    "DeviceMapInfeasible",
+    "DeviceMapPlan",
+    "logit_headroom_bytes",
+    "plan_device_map",
+    "plan_device_map_for_pretrained",
+    "build_meta_model",
+]
+
+_GiB = 1024 ** 3
+
+
+class DeviceMapInfeasible(RuntimeError):
+    """The model plus the requested head headroom does not fit on the GPUs."""
+
+
+# --------------------------------------------------------------------------- #
+# headroom formula
+# --------------------------------------------------------------------------- #
+def logit_headroom_bytes(
+    vocab_size: int,
+    rows_per_chunk: int,
+    *,
+    logit_dtype: torch.dtype = torch.bfloat16,
+    retained_rows: int = 0,
+    softcapped: bool = True,
+    temperature_scaled: bool = False,
+    safety_bytes: int = 256 * 1024 ** 2,
+) -> int:
+    """Bytes that must stay free on the device holding the output head.
+
+    Args:
+        vocab_size: width of the output head (``lm_head.out_features``).
+        rows_per_chunk: number of token rows the log-softmax materialises at
+            once. For ``chunked_hidden_states_selective_log_softmax`` this is
+            ``ceil(total_rows / chunks)``, or the ``TOKENS_PER_CHUNK`` cap if
+            the caller enforces one.
+        logit_dtype: dtype of the matmul output, i.e. the lm_head dtype.
+        retained_rows: total rows whose logits stay alive until backward. ``0``
+            under ``torch.no_grad()``; ``total_rows`` when the log-softmax is
+            differentiated, because autograd keeps every chunk's saved tensors.
+        softcapped: the caller passes a non-zero ``logit_softcapping``, adding a
+            ``tanh`` temporary of the chunk shape (also saved for backward).
+        temperature_scaled: the caller passes ``temperature != 1``, adding one
+            more float32 buffer of the chunk shape.
+        safety_bytes: allocator fragmentation / cuBLAS workspace slack. The
+            default 256 MiB was chosen from measurements: the modelled terms
+            below land within ~0.25 GiB of the observed allocator peak.
+
+    Returns:
+        Headroom in bytes.
+    """
+    if vocab_size <= 0 or rows_per_chunk <= 0:
+        return int(safety_bytes)
+    s = torch.empty((), dtype=logit_dtype).element_size()
+    per_chunk = rows_per_chunk * vocab_size * (s + 4)
+    if softcapped:
+        per_chunk += rows_per_chunk * vocab_size * s
+    if temperature_scaled:
+        per_chunk += rows_per_chunk * vocab_size * 4
+    if retained_rows:
+        # backward allocates one float32 gradient buffer of the chunk shape while
+        # the saved forward tensors of every chunk are still resident.
+        per_chunk += rows_per_chunk * vocab_size * 4
+    retained = int(retained_rows) * vocab_size * (4 + (s if softcapped else 0))
+    return int(per_chunk + retained + safety_bytes)
+
+
+# --------------------------------------------------------------------------- #
+# plan object
+# --------------------------------------------------------------------------- #
+@dataclass
+class DeviceMapPlan:
+    """Result of :func:`plan_device_map`."""
+
+    device_map: dict[str, int]
+    head_module: str | None
+    head_device: int
+    headroom_bytes: int
+    budgets: dict[int, int]
+    """Per-device budget actually available to weights (after every reserve)."""
+    raw_budgets: dict[int, int]
+    """Per-device budget as requested by the caller, before any reserve."""
+    weight_bytes: dict[int, int]
+    activation_reserve_bytes: int
+    total_weight_bytes: int
+    no_split_module_classes: list[str]
+    tied_to_head: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def free_bytes(self) -> dict[int, int]:
+        """Budget minus placed weights, per device (what activations may use)."""
+        return {d: self.raw_budgets[d] - self.weight_bytes.get(d, 0) for d in self.raw_budgets}
+
+    def describe(self) -> str:
+        lines = [
+            f"total weights      : {self.total_weight_bytes / _GiB:.3f} GiB",
+            f"no_split classes   : {sorted(self.no_split_module_classes)}",
+            f"output head        : {self.head_module} -> cuda:{self.head_device}",
+            f"head headroom      : {self.headroom_bytes / _GiB:.3f} GiB",
+            f"activation reserve : {self.activation_reserve_bytes / _GiB:.3f} GiB per device",
+        ]
+        if self.tied_to_head:
+            lines.append(f"tied to head       : {self.tied_to_head}")
+        for d in sorted(self.raw_budgets):
+            w = self.weight_bytes.get(d, 0)
+            lines.append(
+                f"  cuda:{d}  budget {self.raw_budgets[d] / _GiB:6.2f} GiB"
+                f"  weights {w / _GiB:6.3f} GiB"
+                f"  free {(self.raw_budgets[d] - w) / _GiB:6.3f} GiB"
+                + ("   <- output head" if d == self.head_device else "")
+            )
+        lines.extend(f"note: {n}" for n in self.notes)
+        return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# introspection helpers (all generic)
+# --------------------------------------------------------------------------- #
+def _parse_size(value: Any) -> int:
+    """Accept 12345, "14GiB", "14GB", "500MiB"."""
+    if isinstance(value, (int,)) and not isinstance(value, bool):
+        return int(value)
+    if isinstance(value, float):
+        return int(value)
+    s = str(value).strip()
+    units = (("GIB", _GiB), ("MIB", 1024 ** 2), ("KIB", 1024),
+             ("GB", 10 ** 9), ("MB", 10 ** 6), ("KB", 10 ** 3),
+             ("B", 1))
+    up = s.upper().replace(" ", "")
+    for suffix, mult in units:
+        if up.endswith(suffix):
+            return int(float(up[: -len(suffix)]) * mult)
+    return int(float(s))
+
+
+def _module_by_name(model: nn.Module, name: str) -> nn.Module:
+    mod = model
+    if name:
+        for part in name.split("."):
+            mod = getattr(mod, part)
+    return mod
+
+
+def _name_of_module(model: nn.Module, target: nn.Module) -> str | None:
+    for name, mod in model.named_modules():
+        if mod is target:
+            return name
+    return None
+
+
+def resolve_no_split_classes(model: nn.Module) -> list[str]:
+    """Decoder / encoder block classes that must not be split across devices."""
+    classes = getattr(model, "_no_split_modules", None)
+    if classes:
+        return sorted(str(c) for c in classes)
+    # Fallback: every distinct child class of every nn.ModuleList that holds
+    # more than one entry. That is where repeated transformer blocks live.
+    found: set[str] = set()
+    for _, mod in model.named_modules():
+        if isinstance(mod, nn.ModuleList) and len(mod) > 1:
+            for child in mod:
+                if any(True for _ in child.parameters(recurse=True)):
+                    found.add(type(child).__name__)
+    return sorted(found)
+
+
+def resolve_output_head(model: nn.Module) -> tuple[str | None, nn.Module | None]:
+    """Locate the output head generically.
+
+    Prefers ``get_output_embeddings()``. Falls back to a name scan for the
+    usual head attribute names, then to the widest ``nn.Linear`` in the model.
+    """
+    head = None
+    getter = getattr(model, "get_output_embeddings", None)
+    if callable(getter):
+        try:
+            head = getter()
+        except Exception:
+            head = None
+    if head is not None:
+        name = _name_of_module(model, head)
+        if name is not None:
+            return name, head
+    for candidate in ("lm_head", "output", "embed_out", "score",
+                      "language_model.lm_head", "model.lm_head"):
+        try:
+            mod = _module_by_name(model, candidate)
+        except AttributeError:
+            continue
+        if isinstance(mod, nn.Module):
+            return candidate, mod
+    widest_name, widest_mod, widest = None, None, -1
+    for name, mod in model.named_modules():
+        if isinstance(mod, nn.Linear) and mod.out_features > widest:
+            widest_name, widest_mod, widest = name, mod, mod.out_features
+    return widest_name, widest_mod
+
+
+def resolve_head_width(model: nn.Module, head: nn.Module | None) -> int:
+    """Vocabulary width of the output head."""
+    if head is not None:
+        w = getattr(head, "out_features", None)
+        if isinstance(w, int) and w > 0:
+            return w
+        weight = getattr(head, "weight", None)
+        if weight is not None and weight.dim() >= 1:
+            return int(weight.shape[0])
+    cfg = getattr(model, "config", None)
+    for holder in (getattr(cfg, "text_config", None), cfg):
+        v = getattr(holder, "vocab_size", None)
+        if isinstance(v, int) and v > 0:
+            return v
+    return 0
+
+
+def head_is_tied(model: nn.Module, head: nn.Module | None) -> bool:
+    """True when the output head shares storage with the input embedding."""
+    cfg = getattr(model, "config", None)
+    for holder in (cfg, getattr(cfg, "text_config", None)):
+        flag = getattr(holder, "tie_word_embeddings", None)
+        if flag is True:
+            return True
+    if head is None:
+        return False
+    getter = getattr(model, "get_input_embeddings", None)
+    if not callable(getter):
+        return False
+    try:
+        inp = getter()
+    except Exception:
+        return False
+    hw, iw = getattr(head, "weight", None), getattr(inp, "weight", None)
+    return hw is not None and iw is not None and hw is iw
+
+
+def _compute_module_sizes(model: nn.Module, hf_quantizer: Any = None) -> dict[str, int]:
+    """Bytes per module subtree. Uses transformers'/accelerate's version when
+    available so quantised (bnb / Params4bit) sizes match what the loader will
+    actually allocate; otherwise falls back to a plain walk."""
+    for mod_path in ("transformers.integrations.accelerate", "accelerate.utils.modeling"):
+        try:
+            module = __import__(mod_path, fromlist=["compute_module_sizes"])
+            fn = getattr(module, "compute_module_sizes")
+        except Exception:
+            continue
+        try:
+            out = fn(model, hf_quantizer) if hf_quantizer is not None else fn(model)
+        except TypeError:
+            try:
+                out = fn(model)
+            except Exception:
+                continue
+        except Exception:
+            continue
+        if isinstance(out, tuple):
+            out = out[0]
+        if isinstance(out, Mapping) and "" in out:
+            return {k: int(v) for k, v in out.items()}
+    sizes: dict[str, int] = {}
+    for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
+        nbytes = tensor.numel() * tensor.element_size()
+        parts = name.split(".")
+        for i in range(len(parts) + 1):
+            sizes[".".join(parts[:i])] = sizes.get(".".join(parts[:i]), 0) + nbytes
+    sizes.setdefault("", 0)
+    return sizes
+
+
+def _split_units(
+    model: nn.Module,
+    no_split_classes: Sequence[str],
+    sizes: Mapping[str, int],
+) -> list[tuple[str, int]]:
+    """Ordered, non-overlapping list of (module name, bytes) placement units.
+
+    Descends the module tree in definition order and stops at (a) modules whose
+    class is in ``no_split_classes``, (b) modules with no child modules, and
+    (c) modules with no parameters or buffers at all (they still get an entry so
+    the map covers the whole model).
+    """
+    no_split = set(no_split_classes)
+    units: list[tuple[str, int]] = []
+
+    def walk(prefix: str, module: nn.Module) -> None:
+        children = list(module.named_children())
+        size = sizes.get(prefix, 0)
+        if prefix and (type(module).__name__ in no_split or not children or size == 0):
+            units.append((prefix, size))
+            return
+        if not children:
+            units.append((prefix, size))
+            return
+        # Direct parameters/buffers owned by this module (not by a child) have
+        # to travel with the module itself, so keep them as their own unit.
+        own = sum(
+            t.numel() * t.element_size()
+            for t in list(module.parameters(recurse=False)) + list(module.buffers(recurse=False))
+        )
+        if own and prefix:
+            units.append((prefix, own))
+        for child_name, child in children:
+            walk(f"{prefix}.{child_name}" if prefix else child_name, child)
+
+    walk("", model)
+    return units
+
+
+def _usable_devices(max_memory: Mapping[Any, Any] | None) -> list[int]:
+    if max_memory is not None:
+        devs = sorted(int(k) for k in max_memory if isinstance(k, int) or str(k).isdigit())
+        return [d for d in devs if _parse_size(max_memory[d] if d in max_memory else max_memory[str(d)]) > 0]
+    if not torch.cuda.is_available():
+        return []
+    return list(range(torch.cuda.device_count()))
+
+
+# --------------------------------------------------------------------------- #
+# the planner
+# --------------------------------------------------------------------------- #
+def plan_device_map(
+    model: nn.Module,
+    *,
+    max_memory: Mapping[Any, Any] | None = None,
+    rows_per_chunk: int = 128,
+    retained_rows: int = 0,
+    vocab_size: int | None = None,
+    logit_dtype: torch.dtype | None = None,
+    softcapped: bool | None = None,
+    temperature_scaled: bool = False,
+    headroom_bytes: int | None = None,
+    safety_bytes: int = 256 * 1024 ** 2,
+    activation_reserve_bytes: int | Mapping[int, Any] | None = None,
+    free_space_policy: str = "balanced",
+    hf_quantizer: Any = None,
+    no_split_module_classes: Sequence[str] | None = None,
+    prefer_head_device: int | None = None,
+) -> DeviceMapPlan | None:
+    """Build an explicit device map that reserves logit headroom on the head's card.
+
+    Args:
+        model: the model, real or on the meta device (see :func:`build_meta_model`).
+        max_memory: ``{device_index: bytes or "14GiB"}``. Defaults to the free
+            memory reported by every visible CUDA device.
+        rows_per_chunk: rows the log-softmax materialises at once.
+        retained_rows: rows whose float32 logits survive to backward
+            (``total_rows`` with autograd, ``0`` under ``no_grad``).
+        vocab_size: override the detected head width.
+        logit_dtype: dtype of the logits; defaults to the head's dtype.
+        softcapped: whether a non-zero ``logit_softcapping`` is in play.
+            ``None`` (default) reads ``final_logit_softcapping`` off the config.
+        temperature_scaled: whether the caller divides by a temperature != 1.
+        headroom_bytes: bypass the formula entirely.
+        safety_bytes: slack added to the headroom.
+        activation_reserve_bytes: bytes kept free for ordinary activations. An
+            int applies to every device; a ``{device: bytes_or_str}`` mapping
+            sets it per device, which is what you want when one card also holds
+            a vision tower or the generation KV cache. Kept free on *every* device for ordinary
+            activations, on top of the head headroom on the head's device.
+            Defaults follow ``free_space_policy``.
+        free_space_policy: how the leftover memory is shared.
+            ``"balanced"`` (default) gives every device an equal activation
+            budget ``(total_slack - headroom) / n_devices`` and hands the head's
+            device the logit headroom on top. ``"head_max"`` reserves only the
+            largest split unit per device (accelerate's rule) and lets the
+            greedy fill push as much weight as possible off the head's card,
+            which maximises head free space but can starve GPU 0.
+        hf_quantizer: pass the model's ``HfQuantizer`` so quantised sizes are
+            exact.
+        no_split_module_classes: override the detected block classes.
+        prefer_head_device: force the head onto this device index.
+
+    Returns:
+        A :class:`DeviceMapPlan`, or ``None`` when there are fewer than two
+        usable GPUs (the caller should keep its existing behaviour).
+
+    Raises:
+        DeviceMapInfeasible: when no assignment fits without CPU/disk offload.
+    """
+    devices = _usable_devices(max_memory)
+    if len(devices) < 2:
+        return None
+
+    raw_budgets: dict[int, int] = {}
+    for d in devices:
+        if max_memory is not None:
+            raw = max_memory[d] if d in max_memory else max_memory[str(d)]
+            raw_budgets[d] = _parse_size(raw)
+        else:
+            free, _total = torch.cuda.mem_get_info(d)
+            raw_budgets[d] = int(free)
+
+    no_split = list(no_split_module_classes) if no_split_module_classes else resolve_no_split_classes(model)
+    sizes = _compute_module_sizes(model, hf_quantizer)
+    units = _split_units(model, no_split, sizes)
+    total = sizes.get("", sum(s for _, s in units))
+
+    head_name, head_mod = resolve_output_head(model)
+    width = int(vocab_size) if vocab_size else resolve_head_width(model, head_mod)
+    if logit_dtype is None:
+        w = getattr(head_mod, "weight", None)
+        logit_dtype = w.dtype if w is not None and w.dtype.is_floating_point else torch.bfloat16
+
+    if softcapped is None:
+        cfg = getattr(model, "config", None)
+        softcapped = any(
+            bool(getattr(h, "final_logit_softcapping", None))
+            for h in (cfg, getattr(cfg, "text_config", None))
+        )
+
+    if headroom_bytes is None:
+        headroom = logit_headroom_bytes(
+            width, rows_per_chunk,
+            logit_dtype=logit_dtype,
+            retained_rows=retained_rows,
+            softcapped=softcapped,
+            temperature_scaled=temperature_scaled,
+            safety_bytes=safety_bytes,
+        )
+    else:
+        headroom = int(headroom_bytes)
+
+    if free_space_policy not in ("balanced", "head_max"):
+        raise ValueError(f"free_space_policy must be 'balanced' or 'head_max', got {free_space_policy!r}")
+
+    notes: list[str] = []
+    if activation_reserve_bytes is None:
+        if free_space_policy == "balanced":
+            # Give every device the same activation budget, then hand the head's
+            # device the logit headroom on top.
+            #
+            # This equal split is a heuristic and it is only right when the
+            # per-device activation demand is symmetric. It is NOT symmetric for
+            # a vision-LM whose GPU 0 also carries the vision tower, the input
+            # embedding and the generation KV cache: a measured GRPO step
+            # (4 x 640 completion tokens, a 30B 4-bit model, 2 x 14.56 GiB) OOMs on
+            # GPU 0 under the equal split while succeeding under accelerate's
+            # own layout. Pass a per-device mapping when you have measurements.
+            slack = sum(raw_budgets.values()) - total
+            activation_reserve_bytes = int(max(0, (slack - headroom) // len(devices)))
+            # The head's device pays the headroom on top of its share, so an
+            # equal split of the global slack can exceed that one device's own
+            # budget even when the totals fit. Cap by the smallest budget less
+            # the headroom and less that device's expected share of the weights,
+            # otherwise a model that trivially fits is refused.
+            share = -(-total // len(devices))
+            per_device_cap = min(raw_budgets.values()) - headroom - share
+            activation_reserve_bytes = int(max(0, min(activation_reserve_bytes, per_device_cap)))
+        else:
+            # Mirror accelerate: reserve the largest single placement unit.
+            activation_reserve_bytes = max((s for _, s in units), default=0)
+    if isinstance(activation_reserve_bytes, Mapping):
+        reserve = {d: _parse_size(activation_reserve_bytes.get(d, 0)) for d in devices}
+    else:
+        reserve = dict.fromkeys(devices, int(activation_reserve_bytes))
+    activation_reserve_bytes = max(reserve.values()) if reserve else 0
+
+    # Units that must travel with the head.
+    pinned: list[str] = []
+    if head_name is not None:
+        pinned.append(head_name)
+    tied_to_head: list[str] = []
+    if head_is_tied(model, head_mod):
+        getter = getattr(model, "get_input_embeddings", None)
+        inp = getter() if callable(getter) else None
+        inp_name = _name_of_module(model, inp) if inp is not None else None
+        if inp_name is not None and inp_name != head_name:
+            pinned.append(inp_name)
+            tied_to_head.append(inp_name)
+            notes.append(
+                f"tied embeddings: {inp_name} pinned with the head so accelerate "
+                "does not have to mirror the weight across devices"
+            )
+
+    unit_size = dict(units)
+    pinned = [p for p in pinned if p in unit_size]
+    pinned_bytes = sum(unit_size[p] for p in pinned)
+
+    def attempt(head_device: int):
+        """Try progressively smaller activation reserves on the non-head devices.
+
+        The head device always keeps ``activation_reserve + headroom`` free; when
+        block granularity makes the ideal split infeasible we take the slack out
+        of the *other* cards, never out of the head's logit headroom.
+        """
+        for step in range(21):
+            r = _fill(head_device, max(reserve.values()) * (20 - step) // 20)
+            if r is not None:
+                return r
+        return None
+
+    def _fill(head_device: int, other_reserve: int):
+        budget = {
+            d: raw_budgets[d] - (reserve[d] + headroom if d == head_device
+                                 else min(reserve[d], other_reserve))
+            for d in devices
+        }
+        budget[head_device] -= pinned_bytes
+        if any(b < 0 for b in budget.values()):
+            return None
+        used = dict.fromkeys(devices, 0)
+        assign: dict[str, int] = {}
+        cursor = 0
+        for name, size in units:
+            if name in pinned:
+                continue
+            placed = False
+            while cursor < len(devices):
+                d = devices[cursor]
+                if used[d] + size <= budget[d]:
+                    assign[name] = d
+                    used[d] += size
+                    placed = True
+                    break
+                cursor += 1
+            if not placed:
+                # Sequential cursor exhausted: try any earlier device that still
+                # has room rather than falling off to CPU.
+                for d in devices:
+                    if used[d] + size <= budget[d]:
+                        assign[name] = d
+                        used[d] += size
+                        placed = True
+                        break
+            if not placed:
+                return None
+        for p in pinned:
+            assign[p] = head_device
+            used[head_device] += unit_size[p]
+        weight_bytes = {d: used[d] for d in devices}
+        return assign, weight_bytes, {d: budget[d] for d in devices}
+
+    order = [prefer_head_device] if prefer_head_device is not None else list(reversed(devices))
+    result = None
+    chosen = None
+    for cand in order:
+        if cand not in devices:
+            continue
+        result = attempt(cand)
+        if result is not None:
+            chosen = cand
+            break
+    if result is None:
+        slack = sum(raw_budgets.values()) - total - activation_reserve_bytes * len(devices)
+        raise DeviceMapInfeasible(
+            "Cannot place the model and keep "
+            f"{headroom / _GiB:.3f} GiB free on the output head's device.\n"
+            f"  weights                 : {total / _GiB:.3f} GiB\n"
+            f"  budgets                 : "
+            + ", ".join(f"cuda:{d}={raw_budgets[d] / _GiB:.2f} GiB" for d in devices)
+            + "\n"
+            f"  per-device act. reserve : {activation_reserve_bytes / _GiB:.3f} GiB\n"
+            f"  slack after weights     : {slack / _GiB:.3f} GiB\n"
+            f"  head headroom needed    : {headroom / _GiB:.3f} GiB\n"
+            "Reduce rows_per_chunk, reduce retained_rows (run the log-softmax under "
+            "no_grad), use a smaller quantisation, or add a GPU. Refusing to offload "
+            "to CPU/disk: bitsandbytes cannot load a partially offloaded 4-bit model."
+        )
+
+    assign, weight_bytes, budgets = result
+    # Sanity: the map must cover every parameter and buffer.
+    uncovered = []
+    for pname, _ in list(model.named_parameters()) + list(model.named_buffers()):
+        if not any(pname == k or pname.startswith(k + ".") for k in assign):
+            uncovered.append(pname)
+    if uncovered:
+        raise DeviceMapInfeasible(
+            f"internal error: {len(uncovered)} parameters are not covered by the "
+            f"device map, e.g. {uncovered[:5]}"
+        )
+
+    return DeviceMapPlan(
+        device_map=assign,
+        head_module=head_name,
+        head_device=chosen,
+        headroom_bytes=headroom,
+        budgets=budgets,
+        raw_budgets=raw_budgets,
+        weight_bytes=weight_bytes,
+        activation_reserve_bytes=activation_reserve_bytes,
+        total_weight_bytes=total,
+        no_split_module_classes=no_split,
+        tied_to_head=tied_to_head,
+        notes=notes,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# pre-load convenience
+# --------------------------------------------------------------------------- #
+def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
+    """Instantiate the model on the meta device, quantiser included.
+
+    Returns ``(model, hf_quantizer, config)``. Costs no GPU memory and no weight
+    IO, so the plan can be computed before ``from_pretrained``.
+    """
+    from accelerate import init_empty_weights
+    from transformers import AutoConfig
+
+    config = AutoConfig.from_pretrained(model_name_or_path, **from_pretrained_kwargs)
+    auto_cls = _auto_class_for(config)
+    hf_quantizer = None
+    qcfg = getattr(config, "quantization_config", None)
+    if qcfg is not None:
+        from transformers.quantizers import AutoHfQuantizer
+
+        hf_quantizer = AutoHfQuantizer.from_config(qcfg)
+    with init_empty_weights():
+        model = auto_cls.from_config(config)
+    model.eval()
+    if hf_quantizer is not None:
+        # Swap in the quantised Linear classes so the size table matches the
+        # bytes the loader will really allocate.
+        try:
+            hf_quantizer.preprocess_model(model=model, device_map=None, keep_in_fp32_modules=[])
+        except Exception:
+            pass
+    return model, hf_quantizer, config
+
+
+def _auto_class_for(config: Any):
+    """Pick the right Auto* class without hardcoding an architecture."""
+    from transformers import (
+        AutoModelForCausalLM,
+        AutoModelForImageTextToText,
+        AutoModel,
+    )
+
+    archs = list(getattr(config, "architectures", None) or [])
+    for auto_cls in (AutoModelForImageTextToText, AutoModelForCausalLM):
+        mapping = getattr(auto_cls, "_model_mapping", None)
+        if mapping is None:
+            continue
+        try:
+            model_cls = mapping[type(config)]
+        except (KeyError, TypeError):
+            continue
+        names = {model_cls.__name__} if not isinstance(model_cls, (list, tuple)) else {
+            c.__name__ for c in model_cls
+        }
+        if not archs or names & set(archs):
+            return auto_cls
+        return auto_cls
+    return AutoModel
+
+
+def plan_device_map_for_pretrained(
+    model_name_or_path: str,
+    *,
+    max_memory: Mapping[Any, Any] | None = None,
+    rows_per_chunk: int = 128,
+    retained_rows: int = 0,
+    vocab_size: int | None = None,
+    softcapped: bool | None = None,
+    temperature_scaled: bool = False,
+    headroom_bytes: int | None = None,
+    safety_bytes: int = 256 * 1024 ** 2,
+    activation_reserve_bytes: int | Mapping[int, Any] | None = None,
+    free_space_policy: str = "balanced",
+    prefer_head_device: int | None = None,
+    trust_remote_code: bool = False,
+    **config_kwargs: Any,
+) -> DeviceMapPlan | None:
+    """Plan a device map straight from a checkpoint id or path.
+
+    Builds the model on the meta device, so this is cheap and touches no GPU.
+    Returns ``None`` when fewer than two GPUs are usable.
+    """
+    if len(_usable_devices(max_memory)) < 2:
+        return None
+    model, hf_quantizer, _config = build_meta_model(
+        model_name_or_path, trust_remote_code=trust_remote_code, **config_kwargs
+    )
+    return plan_device_map(
+        model,
+        max_memory=max_memory,
+        rows_per_chunk=rows_per_chunk,
+        retained_rows=retained_rows,
+        vocab_size=vocab_size,
+        softcapped=softcapped,
+        temperature_scaled=temperature_scaled,
+        headroom_bytes=headroom_bytes,
+        safety_bytes=safety_bytes,
+        activation_reserve_bytes=activation_reserve_bytes,
+        free_space_policy=free_space_policy,
+        hf_quantizer=hf_quantizer,
+        prefer_head_device=prefer_head_device,
+    )

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -457,12 +457,23 @@ def _quantized_size_kwargs(model: nn.Module, hf_quantizer: Any) -> dict[str, Any
     full unpacked shape in float32, so measuring the modules directly reports a
     4-bit checkpoint at roughly four times its real size, and the planner then
     refuses or badly partitions exactly the quantised models it exists for.
+
+    The fp32 exceptions apply with no quantiser at all: an fp16 checkpoint whose
+    class declares ``_keep_in_fp32_modules`` (the T5 family keeps ``wo`` that
+    way) has those tensors loaded as float32 while the meta model still holds
+    them in the config dtype, so without this the planner charges half.
     """
-    if hf_quantizer is None:
-        return {}
     dtype = _model_dtype(model)
     if dtype is None:
         return {}
+    fp32_modules = _keep_in_fp32_modules(model, hf_quantizer)
+    fp32_dtypes = {
+        name: torch.float32
+        for name, _ in model.named_parameters()
+        if any(m in name for m in fp32_modules)
+    } if fp32_modules else {}
+    if hf_quantizer is None:
+        return {"dtype": dtype, "special_dtypes": fp32_dtypes} if fp32_dtypes else {}
     kwargs: dict[str, Any] = {}
     adjust = getattr(hf_quantizer, "adjust_target_dtype", None)
     if callable(adjust):
@@ -628,7 +639,15 @@ def _split_units(
     units: list[tuple[str, int]] = []
 
     def walk(prefix: str, module: nn.Module) -> None:
-        children = list(module.named_children())
+        # `_modules`, not `named_children()`: that helper drops repeated
+        # registrations of the SAME object, so `nn.ModuleList([block] * n)`
+        # yields one name and the aliases never become placement units. The
+        # coverage check enumerates parameters with `remove_duplicate=False`, so
+        # the missing aliases were then reported as an internal failure on a
+        # model that fits. Sizing counts the shared tensors once, so an alias
+        # unit is zero bytes, and the tied-parameter grouping below co-locates
+        # it with the name that carries the weight.
+        children = [(n, m) for n, m in module._modules.items() if m is not None]
         size = sizes.get(prefix, 0)
         if prefix and (type(module).__name__ in no_split or not children or size == 0):
             units.append((prefix, size))
@@ -997,7 +1016,7 @@ def plan_device_map(
         budget[head_device] -= pinned_bytes
         if any(b < 0 for b in budget.values()):
             return None
-        used, assign = _walk_in_order(free_groups, budget)
+        used, assign = _walk_in_order(free_groups, budget, head_device)
         if used is None:
             # The in-order walk is next-fit with a first-fit rescue, and neither
             # backtracks, so it can run out of room while a valid assignment
@@ -1032,14 +1051,22 @@ def plan_device_map(
         public_budgets[head_device] += pinned_bytes
         return assign, weight_bytes, public_budgets, kept
 
-    def _walk_in_order(free, budget):
+    def _walk_in_order(free, budget, head_device: int):
+        # `head_max` means "push as much weight off the head's card as possible".
+        # Walking plain device order defeats that whenever the head is not the
+        # last device -- `prefer_head_device = 0`, or a higher-index candidate
+        # that could not hold the pinned head -- because the walk then fills the
+        # head's card first and leaves the later GPUs empty.
+        order = devices
+        if free_space_policy == "head_max":
+            order = [d for d in devices if d != head_device] + [head_device]
         used = dict.fromkeys(devices, 0)
         assign: dict[str, int] = {}
         cursor = 0
         for names, size in free:
             placed = False
-            while cursor < len(devices):
-                d = devices[cursor]
+            while cursor < len(order):
+                d = order[cursor]
                 if used[d] + size <= budget[d]:
                     assign.update(dict.fromkeys(names, d))
                     used[d] += size
@@ -1049,7 +1076,7 @@ def plan_device_map(
             if not placed:
                 # Sequential cursor exhausted: try any earlier device that still
                 # has room rather than falling off to CPU.
-                for d in devices:
+                for d in order:
                     if used[d] + size <= budget[d]:
                         assign.update(dict.fromkeys(names, d))
                         used[d] += size
@@ -1143,7 +1170,8 @@ def plan_device_map(
             chosen = cand
             break
     if result is None:
-        slack = sum(raw_budgets.values()) - total - activation_reserve_bytes * len(devices)
+        reserved_total = sum(reserve.values())
+        slack = sum(raw_budgets.values()) - total - reserved_total
         raise DeviceMapInfeasible(
             "Cannot place the model and keep "
             f"{headroom / _GiB:.3f} GiB free on the output head's device.\n"
@@ -1151,7 +1179,9 @@ def plan_device_map(
             f"  budgets                 : "
             + ", ".join(f"cuda:{d}={raw_budgets[d] / _GiB:.2f} GiB" for d in devices)
             + "\n"
-            f"  per-device act. reserve : {activation_reserve_bytes / _GiB:.3f} GiB\n"
+            "  per-device act. reserve : "
+            + ", ".join(f"cuda:{d}={reserve[d] / _GiB:.3f} GiB" for d in devices)
+            + f" ({reserved_total / _GiB:.3f} GiB total)\n"
             f"  slack after weights     : {slack / _GiB:.3f} GiB\n"
             f"  head headroom needed    : {headroom / _GiB:.3f} GiB\n"
             "Reduce rows_per_chunk, reduce retained_rows (run the log-softmax under "


### PR DESCRIPTION
## Problem

When a model is split over several GPUs, accelerate places the tail of the model, the final norm and the output head, on the last device it fills. Anything that materialises full-vocabulary logits then allocates `rows x vocab` on that same device, on top of the weights already resident there. On a 200k vocabulary that is hundreds of MB per chunk, and GRPO's chunked log-softmax does exactly this.

None of the built-in strategies leave room for it:

- `"auto"` / `"balanced"` split the weights evenly, so the head's card carries the same weight load as every other card and has no slack for the logits.
- `"sequential"` fills greedily, but accelerate only reserves `max_layer_size` on GPU 0 (`main_devices = [gpus[0], "cpu"]` in `accelerate.py`), never on the card that ends up with the head.
- Capping the head's card with `max_memory` does not work: the allocator never backtracks, so once that card is full the head itself is pushed to cpu/disk and bitsandbytes refuses with `ValueError: Some modules are dispatched on the CPU or the disk.`

Worked example on two 14.56 GiB cards with a 30B 4-bit model. The bnb quantizer scales each budget by 0.90 and `infer_auto_device_map` subtracts `max_layer_size` only for GPU 0, which predicts `0.9*14.56 - 2.505 = 10.095` and `0.9*14.56 = 12.6`. The real load lands at 10.014 / 10.299 GiB, leaving 4.014 GiB on the head's card.

## What this adds

`unsloth_zoo/device_map_planner.py`, which builds an **explicit** device map: every split unit is named and pinned, so accelerate has no freedom to spill. Headroom on the head's device is sized from the real vocabulary width and row count rather than a constant, and an infeasible request raises `DeviceMapInfeasible` with the arithmetic rather than silently offloading.

```python
from unsloth_zoo.device_map_planner import plan_device_map_for_pretrained

plan = plan_device_map_for_pretrained(
    model_name,
    max_memory = {0: "14.56GiB", 1: "14.56GiB"},
    rows_per_chunk = 128,
    retained_rows  = batch_size * max_seq_length,
    softcapped = True,
)
model = AutoModelForCausalLM.from_pretrained(model_name, device_map = plan.device_map)
```

It returns `None` when fewer than two GPUs are usable, so callers can pass the result straight through without branching.

## Model agnostic by construction

Everything is derived from the model, with no per-architecture code: `no_split_module_classes` from the model's own `_no_split_modules`, the head from `get_output_embeddings`, tied embeddings pinned to the head's device, and vision towers treated like any other unit. Introspection was checked on Llama-3.2, Qwen3, Gemma-3, SmolVLM and a 30B vision-LM.

## Measured, and the honest caveat

On two cards capped to 14.56 GiB the planner moves the head's free space from 4.014 GiB to 6.107 GiB, and three log-softmax shapes that OOM under `"auto"` complete. End to end, a 30B 4-bit GRPO run on 2 x 16 GB that previously died now completes with the peak at 14.32 GiB of 14.56 GiB.

The caveat is in the module docstring because it matters: **activations follow layers.** Moving decoder layers off the head's card raises the other card's peak by more than the head card gains, about 0.55 GiB per layer against 0.27 GiB saved in one measured GRPO step. At one shape, using the aggressive policy regressed a run that worked under `"auto"`. So `free_space_policy` defaults to `"balanced"`, `activation_reserve_bytes` accepts a per-device mapping for when you have measurements, and the docstring says plainly that this guarantees weight placement and head headroom, not that a given run fits.

This composes with, and does not replace, bounding the log-softmax chunk itself.

## Tests

`tests/test_device_map_planner.py` runs entirely on meta devices, so it needs no GPU and no weights. It covers head and block-class discovery, the headroom arithmetic including that the retained term scales with total rows rather than chunk rows, that no unit is ever assigned to cpu or disk, that a tied embedding lands with the head, and that an impossible request raises instead of spilling.