### PR TITLE
Unwrap already-compiled callables in the compile entry points that bypass the funnel

### DIFF
--- a/tests/test_compile_bare_decorators_unwrap.py
+++ b/tests/test_compile_bare_decorators_unwrap.py
@@ -1,0 +1,437 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The compile entry points that do NOT go through `_compile_or_fall_back`.
+
+`_compile_or_fall_back` (the `torch_compile` / `_torch_compile` funnel) learned
+`unwrap_already_compiled`, so the GPT-OSS load path is safe. Three siblings
+reach `torch.compile` without passing through it, and each one is handed a
+caller-supplied callable:
+
+  * `torch_compile_with_fallback` -- a BARE decorator. `compiler.py` writes it
+    into every generated `unsloth_compiled_cache` module and
+    `rl_replacements.py` applies it directly.
+  * `_maybe_compile` -- same, for the generated trainer modules.
+  * `patch_function` -- hand-rolled its own single-hop `.__wrapped__` unwrap.
+
+The failure they share is torch's own, in `torch/_dynamo/eval_frame.py`:
+
+    assert not hasattr(compile_wrapper, "get_compiler_config")
+
+(torch 2.13 spells the same check as an explicit
+`raise AssertionError("compile_wrapper already has a get_compiler_config
+attribute")`.) `compile_wrapper` is built with `functools.wraps(fn)`, which
+copies `fn.__dict__`, so the assert says "the callable you gave me is already a
+compiled one". It is reachable from torch 2.11.0 onwards: up to 2.10 Dynamo's
+`innermost_fn` followed `_torchdynamo_orig_callable` unconditionally and
+unwrapped the copy for us, and 2.11 added an `_torchdynamo_wrapper_id == id(fn)`
+condition that a `functools.wraps` copy cannot satisfy by construction.
+
+`torch_compile_with_fallback` RETURNS such a copy (that is what
+`_fall_back_to_eager_on_recompile_limit` is), so feeding its own output back
+into any of these three is exactly the failing shape.
+
+Most of the tests below assert on WHICH callable reaches `torch.compile` rather
+than on the raise. That holds on every torch from 2.6 up, not only on the ones
+where handing over the wrapper happens to be fatal.
+"""
+
+import functools
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import torch
+
+ZOO = Path(__file__).resolve().parents[1] / "unsloth_zoo"
+
+TORCH_VERSION = tuple(int(x) for x in torch.__version__.split("+")[0].split(".")[:2])
+
+
+def _run(*bodies, **extra_env):
+    """Run the bodies in a fresh interpreter with `UNSLOTH_COMPILE_DISABLE` cleared.
+
+    Same reason as `test_compile_already_compiled_callable.py`: `torch_compile`,
+    `_torch_compile` and `_maybe_compile` all read the variable at import time
+    under a module-level `if`, and unsloth's consolidated CI job pins it to 1 for
+    the whole suite, so rebinding it in-process afterwards cannot undo that.
+
+    Each body is dedented on its own so a shared prelude can be written at its
+    own indentation and still line up with the test that uses it.
+    """
+    source = "".join(textwrap.dedent(body) for body in bodies)
+    env = dict(os.environ)
+    env.pop("UNSLOTH_COMPILE_DISABLE", None)
+    env.update(extra_env)
+    done = subprocess.run(
+        [sys.executable, "-c", source],
+        capture_output = True, text = True, env = env,
+        cwd = str(ZOO.parent),
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+    return done.stdout
+
+
+# The carrier every test starts from: a `functools.wraps` copy of a compiled
+# function, built the way the library builds it, not by hand.
+_CARRIER = """
+    from unsloth_zoo.temporary_patches import common as C
+    from unsloth_zoo.temporary_patches.utils import torch_compile_with_fallback
+
+    def apply_rotary_pos_emb(q, k):
+        return q * 2, k * 2
+
+    carrier = torch_compile_with_fallback(
+        fullgraph = True, dynamic = True, options = C.torch_compile_options,
+    )(apply_rotary_pos_emb)
+    assert hasattr(carrier, "get_compiler_config"), \\
+        "the fallback wrapper stopped advertising itself as compiled"
+"""
+
+
+# ---- what reaches torch.compile -------------------------------------------
+
+def test_torch_compile_with_fallback_hands_torch_the_eager_function():
+    """The decorator the generated cache modules carry.
+
+    Unfixed it passes the wrapper straight through, which torch 2.11+ refuses.
+    """
+    _run(_CARRIER, """
+        import torch
+        seen = []
+        real_compile = torch.compile
+
+        def _recording_compile(model = None, **kwargs):
+            seen.append(model)
+            return real_compile(model, **kwargs)
+
+        torch.compile = _recording_compile
+        try:
+            for fullgraph in (True, False):
+                seen.clear()
+                out = torch_compile_with_fallback(
+                    fullgraph = fullgraph, dynamic = True,
+                )(carrier)
+                assert seen, f"fullgraph = {fullgraph} never reached torch.compile"
+                assert seen[0] is apply_rotary_pos_emb, (
+                    f"torch_compile_with_fallback(fullgraph = {fullgraph}) handed "
+                    f"torch the already-compiled wrapper ({seen[0]!r}), not the "
+                    f"eager original"
+                )
+                assert out is not carrier
+        finally:
+            torch.compile = real_compile
+    """)
+
+
+def test_maybe_compile_hands_torch_the_eager_function():
+    """`_maybe_compile` is emitted into the generated trainer modules.
+
+    Only its non-fullgraph branch reached `torch.compile` bare; the fullgraph
+    branch delegates to `torch_compile_with_fallback`. Both are checked, so a
+    later reshuffle between the two branches cannot lose the unwrap.
+    """
+    _run(_CARRIER, """
+        import torch
+        seen = []
+        real_compile = torch.compile
+
+        def _recording_compile(model = None, **kwargs):
+            seen.append(model)
+            return real_compile(model, **kwargs)
+
+        torch.compile = _recording_compile
+        try:
+            for kwargs in ({"dynamic": True}, {"dynamic": True, "fullgraph": True}):
+                seen.clear()
+                out = C._maybe_compile(**kwargs)(carrier)
+                assert seen, f"_maybe_compile({kwargs}) never reached torch.compile"
+                assert seen[0] is apply_rotary_pos_emb, (
+                    f"_maybe_compile({kwargs}) handed torch the already-compiled "
+                    f"wrapper ({seen[0]!r}), not the eager original"
+                )
+                assert out is not carrier
+        finally:
+            torch.compile = real_compile
+    """)
+
+
+def test_patch_function_unwraps_all_the_way_down():
+    """`patch_function` hand-rolled a SINGLE `.__wrapped__` hop.
+
+    One hop off a doubly-wrapped callable lands on another carrier, which is
+    still what torch 2.11+ refuses. The shared helper loops.
+    """
+    _run(_CARRIER, """
+        import functools
+        import torch
+        from unsloth_zoo.temporary_patches.utils import patch_function
+
+        # Two layers, which is what a re-patched module attribute looks like
+        # after `pre_compile` and `post_compile` have both run.
+        @functools.wraps(carrier)
+        def outer(*args, **kwargs): return carrier(*args, **kwargs)
+
+        class Attention:
+            def forward(self, q, k): return q, k
+
+        seen = []
+        real_compile = torch.compile
+
+        def _recording_compile(model = None, **kwargs):
+            seen.append(model)
+            return real_compile(model, **kwargs)
+
+        torch.compile = _recording_compile
+        try:
+            patch_function(
+                Attention, "forward", outer,
+                fullgraph = True, match_level = "relaxed",
+            )
+        finally:
+            torch.compile = real_compile
+
+        assert seen, "patch_function never reached torch.compile"
+        assert seen[0] is apply_rotary_pos_emb, (
+            f"patch_function handed torch {seen[0]!r}, not the eager original"
+        )
+    """)
+
+
+def test_patch_function_keeps_a_bound_method_bound():
+    """A bound method's `__wrapped__` is the UNBOUND original.
+
+    Following it drops the receiver and turns the first user argument into
+    `self`. torch's own `innermost_fn` stops on a bound method for that reason,
+    and so does `unwrap_already_compiled`; the hand-rolled hop did not.
+
+    torch 2.11+ then refuses to compile the bound method it was handed, which is
+    what the eager guard is for: the patch installs, uncompiled, and the receiver
+    is still attached.
+    """
+    _run("""
+        import torch
+        from unsloth_zoo.temporary_patches.utils import patch_function
+
+        class Helper:
+            def __init__(self): self.calls = []
+            def forward(self, x):
+                self.calls.append(x)
+                return x + 1
+
+        Helper.forward = torch.compile(Helper.forward)
+        helper = Helper()
+        bound = helper.forward
+        assert hasattr(bound, "get_compiler_config"), \\
+            "the bound method stopped forwarding the compiled marker"
+
+        class Target:
+            def forward(self, x): return x
+
+        seen = []
+        real_compile = torch.compile
+
+        def _recording_compile(model = None, **kwargs):
+            seen.append(model)
+            return real_compile(model, **kwargs)
+
+        torch.compile = _recording_compile
+        try:
+            patch_function(
+                Target, "forward", bound,
+                fullgraph = False, match_level = "relaxed",
+            )
+        finally:
+            torch.compile = real_compile
+
+        assert seen, "patch_function never reached torch.compile"
+        assert seen[0] is bound, (
+            f"patch_function unwrapped the bound method to {seen[0]!r} and lost "
+            f"the receiver"
+        )
+        # And what it handed over is still callable AS a bound method: 3 is x,
+        # not self.
+        assert seen[0](3) == 4 and helper.calls == [3], (
+            f"the callable handed to torch lost its receiver "
+            f"(helper.calls = {helper.calls})"
+        )
+        print("BOUND_KEPT")
+    """)
+
+
+def test_patch_function_survives_a_compiler_that_refuses():
+    """A carrier with no `__wrapped__` used to raise `AttributeError` here.
+
+    Now it is handed to torch untouched, and whatever torch makes of it, the
+    model load continues: `patch_function` gets the guard `_compile_or_fall_back`
+    already had.
+    """
+    _run("""
+        import torch
+        from unsloth_zoo.temporary_patches.utils import patch_function
+
+        class Target:
+            def forward(self, x): return x
+
+        def replacement(self, x): return x + 1
+        # A `get_compiler_config` carrier that is not a Dynamo wrapper and has
+        # nothing to unwrap to; an `OptimizedModule` is the real-world shape.
+        replacement.get_compiler_config = lambda: {}
+
+        real_compile = torch.compile
+        def _refuse(model = None, **kwargs):
+            raise AssertionError
+
+        torch.compile = _refuse
+        try:
+            assert patch_function(
+                Target, "forward", replacement,
+                fullgraph = True, match_level = "relaxed",
+            )
+        finally:
+            torch.compile = real_compile
+
+        assert Target().forward(1) == 2, "the eager replacement was not installed"
+        print("REFUSAL_SURVIVED")
+    """)
+
+
+# ---- the raise itself, on the torch that has it ---------------------------
+
+@pytest.mark.skipif(
+    TORCH_VERSION < (2, 11),
+    reason = "torch < 2.11 unwraps a functools.wraps copy itself, so the "
+             "assert this reproduces is unreachable",
+)
+def test_the_bare_decorators_do_not_assert():
+    """End to end on torch 2.11+: decorate a carrier again, with each entry point.
+
+    Unfixed, every line here raises `AssertionError` before any tensor exists.
+    Nothing is executed on purpose, so this stays runnable on a CPU-only box
+    with no working inductor backend.
+    """
+    _run(_CARRIER, """
+        import torch
+        for fullgraph in (True, False):
+            out = torch_compile_with_fallback(
+                fullgraph = fullgraph, dynamic = True,
+            )(carrier)
+            assert callable(out) and out is not carrier
+
+        for kwargs in ({"dynamic": True}, {"dynamic": True, "fullgraph": True}):
+            out = C._maybe_compile(**kwargs)(carrier)
+            assert callable(out) and out is not carrier
+    """)
+
+
+# ---- the cases that must NOT change ---------------------------------------
+
+def test_a_plain_function_is_still_compiled():
+    """Nothing to unwrap: the unwrap must be a no-op, not a fallback to eager.
+
+    Silently running eager where compile works is a performance regression, not
+    a fix.
+    """
+    _run("""
+        import torch
+        from unsloth_zoo.temporary_patches import common as C
+        from unsloth_zoo.temporary_patches.utils import torch_compile_with_fallback
+
+        def eager(x): return x + 1
+
+        for fullgraph in (True, False):
+            out = torch_compile_with_fallback(fullgraph = fullgraph, dynamic = True)(eager)
+            assert out is not eager, \\
+                f"torch_compile_with_fallback(fullgraph = {fullgraph}) returned the eager function"
+
+        for kwargs in ({"dynamic": True}, {"dynamic": True, "fullgraph": True}):
+            out = C._maybe_compile(**kwargs)(eager)
+            assert out is not eager, f"_maybe_compile({kwargs}) returned the eager function"
+
+        # The non-fullgraph result is torch's own wrapper, unwrapped back to the
+        # function we passed in.
+        out = C._maybe_compile(dynamic = True)(eager)
+        assert getattr(out, "_torchdynamo_orig_callable", None) is eager, \\
+            f"_maybe_compile compiled something other than the function given ({out!r})"
+    """)
+
+
+def test_an_nn_module_survives_the_unwrap():
+    """`OptimizedModule` carries `get_compiler_config` and has no `__wrapped__`.
+
+    `unwrap_already_compiled` has to hand it back untouched rather than raise
+    `AttributeError` reaching for one, which is what `patch_function`'s
+    hand-rolled hop did.
+    """
+    _run("""
+        import torch
+        import torch.nn as nn
+        from unsloth_zoo.temporary_patches import common as C
+        from unsloth_zoo.temporary_patches.utils import torch_compile_with_fallback
+
+        class Model(nn.Module):
+            def forward(self, x): return x + 1
+
+        optimized = torch.compile(Model())
+        assert hasattr(optimized, "get_compiler_config"), \\
+            "OptimizedModule stopped advertising itself as compiled"
+        assert not hasattr(optimized, "__wrapped__"), \\
+            "OptimizedModule grew a __wrapped__; this test's premise is gone"
+
+        assert C.unwrap_already_compiled(optimized) is optimized
+
+        # And every entry point still accepts it.
+        assert callable(torch_compile_with_fallback(dynamic = True)(optimized))
+        assert callable(C._maybe_compile(dynamic = True)(optimized))
+        assert callable(C.torch_compile(optimized))
+    """)
+
+
+def test_compile_disable_keeps_everything_eager():
+    """`UNSLOTH_COMPILE_DISABLE = 1` must still turn compilation off.
+
+    The unwrap runs before the disable check in one branch and after it in
+    another, so pin the observable outcome: nothing reaches `torch.compile`.
+    """
+    _run("""
+        import torch
+        from unsloth_zoo.temporary_patches import common as C
+
+        assert C.UNSLOTH_COMPILE_DISABLE, "the environment variable did not take"
+
+        def eager(x): return x + 1
+
+        # `_maybe_compile` short-circuits to identity.
+        assert C._maybe_compile(dynamic = True)(eager) is eager
+        assert C._maybe_compile(dynamic = True, fullgraph = True)(eager) is eager
+
+        def _refuse(model = None, **kwargs):
+            raise AssertionError("torch.compile must not be reached when disabled")
+
+        real_compile = torch.compile
+        torch.compile = _refuse
+        try:
+            # The aliases are `noop`, i.e. `torch.compiler.disable`.
+            for name in ("torch_compile", "_torch_compile"):
+                out = getattr(C, name)(eager)
+                assert getattr(out, "_torchdynamo_disable", False), \\
+                    f"{name} did not disable {eager!r} under UNSLOTH_COMPILE_DISABLE"
+            assert C._maybe_compile(dynamic = True)(eager) is eager
+        finally:
+            torch.compile = real_compile
+        print("DISABLED_OK")
+    """, UNSLOTH_COMPILE_DISABLE = "1")

--- a/tests/test_compile_bare_decorators_unwrap.py
+++ b/tests/test_compile_bare_decorators_unwrap.py
@@ -47,7 +47,6 @@ than on the raise. That holds on every torch from 2.6 up, not only on the ones
 where handing over the wrapper happens to be fatal.
 """
 
