### PR TITLE
Apply logit scale and softcap on the compiled inference path

### DIFF
--- a/tests/test_compiler_inference_logit_transforms.py
+++ b/tests/test_compiler_inference_logit_transforms.py
@@ -1,0 +1,67 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The compiled inference branch must apply the logit transforms.
+
+`compiler.py` emits several forward templates. Each has an `elif labels is
+None:` arm that returns logits straight to the caller, and training arms that
+apply the captured logit scale and softcap. When the inference arm skips those
+transforms the returned distribution is wrong for any model configuring them:
+greedy decoding is unaffected because tanh is monotonic, but sampling,
+logprobs and logit-based scoring are not.
+
+This is a source guard rather than a runtime test, because reaching the
+generated code needs a real checkpoint and a GPU.
+"""
+import re
+
+import unsloth_zoo.compiler as compiler_module
+
+
+def _template_source() -> str:
+    import inspect
+    return inspect.getsource(compiler_module)
+
+
+def test_every_inference_branch_applies_the_softcap():
+    src = _template_source()
+    marker = "elif labels is None:"
+    assert src.count(marker) >= 1, "inference branch template disappeared"
+
+    for match in re.finditer(re.escape(marker), src):
+        # Look at the arm only, i.e. up to the next branch at the same level.
+        tail = src[match.end(): match.end() + 2000]
+        head_call = tail.find("logits = self.lm_head(")
+        assert head_call != -1, "inference arm no longer calls the lm_head"
+        arm = tail[head_call:]
+        for stop in ("\nelif ", "\nelse:"):
+            cut = arm.find(stop)
+            if cut != -1:
+                arm = arm[:cut]
+        assert "torch.tanh(logits)" in arm, (
+            "an inference arm returns logits without applying the softcap; "
+            "the training arms below it do, so the two disagree"
+        )
+
+
+def test_training_and_inference_use_the_same_transform_order():
+    src = _template_source()
+    # scale multiply, then scale divide, then softcap. Any arm that applies the
+    # transforms must do so in this order, otherwise the two paths differ.
+    order = re.compile(
+        r"logits = logits \* \(\\\\2\).*?logits = logits / \(\\\\3\).*?torch\.tanh\(logits\)",
+        re.S,
+    )
+    assert order.search(src), "logit transform order changed in the templates"

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2021,6 +2021,19 @@ if RETURN_HIDDEN_STATES:
 elif labels is None:
     __DYNAMO__RECOMPILING__
     logits = self.lm_head(hidden_states\\1)
+    # Inference returns these logits to the caller, so they must carry the same
+    # scale and softcap transforms the training branches below apply. Leaving
+    # them off does not change greedy decoding, since tanh is monotonic, but it
+    # does change the distribution: sampling, returned logprobs and any scoring
+    # that reads the logits all see uncapped values.
+    if (\\2) != ():
+        logits = logits * (\\2)
+    if (\\3) != ():
+        logits = logits / (\\3)
+    if (\\4) not in (None, (),):
+        logits = logits / (\\4)
+        logits = torch.tanh(logits)
+        logits = logits * (\\4)
 elif ((\\2) == () and (\\3) == ()) and (UNSLOTH_ENABLE_CCE) and NOT_RETURN_LOGITS and self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None and not requires_grad_:
     loss = fused_linear_cross_entropy(
         hidden_states      = hidden_states\\1,
@@ -2100,6 +2113,19 @@ if RETURN_HIDDEN_STATES:
 elif labels is None:
     __DYNAMO__RECOMPILING__
     logits = self.lm_head(hidden_states\\1)
+    # Inference returns these logits to the caller, so they must carry the same
+    # scale and softcap transforms the training branches below apply. Leaving
+    # them off does not change greedy decoding, since tanh is monotonic, but it
+    # does change the distribution: sampling, returned logprobs and any scoring
+    # that reads the logits all see uncapped values.
+    if (\\2) != ():
+        logits = logits * (\\2)
+    if (\\3) != ():
+        logits = logits / (\\3)
+    if (\\4) not in (None, (),):
+        logits = logits / (\\4)
+        logits = torch.tanh(logits)
+        logits = logits * (\\4)
 elif ((\\2) == () and (\\3) == ()) and (UNSLOTH_ENABLE_CCE) and NOT_RETURN_LOGITS and self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None and not requires_grad_:
     loss = fused_linear_cross_entropy(
         hidden_states      = hidden_states\\1,
@@ -2210,6 +2236,19 @@ if RETURN_HIDDEN_STATES:
 elif labels is None:
     __DYNAMO__RECOMPILING__
     logits = self.lm_head(hidden_states\\1)
+    # Inference returns these logits to the caller, so they must carry the same
+    # scale and softcap transforms the training branches below apply. Leaving
+    # them off does not change greedy decoding, since tanh is monotonic, but it
+    # does change the distribution: sampling, returned logprobs and any scoring
+    # that reads the logits all see uncapped values.
+    if (\\2) != ():
+        logits = logits * (\\2)
+    if (\\3) != ():
+        logits = logits / (\\3)
+    if (\\4) not in (None, (),):
+        logits = logits / (\\4)
+        logits = torch.tanh(logits)
+        logits = logits * (\\4)
 else:
     lm_head_weight = self.lm_head.weight
     lm_head_bias   = getattr(self.lm_head, "bias", None)


### PR DESCRIPTION
## Problem

The forward templates in `compiler.py` have an `elif labels is None:` arm that returns logits straight to the caller. It ends at

```python
logits = self.lm_head(hidden_states...)
```

with none of the logit transforms that the training arms immediately below it apply:

```python
if (scale_multiply) != ():
    logits = logits * (scale_multiply)
if (scale_divide) != ():
    logits = logits / (scale_divide)
if (softcapping) not in (None, (),):
    logits = logits / (softcapping)
    logits = torch.tanh(logits)
    logits = logits * (softcapping)
```

So for any model that configures `final_logit_softcapping` or a logit scale, inference returned untransformed logits while training used transformed ones. The two paths disagreed.

## Reproduction

`unsloth/gemma-2-2b-it` sets `final_logit_softcapping = 30.0`. Prompt "The capital of France is", compiled inference path:

| | absmax logit |
|---|---|
| before | 34.500, above the cap of 30.0 |
| after | 24.500 |

A logit of 34.5 against a cap of 30.0 is direct evidence the cap was not applied.

## Scope, stated precisely

This is narrower than it first looks. `tanh` is monotonic, so **top-1 is unchanged and greedy decoding is unaffected**. What changes is the shape of the distribution. On that prompt the last-position top-1 probability moves from 0.4154 to 0.3153 and entropy from 2.0891 to 2.7062 nats, with `KL(correct || previous) = 0.0562` nats.

So the paths affected are temperature and top-p sampling, returned logprobs, and anything scoring with the logits.

Models that leave these unset are unaffected: the emitted guards collapse to `if () != ():`, exactly as they already do in the training arms today.

## Change

Apply the same three transforms, in the same order, in the inference arm. Three template sites.

## Test

`tests/test_compiler_inference_logit_transforms.py` is a source guard, because reaching the generated code needs a real checkpoint and a GPU. It walks every `elif labels is None:` arm and asserts the softcap is applied before the arm ends, and separately pins the transform order shared with the training arms.

Against the current templates it fails with

```
AssertionError: an inference arm returns logits without applying the softcap;
the training arms below it do, so the two disagree
```

and passes with this change.