### PR TITLE
Route Muse Glimmer sliding layers through the banded O(S*w) SDPA kernel

### DIFF
--- a/tests/test_muse_glimmer_banded_attention.py
+++ b/tests/test_muse_glimmer_banded_attention.py
@@ -1,0 +1,299 @@
+"""Muse Glimmer sliding layers must route to the banded O(S*w) kernel, and only there.
+
+Muse Glimmer interleaves 39 sliding_attention layers (window 2048) with 13
+full_attention layers, and hands every sliding layer a dense [B, 1, S, S] band
+mask, so each one pays O(S^2) for a 2048 key window. The router in
+``muse_glimmer_banded_attention`` sends exactly those layers to the block-local
+kernel shared with gemma-4 and defers everything else.
+
+These run on CPU (float32, small shapes), so they are real CI coverage rather
+than GPU-only. They pin three things: the gate defers in every case it must,
+the engaged path matches a reference causal+sliding SDPA, and installing the
+router is idempotent across the three passes unsloth makes over
+TEMPORARY_PATCHES without breaking gemma-4's own re-entry guard.
+"""
+import pytest
+import torch
+import torch.nn.functional as F
+
+from unsloth_zoo.temporary_patches import muse_glimmer_banded_attention as mg
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+W = 16
+S_ON = mg._MIN_SEQ_MULTIPLE_OF_WINDOW * W          # first length that engages
+H, HKV, D = 4, 2, 8
+
+
+def _reference_band(q, k, v, w, scaling, ng):
+    """Full SDPA with the explicit causal+sliding band: what the model does today."""
+    B, Hq, S, d = q.shape
+    Hkv = k.shape[1]
+    if ng > 1:
+        k = k[:, :, None].expand(B, Hkv, ng, S, d).reshape(B, Hq, S, d)
+        v = v[:, :, None].expand(B, Hkv, ng, S, d).reshape(B, Hq, S, d)
+    idx = torch.arange(S, device=q.device)
+    allowed = (idx[None, :] <= idx[:, None]) & (idx[None, :] > idx[:, None] - w)
+    mask = torch.zeros(S, S, device=q.device, dtype=q.dtype).masked_fill(
+        ~allowed, float("-inf"))
+    out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask[None, None], scale=scaling)
+    return out.transpose(1, 2).contiguous()
+
+
+def _band_mask(S, w, device=DEVICE):
+    idx = torch.arange(S, device=device)
+    return ((idx[None, :] <= idx[:, None]) & (idx[None, :] > idx[:, None] - w))[None, None]
+
+
+class MuseGlimmerTextAttention:
+    """Stand-in carrying only the attributes the router gates on."""
+    is_causal = True
+    training = False
+
+    def __init__(self, w=W, ng=H // HKV, is_local_attention=True):
+        self.sliding_window = w
+        self.num_key_value_groups = ng
+        self.is_local_attention = is_local_attention
+
+
+class MuseGlimmerVisionAttention(MuseGlimmerTextAttention):
+    """Vision tower class name: must never be routed, whatever its flags say."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_router(monkeypatch):
+    """Every test drives the router directly, so give it a known wrapped sdpa and
+    a clean env. The env readers are lru_cache(1), so they need cache_clear()."""
+    monkeypatch.delenv("UNSLOTH_MUSE_GLIMMER_BANDED_SDPA", raising=False)
+    monkeypatch.delenv("UNSLOTH_MUSE_GLIMMER_BANDED_FORCE", raising=False)
+    mg._enabled.cache_clear()
+    mg._force_banded.cache_clear()
+    calls = []
+
+    def fake_sdpa(module, q, k, v, mask, dropout=0.0, scaling=None, is_causal=None, **kw):
+        calls.append({"module": module, "mask": mask, "is_causal": is_causal})
+        return "DEFERRED", None
+
+    prev = mg._ORIG_SDPA[0]
+    mg._ORIG_SDPA[0] = fake_sdpa
+    counters = (mg._ENGAGED[0], mg._BANDED_ENGAGED[0], mg._DEFERRED[0])
+    yield calls
+    mg._ORIG_SDPA[0] = prev
+    mg._ENGAGED[0], mg._BANDED_ENGAGED[0], mg._DEFERRED[0] = counters
+    mg._enabled.cache_clear()
+    mg._force_banded.cache_clear()
+
+
+def _qkv(S, dtype=torch.float32, seed=0):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    q = torch.randn(1, H, S, D, generator=g).to(DEVICE, dtype)
+    k = torch.randn(1, HKV, S, D, generator=g).to(DEVICE, dtype)
+    v = torch.randn(1, HKV, S, D, generator=g).to(DEVICE, dtype)
+    return q, k, v
+
+
+def _route(module, S, mask=None, is_causal=None, q=None, k=None, v=None, **kw):
+    if q is None:
+        q, k, v = _qkv(S)
+    return mg._sdpa_maybe_muse_glimmer_banded(
+        module, q, k, v, mask, dropout=0.0, scaling=D ** -0.5, is_causal=is_causal, **kw)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def test_registered_in_temporary_patches():
+    from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
+    assert mg.patch_muse_glimmer_banded_sliding_attention in TEMPORARY_PATCHES
+
+
+# ---------------------------------------------------------------------------
+# The gate must defer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("S", [W, 2 * W, 3 * W - 1])
+def test_defers_below_three_windows(_clean_router, S):
+    """Blocking into (w, 2w) tiles is a measured loss below 2w and break-even at
+    2w, so short-context finetunes must be left completely alone."""
+    out, weights = _route(MuseGlimmerTextAttention(), S)
+    assert out == "DEFERRED" and weights is None
+    assert len(_clean_router) == 1
+
+
+def test_defers_on_full_attention_layer(_clean_router):
+    out, _ = _route(MuseGlimmerTextAttention(is_local_attention=False), S_ON)
+    assert out == "DEFERRED"
+
+
+def test_defers_on_vision_attention(_clean_router):
+    out, _ = _route(MuseGlimmerVisionAttention(), S_ON)
+    assert out == "DEFERRED"
+
+
+def test_defers_on_foreign_module(_clean_router):
+    class LlamaAttention:
+        is_local_attention = True
+        is_causal = True
+        training = False
+        sliding_window = W
+        num_key_value_groups = H // HKV
+
+    out, _ = _route(LlamaAttention(), S_ON)
+    assert out == "DEFERRED"
+
+
+def test_defers_on_decode_step(_clean_router):
+    """Sq=1 against a long cache: the block kernel has no meaning there."""
+    g = torch.Generator(device="cpu").manual_seed(0)
+    q = torch.randn(1, H, 1, D, generator=g).to(DEVICE)
+    k = torch.randn(1, HKV, S_ON, D, generator=g).to(DEVICE)
+    v = torch.randn(1, HKV, S_ON, D, generator=g).to(DEVICE)
+    out, _ = _route(MuseGlimmerTextAttention(), S_ON, q=q, k=k, v=v)
+    assert out == "DEFERRED"
+
+
+def test_defers_on_padded_mask(_clean_router):
+    mask = _band_mask(S_ON, W).clone()
+    mask[..., :, S_ON // 2] = False                 # a padded key column
+    out, _ = _route(MuseGlimmerTextAttention(), S_ON, mask=mask)
+    assert out == "DEFERRED"
+
+
+def test_defers_on_per_head_mask(_clean_router):
+    mask = _band_mask(S_ON, W).expand(1, H, S_ON, S_ON).clone()
+    out, _ = _route(MuseGlimmerTextAttention(), S_ON, mask=mask)
+    assert out == "DEFERRED"
+
+
+def test_defers_on_bidirectional_call_without_mask(_clean_router):
+    out, _ = _route(MuseGlimmerTextAttention(), S_ON, mask=None, is_causal=False)
+    assert out == "DEFERRED"
+
+
+def test_defers_when_training_dropout_is_active(_clean_router):
+    module = MuseGlimmerTextAttention()
+    module.training = True
+    q, k, v = _qkv(S_ON)
+    out, _ = mg._sdpa_maybe_muse_glimmer_banded(
+        module, q, k, v, None, dropout=0.1, scaling=D ** -0.5, is_causal=None)
+    assert out == "DEFERRED"
+
+
+def test_env_off_defers_everywhere(_clean_router, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_MUSE_GLIMMER_BANDED_SDPA", "0")
+    mg._enabled.cache_clear()
+    out, _ = _route(MuseGlimmerTextAttention(), S_ON)
+    assert out == "DEFERRED"
+
+
+# ---------------------------------------------------------------------------
+# The gate must engage, and match the reference
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("with_mask", [False, True])
+def test_engages_and_matches_reference(_clean_router, with_mask):
+    S = S_ON
+    q, k, v = _qkv(S)
+    mask = _band_mask(S, W) if with_mask else None
+    before = mg._BANDED_ENGAGED[0]
+    out, weights = _route(MuseGlimmerTextAttention(), S, mask=mask, q=q, k=k, v=v)
+    assert not _clean_router, "router deferred instead of engaging"
+    assert weights is None
+    assert mg._BANDED_ENGAGED[0] == before + 1
+    ref = _reference_band(q, k, v, W, D ** -0.5, H // HKV)
+    assert out.shape == ref.shape
+    rel = (out - ref).norm() / ref.norm().clamp_min(1e-9)
+    assert rel < 1e-5, f"forward rel {rel:.2e}"
+
+
+def test_backward_matches_reference(_clean_router):
+    S = S_ON
+    q, k, v = _qkv(S)
+    q_r, k_r, v_r = (t.clone().requires_grad_(True) for t in (q, k, v))
+    q_b, k_b, v_b = (t.clone().requires_grad_(True) for t in (q, k, v))
+    ref = _reference_band(q_r, k_r, v_r, W, D ** -0.5, H // HKV)
+    out, _ = _route(MuseGlimmerTextAttention(), S, q=q_b, k=k_b, v=v_b)
+    g = torch.randn_like(ref)
+    (ref * g).sum().backward()
+    (out * g).sum().backward()
+    for name, a, b in (("dq", q_r.grad, q_b.grad),
+                       ("dk", k_r.grad, k_b.grad),
+                       ("dv", v_r.grad, v_b.grad)):
+        rel = (a - b).norm() / a.norm().clamp_min(1e-9)
+        assert rel < 1e-5, f"{name} rel {rel:.2e}"
+
+
+def test_banded_engages_when_sliding_window_comes_from_kwargs(_clean_router):
+    module = MuseGlimmerTextAttention()
+    module.sliding_window = None
+    before = mg._BANDED_ENGAGED[0]
+    _route(module, S_ON, sliding_window=W)
+    assert mg._BANDED_ENGAGED[0] == before + 1
+
+
+# ---------------------------------------------------------------------------
+# Installation is idempotent, and does not break gemma-4's re-entry guard
+# ---------------------------------------------------------------------------
+
+def _sdpa_registry():
+    modeling_utils = pytest.importorskip("transformers.modeling_utils")
+    return modeling_utils.ALL_ATTENTION_FUNCTIONS
+
+
+def test_patch_is_idempotent():
+    """unsloth applies TEMPORARY_PATCHES three times per process (init,
+    pre_compile, post_compile), so a second install must not stack a wrapper."""
+    registry = _sdpa_registry()
+    original = registry["sdpa"]
+    prev_box = mg._ORIG_SDPA[0]
+
+    # Importing unsloth already ran TEMPORARY_PATCHES, so start from a known
+    # plain entry rather than from whatever is installed in this process.
+    def plain_sdpa(module, q, k, v, mask, **kw):
+        return "PLAIN", None
+
+    try:
+        registry["sdpa"] = plain_sdpa
+        mg.patch_muse_glimmer_banded_sliding_attention()
+        installed = registry["sdpa"]
+        assert installed is not plain_sdpa
+        mg.patch_muse_glimmer_banded_sliding_attention()
+        assert registry["sdpa"] is installed
+        assert mg._ORIG_SDPA[0] is plain_sdpa
+    finally:
+        registry["sdpa"] = original
+        mg._ORIG_SDPA[0] = prev_box
+
+
+def test_patch_preserves_wrapped_router_sentinels():
+    """gemma-4's router re-entry guard reads its sentinel off the installed sdpa
+    entry only. Once this router wraps it, that sentinel must still be visible,
+    otherwise gemma-4 would wrap itself again on the next pass."""
+    registry = _sdpa_registry()
+    original = registry["sdpa"]
+    prev_box = mg._ORIG_SDPA[0]
+
+    def gemma4_like(module, q, k, v, mask, **kw):
+        return "GEMMA4", None
+
+    gemma4_like._unsloth_gemma4_flash = True
+    try:
+        registry["sdpa"] = gemma4_like
+        mg.patch_muse_glimmer_banded_sliding_attention()
+        installed = registry["sdpa"]
+        assert installed is not gemma4_like
+        assert getattr(installed, "_unsloth_gemma4_flash", False) is True
+        assert getattr(installed, "_unsloth_muse_glimmer_banded", False) is True
+        mg.unpatch_muse_glimmer_banded_sliding_attention()
+        assert registry["sdpa"] is gemma4_like
+    finally:
+        registry["sdpa"] = original
+        mg._ORIG_SDPA[0] = prev_box
+        # The sentinel was forwarded onto the module-level wrapper; drop it again
+        # so it cannot leak into any later test.
+        vars(mg._sdpa_maybe_muse_glimmer_banded).pop("_unsloth_gemma4_flash", None)
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -52,6 +52,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.ministral",
     "unsloth_zoo.temporary_patches.amd_aiter",
     "unsloth_zoo.temporary_patches.misc",
+    "unsloth_zoo.temporary_patches.muse_glimmer_banded_attention",
     "unsloth_zoo.temporary_patches.mixtral_moe",
     "unsloth_zoo.temporary_patches.moe_bnb",
     "unsloth_zoo.temporary_patches.moe_grouped_modulelist",

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -24,6 +24,7 @@ from .gemma4 import *
 from .gemma4_float32 import *
 from .gemma4_banded_attention import *
 from .gemma4_flash_sliding import *
+from .muse_glimmer_banded_attention import *
 from .gpt_oss import *
 from .qwen3_moe import *
 from .qwen3_moe_float32 import *

--- a/unsloth_zoo/temporary_patches/muse_glimmer_banded_attention.py
+++ b/unsloth_zoo/temporary_patches/muse_glimmer_banded_attention.py
@@ -1,0 +1,258 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ============================================================================
+# Fast sliding-window attention router for Muse Glimmer.
+#
+# Muse Glimmer interleaves 39 sliding_attention layers (window 2048) with 13
+# full_attention layers. It runs `sdpa`, and every sliding layer is handed a
+# dense [B, 1, S, S] boolean mask that is exactly the causal + sliding band, so
+# each of those layers pays O(S^2) in compute and mask traffic even though only
+# a 2048 key window is ever read.
+#
+# This routes just those layers through the block-local O(S*w) kernel that
+# already ships for gemma-4 (`_banded_sdpa_core`), reusing its band probe
+# (`_mask_is_plain_band`) so the engage / defer decision is provably the same
+# one gemma-4 makes. The full-attention layers, the vision tower, decode steps
+# (Sq != Sk), padded or packed batches (the probe rejects them) and every
+# non-Muse-Glimmer module defer untouched to the original SDPA.
+#
+# Why a separate router rather than reusing gemma4_flash_sliding: Muse Glimmer
+# exposes the sliding flag as `is_local_attention`, and gemma-4's router gates on
+# `is_sliding`, which Muse Glimmer never defines. That router is therefore a
+# strict no-op here. Only the routing differs; the kernel and the band probe are
+# shared.
+#
+# Scope, stated plainly: this only helps long context. Blocking into (w, 2w)
+# tiles is a loss below 2x the window and roughly break-even at 2x, so the gate
+# below turns it on only from 3x the window up (S >= 6144 at a 2048 window).
+# A 1024, 2048 or 4096 token finetune is deliberately untouched.
+#
+# On by default. UNSLOTH_MUSE_GLIMMER_BANDED_SDPA=0 reverts to plain SDPA.
+# FlashAttention-2's window kernel is preferred when flash-attn happens to be
+# importable, but it is not a dependency: the pure-SDPA banded path is what runs
+# on a stock install.
+# ============================================================================
+
+import os
+import functools
+import torch
+from .common import TEMPORARY_PATCHES, logger
+from .utils import raise_error
+from .gemma4_banded_attention import _banded_sdpa_core, _mask_is_plain_band
+
+__all__ = ["patch_muse_glimmer_banded_sliding_attention"]
+
+try:
+    from flash_attn import flash_attn_func as _flash_attn_func
+    _HAS_FA2 = True
+except Exception:
+    _flash_attn_func = None
+    _HAS_FA2 = False
+
+_ORIG_SDPA = [None]      # boxed reference to the wrapped sdpa function
+_ENGAGED = [0]           # count of FA2-path invocations (debug)
+_BANDED_ENGAGED = [0]    # count of banded-path invocations (debug)
+_DEFERRED = [0]          # count of sliding calls that fell through (debug)
+
+# Engage only from this multiple of the window upward. Measured on B200 at Muse
+# Glimmer's shapes (32 / 2 heads, head_dim 128, w = 2048, bf16), the banded
+# kernel against the real sdpa_attention_forward, forward plus backward:
+#     S = 1w  0.60x    S = 1.5w 0.43x    S = 2w  0.72x    S = 3w  1.12x
+#     S = 4w  1.43x    S = 6w   2.10x    S = 8w  2.85x    S = 16w 5.74x
+# Below 2w the band already covers nearly the whole causal triangle, so blocking
+# into (w, 2w) tiles costs about 2x the FLOPs of the plain causal kernel and the
+# patch would be a slowdown. 3w is the first length with a clear win, so that is
+# where it turns on, and nothing below it is touched.
+_MIN_SEQ_MULTIPLE_OF_WINDOW = 3
+
+
+def muse_glimmer_banded_stats():
+    """Engagement counters, for tests and benchmarks."""
+    return {
+        "fa2"      : _ENGAGED[0],
+        "banded"   : _BANDED_ENGAGED[0],
+        "deferred" : _DEFERRED[0],
+        "has_fa2"  : _HAS_FA2,
+    }
+
+
+@functools.lru_cache(maxsize=1)
+def _enabled():
+    """Whether the Muse Glimmer sliding-window fast router is active.
+
+    On by default. The pure-SDPA banded kernel works on every dtype and GPU, so
+    this must NOT be gated on flash-attn being importable: that would wrongly
+    disable the fallback that most installs actually run. Set
+    UNSLOTH_MUSE_GLIMMER_BANDED_SDPA=0 to revert to plain SDPA.
+
+    Cached with maxsize=1 since the env var is read once per process. Any code or
+    test that toggles UNSLOTH_MUSE_GLIMMER_BANDED_SDPA at runtime must call
+    _enabled.cache_clear() afterwards for the change to take effect.
+    """
+    return os.environ.get("UNSLOTH_MUSE_GLIMMER_BANDED_SDPA", "1") != "0"
+
+
+@functools.lru_cache(maxsize=1)
+def _force_banded():
+    """Optional override: force the pure-SDPA banded kernel even when flash-attn
+    is importable. The router already prefers FA2 automatically, so this is only
+    for benchmarking the two kernels against each other; off by default.
+
+    Cached with maxsize=1 since the env var is read once per process. Any code or
+    test that toggles UNSLOTH_MUSE_GLIMMER_BANDED_FORCE at runtime must call
+    _force_banded.cache_clear() afterwards for the change to take effect.
+    """
+    return os.environ.get("UNSLOTH_MUSE_GLIMMER_BANDED_FORCE", "0") == "1"
+
+
+def _is_muse_glimmer_sliding_module(module):
+    """Strict gate: a Muse Glimmer text attention layer that is actually sliding.
+
+    Name-prefixed rather than isinstance-checked because Unsloth's compiler
+    regenerates MuseGlimmerTextAttention into unsloth_compiled_cache, so the
+    class the model really runs is not the one importable from transformers.
+    The vision tower is a separate MuseGlimmerVisionAttention, so the
+    MuseGlimmerText prefix excludes it by construction.
+    """
+    if not getattr(module, "is_local_attention", False): return False
+    cls = type(module).__name__
+    return cls.startswith("MuseGlimmerText") and cls.endswith("Attention")
+
+
+def _sdpa_maybe_muse_glimmer_banded(module, query, key, value, attention_mask,
+                                    dropout=0.0, scaling=None, is_causal=None, **kwargs):
+    # Shared layer + band gate for both fast kernels (no _HAS_FA2 / dtype clause
+    # here, so the banded fallback is reachable without flash-attn).
+    if (_enabled()
+            and _is_muse_glimmer_sliding_module(module)
+            and query.dim() == 4):
+        w = kwargs.get("sliding_window", None) or getattr(module, "sliding_window", None)
+        Sq = query.shape[2]
+        Sk = key.shape[2]
+        # Mirror SDPA's derivation. With no explicit mask, only a causal module
+        # may take the causal window; a bidirectional call (is_causal False) must
+        # stay bidirectional instead of being forced causal.
+        causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
+        # Dropout is deliberately excluded rather than forwarded: the block-local
+        # kernel draws its mask over (w, 2w) tiles, so its RNG stream cannot match
+        # full SDPA's. Muse Glimmer's attention_dropout is 0.0, so this only ever
+        # defers a configuration that was never comparable anyway.
+        active_dropout = dropout if getattr(module, "training", False) else 0.0
+        if (w and Sq == Sk and Sq >= _MIN_SEQ_MULTIPLE_OF_WINDOW * w
+                and active_dropout == 0.0
+                and (attention_mask is not None or causal)
+                and _mask_is_plain_band(attention_mask, Sq, w)):
+            # Prefer FlashAttention-2's window kernel when importable and the dtype
+            # and head_dim are supported; otherwise fall to the pure-SDPA banded
+            # kernel so the O(S*w) speedup is automatic with or without flash-attn.
+            # A runtime FA2 failure (unsupported GPU / build, CPU tensors) falls to
+            # the banded kernel too, so it is not skipped, and only then to the
+            # original SDPA.
+            use_fa2 = (_HAS_FA2 and not _force_banded()
+                       and query.shape[-1] <= 256
+                       and query.dtype in (torch.float16, torch.bfloat16))
+            if use_fa2:
+                try:
+                    # flash_attn_func wants (B, S, H, D); a causal window of w keys
+                    # is window_size=(w-1, 0). FA2 handles GQA (H q, Hkv kv heads).
+                    out = _flash_attn_func(
+                        query.transpose(1, 2),
+                        key.transpose(1, 2),
+                        value.transpose(1, 2),
+                        dropout_p=0.0,
+                        softmax_scale=scaling,
+                        causal=True,
+                        window_size=(w - 1, 0),
+                    )
+                    _ENGAGED[0] += 1
+                    if _ENGAGED[0] == 1:
+                        logger.info_once(
+                            f"Unsloth: FlashAttention-2 sliding window engaged for "
+                            f"Muse Glimmer (window={w})."
+                        )
+                    return out, None                      # (B, S, H, D), no weights
+                except Exception as e:
+                    logger.warning_once(
+                        f"Unsloth: Muse Glimmer FA2 sliding fell back to banded SDPA ({e})")
+            # Reached when FA2 is not used or its attempt failed: try the pure-SDPA
+            # block-local kernel before deferring to the original SDPA.
+            try:
+                # ng folds the kv heads up to the q heads exactly as SDPA's GQA
+                # expansion does (Muse Glimmer is 32 / 2, so ng = 16).
+                ng = getattr(module, "num_key_value_groups", query.shape[1] // key.shape[1])
+                out = _banded_sdpa_core(query, key, value, w, scaling, 0.0, ng)
+                _BANDED_ENGAGED[0] += 1
+                if _BANDED_ENGAGED[0] == 1:
+                    logger.info_once(
+                        f"Unsloth: banded sliding SDPA engaged for Muse Glimmer "
+                        f"(window={w})."
+                    )
+                return out, None                      # (B, S, H, D), no weights
+            except Exception as e:
+                logger.warning_once(
+                    f"Unsloth: Muse Glimmer banded sliding fell back to SDPA ({e})")
+        _DEFERRED[0] += 1
+    return _ORIG_SDPA[0](module, query, key, value, attention_mask,
+                         dropout=dropout, scaling=scaling, is_causal=is_causal, **kwargs)
+
+
+def patch_muse_glimmer_banded_sliding_attention():
+    try:
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    except Exception as e:
+        raise_error("transformers.modeling_utils.ALL_ATTENTION_FUNCTIONS", e)
+        return
+    try:
+        current = ALL_ATTENTION_FUNCTIONS["sdpa"]
+    except Exception as e:
+        raise_error("ALL_ATTENTION_FUNCTIONS['sdpa']", e)
+        return
+    if getattr(current, "_unsloth_muse_glimmer_banded", False):
+        return
+    # Wraps whatever is currently installed, so chaining behind gemma-4's router
+    # is safe: a non-Muse-Glimmer module falls straight through to it.
+    _ORIG_SDPA[0] = current
+    # unsloth runs TEMPORARY_PATCHES three times (init, pre_compile, post_compile),
+    # and every sdpa router here guards re-entry by reading one sentinel attribute
+    # off the *installed* entry only. Once this wrapper sits on top, the wrapped
+    # router would no longer see its own sentinel and would wrap a second time on
+    # the next pass, so forward the sentinels of the function we wrap. Idempotency
+    # is then preserved for the whole chain, not just for this router.
+    try:
+        for name, value in vars(current).items():
+            if name.startswith("_unsloth_"):
+                setattr(_sdpa_maybe_muse_glimmer_banded, name, value)
+    except Exception:
+        pass
+    _sdpa_maybe_muse_glimmer_banded._unsloth_muse_glimmer_banded = True
+    # Direct assignment: AttentionInterface.register() does not update the
+    # global mapping that layers read via ALL_ATTENTION_FUNCTIONS["sdpa"].
+    ALL_ATTENTION_FUNCTIONS["sdpa"] = _sdpa_maybe_muse_glimmer_banded
+
+
+def unpatch_muse_glimmer_banded_sliding_attention():
+    """Restore the sdpa entry this router wrapped. For A/B benchmarking and tests."""
+    try:
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    except Exception:
+        return
+    current = ALL_ATTENTION_FUNCTIONS.get("sdpa", None)
+    if getattr(current, "_unsloth_muse_glimmer_banded", False) and _ORIG_SDPA[0] is not None:
+        ALL_ATTENTION_FUNCTIONS["sdpa"] = _ORIG_SDPA[0]
+
+
+TEMPORARY_PATCHES.append(patch_muse_glimmer_banded_sliding_attention)


### PR DESCRIPTION
## What this does

Muse Glimmer interleaves **39 `sliding_attention` layers** (window 2048) with 13 `full_attention` layers. It runs `sdpa`, and every sliding layer is handed a dense `[B, 1, S, S]` boolean mask that is exactly the causal + sliding band. So each of those 39 layers pays **O(S^2)** in compute and mask traffic even though only a 2048 key window is ever read.

This adds a router that sends exactly those layers to the block-local **O(S*w)** kernel that already ships for gemma-4 (`_banded_sdpa_core`), reusing its band probe (`_mask_is_plain_band`) so the engage/defer decision is provably the same one gemma-4 makes. FlashAttention-2's window kernel is preferred when `flash-attn` happens to be importable, but it is not a dependency: the pure-SDPA banded path is what runs on a stock install, and that is what every number below was measured with.

Everything else defers untouched: the 13 full-attention layers, the vision tower, decode steps (`Sq != Sk`), padded or packed batches (the probe rejects them), bidirectional calls, active dropout, and every non-Muse-Glimmer module.

## Why a separate router instead of reusing `gemma4_flash_sliding`

gemma-4's router gates on `module.is_sliding`. Muse Glimmer never defines that attribute: it exposes the flag as `is_local_attention` (`MuseGlimmerTextAttention.is_local_attention = config.layer_types[layer_idx] == "sliding_attention"`). So `gemma4_flash_sliding` is a **strict no-op** on this model today. The module gate here is `is_local_attention` plus a `MuseGlimmerText*Attention` class-name check, which excludes the separate `MuseGlimmerVisionAttention` tower by construction. The name check is used rather than `isinstance` because Unsloth's compiler regenerates the class into `unsloth_compiled_cache`.

Only the routing differs. The kernel and the band probe are shared with gemma-4, unchanged.

## The gate

Below 2x the window the band already covers nearly the whole causal triangle, so blocking into `(w, 2w)` tiles costs about 2x the FLOPs of the plain causal kernel and the patch would be a slowdown. Isolated kernel timing at Muse Glimmer's attention shapes (32/2 heads, head_dim 128, w=2048, bf16, B200, forward plus backward), banded against transformers' real `sdpa_attention_forward` with the dense band mask the model actually builds:

| S | multiple of window | dense (ms) | banded (ms) | speedup |
|---|---|---|---|---|
| 2048 | 1w | 0.816 | 1.365 | 0.60x |
| 3072 | 1.5w | 1.119 | 2.624 | 0.43x |
| 4096 | 2w | 1.742 | 2.424 | 0.72x |
| 6144 | 3w | 3.889 | 3.481 | **1.12x** |
| 8192 | 4w | 6.359 | 4.452 | 1.43x |
| 12288 | 6w | 13.782 | 6.564 | 2.10x |
| 16384 | 8w | 24.150 | 8.467 | 2.85x |
| 32768 | 16w | 95.840 | 16.698 | 5.74x |

Crossover sits between 4096 and 6144, so the gate is `S >= 3 * sliding_window`, i.e. **S >= 6144**. Below that it is a strict no-op, so 1k / 2k / 4k finetunes are deliberately untouched.

## Measured end to end

Real model, `unsloth/Muse-Glimmer-30B-unsloth-bnb-4bit`, LoRA, bsz 1, single B200, transformers 5.15.0.dev0, torch 2.13.0+cu130, no flash-attn (so this is the pure-SDPA banded path). Median of the timed steps, patch off vs patch on in the same process:

| S | engagements/step | tok/s off | tok/s on | speedup | peak GiB off | peak GiB on |
|---|---|---|---|---|---|---|
| 2048 | 0 | 3542.1 | 3581.2 | 1.011 (gate off, noise) | 24.436 | 24.436 |
| 4096 | 0 | 4623.4 | 4624.3 | 1.000 (gate off) | 27.721 | 27.721 |
| **6144** | 78 | 4446.9 | 4536.0 | **1.020** | 26.421 | 26.421 |
| 8192 | 78 | 4395.4 | 4656.0 | **1.059** | 28.227 | 28.227 |
| 16384 | 78 | 3672.7 | 4532.4 | **1.234** | 35.546 | 35.546 |

78 engagements per step is 39 sliding layers x 2 (forward pass of the fwd+bwd step), so every sliding layer routes and none of the 13 full-attention layers does.

**6144 is the point where the gate turns on, and it is a small win end to end (1.02x), not a regression.** That is why the gate stays at `3 * sliding_window` rather than being raised to 4x.

At 2048 and 4096 the engagement count is zero, so the 1.011 and 1.000 are pure run-to-run noise, not an effect of the patch.

Because 1.02x is small, 4096 / 6144 / 8192 were re-measured from scratch in a separate process on a different GPU with 9 timed rounds instead of 5. They reproduced at 1.001x (gate off), **1.021x** and 1.061x, so the 6144 win is small but repeatable rather than noise.

## Caveats, stated up front

- **The kernel is exact standalone.** Against a reference causal+sliding SDPA at S=8192 the forward is **bitwise identical** in both fp32 and bf16 (max abs diff 0.0), and the backward is dq/dk/dv cosine `>= 0.9999944` in bf16, `>= 0.99999999999` in fp32. Same at S=16384.
- **No claim of end-to-end bit equivalence.** Over the whole model, comparing every trainable gradient: loss is bitwise equal at every length tested, logits are bitwise identical, and the concatenated gradient cosine is 0.9999863 (2048, gate off), 0.9999913 (4096, gate off), 0.9999926 (6144), 0.9999929 (8192), 0.9999881 (16384). The gate-off control, which is the same configuration compared against itself twice, sits at 0.9999858 to 0.9999934 over the same lengths, so the patched-vs-unpatched difference is at the level of the run-to-run nondeterminism floor rather than above it. Read that as bf16 accumulation over 39 sliding layers, not as a proof of equality.
- **Peak memory is unchanged**, identical to the megabyte at every length. The model still materialises the dense `[B, 1, S, S]` mask before the attention call, so the win here is compute, not memory. Removing the dense mask is a separate change.
- Under `torch.compile` the band probe defers (its verdict drives Python control flow via `.item()`), so compiled graphs are untouched.

## How to disable

```
UNSLOTH_MUSE_GLIMMER_BANDED_SDPA=0
```

`UNSLOTH_MUSE_GLIMMER_BANDED_FORCE=1` forces the pure-SDPA banded kernel even where flash-attn is importable, for benchmarking the two kernels against each other.

## Tests

New `tests/test_muse_glimmer_banded_attention.py`, 19 tests, CPU-only in float32 at small shapes so it is real CI coverage rather than GPU-only. It pins the registration, every case the gate must defer (below 3w, full-attention layer, vision tower, foreign module, decode step, padded mask, per-head mask, bidirectional call, active dropout, env var off), the engaged path against a reference causal+sliding SDPA forward and backward, and idempotency across the three passes Unsloth makes over `TEMPORARY_PATCHES`.

That last one is worth calling out: each sdpa router guards re-entry by reading one sentinel attribute off the *installed* entry. Once this router wraps gemma-4's, gemma-4 would no longer see its own sentinel and would wrap a second time on the next pass, so this router forwards the `_unsloth_*` sentinels of whatever it wraps. Idempotency then holds for the whole chain, not just for this router. gemma-4's own behaviour is unchanged.

`tests/test_temporary_patches_imports.py` gets the new submodule added to its explicit list, as its docstring requires.

Full run on this branch: 76 passed / 1 skipped for the new test plus the imports and both gemma-4 suites, and 102 passed / 14 skipped for `tests/test_temporary_patches_exhaustive.py`.