-import functools
 import os
 import subprocess
 import sys
@@ -220,8 +219,16 @@ def test_patch_function_keeps_a_bound_method_bound():
     and so does `unwrap_already_compiled`; the hand-rolled hop did not.
 
     torch 2.11+ then refuses to compile the bound method it was handed, which is
-    what the eager guard is for: the patch installs, uncompiled, and the receiver
-    is still attached.
+    what the eager guard is for: the load survives, and what the guard hands on
+    is still bound to its own receiver.
+
+    `can_safely_patch` then declines the patch, because a bound `(x)` cannot
+    stand in for the target's `(self, x)`, and this test asserts only on the
+    receiver, not on the install. Declining is the right answer: installing a
+    bound method as a class attribute would route every instance of the target
+    through the ORIGINAL receiver. Before the fix, one `.__wrapped__` hop
+    reached the unbound original, so the signatures matched, the patch went in
+    and every call raised on the wrong `self`.
     """
     _run("""
         import torch

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -375,8 +375,15 @@ def _maybe_compile(**kwargs):
     if UNSLOTH_COMPILE_DISABLE or UNSLOTH_COMPILE_DISABLE_PARTIAL:
         return lambda fn: fn
     if not kwargs.get("fullgraph"):
-        return torch.compile(**kwargs)
+        # `unwrap_already_compiled` for the same reason the funnel needs it:
+        # `torch.compile(**kwargs)` is Dynamo's own decorator, and handing it a
+        # `functools.wraps` copy of a compiled function is a bare AssertionError
+        # on torch 2.11+.
+        def decorate(function):
+            return torch.compile(unwrap_already_compiled(function), **kwargs)
+        return decorate
     # Under fullgraph Dynamo makes cache exhaustion fatal, so these regions get
