### PR TITLE
Invalidate the compiled cache when TRL changes, not just transformers

### DIFF
--- a/tests/test_compile_overwrite_trl_stamp.py
+++ b/tests/test_compile_overwrite_trl_stamp.py
@@ -18,8 +18,6 @@ The second test is the counterweight: the hatch has to keep working when
 nothing moved, or hand-edited caches stop being editable.
 """
 
-import os
-
 import pytest
 
 from unsloth_zoo import compiler
@@ -28,16 +26,25 @@ PROBE_NAME = "UnslothCompileStampProbe"
 PROBE_SOURCE = "def _unsloth_stamp_probe():\n    return 1\n"
 
 
-def _emit(tmp_path, monkeypatch, overwrite):
-    """Run create_new_function against an isolated cache dir, return the path."""
+_OMIT = object()
+
+
+def _emit(tmp_path, monkeypatch, overwrite=_OMIT):
+    """Run create_new_function against an isolated cache dir, return the path.
+
+    Leaving `overwrite` out exercises the default-argument call sites, which
+    read the cache down a different path than the explicit `overwrite=False`
+    ones and so have to be covered separately.
+    """
     monkeypatch.setattr(compiler, "UNSLOTH_COMPILE_LOCATION", str(tmp_path))
     monkeypatch.setattr(compiler, "UNSLOTH_COMPILE_USE_TEMP", False)
+    kwargs = {} if overwrite is _OMIT else {"overwrite": overwrite}
     compiler.create_new_function(
         PROBE_NAME,
         PROBE_SOURCE,
         "torch",
         [],
-        overwrite=overwrite,
+        **kwargs,
     )
     return tmp_path / f"{PROBE_NAME}.py"
 
@@ -48,15 +55,19 @@ def _stamp_lines(path):
     return [line.strip() for line in header.strip().strip('"').split("\n") if line.strip()]
 
 
-def _rewrite_trl_stamp(path, version):
-    """Doctor only the trl line, leaving transformers and the body alone."""
+def _rewrite_stamp(path, index, version):
+    """Doctor one stamp line, leaving the other entries and the body alone."""
     text = path.read_text()
     lines = _stamp_lines(path)
-    assert len(lines) > 3, lines
-    old = lines[3]
+    assert len(lines) > index, lines
+    old = lines[index]
     head, sep, tail = text.partition("__UNSLOTH_VERSIONING__")
     assert sep, "no version stamp written"
     return path.write_text(head.replace(f"\n{old}\n", f"\n{version}\n", 1) + sep + tail)
+
+
+def _rewrite_trl_stamp(path, version):
+    return _rewrite_stamp(path, 3, version)
 
 
 def test_a_changed_trl_stamp_forces_a_recompile(tmp_path, monkeypatch):
@@ -97,6 +108,73 @@ def test_the_warning_names_the_library_that_moved(tmp_path, monkeypatch, caplog)
         _emit(tmp_path, monkeypatch, overwrite=False)
 
     assert f"trl 0.0.1-stale -> {stale_trl}" in caplog.text
+
+
+def test_a_default_overwrite_caller_is_invalidated_too(tmp_path, monkeypatch):
+    """The zoo's own peft and combined-module caches omit the argument.
+
+    Those callers never populated `file_source`, so the stamp comparison was
+    unreachable for them and the hatch kept the cache whatever had moved.
+    """
+    path = _emit(tmp_path, monkeypatch, overwrite=True)
+    installed_trl = _stamp_lines(path)[3]
+    _rewrite_trl_stamp(path, "0.0.1-stale")
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch)
+
+    assert _stamp_lines(path)[3] == installed_trl
+
+
+def test_the_transformers_half_reaches_default_callers_too(tmp_path, monkeypatch):
+    """Same gap, older half of the check: a transformers bump was ignored."""
+    path = _emit(tmp_path, monkeypatch, overwrite=True)
+    installed_tf = _stamp_lines(path)[2]
+    _rewrite_stamp(path, 2, "0.0.1-stale")
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch)
+
+    assert _stamp_lines(path)[2] == installed_tf
+
+
+def test_an_unchanged_stamp_leaves_a_default_callers_cache_alone(tmp_path, monkeypatch):
+    """Reading the cache must not turn the hatch into an unconditional rebuild."""
+    path = _emit(tmp_path, monkeypatch, overwrite=True)
+    marker = "# hand edited, do not clobber\n"
+    path.write_text(path.read_text() + marker)
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch)
+    _emit(tmp_path, monkeypatch)
+
+    assert marker in path.read_text()
+
+
+def test_a_stamp_that_predates_the_trl_entry_is_replaced(tmp_path, monkeypatch):
+    """A short stamp reads as trl "0", which differs from any installed trl."""
+    path = _emit(tmp_path, monkeypatch, overwrite=True)
+    installed_trl = _stamp_lines(path)[3]
+    if installed_trl == "0":
+        pytest.skip("trl is not installed, so a short stamp is not stale")
+    text = path.read_text()
+    head, sep, tail = text.partition("__UNSLOTH_VERSIONING__")
+    path.write_text(head.replace(f"\n{installed_trl}\n", "\n", 1) + sep + tail)
+    assert len(_stamp_lines(path)) == 3
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch, overwrite=False)
+
+    assert _stamp_lines(path)[3] == installed_trl
+
+
+def test_a_first_run_with_no_cache_still_writes_the_file(tmp_path, monkeypatch):
+    """Nothing to compare against must not mean nothing gets written."""
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    path = _emit(tmp_path, monkeypatch)
+
+    assert path.is_file()
+    assert len(_stamp_lines(path)) == 4
 
 
 if __name__ == "__main__":

--- a/tests/test_compile_overwrite_trl_stamp.py
+++ b/tests/test_compile_overwrite_trl_stamp.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """UNSLOTH_COMPILE_OVERWRITE=0 must still recompile when TRL changes.
 
 The version stamp `create_new_function` writes into every generated file is

