### PR TITLE
fix(gguf): disable missing MTP export

### DIFF
--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -166,8 +166,10 @@ def test_convert_to_gguf_reconciles_mtp_config_to_index(llama_cpp, tmp_path, has
     updated = json.loads(config_path.read_text(encoding = "utf-8"))
     assert "unsloth_fixed_mtp" not in updated
     assert "unsloth_fixed_mtp" not in updated["text_config"]
-    assert ("mtp_num_hidden_layers" in updated) is has_mtp
-    assert ("mtp_num_hidden_layers" in updated["text_config"]) is has_mtp
+    # The declaration survives either way: kept as-is with MTP tensors, and kept
+    # because `--no-mtp` carries the intent without them.
+    assert "mtp_num_hidden_layers" in updated
+    assert "mtp_num_hidden_layers" in updated["text_config"]
     command, = _read_converter_commands(tmp_path)
     assert ("--no-mtp" in command) is not has_mtp
 
@@ -396,3 +398,74 @@ def test_convert_to_gguf_does_not_retry_an_unrelated_converter_failure(llama_cpp
     assert llama_cpp._converter_rejected_no_mtp("") is False
     assert llama_cpp._drop_no_mtp(["x", "--no-mtp", "y"]) == ["x", "y"]
     assert llama_cpp._drop_no_mtp(["x", "y"]) is None
+
+
+def test_convert_to_gguf_stays_idempotent_across_repeated_exports(llama_cpp, tmp_path):
+    """A retry, or a second export from the same folder, must behave like the first.
+
+    Deleting `mtp_num_hidden_layers` made the next run read no declaration, omit
+    `--no-mtp`, and hit the converter assertion the flag exists to avoid.
+    """
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_path = model_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "mtp_num_hidden_layers": 1,
+                "unsloth_fixed_mtp": True,
+                "text_config": {"num_hidden_layers": 24, "mtp_num_hidden_layers": 1},
+            }
+        ),
+        encoding = "utf-8",
+    )
+    _write_index(model_dir, "model.language_model.layers.23.self_attn.q_proj.weight")
+    converter = str(_write_converter(tmp_path))
+
+    for run in range(3):
+        llama_cpp.convert_to_gguf(
+            model_name = str(tmp_path / f"output{run}.gguf"),
+            input_folder = str(model_dir),
+            converter_location = converter,
+            quantization_type = "bf16",
+        )
+
+    # Every run saw the declaration and sent the flag; the internal marker still goes.
+    updated = json.loads(config_path.read_text(encoding = "utf-8"))
+    assert "unsloth_fixed_mtp" not in updated
+    assert updated["mtp_num_hidden_layers"] == 1
+    commands = _read_converter_commands(tmp_path)
+    assert len(commands) == 3
+    assert all("--no-mtp" in command for command in commands)
+
+
+def test_convert_to_gguf_still_strips_the_declaration_for_legacy_converters(llama_cpp, tmp_path):
+    """Without the flag there is nothing to carry the intent, so the key must go."""
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_path = model_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "mtp_num_hidden_layers": 1,
+                "text_config": {"num_hidden_layers": 24, "mtp_num_hidden_layers": 1},
+            }
+        ),
+        encoding = "utf-8",
+    )
+    _write_index(model_dir, "model.language_model.layers.23.self_attn.q_proj.weight")
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(tmp_path / "output.gguf"),
+        input_folder = str(model_dir),
+        converter_location = str(_write_converter(tmp_path, supports_no_mtp = False)),
+        quantization_type = "bf16",
+    )
+
+    updated = json.loads(config_path.read_text(encoding = "utf-8"))
+    assert "mtp_num_hidden_layers" not in updated
+    assert "mtp_num_hidden_layers" not in updated["text_config"]
+    command, = _read_converter_commands(tmp_path)
+    assert "--no-mtp" not in command