-    # `patch_function`'s eager fallback. Lazy import: utils imports this module.
+    # `patch_function`'s eager fallback, which unwraps on its own. Lazy import:
+    # utils imports this module.
     from .utils import torch_compile_with_fallback
     return torch_compile_with_fallback(**kwargs)

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -55,7 +55,7 @@ except:
     from typing_extensions import _TypedDictMeta as t_TypedDictMeta
 
 from ..utils import Version
-from .common import UNSLOTH_ENABLE_LOGGING, UNSLOTH_COMPILE_DISABLE, torch_compile_options, logger
+from .common import UNSLOTH_ENABLE_LOGGING, UNSLOTH_COMPILE_DISABLE, torch_compile_options, logger, unwrap_already_compiled
 
 EMPTY = inspect._empty
 
@@ -1640,8 +1640,16 @@ def torch_compile_with_fallback(fullgraph = False, **compile_kwargs):
 
     `fullgraph = False` is returned untouched: Dynamo already falls back by
     itself there, so wrapping would add a layer that can never fire.
+
+    This is a BARE decorator: `compiler.py` writes it into every generated
+    `unsloth_compiled_cache` module and `rl_replacements.py` applies it directly,
+    so it reaches `torch.compile` without passing through `_compile_or_fall_back`
+    and needs its own `unwrap_already_compiled`. What it returns is a
+    `functools.wraps` copy of a compiled function, which is precisely the shape
+    torch 2.11+ refuses to compile again.
     """
     def _decorate(func):
+        func = unwrap_already_compiled(func)
         compiled = torch.compile(func, fullgraph = fullgraph, **compile_kwargs)
         if not fullgraph:
             return compiled
@@ -1790,25 +1798,42 @@ def patch_function(
 
     # torch.compile if requested.
     if fullgraph is not None and type(fullgraph) is bool and not UNSLOTH_COMPILE_DISABLE:
-        # Unwrap already-compiled functions.
-        if hasattr(new_func, "get_compiler_config"):
-            new_func = new_func.__wrapped__
-        if hasattr(original_func, "get_compiler_config"):
-            original_func = original_func.__wrapped__
+        # Unwrap already-compiled functions. The shared helper rather than a
+        # bare `.__wrapped__`: a carrier without one (an `OptimizedModule`, say)
+        # raised `AttributeError` here, a bound method's `__wrapped__` is the
+        # UNBOUND original and silently dropped the receiver, and one hop is not
+        # always enough to reach the eager function.
+        new_func = unwrap_already_compiled(new_func)
+        original_func = unwrap_already_compiled(original_func)
         _eager_func = new_func
-        new_func = torch.compile(
-            new_func,
-            fullgraph = fullgraph,
-            dynamic = dynamic,
-            options = torch_compile_options,
-        )
-        if fullgraph:
-            # Only fullgraph turns cache exhaustion into a raise; without it
-            # Dynamo already falls back on its own.
-            new_func = _fall_back_to_eager_on_recompile_limit(
-                new_func, _eager_func,
-                f"{getattr(target_obj, '__name__', target_obj)}.{attr_name}",
+        # The compile is guarded the way `_compile_or_fall_back` guards its own,
+        # and for the same reason: a patch that cannot be compiled is a
+        # performance problem, and the eager function is still correct, so it
+        # must not end the model load. Reachable on torch 2.11+ for whatever
+        # `unwrap_already_compiled` deliberately leaves alone -- a compiled BOUND
+        # method keeps its receiver, and torch refuses to compile it again.
+        try:
+            new_func = torch.compile(
+                new_func,
+                fullgraph = fullgraph,
+                dynamic = dynamic,
+                options = torch_compile_options,
             )
+        except Exception as exception:
+            _label = f"{getattr(target_obj, '__name__', target_obj)}.{attr_name}"
+            logger.warning(
+                f"Unsloth: torch.compile refused to wrap {_label}; running it "
+                f"eagerly. ({type(exception).__name__}: {exception})"
+            )
+            new_func = _eager_func
+        else:
+            if fullgraph:
+                # Only fullgraph turns cache exhaustion into a raise; without it
+                # Dynamo already falls back on its own.
+                new_func = _fall_back_to_eager_on_recompile_limit(
+                    new_func, _eager_func,
+                    f"{getattr(target_obj, '__name__', target_obj)}.{attr_name}",
+                )
     pass
 
     # Stash original under a unique name for later restoration.


### PR DESCRIPTION
Follow-up to #1025, which fixed the GPT-OSS load but only for the callers that go through `_compile_or_fall_back`.

## The failure

`torch.compile` builds its wrapper with `functools.wraps(fn)`, which copies `fn.__dict__`, and then checks that the copy did not bring `get_compiler_config` along:

```
torch/_dynamo/eval_frame.py:
    assert not hasattr(compile_wrapper, "get_compiler_config")
AssertionError:
```

A bare assert, so it surfaces with no message at all. torch 2.13 spells the same check as `raise AssertionError("compile_wrapper already has a get_compiler_config attribute")`, which at least says what happened.

The assert means "the callable you handed me is already a compiled one". Dynamo unwraps its own wrappers before that point, so the only way to reach it is a `functools.wraps` copy of a compiled function that forwards `get_compiler_config`. That is precisely what `_fall_back_to_eager_on_recompile_limit` returns, on purpose, so that "is this compiled?" checks keep answering yes once the eager fallback is installed. `torch_compile_with_fallback` is the thing that produces those copies, which makes its own output the shape it refuses.

## Which torch versions

torch 2.11.0 through 2.13.0 (the newest on PyPI), and current pytorch main. 2.6.0 through 2.10.0 are not affected.

Up to 2.10.0 `innermost_fn` followed `_torchdynamo_orig_callable` unconditionally, and a `functools.wraps` copy carries that attribute, so Dynamo unwrapped the copy to the eager original before building its wrapper and the assert could not be reached. 2.11.0 added a second condition:

```python
while (
    hasattr(unaltered_fn, "_torchdynamo_orig_callable")
    # Only follow the chain if _torchdynamo_wrapper_id matches id(fn).
    and getattr(unaltered_fn, "_torchdynamo_wrapper_id", None) == id(unaltered_fn)
):
```

which a `functools.wraps` copy cannot satisfy by construction. I read `innermost_fn` at the v2.6.0, v2.8.0, v2.10.0, v2.11.0 and v2.13.0 tags to place the change, and measured the two shapes on CPU:

| torch | `compile(compile(f))` | `compile(functools.wraps(compiled)(g))` |
| --- | --- | --- |
| 2.9.1 | ok | ok |
| 2.11.0 | ok | `AssertionError` (no message) |
| 2.13.0 | ok | `AssertionError: compile_wrapper already has a get_compiler_config attribute` |

Worth stating plainly, because it is the intuitive guess and it is wrong: a plain double `torch.compile` is fine on every version from 2.6 up. Only the `functools.wraps` copy is refused, and only from 2.11.

## Why these call sites

I fixed the call sites rather than adding a "skip if already compiled" rule, and rather than touching the notebook.

Three entry points reach `torch.compile` without passing through `_compile_or_fall_back`, and each is handed a caller-supplied callable:

- `torch_compile_with_fallback` in `temporary_patches/utils.py`, a bare decorator that `compiler.py` writes into every generated `unsloth_compiled_cache` module and that `rl_replacements.py` applies directly. It had neither the unwrap nor an exception guard, so anything it refused was a fatal load rather than a degraded one.
- `_maybe_compile` in `temporary_patches/common.py`, same role for the generated trainer modules. Its fullgraph branch already delegates to `torch_compile_with_fallback`; its non-fullgraph branch handed back Dynamo's decorator raw.
- `patch_function`, which hand-rolled its own unwrap:

```python
if hasattr(new_func, "get_compiler_config"): new_func = new_func.__wrapped__
```

That copy has three failure modes the shared helper does not: a carrier with no `__wrapped__` (an `OptimizedModule`) raises `AttributeError`; a bound method's `__wrapped__` is the UNBOUND original, so following it drops the receiver and turns the first user argument into `self`, the exact bug #1025 fixed in `unwrap_already_compiled` and left standing here; and one hop is not always enough, so a carrier can still reach `torch.compile`.

`patch_function` is the one that is not hypothetical. `patch_Gemma3nTextAltUp_functions` patches an attribute with itself:

```python
patch_function(Gemma3nTextAltUp, "predict", Gemma3nTextAltUp.predict, fullgraph = True)
```

and unsloth runs `TEMPORARY_PATCHES` three times per load (`init`, `pre_compile`, `post_compile`). Instrumented on transformers 4.56.2 and torch 2.11.0, printing `hasattr(new_func, "get_compiler_config")` at the call:

```
init         -> [('predict', False), ('correct', False), ('scale_corrected_output', False)]
pre_compile  -> [('predict', True),  ('correct', True),  ('scale_corrected_output', True)]
post_compile -> [('predict', True),  ('correct', True),  ('scale_corrected_output', True)]
```

So on every Gemma3n load the hand-rolled unwrap runs on a real already-compiled callable, twice. It does not crash today only because that particular carrier is exactly one hop from the eager function and is never a bound method or an `OptimizedModule`.

Two smaller choices:

- **Unwrap, do not skip.** Returning the callable unchanged would silently drop compilation for anything that arrives wrapped, which is a performance regression dressed as a fix. Unwrapping to the eager original and recompiling reproduces the pre-2.11 outcome exactly.
- **`get_compiler_config` as the predicate**, which is what `unwrap_already_compiled` already uses. It is set on every compile wrapper and every `OptimizedModule` from 2.6.0 through 2.13.0; it is absent on `torch.compiler.disable` wrappers, so a deliberately disabled function is not mistaken for a compiled one; and `functools.wraps` copies it, so it is true in precisely the case that fails. `_torchdynamo_orig_callable` alone would false-positive on disabled functions, and `innermost_fn(fn) is not fn` returns False for the very copy that fails on 2.11+.

`patch_function` also gets the try/except that `_compile_or_fall_back` already had. A compile that torch declines now leaves the patch eager with a warning instead of ending the model load, which matters for the case the unwrap deliberately does not touch: a compiled bound method keeps its receiver, and torch 2.11+ will not compile it again.

## What I ran

**Reproduction.** At `566aa2b` (before #1025), under torch 2.11.0 on CPU, `torch_compile(torch_compile_with_fallback(fullgraph = True)(apply_rotary_pos_emb))` raises the message-less `AssertionError` at `eval_frame.py:1073`, the same line and traceback shape as the reported GPT-OSS load failure. On current `main` that path is fixed; the three entry points here still raise.

**Revert check.** With the diff reverse-applied so the tree is byte-identical to `main`, `tests/test_compile_bare_decorators_unwrap.py` gives:

| torch | reverted | with the fix |
| --- | --- | --- |
| 2.9.1 | 5 failed, 3 passed, 1 skipped | 8 passed, 1 skipped |
| 2.11.0 | 6 failed, 3 passed | 9 passed |
| 2.13.0 | 6 failed, 3 passed | 9 passed |

The three that pass while reverted are the controls: plain function still compiled, `nn.Module` accepted, `UNSLOTH_COMPILE_DISABLE = 1` still eager. The sixth failure on 2.11/2.13 is the end-to-end reproduction, which is skipped below 2.11 because the assert is unreachable there. The other five assert on which callable reaches `torch.compile`, so they hold on every torch from 2.6 up rather than only where the refusal is fatal.

**Suite.** `pytest tests/ -q -p no:randomly --continue-on-collection-errors`, torch 2.9.1, one GPU:

- reverted, excluding the new file: **5 failed, 4461 passed, 168 skipped, 1 error**
- with the fix: **5 failed, 4469 passed, 169 skipped, 1 error**

Same failure set both times; the delta is exactly the 9 new tests (8 pass, 1 skipped on 2.9.1). The five pre-existing failures are not from this branch:

- `test_upstream_pinned_symbols_trl_vllm.py` collection error: `PermissionError` stat-ing a hardcoded path in another workspace.
- `test_pypi_version_sync.py::test_pypi_version_is_not_ahead_of_main`: PyPI is at 2026.8.8, `main` at 2026.8.7.
- four in `test_rl_replacements_compile_disable.py`: an artifact of my machine, whose venv has `huggingface_hub 1.27.0` against `transformers 4.57.6`, which pins `<1.0`. I worked around it with `PYTHONPATH`, and those four tests rebuild their subprocess env with `PYTHONPATH=ROOT`, dropping the workaround. `PYTHONPATH=<repo> python -c "import unsloth_zoo.rl_replacements"` reproduces it with no zoo code involved.

The new tests need no GPU.