--- a/tests/test_compile_overwrite_trl_stamp.py
+++ b/tests/test_compile_overwrite_trl_stamp.py
@@ -1,0 +1,103 @@
+"""UNSLOTH_COMPILE_OVERWRITE=0 must still recompile when TRL changes.
+
+The version stamp `create_new_function` writes into every generated file is
+[unsloth_zoo, unsloth, transformers, trl], but the escape hatch only ever
+compared index 2. TRL matters just as much: the generated RL trainers mirror
+the installed TRL config signature and import symbols straight out of
+`trl.trainer.<x>_trainer`. A cache built against TRL 0.25 and reused on TRL 1.9
+fails to import (`cannot import name 'AutoConfig' from
+'trl.trainer.grpo_trainer'`), Unsloth quietly falls back to TRL's own untouched
+trainer, and the user is back to
+
+    TypeError: GRPOConfig.__init__() got an unexpected keyword argument
+    'max_prompt_length'
+
+with none of Unsloth's patching applied.
+
+The second test is the counterweight: the hatch has to keep working when
+nothing moved, or hand-edited caches stop being editable.
+"""
+
+import os
+
+import pytest
+
+from unsloth_zoo import compiler
+
+PROBE_NAME = "UnslothCompileStampProbe"
+PROBE_SOURCE = "def _unsloth_stamp_probe():\n    return 1\n"
+
+
+def _emit(tmp_path, monkeypatch, overwrite):
+    """Run create_new_function against an isolated cache dir, return the path."""
+    monkeypatch.setattr(compiler, "UNSLOTH_COMPILE_LOCATION", str(tmp_path))
+    monkeypatch.setattr(compiler, "UNSLOTH_COMPILE_USE_TEMP", False)
+    compiler.create_new_function(
+        PROBE_NAME,
+        PROBE_SOURCE,
+        "torch",
+        [],
+        overwrite=overwrite,
+    )
+    return tmp_path / f"{PROBE_NAME}.py"
+
+
+def _stamp_lines(path):
+    header = path.read_text()
+    header = header[: header.find("__UNSLOTH_VERSIONING__")]
+    return [line.strip() for line in header.strip().strip('"').split("\n") if line.strip()]
+
+
+def _rewrite_trl_stamp(path, version):
+    """Doctor only the trl line, leaving transformers and the body alone."""
+    text = path.read_text()
+    lines = _stamp_lines(path)
+    assert len(lines) > 3, lines
+    old = lines[3]
+    head, sep, tail = text.partition("__UNSLOTH_VERSIONING__")
+    assert sep, "no version stamp written"
+    return path.write_text(head.replace(f"\n{old}\n", f"\n{version}\n", 1) + sep + tail)
+
+
+def test_a_changed_trl_stamp_forces_a_recompile(tmp_path, monkeypatch):
+    path = _emit(tmp_path, monkeypatch, overwrite=True)
+    installed_trl = _stamp_lines(path)[3]
+    _rewrite_trl_stamp(path, "0.0.1-stale")
+    assert _stamp_lines(path)[3] == "0.0.1-stale"
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch, overwrite=False)
+
+    # Only TRL moved, so before the fix this file was left stale.
+    assert _stamp_lines(path)[3] == installed_trl
+
+
+def test_an_unchanged_stamp_still_leaves_a_hand_edited_cache_alone(tmp_path, monkeypatch):
+    """The whole point of the hatch: iterate on a generated file by editing it."""
+    path = _emit(tmp_path, monkeypatch, overwrite=True)
+    marker = "# hand edited, do not clobber\n"
+    path.write_text(path.read_text() + marker)
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch, overwrite=False)
+
+    assert marker in path.read_text()
+
+
+def test_the_warning_names_the_library_that_moved(tmp_path, monkeypatch, caplog):
+    """Silently recompiling would leave the user guessing why their edit went."""
+    path = _emit(tmp_path, monkeypatch, overwrite=True)
+    stale_trl = _stamp_lines(path)[3]
+    _rewrite_trl_stamp(path, "0.0.1-stale")
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    # warning_once dedupes process wide, so clear whatever it remembers.
+    getattr(compiler.logger.warning_once, "cache_clear", lambda: None)()
+    with caplog.at_level("WARNING", logger="unsloth_zoo.log"):
+        _emit(tmp_path, monkeypatch, overwrite=False)
+
+    assert f"trl 0.0.1-stale -> {stale_trl}" in caplog.text
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_compile_overwrite_trl_stamp.py
+++ b/tests/test_compile_overwrite_trl_stamp.py
@@ -30,8 +30,10 @@ trainer, and the user is back to
 
 with none of Unsloth's patching applied.
 