--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -93,7 +93,7 @@ def test_has_mtp_weight_tensors_matches_converter_index_precedence(llama_cpp, tm
     assert llama_cpp._has_mtp_weight_tensors(tmp_path, 24) is True
 
 
-def _write_converter(path: Path) -> Path:
+def _write_converter(path: Path, *, supports_no_mtp: bool = True) -> Path:
     converter = path / "fake_convert.py"
     command_log = path / "converter_commands.jsonl"
     converter.write_text(
@@ -108,7 +108,7 @@ def _write_converter(path: Path) -> Path:
             parser.add_argument("--outfile")
             parser.add_argument("--outtype")
             parser.add_argument("--split-max-size")
-            parser.add_argument("--no-mtp", action="store_true")
+            {('parser.add_argument("--no-mtp", action="store_true")' if supports_no_mtp else '')}
             parser.add_argument("--mmproj", action="store_true")
             parser.add_argument("model_dir")
             args = parser.parse_args()
@@ -204,6 +204,32 @@ def test_convert_to_gguf_disables_missing_mtp_only_for_vlm_text(llama_cpp, tmp_p
     assert "--mmproj" not in text_command
     assert "--no-mtp" not in mmproj_command
     assert "--mmproj" in mmproj_command
+
+
+def test_convert_to_gguf_omits_no_mtp_for_legacy_converter(llama_cpp, tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "mtp_num_hidden_layers": 1,
+                "num_hidden_layers": 24,
+            }
+        ),
+        encoding = "utf-8",
+    )
+    _write_index(model_dir, "model.layers.23.self_attn.q_proj.weight")
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(tmp_path / "output.gguf"),
+        input_folder = str(model_dir),
+        converter_location = str(_write_converter(tmp_path, supports_no_mtp = False)),
+        quantization_type = "bf16",
+    )
+
+    command, = _read_converter_commands(tmp_path)
+    assert "--no-mtp" not in command
 
 
 def test_convert_to_gguf_always_removes_null_internal_marker(llama_cpp, tmp_path):

--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -307,9 +307,8 @@ def test_convert_to_gguf_rejects_malformed_layer_count_before_rewrite(llama_cpp,
     ids = ["none", "not-a-path", "empty", "nul-byte"],
 )
 def test_converter_support_probe_never_raises_on_an_unusable_location(llama_cpp, location):
-    """The probe answers "can I prove --no-mtp is supported", so anything it
-    cannot read is False. Only OSError was caught, so a None location raised
-    TypeError out of convert_to_gguf instead of degrading to today's behaviour."""
+    """Anything unreadable is False. Only OSError was caught, so a None
+    location raised TypeError out of convert_to_gguf."""
     assert llama_cpp._converter_supports_no_mtp(location) is False
 
 
