### PR TITLE
Pick a module sizing backend that can carry the fp32 loader exceptions

### DIFF
--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -968,3 +968,48 @@ def test_fp32_loader_exceptions_apply_without_a_quantizer():
     assert upcast["norm"] == plain["norm"] * 2
     assert upcast["layers"] == plain["layers"]
     assert upcast[""] == plain[""] + plain["norm"]
+
+
+def test_fp32_exceptions_survive_a_transformers_that_only_takes_a_quantizer(monkeypatch):
+    """Signature support has to decide the ORDER, not just the arguments.
+
+    `transformers.integrations.accelerate.compute_module_sizes` is preferred and
+    takes only `hf_quantizer`, so on an unquantised model it cannot express the
+    fp32 loader exceptions at all. Returning its answer anyway dropped them and
+    charged an fp16 T5's `wo` half; the local environment happened not to ship
+    that implementation, so only the cross-platform runners caught it."""
+    import types
+
+    pytest.importorskip("accelerate")
+    calls = []
+
+    def quantizer_only(model, hf_quantizer = None, buffers_only = False, only_modules = True):
+        """Newer transformers: no dtype, no special_dtypes."""
+        calls.append("transformers")
+        sizes = {}
+        for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
+            parts = name.split(".")
+            for i in range(len(parts) + 1):
+                key = ".".join(parts[:i])
+                sizes[key] = sizes.get(key, 0) + tensor.numel() * tensor.element_size()
+        sizes.setdefault("", 0)
+        return sizes, {}
+
+    fake = types.ModuleType("transformers.integrations.accelerate")
+    fake.compute_module_sizes = quantizer_only
+    monkeypatch.setitem(sys.modules, "transformers.integrations.accelerate", fake)
+
+    class Cfg:
+        dtype = torch.float16
+
+    with torch.device("meta"):
+        model = _Tiny(hidden = 64, vocab = 512, layers = 4)
+    model.half()
+    model.config = Cfg()
+    plain = _compute_module_sizes(model)
+    model._keep_in_fp32_modules = ["norm"]
+    upcast = _compute_module_sizes(model)
+
+    assert calls, "the preferred implementation should still be tried first"
+    assert upcast["norm"] == plain["norm"] * 2
+    assert upcast["layers"] == plain["layers"]

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -514,8 +514,17 @@ def _compute_module_sizes(model: nn.Module, hf_quantizer: Any = None) -> dict[st
     plain walk below -- which measures a preprocessed meta ``Params4bit`` at the
     full unpacked shape in float32, several times the real size of a 4-bit
     checkpoint.
+
+    Signature support decides the ORDER, not just the arguments. The transformers
+    implementation is preferred, but it takes only ``hf_quantizer``, so on an
+    unquantised model with fp32 loader exceptions it cannot express them at all:
+    picking it there silently dropped the exceptions and charged an fp16 T5's
+    ``wo`` half. An implementation that cannot carry everything
+    :func:`_quantized_size_kwargs` asked for is therefore kept only as a
+    fallback, and the walk continues to one that can.
     """
     size_kwargs = _quantized_size_kwargs(model, hf_quantizer)
+    fallback: dict[str, int] | None = None
     for mod_path in ("transformers.integrations.accelerate", "accelerate.utils.modeling"):
         try:
             module = __import__(mod_path, fromlist=["compute_module_sizes"])
@@ -523,23 +532,24 @@ def _compute_module_sizes(model: nn.Module, hf_quantizer: Any = None) -> dict[st
             accepted = inspect.signature(fn).parameters
         except Exception:
             continue
-        attempts: list[dict[str, Any]] = []
+        # (kwargs, carries everything we needed to say)
+        attempts: list[tuple[dict[str, Any], bool]] = []
         if hf_quantizer is not None and "hf_quantizer" in accepted:
-            attempts.append({"hf_quantizer": hf_quantizer})
+            attempts.append(({"hf_quantizer": hf_quantizer}, True))
         elif size_kwargs:
             supported = {k: v for k, v in size_kwargs.items() if k in accepted}
             # Drop the extras one at a time rather than all at once: an older
             # accelerate without `special_dtypes` still gets the storage dtype,
             # which is the term that actually moves the number.
             if supported:
-                attempts.append(supported)
+                attempts.append((supported, supported.keys() >= size_kwargs.keys()))
             if "dtype" in supported and len(supported) > 1:
-                attempts.append({"dtype": supported["dtype"]})
-        # Last resort. Correct for an unquantised model, an over-estimate for a
-        # quantised one -- which refuses rather than OOMs, so it is the safe way
-        # to be wrong.
-        attempts.append({})
-        for kwargs in attempts:
+                attempts.append(({"dtype": supported["dtype"]}, False))
+        # Last resort. Correct for an unquantised model with nothing to say, an
+        # over-estimate for a quantised one -- which refuses rather than OOMs, so
+        # it is the safe way to be wrong.
+        attempts.append(({}, hf_quantizer is None and not size_kwargs))
+        for kwargs, complete in attempts:
             try:
                 out = fn(model, **kwargs)
             except Exception:
@@ -547,7 +557,14 @@ def _compute_module_sizes(model: nn.Module, hf_quantizer: Any = None) -> dict[st
             if isinstance(out, tuple):
                 out = out[0]
             if isinstance(out, Mapping) and "" in out:
-                return {k: int(v) for k, v in out.items()}
+                sizes = {k: int(v) for k, v in out.items()}
+                if complete:
+                    return sizes
+                if fallback is None:
+                    fallback = sizes
+                break
+    if fallback is not None:
+        return fallback
     sizes: dict[str, int] = {}
     for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
         nbytes = tensor.numel() * tensor.element_size()


### PR DESCRIPTION
Follow-up to #1028. The cross-platform runs on that PR's final head went red on ubuntu-latest and windows-latest with

```
FAILED tests/test_device_map_planner.py::test_fp32_loader_exceptions_apply_without_a_quantizer - assert 256 == (256 * 2)
```

and the failure is real, not a runner artefact.

## What happens

`_compute_module_sizes` walks two implementations in preference order:

* `transformers.integrations.accelerate.compute_module_sizes(model, hf_quantizer = ...)`
* `accelerate.utils.modeling.compute_module_sizes(model, dtype = ..., special_dtypes = ...)`

The transformers one is preferred because it asks the quantiser for each parameter's element size, which is exact. But it takes **only** `hf_quantizer`. On an unquantised model the information we need to pass is `special_dtypes`, which names the modules `from_pretrained` loads in float32 because the model class declares `_keep_in_fp32_modules` (the T5 family keeps `wo` that way). That implementation cannot express it, so the filtered kwargs came out empty, the call succeeded with no arguments, and the result was returned as if it were the answer. The fp32 exceptions were silently dropped and an fp16 checkpoint was charged half for those modules, which is exactly the undercount the check was added to prevent.

It passed locally because this transformers does not ship `transformers.integrations.accelerate`, so the walk fell through to accelerate's implementation, which does accept `special_dtypes`. Only a runner with a newer transformers picks the other branch.

## The fix

Signature support now decides the **order**, not just the arguments. An implementation that cannot carry everything `_quantized_size_kwargs` asked for is kept as a fallback and the walk continues to one that can; the fallback is used only if nothing better answers. The quantised path is unchanged, since `hf_quantizer` conveys everything there and still returns immediately.

## Test

`test_fp32_exceptions_survive_a_transformers_that_only_takes_a_quantizer` injects a `transformers.integrations.accelerate.compute_module_sizes` with the quantiser-only signature, so the preference branch is taken on any environment. It fails on current main with the same `256 == 512` assertion the runners hit, and passes here. The existing test that only exercises the accelerate path is kept.

41 tests pass locally.