-The second test is the counterweight: the hatch has to keep working when
-nothing moved, or hand-edited caches stop being editable.
+The counterweights are that the hatch has to keep working when nothing moved,
+or hand-edited caches stop being editable, and that a TRL bump must not reach
+caches TRL had no hand in: the combined model modules and the peft/torch
+forward patches are generated from transformers, peft and torch source.
 """
 
 import pytest
@@ -41,11 +43,15 @@ from unsloth_zoo import compiler
 PROBE_NAME = "UnslothCompileStampProbe"
 PROBE_SOURCE = "def _unsloth_stamp_probe():\n    return 1\n"
 
+# What unsloth/models/rl.py passes for a generated RL trainer, and what the
+# zoo's own peft / combined-module call sites pass.
+TRL_LOCATION = "trl.trainer.sft_trainer"
+NON_TRL_LOCATION = "transformers.models.qwen2.modeling_qwen2"
 
 _OMIT = object()
 
 
-def _emit(tmp_path, monkeypatch, overwrite=_OMIT):
+def _emit(tmp_path, monkeypatch, overwrite=_OMIT, model_location=TRL_LOCATION, source=PROBE_SOURCE):
     """Run create_new_function against an isolated cache dir, return the path.
 
     Leaving `overwrite` out exercises the default-argument call sites, which
@@ -57,8 +63,8 @@ def _emit(tmp_path, monkeypatch, overwrite=_OMIT):
     kwargs = {} if overwrite is _OMIT else {"overwrite": overwrite}
     compiler.create_new_function(
         PROBE_NAME,
-        PROBE_SOURCE,
-        "torch",
+        source,
+        model_location,
         [],
         **kwargs,
     )
@@ -179,7 +185,7 @@ def test_a_stamp_that_predates_the_trl_entry_is_replaced(tmp_path, monkeypatch):
     assert len(_stamp_lines(path)) == 3
 
     monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
