### PR TITLE
Derive the balanced reserve per head candidate, honour runtime quantisation, and forward the no-split override

### DIFF
--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -35,6 +35,7 @@ from unsloth_zoo.device_map_planner import (
     _from_config_remote_aware,
     _split_units,
     _keep_in_fp32_modules,
+    _runtime_quantization_config,
     logit_headroom_bytes,
     plan_device_map,
     resolve_head_width,
@@ -968,3 +969,64 @@ def test_fp32_loader_exceptions_apply_without_a_quantizer():
     assert upcast["norm"] == plain["norm"] * 2
     assert upcast["layers"] == plain["layers"]
     assert upcast[""] == plain[""] + plain["norm"]
+
+
+def test_the_balanced_reserve_is_derived_per_head_candidate():
+    """The cap depends on which card pays the headroom, so deriving it once
+    against the smallest budget clamped the reserve using a card that will not
+    hold the head, and the balanced policy stopped balancing."""
+    model = _meta(hidden = 512, vocab = 8192, layers = 8)
+    plan = plan_device_map(
+        model,
+        max_memory = {0: 3 * _GiB, 1: 16 * _GiB},
+        headroom_bytes = (5 * _GiB) // 2,
+        prefer_head_device = 1,
+    )
+    assert plan.head_device == 1
+    kept = plan.activation_reserve_by_device
+    # cuda:0 does not hold the head, so its cap is its own 3 GiB less the weight
+    # share (about 2.98 GiB). The shared cap charged it the 2.5 GiB of headroom
+    # as well and left it under 0.5 GiB.
+    assert kept[0] > 1 * _GiB
+    for device, reserve in kept.items():
+        head_extra = plan.headroom_bytes if device == plan.head_device else 0
+        assert plan.weight_bytes[device] + reserve + head_extra <= plan.raw_budgets[device]
+
+
+def test_runtime_quantization_options_build_a_quantizer(monkeypatch):
+    """`load_in_4bit=True` on a full-precision checkpoint creates no serialized
+    `config.quantization_config`, so inspecting the config alone sized it at full
+    precision and skipped the quantiser's budget adjustment."""
+    kwargs = {"load_in_4bit": True, "trust_remote_code": False}
+    qcfg = _runtime_quantization_config(kwargs)
+    assert qcfg is not None and qcfg.load_in_4bit is True
+    # Popped, so they never reach AutoConfig as stray attributes.
+    assert kwargs == {"trust_remote_code": False}
+
+    explicit = object()
+    assert _runtime_quantization_config({"quantization_config": explicit}) is explicit
+    assert _runtime_quantization_config({}) is None
+    assert _runtime_quantization_config({"load_in_8bit": True}).load_in_8bit is True
+
+
+def test_the_pretrained_helper_forwards_the_no_split_override(monkeypatch):
+    """Routed through `**config_kwargs` the override would go to `AutoConfig`,
+    so the plan silently used the model's detected classes and the convenience
+    API refused a model the planner itself can place."""
+    import unsloth_zoo.device_map_planner as planner
+
+    with torch.device("meta"):
+        model = _FatBlockModel()
+    monkeypatch.setattr(planner, "build_meta_model", lambda *a, **k: (model, None, None))
+    monkeypatch.setattr(planner, "_usable_devices", lambda max_memory: [0, 1])
+
+    budgets = {0: 7 * _MiB, 1: 7 * _MiB}
+    with pytest.raises(DeviceMapInfeasible):
+        planner.plan_device_map_for_pretrained(
+            "x", max_memory = budgets, headroom_bytes = 0, activation_reserve_bytes = 0,
+        )
+    plan = planner.plan_device_map_for_pretrained(
+        "x", max_memory = budgets, headroom_bytes = 0, activation_reserve_bytes = 0,
+        no_split_module_classes = [],
+    )
+    assert plan.no_split_module_classes == []

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1008,6 +1008,23 @@ def test_runtime_quantization_options_build_a_quantizer(monkeypatch):
     assert _runtime_quantization_config({}) is None
     assert _runtime_quantization_config({"load_in_8bit": True}).load_in_8bit is True
 
+    # The loader consumes every BitsAndBytesConfig option from its kwargs, and
+    # `llm_int8_skip_modules` becomes `modules_to_not_convert`: ignoring it sizes
+    # whole modules at the quantised width that the loader keeps full precision.
+    kwargs = {"load_in_8bit": True, "llm_int8_skip_modules": ["lm_head"],
+              "trust_remote_code": True}
+    qcfg = _runtime_quantization_config(kwargs)
+    assert qcfg.llm_int8_skip_modules == ["lm_head"]
+    assert kwargs.get("trust_remote_code") is True
+    assert "llm_int8_skip_modules" not in kwargs
+
+    kwargs = {"load_in_4bit": True, "bnb_4bit_quant_type": "nf4"}
+    assert _runtime_quantization_config(kwargs).bnb_4bit_quant_type == "nf4"
+
+    # The same contradiction `from_pretrained` refuses.
+    with pytest.raises(ValueError, match = "not both"):
+        _runtime_quantization_config({"load_in_4bit": True, "quantization_config": explicit})
+
 
 def test_the_pretrained_helper_forwards_the_no_split_override(monkeypatch):
     """Routed through `**config_kwargs` the override would go to `AutoConfig`,
@@ -1030,3 +1047,39 @@ def test_the_pretrained_helper_forwards_the_no_split_override(monkeypatch):
         no_split_module_classes = [],
     )
     assert plan.no_split_module_classes == []
+
+
+class _OneFatBlock(nn.Module):
+    """A single atomic block that fits on no card except beside the head."""
+
+    _no_split_modules = ["_Block"]
+
+    def __init__(self, hidden = 1024):
+        super().__init__()
+        self.layers = nn.ModuleList([_Block(hidden)])
+        self.lm_head = nn.Linear(hidden, 64, bias = False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_the_auto_reserve_relaxes_on_the_head_as_a_last_resort():
+    """The relaxation loop only ever took the reserve off the OTHER cards, so an
+    atomic unit that fits nowhere else could miss the head's card by less than
+    the reserve and the plan was refused. An auto-derived reserve is documented
+    as relaxable; the logit headroom is still never touched."""
+    with torch.device("meta"):
+        model = _OneFatBlock()
+    block = 1024 * 1024 * 4          # 4 MiB
+    head = 1024 * 64 * 4             # 0.25 MiB
+    headroom = 1 * _MiB
+    plan = plan_device_map(
+        model,
+        max_memory = {0: block - 1, 1: block + head + headroom + (_MiB // 2)},
+        headroom_bytes = headroom,
+        prefer_head_device = 1,
+    )
+    assert plan.head_device == 1
+    assert plan.device_map["layers.0"] == 1
+    # The headroom survives in full; only the activation reserve gave way.
+    assert plan.raw_budgets[1] - plan.weight_bytes[1] >= headroom

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -947,43 +947,58 @@ def plan_device_map(
     # quietly reduced to zero and the run would OOM on a card the plan still
     # claimed had the reserve free.
     reserve_is_explicit = activation_reserve_bytes is not None
-    if activation_reserve_bytes is None:
-        if free_space_policy == "balanced":
-            # Give every device the same activation budget, then hand the head's
-            # device the logit headroom on top.
-            #
-            # This equal split is a heuristic and it is only right when the
-            # per-device activation demand is symmetric. It is NOT symmetric for
-            # a vision-LM whose GPU 0 also carries the vision tower, the input
-            # embedding and the generation KV cache: a measured GRPO step
-            # (4 x 640 completion tokens, a 30B 4-bit model, 2 x 14.56 GiB) OOMs on
-            # GPU 0 under the equal split while succeeding under accelerate's
-            # own layout. Pass a per-device mapping when you have measurements.
-            slack = sum(raw_budgets.values()) - total
-            activation_reserve_bytes = int(max(0, (slack - headroom) // len(devices)))
-            # The head's device pays the headroom on top of its share, so an
-            # equal split of the global slack can exceed that one device's own
-            # budget even when the totals fit. Cap by the smallest budget less
-            # the headroom and less the weight that device has to hold,
-            # otherwise a model that trivially fits is refused.
-            #
-            # That weight is at least the pinned units, which the head's device
-            # takes whole. An average share alone is not enough: `attempt` only
-            # relaxes the reserve on the OTHER cards, so once the head's budget
-            # goes negative every step fails and the plan is refused. A four-layer
-            # model whose head is larger than half the weights (share 24 KiB,
-            # head 32 KiB) was rejected on 2 x 8 GiB for exactly that reason.
-            share = max(-(-total // len(devices)), pinned_bytes)
-            per_device_cap = min(raw_budgets.values()) - headroom - share
-            activation_reserve_bytes = int(max(0, min(activation_reserve_bytes, per_device_cap)))
-        else:
-            # Mirror accelerate: reserve the largest single placement unit.
-            activation_reserve_bytes = max((s for _, s in units), default=0)
-    if isinstance(activation_reserve_bytes, Mapping):
-        reserve = {d: _parse_size(activation_reserve_bytes.get(d, 0)) for d in devices}
-    else:
-        reserve = dict.fromkeys(devices, int(activation_reserve_bytes))
-    activation_reserve_bytes = max(reserve.values()) if reserve else 0
+    requested_reserve = activation_reserve_bytes
+
+    def reserve_for(head_device: int) -> dict[int, int]:
+        """The per-device reserve to try for this head candidate.
+
+        Derived PER CANDIDATE, because the cap below depends on which card pays
+        the headroom. Computing it once against the smallest budget clamped the
+        reserve using a card that will not hold the head: with 8 and 16 GiB
+        budgets, 10 GiB of weights and 2 GiB of headroom the equal share is
+        6 GiB but the shared cap cut it to 1 GiB, so the balanced policy stopped
+        balancing and the packing could fill the small card to within 1 GiB.
+        """
+        value = requested_reserve
+        if value is None:
+            if free_space_policy == "balanced":
+                # Give every device the same activation budget, then hand the
+                # head's device the logit headroom on top.
+                #
+                # This equal split is a heuristic and it is only right when the
+                # per-device activation demand is symmetric. It is NOT symmetric
+                # for a vision-LM whose GPU 0 also carries the vision tower, the
+                # input embedding and the generation KV cache: a measured GRPO
+                # step (4 x 640 completion tokens, a 30B 4-bit model,
+                # 2 x 14.56 GiB) OOMs on GPU 0 under the equal split while
+                # succeeding under accelerate's own layout. Pass a per-device
+                # mapping when you have measurements.
+                slack = sum(raw_budgets.values()) - total
+                value = max(0, (slack - headroom) // len(devices))
+                # The head's device pays the headroom on top of its share, so an
+                # equal split of the global slack can exceed that one device's
+                # own budget even when the totals fit. Cap by each device's own
+                # budget less the weight it has to hold, and less the headroom
+                # only on the card that will carry it, otherwise a model that
+                # trivially fits is refused.
+                #
+                # That weight is at least the pinned units, which the head's
+                # device takes whole. An average share alone is not enough:
+                # `attempt` only relaxes the reserve on the OTHER cards, so once
+                # the head's budget goes negative every step fails and the plan
+                # is refused. A four-layer model whose head is larger than half
+                # the weights (share 24 KiB, head 32 KiB) was rejected on
+                # 2 x 8 GiB for exactly that reason.
+                share = max(-(-total // len(devices)), pinned_bytes)
+                cap = min(raw_budgets[d] - share - (headroom if d == head_device else 0)
+                          for d in devices)
+                value = int(max(0, min(value, cap)))
+            else:
+                # Mirror accelerate: reserve the largest single placement unit.
+                value = max((s for _, s in units), default=0)
+        if isinstance(value, Mapping):
+            return {d: _parse_size(value.get(d, 0)) for d in devices}
+        return dict.fromkeys(devices, int(value))
 
     def attempt(head_device: int):
         """Try progressively smaller activation reserves on the non-head devices.
@@ -995,14 +1010,15 @@ def plan_device_map(
         Only an auto-derived reserve is relaxed. A caller-supplied one is a hard
         constraint, so an explicit reserve either fits or the plan is refused.
         """
+        reserve = reserve_for(head_device)
         steps = 1 if reserve_is_explicit else 21
         for step in range(steps):
-            r = _fill(head_device, max(reserve.values()) * (20 - step) // 20)
+            r = _fill(head_device, reserve, max(reserve.values()) * (20 - step) // 20)
             if r is not None:
                 return r
         return None
 
-    def _fill(head_device: int, other_reserve: int):
+    def _fill(head_device: int, reserve: dict[int, int], other_reserve: int):
         # What this attempt really keeps free per device, which is what the plan
         # reports: a per-device mapping is not one number, and `attempt` relaxes
         # the reserve on the non-head cards, so a single scalar would promise
@@ -1170,6 +1186,9 @@ def plan_device_map(
             chosen = cand
             break
     if result is None:
+        # Report the reserve of the first candidate actually tried; it is what
+        # the failing arithmetic used.
+        reserve = reserve_for(next((c for c in order if c in devices), devices[0]))
         reserved_total = sum(reserve.values())
         slack = sum(raw_budgets.values()) - total - reserved_total
         raise DeviceMapInfeasible(
@@ -1190,6 +1209,7 @@ def plan_device_map(
         )
 
     assign, weight_bytes, budgets, reserve_kept = result
+    activation_reserve_bytes = max(reserve_kept.values()) if reserve_kept else 0
     # Sanity: the map must cover every parameter and buffer.
     # `remove_duplicate=False`, because accelerate's own `check_device_map`
     # walks `state_dict()`, which lists a tied tensor under every name it has.
@@ -1226,24 +1246,62 @@ def plan_device_map(
 # --------------------------------------------------------------------------- #
 # pre-load convenience
 # --------------------------------------------------------------------------- #
+def _runtime_quantization_config(kwargs: dict[str, Any]) -> Any:
+    """The quantisation the CALLER asked for, popped out of the loader kwargs.
+
+    A full-precision checkpoint loaded with ``load_in_4bit=True`` has no
+    serialized ``config.quantization_config``, so inspecting the config alone
+    left the quantiser as ``None``: the planner then sized the checkpoint at
+    full precision and skipped the quantiser's budget adjustment, refusing
+    models the matching ``from_pretrained`` loads happily. Mirrors the loader,
+    which builds a ``BitsAndBytesConfig`` from these flags.
+
+    Pops rather than reads: these are loader options, not config options, and
+    ``AutoConfig`` would otherwise set them as stray config attributes.
+    """
+    explicit = kwargs.pop("quantization_config", None)
+    load_in_4bit = kwargs.pop("load_in_4bit", False)
+    load_in_8bit = kwargs.pop("load_in_8bit", False)
+    if explicit is not None:
+        return explicit
+    if load_in_4bit or load_in_8bit:
+        from transformers import BitsAndBytesConfig
+
+        return BitsAndBytesConfig(load_in_4bit=bool(load_in_4bit),
+                                  load_in_8bit=bool(load_in_8bit))
+    return None
+
+
 def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
     """Instantiate the model on the meta device, quantiser included.
 
     Returns ``(model, hf_quantizer, config)``. Costs no GPU memory and no weight
     IO, so the plan can be computed before ``from_pretrained``.
+
+    ``quantization_config`` / ``load_in_4bit`` / ``load_in_8bit`` are honoured
+    the way the loader honours them, so runtime quantisation of a full-precision
+    checkpoint is sized as it will really be loaded.
     """
     from accelerate import init_empty_weights
     from transformers import AutoConfig
 
+    runtime_qcfg = _runtime_quantization_config(from_pretrained_kwargs)
     config = AutoConfig.from_pretrained(model_name_or_path, **from_pretrained_kwargs)
     trust_remote_code = bool(from_pretrained_kwargs.get("trust_remote_code", False))
     auto_cls = _auto_class_for(config, trust_remote_code=trust_remote_code)
     hf_quantizer = None
-    qcfg = getattr(config, "quantization_config", None)
-    if qcfg is not None:
+    serialized_qcfg = getattr(config, "quantization_config", None)
+    if runtime_qcfg is not None or serialized_qcfg is not None:
         from transformers.quantizers import AutoHfQuantizer
 
-        hf_quantizer = AutoHfQuantizer.from_config(qcfg)
+        # An explicit request wins over the checkpoint's own, as in the loader.
+        # `pre_quantized` says whether the weights on disk are ALREADY quantised:
+        # false for runtime quantisation of a full-precision checkpoint, which is
+        # also what stops a calibration-free quantiser taking the wrong path.
+        if runtime_qcfg is not None and serialized_qcfg is None:
+            hf_quantizer = AutoHfQuantizer.from_config(runtime_qcfg, pre_quantized=False)
+        else:
+            hf_quantizer = AutoHfQuantizer.from_config(runtime_qcfg or serialized_qcfg)
     with init_empty_weights():
         # `trust_remote_code` has to travel to `from_config` too. AutoConfig can
         # resolve a dynamic config on its own, but the model class then lives in
@@ -1377,6 +1435,7 @@ def plan_device_map_for_pretrained(
     safety_bytes: int = 256 * 1024 ** 2,
     activation_reserve_bytes: int | Mapping[int, Any] | None = None,
     free_space_policy: str = "balanced",
+    no_split_module_classes: Sequence[str] | None = None,
     prefer_head_device: int | None = None,
     trust_remote_code: bool = False,
     **config_kwargs: Any,
@@ -1385,6 +1444,15 @@ def plan_device_map_for_pretrained(
 
     Builds the model on the meta device, so this is cheap and touches no GPU.
     Returns ``None`` when fewer than two GPUs are usable.
+
+    Takes the same ``no_split_module_classes`` override as :func:`plan_device_map`
+    (``[]`` to allow splitting inside a block that fits on no single card). It has
+    to be declared here: routed through ``**config_kwargs`` it would go to
+    ``AutoConfig`` instead, and the plan would silently use the detected classes.
+
+    ``quantization_config`` / ``load_in_4bit`` / ``load_in_8bit`` pass through to
+    :func:`build_meta_model`, so a full-precision checkpoint you intend to load
+    quantised is sized as it will really be loaded.
     """
     if len(_usable_devices(max_memory)) < 2:
         return None
@@ -1405,5 +1473,6 @@ def plan_device_map_for_pretrained(
         activation_reserve_bytes=activation_reserve_bytes,
         free_space_policy=free_space_policy,
         hf_quantizer=hf_quantizer,
+        no_split_module_classes=no_split_module_classes,
         prefer_head_device=prefer_head_device,
     )

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -1016,6 +1016,18 @@ def plan_device_map(
             r = _fill(head_device, reserve, max(reserve.values()) * (20 - step) // 20)
             if r is not None:
                 return r
+        if reserve_is_explicit:
+            return None
+        # Last resort: relax the head's own activation reserve too. An
+        # auto-derived reserve is documented as relaxable and the loop above only
+        # ever took it off the OTHER cards, so a single atomic unit that fits
+        # nowhere else could miss the head's card by less than the reserve and
+        # the plan was refused. The logit headroom is never touched.
+        for step in range(1, 21):
+            scaled = {d: v * (20 - step) // 20 for d, v in reserve.items()}
+            r = _fill(head_device, scaled, max(scaled.values()))
+            if r is not None:
+                return r
         return None
 
     def _fill(head_device: int, reserve: dict[int, int], other_reserve: int):
@@ -1253,8 +1265,14 @@ def _runtime_quantization_config(kwargs: dict[str, Any]) -> Any:
     serialized ``config.quantization_config``, so inspecting the config alone
     left the quantiser as ``None``: the planner then sized the checkpoint at
     full precision and skipped the quantiser's budget adjustment, refusing
-    models the matching ``from_pretrained`` loads happily. Mirrors the loader,
-    which builds a ``BitsAndBytesConfig`` from these flags.
+    models the matching ``from_pretrained`` loads happily.
+
+    Built the way the loader builds it, through
+    ``BitsAndBytesConfig.from_dict(..., return_unused_kwargs=True)`` over the
+    remaining kwargs. The two booleans alone are not enough: the loader also
+    consumes options like ``llm_int8_skip_modules``, which becomes
+    ``modules_to_not_convert`` and keeps whole modules at full precision, so
+    ignoring them sizes those modules small and the map OOMs on load.
 
     Pops rather than reads: these are loader options, not config options, and
     ``AutoConfig`` would otherwise set them as stray config attributes.
@@ -1262,14 +1280,26 @@ def _runtime_quantization_config(kwargs: dict[str, Any]) -> Any:
     explicit = kwargs.pop("quantization_config", None)
     load_in_4bit = kwargs.pop("load_in_4bit", False)
     load_in_8bit = kwargs.pop("load_in_8bit", False)
-    if explicit is not None:
+    if not (load_in_4bit or load_in_8bit):
         return explicit
-    if load_in_4bit or load_in_8bit:
-        from transformers import BitsAndBytesConfig
+    if explicit is not None:
+        # Same contradiction `from_pretrained` refuses, raised here rather than
+        # silently planning for one of the two.
+        raise ValueError(
+            "Pass either `quantization_config` or `load_in_4bit` / `load_in_8bit`, "
+            "not both."
+        )
+    from transformers import BitsAndBytesConfig
 
-        return BitsAndBytesConfig(load_in_4bit=bool(load_in_4bit),
-                                  load_in_8bit=bool(load_in_8bit))
-    return None
+    accepted = inspect.signature(BitsAndBytesConfig).parameters
+    config_dict = {k: v for k, v in kwargs.items() if k in accepted}
+    config_dict.update(load_in_4bit=bool(load_in_4bit), load_in_8bit=bool(load_in_8bit))
+    quantization_config, unused = BitsAndBytesConfig.from_dict(
+        config_dict=config_dict, return_unused_kwargs=True, **kwargs
+    )
+    kwargs.clear()
+    kwargs.update(unused)
+    return quantization_config
 
 
 def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
@@ -1294,14 +1324,20 @@ def build_meta_model(model_name_or_path: str, **from_pretrained_kwargs: Any):
     if runtime_qcfg is not None or serialized_qcfg is not None:
         from transformers.quantizers import AutoHfQuantizer
 
-        # An explicit request wins over the checkpoint's own, as in the loader.
         # `pre_quantized` says whether the weights on disk are ALREADY quantised:
         # false for runtime quantisation of a full-precision checkpoint, which is
         # also what stops a calibration-free quantiser taking the wrong path.
-        if runtime_qcfg is not None and serialized_qcfg is None:
+        if serialized_qcfg is None:
             hf_quantizer = AutoHfQuantizer.from_config(runtime_qcfg, pre_quantized=False)
         else:
-            hf_quantizer = AutoHfQuantizer.from_config(runtime_qcfg or serialized_qcfg)
+            # The checkpoint's own method wins and the runtime config only
+            # overlays its loading attributes -- an 8-bit checkpoint handed a
+            # 4-bit runtime config still loads as 8-bit, so sizing it as 4-bit
+            # would underestimate it. `merge_quantization_configs` is the
+            # loader's own rule, including the mismatched-class error.
+            merge = getattr(AutoHfQuantizer, "merge_quantization_configs", None)
+            qcfg = merge(serialized_qcfg, runtime_qcfg) if callable(merge) else serialized_qcfg
+            hf_quantizer = AutoHfQuantizer.from_config(qcfg)
     with init_empty_weights():
         # `trust_remote_code` has to travel to `from_config` too. AutoConfig can
         # resolve a dynamic config on its own, but the model class then lives in


### PR DESCRIPTION
Second follow-up to #1028, covering the three remaining review findings on that PR. Independent of #1031, which fixes the sizing backend choice.

## 1. The balanced reserve was capped by a card that does not hold the head (P1)

The cap was derived once, before a head candidate was chosen, against `min(raw_budgets.values())` less the headroom. When budgets differ and the head goes on the larger card, that charges the headroom to a card that will never carry it.

With budgets of 8 and 16 GiB, 10 GiB of weights and 2 GiB of headroom, the equal share is 6 GiB but `min(8, 16) - 2 - 5` clamps it to 1 GiB, so the default balanced policy stops balancing and an in-order packing can fill the small card to within 1 GiB.

`reserve_for(head_device)` now derives it inside each candidate's attempt, subtracting the headroom only from that candidate's budget. The reported `activation_reserve_bytes` comes from the reserve the accepted attempt actually kept.

## 2. Runtime quantisation was ignored (P2)

`load_in_4bit = True` on a full-precision checkpoint creates no serialized `config.quantization_config`, so inspecting the config alone left `hf_quantizer` as `None`: the planner sized the checkpoint at full precision and skipped the quantiser's budget adjustment, refusing models the matching `from_pretrained` loads happily.

`_runtime_quantization_config` now builds a `BitsAndBytesConfig` from `load_in_4bit` / `load_in_8bit`, honours an explicit `quantization_config`, and constructs the quantiser with `pre_quantized = False` when the weights on disk are not already quantised. It pops the options rather than reading them, so they no longer reach `AutoConfig` as stray config attributes.

## 3. `no_split_module_classes` was unreachable from the convenience API (P2)

`plan_device_map` takes the override (`[]` to allow splitting inside a block that fits on no single card), but `plan_device_map_for_pretrained` neither declared nor forwarded it, so the name landed in `**config_kwargs` and went to `AutoConfig` while the plan silently used the detected classes. The helper now declares and forwards it.

## Tests

Three regression tests, each checked to fail with only its own fix reverted:

* `test_the_balanced_reserve_is_derived_per_head_candidate` uses 3 and 16 GiB budgets with 2.5 GiB of headroom, where the shared cap left cuda:0 under 0.5 GiB.
* `test_runtime_quantization_options_build_a_quantizer` covers the flags, an explicit config, the empty case, and that the options are popped.
* `test_the_pretrained_helper_forwards_the_no_split_override` asserts the helper refuses without the override and plans with it.

43 tests pass locally.