@@ -318,11 +317,8 @@ def test_converter_support_probe_reads_a_directory_as_unsupported(llama_cpp, tmp
 
 
 def _write_arch_gated_converter(path: Path) -> Path:
-    """A converter that declares `--no-mtp` but refuses it for this architecture.
-
-    llama.cpp `25558268` added the flag and its architecture allowlist in the
-    same commit, so "the option exists" never implies "this model may use it".
-    """
+    """Declares `--no-mtp` but refuses it for this architecture: llama.cpp
+    25558268 added the flag and its allowlist in the same commit."""
     converter = path / "arch_gated_convert.py"
     command_log = path / "converter_commands.jsonl"
     converter.write_text(
@@ -358,14 +354,9 @@ def _write_arch_gated_converter(path: Path) -> Path:
 
 
 def test_convert_to_gguf_drops_no_mtp_when_the_architecture_refuses_it(llama_cpp, tmp_path):
-    """A declared-but-unsupported MTP key must not break a conversion that worked.
-
-    `_mtp_declared` reads config.json only, so a checkpoint that carries
-    `mtp_num_hidden_layers` while its architecture has no MTP block (Qwen3.5
-    weights republished under `Qwen3ForCausalLM`, for instance) would send
-    `--no-mtp` to a converter that hard-rejects it. Before the retry, that turned
-    a working export into a failure citing a flag the caller never passed.
-    """
+    """`_mtp_declared` reads config.json only, so Qwen3.5 weights republished
+    under `Qwen3ForCausalLM` sent `--no-mtp` to a converter that rejects it,
+    turning a working export into a failure citing a flag nobody passed."""
     model_dir = tmp_path / "model"
     model_dir.mkdir()
     (model_dir / "config.json").write_text(

--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -95,24 +95,38 @@ def test_has_mtp_weight_tensors_matches_converter_index_precedence(llama_cpp, tm
 
 def _write_converter(path: Path) -> Path:
     converter = path / "fake_convert.py"
+    command_log = path / "converter_commands.jsonl"
     converter.write_text(
         textwrap.dedent(
-            """
+            f"""
             import argparse
+            import json
+            import sys
             from pathlib import Path
 
             parser = argparse.ArgumentParser()
             parser.add_argument("--outfile")
             parser.add_argument("--outtype")
             parser.add_argument("--split-max-size")
+            parser.add_argument("--no-mtp", action="store_true")
+            parser.add_argument("--mmproj", action="store_true")
             parser.add_argument("model_dir")
             args = parser.parse_args()
+            with Path({str(command_log)!r}).open("a", encoding="utf-8") as log:
+                log.write(json.dumps(sys.argv[1:]) + "\\n")
             Path(args.outfile).write_bytes(b"GGUF")
             """
         ),
         encoding = "utf-8",
     )
     return converter
+
+
+def _read_converter_commands(path: Path) -> list[list[str]]:
+    return [
+        json.loads(line)
+        for line in (path / "converter_commands.jsonl").read_text(encoding = "utf-8").splitlines()
+    ]
 
 
 @pytest.mark.parametrize("has_mtp", (False, True))
@@ -154,6 +168,42 @@ def test_convert_to_gguf_reconciles_mtp_config_to_index(llama_cpp, tmp_path, has
     assert "unsloth_fixed_mtp" not in updated["text_config"]
     assert ("mtp_num_hidden_layers" in updated) is has_mtp
     assert ("mtp_num_hidden_layers" in updated["text_config"]) is has_mtp
+    command, = _read_converter_commands(tmp_path)
+    assert ("--no-mtp" in command) is not has_mtp
+
+
+def test_convert_to_gguf_disables_missing_mtp_only_for_vlm_text(llama_cpp, tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "mtp_num_hidden_layers": 1,
+                "text_config": {
+                    "num_hidden_layers": 24,
+                    "mtp_num_hidden_layers": 1,
+                },
+            }
+        ),
+        encoding = "utf-8",
+    )
+    _write_index(model_dir, "model.language_model.layers.23.self_attn.q_proj.weight")
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(tmp_path / "output.gguf"),
+        input_folder = str(model_dir),
+        converter_location = str(_write_converter(tmp_path)),
+        supported_vision_archs = {"Qwen3_5ForConditionalGeneration"},
+        quantization_type = "bf16",
+        is_vlm = True,
+    )
+
+    text_command, mmproj_command = _read_converter_commands(tmp_path)
+    assert "--no-mtp" in text_command
+    assert "--mmproj" not in text_command
+    assert "--no-mtp" not in mmproj_command
+    assert "--mmproj" in mmproj_command
 
 
 def test_convert_to_gguf_always_removes_null_internal_marker(llama_cpp, tmp_path):

--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -299,3 +299,109 @@ def test_convert_to_gguf_rejects_malformed_layer_count_before_rewrite(llama_cpp,
         )
 
     assert json.loads(config_path.read_text(encoding = "utf-8")) == config
+
+
+@pytest.mark.parametrize(
+    "location",
+    [None, 123, "", "\x00bad"],
+    ids = ["none", "not-a-path", "empty", "nul-byte"],
+)
+def test_converter_support_probe_never_raises_on_an_unusable_location(llama_cpp, location):
+    """The probe answers "can I prove --no-mtp is supported", so anything it
+    cannot read is False. Only OSError was caught, so a None location raised
+    TypeError out of convert_to_gguf instead of degrading to today's behaviour."""
+    assert llama_cpp._converter_supports_no_mtp(location) is False
+
+
+def test_converter_support_probe_reads_a_directory_as_unsupported(llama_cpp, tmp_path):
+    assert llama_cpp._converter_supports_no_mtp(str(tmp_path)) is False
+
+
+def _write_arch_gated_converter(path: Path) -> Path:
+    """A converter that declares `--no-mtp` but refuses it for this architecture.
+
+    llama.cpp `25558268` added the flag and its architecture allowlist in the
+    same commit, so "the option exists" never implies "this model may use it".
+    """
+    converter = path / "arch_gated_convert.py"
+    command_log = path / "converter_commands.jsonl"
+    converter.write_text(
+        textwrap.dedent(
+            f"""
+            import argparse
+            import json
+            import sys
+            from pathlib import Path
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--outfile")
+            parser.add_argument("--outtype")
+            parser.add_argument("--split-max-size")
+            parser.add_argument("--no-nextn", "--no-mtp", dest="no_mtp", action="store_true")
+            parser.add_argument("--mmproj", action="store_true")
+            parser.add_argument("model_dir")
+            args = parser.parse_args()
+            with Path({str(command_log)!r}).open("a", encoding="utf-8") as log:
+                log.write(json.dumps(sys.argv[1:]) + "\\n")
+            if args.no_mtp:
+                sys.stderr.write(
+                    "ERROR:hf-to-gguf:--mtp / --no-nextn are not supported "
+                    "for LlamaForCausalLM\\n"
+                )
+                raise SystemExit(1)
+            Path(args.outfile).write_bytes(b"GGUF")
+            """
+        ),
+        encoding = "utf-8",
+    )
+    return converter
+
+
+def test_convert_to_gguf_drops_no_mtp_when_the_architecture_refuses_it(llama_cpp, tmp_path):
+    """A declared-but-unsupported MTP key must not break a conversion that worked.
+
+    `_mtp_declared` reads config.json only, so a checkpoint that carries
+    `mtp_num_hidden_layers` while its architecture has no MTP block (Qwen3.5
+    weights republished under `Qwen3ForCausalLM`, for instance) would send
+    `--no-mtp` to a converter that hard-rejects it. Before the retry, that turned
+    a working export into a failure citing a flag the caller never passed.
+    """
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3ForCausalLM"],
+                "mtp_num_hidden_layers": 1,
+                "unsloth_fixed_mtp": True,
+                "num_hidden_layers": 24,
+            }
+        ),
+        encoding = "utf-8",
+    )
+    _write_index(model_dir, "model.layers.23.self_attn.q_proj.weight")
+    output = tmp_path / "output.gguf"
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(output),
+        input_folder = str(model_dir),
+        converter_location = str(_write_arch_gated_converter(tmp_path)),
+        quantization_type = "bf16",
+    )
+
+    first, second = _read_converter_commands(tmp_path)
+    assert "--no-mtp" in first        # tried, because the option is declared
+    assert "--no-mtp" not in second   # retried without it once refused
+    assert output.read_bytes() == b"GGUF"
+
+
+def test_convert_to_gguf_does_not_retry_an_unrelated_converter_failure(llama_cpp, tmp_path):
+    """The retry is keyed on the architecture refusal, not on any failure."""
+    assert llama_cpp._converter_rejected_no_mtp(
+        "ERROR:hf-to-gguf:--mtp / --no-nextn are not supported for LlamaForCausalLM"
+    ) is True
+    assert llama_cpp._converter_rejected_no_mtp("MemoryError: out of memory") is False
+    assert llama_cpp._converter_rejected_no_mtp("INFO: exporting with --no-mtp") is False
+    assert llama_cpp._converter_rejected_no_mtp("") is False
+    assert llama_cpp._drop_no_mtp(["x", "--no-mtp", "y"]) == ["x", "y"]
+    assert llama_cpp._drop_no_mtp(["x", "y"]) is None

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2318,6 +2318,19 @@ def _has_mtp_weight_tensors(input_folder, num_layers):
     return False
 
 
+def _converter_supports_no_mtp(converter_location):
+    """Return whether the selected converter declares the `--no-mtp` option."""
+    try:
+        source = Path(converter_location).read_bytes()
+    except OSError:
+        return False
+    return re.search(
+        rb"parser\.add_argument\([^)]*[\"']--no-mtp[\"']",
+        source,
+        flags = re.DOTALL,
+    ) is not None
+
+
 def _find_bitsandbytes_quantization(config, _path = "config.json"):
     """Where a bitsandbytes `quantization_config` sits, or None.
 
@@ -2476,7 +2489,11 @@ def convert_to_gguf(
             "`config.json` was not changed."
         )
     _keep_mtp = _mtp_declared and _has_mtp_weight_tensors(input_folder, _num_layers)
-    _no_mtp = _mtp_declared and not _keep_mtp
+    _no_mtp = (
+        _mtp_declared
+        and not _keep_mtp
+        and _converter_supports_no_mtp(converter_location)
+    )
     _strip_keys = (
         ("unsloth_fixed_mtp",)
         if _keep_mtp

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2322,11 +2322,9 @@ def _converter_supports_no_mtp(converter_location):
     """Return whether the selected converter declares the `--no-mtp` option."""
     try:
         source = Path(converter_location).read_bytes()
+    # Missing/unreadable path, or None and NUL-bearing ones: all mean "cannot
+    # prove support", and omitting --no-mtp just restores the old behaviour.
     except (OSError, TypeError, ValueError):
-        # OSError covers a missing path, a directory and an unreadable file;
-        # TypeError/ValueError cover None and a path carrying a NUL. Every one of
-        # them means "cannot prove support", which is the safe answer: omitting
-        # --no-mtp only restores the pre-existing behaviour.
         return False
     return re.search(
         rb"parser\.add_argument\([^)]*[\"']--no-mtp[\"']",
@@ -2704,10 +2702,9 @@ def convert_to_gguf(
                     except Exception as repair_error:
                         repair_note = f"\n--- dependency reinstall failed ---\n{repair_error}"
 
-                # The `--no-mtp` gate is an architecture allowlist, so a
-                # config key alone cannot prove the flag is accepted. Drop it
-                # and retry once: that is exactly the pre-existing behaviour,
-                # which is correct for an arch with no MTP block to strip.
+                # `--no-mtp` is architecture-gated, so a config key alone cannot
+                # prove it is accepted. Retry once without it: the pre-existing
+                # behaviour, and correct for an arch with no MTP block to strip.
                 if not attempted_no_mtp_drop and _converter_rejected_no_mtp(captured):
                     retry = _drop_no_mtp(command)
                     if retry is not None:

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2476,6 +2476,7 @@ def convert_to_gguf(
             "`config.json` was not changed."
         )
     _keep_mtp = _mtp_declared and _has_mtp_weight_tensors(input_folder, _num_layers)
+    _no_mtp = _mtp_declared and not _keep_mtp
     _strip_keys = (
         ("unsloth_fixed_mtp",)
         if _keep_mtp
@@ -2546,6 +2547,8 @@ def convert_to_gguf(
                 "--outtype"        : quantization_type,
                 "--split-max-size" : max_shard_size,
             }
+        if _no_mtp:
+            text_args["--no-mtp"] = ""
         runs_to_do.append((text_args, text_output, "text model", True))
 
         # Vision projector conversion
@@ -2582,6 +2585,8 @@ def convert_to_gguf(
                 "--outtype"        : quantization_type,
                 "--split-max-size" : max_shard_size,
             }
+        if _no_mtp:
+            args["--no-mtp"] = ""
         runs_to_do.append((args, final_output, "model", True))
 
     # A bare --outfile lands in the process CWD. On Windows that CWD is often not writable

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2514,9 +2514,12 @@ def convert_to_gguf(
         and not _keep_mtp
         and _converter_supports_no_mtp(converter_location)
     )
+    # Keep the declaration when `--no-mtp` carries the intent instead. Deleting it
+    # made the export non-idempotent: a retry or a second export from the same
+    # folder read no declaration, omitted the flag, and hit the assertion again.
     _strip_keys = (
         ("unsloth_fixed_mtp",)
-        if _keep_mtp
+        if _keep_mtp or _no_mtp
         else ("unsloth_fixed_mtp", "mtp_num_hidden_layers")
     )
     _changed = False

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2514,9 +2514,8 @@ def convert_to_gguf(
         and not _keep_mtp
         and _converter_supports_no_mtp(converter_location)
     )
-    # Keep the declaration when `--no-mtp` carries the intent instead. Deleting it
-    # made the export non-idempotent: a retry or a second export from the same
-    # folder read no declaration, omitted the flag, and hit the assertion again.
+    # Keep the declaration when `--no-mtp` carries the intent: deleting it made
+    # a retry or second export read none, omit the flag, and hit the assertion.
     _strip_keys = (
         ("unsloth_fixed_mtp",)
         if _keep_mtp or _no_mtp

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2322,7 +2322,11 @@ def _converter_supports_no_mtp(converter_location):
     """Return whether the selected converter declares the `--no-mtp` option."""
     try:
         source = Path(converter_location).read_bytes()
-    except OSError:
+    except (OSError, TypeError, ValueError):
+        # OSError covers a missing path, a directory and an unreadable file;
+        # TypeError/ValueError cover None and a path carrying a NUL. Every one of
+        # them means "cannot prove support", which is the safe answer: omitting
+        # --no-mtp only restores the pre-existing behaviour.
         return False
     return re.search(
         rb"parser\.add_argument\([^)]*[\"']--no-mtp[\"']",
@@ -2361,6 +2365,24 @@ def _converter_was_oom_killed(exc):
     if getattr(exc, "returncode", None) in (-9, 137):
         return True
     return "sigkill" in f"{exc}".lower()
+
+
+def _converter_rejected_no_mtp(text):
+    """Did the converter refuse `--no-mtp` because this architecture has no MTP?"""
+    if not text: return False
+    for line in text.splitlines():
+        low = line.lower()
+        if "--mtp" not in low and "--no-mtp" not in low and "--no-nextn" not in low:
+            continue
+        if "not supported" in low or "only supported" in low:
+            return True
+    return False
+
+
+def _drop_no_mtp(command):
+    """The same command without `--no-mtp`, or None when it has none to drop."""
+    if "--no-mtp" not in command: return None
+    return [token for token in command if token != "--no-mtp"]
 
 
 def _retry_with_temp_file(command):
@@ -2647,6 +2669,7 @@ def convert_to_gguf(
         # is broken. No cost on the happy path.
         attempted_repair = False
         attempted_temp_file = False
+        attempted_no_mtp_drop = False
         repair_note = ""
         optional_failed = False
         while True:
@@ -2680,6 +2703,17 @@ def convert_to_gguf(
                         repair_note = f"\n--- dependency reinstall failed ---\n{(repair.stdout or '').strip()}"
                     except Exception as repair_error:
                         repair_note = f"\n--- dependency reinstall failed ---\n{repair_error}"
+
+                # The `--no-mtp` gate is an architecture allowlist, so a
+                # config key alone cannot prove the flag is accepted. Drop it
+                # and retry once: that is exactly the pre-existing behaviour,
+                # which is correct for an arch with no MTP block to strip.
+                if not attempted_no_mtp_drop and _converter_rejected_no_mtp(captured):
+                    retry = _drop_no_mtp(command)
+                    if retry is not None:
+                        attempted_no_mtp_drop = True
+                        command = retry
+                        continue
 
                 # OOM-killed: retry once spooling to disk, the one resource
                 # these machines have. Only for a kill, so a converter that


### PR DESCRIPTION
## Summary

- pass `--no-mtp` to llama.cpp text-model conversion when existing reconciliation finds that MTP is declared but the checkpoint has no MTP tensors
- preserve normal MTP metadata and export when MTP tensors are present
- keep `--no-mtp` off the mmproj command during VLM dual conversion
- omit `--no-mtp` for legacy converter entrypoints that do not declare the option
- add focused command-routing regression coverage to the existing MTP reconciliation tests

## Root cause

This was triggered by an upstream llama.cpp update.

The Qwen3.5 base checkpoint declares MTP, but the MLX merged checkpoint exports only the main model layers and contains no MTP tensors. Zoo reconciles that mismatch by stripping `mtp_num_hidden_layers` before conversion.

Previously, llama.cpp treated absent MTP metadata as effectively meaning “no MTP,” so stripping the key was sufficient and conversion succeeded implicitly.

On August 3, llama.cpp commit [`4ed2b13f`](https://github.com/ggml-org/llama.cpp/commit/4ed2b13f758e) added Qwen3-Next MTP inference. With the updated converter, absent MTP metadata can instead mean “infer the MTP count from tensors.” For Zoo's MLX merged checkpoint, inference finds no MTP tensors, leaves the count at zero, and reaches the converter assertion.

Zoo therefore needs to explicitly pass `--no-mtp` to disambiguate “MTP intentionally omitted” from “MTP metadata missing; infer it from tensors.”

## Impact

Qwen3.5 MLX merged checkpoints that retain an MTP declaration but contain only the main model layers can once again export to GGUF. Checkpoints that retain MTP tensors continue through the normal MTP export path.

## Validation

- `python -m pytest tests/test_convert_to_gguf_mtp_reconcile.py -q` (`14 passed`)
- mutation-checked the missing-MTP text, VLM routing, and legacy-converter assertions
- loaded the Studio Qwen3.5 0.8B adapter checkpoint, performed the real MLX merge, and exported BF16 text and mmproj GGUFs
- loaded both exported files with the bundled `llama-server`; `/health` returned `{"status":"ok"}`