-    _emit(tmp_path, monkeypatch, overwrite=False)
+    _emit(tmp_path, monkeypatch)
 
     assert _stamp_lines(path)[3] == installed_trl
 
@@ -191,6 +197,96 @@ def test_a_first_run_with_no_cache_still_writes_the_file(tmp_path, monkeypatch):
 
     assert path.is_file()
     assert len(_stamp_lines(path)) == 4
+
+
+def test_a_trl_bump_leaves_a_non_trl_cache_alone(tmp_path, monkeypatch):
+    """A combined model module cannot go stale because TRL moved.
+
+    It is generated from transformers source and never imports trl, so
+    regenerating it here would destroy the hand edit for nothing.
+    """
+    path = _emit(tmp_path, monkeypatch, overwrite=True, model_location=NON_TRL_LOCATION)
+    marker = "# hand edited, do not clobber\n"
+    path.write_text(path.read_text() + marker)
+    _rewrite_trl_stamp(path, "0.0.1-stale")
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch, model_location=NON_TRL_LOCATION)
+
+    assert marker in path.read_text()
+    assert _stamp_lines(path)[3] == "0.0.1-stale"
+
+
+def test_a_transformers_bump_still_reaches_a_non_trl_cache(tmp_path, monkeypatch):
+    """The narrowing is for the TRL half only; transformers stays unconditional."""
+    path = _emit(tmp_path, monkeypatch, overwrite=True, model_location=NON_TRL_LOCATION)
+    installed_tf = _stamp_lines(path)[2]
+    _rewrite_stamp(path, 2, "0.0.1-stale")
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch, model_location=NON_TRL_LOCATION)
+
+    assert _stamp_lines(path)[2] == installed_tf
+
+
+def test_a_trl_body_is_invalidated_even_from_a_non_trl_location(tmp_path, monkeypatch):
+    """Backstop for a model_location that ever resolves outside trl.
+
+    Missing an invalidation is the expensive direction: the stale trainer fails
+    to import and Unsloth silently falls back to TRL's own untouched trainer.
+    Every generated trainer body carries the marker even if the path does not.
+    """
+    trl_body = 'def _unsloth_stamp_probe():\n    _tag_names = ["trl", "sft"]\n    return 1\n'
+    path = _emit(
+        tmp_path, monkeypatch, overwrite=True,
+        model_location="somewhere.else.weird_trainer", source=trl_body,
+    )
+    installed_trl = _stamp_lines(path)[3]
+    _rewrite_trl_stamp(path, "0.0.1-stale")
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(
+        tmp_path, monkeypatch,
+        model_location="somewhere.else.weird_trainer", source=trl_body,
+    )
+
+    assert _stamp_lines(path)[3] == installed_trl
+
+
+def test_a_relocated_experimental_trainer_is_still_invalidated(tmp_path, monkeypatch):
+    """TRL moves trainers to trl.experimental, and rl.py follows them there.
+
+    On trl 0.25.1 BCO already resolves to trl.experimental.bco.bco_trainer, so
+    the dependency signal keys on the top-level package rather than a
+    `trl.trainer.` prefix, which would skip exactly the trainers that moved.
+    """
+    location = "trl.experimental.bco.bco_trainer"
+    path = _emit(tmp_path, monkeypatch, overwrite=True, model_location=location)
+    installed_trl = _stamp_lines(path)[3]
+    _rewrite_trl_stamp(path, "0.0.1-stale")
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch, overwrite=False, model_location=location)
+
+    assert _stamp_lines(path)[3] == installed_trl
+
+
+def test_the_trl_marker_is_matched_as_a_whole_word(tmp_path, monkeypatch):
+    """`ctrl` in a body must not make a non-TRL cache look TRL-dependent."""
+    ctrl_body = 'def _unsloth_stamp_probe():\n    ctrl = 1  # ctrl, not trl\n    return ctrl\n'
+    path = _emit(
+        tmp_path, monkeypatch, overwrite=True,
+        model_location=NON_TRL_LOCATION, source=ctrl_body,
+    )
+    # The body comment above deliberately contains a real whole-word `trl`;
+    # strip it so only `ctrl` remains, which must not trip the backstop.
+    path.write_text(path.read_text().replace("# ctrl, not trl", "# ctrl only"))
+    _rewrite_trl_stamp(path, "0.0.1-stale")
+
+    monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "0")
+    _emit(tmp_path, monkeypatch, model_location=NON_TRL_LOCATION, source=ctrl_body)
+
+    assert _stamp_lines(path)[3] == "0.0.1-stale"
 
 
 if __name__ == "__main__":

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1282,6 +1282,17 @@ def create_new_function(
         # to TRL's own untouched trainer) or forwards arguments that TRL has
         # since retired. Checking transformers alone let a TRL 0.25 cache be
         # reused on TRL 1.9 and reinstated the very TypeError it was fixed for.
+        if file_source is None and os.path.isfile(function_location):
+            # Callers that leave overwrite at its default never took the read
+            # above, so without this the comparison below is dead code for them
+            # and the hatch pins whatever is on disk no matter which library
+            # moved. On a read failure we fall back to None, which lands on the
+            # same "leave it alone" branch as before.
+            try:
+                with open(function_location, "r", encoding="utf-8") as f:
+                    file_source = f.read()
+            except Exception:
+                file_source = None
         if file_source is not None and "__UNSLOTH_VERSIONING__" in file_source:
             cached_versions = file_source[:file_source.find("__UNSLOTH_VERSIONING__")]
             cached_lines = [l.strip() for l in cached_versions.strip().strip('"').split("\n") if l.strip()]

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1299,10 +1299,25 @@ def create_new_function(
             # Format: [unsloth_zoo_version, unsloth_version, transformers_version, trl_version]
             cached_tf_version = cached_lines[2] if len(cached_lines) > 2 else "0"
             cached_trl_version = cached_lines[3] if len(cached_lines) > 3 else "0"
+            # Only a cache generated from TRL can go stale when TRL moves. The
+            # combined model modules and the peft/torch forward patches come
+            # from transformers, peft and torch source and never import trl, so
+            # regenerating them on a TRL bump would only destroy the hand edit
+            # this escape hatch exists to protect. Deliberately over-inclusive,
+            # because a false positive costs one extra rewrite while a false
+            # negative silently keeps a broken trainer: model_location covers
+            # the normal path, including trl.experimental once TRL relocates a
+            # trainer, and the cached body is the backstop for a model_location
+            # that ever resolves outside trl, since every generated trainer
+            # carries both a `from trl` import and `_tag_names = ["trl", ...]`.
+            trl_dependent = (
+                str(model_location).split(".", 1)[0] == "trl"
+                or re.search(r"\btrl\b", file_source) is not None
+            )
             changed = []
             if cached_tf_version != transformers_version:
                 changed.append(f"transformers {cached_tf_version} -> {transformers_version}")
-            if cached_trl_version != trl_version:
+            if trl_dependent and cached_trl_version != trl_version:
                 changed.append(f"trl {cached_trl_version} -> {trl_version}")
             if changed:
                 logger.warning_once(

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1274,16 +1274,29 @@ def create_new_function(
                     overwrite = True
     pass
     if os.environ.get("UNSLOTH_COMPILE_OVERWRITE", "1") == "0":
-        # Even with OVERWRITE disabled, force recompile on transformers version mismatch
+        # Even with OVERWRITE disabled, force recompile on a library version
+        # mismatch. TRL counts as much as transformers here: the generated RL
+        # trainers mirror the installed TRL config signature and import symbols
+        # straight out of trl.trainer.<x>_trainer, so a cache built against a
+        # different TRL either fails to import (and Unsloth silently falls back
+        # to TRL's own untouched trainer) or forwards arguments that TRL has
+        # since retired. Checking transformers alone let a TRL 0.25 cache be
+        # reused on TRL 1.9 and reinstated the very TypeError it was fixed for.
         if file_source is not None and "__UNSLOTH_VERSIONING__" in file_source:
             cached_versions = file_source[:file_source.find("__UNSLOTH_VERSIONING__")]
             cached_lines = [l.strip() for l in cached_versions.strip().strip('"').split("\n") if l.strip()]
             # Format: [unsloth_zoo_version, unsloth_version, transformers_version, trl_version]
             cached_tf_version = cached_lines[2] if len(cached_lines) > 2 else "0"
+            cached_trl_version = cached_lines[3] if len(cached_lines) > 3 else "0"
+            changed = []
             if cached_tf_version != transformers_version:
+                changed.append(f"transformers {cached_tf_version} -> {transformers_version}")
+            if cached_trl_version != trl_version:
+                changed.append(f"trl {cached_trl_version} -> {trl_version}")
+            if changed:
                 logger.warning_once(
-                    f"Unsloth: UNSLOTH_COMPILE_OVERWRITE=0 is set, but transformers version changed "
-                    f"({cached_tf_version} -> {transformers_version}). Forcing recompile of {name}."
+                    f"Unsloth: UNSLOTH_COMPILE_OVERWRITE=0 is set, but "
+                    f"{' and '.join(changed)}. Forcing recompile of {name}."
                 )
                 # Don't set overwrite = False; keep overwrite = True from version mismatch detection
             else:


### PR DESCRIPTION
Companion to unslothai/unsloth#8330, but independent of it.

## The bug

`create_new_function` stamps every generated file with a four-part version header:

```
"""
2026.8.8      <- unsloth_zoo
2026.8.10     <- unsloth
4.57.6        <- transformers
0.25.1        <- trl
__UNSLOTH_VERSIONING__
"""
```

By default the whole payload is compared, so any version change regenerates the file. But under `UNSLOTH_COMPILE_OVERWRITE=0`, the escape hatch for iterating on a hand-edited cache, only index 2 is checked:

```python
cached_tf_version = cached_lines[2] if len(cached_lines) > 2 else "0"
if cached_tf_version != transformers_version:
```

The comment directly above it even names all four entries. TRL is written into the stamp and then never compared.

## Why TRL matters as much as transformers

The generated RL trainers mirror the installed TRL config signature and import symbols straight out of `trl.trainer.<x>_trainer`. A cache built against a different TRL is not merely stale, it is unloadable.

Observed directly: generate the cache under TRL 0.25.1, then run under TRL 1.9.2 with transformers unchanged at 4.57.6 and `UNSLOTH_COMPILE_OVERWRITE=0`. The stale file is reused, and:

```
Unsloth: Could not build the patched trl.trainer.grpo_trainer, so training will
use trl's own trainer instead: RuntimeError: Direct module loading failed for
UnslothGRPOTrainer: cannot import name 'AutoConfig' from 'trl.trainer.grpo_trainer'
```

Five trainers fell back that way in one run (grpo, kto, reward, rloo, sft). Unsloth then silently disables itself, and stock TRL raises the `TypeError` that unslothai/unsloth#8330 exists to absorb, because Unsloth's generated config is no longer in the call path to absorb it.

The user-visible result is a run that quietly loses all Unsloth patching, which is worse than a loud recompile.

## The fix

Compare the TRL entry too, and name whichever library moved:

```
Unsloth: UNSLOTH_COMPILE_OVERWRITE=0 is set, but trl 0.25.1 -> 1.9.2.
Forcing recompile of UnslothGRPOTrainer.
```

This does not weaken the escape hatch. When nothing has moved, a hand-edited cache is still left alone, which is the entire reason the hatch exists. The only new recompiles are the ones where the edit was made against a different TRL and would not have loaded anyway.

## Verification

Three new cases in `tests/test_compile_overwrite_trl_stamp.py`:

- a doctored TRL stamp forces a recompile with `UNSLOTH_COMPILE_OVERWRITE=0`
- an unchanged stamp still leaves a hand-edited cache untouched
- the warning names the library that moved

Against unmodified main, the first and third fail and the second passes, which is the intended split: the middle test is the counterweight guarding against over-invalidation, so it must pass both before and after.

Full CPU suite on this branch: **1 failed, 4401 passed, 267 skipped, 2 deselected**. The single failure is `tests/test_zoo_source_upstream_refs.py::test_logging_utils_utils_notebook`, which fails identically on unmodified main in this environment. `tests/test_upstream_pinned_symbols_trl_vllm.py` was excluded because it reads a hardcoded absolute path outside this checkout that is not readable here.