### PR TITLE
Stop reporting two non-OOM vLLM load failures as out of memory

### DIFF
--- a/tests/test_vllm_standby_expandable_segments_error.py
+++ b/tests/test_vllm_standby_expandable_segments_error.py
@@ -39,11 +39,10 @@ A third failure is mislabelled the same way. vLLM asserts that free VRAM went
     container release GPU memory while vLLM is profiling during initialization.
 
 when another tenant on a shared GPU frees memory mid-profile. Free memory went
-*up*, so nothing ran out; but the text says "free memory", which is a genuine
-out of memory marker (vLLM's real startup shortfall reads "Free memory on
-device ... is less than desired GPU memory utilization"), so it too was reported
-as an OOM. It is transient and clears on a plain retry. Seen twice on a shared
-8x B200 with 178.4 GB per GPU.
+*up*, so nothing ran out, but "free memory" is itself a genuine OOM marker
+(vLLM's real shortfall reads "Free memory on device ... is less than desired
+GPU memory utilization"), so this was reported as an OOM too. It is transient
+and clears on a plain retry. Seen twice on a shared 8x B200, 178.4 GB per GPU.
 
 These tests pin the classification (config clash vs profiling race vs real
 OOM), the wording of the new messages, and the wiring inside `load_vllm`.
@@ -221,9 +220,8 @@ def test_message_lists_all_three_env_vars_when_none_are_visible():
 
 @pytest.mark.parametrize("error", (_PROFILING_RACE, _PROFILING_RACE_XPU))
 def test_profiling_race_is_not_an_oom(error):
-    # The bug: "free memory" appears twice in this text, so the OOM markers
-    # matched and the user was told their 178 GB GPU ran out of memory while
-    # 138.8 GiB of it was free.
+    # The bug: "free memory" appears twice here, so the OOM markers matched and
+    # a 178 GB GPU was reported out of memory with 138.8 GiB of it free.
     assert "free memory" in error.lower()
     assert vllm_utils._is_memory_profiling_race_error(error) is True
     assert vllm_utils._is_out_of_memory_error(error) is False
@@ -240,8 +238,8 @@ def test_profiling_race_and_kv_cache_oom_classify_differently():
 
 
 def test_free_memory_marker_still_covers_the_real_startup_shortfall():
-    # Removing the "free memory" marker would be the easy way to stop matching
-    # the profiling race, and it would silently drop this genuine one, whose
+    # Dropping the "free memory" marker is the easy way to stop matching the
+    # profiling race, and it would silently lose this genuine shortfall, whose
     # text never says "out of memory" (vllm/v1/worker/utils.py request_memory).
     shortfall = (
         "Free memory on device (78.68/79.15 GiB) on startup is less than desired GPU memory "

--- a/tests/test_vllm_standby_expandable_segments_error.py
+++ b/tests/test_vllm_standby_expandable_segments_error.py
@@ -1,0 +1,197 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for vLLM load-failure classification with standby mode.
+
+`load_vllm` used to classify a failed vLLM load as an out of memory condition
+with `("memory" in error.lower() or "alloc" in error.lower())`. The bare
+`"alloc"` substring also matches the deterministic *configuration* assertion
+raised by `CuMemAllocator.__init__`:
+
+    Standby mode is not supported with expandable segments.
+    Please set environment variable PYTORCH_CUDA_ALLOC_CONF without
+    `expandable_segments:True`.
+
+because that text contains `PYTORCH_CUDA_ALLOC_CONF`. Upstream vLLM's own
+wording ("Expandable segments are not compatible with memory pool.") collides
+with the `"memory"` half instead. Either way the user was told their GPU ran
+out of memory and offered three fixes, two of which cannot possibly help. This
+was reproduced on a 183 GB B200 with roughly 180 GB free.
+
+These tests pin the classification (config clash vs real OOM), the wording of
+the new message, and the wiring inside `load_vllm`.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from unittest import mock
+
+import pytest
+
+from unsloth_zoo import vllm_utils
+
+
+# The message our patched CuMemAllocator.__init__ asserts with, per env var.
+def _unsloth_assertion(env_var = "PYTORCH_CUDA_ALLOC_CONF"):
+    return (
+        "Standby mode is not supported with expandable segments.\n"
+        f"Please set environment variable {env_var} without `expandable_segments:True`.\n"
+    )
+
+
+# Upstream vLLM's own wording (vllm/device_allocator/cumem.py).
+_VLLM_ASSERTION = (
+    "Expandable segments are not compatible with memory pool. "
+    "Please track https://github.com/pytorch/pytorch/issues/147851 "
+    "for the latest updates."
+)
+
+_REAL_OOM_ERRORS = (
+    # torch. Captured verbatim from torch 2.9.1+cu128. Note it recommends
+    # expandable segments, so classification must not key off that phrase alone.
+    "CUDA out of memory. Tried to allocate 37252.90 GiB. GPU 0 has a total capacity of "
+    "178.35 GiB of which 177.06 GiB is free. Process 597697 has 692.00 MiB memory in use. "
+    "Including non-PyTorch memory, this process has 612.00 MiB memory in use. Of the "
+    "allocated memory 0 bytes is allocated by PyTorch, and 0 bytes is reserved by PyTorch "
+    "but unallocated. If reserved but unallocated memory is large try setting "
+    "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See "
+    "documentation for Memory Management  "
+    "(https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)",
+    "CUDA out of memory. Tried to allocate 2.00 GiB. GPU 0 has a total capacity of "
+    "79.15 GiB of which 1.06 GiB is free.",
+    "torch.OutOfMemoryError: CUDA out of memory.",
+    # ROCm / HIP
+    "HIP out of memory. Tried to allocate 512.00 MiB",
+    # vLLM engine-side
+    "Free memory on device (78.68/79.15 GiB) on startup is less than desired GPU memory "
+    "utilization (0.9, 71.24 GiB). Decrease GPU memory utilization or reduce GPU memory used "
+    "by other processes.",
+    "No available memory for the cache blocks. Try increasing `gpu_memory_utilization`.",
+    "To serve at least one request with the model's max seq len (8192), (18.00 GiB KV cache "
+    "is needed, which is larger than the available KV cache memory (4.00 GiB).",
+    # C++ level
+    "std::bad_alloc",
+)
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    ("PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_HIP_ALLOC_CONF", "PYTORCH_ALLOC_CONF"),
+)
+def test_expandable_segments_assertion_is_not_an_oom(env_var):
+    # The bug: this returned True via the bare "alloc" substring (and via
+    # "memory" for the upstream wording), so a config clash was raised as
+    # MemoryError("Your GPU ran out of memory").
+    error = _unsloth_assertion(env_var)
+    assert vllm_utils._is_expandable_segments_error(error) is True
+    assert vllm_utils._is_out_of_memory_error(error) is False
+
+
+def test_upstream_vllm_expandable_segments_assertion_is_not_an_oom():
+    assert vllm_utils._is_expandable_segments_error(_VLLM_ASSERTION) is True
+    assert vllm_utils._is_out_of_memory_error(_VLLM_ASSERTION) is False
+
+
+@pytest.mark.parametrize("error", _REAL_OOM_ERRORS)
+def test_real_oom_is_still_classified_as_oom(error):
+    assert vllm_utils._is_out_of_memory_error(error) is True
+    assert vllm_utils._is_expandable_segments_error(error) is False
+
+
+@pytest.mark.parametrize(
+    "error",
+    (
+        "ValueError: Model architecture FooForCausalLM is not supported.",
+        "Could not find nvcc, please install the CUDA toolkit",
+        "",
+    ),
+)
+def test_unrelated_errors_are_neither(error):
+    assert vllm_utils._is_out_of_memory_error(error) is False
+    assert vllm_utils._is_expandable_segments_error(error) is False
+
+
+def test_torch_oom_hint_about_expandable_segments_is_not_a_config_clash():
+    # torch's genuine OOM text ends with "try setting
+    # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation",
+    # so the config-clash markers must be full phrases, not a bare substring,
+    # or a real OOM would be routed to the configuration message.
+    torch_oom = _REAL_OOM_ERRORS[0]
+    assert "expandable_segments:True" in torch_oom
+    assert vllm_utils._is_out_of_memory_error(torch_oom) is True
+    assert vllm_utils._is_expandable_segments_error(torch_oom) is False
+
+
+def test_classifiers_accept_exception_objects_not_just_strings():
+    error = AssertionError(_unsloth_assertion())
+    assert vllm_utils._is_expandable_segments_error(error) is True
+    assert vllm_utils._is_out_of_memory_error(error) is False
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    ("PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_HIP_ALLOC_CONF", "PYTORCH_ALLOC_CONF"),
+)
+def test_message_names_the_offending_env_var_on_every_platform(env_var):
+    # PYTORCH_HIP_ALLOC_CONF is the ROCm/AMD one, PYTORCH_ALLOC_CONF the unified
+    # torch >= 2.10 one. Whichever actually carries the setting must be named.
+    cleared = {k: "" for k in vllm_utils._ALLOC_CONF_ENV_VARS}
+    cleared[env_var] = "expandable_segments:True,roundup_power2_divisions:[32:256]"
+    with mock.patch.dict(vllm_utils.os.environ, cleared, clear = False):
+        assert vllm_utils._expandable_segments_env_vars() == [env_var]
+        message = vllm_utils._expandable_segments_standby_message(_unsloth_assertion(env_var))
+    assert env_var in message
+    # Never claim the GPU ran out of memory for a config clash.
+    assert "ran out of memory" not in message
+    assert "NOT an out of memory error" in message
+    # The remedy that actually works must be present, the useless ones absent.
+    assert "expandable_segments" in message
+    assert "load_in_4bit" not in message
+    assert "gpu_memory_utilization=0.6" not in message
+    # Preserve the underlying error for debugging.
+    assert "Original error:" in message
+    assert "Standby mode is not supported with expandable segments." in message
+
+
+def test_message_lists_all_three_env_vars_when_none_are_visible():
+    cleared = {k: "" for k in vllm_utils._ALLOC_CONF_ENV_VARS}
+    with mock.patch.dict(vllm_utils.os.environ, cleared, clear = False):
+        assert vllm_utils._expandable_segments_env_vars() == []
+        message = vllm_utils._expandable_segments_standby_message(_VLLM_ASSERTION)
+    for env_var in ("PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_HIP_ALLOC_CONF", "PYTORCH_ALLOC_CONF"):
+        assert env_var in message
+    assert "Original error:" in message
+
+
+def test_load_vllm_retry_handler_is_wired_to_the_precise_classifiers():
+    # Guards the raise site itself: the loose substring test must be gone, the
+    # config clash must be checked before the MemoryError, and the OOM branch
+    # must keep `Original error:`.
+    source = inspect.getsource(vllm_utils.load_vllm)
+    assert '"alloc" in error.lower()' not in source
+    assert not re.search(r'\(\s*"memory" in error\.lower\(\)', source)
+
+    config_at = source.index("_is_expandable_segments_error(error)")
+    oom_at = source.index("_is_out_of_memory_error(error)")
+    memory_error_at = source.index("raise MemoryError(")
+    assert config_at < memory_error_at
+    assert oom_at < memory_error_at
+
+    oom_block = source[memory_error_at:]
+    assert "Your GPU ran out of memory loading vLLM with standby mode enabled" in oom_block
+    assert "Original error:" in oom_block

--- a/tests/test_vllm_standby_expandable_segments_error.py
+++ b/tests/test_vllm_standby_expandable_segments_error.py
@@ -31,8 +31,22 @@ with the `"memory"` half instead. Either way the user was told their GPU ran
 out of memory and offered three fixes, two of which cannot possibly help. This
 was reproduced on a 183 GB B200 with roughly 180 GB free.
 
-These tests pin the classification (config clash vs real OOM), the wording of
-the new message, and the wiring inside `load_vllm`.
+A third failure is mislabelled the same way. vLLM asserts that free VRAM went
+*down* across its profiling forward pass, and raises
+
+    Error in memory profiling. Initial free memory 11.87 GiB, current free
+    memory 138.8 GiB. This happens when other processes sharing the same
+    container release GPU memory while vLLM is profiling during initialization.
+
+when another tenant on a shared GPU frees memory mid-profile. Free memory went
+*up*, so nothing ran out; but the text says "free memory", which is a genuine
+out of memory marker (vLLM's real startup shortfall reads "Free memory on
+device ... is less than desired GPU memory utilization"), so it too was reported
+as an OOM. It is transient and clears on a plain retry. Seen twice on a shared
+8x B200 with 178.4 GB per GPU.
+
+These tests pin the classification (config clash vs profiling race vs real
+OOM), the wording of the new messages, and the wiring inside `load_vllm`.
 """
 
 from __future__ import annotations
@@ -61,6 +75,32 @@ _VLLM_ASSERTION = (
     "for the latest updates."
 )
 
+# Verbatim from a shared 8x B200, 178.4 GB per GPU, GRPO notebook. Raised by
+# the assert in vllm/v1/worker/gpu_worker.py determine_available_memory().
+_PROFILING_RACE = (
+    "Error in memory profiling. Initial free memory 11.87 GiB, current free memory 138.8 GiB. "
+    "This happens when other processes sharing the same container release GPU memory while vLLM "
+    "is profiling during initialization. To fix this, ensure consistent GPU memory allocation or "
+    "isolate vLLM in its own container."
+)
+
+# The XPU worker asserts with the same opening phrase and a different tail
+# (vllm/v1/worker/xpu_worker.py), so the marker must not depend on the tail.
+_PROFILING_RACE_XPU = (
+    "Error in memory profiling. Initial free memory 12746588160, current free memory 149023916032. "
+    "This happens when the GPU memory was not properly cleaned up before initializing the vLLM "
+    "instance."
+)
+
+# vLLM's real KV cache exhaustion (vllm/v1/core/kv_cache_utils.py). Unlike the
+# profiling race this is deterministic and gpu_memory_utilization is the fix.
+_KV_CACHE_OOM = (
+    "To serve at least one request with the models's max seq len (8192), (18.00 GiB KV cache is "
+    "needed, which is larger than the available KV cache memory (4.00 GiB). Based on the available "
+    "memory, the estimated maximum model length is 1808. Try increasing `gpu_memory_utilization` "
+    "or decreasing `max_model_len` when initializing the engine."
+)
+
 _REAL_OOM_ERRORS = (
     # torch. Captured verbatim from torch 2.9.1+cu128. Note it recommends
     # expandable segments, so classification must not key off that phrase alone.
@@ -84,6 +124,7 @@ _REAL_OOM_ERRORS = (
     "No available memory for the cache blocks. Try increasing `gpu_memory_utilization`.",
     "To serve at least one request with the model's max seq len (8192), (18.00 GiB KV cache "
     "is needed, which is larger than the available KV cache memory (4.00 GiB).",
+    _KV_CACHE_OOM,
     # C++ level
     "std::bad_alloc",
 )
@@ -176,6 +217,121 @@ def test_message_lists_all_three_env_vars_when_none_are_visible():
     for env_var in ("PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_HIP_ALLOC_CONF", "PYTORCH_ALLOC_CONF"):
         assert env_var in message
     assert "Original error:" in message
+
+
+@pytest.mark.parametrize("error", (_PROFILING_RACE, _PROFILING_RACE_XPU))
+def test_profiling_race_is_not_an_oom(error):
+    # The bug: "free memory" appears twice in this text, so the OOM markers
+    # matched and the user was told their 178 GB GPU ran out of memory while
+    # 138.8 GiB of it was free.
+    assert "free memory" in error.lower()
+    assert vllm_utils._is_memory_profiling_race_error(error) is True
+    assert vllm_utils._is_out_of_memory_error(error) is False
+    assert vllm_utils._is_expandable_segments_error(error) is False
+
+
+def test_profiling_race_and_kv_cache_oom_classify_differently():
+    # Both talk about KV cache memory in GiB. Only one of them is a shortage.
+    assert vllm_utils._is_memory_profiling_race_error(_PROFILING_RACE) is True
+    assert vllm_utils._is_out_of_memory_error(_PROFILING_RACE) is False
+
+    assert vllm_utils._is_memory_profiling_race_error(_KV_CACHE_OOM) is False
+    assert vllm_utils._is_out_of_memory_error(_KV_CACHE_OOM) is True
+
+
+def test_free_memory_marker_still_covers_the_real_startup_shortfall():
+    # Removing the "free memory" marker would be the easy way to stop matching
+    # the profiling race, and it would silently drop this genuine one, whose
+    # text never says "out of memory" (vllm/v1/worker/utils.py request_memory).
+    shortfall = (
+        "Free memory on device (78.68/79.15 GiB) on startup is less than desired GPU memory "
+        "utilization (0.9, 71.24 GiB). Decrease GPU memory utilization or reduce GPU memory "
+        "used by other processes."
+    )
+    assert "out of memory" not in shortfall.lower()
+    assert "free memory" in vllm_utils._OUT_OF_MEMORY_MARKERS
+    assert vllm_utils._is_out_of_memory_error(shortfall) is True
+    assert vllm_utils._is_memory_profiling_race_error(shortfall) is False
+
+
+def test_profiling_race_classifier_accepts_exception_objects():
+    assert vllm_utils._is_memory_profiling_race_error(AssertionError(_PROFILING_RACE)) is True
+
+
+@pytest.mark.parametrize("standby", (False, True))
+def test_profiling_race_message_never_offers_the_oom_remedies(standby):
+    message = vllm_utils._memory_profiling_race_message(
+        _PROFILING_RACE, trials = 3, unsloth_vllm_standby = standby,
+    )
+    # Name the actual cause: a shared GPU, and a transient one.
+    assert "transient" in message
+    assert "sharing this GPU" in message
+    assert "NOT an out of memory error" in message
+    assert "ran out of memory" not in message
+    # Say it can simply be retried.
+    assert "Load the model again" in message
+    assert "Unsloth already tried loading 3 times." in message
+    # None of the three OOM remedies may be *offered*. Scope this to the list of
+    # fixes, since the prose above it names them precisely to rule them out.
+    remedies = message[message.index("Try one of these fixes:"):message.index("Original error:")]
+    for useless in ("load_in_4bit", "smaller model", "4bit", "Lower gpu_memory_utilization"):
+        assert useless not in remedies
+    assert "gpu_memory_utilization" not in remedies
+    # Preserve the underlying error for debugging.
+    assert "Original error:" in message
+    assert _PROFILING_RACE in message
+
+
+def test_profiling_race_message_explains_why_standby_cannot_retry_in_process():
+    # Standby keeps weights in CuMemAllocator, a process wide singleton, and
+    # Unsloth runs the engine in-process (VLLM_ENABLE_V1_MULTIPROCESSING=0), so
+    # the retry has to be a fresh process. Say so instead of staying silent.
+    standby = vllm_utils._memory_profiling_race_message(
+        _PROFILING_RACE, trials = 1, unsloth_vllm_standby = True,
+    )
+    plain = vllm_utils._memory_profiling_race_message(
+        _PROFILING_RACE, trials = 1, unsloth_vllm_standby = False,
+    )
+    assert "CuMemAllocator" in standby
+    assert "restart the notebook kernel" in standby
+    assert "CuMemAllocator" not in plain
+    # A single attempt is not a retry, so do not claim it was.
+    assert "already tried loading" not in standby
+
+
+def test_load_vllm_retries_a_profiling_race_without_shrinking_anything():
+    # The generic branch below reacts to "memory" by scaling gpu_memory_utilization
+    # by 0.85 and max_num_seqs by 0.75 for the rest of the run. Nothing about
+    # either caused a profiling race, so the retry must be of the identical load.
+    source = inspect.getsource(vllm_utils.load_vllm)
+    race_at = source.index("_is_memory_profiling_race_error(error)")
+    standby_at = source.index("if trials >= 2 or unsloth_vllm_standby:")
+    shrink_at = source.index('engine_args["gpu_memory_utilization"] *= 0.85')
+    # Checked before the standby short-circuit, which would otherwise give up
+    # after a single attempt on a transient fault.
+    assert race_at < standby_at < shrink_at
+    # And it retries rather than falling through to the shrink.
+    assert "continue" in source[race_at:standby_at]
+    assert "_MEMORY_PROFILING_RACE_MAX_TRIALS" in source[race_at:standby_at]
+    assert vllm_utils._MEMORY_PROFILING_RACE_MAX_TRIALS >= 2
+
+
+def test_profiling_race_retries_do_not_spend_the_generic_retry_budget():
+    # A race is counted on its own `race_trials`. If it shared `trials` with the
+    # generic handler, a race on the first attempt followed by a genuine OOM on
+    # the second would hit `trials >= 2` and raise, skipping the shrink-and-retry
+    # that a first-attempt OOM gets today.
+    source = inspect.getsource(vllm_utils.load_vllm)
+    race_at = source.index("_is_memory_profiling_race_error(error)")
+    bump_at = source.index("            trials += 1")
+    standby_at = source.index("if trials >= 2 or unsloth_vllm_standby:")
+    # The generic counter is bumped only after the race branch has passed on it.
+    assert race_at < bump_at < standby_at
+    assert source.count("            trials += 1") == 1
+    # The race branch uses its own counter, never the generic one.
+    race_branch = source[race_at:bump_at]
+    assert "race_trials += 1" in race_branch
+    assert "trials <" not in race_branch.replace("race_trials <", "")
 
 
 def test_load_vllm_retry_handler_is_wired_to_the_precise_classifiers():

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2063,30 +2063,18 @@ _EXPANDABLE_SEGMENTS_MARKERS = (
     "expandable_segments are not compatible",
 )
 
-# vLLM profiles memory by taking a free-VRAM snapshot, running a dummy forward
-# pass, and taking a second snapshot. It then asserts free memory went *down*:
-#
-#   assert self.init_snapshot.free_memory > free_gpu_memory, (
-#       "Error in memory profiling. "
-#       f"Initial free memory {...} GiB, current free memory {...} GiB. ...")
-#
-# (vllm/v1/worker/gpu_worker.py, and the same opening phrase in xpu_worker.py
-# with a different second half). It fires when *another* tenant on a shared GPU
-# frees memory mid-profile, so free memory rises. That is a transient race, not
-# an out of memory condition: the load usually succeeds when simply repeated.
-#
-# The marker has to be checked before the out of memory markers, because the
-# message quotes "free memory" twice and would otherwise be reported as an OOM
-# and answered with three fixes that cannot help. The opening phrase is the
-# distinctive part, so match on that alone; the rest of the sentence differs
-# between the CUDA and XPU workers and across vLLM versions.
+# vLLM asserts free VRAM went *down* across its profiling forward pass
+# (gpu_worker.py, same opening phrase in xpu_worker.py). It fires when another
+# tenant on a shared GPU frees memory mid-profile, so free memory rose: a
+# transient race, not an out of memory condition. Checked before the out of
+# memory markers, since the text quotes "free memory" twice. Match the opening
+# phrase alone; the rest differs between workers and vLLM versions.
 _MEMORY_PROFILING_RACE_MARKERS = (
     "error in memory profiling",
 )
 
-# How many times to reload after a profiling race. The race is timing dependent
-# and clears on its own, so unlike a real OOM there is nothing to tune between
-# attempts and repeating the identical load is the whole remedy.
+# The race clears on its own, so there is nothing to tune between attempts and
+# repeating the identical load is the whole remedy.
 _MEMORY_PROFILING_RACE_MAX_TRIALS = 3
 
 # Genuine out of memory signatures. Deliberately specific: a bare "alloc" or
@@ -2098,11 +2086,10 @@ _OUT_OF_MEMORY_MARKERS = (
     "insufficient memory",
     "not enough memory",
     "no available memory",
-    # Kept on purpose. vLLM's real startup shortfall (v1/worker/utils.py) reads
-    # "Free memory on device (78.68/79.15 GiB) on startup is less than desired
-    # GPU memory utilization ...", and nothing else in it says "out of memory".
-    # The profiling race quotes the same words, so it is excluded by name below
-    # rather than by weakening this marker.
+    # Kept on purpose: vLLM's real startup shortfall (v1/worker/utils.py) says
+    # only "Free memory on device ... is less than desired GPU memory
+    # utilization". The profiling race quotes the same words, so it is excluded
+    # by name below rather than by weakening this marker.
     "free memory",
     "available kv cache memory",
     "kv cache is needed",
@@ -2118,8 +2105,8 @@ _OUT_OF_MEMORY_MARKERS = (
 
 
 def _is_memory_profiling_race_error(error_text):
-    # Another process on a shared GPU freed memory while vLLM was profiling.
-    # Transient, and retryable by repeating the identical load.
+    # Another process on a shared GPU freed memory mid-profile. Transient, and
+    # retryable by repeating the identical load.
     error_text = str(error_text).lower()
     return any(marker in error_text for marker in _MEMORY_PROFILING_RACE_MARKERS)
 
@@ -2128,12 +2115,10 @@ def _is_out_of_memory_error(error_text):
     # A real out of memory condition, as opposed to anything that merely
     # contains the letters "alloc" or the word "memory".
     error_text = str(error_text).lower()
-    # The profiling race wins over the out of memory markers, the opposite of
-    # the precedence used for the expandable segments clash below. The rule in
-    # both cases is that the more specific phrase decides: torch's OOM text only
-    # *suggests* expandable segments, so OOM wins there, whereas "Error in
-    # memory profiling" is emitted by exactly one assert and can only ever mean
-    # the race, however much free memory arithmetic it happens to quote.
+    # The more specific phrase decides, which is why the race wins here while
+    # OOM wins over the expandable segments clash below: torch's OOM text merely
+    # *suggests* expandable segments, whereas "Error in memory profiling" comes
+    # from one assert and can only mean the race, whatever arithmetic it quotes.
     if _is_memory_profiling_race_error(error_text):
         return False
     return any(marker in error_text for marker in _OUT_OF_MEMORY_MARKERS)
@@ -2191,20 +2176,18 @@ def _expandable_segments_standby_message(error):
 
 
 def _memory_profiling_race_message(error, trials = 0, unsloth_vllm_standby = False):
-    # Deliberately none of the out of memory advice. Free VRAM went *up* during
-    # profiling, so there was never a shortage: a smaller model, 4bit weights or
-    # a lower gpu_memory_utilization change nothing about the assert, which only
-    # compares two free-memory snapshots taken around the profiling forward pass.
+    # Deliberately none of the out of memory advice. Free VRAM went *up*, so
+    # there was no shortage, and a smaller model, 4bit weights or a lower
+    # gpu_memory_utilization change nothing about an assert that only compares
+    # two free-memory snapshots.
     attempts = ""
     if trials > 1:
         attempts = f"Unsloth already tried loading {trials} times.\n"
     standby_note = ""
     if unsloth_vllm_standby:
-        # Standby keeps weights inside vLLM's CuMemAllocator, a process wide
-        # singleton, and Unsloth runs the engine in this same process
-        # (VLLM_ENABLE_V1_MULTIPROCESSING=0), so the failed attempt's pool is
-        # still live here and reloading on top of it is not safe. A fresh
-        # process is the reliable retry.
+        # CuMemAllocator is a process wide singleton and Unsloth runs the engine
+        # in this process (VLLM_ENABLE_V1_MULTIPROCESSING=0), so the failed
+        # attempt's pool is still live and a fresh process is the only safe retry.
         standby_note = (
             "Standby mode is on, so Unsloth cannot safely reload inside this process: "
             "vLLM's CuMemAllocator is a process wide singleton that still holds the failed "
@@ -2865,16 +2848,14 @@ def load_vllm(
             # reported it as an OOM and sent users to fixes that cannot work.
             if _is_expandable_segments_error(error):
                 raise RuntimeError(_expandable_segments_standby_message(error))
-            # A profiling race is transient: another tenant on this GPU freed
-            # memory mid-profile. Retry the *identical* load rather than falling
+            # A transient race: retry the *identical* load rather than fall
             # through to the generic "memory" branch below, which would shrink
             # gpu_memory_utilization and max_num_seqs for the rest of the run
-            # even though neither had anything to do with the failure. Standby
-            # is excluded from the in-process retry because CuMemAllocator is a
-            # singleton and the engine runs in this process, so a second load
-            # would stack on the failed attempt's pool. It is counted separately
-            # from `trials` so a race does not spend the budget below: a race
-            # followed by a genuine OOM must still get its shrink-and-retry.
+            # over a failure neither caused. Standby is excluded because
+            # CuMemAllocator is a singleton in this process, so a second load
+            # would stack on the failed attempt's pool. Counted separately from
+            # `trials` so a race followed by a genuine OOM still gets its
+            # shrink-and-retry.
             if _is_memory_profiling_race_error(error):
                 race_trials += 1
                 if race_trials < _MEMORY_PROFILING_RACE_MAX_TRIALS and not unsloth_vllm_standby:

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2063,6 +2063,32 @@ _EXPANDABLE_SEGMENTS_MARKERS = (
     "expandable_segments are not compatible",
 )
 
+# vLLM profiles memory by taking a free-VRAM snapshot, running a dummy forward
+# pass, and taking a second snapshot. It then asserts free memory went *down*:
+#
+#   assert self.init_snapshot.free_memory > free_gpu_memory, (
+#       "Error in memory profiling. "
+#       f"Initial free memory {...} GiB, current free memory {...} GiB. ...")
+#
+# (vllm/v1/worker/gpu_worker.py, and the same opening phrase in xpu_worker.py
+# with a different second half). It fires when *another* tenant on a shared GPU
+# frees memory mid-profile, so free memory rises. That is a transient race, not
+# an out of memory condition: the load usually succeeds when simply repeated.
+#
+# The marker has to be checked before the out of memory markers, because the
+# message quotes "free memory" twice and would otherwise be reported as an OOM
+# and answered with three fixes that cannot help. The opening phrase is the
+# distinctive part, so match on that alone; the rest of the sentence differs
+# between the CUDA and XPU workers and across vLLM versions.
+_MEMORY_PROFILING_RACE_MARKERS = (
+    "error in memory profiling",
+)
+
+# How many times to reload after a profiling race. The race is timing dependent
+# and clears on its own, so unlike a real OOM there is nothing to tune between
+# attempts and repeating the identical load is the whole remedy.
+_MEMORY_PROFILING_RACE_MAX_TRIALS = 3
+
 # Genuine out of memory signatures. Deliberately specific: a bare "alloc" or
 # "memory" substring also matches allocator *configuration* errors (which carry
 # words like PYTORCH_CUDA_ALLOC_CONF or "memory pool") and would mislabel them.
@@ -2072,6 +2098,11 @@ _OUT_OF_MEMORY_MARKERS = (
     "insufficient memory",
     "not enough memory",
     "no available memory",
+    # Kept on purpose. vLLM's real startup shortfall (v1/worker/utils.py) reads
+    # "Free memory on device (78.68/79.15 GiB) on startup is less than desired
+    # GPU memory utilization ...", and nothing else in it says "out of memory".
+    # The profiling race quotes the same words, so it is excluded by name below
+    # rather than by weakening this marker.
     "free memory",
     "available kv cache memory",
     "kv cache is needed",
@@ -2086,10 +2117,25 @@ _OUT_OF_MEMORY_MARKERS = (
 )
 
 
+def _is_memory_profiling_race_error(error_text):
+    # Another process on a shared GPU freed memory while vLLM was profiling.
+    # Transient, and retryable by repeating the identical load.
+    error_text = str(error_text).lower()
+    return any(marker in error_text for marker in _MEMORY_PROFILING_RACE_MARKERS)
+
+
 def _is_out_of_memory_error(error_text):
     # A real out of memory condition, as opposed to anything that merely
     # contains the letters "alloc" or the word "memory".
     error_text = str(error_text).lower()
+    # The profiling race wins over the out of memory markers, the opposite of
+    # the precedence used for the expandable segments clash below. The rule in
+    # both cases is that the more specific phrase decides: torch's OOM text only
+    # *suggests* expandable segments, so OOM wins there, whereas "Error in
+    # memory profiling" is emitted by exactly one assert and can only ever mean
+    # the race, however much free memory arithmetic it happens to quote.
+    if _is_memory_profiling_race_error(error_text):
+        return False
     return any(marker in error_text for marker in _OUT_OF_MEMORY_MARKERS)
 
 
@@ -2140,6 +2186,44 @@ def _expandable_segments_standby_message(error):
         f"`os.environ['PYTORCH_CUDA_ALLOC_CONF'] = ''` (`PYTORCH_HIP_ALLOC_CONF` on AMD ROCm, "
         f"`PYTORCH_ALLOC_CONF` on torch >= 2.10)\n"
         f"  3. Disable standby mode: remove os.environ['UNSLOTH_VLLM_STANDBY'] = '1'\n"
+        f"Original error: {error}"
+    )
+
+
+def _memory_profiling_race_message(error, trials = 0, unsloth_vllm_standby = False):
+    # Deliberately none of the out of memory advice. Free VRAM went *up* during
+    # profiling, so there was never a shortage: a smaller model, 4bit weights or
+    # a lower gpu_memory_utilization change nothing about the assert, which only
+    # compares two free-memory snapshots taken around the profiling forward pass.
+    attempts = ""
+    if trials > 1:
+        attempts = f"Unsloth already tried loading {trials} times.\n"
+    standby_note = ""
+    if unsloth_vllm_standby:
+        # Standby keeps weights inside vLLM's CuMemAllocator, a process wide
+        # singleton, and Unsloth runs the engine in this same process
+        # (VLLM_ENABLE_V1_MULTIPROCESSING=0), so the failed attempt's pool is
+        # still live here and reloading on top of it is not safe. A fresh
+        # process is the reliable retry.
+        standby_note = (
+            "Standby mode is on, so Unsloth cannot safely reload inside this process: "
+            "vLLM's CuMemAllocator is a process wide singleton that still holds the failed "
+            "attempt's weights. Re-run the script, or restart the notebook kernel, and load again.\n"
+        )
+    return (
+        f"Unsloth: vLLM could not finish memory profiling because another process sharing this GPU "
+        f"released memory while vLLM was measuring it.\n"
+        f"This is a transient race on a shared GPU, NOT an out of memory error. Free VRAM went up "
+        f"during profiling rather than down, so lowering `gpu_memory_utilization`, using 4bit or "
+        f"picking a smaller model will not help.\n"
+        f"{attempts}"
+        f"{standby_note}"
+        f"Try one of these fixes:\n"
+        f"  1. Load the model again. The race is timing dependent and usually clears by itself\n"
+        f"  2. Load when the GPU is not shared, for example by pinning one to this process with "
+        f"CUDA_VISIBLE_DEVICES\n"
+        f"  3. Skip profiling altogether by fixing the KV cache size, for example "
+        f"kv_cache_memory_bytes=64_000_000_000\n"
         f"Original error: {error}"
     )
 
@@ -2755,6 +2839,7 @@ def load_vllm(
 
     # Keep trying until success (2 times)
     trials = 0
+    race_trials = 0
     while True:
         try:
             if use_async:
@@ -2766,7 +2851,6 @@ def load_vllm(
             pass
             break
         except Exception as error:
-            trials += 1
             # Cleanup
             for _ in range(3):
                 gc.collect()
@@ -2781,6 +2865,31 @@ def load_vllm(
             # reported it as an OOM and sent users to fixes that cannot work.
             if _is_expandable_segments_error(error):
                 raise RuntimeError(_expandable_segments_standby_message(error))
+            # A profiling race is transient: another tenant on this GPU freed
+            # memory mid-profile. Retry the *identical* load rather than falling
+            # through to the generic "memory" branch below, which would shrink
+            # gpu_memory_utilization and max_num_seqs for the rest of the run
+            # even though neither had anything to do with the failure. Standby
+            # is excluded from the in-process retry because CuMemAllocator is a
+            # singleton and the engine runs in this process, so a second load
+            # would stack on the failed attempt's pool. It is counted separately
+            # from `trials` so a race does not spend the budget below: a race
+            # followed by a genuine OOM must still get its shrink-and-retry.
+            if _is_memory_profiling_race_error(error):
+                race_trials += 1
+                if race_trials < _MEMORY_PROFILING_RACE_MAX_TRIALS and not unsloth_vllm_standby:
+                    print(
+                        f"Unsloth: Another process on this GPU freed memory while vLLM was profiling. "
+                        f"Retrying the load unchanged ({race_trials} of {_MEMORY_PROFILING_RACE_MAX_TRIALS}).\n"
+                        f"Error:\n{error}"
+                    )
+                    continue
+                raise RuntimeError(_memory_profiling_race_message(
+                    error,
+                    trials = race_trials,
+                    unsloth_vllm_standby = unsloth_vllm_standby,
+                ))
+            trials += 1
             if trials >= 2 or unsloth_vllm_standby:
                 # Sleep mode uses CuMemAllocator which can't run multiple instances in single process.
                 # We can't do retry because vLLM will fail to load with said error.

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2036,6 +2036,114 @@ def _clear_flashinfer_env_on_hip():
     return True
 
 
+# Allocator config env vars. PYTORCH_CUDA_ALLOC_CONF is the legacy NVIDIA one,
+# PYTORCH_HIP_ALLOC_CONF the legacy AMD/ROCm one, PYTORCH_ALLOC_CONF the unified
+# one read from torch 2.10 onwards. All three must be checked on every platform.
+_ALLOC_CONF_ENV_VARS = (
+    "PYTORCH_CUDA_ALLOC_CONF",
+    "PYTORCH_HIP_ALLOC_CONF",
+    "PYTORCH_ALLOC_CONF",
+)
+
+# CuMemAllocator (standby / sleep mode) refuses to start when the caching
+# allocator runs with expandable segments. Both our patched __init__ and the
+# upstream vLLM one raise a deterministic AssertionError; match either wording.
+# This is a configuration failure, never an out of memory condition.
+#
+# The phrases are full ones on purpose. Torch's genuine OOM message *also*
+# mentions expandable segments ("... try setting
+# PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation"), so
+# a bare "expandable_segments" test would mislabel real OOMs the other way.
+_EXPANDABLE_SEGMENTS_MARKERS = (
+    # unsloth_zoo.vllm_utils.patch_vllm_enable_sleep_mode
+    "not supported with expandable segments",
+    "not supported with expandable_segments",
+    # vllm/device_allocator/cumem.py
+    "expandable segments are not compatible",
+    "expandable_segments are not compatible",
+)
+
+# Genuine out of memory signatures. Deliberately specific: a bare "alloc" or
+# "memory" substring also matches allocator *configuration* errors (which carry
+# words like PYTORCH_CUDA_ALLOC_CONF or "memory pool") and would mislabel them.
+_OUT_OF_MEMORY_MARKERS = (
+    "out of memory",
+    "outofmemoryerror",
+    "insufficient memory",
+    "not enough memory",
+    "no available memory",
+    "free memory",
+    "available kv cache memory",
+    "kv cache is needed",
+    "std::bad_alloc",
+    "bad_alloc",
+    "failed to allocate",
+    "allocation failed",
+    "cudaerrormemoryallocation",
+    "hiperroroutofmemory",
+    "cannot allocate memory",
+    "unable to allocate",
+)
+
+
+def _is_out_of_memory_error(error_text):
+    # A real out of memory condition, as opposed to anything that merely
+    # contains the letters "alloc" or the word "memory".
+    error_text = str(error_text).lower()
+    return any(marker in error_text for marker in _OUT_OF_MEMORY_MARKERS)
+
+
+def _is_expandable_segments_error(error_text):
+    # Standby mode + `expandable_segments:True` is a config clash, not an OOM.
+    # A real OOM wins: torch's OOM text suggests expandable segments as a fix,
+    # so it must never be routed to the configuration message.
+    error_text = str(error_text).lower()
+    if _is_out_of_memory_error(error_text):
+        return False
+    return any(marker in error_text for marker in _EXPANDABLE_SEGMENTS_MARKERS)
+
+
+def _expandable_segments_env_vars():
+    # Which allocator env vars actually carry expandable_segments:True right now.
+    return [
+        key for key in _ALLOC_CONF_ENV_VARS
+        if "expandable_segments:true" in os.environ.get(key, "").lower()
+    ]
+
+
+def _expandable_segments_standby_message(error):
+    # Note on why this is a message and not an automatic fix: torch parses the
+    # allocator config once (a process-wide singleton, read at torch import on
+    # 2.10+ and at first allocation before that), so clearing the env var here
+    # would NOT turn expandable segments off. Existing segments stay expandable
+    # (torch.cuda.memory_snapshot() still reports is_expandable=True), and we
+    # would have silenced the guard while the incompatibility remains, trading a
+    # deterministic assertion for a crash (pytorch/pytorch#147851). The variable
+    # has to be right before `import unsloth`, so we say exactly that.
+    offenders = _expandable_segments_env_vars()
+    if len(offenders) == 0:
+        # Not currently visible in this process (child process env, or already
+        # cleared), so name all three rather than guessing.
+        offenders = list(_ALLOC_CONF_ENV_VARS)
+        which = "your allocator config (" + ", ".join(offenders) + ")"
+    else:
+        which = ", ".join(offenders)
+    return (
+        f"Unsloth: vLLM standby mode cannot start because `expandable_segments:True` is set in {which}.\n"
+        f"This is a configuration clash, NOT an out of memory error, so lowering "
+        f"`gpu_memory_utilization` or using 4bit will not help.\n"
+        f"Standby mode uses vLLM's CuMemAllocator, which is incompatible with expandable segments.\n"
+        f"Try one of these fixes:\n"
+        f"  1. Set `os.environ['UNSLOTH_VLLM_STANDBY'] = '1'` BEFORE `import unsloth`, so Unsloth "
+        f"removes `expandable_segments` for you (in notebooks, restart and run the cells in order)\n"
+        f"  2. Remove `expandable_segments:True` yourself before importing unsloth, for example "
+        f"`os.environ['PYTORCH_CUDA_ALLOC_CONF'] = ''` (`PYTORCH_HIP_ALLOC_CONF` on AMD ROCm, "
+        f"`PYTORCH_ALLOC_CONF` on torch >= 2.10)\n"
+        f"  3. Disable standby mode: remove os.environ['UNSLOTH_VLLM_STANDBY'] = '1'\n"
+        f"Original error: {error}"
+    )
+
+
 def load_vllm(
     model_name             : str   = "unsloth/Llama-3.2-3B-Instruct-unsloth-bnb-4bit",
     config                 = None,
@@ -2665,10 +2773,18 @@ def load_vllm(
                 torch.cuda.empty_cache()
             pass
             error = str(error)
+            # `expandable_segments:True` + sleep/standby mode is a deterministic
+            # config clash raised by CuMemAllocator.__init__, not an OOM, and
+            # retrying with a smaller gpu_memory_utilization can never clear it.
+            # Its text mentions PYTORCH_CUDA_ALLOC_CONF (ours) or "memory pool"
+            # (upstream vLLM), so a loose "alloc" / "memory" substring test
+            # reported it as an OOM and sent users to fixes that cannot work.
+            if _is_expandable_segments_error(error):
+                raise RuntimeError(_expandable_segments_standby_message(error))
             if trials >= 2 or unsloth_vllm_standby:
                 # Sleep mode uses CuMemAllocator which can't run multiple instances in single process.
                 # We can't do retry because vLLM will fail to load with said error.
-                if unsloth_vllm_standby and ("memory" in error.lower() or "alloc" in error.lower()):
+                if unsloth_vllm_standby and _is_out_of_memory_error(error):
                     raise MemoryError(
                         f"Unsloth: Your GPU ran out of memory loading vLLM with standby mode enabled.\n"
                         f"Your GPU has {total_gb:.1f} GB VRAM with gpu_memory_utilization={gpu_memory_utilization:.3f}.\n"


### PR DESCRIPTION
Two vLLM load failures that are not out of memory were being reported as out of memory, sending users to remedies that cannot work.

Both were found while running the GRPO notebooks on a B200 with roughly 180 GB free, where `MemoryError: Your GPU ran out of memory` is self-evidently wrong.

## 1. The standby + expandable_segments config clash

`CuMemAllocator.__init__` asserts when standby mode meets `expandable_segments:True`. Its text names `PYTORCH_CUDA_ALLOC_CONF`, and the classifier tested `"alloc" in error.lower()`, so a deterministic configuration error became an OOM whose three suggested fixes are all useless for it.

How it is reached: `unsloth_zoo/__init__.py` sets `expandable_segments:True` at import and strips it again only when `UNSLOTH_VLLM_STANDBY` is already set at that moment. Anyone who sets that variable after importing unsloth keeps expandable segments on. Cell reordering or a kernel restart in Colab is enough.

Two traps the obvious fix falls into, both checked against the installed binaries:

- torch's genuine OOM message itself contains `expandable_segments:True` ("if reserved but unallocated memory is large try setting `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`"), so keying the config branch off that substring inverts the bug. A real OOM takes precedence.
- upstream vLLM's own guard uses different wording, "Expandable segments are not compatible with memory pool", which collides with the `"memory"` half instead. Both phrasings are matched.

Stripping `expandable_segments` lazily at load time was considered and rejected. torch parses the allocator config once into a process-wide singleton: after `os.environ.pop(...)`, `empty_cache()` and a fresh allocation, `torch.cuda.memory_snapshot()` still reports `is_expandable: {True}`. Stripping late would silence the guard while the incompatibility remained.

## 2. The memory profiling race

```
Error in memory profiling. Initial free memory 11.87 GiB, current free memory 138.8 GiB.
This happens when other processes sharing the same container release GPU memory while
vLLM is profiling during initialization.
```

Free memory went up, from 11.87 to 138.8 GiB: another process released memory mid-profile. The old `"memory"` test caught this, and so would a naive marker list, since the text says "free memory".

The identical load is now retried up to 3 times rather than falling through to the branch that shrinks `gpu_memory_utilization` and `max_num_seqs` for the rest of the run over a failure neither caused. The count is kept separate from `trials`, so a race followed by a genuine OOM still gets its shrink-and-retry.

Standby is excluded from the in-process retry on purpose: `CuMemAllocator` is a singleton in the process, so a second load would stack on the failed attempt's pool. Under standby the race now raises with its own message naming the cause, instead of a bogus OOM.

## Verification

- 33 tests in `tests/test_vllm_standby_expandable_segments_error.py`, needing no GPU or vLLM. All of them fail on a temporary in-place revert of `vllm_utils.py`, including a behavioural guard asserting the old `"alloc" in error.lower()` test is gone.
- 22 real error strings extracted from the installed vLLM 0.15.1 and torch binaries classify correctly.
- An AST sweep over every `raise` and `assert` in vLLM mentioning memory or alloc found 25 sites the new markers do not match. All 25 are genuinely not out of memory conditions, and all 25 were false positives under the old test, so the change is strictly an improvement.
- Full zoo suite: 4454 passed, 167 skipped, 4 failed, 1 error. Neither the failures nor the error come from this branch. The 4 are `tests/test_rl_replacements_compile_disable.py`, which spawns subprocesses with `PYTHONPATH` overwritten; this box has huggingface-hub 1.27.0 installed against transformers 4.57.6, which requires `<1.0`, so those subprocesses abort on the version guard before reaching the assertion. They fail identically with this branch's two files reverted to the base commit. The collection error is pre-existing: that test stats a hardcoded path belonging to a different workspace and is untouched here.

