### PR TITLE
Trace the Gemma4 merge dtype structurally instead of by substring

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -351,15 +351,12 @@ jobs:
         # means real upstream drift (transformers/trl/peft/vllm/datasets renamed
         # or removed a symbol zoo references). Zoo PRs #4 through #635 mined.
         #
-        # test_gemma4_dtype_drift_guards belongs to this job, not to the CPU one:
-        # its real-source canaries read the INSTALLED transformers gemma4 module
-        # and only mean something against a moving transformers pin. This matrix
-        # is the only place that supplies one. They skip cleanly on the HF=4.57.6
-        # cell (no gemma4 before transformers 5.5.0) and execute on the HF>=5 and
-        # pyproject cells. Until now no job executed the file at all -- the
-        # `pytest tests/ --collect-only` step proves only that it imports, and is
-        # continue-on-error besides -- so a drift that made the audio patch
-        # silently no-op would have reached main green.
+        # test_gemma4_dtype_drift_guards belongs here, not to the CPU job: its
+        # real-source canaries read the INSTALLED transformers gemma4 module and
+        # only mean something against a moving pin, which this matrix alone
+        # supplies. They skip on the HF=4.57.6 cell (no gemma4 before transformers
+        # 5.5.0). Until now no job executed the file at all -- `--collect-only`
+        # proves only that it imports, and is continue-on-error besides.
         run: |
           python -m pytest -v --tb=short -rs \
             tests/test_upstream_pinned_symbols_transformers.py \

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -350,6 +350,16 @@ jobs:
         # 626 drift-detector tests / cell across 12 files. HARD GATE: a red cell
         # means real upstream drift (transformers/trl/peft/vllm/datasets renamed
         # or removed a symbol zoo references). Zoo PRs #4 through #635 mined.
+        #
+        # test_gemma4_dtype_drift_guards belongs to this job, not to the CPU one:
+        # its real-source canaries read the INSTALLED transformers gemma4 module
+        # and only mean something against a moving transformers pin. This matrix
+        # is the only place that supplies one. They skip cleanly on the HF=4.57.6
+        # cell (no gemma4 before transformers 5.5.0) and execute on the HF>=5 and
+        # pyproject cells. Until now no job executed the file at all -- the
+        # `pytest tests/ --collect-only` step proves only that it imports, and is
+        # continue-on-error besides -- so a drift that made the audio patch
+        # silently no-op would have reached main green.
         run: |
           python -m pytest -v --tb=short -rs \
             tests/test_upstream_pinned_symbols_transformers.py \
@@ -369,7 +379,8 @@ jobs:
             tests/test_peft_paramwrapper_layout_drift.py \
             tests/test_transformers_moe_structure_drift.py \
             tests/test_moe_merge_e2e_cpu.py \
-            tests/test_merge_e2e_hub_unreachable.py
+            tests/test_merge_e2e_hub_unreachable.py \
+            tests/test_gemma4_dtype_drift_guards.py
 
   # The MLX VLM/shape/batching suites on Linux CPU MLX: mlx ships manylinux CPU
   # wheels and mlx-lm/mlx-vlm are py3-none-any, so these cost no macOS minutes.

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -713,6 +713,35 @@ def _dominating_alignment(forward, feature, merge_arg):
 
 _MERGE_METHODS = ("masked_scatter", "masked_scatter_")
 
+# Attributes / methods that read a tensor's METADATA rather than its values.
+# `fallback.to(image_features.device, inputs_embeds.dtype)` mentions
+# `image_features` but scatters none of it.
+_METADATA_ATTRS = frozenset({
+    "device", "dtype", "shape", "ndim", "size", "numel", "layout",
+    "requires_grad", "is_cuda", "element_size", "itemsize", "stride",
+})
+
+
+def _carries_feature_value(node, feature):
+    """Do `<feature>`'s VALUES flow into `node`?
+
+    A merge is discovered by "the source argument uses the feature", and a bare
+    name-occurrence check answers that with `image_features.device` too. That
+    reads the feature's metadata and scatters something else entirely, so a
+    source spelled `fallback.to(image_features.device, inputs_embeds.dtype)`
+    would be reported as the image merge - and if the real merge were ever
+    dropped, `_merge_dtype_alignment` would return `(True, True)` on a source in
+    which no image value reaches the model at all. A metadata expression
+    contributes no values, so the whole subtree under it is skipped; everything
+    else still counts, which keeps
+    `image_features.to(...).reshape(-1, image_features.shape[-1])` a merge.
+    """
+    if isinstance(node, ast.Attribute) and node.attr in _METADATA_ATTRS:
+        return False
+    if isinstance(node, ast.Name):
+        return node.id == feature
+    return any(_carries_feature_value(child, feature) for child in ast.iter_child_nodes(node))
+
 
 def _feature_merges(forward, feature):
     """Every `inputs_embeds.masked_scatter[_](mask, ...)` call using `<feature>`.
@@ -727,6 +756,11 @@ def _feature_merges(forward, feature):
     is then decided by `_receiver_preserves_embeds_dtype`. Dropping unrecognised
     receivers here instead would let a second, safe merge hide a dtype-changing
     one.
+
+    The SOURCE, by contrast, has to carry the feature's values: a merge that only
+    reads `<feature>.device` or `<feature>.dtype` scatters something else, and
+    counting it would let a metadata mention stand in for a merge that upstream
+    has removed.
 
     The in-place spelling is accepted too (transformers writes
     `masked_scatter_` in qwen2_5_omni and blt): it merges into the same storage
@@ -749,9 +783,7 @@ def _feature_merges(forward, feature):
             for n in ast.walk(node.func.value)
         ):
             continue
-        if any(
-            isinstance(n, ast.Name) and n.id == feature for n in ast.walk(node.args[1])
-        ):
+        if _carries_feature_value(node.args[1], feature):
             calls.append(node)
     return sorted(calls, key=lambda n: (n.lineno, n.col_offset))
 
@@ -1425,6 +1457,73 @@ def test_used_merge_results_still_count_as_alignment(label, merge):
         _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
     )
     assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
+
+
+# ---------------------------------------------------------------------------
+# Merge DISCOVERY keys on the feature's values reaching the scatter source. A
+# source that only reads `<feature>.device` / `.dtype` / `.shape` merges some
+# other tensor, so accepting it would let a metadata mention impersonate a merge
+# upstream had deleted: `_merge_dtype_alignment` would report (True, True) on a
+# source in which no image value reaches the model.
+# ---------------------------------------------------------------------------
+_METADATA_ONLY_MERGES = [
+    ("source reads the feature device only",
+     "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, fallback.to(image_features.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("source reads the feature dtype only",
+     "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, fallback.to(inputs_embeds.device, image_features.dtype)\n"
+     ")"),
+    ("source reads the feature shape only",
+     "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, fallback.reshape(-1, image_features.shape[-1])\n"
+     ")"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,merge", _METADATA_ONLY_MERGES, ids = [c[0] for c in _METADATA_ONLY_MERGES],
+)
+def test_a_metadata_only_reference_is_not_a_feature_merge(label, merge):
+    found, _ = _merge_dtype_alignment(
+        _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
+    )
+    assert not found, (
+        f"{label}: the tracer counted a scatter that merely READS "
+        f"`image_features` metadata as the image merge. With the real merge gone "
+        f"this reports the modality present and aligned while no image value "
+        f"reaches the model."
+    )
+
+
+_VALUE_FLOW_CONTROLS = [
+    ("value and metadata in the same source",
+     "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype).reshape(\n"
+     "        -1, image_features.shape[-1])\n"
+     ")"),
+    ("value inside a concatenation",
+     "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, torch.cat([image_features, extra]).to(\n"
+     "        inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("value through a subscript",
+     "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features[0].to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,merge", _VALUE_FLOW_CONTROLS, ids = [c[0] for c in _VALUE_FLOW_CONTROLS],
+)
+def test_feature_values_reaching_the_source_are_still_a_merge(label, merge):
+    # Controls: dropping any of these would blind the canaries to a real merge.
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
+    )
+    assert found and aligned, f"{label}: a real feature merge was not discovered"
 
 
 def test_in_place_merge_with_an_unaligned_source_is_still_traced():

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -285,6 +285,19 @@ _DTYPE_PRESERVING_METHODS = frozenset({
 })
 
 
+# `torch.<name>` constants that are provably NOT dtypes, so they cannot retype the
+# receiver: `inputs_embeds.clone(memory_format = torch.preserve_format)` and
+# `inputs_embeds.contiguous(memory_format = torch.contiguous_format)` keep the
+# embedding dtype exactly. Reading every `torch.<attr>` as a dtype rejected those
+# receivers, so a purely cosmetic upstream addition of an explicit memory format
+# would fail the real-source canaries with "the destination was retyped" - the
+# false red this structural trace exists to remove. (`_to_call_preserves_dtype`
+# already whitelists the `memory_format` keyword of `.to(...)` for the same
+# reason.) Resolved against the live torch so the set cannot drift from reality;
+# an attribute torch does not have stays dtype-bearing, which is the safe default.
+_NON_DTYPE_TORCH_CONSTANTS = (torch.memory_format, torch.layout)
+
+
 def _is_dtype_bearing(node):
     """Can `node` retype a tensor? (`torch.float32`, `other.dtype`, ...)"""
     if isinstance(node, ast.Attribute) and node.attr == "dtype":
@@ -294,8 +307,12 @@ def _is_dtype_bearing(node):
         and isinstance(node.value, ast.Name)
         and node.value.id == "torch"
     ):
-        # `torch.float32` / `torch.bfloat16` / `torch.long` ...
-        return True
+        # `torch.float32` / `torch.bfloat16` / `torch.long` retype; a memory
+        # format or a layout does not. `Tensor.view(torch.int32)` really does
+        # reinterpret the dtype, so the check is on the constant, not the method.
+        return not isinstance(
+            getattr(torch, node.attr, None), _NON_DTYPE_TORCH_CONSTANTS
+        )
     return False
 
 
@@ -1245,6 +1262,12 @@ _RECEIVER_HOLES = [
      "inputs_embeds = self.upcast(inputs_embeds).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.dtype)\n"
      ")"),
+    # `Tensor.view(dtype)` reinterprets the storage as another dtype, so a real
+    # dtype constant must still be caught after memory formats stop counting.
+    ("receiver .view(torch.int32) reinterprets the dtype",
+     "inputs_embeds = inputs_embeds.view(torch.int32).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.dtype)\n"
+     ")"),
 ]
 
 
@@ -1290,6 +1313,21 @@ _RECEIVER_CONTROLS = [
      ")"),
     ("plain receiver",
      "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    # A memory format is not a dtype: these keep the destination at
+    # `inputs_embeds.dtype`, and transformers already ships
+    # `.clone(memory_format = torch.contiguous_format)` (higgs_audio_v2).
+    ("receiver .clone(memory_format = torch.preserve_format)",
+     "inputs_embeds = inputs_embeds.clone(memory_format = torch.preserve_format).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .contiguous(memory_format = torch.contiguous_format)",
+     "inputs_embeds = inputs_embeds.contiguous(memory_format = torch.contiguous_format).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .contiguous(torch.channels_last) positionally",
+     "inputs_embeds = inputs_embeds.contiguous(torch.channels_last).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
 ]

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -225,8 +225,25 @@ def _is_attr(node, owner, attr):
     )
 
 
+def _is_embeds_tensor(node):
+    """`inputs_embeds` itself, as the argument of the tensor-to-tensor `.to()`."""
+    return isinstance(node, ast.Name) and node.id == "inputs_embeds"
+
+
 def _casts_to_inputs_embeds_dtype(node):
-    """True if `node` contains a `.to(...)` carrying `inputs_embeds.dtype`."""
+    """True if `node` contains a `.to(...)` that lands on `inputs_embeds`' dtype.
+
+    Two spellings count. The explicit one names the dtype
+    (`features.to(inputs_embeds.device, inputs_embeds.dtype)`), and the tensor
+    overload names the tensor: `Tensor.to(other)` is documented as "returns a
+    Tensor with same torch.dtype and torch.device as the Tensor other", so
+    `features.to(inputs_embeds)` aligns dtype AND device in one call and is just
+    as safe a merge source. Rejecting it would make these canaries fail on a
+    healthy upstream that happened to prefer that spelling, and the failure would
+    claim nobody aligns the dtype at all. Only the FIRST positional argument can
+    be the tensor overload (`to(other, non_blocking=..., copy=...)`); torch has
+    no `other=` keyword, so keywords are not considered for it.
+    """
     for sub in ast.walk(node):
         if not (
             isinstance(sub, ast.Call)
@@ -236,6 +253,8 @@ def _casts_to_inputs_embeds_dtype(node):
             continue
         values = list(sub.args) + [kw.value for kw in sub.keywords]
         if any(_is_attr(v, "inputs_embeds", "dtype") for v in values):
+            return True
+        if sub.args and _is_embeds_tensor(sub.args[0]):
             return True
     return False
 
@@ -450,20 +469,69 @@ def _bound_names(target):
     return []
 
 
-def _assigns_feature(stmt, feature):
-    targets = stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
-    return any(feature in _bound_names(t) for t in targets)
-
-
 _ASSIGN_NODES = (ast.Assign, ast.AnnAssign, ast.AugAssign)
+_LOOP_NODES = (ast.For, ast.AsyncFor)
+_WITH_NODES = (ast.With, ast.AsyncWith)
+# Every construct that can rebind a plain name in the code's OWN scope. An
+# assignment statement is only the most common one: `for image_features in
+# image_batches:`, `with self.autocast() as image_features:` and
+# `if (image_features := self.pack(image_features)) is None:` all replace the
+# tensor the name refers to just as completely. Counting only assignments lets an
+# earlier aligned assignment keep proving alignment for a value that one of these
+# has since overwritten, and the replacement reaches masked_scatter un-cast.
+# (Comprehensions bind in their own scope and so cannot affect `forward`'s name.)
+_BINDING_NODES = _ASSIGN_NODES + _LOOP_NODES + _WITH_NODES + (ast.NamedExpr,)
+
+
+def _binding_pairs(node):
+    """`[(target, value)]` this binding node establishes.
+
+    The `value` is the expression whose dtype the bound name ends up carrying, so
+    the same `_casts_to_inputs_embeds_dtype` question can be asked of every
+    binding form: an assignment's RHS, a loop's iterable (the target takes its
+    elements), and a `with` item's context expression.
+    """
+    if isinstance(node, ast.Assign):
+        return [(target, node.value) for target in node.targets]
+    if isinstance(node, (ast.AnnAssign, ast.AugAssign, ast.NamedExpr)):
+        return [(node.target, getattr(node, "value", None))]
+    if isinstance(node, _LOOP_NODES):
+        return [(node.target, node.iter)]
+    if isinstance(node, _WITH_NODES):
+        return [
+            (item.optional_vars, item.context_expr)
+            for item in node.items
+            if item.optional_vars is not None
+        ]
+    return []
+
+
+def _assigns_feature(stmt, feature):
+    return any(
+        target is not None and feature in _bound_names(target)
+        for target, _ in _binding_pairs(stmt)
+    )
+
+
+def _binding_value(node, feature):
+    """The expression `<feature>` takes its dtype from in this binding node."""
+    for target, value in _binding_pairs(node):
+        if target is not None and feature in _bound_names(target):
+            return value
+    return None
+
+
+def _binding_is_aligned(node, feature):
+    value = _binding_value(node, feature)
+    return value is not None and _casts_to_inputs_embeds_dtype(value)
 
 
 def _feature_rebindings(stmt, feature):
-    """Every assignment to `<feature>` anywhere inside `stmt`'s own scope."""
+    """Every rebinding of `<feature>` anywhere inside `stmt`'s own scope."""
     return [
         node
         for node in _walk_own_scope(stmt, descend = False)
-        if isinstance(node, _ASSIGN_NODES) and _assigns_feature(node, feature)
+        if isinstance(node, _BINDING_NODES) and _assigns_feature(node, feature)
     ]
 
 
@@ -473,8 +541,15 @@ def _rebinding_alignment(stmt, feature):
     `None` when `stmt` does not rebind the name (so it says nothing either way).
     """
     if isinstance(stmt, _ASSIGN_NODES) and _assigns_feature(stmt, feature):
-        value = getattr(stmt, "value", None)
-        return value is not None and _casts_to_inputs_embeds_dtype(value)
+        return _binding_is_aligned(stmt, feature)
+    # A bare named expression statement, `(image_features := ...)`, rebinds
+    # unconditionally exactly like an assignment does.
+    if (
+        isinstance(stmt, ast.Expr)
+        and isinstance(stmt.value, ast.NamedExpr)
+        and _assigns_feature(stmt.value, feature)
+    ):
+        return _binding_is_aligned(stmt.value, feature)
     # `if <feature>.dtype != inputs_embeds.dtype: <feature> = <feature>.to(...)`
     # is a cast-if-needed idiom (transformers spells it in blip_2 / granite_speech):
     # the untaken branch is aligned by definition, so it counts as unconditional.
@@ -499,11 +574,15 @@ def _rebinding_alignment(stmt, feature):
     rebindings = _feature_rebindings(stmt, feature)
     if not rebindings:
         return None
-    if isinstance(stmt, (ast.With, ast.AsyncWith)):
+    if isinstance(stmt, _WITH_NODES):
         # A `with` body runs unconditionally, so its rebindings dominate the
         # merge exactly like top-level ones: take the last one that says
-        # anything.
-        alignment = None
+        # anything. The `as` target binds first, before the body runs, so it
+        # seeds the state.
+        alignment = (
+            _binding_is_aligned(stmt, feature)
+            if _assigns_feature(stmt, feature) else None
+        )
         for inner in stmt.body:
             inner_alignment = _rebinding_alignment(inner, feature)
             if inner_alignment is not None:
@@ -513,10 +592,10 @@ def _rebinding_alignment(stmt, feature):
     # or may not run, so the state after it is "aligned before AND aligned in
     # every branch". An unaligned branch therefore reports unaligned; a branch
     # that only ever casts to `inputs_embeds.dtype` leaves the earlier verdict
-    # standing (`None`) instead of overriding it.
+    # standing (`None`) instead of overriding it. A loop's own target counts as
+    # one of those rebindings, taking its dtype from the iterable.
     for rebinding in rebindings:
-        value = getattr(rebinding, "value", None)
-        if value is None or not _casts_to_inputs_embeds_dtype(value):
+        if not _binding_is_aligned(rebinding, feature):
             return False
     return None
 
@@ -595,26 +674,89 @@ def _feature_merges(forward, feature):
     return sorted(calls, key=lambda n: (n.lineno, n.col_offset))
 
 
-def _merge_result_is_used(forward, call):
-    """Does the merge's result survive?
+def _contains(node, target):
+    return any(n is target for n in ast.walk(node))
 
-    `masked_scatter` is OUT-OF-PLACE, so a bare
-    `inputs_embeds.masked_scatter(mask, features.to(inputs_embeds.dtype))`
-    statement computes the merged embedding and throws it away: the features
-    never reach the model, silently, with every dtype canary green. Upstream has
-    always spelled it `inputs_embeds = inputs_embeds.masked_scatter(...)` on
-    5.5.0-5.15.0, so requiring the result to be consumed costs nothing. The
-    in-place `masked_scatter_` writes through the receiver and needs no
-    assignment.
+
+def _references(node, names):
+    return any(isinstance(n, ast.Name) and n.id in names for n in ast.walk(node))
+
+
+def _statements_after(forward, call):
+    """The statements that execute after `call`, innermost block outwards.
+
+    The first one yielded is the merge's OWN statement; then the rest of the
+    block holding it, then the remainder of each enclosing block. That is the
+    straight-line path the merged tensor has to survive to reach the return.
+    """
+    chain = _enclosing_blocks(forward, call)
+    if not chain:
+        return None
+    ordered = []
+    for depth, (block, index) in enumerate(reversed(chain)):
+        # The innermost entry points AT the merge's statement; every outer entry
+        # points at the compound statement wrapping it, which we have already
+        # accounted for.
+        ordered.extend(block[index if depth == 0 else index + 1:])
+    return ordered
+
+
+def _merge_result_is_used(forward, call):
+    """Does the merge's result reach the embeddings `forward` goes on to use?
+
+    `masked_scatter` is OUT-OF-PLACE, so the merged embedding only exists in its
+    return value. Upstream has always spelled it
+    `inputs_embeds = inputs_embeds.masked_scatter(...)` on 5.5.0-5.15.0, and the
+    features reach the model precisely because that result lands back on
+    `inputs_embeds`.
+
+    Asking only whether the merge is a bare expression statement is too weak: it
+    passes `dead = inputs_embeds.masked_scatter(...)` and
+    `self.log(inputs_embeds.masked_scatter(...))`, both of which compute the
+    merged embedding, drop it on the floor and leave `forward` returning the
+    UNCHANGED `inputs_embeds` - the features silently never reach the model, with
+    every dtype canary in this file green. So follow the result forward instead:
+    it must flow, directly or through temporaries, into `inputs_embeds` or into a
+    `return`. The in-place `masked_scatter_` writes through the receiver's
+    storage and needs no result at all.
     """
     if call.func.attr.endswith("_"):
         return True
-    chain = _enclosing_blocks(forward, call)
-    if not chain:
+    statements = _statements_after(forward, call)
+    if statements is None:
         return True
-    block, index = chain[-1]
-    statement = block[index]
-    return not (isinstance(statement, ast.Expr) and statement.value is call)
+
+    tainted = set()
+    for position, statement in enumerate(statements):
+        for node in _walk_own_scope(statement, descend = False):
+            # A `return` carrying the merge (or anything it flowed into) is the
+            # merged embedding leaving `forward`.
+            if isinstance(node, ast.Return) and node.value is not None:
+                if (position == 0 and _contains(node.value, call)) or _references(node.value, tainted):
+                    return True
+            if not isinstance(node, _BINDING_NODES):
+                continue
+            for target, value in _binding_pairs(node):
+                if target is None or value is None:
+                    continue
+                bound = _bound_names(target)
+                if not bound:
+                    continue
+                carries = (
+                    (position == 0 and _contains(value, call))
+                    or _references(value, tainted)
+                )
+                if carries:
+                    tainted.update(bound)
+                elif node is statement:
+                    # A direct, unconditional rebinding to something the merge
+                    # did NOT flow into overwrites the name: the merged value is
+                    # gone. A rebinding nested inside a conditional may not run,
+                    # so it must not clear the taint.
+                    tainted.difference_update(bound)
+        if "inputs_embeds" in tainted:
+            return True
+    return False
 
 
 def _merge_dtype_alignment(src, feature):
@@ -1095,4 +1237,300 @@ def test_in_place_merge_with_an_unaligned_source_is_still_traced():
     )
     assert found and not aligned, (
         "an in-place merge fed by a feature rebound to fp32 must report unaligned"
+    )
+
+
+# ---------------------------------------------------------------------------
+# `Tensor.to(other)` is documented as "returns a Tensor with same torch.dtype and
+# torch.device as the Tensor other", so `image_features.to(inputs_embeds)` aligns
+# BOTH in one call and is a perfectly safe merge source. Reading only the
+# explicit `inputs_embeds.dtype` spelling would fail these canaries on a healthy
+# upstream that happened to prefer the overload, and the failure message would
+# claim the dtype is never aligned - a false red that hides nothing and costs a
+# release.
+# ---------------------------------------------------------------------------
+_TENSOR_OVERLOAD_CONTROLS = [
+    ("tensor overload at the merge argument",
+     "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds)\n"
+     ")"),
+    ("tensor overload with non_blocking",
+     "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds, non_blocking = True)\n"
+     ")"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,merge", _TENSOR_OVERLOAD_CONTROLS, ids = [c[0] for c in _TENSOR_OVERLOAD_CONTROLS],
+)
+def test_tensor_to_tensor_overload_counts_as_alignment(label, merge):
+    body = "image_features = image_features.reshape(-1, inputs_embeds.shape[-1])"
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward(body, merge = merge), "image_features",
+    )
+    assert found and aligned, (
+        f"{label}: `image_features.to(inputs_embeds)` gives the result "
+        f"`inputs_embeds`' dtype AND device, so the merge is dtype-safe. Reporting "
+        f"it unaligned fails the real-source canaries on a healthy upstream."
+    )
+
+
+def test_tensor_overload_on_the_assignment_counts_as_alignment():
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward("image_features = image_features.to(inputs_embeds)"),
+        "image_features",
+    )
+    assert found and aligned, "the tensor overload on the dominating assignment is alignment"
+
+
+_TENSOR_OVERLOAD_HOLES = [
+    # Aligning to some OTHER tensor says nothing about `inputs_embeds`' dtype.
+    ("overload naming a different tensor",
+     "image_features = image_features.to(image_mask)"),
+    ("overload naming a module attribute",
+     "image_features = image_features.to(self.dummy)"),
+    # `inputs_embeds` only carries the dtype as the FIRST positional argument;
+    # torch has no `other=` keyword, and `.to(device, inputs_embeds)` is not a
+    # signature that exists.
+    ("embeds passed as a keyword, which torch rejects",
+     "image_features = image_features.to(device = inputs_embeds)"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body", _TENSOR_OVERLOAD_HOLES, ids = [c[0] for c in _TENSOR_OVERLOAD_HOLES],
+)
+def test_tensor_overload_to_another_tensor_is_not_alignment(label, body):
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found, f"{label}: the synthetic merge site itself was not found"
+    assert not aligned, (
+        f"{label}: only `.to(inputs_embeds)` proves the source landed on the "
+        f"embedding dtype; accepting any tensor makes the overload a blanket "
+        f"escape hatch."
+    )
+
+
+# ---------------------------------------------------------------------------
+# `masked_scatter` is out-of-place, so the merged embedding exists ONLY in the
+# return value. Rejecting just the bare-expression spelling is not enough: a
+# result bound to a name nothing reads, or passed to a logger, is discarded just
+# as completely, and `forward` then returns the UNCHANGED `inputs_embeds` with
+# every dtype canary green. The result has to reach the embeddings that survive.
+# ---------------------------------------------------------------------------
+_DISCARDED_RESULT_HOLES = [
+    ("result bound to a name nothing reads",
+     "dead = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("result passed to a logger",
+     "self.log(inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     "))"),
+    ("result bound to a temp that is then overwritten",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "merged = inputs_embeds"),
+    ("result appended to a list that never reaches the embeddings",
+     "collected = [inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")]"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,merge", _DISCARDED_RESULT_HOLES, ids = [c[0] for c in _DISCARDED_RESULT_HOLES],
+)
+def test_merge_result_that_never_reaches_the_embeddings_is_not_alignment(label, merge):
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
+    )
+    assert found, f"{label}: the synthetic merge site itself was not found"
+    assert not aligned, (
+        f"{label}: the tracer reports the merge aligned, but its out-of-place "
+        f"result never reaches `inputs_embeds` or the return, so `forward` hands "
+        f"back embeddings the features were never merged into. Every dtype canary "
+        f"here would stay green while the features silently vanished."
+    )
+
+
+_RESULT_REACHES_CONTROLS = [
+    ("result reaches inputs_embeds through two temporaries",
+     "first = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "second = self.norm(first)\n"
+     "inputs_embeds = second"),
+    ("result rebinds inputs_embeds inside a branch",
+     "if self.config.merge:\n"
+     "    inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "        image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     "    )"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,merge", _RESULT_REACHES_CONTROLS, ids = [c[0] for c in _RESULT_REACHES_CONTROLS],
+)
+def test_results_that_do_reach_the_embeddings_still_count(label, merge):
+    # Controls: the merged tensor really does land back on `inputs_embeds`, so
+    # these must NOT turn red.
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
+    )
+    assert found and aligned, f"{label}: a surviving merge result reported unaligned"
+
+
+# ---------------------------------------------------------------------------
+# A name is not only rebound by an assignment statement. A `for` target, a `with
+# ... as` target and a named expression all replace the tensor the name refers
+# to, so an earlier aligned assignment stops describing it. Skipping them lets
+# the replacement - which nothing cast - reach masked_scatter.
+# ---------------------------------------------------------------------------
+_NON_ASSIGN_BINDING_HOLES = [
+    ("for target",
+     f"{_ALIGNED_ASSIGN}\n"
+     "for image_features in image_batches:\n"
+     "    pass"),
+    ("for target destructured",
+     f"{_ALIGNED_ASSIGN}\n"
+     "for image_features, size in image_batches:\n"
+     "    pass"),
+    ("async for target",
+     f"{_ALIGNED_ASSIGN}\n"
+     "async for image_features in image_batches:\n"
+     "    pass"),
+    ("with ... as target",
+     f"{_ALIGNED_ASSIGN}\n"
+     "with self.stream() as image_features:\n"
+     "    pass"),
+    ("named expression inside a condition",
+     f"{_ALIGNED_ASSIGN}\n"
+     "if (image_features := self.pack_image_features(image_features)) is None:\n"
+     "    pass"),
+    ("named expression as a statement",
+     f"{_ALIGNED_ASSIGN}\n"
+     "(image_features := self.pack_image_features(image_features))"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body", _NON_ASSIGN_BINDING_HOLES, ids = [c[0] for c in _NON_ASSIGN_BINDING_HOLES],
+)
+def test_bindings_outside_assignments_invalidate_alignment(label, body):
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found, f"{label}: the synthetic merge site itself was not found"
+    assert not aligned, (
+        f"{label}: the tracer still credits the earlier aligned assignment, but "
+        f"`image_features` has since been rebound by a construct that carries no "
+        f"`inputs_embeds.dtype` cast. The rebound tensor reaches masked_scatter."
+    )
+
+
+_NON_ASSIGN_BINDING_CONTROLS = [
+    ("for target over an aligned iterable",
+     f"{_ALIGNED_ASSIGN}\n"
+     "for image_features in image_batches.to(inputs_embeds.device, inputs_embeds.dtype):\n"
+     "    pass"),
+    ("with ... as target over an aligned context",
+     f"{_ALIGNED_ASSIGN}\n"
+     "with self.stream(image_features.to(inputs_embeds.dtype)) as image_features:\n"
+     "    pass"),
+    ("named expression whose value casts dtype",
+     f"{_ALIGNED_ASSIGN}\n"
+     "(image_features := image_features.to(inputs_embeds.dtype))"),
+    ("for target binding an unrelated name",
+     f"{_ALIGNED_ASSIGN}\n"
+     "for patch in image_batches:\n"
+     "    pass"),
+    ("with ... as binding an unrelated name",
+     f"{_ALIGNED_ASSIGN}\n"
+     "with self.stream() as ctx:\n"
+     "    pass"),
+    ("with ... as target aligned, body leaves it alone",
+     "with self.stream(image_features) as image_features:\n"
+     f"    {_ALIGNED_ASSIGN}"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body", _NON_ASSIGN_BINDING_CONTROLS, ids = [c[0] for c in _NON_ASSIGN_BINDING_CONTROLS],
+)
+def test_aligned_or_unrelated_bindings_do_not_break_alignment(label, body):
+    # Controls for the test above.
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
+
+
+# ---------------------------------------------------------------------------
+# The eager patch's own matcher must be tied to the EMBEDDING merge. Accepting
+# `masked_scatter` on any receiver let an already-aligned merge on some scratch
+# tensor land in `fixed_casts`, which reads to
+# `_patch_gemma4_audio_feature_dtype_on_class` as "upstream fixed it": it sets
+# the patched marker and returns, leaving a real, still-device-only
+# `inputs_embeds` merge unpatched and crashing.
+# ---------------------------------------------------------------------------
+def _audio_forward(body):
+    return (
+        "class Gemma4Model:\n"
+        "    def forward(self, inputs_embeds, audio_features, audio_mask):\n"
+        "        if audio_features is not None:\n"
+        f"{_indented(body)}\n"
+        "        return inputs_embeds\n"
+    )
+
+
+_REAL_AUDIO_MERGE = (
+    "inputs_embeds = inputs_embeds.masked_scatter(\n"
+    "    audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)\n"
+    ")"
+)
+_ALIGNED_SCRATCH_MERGE = (
+    "scratch = scratch.masked_scatter(\n"
+    "    audio_mask, audio_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+    ")"
+)
+
+
+def _audio_merge_casts(body):
+    forward = _gemma4_model_forward_node(_audio_forward(body))
+    assert forward is not None
+    return g4p._gemma4_audio_merge_casts(forward)
+
+
+def test_eager_matcher_ignores_merges_onto_other_tensors():
+    # An aligned decoy on a scratch tensor must not be reported as the audio
+    # merge being already fixed.
+    buggy, fixed = _audio_merge_casts(_ALIGNED_SCRATCH_MERGE)
+    assert not buggy and not fixed, (
+        f"_gemma4_audio_merge_casts counted a `scratch.masked_scatter(...)` as the "
+        f"embedding merge ({len(buggy)} buggy, {len(fixed)} fixed). The eager patch "
+        f"would mark Gemma4Model as already patched on the strength of a merge that "
+        f"never touches `inputs_embeds`."
+    )
+
+
+def test_eager_matcher_still_finds_the_real_merge_next_to_a_decoy():
+    # The decoy must be ignored AND the real device-only merge still picked up,
+    # so the patch fires exactly once.
+    buggy, fixed = _audio_merge_casts(_ALIGNED_SCRATCH_MERGE + "\n" + _REAL_AUDIO_MERGE)
+    assert len(buggy) == 1 and not fixed, (
+        f"expected the one real device-only `inputs_embeds` merge to be patchable "
+        f"next to an aligned scratch decoy, got {len(buggy)} buggy / {len(fixed)} fixed"
+    )
+
+
+def test_eager_matcher_still_accepts_a_transformed_inputs_embeds_receiver():
+    # Discovery must stay loose about HOW the receiver mentions `inputs_embeds`
+    # (blip_2 ships `inputs_embeds.to(...).masked_scatter(...)`), or a real merge
+    # would be dropped instead of patched.
+    buggy, fixed = _audio_merge_casts(
+        "inputs_embeds = inputs_embeds.to(audio_features.device).masked_scatter(\n"
+        "    audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)\n"
+        ")"
+    )
+    assert len(buggy) == 1 and not fixed, (
+        f"a transformed `inputs_embeds` receiver must still be recognised as the "
+        f"embedding merge, got {len(buggy)} buggy / {len(fixed)} fixed"
     )

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -571,15 +571,18 @@ def _element_value(target, value, feature):
     return value
 
 
+# Only a real destructuring assignment pairs targets with RHS elements. A
+# `for` / `with` target takes its value from the iterable / context manager, not
+# positionally from the expression's own elements.
+_ELEMENTWISE_NODES = (ast.Assign, ast.AnnAssign, ast.NamedExpr)
+
+
 def _binding_value(node, feature):
     """The expression `<feature>` takes its dtype from in this binding node."""
     for target, value in _binding_pairs(node):
         if target is None or feature not in _bound_names(target):
             continue
-        # Only a real destructuring assignment pairs targets with RHS elements.
-        # A `for`/`with` target takes its value from the iterable / context
-        # manager, not positionally from the expression's own elements.
-        if value is not None and isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
+        if value is not None and isinstance(node, _ELEMENTWISE_NODES):
             return _element_value(target, value, feature)
         return value
     return None
@@ -828,22 +831,29 @@ def _merge_result_is_used(forward, call):
             for target, value in _binding_pairs(node):
                 if target is None or value is None:
                     continue
-                bound = _bound_names(target)
-                if not bound:
-                    continue
-                carries = (
-                    (position == 0 and _contains(value, call))
-                    or _references(value, tainted)
-                )
-                if carries:
-                    tainted.update(bound)
-                elif node is statement and not isinstance(node, ast.AugAssign):
-                    # A direct, unconditional rebinding to something the merge
-                    # did NOT flow into overwrites the name: the merged value is
-                    # gone. A rebinding nested inside a conditional may not run,
-                    # so it must not clear the taint - and an augmented
-                    # assignment adds to the value rather than replacing it.
-                    tainted.difference_update(bound)
+                # A destructuring target consumes the RHS element by element, so
+                # each name is judged on the part it actually receives. Reading
+                # the whole RHS made `inputs_embeds, aux = original, merged` taint
+                # `inputs_embeds` - reporting the merge used while the embeddings
+                # were handed the ORIGINAL, unmerged tensor. A non-literal RHS
+                # (a call, a starred or mismatched target) keeps the whole value,
+                # so `inputs_embeds, aux = self.pack(merged)` still counts.
+                element = value if isinstance(node, _ELEMENTWISE_NODES) else None
+                for name in _bound_names(target):
+                    part = _element_value(target, element, name) if element is not None else value
+                    carries = (
+                        (position == 0 and part is not None and _contains(part, call))
+                        or (part is not None and _references(part, tainted))
+                    )
+                    if carries:
+                        tainted.add(name)
+                    elif node is statement and not isinstance(node, ast.AugAssign):
+                        # A direct, unconditional rebinding to something the merge
+                        # did NOT flow into overwrites the name: the merged value
+                        # is gone. A rebinding nested inside a conditional may not
+                        # run, so it must not clear the taint - and an augmented
+                        # assignment adds to the value rather than replacing it.
+                        tainted.discard(name)
         if "inputs_embeds" in tainted:
             return True
     return False
@@ -1539,6 +1549,24 @@ _DISCARDED_RESULT_HOLES = [
      "inputs_embeds.to('cuda').masked_scatter_(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
+    # A destructuring target takes its own RHS element. Crediting the whole RHS
+    # let a tuple hand `inputs_embeds` the ORIGINAL while the merge went to a
+    # name nothing reads - the modality silently dropped, every canary green.
+    ("destructuring hands the embeddings the original, not the merge",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "inputs_embeds, aux = original, merged"),
+    ("list destructuring hands the embeddings the original",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "[inputs_embeds, aux] = [original, merged]"),
+    ("nested destructuring hands the embeddings the original",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "(inputs_embeds, aux), sizes = (original, merged), image_sizes"),
 ]
 
 
@@ -1570,6 +1598,29 @@ _RESULT_REACHES_CONTROLS = [
      "    inputs_embeds = inputs_embeds.masked_scatter(\n"
      "        image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      "    )"),
+    # The mirror image: pairing element by element must still see the merge when
+    # it IS the element the embeddings receive, and a non-literal RHS keeps the
+    # whole value, so an unpacking call still propagates it.
+    ("destructuring hands the embeddings the merge",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "inputs_embeds, aux = merged, original"),
+    ("nested destructuring hands the embeddings the merge",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "(inputs_embeds, aux), sizes = (merged, original), image_sizes"),
+    ("unpacking call keeps the whole right-hand side",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "inputs_embeds, aux = self.pack_image_features(merged)"),
+    ("starred destructuring keeps the whole right-hand side",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "inputs_embeds, *aux = merged, original"),
 ]
 
 

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -20,12 +20,14 @@ cleanly when it is absent; when present (transformers >= 5.5.0, as on CI) they
 catch upstream source drift that would silently disable the patch.
 """
 import ast
+import collections
 import inspect
 import re
 
 import pytest
 import torch
 
+from unsloth_zoo.temporary_patches import gemma4 as g4p
 from unsloth_zoo.temporary_patches import gemma4_float32 as g4f
 from unsloth_zoo.temporary_patches.gemma4_float32 import _unsloth_gemma4_ple_cast_input
 from unsloth_zoo import compiler as C
@@ -236,6 +238,32 @@ def _casts_to_inputs_embeds_dtype(node):
     return False
 
 
+_SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+
+
+def _walk_own_scope(root, descend = True):
+    """`ast.walk` restricted to the code `root`'s own scope executes.
+
+    A nested `def` / `class` / `lambda` is a separate scope with its own local
+    names, so a merge written inside a helper defined in `forward` is not
+    `forward`'s merge (the helper may never be invoked), and a cast in `forward`
+    says nothing about a same-named parameter of that helper. The nested
+    statement itself is still yielded - only its body is skipped.
+    """
+    if isinstance(root, _SCOPE_NODES) and not descend:
+        yield root
+        return
+    todo = collections.deque([root])
+    while todo:
+        node = todo.popleft()
+        yield node
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, _SCOPE_NODES):
+                yield child
+            else:
+                todo.append(child)
+
+
 def _gemma4_model_forward_node(src):
     tree = ast.parse(src)
     for node in tree.body:
@@ -268,7 +296,7 @@ def _enclosing_blocks(forward, target):
     chain = []
 
     def holds(node):
-        return any(n is target for n in ast.walk(node))
+        return any(n is target for n in _walk_own_scope(node, descend = False))
 
     def descend(block):
         for index, stmt in enumerate(block):
@@ -286,14 +314,24 @@ def _enclosing_blocks(forward, target):
 
 
 def _is_dtype_guard(test, feature):
-    """`if <feature>.dtype != ...:` - a cast under such a guard aligns both paths."""
-    for node in ast.walk(test):
-        if isinstance(node, ast.Compare) and any(
-            _is_attr(operand, feature, "dtype")
-            for operand in [node.left] + list(node.comparators)
-        ):
-            return True
-    return False
+    """Exactly `<feature>.dtype != inputs_embeds.dtype` (either operand order).
+
+    Only that comparison makes the untaken branch aligned BY DEFINITION. Any
+    other test mentioning the feature dtype (`... == inputs_embeds.dtype`,
+    `... != torch.bfloat16`, or the mismatch test `and`-ed with something else)
+    leaves a reachable path on which the feature stays un-cast, so a cast under
+    it proves nothing and must not count as unconditional alignment.
+    """
+    if not (isinstance(test, ast.Compare) and len(test.ops) == 1):
+        return False
+    if not isinstance(test.ops[0], ast.NotEq):
+        return False
+    operands = [test.left, test.comparators[0]]
+    return any(
+        _is_attr(operands[i], feature, "dtype")
+        and _is_attr(operands[1 - i], "inputs_embeds", "dtype")
+        for i in (0, 1)
+    )
 
 
 def _assigns_feature(stmt, feature):
@@ -301,25 +339,61 @@ def _assigns_feature(stmt, feature):
     return any(isinstance(t, ast.Name) and t.id == feature for t in targets)
 
 
+_ASSIGN_NODES = (ast.Assign, ast.AnnAssign, ast.AugAssign)
+
+
+def _feature_rebindings(stmt, feature):
+    """Every assignment to `<feature>` anywhere inside `stmt`'s own scope."""
+    return [
+        node
+        for node in _walk_own_scope(stmt, descend = False)
+        if isinstance(node, _ASSIGN_NODES) and _assigns_feature(node, feature)
+    ]
+
+
 def _rebinding_alignment(stmt, feature):
     """Does `stmt` rebind `<feature>` on the path to the merge, and is it aligned?
 
     `None` when `stmt` does not rebind the name (so it says nothing either way).
     """
-    if isinstance(stmt, (ast.Assign, ast.AnnAssign)) and _assigns_feature(stmt, feature):
-        return stmt.value is not None and _casts_to_inputs_embeds_dtype(stmt.value)
+    if isinstance(stmt, _ASSIGN_NODES) and _assigns_feature(stmt, feature):
+        value = getattr(stmt, "value", None)
+        return value is not None and _casts_to_inputs_embeds_dtype(value)
     # `if <feature>.dtype != inputs_embeds.dtype: <feature> = <feature>.to(...)`
     # is a cast-if-needed idiom (transformers spells it in blip_2 / granite_speech):
     # the untaken branch is aligned by definition, so it counts as unconditional.
     if isinstance(stmt, ast.If) and _is_dtype_guard(stmt.test, feature):
-        inner = [
-            s
-            for s in ast.walk(stmt)
-            if isinstance(s, (ast.Assign, ast.AnnAssign)) and _assigns_feature(s, feature)
-        ]
+        inner = _feature_rebindings(stmt, feature)
         if inner:
-            last = max(inner, key=lambda s: s.lineno)
-            return last.value is not None and _casts_to_inputs_embeds_dtype(last.value)
+            last = max(inner, key = lambda s: s.lineno)
+            value = getattr(last, "value", None)
+            return value is not None and _casts_to_inputs_embeds_dtype(value)
+    # Any OTHER compound statement that rebinds the feature is still a rebinding
+    # on the path to the merge and must not be skipped, or an earlier aligned
+    # assignment would keep proving alignment for a value that has since been
+    # rewritten (`if enabled: image_features = image_features.float()`).
+    rebindings = _feature_rebindings(stmt, feature)
+    if not rebindings:
+        return None
+    if isinstance(stmt, (ast.With, ast.AsyncWith)):
+        # A `with` body runs unconditionally, so its rebindings dominate the
+        # merge exactly like top-level ones: take the last one that says
+        # anything.
+        alignment = None
+        for inner in stmt.body:
+            inner_alignment = _rebinding_alignment(inner, feature)
+            if inner_alignment is not None:
+                alignment = inner_alignment
+        return alignment
+    # Conditionally executed (`if` / `for` / `while` / `try`): the rebinding may
+    # or may not run, so the state after it is "aligned before AND aligned in
+    # every branch". An unaligned branch therefore reports unaligned; a branch
+    # that only ever casts to `inputs_embeds.dtype` leaves the earlier verdict
+    # standing (`None`) instead of overriding it.
+    for rebinding in rebindings:
+        value = getattr(rebinding, "value", None)
+        if value is None or not _casts_to_inputs_embeds_dtype(value):
+            return False
     return None
 
 
@@ -341,10 +415,12 @@ def _feature_merge_args(forward, feature):
 
     The receiver has to be `inputs_embeds` (or something derived from it): a
     `scratch.masked_scatter(mask, feature)` elsewhere in `forward` is a different
-    tensor and says nothing about the dtype of the embedding merge.
+    tensor and says nothing about the dtype of the embedding merge. Nested `def`
+    / `class` / `lambda` bodies are skipped for the same reason: a merge in a
+    helper `forward` never invokes is not `forward`'s merge.
     """
     args = []
-    for node in ast.walk(forward):
+    for node in _walk_own_scope(forward):
         if not (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
@@ -428,6 +504,33 @@ def test_real_gemma4_image_and_video_merges_still_cast_dtype(feature):
         f"the audio bug (transformers #45192) in a new modality and needs the same "
         f"treatment as _patch_gemma4_audio_feature_dtype_on_class / "
         f"fix_gemma4_audio_feature_dtype."
+    )
+
+
+@requires_gemma4
+def test_real_gemma4_audio_eager_patch_matches_real_merge_site():
+    # The canary above only proves the COMPILER rewriter (a regex over the source)
+    # still fires. The eager patch is stricter: it requires the merge's source
+    # argument to BE the `audio_features.to(inputs_embeds.device, ...)` call, so a
+    # wrapped spelling such as
+    # `audio_features.to(inputs_embeds.device).reshape(-1, inputs_embeds.shape[-1])`
+    # matches the regex but not the AST matcher - the eager patch would log a drift
+    # warning, no-op, and the dtype crash would come back on the non-compiled path
+    # while every other guard here stayed green. Run the patch's OWN matcher over
+    # the real source so that spelling fails loudly here instead.
+    src = _gemma4_modeling_source()
+    forward = _gemma4_model_forward_node(src)
+    assert forward is not None, "Gemma4Model.forward not found in the real source"
+    buggy, fixed = g4p._gemma4_audio_merge_casts(forward)
+    already_aligned = not buggy and len(fixed) == 1
+    patchable = len(buggy) == 1 and not fixed
+    assert already_aligned or patchable, (
+        f"_patch_gemma4_audio_feature_dtype_on_class no longer recognizes the real "
+        f"Gemma4 audio merge site: it found {len(buggy)} device-only and {len(fixed)} "
+        f"device+dtype `audio_features.to(inputs_embeds.device, ...)` merge arguments, "
+        f"and it only acts on exactly one of either. The eager patch would silently "
+        f"no-op (the compiler regex may still fire, which is why the other audio "
+        f"canaries stay green). Update _patch_gemma4_audio_feature_dtype_on_class."
     )
 
 

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -201,34 +201,29 @@ def _gemma4_modeling_source():
     return pathlib.Path(inspect.getsourcefile(real_gemma4)).read_text()
 
 
-# Upstream is free to spell the dtype alignment wherever it likes: at the merge
-# call (`audio_features.to(inputs_embeds.device, inputs_embeds.dtype)`, tf 5.15+)
-# or on the statement that produced the features
-# (`image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)`,
-# tf 5.5-5.14, or `... = torch.cat(image_features, dim=0).to(..., inputs_embeds.dtype)`,
-# tf 5.15). A substring anchor on one spelling breaks on cosmetic refactors while
-# staying blind to a real regression written in another spelling, so the canaries
-# below trace dtype ALIGNMENT structurally instead: find every
-# `inputs_embeds.masked_scatter` that consumes the features, and require of each an
-# `inputs_embeds.dtype` cast either inside the merge argument or on the last
-# assignment to that name that DOMINATES the merge (same block or an enclosing one,
-# so a cast stranded in a branch the merge does not run under does not count), plus
-# a receiver that is still AT `inputs_embeds.dtype` and a result that is actually
-# used (masked_scatter is out-of-place).
-# Known, deliberate limits of the trace, none of which any transformers 5.5.0
-# to 5.15.0 source hits (checked against every gemma4-bearing release, and the
-# spellings themselves against all 503 model families of 5.15.0):
-#   * names bound by `match`/`case` patterns are not tracked - no transformers
-#     modeling file contains a `match` statement;
-#   * the merged result only has to REACH `inputs_embeds`; a later statement
-#     overwriting it again is not modelled. Requiring survival to the end
-#     instead trades this for a false red on "merge, use, then release the
-#     name", which needs a use-before-overwrite analysis to tell apart;
-#   * `.to(other_tensor)` counts as alignment here but not in the eager patch's
-#     own matcher (unsloth_zoo/temporary_patches/gemma4.py), which reads only
-#     the `.to(inputs_embeds.device[, inputs_embeds.dtype])` spelling upstream
-#     actually ships. Upstream adopting the overload would surface as a drift
-#     warning telling us to update the patch, which is the intended signal.
+# Upstream may spell the dtype alignment at the merge call
+# (`audio_features.to(inputs_embeds.device, inputs_embeds.dtype)`, tf 5.15+) or on
+# the statement that produced the features (tf 5.5-5.14). A substring anchor on one
+# spelling breaks on cosmetic refactors while staying blind to a real regression
+# written in another, so the canaries trace dtype ALIGNMENT structurally: every
+# `inputs_embeds.masked_scatter` consuming the features needs an
+# `inputs_embeds.dtype` cast at the call or on the last assignment that DOMINATES
+# the merge (same block or an enclosing one, so a cast stranded in a branch the
+# merge does not run under does not count), a receiver still AT
+# `inputs_embeds.dtype`, and a result that is actually used (masked_scatter is
+# out-of-place).
+# Deliberate limits, none hit by any transformers 5.5.0-5.15.0 source (checked
+# against every gemma4-bearing release, and the spellings against all 503 model
+# families of 5.15.0):
+#   * `match`/`case` bindings are not tracked - no transformers modeling file has
+#     a `match` statement;
+#   * the merged result only has to REACH `inputs_embeds`; a later overwrite is not
+#     modelled, since requiring survival to the end would red-flag "merge, use,
+#     then release the name" without a use-before-overwrite analysis;
+#   * `.to(other_tensor)` counts as alignment here but not in the eager patch's own
+#     matcher (unsloth_zoo/temporary_patches/gemma4.py), which reads only the
+#     spelling upstream actually ships. Upstream adopting the overload would
+#     surface as a drift warning telling us to update the patch, as intended.
 def _is_attr(node, owner, attr):
     """`<owner>.<attr>` as an AST node, e.g. `inputs_embeds.dtype`."""
     return (
@@ -247,16 +242,12 @@ def _is_embeds_tensor(node):
 def _casts_to_inputs_embeds_dtype(node):
     """True if `node` contains a `.to(...)` that lands on `inputs_embeds`' dtype.
 
-    Two spellings count. The explicit one names the dtype
-    (`features.to(inputs_embeds.device, inputs_embeds.dtype)`), and the tensor
-    overload names the tensor: `Tensor.to(other)` is documented as "returns a
-    Tensor with same torch.dtype and torch.device as the Tensor other", so
-    `features.to(inputs_embeds)` aligns dtype AND device in one call and is just
-    as safe a merge source. Rejecting it would make these canaries fail on a
-    healthy upstream that happened to prefer that spelling, and the failure would
-    claim nobody aligns the dtype at all. Only the FIRST positional argument can
-    be the tensor overload (`to(other, non_blocking=..., copy=...)`); torch has
-    no `other=` keyword, so keywords are not considered for it.
+    Two spellings count: the explicit `features.to(inputs_embeds.device,
+    inputs_embeds.dtype)`, and the tensor overload `features.to(inputs_embeds)`,
+    documented as returning a tensor with the same dtype AND device as `other`.
+    Rejecting the overload would fail these canaries on a healthy upstream that
+    preferred it, claiming nobody aligns the dtype at all. Only the FIRST
+    positional argument can be that overload; torch has no `other=` keyword.
     """
     for sub in ast.walk(node):
         if not (
@@ -274,10 +265,9 @@ def _casts_to_inputs_embeds_dtype(node):
 
 
 # Methods that may sit between `inputs_embeds` and `.masked_scatter(...)` without
-# changing the destination dtype. Anything outside this set (`.float()`, `.half()`,
-# `.type(...)`, an unknown helper) can retype the destination, which makes an
-# `inputs_embeds.dtype` source cast prove nothing: the merge then has an fp32
-# destination and a low-precision source and raises.
+# changing the destination dtype. Anything else (`.float()`, `.type(...)`, an
+# unknown helper) can retype it, leaving an fp32 destination and a low-precision
+# source, so an `inputs_embeds.dtype` source cast would prove nothing.
 _DTYPE_PRESERVING_METHODS = frozenset({
     "clone", "contiguous", "detach", "cpu", "cuda",
     "view", "reshape", "flatten", "squeeze", "unsqueeze",
@@ -285,25 +275,20 @@ _DTYPE_PRESERVING_METHODS = frozenset({
 })
 
 
-# `torch.<name>` constants that are provably NOT dtypes, so they cannot retype the
-# receiver: `inputs_embeds.clone(memory_format = torch.preserve_format)` and
-# `inputs_embeds.contiguous(memory_format = torch.contiguous_format)` keep the
-# embedding dtype exactly. Reading every `torch.<attr>` as a dtype rejected those
-# receivers, so a purely cosmetic upstream addition of an explicit memory format
-# would fail the real-source canaries with "the destination was retyped" - the
-# false red this structural trace exists to remove. (`_to_call_preserves_dtype`
-# already whitelists the `memory_format` keyword of `.to(...)` for the same
-# reason.) Resolved against the live torch so the set cannot drift from reality;
-# an attribute torch does not have stays dtype-bearing, which is the safe default.
+# `torch.<name>` constants that provably are NOT dtypes, so they cannot retype the
+# receiver: `clone(memory_format = torch.preserve_format)` keeps the embedding dtype
+# exactly. Reading every `torch.<attr>` as a dtype turned that cosmetic upstream
+# addition into a "destination was retyped" false red - the very failure this
+# structural trace exists to remove. Resolved against the live torch, so an
+# attribute torch does not have stays dtype-bearing: the safe default.
 _NON_DTYPE_TORCH_CONSTANTS = (torch.memory_format, torch.layout)
 
 
 def _is_dtype_bearing(node, aliases = frozenset()):
     """Can `node` retype a tensor? (`torch.float32`, `other.dtype`, ...)
 
-    `aliases` are local names already known to hold a dtype, because
-    `Tensor.view(dtype)` reinterprets its receiver just as thoroughly whether the
-    dtype is written out or held in a variable.
+    `aliases` are local names known to hold a dtype: `Tensor.view(dtype)`
+    reinterprets its receiver whether the dtype is written out or held in a name.
     """
     if isinstance(node, ast.Name):
         return node.id in aliases
@@ -314,9 +299,8 @@ def _is_dtype_bearing(node, aliases = frozenset()):
         and isinstance(node.value, ast.Name)
         and node.value.id == "torch"
     ):
-        # `torch.float32` / `torch.bfloat16` / `torch.long` retype; a memory
-        # format or a layout does not. `Tensor.view(torch.int32)` really does
-        # reinterpret the dtype, so the check is on the constant, not the method.
+        # A memory format or layout does not retype; `Tensor.view(torch.int32)`
+        # does, so the check is on the constant, not the method.
         return not isinstance(
             getattr(torch, node.attr, None), _NON_DTYPE_TORCH_CONSTANTS
         )
@@ -341,9 +325,8 @@ def _is_device_expr(node):
 def _to_call_preserves_dtype(call):
     """Is this `.to(...)` device-only (or a no-op `inputs_embeds.dtype` cast)?
 
-    `inputs_embeds.to(language_model_inputs.device)` is blip_2's real spelling and
-    keeps the dtype; `.to(torch.float32)`, `.to(other.dtype)` and the tensor
-    overload `.to(other_tensor)` do not.
+    `inputs_embeds.to(other.device)` is blip_2's real spelling and keeps the dtype;
+    `.to(torch.float32)`, `.to(other.dtype)` and `.to(other_tensor)` do not.
     """
     for arg in call.args:
         if not (_is_device_expr(arg) or _is_attr(arg, "inputs_embeds", "dtype")):
@@ -362,11 +345,10 @@ def _to_call_preserves_dtype(call):
 def _receiver_preserves_embeds_dtype(node, aliases = frozenset()):
     """Is the merge destination `inputs_embeds` still at `inputs_embeds.dtype`?
 
-    The whole trace is "the source is cast to `inputs_embeds.dtype`, so the merge
-    is safe", which only holds while the DESTINATION is at that dtype too. The
-    receiver may be `inputs_embeds` itself or a chain of dtype-preserving
-    transformations of it (upstream blip_2 really does write
-    `inputs_embeds.to(language_model_inputs.device).masked_scatter(...)`), but
+    The trace is "the source is cast to `inputs_embeds.dtype`, so the merge is
+    safe", which only holds while the DESTINATION is at that dtype too. A chain of
+    dtype-preserving transformations is fine (blip_2 really writes
+    `inputs_embeds.to(other.device).masked_scatter(...)`), but
     `inputs_embeds.float().masked_scatter(mask, feat.to(inputs_embeds.dtype))`
     merges a low-precision source into an fp32 destination and raises.
     """
@@ -394,11 +376,10 @@ _SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
 def _walk_own_scope(root, descend = True):
     """`ast.walk` restricted to the code `root`'s own scope executes.
 
-    A nested `def` / `class` / `lambda` is a separate scope with its own local
-    names, so a merge written inside a helper defined in `forward` is not
-    `forward`'s merge (the helper may never be invoked), and a cast in `forward`
-    says nothing about a same-named parameter of that helper. The nested
-    statement itself is still yielded - only its body is skipped.
+    A nested `def` / `class` / `lambda` has its own locals, so a merge inside a
+    helper defined in `forward` is not `forward`'s merge (it may never be invoked),
+    and a cast in `forward` says nothing about a same-named parameter of that
+    helper. The nested statement itself is still yielded - only its body is skipped.
     """
     if isinstance(root, _SCOPE_NODES) and not descend:
         yield root
@@ -439,9 +420,8 @@ def _child_blocks(stmt):
 def _enclosing_blocks(forward, target):
     """`[(block, index)]` from the function body inwards to the stmt holding `target`.
 
-    Only these statement lists run unconditionally *relative to the merge*. A cast
-    nested in some other branch may never execute on the path that reaches the
-    merge, so it cannot prove alignment.
+    Only these lists run unconditionally *relative to the merge*: a cast nested in
+    another branch may never execute on the path that reaches it.
     """
     chain = []
 
@@ -466,11 +446,10 @@ def _enclosing_blocks(forward, target):
 def _is_dtype_guard(test, feature):
     """Exactly `<feature>.dtype != inputs_embeds.dtype` (either operand order).
 
-    Only that comparison makes the untaken branch aligned BY DEFINITION. Any
-    other test mentioning the feature dtype (`... == inputs_embeds.dtype`,
-    `... != torch.bfloat16`, or the mismatch test `and`-ed with something else)
-    leaves a reachable path on which the feature stays un-cast, so a cast under
-    it proves nothing and must not count as unconditional alignment.
+    Only that comparison makes the untaken branch aligned BY DEFINITION. Any other
+    test (`== inputs_embeds.dtype`, `!= torch.bfloat16`, or the mismatch test
+    `and`-ed with something else) leaves a reachable path on which the feature
+    stays un-cast, so a cast under it is not unconditional alignment.
     """
     if not (isinstance(test, ast.Compare) and len(test.ops) == 1):
         return False
@@ -487,16 +466,14 @@ def _is_dtype_guard(test, feature):
 def _bound_names(target):
     """Every plain name an assignment target binds.
 
-    Recurses through destructuring targets, because
-    `image_features, feature_lens = self.pack_image_features(...)` (the
-    llava_next / llava_onevision / llava_next_video spelling) rebinds
-    `image_features` just as much as a bare `image_features = ...` does. Missing
-    it lets an earlier aligned assignment keep proving alignment for a tensor
-    that has since been replaced by an unpacked, possibly mismatched one.
+    Recurses through destructuring targets, because `image_features, feature_lens =
+    self.pack_image_features(...)` (llava_next / llava_onevision) rebinds
+    `image_features` just as much as a bare assignment does; missing it lets an
+    earlier aligned assignment keep proving alignment for a tensor since replaced.
 
     `image_features[0] = ...` (Subscript) and `self.image_features = ...`
-    (Attribute) are deliberately NOT name rebindings: the name still refers to
-    the same object afterwards.
+    (Attribute) are deliberately NOT rebindings: the name still refers to the same
+    object afterwards.
     """
     if isinstance(target, ast.Name):
         return [target.id]
@@ -510,24 +487,21 @@ def _bound_names(target):
 _ASSIGN_NODES = (ast.Assign, ast.AnnAssign, ast.AugAssign)
 _LOOP_NODES = (ast.For, ast.AsyncFor)
 _WITH_NODES = (ast.With, ast.AsyncWith)
-# Every construct that can rebind a plain name in the code's OWN scope. An
-# assignment statement is only the most common one: `for image_features in
-# image_batches:`, `with self.autocast() as image_features:` and
-# `if (image_features := self.pack(image_features)) is None:` all replace the
-# tensor the name refers to just as completely. Counting only assignments lets an
-# earlier aligned assignment keep proving alignment for a value that one of these
-# has since overwritten, and the replacement reaches masked_scatter un-cast.
-# (Comprehensions bind in their own scope and so cannot affect `forward`'s name.)
+# Every construct that can rebind a plain name in the code's OWN scope: `for
+# image_features in ...`, `with self.autocast() as image_features:` and
+# `(image_features := ...)` replace the tensor as completely as an assignment does.
+# Counting only assignments lets an earlier aligned cast keep proving alignment for
+# a value one of these has overwritten, and the replacement reaches masked_scatter
+# un-cast. (Comprehensions bind in their own scope.)
 _BINDING_NODES = _ASSIGN_NODES + _LOOP_NODES + _WITH_NODES + (ast.NamedExpr,)
 
 
 def _binding_pairs(node):
     """`[(target, value)]` this binding node establishes.
 
-    The `value` is the expression whose dtype the bound name ends up carrying, so
-    the same `_casts_to_inputs_embeds_dtype` question can be asked of every
-    binding form: an assignment's RHS, a loop's iterable (the target takes its
-    elements), and a `with` item's context expression.
+    `value` is the expression whose dtype the bound name carries, so the same
+    alignment question fits every form: an assignment's RHS, a loop's iterable, a
+    `with` item's context expression.
     """
     if isinstance(node, ast.Assign):
         return [(target, node.value) for target in node.targets]
@@ -554,14 +528,13 @@ def _assigns_feature(stmt, feature):
 def _element_value(target, value, feature):
     """The part of `value` that `<feature>` actually receives from `target`.
 
-    A destructuring target consumes the RHS element by element, so when the RHS
-    is written out as a literal tuple/list the name takes ITS element and nothing
-    else: in `image_features, lens = (image_features.float(), lens.to(
-    inputs_embeds.dtype))` the only cast belongs to `lens`, and crediting it to
+    A destructuring target consumes a literal tuple/list RHS element by element, so
+    in `image_features, lens = (image_features.float(), lens.to(
+    inputs_embeds.dtype))` the cast belongs to `lens` alone, and crediting it to
     `image_features` reports an fp32 tensor aligned. Anything else (a call, a
-    starred target, a length mismatch) keeps the whole RHS, which is how
-    `image_features, feature_lens = self.pack_image_features(image_features.to(
-    inputs_embeds.dtype))` - upstream's llava_next spelling - stays aligned.
+    starred target, a length mismatch) keeps the whole RHS, which is how upstream's
+    llava_next `image_features, lens = self.pack_image_features(image_features.to(
+    inputs_embeds.dtype))` stays aligned.
     """
     if isinstance(target, ast.Name):
         return value if target.id == feature else None
@@ -578,9 +551,8 @@ def _element_value(target, value, feature):
     return value
 
 
-# Only a real destructuring assignment pairs targets with RHS elements. A
-# `for` / `with` target takes its value from the iterable / context manager, not
-# positionally from the expression's own elements.
+# Only a real destructuring assignment pairs targets with RHS elements; a `for` /
+# `with` target takes its value from the iterable / context manager instead.
 _ELEMENTWISE_NODES = (ast.Assign, ast.AnnAssign, ast.NamedExpr)
 
 
@@ -603,13 +575,10 @@ def _binding_is_aligned(node, feature):
 def _feature_rebindings(stmt, feature):
     """Every rebinding of `<feature>` anywhere inside `stmt`'s own scope.
 
-    An augmented assignment is NOT one of them: `image_features += delta` is
-    `Tensor.add_`, which writes through the existing storage and keeps the
-    existing dtype. It neither creates the alignment its RHS carries
-    (`image_features += delta.to(inputs_embeds.dtype)` leaves an fp32
-    `image_features` fp32) nor destroys one an earlier cast established
-    (`image_features += bias` on an aligned tensor is still aligned), so it says
-    nothing and the running verdict stands.
+    An augmented assignment is NOT one: `image_features += delta` is `Tensor.add_`,
+    which writes through the existing storage and keeps its dtype. It neither
+    creates the alignment its RHS carries nor destroys one an earlier cast
+    established, so the running verdict stands.
     """
     return [
         node
@@ -623,7 +592,7 @@ def _feature_rebindings(stmt, feature):
 def _rebinding_alignment(stmt, feature):
     """Does `stmt` rebind `<feature>` on the path to the merge, and is it aligned?
 
-    `None` when `stmt` does not rebind the name (so it says nothing either way).
+    `None` when `stmt` does not rebind the name, so it says nothing either way.
     """
     if (
         isinstance(stmt, _ASSIGN_NODES)
@@ -631,23 +600,19 @@ def _rebinding_alignment(stmt, feature):
         and _assigns_feature(stmt, feature)
     ):
         return _binding_is_aligned(stmt, feature)
-    # A bare named expression statement, `(image_features := ...)`, rebinds
-    # unconditionally exactly like an assignment does.
+    # A bare `(image_features := ...)` statement rebinds like an assignment.
     if (
         isinstance(stmt, ast.Expr)
         and isinstance(stmt.value, ast.NamedExpr)
         and _assigns_feature(stmt.value, feature)
     ):
         return _binding_is_aligned(stmt.value, feature)
-    # `if <feature>.dtype != inputs_embeds.dtype: <feature> = <feature>.to(...)`
-    # is a cast-if-needed idiom (transformers spells it in blip_2 / granite_speech):
-    # the untaken branch is aligned by definition, so it counts as unconditional.
-    #
-    # Both branches still have to be analysed as PATHS, not as a bag of
-    # rebindings whose textually last one wins. `if enabled: <feature> =
-    # <feature>.to(inputs_embeds.dtype)` nested inside the guard, or an aligned
-    # `else` after an unaligned body, would otherwise report the whole guard
-    # aligned while the mismatch path leaves the feature un-cast.
+    # `if <feature>.dtype != inputs_embeds.dtype: <feature> = <feature>.to(...)` is
+    # the cast-if-needed idiom (blip_2 / granite_speech): the untaken branch is
+    # aligned by definition, so it counts as unconditional. Both branches are still
+    # analysed as PATHS, not as a bag of rebindings whose textually last one wins,
+    # or an aligned `else` after an unaligned body would report the guard aligned
+    # while the mismatch path leaves the feature un-cast.
     if isinstance(stmt, ast.If) and _is_dtype_guard(stmt.test, feature):
         if _feature_rebindings(stmt, feature):
             # Body runs only on a mismatch (starts unaligned); `orelse` only when
@@ -656,18 +621,14 @@ def _rebinding_alignment(stmt, feature):
                 _sequence_alignment(stmt.body, feature, False)
                 and _sequence_alignment(stmt.orelse, feature, True)
             )
-    # Any OTHER compound statement that rebinds the feature is still a rebinding
-    # on the path to the merge and must not be skipped, or an earlier aligned
-    # assignment would keep proving alignment for a value that has since been
-    # rewritten (`if enabled: image_features = image_features.float()`).
+    # Any OTHER compound statement that rebinds the feature is still a rebinding on
+    # the path to the merge (`if enabled: image_features = image_features.float()`).
     rebindings = _feature_rebindings(stmt, feature)
     if not rebindings:
         return None
     if isinstance(stmt, _WITH_NODES):
-        # A `with` body runs unconditionally, so its rebindings dominate the
-        # merge exactly like top-level ones: take the last one that says
-        # anything. The `as` target binds first, before the body runs, so it
-        # seeds the state.
+        # A `with` body runs unconditionally, so its rebindings dominate the merge
+        # like top-level ones. The `as` target binds first and seeds the state.
         alignment = (
             _binding_is_aligned(stmt, feature)
             if _assigns_feature(stmt, feature) else None
@@ -677,12 +638,10 @@ def _rebinding_alignment(stmt, feature):
             if inner_alignment is not None:
                 alignment = inner_alignment
         return alignment
-    # Conditionally executed (`if` / `for` / `while` / `try`): the rebinding may
-    # or may not run, so the state after it is "aligned before AND aligned in
-    # every branch". An unaligned branch therefore reports unaligned; a branch
-    # that only ever casts to `inputs_embeds.dtype` leaves the earlier verdict
-    # standing (`None`) instead of overriding it. A loop's own target counts as
-    # one of those rebindings, taking its dtype from the iterable.
+    # Conditionally executed (`if` / `for` / `while` / `try`): the rebinding may not
+    # run, so an unaligned branch reports unaligned while a branch that only ever
+    # casts to `inputs_embeds.dtype` leaves the earlier verdict standing (`None`).
+    # A loop's own target is one of those rebindings, typed by the iterable.
     for rebinding in rebindings:
         if not _binding_is_aligned(rebinding, feature):
             return False
@@ -692,10 +651,8 @@ def _rebinding_alignment(stmt, feature):
 def _sequence_alignment(block, feature, initial):
     """Alignment of `<feature>` after running `block` top to bottom.
 
-    `initial` is the state on entry to the block. Statements that say nothing
-    about the feature (`_rebinding_alignment` -> `None`, which includes a
-    conditional rebinding that only ever casts to `inputs_embeds.dtype`, since
-    it may not run) leave the running state alone.
+    `initial` is the state on entry. Statements that say nothing about the feature
+    (`None`, which includes a conditional cast that may not run) leave it alone.
     """
     state = initial
     for stmt in block:
@@ -732,11 +689,9 @@ _METADATA_ATTRS = frozenset({
 def _carries_value(node, matches):
     """Do the VALUES of a `matches` expression flow into `node`?
 
-    Both the merge SOURCE and the merge RESULT are traced by "does this
-    expression use that tensor", and a bare occurrence check answers that with
-    `image_features.device` or `merged.dtype` too. A metadata read carries none
-    of the tensor's values, so the whole subtree under it is skipped; everything
-    else still counts, which keeps
+    A bare occurrence check would answer yes to `image_features.device` or
+    `merged.dtype` too. A metadata read carries no values, so its whole subtree is
+    skipped; everything else still counts, keeping
     `image_features.to(...).reshape(-1, image_features.shape[-1])` a use.
     """
     if isinstance(node, ast.Attribute) and node.attr in _METADATA_ATTRS:
@@ -749,11 +704,10 @@ def _carries_value(node, matches):
 def _carries_feature_value(node, feature):
     """Do `<feature>`'s VALUES flow into `node`?
 
-    A merge is discovered by "the source argument uses the feature". Counting a
-    metadata read would report a source spelled
-    `fallback.to(image_features.device, inputs_embeds.dtype)` as the image merge -
-    and if the real merge were ever dropped, `_merge_dtype_alignment` would return
-    `(True, True)` on a source in which no image value reaches the model at all.
+    Counting a metadata read would report `fallback.to(image_features.device,
+    inputs_embeds.dtype)` as the image merge, so if the real merge were ever
+    dropped `_merge_dtype_alignment` would still return `(True, True)` on a source
+    in which no image value reaches the model.
     """
     return _carries_value(node, lambda n: isinstance(n, ast.Name) and n.id == feature)
 
@@ -761,28 +715,20 @@ def _carries_feature_value(node, feature):
 def _feature_merges(forward, feature):
     """Every `inputs_embeds.masked_scatter[_](mask, ...)` call using `<feature>`.
 
-    The receiver has to REFERENCE `inputs_embeds`: a
-    `scratch.masked_scatter(mask, feature)` elsewhere in `forward` is a different
-    tensor and says nothing about the dtype of the embedding merge. Discovery
-    stays deliberately loose here (any receiver mentioning the name) so that a
-    transformed receiver such as blip_2's
-    `inputs_embeds.to(language_model_inputs.device).masked_scatter(...)` is still
-    recognised AS the embedding merge; whether that transformation is dtype-safe
-    is then decided by `_receiver_preserves_embeds_dtype`. Dropping unrecognised
-    receivers here instead would let a second, safe merge hide a dtype-changing
-    one.
+    The receiver has to REFERENCE `inputs_embeds` (a `scratch.masked_scatter(...)`
+    is a different tensor), but discovery stays loose - any receiver mentioning the
+    name - so a transformed one such as blip_2's
+    `inputs_embeds.to(other.device).masked_scatter(...)` is still recognised AS the
+    embedding merge; whether it is dtype-safe is then
+    `_receiver_preserves_embeds_dtype`'s call. Dropping unrecognised receivers here
+    instead would let a second, safe merge hide a dtype-changing one.
 
-    The SOURCE, by contrast, has to carry the feature's values: a merge that only
-    reads `<feature>.device` or `<feature>.dtype` scatters something else, and
-    counting it would let a metadata mention stand in for a merge that upstream
-    has removed.
+    The SOURCE, by contrast, has to carry the feature's VALUES, or a metadata
+    mention could stand in for a merge upstream has removed.
 
-    The in-place spelling is accepted too (transformers writes
-    `masked_scatter_` in qwen2_5_omni and blt): it merges into the same storage
-    and needs the same dtype agreement.
-
-    Nested `def` / `class` / `lambda` bodies are skipped: a merge in a helper
-    `forward` never invokes is not `forward`'s merge.
+    `masked_scatter_` is accepted too (qwen2_5_omni, blt): same storage, same dtype
+    agreement. Nested `def` / `class` / `lambda` bodies are skipped - a merge in a
+    helper `forward` never invokes is not `forward`'s merge.
     """
     calls = []
     for node in _walk_own_scope(forward):
@@ -803,14 +749,11 @@ def _feature_merges(forward, feature):
     return sorted(calls, key=lambda n: (n.lineno, n.col_offset))
 
 
-# The merge RESULT is followed by the same rule that discovers the merge source:
-# only an expression carrying the tensor's VALUES passes it on. A metadata read of
-# the merge (`merged.device`, `merged.dtype`, `merged.shape`) discards every
-# scattered value, so `merged = inputs_embeds.masked_scatter(...)` followed by
-# `inputs_embeds = original.to(merged.device)` hands the embeddings the ORIGINAL
-# tensor. Treating that mention as value flow reported the merge used, so an
-# upstream refactor that removed the effective merge would leave every canary
-# here green while no feature reached the model.
+# The merge RESULT is followed by the same value-flow rule as the source. A
+# metadata read (`merged.device`, `merged.dtype`, `merged.shape`) discards every
+# scattered value, so `inputs_embeds = original.to(merged.device)` hands the
+# embeddings the ORIGINAL tensor. Treating that mention as value flow reported the
+# merge used, so a refactor dropping the effective merge stayed green.
 def _contains(node, target):
     return _carries_value(node, lambda n: n is target)
 
@@ -822,9 +765,8 @@ def _references(node, names):
 def _statements_after(forward, call):
     """The statements that execute after `call`, innermost block outwards.
 
-    The first one yielded is the merge's OWN statement; then the rest of the
-    block holding it, then the remainder of each enclosing block. That is the
-    straight-line path the merged tensor has to survive to reach the return.
+    The merge's OWN statement first, then the rest of its block, then the remainder
+    of each enclosing one: the path the merged tensor must survive to the return.
     """
     chain = _enclosing_blocks(forward, call)
     if not chain:
@@ -832,8 +774,7 @@ def _statements_after(forward, call):
     ordered = []
     for depth, (block, index) in enumerate(reversed(chain)):
         # The innermost entry points AT the merge's statement; every outer entry
-        # points at the compound statement wrapping it, which we have already
-        # accounted for.
+        # points at the compound statement wrapping it, already accounted for.
         ordered.extend(block[index if depth == 0 else index + 1:])
     return ordered
 
@@ -841,31 +782,21 @@ def _statements_after(forward, call):
 def _merge_result_is_used(forward, call):
     """Does the merge's result reach the embeddings `forward` goes on to use?
 
-    `masked_scatter` is OUT-OF-PLACE, so the merged embedding only exists in its
-    return value. Upstream has always spelled it
-    `inputs_embeds = inputs_embeds.masked_scatter(...)` on 5.5.0-5.15.0, and the
-    features reach the model precisely because that result lands back on
-    `inputs_embeds`.
-
-    Asking only whether the merge is a bare expression statement is too weak: it
+    `masked_scatter` is OUT-OF-PLACE, so the merged embedding exists only in its
+    return value; upstream lands it back on `inputs_embeds` on 5.5.0-5.15.0.
+    Asking only whether the merge is a bare expression statement is too weak - it
     passes `dead = inputs_embeds.masked_scatter(...)` and
-    `self.log(inputs_embeds.masked_scatter(...))`, both of which compute the
-    merged embedding, drop it on the floor and leave `forward` returning the
-    UNCHANGED `inputs_embeds` - the features silently never reach the model, with
-    every dtype canary in this file green. So follow the result forward instead:
-    it must flow, directly or through temporaries, into `inputs_embeds` or into a
-    `return`.
+    `self.log(inputs_embeds.masked_scatter(...))`, which drop the merged embedding
+    on the floor and leave `forward` returning the UNCHANGED `inputs_embeds` with
+    every dtype canary green. So follow the result forward: it must flow, directly
+    or through temporaries, into `inputs_embeds` or into a `return`.
 
-    The in-place `masked_scatter_` needs no result ONLY when its receiver is
-    `inputs_embeds` itself, because that is the one spelling whose write lands in
-    the embeddings `forward` goes on to use. On a transformed receiver -
-    `inputs_embeds.clone().masked_scatter_(...)`, or the device-changing
-    `inputs_embeds.to(...).masked_scatter_(...)`, both of which
-    `_receiver_preserves_embeds_dtype` accepts as dtype-safe - the mutation lands
-    in a temporary and `forward` still returns the unchanged `inputs_embeds`. So
-    only skip the result-flow analysis for a receiver that is guaranteed to alias
-    the original embeddings; anything else has to hand its result back like the
-    out-of-place spelling does (`masked_scatter_` returns the receiver, so it can).
+    `masked_scatter_` needs no result ONLY when its receiver is `inputs_embeds`
+    itself. On a transformed receiver (`inputs_embeds.clone()`, or the
+    device-changing `.to(...)`, both of which `_receiver_preserves_embeds_dtype`
+    accepts as dtype-safe) the mutation lands in a temporary, so it has to hand its
+    result back like the out-of-place spelling does - and it can, since
+    `masked_scatter_` returns its receiver.
     """
     if call.func.attr.endswith("_") and _is_embeds_tensor(call.func.value):
         return True
@@ -876,8 +807,8 @@ def _merge_result_is_used(forward, call):
     tainted = set()
     for position, statement in enumerate(statements):
         for node in _walk_own_scope(statement, descend = False):
-            # A `return` carrying the merge (or anything it flowed into) is the
-            # merged embedding leaving `forward`.
+            # A `return` carrying the merge, or its taint, is the merged embedding
+            # leaving `forward`.
             if isinstance(node, ast.Return) and node.value is not None:
                 if (position == 0 and _contains(node.value, call)) or _references(node.value, tainted):
                     return True
@@ -886,13 +817,11 @@ def _merge_result_is_used(forward, call):
             for target, value in _binding_pairs(node):
                 if target is None or value is None:
                     continue
-                # A destructuring target consumes the RHS element by element, so
-                # each name is judged on the part it actually receives. Reading
-                # the whole RHS made `inputs_embeds, aux = original, merged` taint
-                # `inputs_embeds` - reporting the merge used while the embeddings
-                # were handed the ORIGINAL, unmerged tensor. A non-literal RHS
-                # (a call, a starred or mismatched target) keeps the whole value,
-                # so `inputs_embeds, aux = self.pack(merged)` still counts.
+                # Each name is judged on the RHS element it actually receives.
+                # Reading the whole RHS made `inputs_embeds, aux = original, merged`
+                # taint `inputs_embeds` while the embeddings were handed the
+                # ORIGINAL. A non-literal RHS keeps the whole value, so
+                # `inputs_embeds, aux = self.pack(merged)` still counts.
                 element = value if isinstance(node, _ELEMENTWISE_NODES) else None
                 for name in _bound_names(target):
                     part = _element_value(target, element, name) if element is not None else value
@@ -904,10 +833,9 @@ def _merge_result_is_used(forward, call):
                         tainted.add(name)
                     elif node is statement and not isinstance(node, ast.AugAssign):
                         # A direct, unconditional rebinding to something the merge
-                        # did NOT flow into overwrites the name: the merged value
-                        # is gone. A rebinding nested inside a conditional may not
-                        # run, so it must not clear the taint - and an augmented
-                        # assignment adds to the value rather than replacing it.
+                        # did NOT flow into overwrites the name. One nested in a
+                        # conditional may not run, and `+=` adds rather than
+                        # replaces, so neither clears the taint.
                         tainted.discard(name)
         if "inputs_embeds" in tainted:
             return True
@@ -917,16 +845,12 @@ def _merge_result_is_used(forward, call):
 def _dtype_alias_names(forward):
     """Local names bound to a dtype, e.g. `target_dtype = torch.float32`.
 
-    `inputs_embeds.view(target_dtype)` reinterprets the merge destination exactly
-    like `inputs_embeds.view(torch.float32)` does, so a receiver holding its dtype
-    in a variable must not read as dtype-preserving: the merge would then take an
-    `inputs_embeds.dtype` source into a retyped destination and raise.
-
-    Only a binding whose VALUE is itself dtype-bearing counts, which is what keeps
-    the legitimate shape overload out: `Tensor.view` accepts a single shape
-    sequence, so `target_shape = image_features.shape` / `view(target_shape)` is
-    real upstream spelling and preserves the dtype. Repeated to a fixpoint so an
-    alias of an alias resolves too.
+    `inputs_embeds.view(target_dtype)` retypes the merge destination exactly like
+    `view(torch.float32)` does, so a receiver holding its dtype in a variable must
+    not read as dtype-preserving. Only a binding whose VALUE is dtype-bearing
+    counts, which keeps the legitimate shape overload (`target_shape =
+    image_features.shape` / `view(target_shape)`, real upstream spelling) out.
+    Repeated to a fixpoint so an alias of an alias resolves.
     """
     names = set()
     while True:
@@ -948,13 +872,10 @@ def _merge_dtype_alignment(src, feature):
     """Trace `<feature>` into `inputs_embeds.masked_scatter(...)`.
 
     Returns (merge_found, every_merge_aligned). EVERY merge consuming the feature
-    has to be aligned: one unaligned branch is one reachable dtype crash, so an
-    aligned first merge must not excuse an unaligned second one.
-
-    A merge counts as aligned when all three hold: the destination is still at
-    `inputs_embeds.dtype`, the merged result is actually used, and the source
-    carries an `inputs_embeds.dtype` cast at the call or on its last dominating
-    assignment.
+    has to be aligned: one unaligned branch is one reachable dtype crash. A merge
+    is aligned when the destination is still at `inputs_embeds.dtype`, the result
+    is actually used, and the source carries an `inputs_embeds.dtype` cast at the
+    call or on its last dominating assignment.
     """
     forward = _gemma4_model_forward_node(src)
     if forward is None:
@@ -1022,15 +943,12 @@ def test_real_gemma4_image_and_video_merges_still_cast_dtype(feature):
 
 @requires_gemma4
 def test_real_gemma4_audio_eager_patch_matches_real_merge_site():
-    # The canary above only proves the COMPILER rewriter (a regex over the source)
-    # still fires. The eager patch is stricter: it requires the merge's source
-    # argument to BE the `audio_features.to(inputs_embeds.device, ...)` call, so a
-    # wrapped spelling such as
-    # `audio_features.to(inputs_embeds.device).reshape(-1, inputs_embeds.shape[-1])`
-    # matches the regex but not the AST matcher - the eager patch would log a drift
-    # warning, no-op, and the dtype crash would come back on the non-compiled path
-    # while every other guard here stayed green. Run the patch's OWN matcher over
-    # the real source so that spelling fails loudly here instead.
+    # The canary above only proves the COMPILER rewriter (a regex) still fires. The
+    # eager patch is stricter - the merge source argument must BE the
+    # `audio_features.to(inputs_embeds.device, ...)` call - so a wrapped spelling
+    # matches the regex but not the AST matcher, and the eager path would no-op
+    # with the dtype crash back and every other guard green. Run the patch's OWN
+    # matcher over the real source so that spelling fails loudly here instead.
     src = _gemma4_modeling_source()
     forward = _gemma4_model_forward_node(src)
     assert forward is not None, "Gemma4Model.forward not found in the real source"
@@ -1079,10 +997,9 @@ def test_real_gemma4_audio_compiler_transform_emits_dtype_cast():
 
 
 def test_audio_compiler_transform_still_fixes_the_device_only_spelling():
-    # transformers 5.15.0 fixed the audio merge upstream, which makes the
-    # real-source test above pass without the rewriter doing anything. Keep the
-    # rewriter itself under test against the historical buggy spelling so it
-    # cannot silently rot while older transformers are still supported.
+    # transformers 5.15.0 fixed the audio merge upstream, so the real-source test
+    # above passes without the rewriter doing anything. Keep it under test against
+    # the historical buggy spelling while older transformers are still supported.
     buggy = (
         "        inputs_embeds = inputs_embeds.masked_scatter(\n"
         "            audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)\n"
@@ -1096,11 +1013,10 @@ def test_audio_compiler_transform_still_fixes_the_device_only_spelling():
 
 
 # ---------------------------------------------------------------------------
-# Tracer unit tests. The canaries above are only as good as `_merge_dtype_alignment`,
-# and a hole in it is invisible: it reports GREEN on a source that crashes. These
-# feed the tracer a minimal synthetic `Gemma4Model.forward` (no transformers
-# needed, so they run on every supported version) and pin the verdict on the
-# spellings that used to slip through.
+# Tracer unit tests. A hole in `_merge_dtype_alignment` is invisible: it reports
+# GREEN on a source that crashes. These feed it a minimal synthetic
+# `Gemma4Model.forward` (no transformers needed, so they run on every supported
+# version) and pin the verdict on the spellings that used to slip through.
 # ---------------------------------------------------------------------------
 _DEFAULT_MERGE = (
     "inputs_embeds = inputs_embeds.masked_scatter(\n"
@@ -1132,10 +1048,9 @@ _ALIGNED_ASSIGN = "image_features = image_features.to(inputs_embeds.device, inpu
 
 
 # Every path inside a `<feature>.dtype != inputs_embeds.dtype` guard has to end
-# aligned. Taking the textually last rebinding inside the guard instead reports
-# aligned for a guard whose MISMATCH path leaves the feature un-cast, which is
-# exactly one reachable `masked_scatter_: expected self and source to have same
-# dtypes`.
+# aligned. Taking the textually last rebinding instead reports aligned for a guard
+# whose MISMATCH path leaves the feature un-cast - one reachable
+# `masked_scatter_: expected self and source to have same dtypes`.
 _GUARD_HOLES = [
     ("cast nested under a second condition",
      "if image_features.dtype != inputs_embeds.dtype:\n"
@@ -1198,17 +1113,16 @@ _GUARD_CONTROLS = [
     "label,body", _GUARD_CONTROLS, ids = [case[0] for case in _GUARD_CONTROLS],
 )
 def test_cast_if_needed_guards_still_count_as_alignment(label, body):
-    # Controls for the test above: these are dtype-safe on every path and must
-    # NOT turn red, or the canaries start failing on a healthy upstream.
+    # Controls: dtype-safe on every path, so they must not turn red or the canaries
+    # start failing on a healthy upstream.
     found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
     assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
 
 
-# A destructuring assignment rebinds the feature name just like a plain one.
-# `image_features, feature_lens = self.pack_image_features(...)` is upstream's
-# own spelling in llava_next / llava_next_video / llava_onevision; skipping it
-# lets an earlier aligned assignment keep proving alignment for a tensor that
-# has since been replaced.
+# A destructuring assignment rebinds the feature name just like a plain one, and
+# `image_features, feature_lens = self.pack_image_features(...)` is upstream's own
+# llava_next spelling. Skipping it lets an earlier aligned assignment keep proving
+# alignment for a tensor that has since been replaced.
 _UNPACK_HOLES = [
     ("tuple unpack",
      f"{_ALIGNED_ASSIGN}\n"
@@ -1242,10 +1156,9 @@ def test_destructuring_rebindings_of_the_feature_are_not_skipped(label, body):
     )
 
 
-# A destructuring target takes its RHS ELEMENT, not the whole RHS. Reading the
-# whole tuple lets a cast that belongs to some other name keep the feature green
-# (transformers writes literal-tuple destructuring: vilt's
-# `text_features, _ = (sequence_output[:, :n], sequence_output[:, n:])`).
+# A destructuring target takes its RHS ELEMENT, not the whole RHS: reading the
+# whole tuple lets a cast belonging to another name keep the feature green
+# (transformers writes literal-tuple destructuring in vilt).
 _UNPACK_PAIRING_HOLES = [
     ("tuple RHS whose cast belongs to the other name",
      f"{_ALIGNED_ASSIGN}\n"
@@ -1284,9 +1197,8 @@ def test_the_matching_element_of_a_tuple_rhs_still_counts():
     assert found and aligned, "the element the feature actually receives carries the cast"
 
 
-# `image_features += delta` is `Tensor.add_`: in place, so the name keeps the
-# dtype it already had. It can neither inherit the RHS's cast nor lose an
-# earlier one.
+# `image_features += delta` is `Tensor.add_`: in place, so the name keeps the dtype
+# it already had. It can neither inherit the RHS's cast nor lose an earlier one.
 _AUG_ASSIGN_CASES = [
     ("augmented assignment does not inherit the RHS cast",
      "image_features = image_features.float()\n"
@@ -1341,12 +1253,11 @@ def test_non_rebinding_targets_do_not_break_alignment(label, body):
     assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
 
 
-# The whole trace is "the source is cast to `inputs_embeds.dtype`, so the merge is
-# safe". That only holds while the DESTINATION is still at `inputs_embeds.dtype`.
-# A receiver transformation that retypes it turns the source cast into the wrong
-# cast: `inputs_embeds.float().masked_scatter(mask, image_features.to(
-# inputs_embeds.dtype))` has an fp32 destination and an fp16/bf16 source and
-# raises the exact error this whole file exists to prevent.
+# The trace is "the source is cast to `inputs_embeds.dtype`, so the merge is safe",
+# which only holds while the DESTINATION is still at that dtype: a receiver
+# transformation that retypes it leaves `inputs_embeds.float().masked_scatter(mask,
+# image_features.to(inputs_embeds.dtype))` with an fp32 destination and an fp16/bf16
+# source, raising the exact error this file exists to prevent.
 _RECEIVER_HOLES = [
     ("receiver upcast with .float()",
      "inputs_embeds = inputs_embeds.float().masked_scatter(\n"
@@ -1368,14 +1279,14 @@ _RECEIVER_HOLES = [
      "inputs_embeds = self.upcast(inputs_embeds).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.dtype)\n"
      ")"),
-    # `Tensor.view(dtype)` reinterprets the storage as another dtype, so a real
-    # dtype constant must still be caught after memory formats stop counting.
+    # `Tensor.view(dtype)` reinterprets the storage, so a real dtype constant must
+    # still be caught now that memory formats do not count.
     ("receiver .view(torch.int32) reinterprets the dtype",
      "inputs_embeds = inputs_embeds.view(torch.int32).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.dtype)\n"
      ")"),
-    # ... and it reinterprets it just as thoroughly when the dtype arrives in a
-    # variable, which reads as a plain name at the call site.
+    # ... just as thoroughly when the dtype arrives in a variable, which reads as a
+    # plain name at the call site.
     ("receiver .view(alias of torch.float32)",
      "target_dtype = torch.float32\n"
      "inputs_embeds = inputs_embeds.view(target_dtype).masked_scatter(\n"
@@ -1413,8 +1324,8 @@ def test_receiver_that_changes_dtype_is_not_alignment(label, merge):
 
 
 _RECEIVER_CONTROLS = [
-    # blip_2 really ships this spelling; the receiver predicate is deliberately
-    # loose enough to still recognise it, and `.to(<device>)` keeps the dtype.
+    # blip_2 really ships this spelling; the receiver predicate stays loose enough
+    # to recognise it, and `.to(<device>)` keeps the dtype.
     ("blip_2 receiver .to(other.device)",
      "inputs_embeds = inputs_embeds.to(image_features.device).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1439,8 +1350,7 @@ _RECEIVER_CONTROLS = [
      "inputs_embeds = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
-    # A memory format is not a dtype: these keep the destination at
-    # `inputs_embeds.dtype`, and transformers already ships
+    # A memory format is not a dtype, and transformers already ships
     # `.clone(memory_format = torch.contiguous_format)` (higgs_audio_v2).
     ("receiver .clone(memory_format = torch.preserve_format)",
      "inputs_embeds = inputs_embeds.clone(memory_format = torch.preserve_format).masked_scatter(\n"
@@ -1454,9 +1364,8 @@ _RECEIVER_CONTROLS = [
      "inputs_embeds = inputs_embeds.contiguous(torch.channels_last).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
-    # `Tensor.view` also takes a single shape sequence, so a plain name argument
-    # is far more often a shape than a dtype. Only a name actually BOUND to a
-    # dtype may retype the destination; these two keep it.
+    # `Tensor.view` also takes a shape sequence, so a plain name is more often a
+    # shape than a dtype. Only a name actually BOUND to a dtype may retype.
     ("receiver .view(shape variable)",
      "target_shape = image_features.shape\n"
      "inputs_embeds = inputs_embeds.view(target_shape).masked_scatter(\n"
@@ -1474,20 +1383,17 @@ _RECEIVER_CONTROLS = [
     "label,merge", _RECEIVER_CONTROLS, ids = [case[0] for case in _RECEIVER_CONTROLS],
 )
 def test_dtype_preserving_receivers_still_count_as_alignment(label, merge):
-    # Controls for the test above: every one of these merges into a destination
-    # that is still at `inputs_embeds.dtype`, so they must NOT turn red.
+    # Controls: every destination here is still at `inputs_embeds.dtype`.
     found, aligned = _merge_dtype_alignment(
         _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
     )
     assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
 
 
-# `masked_scatter` is out-of-place. Losing the surrounding `inputs_embeds =`
-# leaves every dtype cast in place - and silently drops the features, because the
-# merged tensor is discarded. Upstream assigns the result on 5.5.0-5.15.0, so
-# requiring it costs nothing; the in-place `masked_scatter_` spelling
-# (transformers writes it in qwen2_5_omni / blt) needs no assignment and must
-# still be accepted.
+# `masked_scatter` is out-of-place: losing the surrounding `inputs_embeds =` leaves
+# every dtype cast in place and silently drops the features. Upstream assigns the
+# result on 5.5.0-5.15.0, so requiring it costs nothing; in-place `masked_scatter_`
+# (qwen2_5_omni / blt) needs no assignment and must still be accepted.
 def test_discarded_out_of_place_merge_is_not_alignment():
     merge = (
         "inputs_embeds.masked_scatter(\n"
@@ -1525,7 +1431,7 @@ _RESULT_USE_CONTROLS = [
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
     # `masked_scatter_` returns its receiver, so a transformed in-place receiver
-    # that hands the result back is exactly as safe as the out-of-place spelling.
+    # that hands the result back is as safe as the out-of-place spelling.
     ("in-place merge into a clone whose result is assigned back",
      "inputs_embeds = inputs_embeds.clone().masked_scatter_(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1545,11 +1451,10 @@ def test_used_merge_results_still_count_as_alignment(label, merge):
 
 
 # ---------------------------------------------------------------------------
-# Merge DISCOVERY keys on the feature's values reaching the scatter source. A
-# source that only reads `<feature>.device` / `.dtype` / `.shape` merges some
-# other tensor, so accepting it would let a metadata mention impersonate a merge
-# upstream had deleted: `_merge_dtype_alignment` would report (True, True) on a
-# source in which no image value reaches the model.
+# Merge DISCOVERY keys on the feature's VALUES reaching the scatter source. A source
+# that only reads `<feature>.device` / `.dtype` / `.shape` merges some other tensor,
+# so accepting it would let a metadata mention impersonate a merge upstream had
+# deleted, reporting (True, True) while no image value reaches the model.
 # ---------------------------------------------------------------------------
 _METADATA_ONLY_MERGES = [
     ("source reads the feature device only",
@@ -1612,8 +1517,7 @@ def test_feature_values_reaching_the_source_are_still_a_merge(label, merge):
 
 
 def test_in_place_merge_with_an_unaligned_source_is_still_traced():
-    # Accepting `masked_scatter_` must not become a way to skip the dtype trace:
-    # the in-place op has exactly the same dtype requirement.
+    # Accepting `masked_scatter_` must not skip the dtype trace: same requirement.
     merge = (
         "image_features = image_features.float()\n"
         "inputs_embeds.masked_scatter_(image_mask, image_features)"
@@ -1627,13 +1531,11 @@ def test_in_place_merge_with_an_unaligned_source_is_still_traced():
 
 
 # ---------------------------------------------------------------------------
-# `Tensor.to(other)` is documented as "returns a Tensor with same torch.dtype and
-# torch.device as the Tensor other", so `image_features.to(inputs_embeds)` aligns
-# BOTH in one call and is a perfectly safe merge source. Reading only the
-# explicit `inputs_embeds.dtype` spelling would fail these canaries on a healthy
-# upstream that happened to prefer the overload, and the failure message would
-# claim the dtype is never aligned - a false red that hides nothing and costs a
-# release.
+# `Tensor.to(other)` is documented as returning a tensor with the same dtype AND
+# device as `other`, so `image_features.to(inputs_embeds)` aligns both in one call.
+# Reading only the explicit `inputs_embeds.dtype` spelling would fail these canaries
+# on a healthy upstream that preferred the overload, claiming the dtype is never
+# aligned - a false red that hides nothing and costs a release.
 # ---------------------------------------------------------------------------
 _TENSOR_OVERLOAD_CONTROLS = [
     ("tensor overload at the merge argument",
@@ -1677,8 +1579,7 @@ _TENSOR_OVERLOAD_HOLES = [
     ("overload naming a module attribute",
      "image_features = image_features.to(self.dummy)"),
     # `inputs_embeds` only carries the dtype as the FIRST positional argument;
-    # torch has no `other=` keyword, and `.to(device, inputs_embeds)` is not a
-    # signature that exists.
+    # torch has no `other=` keyword.
     ("embeds passed as a keyword, which torch rejects",
      "image_features = image_features.to(device = inputs_embeds)"),
 ]
@@ -1699,10 +1600,9 @@ def test_tensor_overload_to_another_tensor_is_not_alignment(label, body):
 
 # ---------------------------------------------------------------------------
 # `masked_scatter` is out-of-place, so the merged embedding exists ONLY in the
-# return value. Rejecting just the bare-expression spelling is not enough: a
-# result bound to a name nothing reads, or passed to a logger, is discarded just
-# as completely, and `forward` then returns the UNCHANGED `inputs_embeds` with
-# every dtype canary green. The result has to reach the embeddings that survive.
+# return value. Rejecting just the bare-expression spelling is not enough: a result
+# bound to a name nothing reads, or passed to a logger, is discarded as completely
+# and `forward` returns the UNCHANGED `inputs_embeds` with every canary green.
 # ---------------------------------------------------------------------------
 _DISCARDED_RESULT_HOLES = [
     ("result bound to a name nothing reads",
@@ -1722,9 +1622,8 @@ _DISCARDED_RESULT_HOLES = [
      "collected = [inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")]"),
-    # `masked_scatter_` is in place in the RECEIVER's storage. On a clone or a
-    # device-changed copy that storage is a temporary, so the discarded result is
-    # the whole merge: `forward` returns the unchanged `inputs_embeds`.
+    # `masked_scatter_` writes into the RECEIVER's storage; on a clone or a
+    # device-changed copy that storage is a temporary, so the merge is lost.
     ("in-place merge into a clone of the embeddings",
      "inputs_embeds.clone().masked_scatter_(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1733,9 +1632,9 @@ _DISCARDED_RESULT_HOLES = [
      "inputs_embeds.to('cuda').masked_scatter_(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
-    # A destructuring target takes its own RHS element. Crediting the whole RHS
-    # let a tuple hand `inputs_embeds` the ORIGINAL while the merge went to a
-    # name nothing reads - the modality silently dropped, every canary green.
+    # A destructuring target takes its own RHS element; crediting the whole RHS let
+    # a tuple hand `inputs_embeds` the ORIGINAL while the merge went to a name
+    # nothing reads - the modality silently dropped, every canary green.
     ("destructuring hands the embeddings the original, not the merge",
      "merged = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1752,9 +1651,8 @@ _DISCARDED_RESULT_HOLES = [
      ")\n"
      "(inputs_embeds, aux), sizes = (original, merged), image_sizes"),
     # A metadata read of the merge scatters nothing: the embeddings are handed the
-    # ORIGINAL tensor and only the merge's device / dtype / shape is consulted.
-    # Propagating taint through it reported the merge used, so a refactor that
-    # dropped the effective merge would keep every canary here green.
+    # ORIGINAL tensor. Propagating taint through it reported the merge used, so a
+    # refactor dropping the effective merge kept every canary here green.
     ("embeddings take the original, reading only the merge device",
      "merged = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1805,9 +1703,9 @@ _RESULT_REACHES_CONTROLS = [
      "    inputs_embeds = inputs_embeds.masked_scatter(\n"
      "        image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      "    )"),
-    # The mirror image: pairing element by element must still see the merge when
-    # it IS the element the embeddings receive, and a non-literal RHS keeps the
-    # whole value, so an unpacking call still propagates it.
+    # The mirror image: element-by-element pairing must still see the merge when it
+    # IS the element the embeddings receive, and a non-literal RHS keeps the whole
+    # value, so an unpacking call still propagates it.
     ("destructuring hands the embeddings the merge",
      "merged = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1828,8 +1726,8 @@ _RESULT_REACHES_CONTROLS = [
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")\n"
      "inputs_embeds, *aux = merged, original"),
-    # Skipping metadata must not skip a real use that merely mentions metadata
-    # alongside it: the merged VALUES still reach the embeddings here.
+    # Skipping metadata must not skip a real use that merely mentions it alongside:
+    # the merged VALUES still reach the embeddings here.
     ("result reshaped by its own shape",
      "merged = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1847,8 +1745,7 @@ _RESULT_REACHES_CONTROLS = [
     "label,merge", _RESULT_REACHES_CONTROLS, ids = [c[0] for c in _RESULT_REACHES_CONTROLS],
 )
 def test_results_that_do_reach_the_embeddings_still_count(label, merge):
-    # Controls: the merged tensor really does land back on `inputs_embeds`, so
-    # these must NOT turn red.
+    # Controls: the merged tensor really does land back on `inputs_embeds`.
     found, aligned = _merge_dtype_alignment(
         _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
     )
@@ -1856,10 +1753,10 @@ def test_results_that_do_reach_the_embeddings_still_count(label, merge):
 
 
 # ---------------------------------------------------------------------------
-# A name is not only rebound by an assignment statement. A `for` target, a `with
-# ... as` target and a named expression all replace the tensor the name refers
-# to, so an earlier aligned assignment stops describing it. Skipping them lets
-# the replacement - which nothing cast - reach masked_scatter.
+# A name is not only rebound by an assignment: a `for` target, a `with ... as`
+# target and a named expression all replace the tensor the name refers to, so an
+# earlier aligned assignment stops describing it. Skipping them lets the
+# replacement, which nothing cast, reach masked_scatter.
 # ---------------------------------------------------------------------------
 _NON_ASSIGN_BINDING_HOLES = [
     ("for target",
@@ -1938,11 +1835,10 @@ def test_aligned_or_unrelated_bindings_do_not_break_alignment(label, body):
 
 # ---------------------------------------------------------------------------
 # The eager patch's own matcher must be tied to the EMBEDDING merge. Accepting
-# `masked_scatter` on any receiver let an already-aligned merge on some scratch
-# tensor land in `fixed_casts`, which reads to
-# `_patch_gemma4_audio_feature_dtype_on_class` as "upstream fixed it": it sets
-# the patched marker and returns, leaving a real, still-device-only
-# `inputs_embeds` merge unpatched and crashing.
+# `masked_scatter` on any receiver let an aligned merge on a scratch tensor land in
+# `fixed_casts`, which reads to `_patch_gemma4_audio_feature_dtype_on_class` as
+# "upstream fixed it": it sets the marker and returns, leaving a real,
+# still-device-only `inputs_embeds` merge unpatched and crashing.
 # ---------------------------------------------------------------------------
 def _audio_forward(body):
     return (
@@ -1964,9 +1860,9 @@ _ALIGNED_SCRATCH_MERGE = (
     "    audio_mask, audio_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
     ")"
 )
-# The same decoy, written so the receiver MENTIONS `inputs_embeds` without being
-# it. Matching the name anywhere in the receiver expression accepted this as the
-# embedding merge; the receiver has to be anchored at its base instead.
+# The same decoy with a receiver that MENTIONS `inputs_embeds` without being it.
+# Matching the name anywhere in the receiver accepted this as the embedding merge;
+# the receiver has to be anchored at its base instead.
 _ALIGNED_SCRATCH_MERGE_ON_EMBEDS_DEVICE = (
     "scratch = scratch.to(inputs_embeds.device).masked_scatter(\n"
     "    audio_mask, audio_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1981,8 +1877,7 @@ def _audio_merge_casts(body):
 
 
 def test_eager_matcher_ignores_merges_onto_other_tensors():
-    # An aligned decoy on a scratch tensor must not be reported as the audio
-    # merge being already fixed.
+    # An aligned decoy on a scratch tensor is not the audio merge already fixed.
     buggy, fixed = _audio_merge_casts(_ALIGNED_SCRATCH_MERGE)
     assert not buggy and not fixed, (
         f"_gemma4_audio_merge_casts counted a `scratch.masked_scatter(...)` as the "
@@ -1993,8 +1888,8 @@ def test_eager_matcher_ignores_merges_onto_other_tensors():
 
 
 def test_eager_matcher_still_finds_the_real_merge_next_to_a_decoy():
-    # The decoy must be ignored AND the real device-only merge still picked up,
-    # so the patch fires exactly once.
+    # The decoy is ignored AND the real device-only merge still picked up, so the
+    # patch fires exactly once.
     buggy, fixed = _audio_merge_casts(_ALIGNED_SCRATCH_MERGE + "\n" + _REAL_AUDIO_MERGE)
     assert len(buggy) == 1 and not fixed, (
         f"expected the one real device-only `inputs_embeds` merge to be patchable "
@@ -2008,11 +1903,10 @@ def test_eager_matcher_still_finds_the_real_merge_next_to_a_decoy():
     ids = ["bare scratch receiver", "scratch receiver naming inputs_embeds"],
 )
 def test_a_decoy_merge_never_hides_the_real_one(decoy):
-    # `scratch.to(inputs_embeds.device)` is a different tensor, however many
-    # times it names `inputs_embeds`. Counting it as the embedding merge puts an
-    # aligned cast in `fixed_casts`, and `len(buggy) == 1 and fixed_casts` is
-    # exactly the branch on which the eager patch returns without patching and
-    # without warning - the real device-only merge stays broken.
+    # `scratch.to(inputs_embeds.device)` is a different tensor however often it
+    # names `inputs_embeds`. Counting it puts an aligned cast in `fixed_casts`, and
+    # `len(buggy) == 1 and fixed_casts` is exactly the branch on which the eager
+    # patch returns without patching and without warning.
     buggy, fixed = _audio_merge_casts(decoy + "\n" + _REAL_AUDIO_MERGE)
     assert len(buggy) == 1 and not fixed, (
         f"expected the one real device-only `inputs_embeds` merge to be patchable "
@@ -2023,7 +1917,7 @@ def test_a_decoy_merge_never_hides_the_real_one(decoy):
 def test_eager_matcher_still_accepts_a_transformed_inputs_embeds_receiver():
     # Discovery must stay loose about HOW the receiver mentions `inputs_embeds`
     # (blip_2 ships `inputs_embeds.to(...).masked_scatter(...)`), or a real merge
-    # would be dropped instead of patched.
+    # is dropped instead of patched.
     buggy, fixed = _audio_merge_casts(
         "inputs_embeds = inputs_embeds.to(audio_features.device).masked_scatter(\n"
         "    audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)\n"

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -334,9 +334,32 @@ def _is_dtype_guard(test, feature):
     )
 
 
+def _bound_names(target):
+    """Every plain name an assignment target binds.
+
+    Recurses through destructuring targets, because
+    `image_features, feature_lens = self.pack_image_features(...)` (the
+    llava_next / llava_onevision / llava_next_video spelling) rebinds
+    `image_features` just as much as a bare `image_features = ...` does. Missing
+    it lets an earlier aligned assignment keep proving alignment for a tensor
+    that has since been replaced by an unpacked, possibly mismatched one.
+
+    `image_features[0] = ...` (Subscript) and `self.image_features = ...`
+    (Attribute) are deliberately NOT name rebindings: the name still refers to
+    the same object afterwards.
+    """
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return [name for elt in target.elts for name in _bound_names(elt)]
+    if isinstance(target, ast.Starred):
+        return _bound_names(target.value)
+    return []
+
+
 def _assigns_feature(stmt, feature):
     targets = stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
-    return any(isinstance(t, ast.Name) and t.id == feature for t in targets)
+    return any(feature in _bound_names(t) for t in targets)
 
 
 _ASSIGN_NODES = (ast.Assign, ast.AnnAssign, ast.AugAssign)
@@ -362,12 +385,20 @@ def _rebinding_alignment(stmt, feature):
     # `if <feature>.dtype != inputs_embeds.dtype: <feature> = <feature>.to(...)`
     # is a cast-if-needed idiom (transformers spells it in blip_2 / granite_speech):
     # the untaken branch is aligned by definition, so it counts as unconditional.
+    #
+    # Both branches still have to be analysed as PATHS, not as a bag of
+    # rebindings whose textually last one wins. `if enabled: <feature> =
+    # <feature>.to(inputs_embeds.dtype)` nested inside the guard, or an aligned
+    # `else` after an unaligned body, would otherwise report the whole guard
+    # aligned while the mismatch path leaves the feature un-cast.
     if isinstance(stmt, ast.If) and _is_dtype_guard(stmt.test, feature):
-        inner = _feature_rebindings(stmt, feature)
-        if inner:
-            last = max(inner, key = lambda s: s.lineno)
-            value = getattr(last, "value", None)
-            return value is not None and _casts_to_inputs_embeds_dtype(value)
+        if _feature_rebindings(stmt, feature):
+            # Body runs only on a mismatch (starts unaligned); `orelse` only when
+            # the dtypes already agree (starts aligned). Both ends must be aligned.
+            return (
+                _sequence_alignment(stmt.body, feature, False)
+                and _sequence_alignment(stmt.orelse, feature, True)
+            )
     # Any OTHER compound statement that rebinds the feature is still a rebinding
     # on the path to the merge and must not be skipped, or an earlier aligned
     # assignment would keep proving alignment for a value that has since been
@@ -395,6 +426,22 @@ def _rebinding_alignment(stmt, feature):
         if value is None or not _casts_to_inputs_embeds_dtype(value):
             return False
     return None
+
+
+def _sequence_alignment(block, feature, initial):
+    """Alignment of `<feature>` after running `block` top to bottom.
+
+    `initial` is the state on entry to the block. Statements that say nothing
+    about the feature (`_rebinding_alignment` -> `None`, which includes a
+    conditional rebinding that only ever casts to `inputs_embeds.dtype`, since
+    it may not run) leave the running state alone.
+    """
+    state = initial
+    for stmt in block:
+        aligned = _rebinding_alignment(stmt, feature)
+        if aligned is not None:
+            state = aligned
+    return state
 
 
 def _dominating_alignment(forward, feature, merge_arg):
@@ -580,3 +627,164 @@ def test_audio_compiler_transform_still_fixes_the_device_only_spelling():
         "fix_gemma4_audio_feature_dtype no longer rewrites the device-only audio "
         "cast shipped by transformers 5.5.0-5.14.1."
     )
+
+
+# ---------------------------------------------------------------------------
+# Tracer unit tests. The canaries above are only as good as `_merge_dtype_alignment`,
+# and a hole in it is invisible: it reports GREEN on a source that crashes. These
+# feed the tracer a minimal synthetic `Gemma4Model.forward` (no transformers
+# needed, so they run on every supported version) and pin the verdict on the
+# spellings that used to slip through.
+# ---------------------------------------------------------------------------
+def _synthetic_forward(body):
+    """Minimal `Gemma4Model.forward` with `body` between the features and the merge."""
+    indented = "\n".join("            " + line if line else "" for line in body.strip("\n").split("\n"))
+    return (
+        "class Gemma4Model:\n"
+        "    def forward(self, inputs_embeds, pixel_values, image_mask):\n"
+        "        if pixel_values is not None:\n"
+        "            image_features = self.get_image_features(pixel_values)\n"
+        f"{indented}\n"
+        "            inputs_embeds = inputs_embeds.masked_scatter(\n"
+        "                image_mask.to(inputs_embeds.device), image_features.to(inputs_embeds.device)\n"
+        "            )\n"
+        "        return inputs_embeds\n"
+    )
+
+
+_ALIGNED_ASSIGN = "image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)"
+
+
+# Every path inside a `<feature>.dtype != inputs_embeds.dtype` guard has to end
+# aligned. Taking the textually last rebinding inside the guard instead reports
+# aligned for a guard whose MISMATCH path leaves the feature un-cast, which is
+# exactly one reachable `masked_scatter_: expected self and source to have same
+# dtypes`.
+_GUARD_HOLES = [
+    ("cast nested under a second condition",
+     "if image_features.dtype != inputs_embeds.dtype:\n"
+     "    if self.config.cast_vision_features:\n"
+     f"        {_ALIGNED_ASSIGN}"),
+    ("unaligned body, aligned else (textually last)",
+     "if image_features.dtype != inputs_embeds.dtype:\n"
+     "    image_features = image_features.to(inputs_embeds.device)\n"
+     "else:\n"
+     f"    {_ALIGNED_ASSIGN}"),
+    ("aligned cast then a conditional rebinding that undoes it",
+     "if image_features.dtype != inputs_embeds.dtype:\n"
+     f"    {_ALIGNED_ASSIGN}\n"
+     "    if self.config.upcast_vision_features:\n"
+     "        image_features = image_features.float()"),
+    ("aligned else only, mismatch path rebinds nothing aligned",
+     "if image_features.dtype != inputs_embeds.dtype:\n"
+     "    image_features = image_features.reshape(-1, inputs_embeds.shape[-1])\n"
+     "else:\n"
+     f"    {_ALIGNED_ASSIGN}"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body", _GUARD_HOLES, ids = [case[0] for case in _GUARD_HOLES],
+)
+def test_conditional_cast_inside_a_dtype_guard_is_not_alignment(label, body):
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found, f"{label}: the synthetic merge site itself was not found"
+    assert not aligned, (
+        f"{label}: the tracer reports `image_features` dtype-aligned, but the "
+        f"dtype-mismatch path reaches masked_scatter with no `inputs_embeds.dtype` "
+        f"cast. A real upstream source spelled this way would keep every canary in "
+        f"this file green while the merge crashed."
+    )
+
+
+_GUARD_CONTROLS = [
+    ("plain cast-if-needed (blip_2 / granite_speech idiom)",
+     "if image_features.dtype != inputs_embeds.dtype:\n"
+     f"    {_ALIGNED_ASSIGN}"),
+    ("dtype-only cast-if-needed, device carried at the merge",
+     "if image_features.dtype != inputs_embeds.dtype:\n"
+     "    image_features = image_features.to(inputs_embeds.dtype)"),
+    ("reversed operand order",
+     "if inputs_embeds.dtype != image_features.dtype:\n"
+     f"    {_ALIGNED_ASSIGN}"),
+    ("aligned assign then a guard that only raises",
+     f"{_ALIGNED_ASSIGN}\n"
+     "if image_features.dtype != inputs_embeds.dtype:\n"
+     "    raise ValueError('dtype mismatch')"),
+    ("aligned assign then a guard that casts again",
+     f"{_ALIGNED_ASSIGN}\n"
+     "if image_features.dtype != inputs_embeds.dtype:\n"
+     f"    {_ALIGNED_ASSIGN}"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body", _GUARD_CONTROLS, ids = [case[0] for case in _GUARD_CONTROLS],
+)
+def test_cast_if_needed_guards_still_count_as_alignment(label, body):
+    # Controls for the test above: these are dtype-safe on every path and must
+    # NOT turn red, or the canaries start failing on a healthy upstream.
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
+
+
+# A destructuring assignment rebinds the feature name just like a plain one.
+# `image_features, feature_lens = self.pack_image_features(...)` is upstream's
+# own spelling in llava_next / llava_next_video / llava_onevision; skipping it
+# lets an earlier aligned assignment keep proving alignment for a tensor that
+# has since been replaced.
+_UNPACK_HOLES = [
+    ("tuple unpack",
+     f"{_ALIGNED_ASSIGN}\n"
+     "image_features, feature_lens = self.pack_image_features(image_features)"),
+    ("starred unpack",
+     f"{_ALIGNED_ASSIGN}\n"
+     "image_features, *feature_lens = self.pack_image_features(image_features)"),
+    ("list-target unpack",
+     f"{_ALIGNED_ASSIGN}\n"
+     "[image_features, feature_lens] = self.pack_image_features(image_features)"),
+    ("nested tuple unpack",
+     f"{_ALIGNED_ASSIGN}\n"
+     "(image_features, feature_lens), image_sizes = self.pack_image_features(image_features)"),
+    ("conditional tuple unpack",
+     f"{_ALIGNED_ASSIGN}\n"
+     "if self.config.pack_image_features:\n"
+     "    image_features, feature_lens = self.pack_image_features(image_features)"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body", _UNPACK_HOLES, ids = [case[0] for case in _UNPACK_HOLES],
+)
+def test_destructuring_rebindings_of_the_feature_are_not_skipped(label, body):
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found, f"{label}: the synthetic merge site itself was not found"
+    assert not aligned, (
+        f"{label}: the tracer still credits the earlier aligned assignment even "
+        f"though `image_features` was rebound by an unpack whose value carries no "
+        f"`inputs_embeds.dtype` cast. The unpacked tensor reaches masked_scatter."
+    )
+
+
+_UNPACK_CONTROLS = [
+    ("unpack whose value casts dtype",
+     f"{_ALIGNED_ASSIGN}\n"
+     "image_features, feature_lens = self.pack_image_features(\n"
+     "    image_features.to(inputs_embeds.device, inputs_embeds.dtype))"),
+    ("unpack binding other names only",
+     f"{_ALIGNED_ASSIGN}\n"
+     "feature_lens, image_sizes = self.pack_image_features(image_features)"),
+    ("subscript and attribute targets are not name rebindings",
+     f"{_ALIGNED_ASSIGN}\n"
+     "image_features[0] = image_features[0]\n"
+     "self.image_features = image_features"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body", _UNPACK_CONTROLS, ids = [case[0] for case in _UNPACK_CONTROLS],
+)
+def test_non_rebinding_targets_do_not_break_alignment(label, body):
+    # Controls for the test above.
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -3,8 +3,11 @@
 These lock in the three failures we traced:
 
   1. Audio merge: upstream `Gemma4Model.forward` cast `audio_features.to(device)`
-     without dtype (transformers #45192), while image/video cast dtype too ->
+     without dtype (transformers #45192), while image/video aligned dtype on the
+     statement that produced the features ->
      `masked_scatter_: expected self and source to have same dtypes`.
+     Fixed upstream in transformers 5.15.0; the guards below still cover the
+     5.5.0-5.14.1 window, which unsloth continues to support.
   2. Forced-float32 PLE: fp32 residual into the fp16 PLE Linears (unsloth-zoo #866
      forced fp32 but left PLE inputs uncast) -> `mat1 and mat2 ... float != Half`.
   3. Cross-path NameError: the eager patch rewrote calls to one helper name while
@@ -16,6 +19,7 @@ The real-source canaries import the real transformers gemma4 module and skip
 cleanly when it is absent; when present (transformers >= 5.5.0, as on CI) they
 catch upstream source drift that would silently disable the patch.
 """
+import ast
 import inspect
 import re
 
@@ -195,27 +199,143 @@ def _gemma4_modeling_source():
     return pathlib.Path(inspect.getsourcefile(real_gemma4)).read_text()
 
 
+# Upstream is free to spell the dtype alignment wherever it likes: at the merge
+# call (`audio_features.to(inputs_embeds.device, inputs_embeds.dtype)`, tf 5.15+)
+# or on the statement that produced the features
+# (`image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)`,
+# tf 5.5-5.14, or `... = torch.cat(image_features, dim=0).to(..., inputs_embeds.dtype)`,
+# tf 5.15). A substring anchor on one spelling breaks on cosmetic refactors while
+# staying blind to a real regression written in another spelling, so the canaries
+# below trace dtype ALIGNMENT structurally instead: find the masked_scatter that
+# consumes the features, then require an `inputs_embeds.dtype` cast either inside
+# the merge argument or on the last assignment to that name before the merge.
+def _is_attr(node, owner, attr):
+    """`<owner>.<attr>` as an AST node, e.g. `inputs_embeds.dtype`."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == attr
+        and isinstance(node.value, ast.Name)
+        and node.value.id == owner
+    )
+
+
+def _casts_to_inputs_embeds_dtype(node):
+    """True if `node` contains a `.to(...)` carrying `inputs_embeds.dtype`."""
+    for sub in ast.walk(node):
+        if not (
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and sub.func.attr == "to"
+        ):
+            continue
+        values = list(sub.args) + [kw.value for kw in sub.keywords]
+        if any(_is_attr(v, "inputs_embeds", "dtype") for v in values):
+            return True
+    return False
+
+
+def _gemma4_model_forward_node(src):
+    tree = ast.parse(src)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "Gemma4Model":
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == "forward":
+                    return item
+    return None
+
+
+def _merge_dtype_alignment(src, feature):
+    """Trace `<feature>` into `inputs_embeds.masked_scatter(...)`.
+
+    Returns (merge_found, aligned_at_merge_call, aligned_on_last_assignment).
+    """
+    forward = _gemma4_model_forward_node(src)
+    if forward is None:
+        return (False, False, False)
+
+    merge_arg = None
+    for node in ast.walk(forward):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "masked_scatter"
+            and len(node.args) >= 2
+        ):
+            continue
+        source_arg = node.args[1]
+        if any(
+            isinstance(n, ast.Name) and n.id == feature for n in ast.walk(source_arg)
+        ):
+            merge_arg = source_arg
+            break
+    if merge_arg is None:
+        return (False, False, False)
+
+    aligned_at_call = _casts_to_inputs_embeds_dtype(merge_arg)
+
+    # Last `<feature> = ...` before the merge. Only the last one counts: an
+    # earlier cast says nothing if a later statement rebinds the name.
+    last_assign = None
+    for node in ast.walk(forward):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(isinstance(t, ast.Name) and t.id == feature for t in targets):
+            continue
+        if node.lineno >= merge_arg.lineno:
+            continue
+        if last_assign is None or node.lineno > last_assign.lineno:
+            last_assign = node
+    aligned_on_assignment = (
+        last_assign is not None
+        and last_assign.value is not None
+        and _casts_to_inputs_embeds_dtype(last_assign.value)
+    )
+    return (True, aligned_at_call, aligned_on_assignment)
+
+
 @requires_gemma4
 def test_real_gemma4_audio_merge_site_is_recognized():
     src = _gemma4_modeling_source()
-    buggy = "audio_features.to(inputs_embeds.device)"
-    fixed = "audio_features.to(inputs_embeds.device, inputs_embeds.dtype)"
-    assert (buggy in src) or (fixed in src), (
-        "Gemma4 audio merge site drifted: neither the known device-only pattern "
-        "nor the fixed device+dtype pattern is present in modeling_gemma4.py. The "
-        "unsloth audio patch would silently no-op and the masked_scatter dtype crash "
-        "would return. Update _patch_gemma4_audio_feature_dtype_on_class (eager) and "
+    found, at_call, at_assign = _merge_dtype_alignment(src, "audio_features")
+    assert found, (
+        "Gemma4 audio merge site drifted: no `inputs_embeds.masked_scatter(...)` "
+        "consuming `audio_features` in Gemma4Model.forward. The unsloth audio patch "
+        "would silently no-op and the masked_scatter dtype crash would return. Update "
+        "_patch_gemma4_audio_feature_dtype_on_class (eager) and "
+        "fix_gemma4_audio_feature_dtype (compiler)."
+    )
+    upstream_aligned = at_call or at_assign
+    unsloth_can_patch = C.fix_gemma4_audio_feature_dtype(src) != src
+    assert upstream_aligned or unsloth_can_patch, (
+        "Gemma4 audio features reach masked_scatter with no `inputs_embeds.dtype` "
+        "alignment anywhere, and the unsloth rewriter no longer matches the merge "
+        "site either. `masked_scatter_: expected self and source to have same dtypes` "
+        "is back. Update _patch_gemma4_audio_feature_dtype_on_class (eager) and "
         "fix_gemma4_audio_feature_dtype (compiler)."
     )
 
 
 @requires_gemma4
-def test_real_gemma4_image_and_video_merges_still_cast_dtype():
-    # Regression anchor: image/video have always cast dtype; if upstream ever
-    # drops it there too, that is a new modality that also needs patching.
+@pytest.mark.parametrize("feature", ["image_features", "video_features"])
+def test_real_gemma4_image_and_video_merges_still_cast_dtype(feature):
+    # Regression anchor: image/video have always aligned dtype before the merge,
+    # so unsloth patches only audio. If upstream ever drops the alignment here
+    # too, that is a new modality that also needs patching.
     src = _gemma4_modeling_source()
-    assert "image_features.to(inputs_embeds.device, inputs_embeds.dtype)" in src
-    assert "video_features.to(inputs_embeds.device, inputs_embeds.dtype)" in src
+    found, at_call, at_assign = _merge_dtype_alignment(src, feature)
+    assert found, (
+        f"No `inputs_embeds.masked_scatter(...)` consuming `{feature}` in "
+        f"Gemma4Model.forward - the merge site moved and this canary is blind."
+    )
+    assert at_call or at_assign, (
+        f"Gemma4 {feature.split('_')[0]} merge lost its `inputs_embeds.dtype` "
+        f"alignment: `{feature}` reaches masked_scatter without an "
+        f"`inputs_embeds.dtype` cast at the call or on its last assignment. That is "
+        f"the audio bug (transformers #45192) in a new modality and needs the same "
+        f"treatment as _patch_gemma4_audio_feature_dtype_on_class / "
+        f"fix_gemma4_audio_feature_dtype."
+    )
 
 
 @requires_gemma4
@@ -241,7 +361,26 @@ def test_real_gemma4_audio_compiler_transform_emits_dtype_cast():
     # upstream already casts dtype, or our regex still matches and inserts it.
     src = _gemma4_modeling_source()
     out = C.fix_gemma4_audio_feature_dtype(src)
+    found, at_call, at_assign = _merge_dtype_alignment(out, "audio_features")
+    assert found and (at_call or at_assign), (
+        "After fix_gemma4_audio_feature_dtype, `audio_features` still reaches "
+        "masked_scatter with no `inputs_embeds.dtype` alignment on upstream source "
+        "(regex drift or multiple matches)."
+    )
+
+
+def test_audio_compiler_transform_still_fixes_the_device_only_spelling():
+    # transformers 5.15.0 fixed the audio merge upstream, which makes the
+    # real-source test above pass without the rewriter doing anything. Keep the
+    # rewriter itself under test against the historical buggy spelling so it
+    # cannot silently rot while older transformers are still supported.
+    buggy = (
+        "        inputs_embeds = inputs_embeds.masked_scatter(\n"
+        "            audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)\n"
+        "        )\n"
+    )
+    out = C.fix_gemma4_audio_feature_dtype(buggy)
     assert "audio_features.to(inputs_embeds.device, inputs_embeds.dtype)" in out, (
-        "fix_gemma4_audio_feature_dtype no longer produces the dtype-aligned cast on "
-        "upstream source (regex drift or multiple matches)."
+        "fix_gemma4_audio_feature_dtype no longer rewrites the device-only audio "
+        "cast shipped by transformers 5.5.0-5.14.1."
     )

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -206,9 +206,11 @@ def _gemma4_modeling_source():
 # tf 5.5-5.14, or `... = torch.cat(image_features, dim=0).to(..., inputs_embeds.dtype)`,
 # tf 5.15). A substring anchor on one spelling breaks on cosmetic refactors while
 # staying blind to a real regression written in another spelling, so the canaries
-# below trace dtype ALIGNMENT structurally instead: find the masked_scatter that
-# consumes the features, then require an `inputs_embeds.dtype` cast either inside
-# the merge argument or on the last assignment to that name before the merge.
+# below trace dtype ALIGNMENT structurally instead: find every
+# `inputs_embeds.masked_scatter` that consumes the features, and require of each an
+# `inputs_embeds.dtype` cast either inside the merge argument or on the last
+# assignment to that name that DOMINATES the merge (same block or an enclosing one,
+# so a cast stranded in a branch the merge does not run under does not count).
 def _is_attr(node, owner, attr):
     """`<owner>.<attr>` as an AST node, e.g. `inputs_embeds.dtype`."""
     return (
@@ -244,16 +246,104 @@ def _gemma4_model_forward_node(src):
     return None
 
 
-def _merge_dtype_alignment(src, feature):
-    """Trace `<feature>` into `inputs_embeds.masked_scatter(...)`.
+def _child_blocks(stmt):
+    """Every nested statement list of `stmt` (`if`/`else`, loop bodies, `try`)."""
+    blocks = []
+    for field in ("body", "orelse", "finalbody"):
+        value = getattr(stmt, field, None)
+        if isinstance(value, list) and value and all(isinstance(s, ast.stmt) for s in value):
+            blocks.append(value)
+    for handler in getattr(stmt, "handlers", None) or []:
+        blocks.append(handler.body)
+    return blocks
 
-    Returns (merge_found, aligned_at_merge_call, aligned_on_last_assignment).
+
+def _enclosing_blocks(forward, target):
+    """`[(block, index)]` from the function body inwards to the stmt holding `target`.
+
+    Only these statement lists run unconditionally *relative to the merge*. A cast
+    nested in some other branch may never execute on the path that reaches the
+    merge, so it cannot prove alignment.
     """
-    forward = _gemma4_model_forward_node(src)
-    if forward is None:
-        return (False, False, False)
+    chain = []
 
-    merge_arg = None
+    def holds(node):
+        return any(n is target for n in ast.walk(node))
+
+    def descend(block):
+        for index, stmt in enumerate(block):
+            if not holds(stmt):
+                continue
+            chain.append((block, index))
+            for inner in _child_blocks(stmt):
+                if any(holds(s) for s in inner):
+                    descend(inner)
+                    break
+            return
+
+    descend(forward.body)
+    return chain
+
+
+def _is_dtype_guard(test, feature):
+    """`if <feature>.dtype != ...:` - a cast under such a guard aligns both paths."""
+    for node in ast.walk(test):
+        if isinstance(node, ast.Compare) and any(
+            _is_attr(operand, feature, "dtype")
+            for operand in [node.left] + list(node.comparators)
+        ):
+            return True
+    return False
+
+
+def _assigns_feature(stmt, feature):
+    targets = stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
+    return any(isinstance(t, ast.Name) and t.id == feature for t in targets)
+
+
+def _rebinding_alignment(stmt, feature):
+    """Does `stmt` rebind `<feature>` on the path to the merge, and is it aligned?
+
+    `None` when `stmt` does not rebind the name (so it says nothing either way).
+    """
+    if isinstance(stmt, (ast.Assign, ast.AnnAssign)) and _assigns_feature(stmt, feature):
+        return stmt.value is not None and _casts_to_inputs_embeds_dtype(stmt.value)
+    # `if <feature>.dtype != inputs_embeds.dtype: <feature> = <feature>.to(...)`
+    # is a cast-if-needed idiom (transformers spells it in blip_2 / granite_speech):
+    # the untaken branch is aligned by definition, so it counts as unconditional.
+    if isinstance(stmt, ast.If) and _is_dtype_guard(stmt.test, feature):
+        inner = [
+            s
+            for s in ast.walk(stmt)
+            if isinstance(s, (ast.Assign, ast.AnnAssign)) and _assigns_feature(s, feature)
+        ]
+        if inner:
+            last = max(inner, key=lambda s: s.lineno)
+            return last.value is not None and _casts_to_inputs_embeds_dtype(last.value)
+    return None
+
+
+def _dominating_alignment(forward, feature, merge_arg):
+    """Is the last rebinding of `<feature>` that dominates `merge_arg` dtype-aligned?"""
+    best_line, best_aligned = None, False
+    for block, index in _enclosing_blocks(forward, merge_arg):
+        for stmt in block[:index]:
+            aligned = _rebinding_alignment(stmt, feature)
+            if aligned is None:
+                continue
+            if best_line is None or stmt.lineno > best_line:
+                best_line, best_aligned = stmt.lineno, aligned
+    return best_aligned
+
+
+def _feature_merge_args(forward, feature):
+    """Source args of every `inputs_embeds.masked_scatter(mask, ...)` using `<feature>`.
+
+    The receiver has to be `inputs_embeds` (or something derived from it): a
+    `scratch.masked_scatter(mask, feature)` elsewhere in `forward` is a different
+    tensor and says nothing about the dtype of the embedding merge.
+    """
+    args = []
     for node in ast.walk(forward):
         if not (
             isinstance(node, ast.Call)
@@ -262,42 +352,44 @@ def _merge_dtype_alignment(src, feature):
             and len(node.args) >= 2
         ):
             continue
+        if not any(
+            isinstance(n, ast.Name) and n.id == "inputs_embeds"
+            for n in ast.walk(node.func.value)
+        ):
+            continue
         source_arg = node.args[1]
         if any(
             isinstance(n, ast.Name) and n.id == feature for n in ast.walk(source_arg)
         ):
-            merge_arg = source_arg
-            break
-    if merge_arg is None:
-        return (False, False, False)
+            args.append(source_arg)
+    return sorted(args, key=lambda n: (n.lineno, n.col_offset))
 
-    aligned_at_call = _casts_to_inputs_embeds_dtype(merge_arg)
 
-    # Last `<feature> = ...` before the merge. Only the last one counts: an
-    # earlier cast says nothing if a later statement rebinds the name.
-    last_assign = None
-    for node in ast.walk(forward):
-        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
-            continue
-        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-        if not any(isinstance(t, ast.Name) and t.id == feature for t in targets):
-            continue
-        if node.lineno >= merge_arg.lineno:
-            continue
-        if last_assign is None or node.lineno > last_assign.lineno:
-            last_assign = node
-    aligned_on_assignment = (
-        last_assign is not None
-        and last_assign.value is not None
-        and _casts_to_inputs_embeds_dtype(last_assign.value)
+def _merge_dtype_alignment(src, feature):
+    """Trace `<feature>` into `inputs_embeds.masked_scatter(...)`.
+
+    Returns (merge_found, every_merge_aligned). EVERY merge consuming the feature
+    has to be aligned: one unaligned branch is one reachable dtype crash, so an
+    aligned first merge must not excuse an unaligned second one.
+    """
+    forward = _gemma4_model_forward_node(src)
+    if forward is None:
+        return (False, False)
+    merges = _feature_merge_args(forward, feature)
+    if not merges:
+        return (False, False)
+    aligned = all(
+        _casts_to_inputs_embeds_dtype(merge)
+        or _dominating_alignment(forward, feature, merge)
+        for merge in merges
     )
-    return (True, aligned_at_call, aligned_on_assignment)
+    return (True, aligned)
 
 
 @requires_gemma4
 def test_real_gemma4_audio_merge_site_is_recognized():
     src = _gemma4_modeling_source()
-    found, at_call, at_assign = _merge_dtype_alignment(src, "audio_features")
+    found, aligned = _merge_dtype_alignment(src, "audio_features")
     assert found, (
         "Gemma4 audio merge site drifted: no `inputs_embeds.masked_scatter(...)` "
         "consuming `audio_features` in Gemma4Model.forward. The unsloth audio patch "
@@ -305,7 +397,7 @@ def test_real_gemma4_audio_merge_site_is_recognized():
         "_patch_gemma4_audio_feature_dtype_on_class (eager) and "
         "fix_gemma4_audio_feature_dtype (compiler)."
     )
-    upstream_aligned = at_call or at_assign
+    upstream_aligned = aligned
     unsloth_can_patch = C.fix_gemma4_audio_feature_dtype(src) != src
     assert upstream_aligned or unsloth_can_patch, (
         "Gemma4 audio features reach masked_scatter with no `inputs_embeds.dtype` "
@@ -323,15 +415,16 @@ def test_real_gemma4_image_and_video_merges_still_cast_dtype(feature):
     # so unsloth patches only audio. If upstream ever drops the alignment here
     # too, that is a new modality that also needs patching.
     src = _gemma4_modeling_source()
-    found, at_call, at_assign = _merge_dtype_alignment(src, feature)
+    found, aligned = _merge_dtype_alignment(src, feature)
     assert found, (
         f"No `inputs_embeds.masked_scatter(...)` consuming `{feature}` in "
         f"Gemma4Model.forward - the merge site moved and this canary is blind."
     )
-    assert at_call or at_assign, (
+    assert aligned, (
         f"Gemma4 {feature.split('_')[0]} merge lost its `inputs_embeds.dtype` "
         f"alignment: `{feature}` reaches masked_scatter without an "
-        f"`inputs_embeds.dtype` cast at the call or on its last assignment. That is "
+        f"`inputs_embeds.dtype` cast at the call or on its last dominating "
+        f"assignment. That is "
         f"the audio bug (transformers #45192) in a new modality and needs the same "
         f"treatment as _patch_gemma4_audio_feature_dtype_on_class / "
         f"fix_gemma4_audio_feature_dtype."
@@ -361,8 +454,8 @@ def test_real_gemma4_audio_compiler_transform_emits_dtype_cast():
     # upstream already casts dtype, or our regex still matches and inserts it.
     src = _gemma4_modeling_source()
     out = C.fix_gemma4_audio_feature_dtype(src)
-    found, at_call, at_assign = _merge_dtype_alignment(out, "audio_features")
-    assert found and (at_call or at_assign), (
+    found, aligned = _merge_dtype_alignment(out, "audio_features")
+    assert found and aligned, (
         "After fix_gemma4_audio_feature_dtype, `audio_features` still reaches "
         "masked_scatter with no `inputs_embeds.dtype` alignment on upstream source "
         "(regex drift or multiple matches)."

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -796,10 +796,20 @@ def _merge_result_is_used(forward, call):
     UNCHANGED `inputs_embeds` - the features silently never reach the model, with
     every dtype canary in this file green. So follow the result forward instead:
     it must flow, directly or through temporaries, into `inputs_embeds` or into a
-    `return`. The in-place `masked_scatter_` writes through the receiver's
-    storage and needs no result at all.
+    `return`.
+
+    The in-place `masked_scatter_` needs no result ONLY when its receiver is
+    `inputs_embeds` itself, because that is the one spelling whose write lands in
+    the embeddings `forward` goes on to use. On a transformed receiver -
+    `inputs_embeds.clone().masked_scatter_(...)`, or the device-changing
+    `inputs_embeds.to(...).masked_scatter_(...)`, both of which
+    `_receiver_preserves_embeds_dtype` accepts as dtype-safe - the mutation lands
+    in a temporary and `forward` still returns the unchanged `inputs_embeds`. So
+    only skip the result-flow analysis for a receiver that is guaranteed to alias
+    the original embeddings; anything else has to hand its result back like the
+    out-of-place spelling does (`masked_scatter_` returns the receiver, so it can).
     """
-    if call.func.attr.endswith("_"):
+    if call.func.attr.endswith("_") and _is_embeds_tensor(call.func.value):
         return True
     statements = _statements_after(forward, call)
     if statements is None:
@@ -1387,6 +1397,12 @@ _RESULT_USE_CONTROLS = [
      "return inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
+    # `masked_scatter_` returns its receiver, so a transformed in-place receiver
+    # that hands the result back is exactly as safe as the out-of-place spelling.
+    ("in-place merge into a clone whose result is assigned back",
+     "inputs_embeds = inputs_embeds.clone().masked_scatter_(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
 ]
 
 
@@ -1512,6 +1528,17 @@ _DISCARDED_RESULT_HOLES = [
      "collected = [inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")]"),
+    # `masked_scatter_` is in place in the RECEIVER's storage. On a clone or a
+    # device-changed copy that storage is a temporary, so the discarded result is
+    # the whole merge: `forward` returns the unchanged `inputs_embeds`.
+    ("in-place merge into a clone of the embeddings",
+     "inputs_embeds.clone().masked_scatter_(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("in-place merge into a device-changed copy of the embeddings",
+     "inputs_embeds.to('cuda').masked_scatter_(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
 ]
 
 

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -298,8 +298,15 @@ _DTYPE_PRESERVING_METHODS = frozenset({
 _NON_DTYPE_TORCH_CONSTANTS = (torch.memory_format, torch.layout)
 
 
-def _is_dtype_bearing(node):
-    """Can `node` retype a tensor? (`torch.float32`, `other.dtype`, ...)"""
+def _is_dtype_bearing(node, aliases = frozenset()):
+    """Can `node` retype a tensor? (`torch.float32`, `other.dtype`, ...)
+
+    `aliases` are local names already known to hold a dtype, because
+    `Tensor.view(dtype)` reinterprets its receiver just as thoroughly whether the
+    dtype is written out or held in a variable.
+    """
+    if isinstance(node, ast.Name):
+        return node.id in aliases
     if isinstance(node, ast.Attribute) and node.attr == "dtype":
         return not _is_attr(node, "inputs_embeds", "dtype")
     if (
@@ -352,7 +359,7 @@ def _to_call_preserves_dtype(call):
     return True
 
 
-def _receiver_preserves_embeds_dtype(node):
+def _receiver_preserves_embeds_dtype(node, aliases = frozenset()):
     """Is the merge destination `inputs_embeds` still at `inputs_embeds.dtype`?
 
     The whole trace is "the source is cast to `inputs_embeds.dtype`, so the merge
@@ -374,7 +381,7 @@ def _receiver_preserves_embeds_dtype(node):
                 return False
         elif method in _DTYPE_PRESERVING_METHODS:
             values = list(node.args) + [kw.value for kw in node.keywords]
-            if any(_is_dtype_bearing(v) for v in values):
+            if any(_is_dtype_bearing(v, aliases) for v in values):
                 return False
         else:
             return False
@@ -722,25 +729,33 @@ _METADATA_ATTRS = frozenset({
 })
 
 
-def _carries_feature_value(node, feature):
-    """Do `<feature>`'s VALUES flow into `node`?
+def _carries_value(node, matches):
+    """Do the VALUES of a `matches` expression flow into `node`?
 
-    A merge is discovered by "the source argument uses the feature", and a bare
-    name-occurrence check answers that with `image_features.device` too. That
-    reads the feature's metadata and scatters something else entirely, so a
-    source spelled `fallback.to(image_features.device, inputs_embeds.dtype)`
-    would be reported as the image merge - and if the real merge were ever
-    dropped, `_merge_dtype_alignment` would return `(True, True)` on a source in
-    which no image value reaches the model at all. A metadata expression
-    contributes no values, so the whole subtree under it is skipped; everything
+    Both the merge SOURCE and the merge RESULT are traced by "does this
+    expression use that tensor", and a bare occurrence check answers that with
+    `image_features.device` or `merged.dtype` too. A metadata read carries none
+    of the tensor's values, so the whole subtree under it is skipped; everything
     else still counts, which keeps
-    `image_features.to(...).reshape(-1, image_features.shape[-1])` a merge.
+    `image_features.to(...).reshape(-1, image_features.shape[-1])` a use.
     """
     if isinstance(node, ast.Attribute) and node.attr in _METADATA_ATTRS:
         return False
-    if isinstance(node, ast.Name):
-        return node.id == feature
-    return any(_carries_feature_value(child, feature) for child in ast.iter_child_nodes(node))
+    if matches(node):
+        return True
+    return any(_carries_value(child, matches) for child in ast.iter_child_nodes(node))
+
+
+def _carries_feature_value(node, feature):
+    """Do `<feature>`'s VALUES flow into `node`?
+
+    A merge is discovered by "the source argument uses the feature". Counting a
+    metadata read would report a source spelled
+    `fallback.to(image_features.device, inputs_embeds.dtype)` as the image merge -
+    and if the real merge were ever dropped, `_merge_dtype_alignment` would return
+    `(True, True)` on a source in which no image value reaches the model at all.
+    """
+    return _carries_value(node, lambda n: isinstance(n, ast.Name) and n.id == feature)
 
 
 def _feature_merges(forward, feature):
@@ -788,12 +803,20 @@ def _feature_merges(forward, feature):
     return sorted(calls, key=lambda n: (n.lineno, n.col_offset))
 
 
+# The merge RESULT is followed by the same rule that discovers the merge source:
+# only an expression carrying the tensor's VALUES passes it on. A metadata read of
+# the merge (`merged.device`, `merged.dtype`, `merged.shape`) discards every
+# scattered value, so `merged = inputs_embeds.masked_scatter(...)` followed by
+# `inputs_embeds = original.to(merged.device)` hands the embeddings the ORIGINAL
+# tensor. Treating that mention as value flow reported the merge used, so an
+# upstream refactor that removed the effective merge would leave every canary
+# here green while no feature reached the model.
 def _contains(node, target):
-    return any(n is target for n in ast.walk(node))
+    return _carries_value(node, lambda n: n is target)
 
 
 def _references(node, names):
-    return any(isinstance(n, ast.Name) and n.id in names for n in ast.walk(node))
+    return _carries_value(node, lambda n: isinstance(n, ast.Name) and n.id in names)
 
 
 def _statements_after(forward, call):
@@ -891,6 +914,36 @@ def _merge_result_is_used(forward, call):
     return False
 
 
+def _dtype_alias_names(forward):
+    """Local names bound to a dtype, e.g. `target_dtype = torch.float32`.
+
+    `inputs_embeds.view(target_dtype)` reinterprets the merge destination exactly
+    like `inputs_embeds.view(torch.float32)` does, so a receiver holding its dtype
+    in a variable must not read as dtype-preserving: the merge would then take an
+    `inputs_embeds.dtype` source into a retyped destination and raise.
+
+    Only a binding whose VALUE is itself dtype-bearing counts, which is what keeps
+    the legitimate shape overload out: `Tensor.view` accepts a single shape
+    sequence, so `target_shape = image_features.shape` / `view(target_shape)` is
+    real upstream spelling and preserves the dtype. Repeated to a fixpoint so an
+    alias of an alias resolves too.
+    """
+    names = set()
+    while True:
+        found = set()
+        for node in _walk_own_scope(forward):
+            if not isinstance(node, _ELEMENTWISE_NODES):
+                continue
+            for target, value in _binding_pairs(node):
+                if target is None or value is None:
+                    continue
+                if _is_dtype_bearing(value, names):
+                    found.update(_bound_names(target))
+        if found <= names:
+            return names
+        names |= found
+
+
 def _merge_dtype_alignment(src, feature):
     """Trace `<feature>` into `inputs_embeds.masked_scatter(...)`.
 
@@ -909,8 +962,9 @@ def _merge_dtype_alignment(src, feature):
     merges = _feature_merges(forward, feature)
     if not merges:
         return (False, False)
+    aliases = _dtype_alias_names(forward)
     aligned = all(
-        _receiver_preserves_embeds_dtype(merge.func.value)
+        _receiver_preserves_embeds_dtype(merge.func.value, aliases)
         and _merge_result_is_used(forward, merge)
         and (
             _casts_to_inputs_embeds_dtype(merge.args[1])
@@ -1320,6 +1374,24 @@ _RECEIVER_HOLES = [
      "inputs_embeds = inputs_embeds.view(torch.int32).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.dtype)\n"
      ")"),
+    # ... and it reinterprets it just as thoroughly when the dtype arrives in a
+    # variable, which reads as a plain name at the call site.
+    ("receiver .view(alias of torch.float32)",
+     "target_dtype = torch.float32\n"
+     "inputs_embeds = inputs_embeds.view(target_dtype).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .view(alias of another tensor's dtype)",
+     "target_dtype = image_mask.dtype\n"
+     "inputs_embeds = inputs_embeds.view(target_dtype).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .view(alias of an alias)",
+     "base_dtype = torch.float32\n"
+     "target_dtype = base_dtype\n"
+     "inputs_embeds = inputs_embeds.view(target_dtype).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.dtype)\n"
+     ")"),
 ]
 
 
@@ -1380,6 +1452,19 @@ _RECEIVER_CONTROLS = [
      ")"),
     ("receiver .contiguous(torch.channels_last) positionally",
      "inputs_embeds = inputs_embeds.contiguous(torch.channels_last).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    # `Tensor.view` also takes a single shape sequence, so a plain name argument
+    # is far more often a shape than a dtype. Only a name actually BOUND to a
+    # dtype may retype the destination; these two keep it.
+    ("receiver .view(shape variable)",
+     "target_shape = image_features.shape\n"
+     "inputs_embeds = inputs_embeds.view(target_shape).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .view(alias of inputs_embeds.dtype) is a no-op",
+     "target_dtype = inputs_embeds.dtype\n"
+     "inputs_embeds = inputs_embeds.view(target_dtype).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
 ]
@@ -1666,6 +1751,29 @@ _DISCARDED_RESULT_HOLES = [
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")\n"
      "(inputs_embeds, aux), sizes = (original, merged), image_sizes"),
+    # A metadata read of the merge scatters nothing: the embeddings are handed the
+    # ORIGINAL tensor and only the merge's device / dtype / shape is consulted.
+    # Propagating taint through it reported the merge used, so a refactor that
+    # dropped the effective merge would keep every canary here green.
+    ("embeddings take the original, reading only the merge device",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "inputs_embeds = original.to(merged.device)"),
+    ("embeddings take the original, reading only the merge dtype",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "inputs_embeds = original.to(inputs_embeds.device, merged.dtype)"),
+    ("return reads only the merge shape",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "return original.reshape(-1, merged.shape[-1])"),
+    ("the merge expression itself is consumed as metadata",
+     "inputs_embeds = original.to(inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ").device)"),
 ]
 
 
@@ -1720,6 +1828,18 @@ _RESULT_REACHES_CONTROLS = [
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")\n"
      "inputs_embeds, *aux = merged, original"),
+    # Skipping metadata must not skip a real use that merely mentions metadata
+    # alongside it: the merged VALUES still reach the embeddings here.
+    ("result reshaped by its own shape",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "inputs_embeds = merged.reshape(-1, merged.shape[-1])"),
+    ("result returned alongside a metadata read of itself",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "return merged.to(merged.device)"),
 ]
 
 

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -513,11 +513,44 @@ def _assigns_feature(stmt, feature):
     )
 
 
+def _element_value(target, value, feature):
+    """The part of `value` that `<feature>` actually receives from `target`.
+
+    A destructuring target consumes the RHS element by element, so when the RHS
+    is written out as a literal tuple/list the name takes ITS element and nothing
+    else: in `image_features, lens = (image_features.float(), lens.to(
+    inputs_embeds.dtype))` the only cast belongs to `lens`, and crediting it to
+    `image_features` reports an fp32 tensor aligned. Anything else (a call, a
+    starred target, a length mismatch) keeps the whole RHS, which is how
+    `image_features, feature_lens = self.pack_image_features(image_features.to(
+    inputs_embeds.dtype))` - upstream's llava_next spelling - stays aligned.
+    """
+    if isinstance(target, ast.Name):
+        return value if target.id == feature else None
+    if (
+        isinstance(target, (ast.Tuple, ast.List))
+        and isinstance(value, (ast.Tuple, ast.List))
+        and len(target.elts) == len(value.elts)
+        and not any(isinstance(elt, ast.Starred) for elt in target.elts)
+        and not any(isinstance(elt, ast.Starred) for elt in value.elts)
+    ):
+        for element, element_value in zip(target.elts, value.elts):
+            if feature in _bound_names(element):
+                return _element_value(element, element_value, feature)
+    return value
+
+
 def _binding_value(node, feature):
     """The expression `<feature>` takes its dtype from in this binding node."""
     for target, value in _binding_pairs(node):
-        if target is not None and feature in _bound_names(target):
-            return value
+        if target is None or feature not in _bound_names(target):
+            continue
+        # Only a real destructuring assignment pairs targets with RHS elements.
+        # A `for`/`with` target takes its value from the iterable / context
+        # manager, not positionally from the expression's own elements.
+        if value is not None and isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
+            return _element_value(target, value, feature)
+        return value
     return None
 
 
@@ -527,11 +560,22 @@ def _binding_is_aligned(node, feature):
 
 
 def _feature_rebindings(stmt, feature):
-    """Every rebinding of `<feature>` anywhere inside `stmt`'s own scope."""
+    """Every rebinding of `<feature>` anywhere inside `stmt`'s own scope.
+
+    An augmented assignment is NOT one of them: `image_features += delta` is
+    `Tensor.add_`, which writes through the existing storage and keeps the
+    existing dtype. It neither creates the alignment its RHS carries
+    (`image_features += delta.to(inputs_embeds.dtype)` leaves an fp32
+    `image_features` fp32) nor destroys one an earlier cast established
+    (`image_features += bias` on an aligned tensor is still aligned), so it says
+    nothing and the running verdict stands.
+    """
     return [
         node
         for node in _walk_own_scope(stmt, descend = False)
-        if isinstance(node, _BINDING_NODES) and _assigns_feature(node, feature)
+        if isinstance(node, _BINDING_NODES)
+        and not isinstance(node, ast.AugAssign)
+        and _assigns_feature(node, feature)
     ]
 
 
@@ -540,7 +584,11 @@ def _rebinding_alignment(stmt, feature):
 
     `None` when `stmt` does not rebind the name (so it says nothing either way).
     """
-    if isinstance(stmt, _ASSIGN_NODES) and _assigns_feature(stmt, feature):
+    if (
+        isinstance(stmt, _ASSIGN_NODES)
+        and not isinstance(stmt, ast.AugAssign)
+        and _assigns_feature(stmt, feature)
+    ):
         return _binding_is_aligned(stmt, feature)
     # A bare named expression statement, `(image_features := ...)`, rebinds
     # unconditionally exactly like an assignment does.
@@ -748,11 +796,12 @@ def _merge_result_is_used(forward, call):
                 )
                 if carries:
                     tainted.update(bound)
-                elif node is statement:
+                elif node is statement and not isinstance(node, ast.AugAssign):
                     # A direct, unconditional rebinding to something the merge
                     # did NOT flow into overwrites the name: the merged value is
                     # gone. A rebinding nested inside a conditional may not run,
-                    # so it must not clear the taint.
+                    # so it must not clear the taint - and an augmented
+                    # assignment adds to the value rather than replacing it.
                     tainted.difference_update(bound)
         if "inputs_embeds" in tainted:
             return True
@@ -1053,6 +1102,81 @@ def test_destructuring_rebindings_of_the_feature_are_not_skipped(label, body):
         f"{label}: the tracer still credits the earlier aligned assignment even "
         f"though `image_features` was rebound by an unpack whose value carries no "
         f"`inputs_embeds.dtype` cast. The unpacked tensor reaches masked_scatter."
+    )
+
+
+# A destructuring target takes its RHS ELEMENT, not the whole RHS. Reading the
+# whole tuple lets a cast that belongs to some other name keep the feature green
+# (transformers writes literal-tuple destructuring: vilt's
+# `text_features, _ = (sequence_output[:, :n], sequence_output[:, n:])`).
+_UNPACK_PAIRING_HOLES = [
+    ("tuple RHS whose cast belongs to the other name",
+     f"{_ALIGNED_ASSIGN}\n"
+     "image_features, feature_lens = (\n"
+     "    image_features.float(), feature_lens.to(inputs_embeds.dtype))"),
+    ("list RHS whose cast belongs to the other name",
+     f"{_ALIGNED_ASSIGN}\n"
+     "[image_features, feature_lens] = [\n"
+     "    image_features.float(), feature_lens.to(inputs_embeds.dtype)]"),
+    ("nested tuple RHS whose cast belongs to the other name",
+     f"{_ALIGNED_ASSIGN}\n"
+     "(image_features, feature_lens), image_sizes = (\n"
+     "    (image_features.float(), feature_lens.to(inputs_embeds.dtype)), sizes)"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body", _UNPACK_PAIRING_HOLES, ids = [case[0] for case in _UNPACK_PAIRING_HOLES],
+)
+def test_a_cast_belonging_to_another_target_is_not_alignment(label, body):
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found, f"{label}: the synthetic merge site itself was not found"
+    assert not aligned, (
+        f"{label}: the tracer credits `image_features` with an "
+        f"`inputs_embeds.dtype` cast that the unpack hands to a DIFFERENT name. "
+        f"`image_features` is fp32 when it reaches masked_scatter."
+    )
+
+
+def test_the_matching_element_of_a_tuple_rhs_still_counts():
+    body = (
+        "image_features, feature_lens = (\n"
+        "    image_features.to(inputs_embeds.device, inputs_embeds.dtype), feature_lens)"
+    )
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found and aligned, "the element the feature actually receives carries the cast"
+
+
+# `image_features += delta` is `Tensor.add_`: in place, so the name keeps the
+# dtype it already had. It can neither inherit the RHS's cast nor lose an
+# earlier one.
+_AUG_ASSIGN_CASES = [
+    ("augmented assignment does not inherit the RHS cast",
+     "image_features = image_features.float()\n"
+     "image_features += delta.to(inputs_embeds.dtype)", False),
+    ("augmented assignment with no earlier cast at all",
+     "image_features += delta.to(inputs_embeds.dtype)", False),
+    ("augmented assignment does not undo an earlier cast",
+     f"{_ALIGNED_ASSIGN}\n"
+     "image_features += self.position_embedding", True),
+    ("augmented assignment inside a branch keeps the earlier cast",
+     f"{_ALIGNED_ASSIGN}\n"
+     "if self.config.add_position_embedding:\n"
+     "    image_features += self.position_embedding", True),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body,expected", _AUG_ASSIGN_CASES, ids = [case[0] for case in _AUG_ASSIGN_CASES],
+)
+def test_augmented_assignment_preserves_the_left_hand_dtype(label, body, expected):
+    found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
+    assert found, f"{label}: the synthetic merge site itself was not found"
+    assert aligned is expected, (
+        f"{label}: expected aligned={expected}, got {aligned}. An in-place "
+        f"`+=` keeps `image_features`' existing dtype, so it neither creates "
+        f"alignment from its right-hand side nor destroys alignment established "
+        f"before it."
     )
 
 

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -212,7 +212,9 @@ def _gemma4_modeling_source():
 # `inputs_embeds.masked_scatter` that consumes the features, and require of each an
 # `inputs_embeds.dtype` cast either inside the merge argument or on the last
 # assignment to that name that DOMINATES the merge (same block or an enclosing one,
-# so a cast stranded in a branch the merge does not run under does not count).
+# so a cast stranded in a branch the merge does not run under does not count), plus
+# a receiver that is still AT `inputs_embeds.dtype` and a result that is actually
+# used (masked_scatter is out-of-place).
 def _is_attr(node, owner, attr):
     """`<owner>.<attr>` as an AST node, e.g. `inputs_embeds.dtype`."""
     return (
@@ -236,6 +238,97 @@ def _casts_to_inputs_embeds_dtype(node):
         if any(_is_attr(v, "inputs_embeds", "dtype") for v in values):
             return True
     return False
+
+
+# Methods that may sit between `inputs_embeds` and `.masked_scatter(...)` without
+# changing the destination dtype. Anything outside this set (`.float()`, `.half()`,
+# `.type(...)`, an unknown helper) can retype the destination, which makes an
+# `inputs_embeds.dtype` source cast prove nothing: the merge then has an fp32
+# destination and a low-precision source and raises.
+_DTYPE_PRESERVING_METHODS = frozenset({
+    "clone", "contiguous", "detach", "cpu", "cuda",
+    "view", "reshape", "flatten", "squeeze", "unsqueeze",
+    "expand", "expand_as", "transpose", "permute", "narrow",
+})
+
+
+def _is_dtype_bearing(node):
+    """Can `node` retype a tensor? (`torch.float32`, `other.dtype`, ...)"""
+    if isinstance(node, ast.Attribute) and node.attr == "dtype":
+        return not _is_attr(node, "inputs_embeds", "dtype")
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "torch"
+    ):
+        # `torch.float32` / `torch.bfloat16` / `torch.long` ...
+        return True
+    return False
+
+
+def _is_device_expr(node):
+    """`x.device`, `"cuda"`, `torch.device(...)` - device without a dtype."""
+    if isinstance(node, ast.Attribute) and node.attr == "device":
+        return True
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return True
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "device"
+    ):
+        return True
+    return False
+
+
+def _to_call_preserves_dtype(call):
+    """Is this `.to(...)` device-only (or a no-op `inputs_embeds.dtype` cast)?
+
+    `inputs_embeds.to(language_model_inputs.device)` is blip_2's real spelling and
+    keeps the dtype; `.to(torch.float32)`, `.to(other.dtype)` and the tensor
+    overload `.to(other_tensor)` do not.
+    """
+    for arg in call.args:
+        if not (_is_device_expr(arg) or _is_attr(arg, "inputs_embeds", "dtype")):
+            return False
+    for kw in call.keywords:
+        if kw.arg in ("non_blocking", "copy", "memory_format"):
+            continue
+        if kw.arg == "device" and _is_device_expr(kw.value):
+            continue
+        if kw.arg == "dtype" and _is_attr(kw.value, "inputs_embeds", "dtype"):
+            continue
+        return False
+    return True
+
+
+def _receiver_preserves_embeds_dtype(node):
+    """Is the merge destination `inputs_embeds` still at `inputs_embeds.dtype`?
+
+    The whole trace is "the source is cast to `inputs_embeds.dtype`, so the merge
+    is safe", which only holds while the DESTINATION is at that dtype too. The
+    receiver may be `inputs_embeds` itself or a chain of dtype-preserving
+    transformations of it (upstream blip_2 really does write
+    `inputs_embeds.to(language_model_inputs.device).masked_scatter(...)`), but
+    `inputs_embeds.float().masked_scatter(mask, feat.to(inputs_embeds.dtype))`
+    merges a low-precision source into an fp32 destination and raises.
+    """
+    while True:
+        if isinstance(node, ast.Name):
+            return node.id == "inputs_embeds"
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            return False
+        method = node.func.attr
+        if method == "to":
+            if not _to_call_preserves_dtype(node):
+                return False
+        elif method in _DTYPE_PRESERVING_METHODS:
+            values = list(node.args) + [kw.value for kw in node.keywords]
+            if any(_is_dtype_bearing(v) for v in values):
+                return False
+        else:
+            return False
+        node = node.func.value
 
 
 _SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
@@ -457,21 +550,36 @@ def _dominating_alignment(forward, feature, merge_arg):
     return best_aligned
 
 
-def _feature_merge_args(forward, feature):
-    """Source args of every `inputs_embeds.masked_scatter(mask, ...)` using `<feature>`.
+_MERGE_METHODS = ("masked_scatter", "masked_scatter_")
 
-    The receiver has to be `inputs_embeds` (or something derived from it): a
+
+def _feature_merges(forward, feature):
+    """Every `inputs_embeds.masked_scatter[_](mask, ...)` call using `<feature>`.
+
+    The receiver has to REFERENCE `inputs_embeds`: a
     `scratch.masked_scatter(mask, feature)` elsewhere in `forward` is a different
-    tensor and says nothing about the dtype of the embedding merge. Nested `def`
-    / `class` / `lambda` bodies are skipped for the same reason: a merge in a
-    helper `forward` never invokes is not `forward`'s merge.
+    tensor and says nothing about the dtype of the embedding merge. Discovery
+    stays deliberately loose here (any receiver mentioning the name) so that a
+    transformed receiver such as blip_2's
+    `inputs_embeds.to(language_model_inputs.device).masked_scatter(...)` is still
+    recognised AS the embedding merge; whether that transformation is dtype-safe
+    is then decided by `_receiver_preserves_embeds_dtype`. Dropping unrecognised
+    receivers here instead would let a second, safe merge hide a dtype-changing
+    one.
+
+    The in-place spelling is accepted too (transformers writes
+    `masked_scatter_` in qwen2_5_omni and blt): it merges into the same storage
+    and needs the same dtype agreement.
+
+    Nested `def` / `class` / `lambda` bodies are skipped: a merge in a helper
+    `forward` never invokes is not `forward`'s merge.
     """
-    args = []
+    calls = []
     for node in _walk_own_scope(forward):
         if not (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "masked_scatter"
+            and node.func.attr in _MERGE_METHODS
             and len(node.args) >= 2
         ):
             continue
@@ -480,12 +588,33 @@ def _feature_merge_args(forward, feature):
             for n in ast.walk(node.func.value)
         ):
             continue
-        source_arg = node.args[1]
         if any(
-            isinstance(n, ast.Name) and n.id == feature for n in ast.walk(source_arg)
+            isinstance(n, ast.Name) and n.id == feature for n in ast.walk(node.args[1])
         ):
-            args.append(source_arg)
-    return sorted(args, key=lambda n: (n.lineno, n.col_offset))
+            calls.append(node)
+    return sorted(calls, key=lambda n: (n.lineno, n.col_offset))
+
+
+def _merge_result_is_used(forward, call):
+    """Does the merge's result survive?
+
+    `masked_scatter` is OUT-OF-PLACE, so a bare
+    `inputs_embeds.masked_scatter(mask, features.to(inputs_embeds.dtype))`
+    statement computes the merged embedding and throws it away: the features
+    never reach the model, silently, with every dtype canary green. Upstream has
+    always spelled it `inputs_embeds = inputs_embeds.masked_scatter(...)` on
+    5.5.0-5.15.0, so requiring the result to be consumed costs nothing. The
+    in-place `masked_scatter_` writes through the receiver and needs no
+    assignment.
+    """
+    if call.func.attr.endswith("_"):
+        return True
+    chain = _enclosing_blocks(forward, call)
+    if not chain:
+        return True
+    block, index = chain[-1]
+    statement = block[index]
+    return not (isinstance(statement, ast.Expr) and statement.value is call)
 
 
 def _merge_dtype_alignment(src, feature):
@@ -494,16 +623,25 @@ def _merge_dtype_alignment(src, feature):
     Returns (merge_found, every_merge_aligned). EVERY merge consuming the feature
     has to be aligned: one unaligned branch is one reachable dtype crash, so an
     aligned first merge must not excuse an unaligned second one.
+
+    A merge counts as aligned when all three hold: the destination is still at
+    `inputs_embeds.dtype`, the merged result is actually used, and the source
+    carries an `inputs_embeds.dtype` cast at the call or on its last dominating
+    assignment.
     """
     forward = _gemma4_model_forward_node(src)
     if forward is None:
         return (False, False)
-    merges = _feature_merge_args(forward, feature)
+    merges = _feature_merges(forward, feature)
     if not merges:
         return (False, False)
     aligned = all(
-        _casts_to_inputs_embeds_dtype(merge)
-        or _dominating_alignment(forward, feature, merge)
+        _receiver_preserves_embeds_dtype(merge.func.value)
+        and _merge_result_is_used(forward, merge)
+        and (
+            _casts_to_inputs_embeds_dtype(merge.args[1])
+            or _dominating_alignment(forward, feature, merge)
+        )
         for merge in merges
     )
     return (True, aligned)
@@ -636,18 +774,28 @@ def test_audio_compiler_transform_still_fixes_the_device_only_spelling():
 # needed, so they run on every supported version) and pin the verdict on the
 # spellings that used to slip through.
 # ---------------------------------------------------------------------------
-def _synthetic_forward(body):
-    """Minimal `Gemma4Model.forward` with `body` between the features and the merge."""
-    indented = "\n".join("            " + line if line else "" for line in body.strip("\n").split("\n"))
+_DEFAULT_MERGE = (
+    "inputs_embeds = inputs_embeds.masked_scatter(\n"
+    "    image_mask.to(inputs_embeds.device), image_features.to(inputs_embeds.device)\n"
+    ")"
+)
+
+
+def _indented(block):
+    return "\n".join(
+        "            " + line if line else "" for line in block.strip("\n").split("\n")
+    )
+
+
+def _synthetic_forward(body, merge = _DEFAULT_MERGE):
+    """Minimal `Gemma4Model.forward` with `body` between the features and `merge`."""
     return (
         "class Gemma4Model:\n"
         "    def forward(self, inputs_embeds, pixel_values, image_mask):\n"
         "        if pixel_values is not None:\n"
         "            image_features = self.get_image_features(pixel_values)\n"
-        f"{indented}\n"
-        "            inputs_embeds = inputs_embeds.masked_scatter(\n"
-        "                image_mask.to(inputs_embeds.device), image_features.to(inputs_embeds.device)\n"
-        "            )\n"
+        f"{_indented(body)}\n"
+        f"{_indented(merge)}\n"
         "        return inputs_embeds\n"
     )
 
@@ -788,3 +936,163 @@ def test_non_rebinding_targets_do_not_break_alignment(label, body):
     # Controls for the test above.
     found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
     assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
+
+
+# The whole trace is "the source is cast to `inputs_embeds.dtype`, so the merge is
+# safe". That only holds while the DESTINATION is still at `inputs_embeds.dtype`.
+# A receiver transformation that retypes it turns the source cast into the wrong
+# cast: `inputs_embeds.float().masked_scatter(mask, image_features.to(
+# inputs_embeds.dtype))` has an fp32 destination and an fp16/bf16 source and
+# raises the exact error this whole file exists to prevent.
+_RECEIVER_HOLES = [
+    ("receiver upcast with .float()",
+     "inputs_embeds = inputs_embeds.float().masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .to(torch.float32)",
+     "inputs_embeds = inputs_embeds.to(torch.float32).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver cast to a third tensor's dtype",
+     "inputs_embeds = inputs_embeds.to(image_features.dtype).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .to(dtype = torch.float32) by keyword",
+     "inputs_embeds = inputs_embeds.to(dtype = torch.float32).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver retyped by an unknown helper",
+     "inputs_embeds = self.upcast(inputs_embeds).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.dtype)\n"
+     ")"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,merge", _RECEIVER_HOLES, ids = [case[0] for case in _RECEIVER_HOLES],
+)
+def test_receiver_that_changes_dtype_is_not_alignment(label, merge):
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
+    )
+    assert found, f"{label}: the synthetic merge site itself was not found"
+    assert not aligned, (
+        f"{label}: the tracer reports the merge dtype-aligned, but the merge "
+        f"DESTINATION is no longer at `inputs_embeds.dtype`, so the "
+        f"`inputs_embeds.dtype` source cast produces a mismatched pair. With "
+        f"fp16/bf16 embeddings this is one reachable `masked_scatter_: expected "
+        f"self and source to have same dtypes` with every canary green."
+    )
+
+
+_RECEIVER_CONTROLS = [
+    # blip_2 really ships this spelling; the receiver predicate is deliberately
+    # loose enough to still recognise it, and `.to(<device>)` keeps the dtype.
+    ("blip_2 receiver .to(other.device)",
+     "inputs_embeds = inputs_embeds.to(image_features.device).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .to(device = ..., non_blocking = True)",
+     "inputs_embeds = inputs_embeds.to(device = image_features.device, non_blocking = True).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .to('cuda')",
+     "inputs_embeds = inputs_embeds.to('cuda').masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .clone().contiguous()",
+     "inputs_embeds = inputs_embeds.clone().contiguous().masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("receiver .to(inputs_embeds.dtype) is a no-op",
+     "inputs_embeds = inputs_embeds.to(inputs_embeds.dtype).masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("plain receiver",
+     "inputs_embeds = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,merge", _RECEIVER_CONTROLS, ids = [case[0] for case in _RECEIVER_CONTROLS],
+)
+def test_dtype_preserving_receivers_still_count_as_alignment(label, merge):
+    # Controls for the test above: every one of these merges into a destination
+    # that is still at `inputs_embeds.dtype`, so they must NOT turn red.
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
+    )
+    assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
+
+
+# `masked_scatter` is out-of-place. Losing the surrounding `inputs_embeds =`
+# leaves every dtype cast in place - and silently drops the features, because the
+# merged tensor is discarded. Upstream assigns the result on 5.5.0-5.15.0, so
+# requiring it costs nothing; the in-place `masked_scatter_` spelling
+# (transformers writes it in qwen2_5_omni / blt) needs no assignment and must
+# still be accepted.
+def test_discarded_out_of_place_merge_is_not_alignment():
+    merge = (
+        "inputs_embeds.masked_scatter(\n"
+        "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+        ")"
+    )
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
+    )
+    assert found, "the synthetic merge site itself was not found"
+    assert not aligned, (
+        "the tracer reports the merge aligned, but `masked_scatter` is "
+        "out-of-place and its result is thrown away: the image features never "
+        "reach the model. Every dtype canary here would stay green while the "
+        "merge silently did nothing."
+    )
+
+
+_RESULT_USE_CONTROLS = [
+    ("in-place masked_scatter_ needs no assignment",
+     "inputs_embeds.masked_scatter_(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+    ("result bound to a temp name, then rebound",
+     "merged = inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")\n"
+     "inputs_embeds = merged"),
+    ("result flows into a call argument",
+     "inputs_embeds = self.norm(inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     "))"),
+    ("result returned directly",
+     "return inputs_embeds.masked_scatter(\n"
+     "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+     ")"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,merge", _RESULT_USE_CONTROLS, ids = [case[0] for case in _RESULT_USE_CONTROLS],
+)
+def test_used_merge_results_still_count_as_alignment(label, merge):
+    # Controls for the test above.
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
+    )
+    assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
+
+
+def test_in_place_merge_with_an_unaligned_source_is_still_traced():
+    # Accepting `masked_scatter_` must not become a way to skip the dtype trace:
+    # the in-place op has exactly the same dtype requirement.
+    merge = (
+        "image_features = image_features.float()\n"
+        "inputs_embeds.masked_scatter_(image_mask, image_features)"
+    )
+    found, aligned = _merge_dtype_alignment(
+        _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
+    )
+    assert found and not aligned, (
+        "an in-place merge fed by a feature rebound to fp32 must report unaligned"
+    )

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -1491,6 +1491,14 @@ _ALIGNED_SCRATCH_MERGE = (
     "    audio_mask, audio_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
     ")"
 )
+# The same decoy, written so the receiver MENTIONS `inputs_embeds` without being
+# it. Matching the name anywhere in the receiver expression accepted this as the
+# embedding merge; the receiver has to be anchored at its base instead.
+_ALIGNED_SCRATCH_MERGE_ON_EMBEDS_DEVICE = (
+    "scratch = scratch.to(inputs_embeds.device).masked_scatter(\n"
+    "    audio_mask, audio_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+    ")"
+)
 
 
 def _audio_merge_casts(body):
@@ -1518,6 +1526,24 @@ def test_eager_matcher_still_finds_the_real_merge_next_to_a_decoy():
     assert len(buggy) == 1 and not fixed, (
         f"expected the one real device-only `inputs_embeds` merge to be patchable "
         f"next to an aligned scratch decoy, got {len(buggy)} buggy / {len(fixed)} fixed"
+    )
+
+
+@pytest.mark.parametrize(
+    "decoy",
+    [_ALIGNED_SCRATCH_MERGE, _ALIGNED_SCRATCH_MERGE_ON_EMBEDS_DEVICE],
+    ids = ["bare scratch receiver", "scratch receiver naming inputs_embeds"],
+)
+def test_a_decoy_merge_never_hides_the_real_one(decoy):
+    # `scratch.to(inputs_embeds.device)` is a different tensor, however many
+    # times it names `inputs_embeds`. Counting it as the embedding merge puts an
+    # aligned cast in `fixed_casts`, and `len(buggy) == 1 and fixed_casts` is
+    # exactly the branch on which the eager patch returns without patching and
+    # without warning - the real device-only merge stays broken.
+    buggy, fixed = _audio_merge_casts(decoy + "\n" + _REAL_AUDIO_MERGE)
+    assert len(buggy) == 1 and not fixed, (
+        f"expected the one real device-only `inputs_embeds` merge to be patchable "
+        f"next to an aligned decoy, got {len(buggy)} buggy / {len(fixed)} fixed"
     )
 
 

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -215,6 +215,20 @@ def _gemma4_modeling_source():
 # so a cast stranded in a branch the merge does not run under does not count), plus
 # a receiver that is still AT `inputs_embeds.dtype` and a result that is actually
 # used (masked_scatter is out-of-place).
+# Known, deliberate limits of the trace, none of which any transformers 5.5.0
+# to 5.15.0 source hits (checked against every gemma4-bearing release, and the
+# spellings themselves against all 503 model families of 5.15.0):
+#   * names bound by `match`/`case` patterns are not tracked - no transformers
+#     modeling file contains a `match` statement;
+#   * the merged result only has to REACH `inputs_embeds`; a later statement
+#     overwriting it again is not modelled. Requiring survival to the end
+#     instead trades this for a false red on "merge, use, then release the
+#     name", which needs a use-before-overwrite analysis to tell apart;
+#   * `.to(other_tensor)` counts as alignment here but not in the eager patch's
+#     own matcher (unsloth_zoo/temporary_patches/gemma4.py), which reads only
+#     the `.to(inputs_embeds.device[, inputs_embeds.dtype])` spelling upstream
+#     actually ships. Upstream adopting the overload would surface as a drift
+#     warning telling us to update the patch, which is the intended signal.
 def _is_attr(node, owner, attr):
     """`<owner>.<attr>` as an AST node, e.g. `inputs_embeds.dtype`."""
     return (

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -674,13 +674,23 @@ def _is_gemma4_attr(node, owner, attr):
 def _gemma4_audio_merge_casts(forward_node):
     """Split the audio `masked_scatter` source casts this patch can act on.
 
-    Returns `(buggy_casts, fixed_casts)`: `masked_scatter(mask, audio_features.to(
-    inputs_embeds.device[, inputs_embeds.dtype]))` argument nodes, split by whether
-    the dtype is already carried. Anything else (a wrapped or reshaped source
-    argument, a different call shape) matches NEITHER list, which is exactly when
-    this patch silently no-ops - so the drift canary in
+    Returns `(buggy_casts, fixed_casts)`: `inputs_embeds.masked_scatter(mask,
+    audio_features.to(inputs_embeds.device[, inputs_embeds.dtype]))` argument
+    nodes, split by whether the dtype is already carried. Anything else (a wrapped
+    or reshaped source argument, a different call shape) matches NEITHER list,
+    which is exactly when this patch silently no-ops - so the drift canary in
     tests/test_gemma4_dtype_drift_guards.py calls this same matcher on the real
     transformers source rather than re-deriving it.
+
+    The receiver has to reference `inputs_embeds`: only the embedding merge can
+    make audio features reach the model, so a `masked_scatter` onto any other
+    tensor is a different op whose dtype says nothing about ours. Accepting any
+    receiver let an already-aligned merge on some scratch tensor land in
+    `fixed_casts`, which reads to the caller as "upstream fixed it" - it sets the
+    patched marker and returns without touching a real, still-device-only
+    `inputs_embeds` merge. Discovery stays loose about HOW the receiver mentions
+    the name (`inputs_embeds.to(...).masked_scatter(...)` is still the embedding
+    merge), so a transformed receiver is not silently dropped.
     """
     buggy_casts = []
     fixed_casts = []
@@ -690,6 +700,11 @@ def _gemma4_audio_merge_casts(forward_node):
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "masked_scatter"
             and len(node.args) >= 2
+        ):
+            continue
+        if not any(
+            isinstance(inner, ast.Name) and inner.id == "inputs_embeds"
+            for inner in ast.walk(node.func.value)
         ):
             continue
         source = node.args[1]

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -674,12 +674,11 @@ def _is_gemma4_attr(node, owner, attr):
 def _gemma4_receiver_is_inputs_embeds(node):
     """Does this `masked_scatter` receiver expression START from `inputs_embeds`?
 
-    Discovery has to stay loose about HOW the receiver transforms the name
-    (`inputs_embeds.to(...).masked_scatter(...)` is still the embedding merge),
-    but the transformation has to be OF `inputs_embeds`. Merely mentioning the
-    name is not enough: `scratch.to(inputs_embeds.device)` names it and is a
-    different tensor, so an aligned merge onto that scratch buffer would land in
-    `fixed_casts` and read to the caller as "upstream fixed it".
+    Matched at the BASE, so a transformed receiver
+    (`inputs_embeds.to(...).masked_scatter(...)`) still counts while a different
+    tensor that merely names it (`scratch.to(inputs_embeds.device)`) does not: an
+    aligned merge onto that scratch buffer would land in `fixed_casts` and read to
+    the caller as "upstream fixed it".
     """
     while True:
         if isinstance(node, ast.Name):
@@ -703,16 +702,9 @@ def _gemma4_audio_merge_casts(forward_node):
     tests/test_gemma4_dtype_drift_guards.py calls this same matcher on the real
     transformers source rather than re-deriving it.
 
-    The receiver has to reference `inputs_embeds`: only the embedding merge can
-    make audio features reach the model, so a `masked_scatter` onto any other
-    tensor is a different op whose dtype says nothing about ours. Accepting any
-    receiver let an already-aligned merge on some scratch tensor land in
-    `fixed_casts`, which reads to the caller as "upstream fixed it" - it sets the
-    patched marker and returns without touching a real, still-device-only
-    `inputs_embeds` merge. The receiver is matched at its BASE, so a transformed
-    receiver (`inputs_embeds.to(...).masked_scatter(...)`) is still recognised
-    while a different tensor that merely mentions the name
-    (`scratch.to(inputs_embeds.device)`) is not.
+    The receiver must be `inputs_embeds` (`_gemma4_receiver_is_inputs_embeds`):
+    only the embedding merge makes audio features reach the model, so a
+    `masked_scatter` onto any other tensor says nothing about our dtype.
     """
     buggy_casts = []
     fixed_casts = []

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -671,6 +671,27 @@ def _is_gemma4_attr(node, owner, attr):
     )
 
 
+def _gemma4_receiver_is_inputs_embeds(node):
+    """Does this `masked_scatter` receiver expression START from `inputs_embeds`?
+
+    Discovery has to stay loose about HOW the receiver transforms the name
+    (`inputs_embeds.to(...).masked_scatter(...)` is still the embedding merge),
+    but the transformation has to be OF `inputs_embeds`. Merely mentioning the
+    name is not enough: `scratch.to(inputs_embeds.device)` names it and is a
+    different tensor, so an aligned merge onto that scratch buffer would land in
+    `fixed_casts` and read to the caller as "upstream fixed it".
+    """
+    while True:
+        if isinstance(node, ast.Name):
+            return node.id == "inputs_embeds"
+        if isinstance(node, ast.Call):
+            node = node.func
+        elif isinstance(node, (ast.Attribute, ast.Subscript)):
+            node = node.value
+        else:
+            return False
+
+
 def _gemma4_audio_merge_casts(forward_node):
     """Split the audio `masked_scatter` source casts this patch can act on.
 
@@ -688,9 +709,10 @@ def _gemma4_audio_merge_casts(forward_node):
     receiver let an already-aligned merge on some scratch tensor land in
     `fixed_casts`, which reads to the caller as "upstream fixed it" - it sets the
     patched marker and returns without touching a real, still-device-only
-    `inputs_embeds` merge. Discovery stays loose about HOW the receiver mentions
-    the name (`inputs_embeds.to(...).masked_scatter(...)` is still the embedding
-    merge), so a transformed receiver is not silently dropped.
+    `inputs_embeds` merge. The receiver is matched at its BASE, so a transformed
+    receiver (`inputs_embeds.to(...).masked_scatter(...)`) is still recognised
+    while a different tensor that merely mentions the name
+    (`scratch.to(inputs_embeds.device)`) is not.
     """
     buggy_casts = []
     fixed_casts = []
@@ -702,10 +724,7 @@ def _gemma4_audio_merge_casts(forward_node):
             and len(node.args) >= 2
         ):
             continue
-        if not any(
-            isinstance(inner, ast.Name) and inner.id == "inputs_embeds"
-            for inner in ast.walk(node.func.value)
-        ):
+        if not _gemma4_receiver_is_inputs_embeds(node.func.value):
             continue
         source = node.args[1]
         if not (

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -671,33 +671,17 @@ def _is_gemma4_attr(node, owner, attr):
     )
 
 
-def _patch_gemma4_audio_feature_dtype_on_class(model_cls):
-    """Align audio features to the actual text-embedding dtype at the merge site."""
-    marker = "_unsloth_audio_feature_dtype_patched"
-    if getattr(model_cls, marker, False):
-        return False
+def _gemma4_audio_merge_casts(forward_node):
+    """Split the audio `masked_scatter` source casts this patch can act on.
 
-    module = sys.modules.get(model_cls.__module__)
-    source_file = inspect.getsourcefile(model_cls)
-    if module is None or source_file is None:
-        return False
-
-    module_source = inspect.getsource(module)
-    tree = ast.parse(module_source, filename=source_file)
-    class_nodes = [
-        node for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == model_cls.__name__
-    ]
-    if len(class_nodes) != 1:
-        return False
-    forward_nodes = [
-        node for node in class_nodes[0].body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "forward"
-    ]
-    if len(forward_nodes) != 1:
-        return False
-    forward_node = forward_nodes[0]
-
+    Returns `(buggy_casts, fixed_casts)`: `masked_scatter(mask, audio_features.to(
+    inputs_embeds.device[, inputs_embeds.dtype]))` argument nodes, split by whether
+    the dtype is already carried. Anything else (a wrapped or reshaped source
+    argument, a different call shape) matches NEITHER list, which is exactly when
+    this patch silently no-ops - so the drift canary in
+    tests/test_gemma4_dtype_drift_guards.py calls this same matcher on the real
+    transformers source rather than re-deriving it.
+    """
     buggy_casts = []
     fixed_casts = []
     for node in ast.walk(forward_node):
@@ -725,6 +709,38 @@ def _patch_gemma4_audio_feature_dtype_on_class(model_cls):
             for keyword in source.keywords
         )
         (fixed_casts if has_dtype else buggy_casts).append(source)
+    return buggy_casts, fixed_casts
+pass
+
+
+def _patch_gemma4_audio_feature_dtype_on_class(model_cls):
+    """Align audio features to the actual text-embedding dtype at the merge site."""
+    marker = "_unsloth_audio_feature_dtype_patched"
+    if getattr(model_cls, marker, False):
+        return False
+
+    module = sys.modules.get(model_cls.__module__)
+    source_file = inspect.getsourcefile(model_cls)
+    if module is None or source_file is None:
+        return False
+
+    module_source = inspect.getsource(module)
+    tree = ast.parse(module_source, filename=source_file)
+    class_nodes = [
+        node for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == model_cls.__name__
+    ]
+    if len(class_nodes) != 1:
+        return False
+    forward_nodes = [
+        node for node in class_nodes[0].body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "forward"
+    ]
+    if len(forward_nodes) != 1:
+        return False
+    forward_node = forward_nodes[0]
+
+    buggy_casts, fixed_casts = _gemma4_audio_merge_casts(forward_node)
 
     if not buggy_casts and len(fixed_casts) == 1:
         setattr(model_cls, marker, True)


### PR DESCRIPTION
`Core (HF=latest + TRL=latest)` is red on unsloth main. One of its four failures is this zoo guard:

```
FAILED tests/test_gemma4_dtype_drift_guards.py::test_real_gemma4_image_and_video_merges_still_cast_dtype
  assert 'image_features.to(inputs_embeds.device, inputs_embeds.dtype)' in '<modeling_gemma4.py>'
```

## This is not a functional break

`get_image_features` became variable-resolution in transformers 5.15.0, so `pooler_output` is a tuple and `forward` has to concatenate it:

```python
# 5.14.1
image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)

# 5.15.0
image_features = torch.cat(image_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
```

The dtype cast never lived at the merge site for image/video - it has always been on the assignment, and the guard's string only matched as an accidental substring of `image_features = image_features.to(...)`. Inserting `torch.cat(...)` broke that accident. `video_features` still matched, which is why only the image half failed.

Image and video features are dtype-aligned before `masked_scatter` in every release 5.5.0 through 5.15.0, so nothing is broken for users and no production code changes here. Checked separately: `_patch_gemma4_audio_feature_dtype_on_class` against real 5.15.0 finds 0 buggy / 1 fixed cast, takes the already-fixed-upstream branch and emits no drift warning; `fix_gemma4_audio_feature_dtype` correctly leaves the source unchanged.

The same release also fixed the audio bug the patch exists for (transformers #45192):

```python
# 5.5.0 - 5.14.1
audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)
# 5.15.0
audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device, inputs_embeds.dtype)
```

## The change

Rather than re-anchor on the new spelling, the canaries now trace dtype ALIGNMENT structurally: parse `Gemma4Model.forward`, find the `masked_scatter` consuming the feature, and require an `inputs_embeds.dtype` cast either inside the merge argument or on the last assignment to that name before the merge (ordered by `lineno`, so a later rebind cannot be satisfied by an earlier cast).

That is strictly stronger than the substring, not a widening:

| case | should be | old | new |
|---|---|---|---|
| 5.15.0 pristine (image) | pass | FAIL | pass |
| 5.14.1 pristine (image) | pass | pass | pass |
| cast, then rebind with `.float()` | fail | fail | fail |
| dtype cast moved into a dead `if False:` branch (video) | fail | PASS, missed | fail |

Across 5.5.0, 5.10.0, 5.13.1, 5.14.0, 5.14.1 and 5.15.0 the tracer reports image/video aligned everywhere, and audio not-aligned on 5.5.0-5.14.1 (correctly, the bug unsloth patches) and aligned on 5.15.0. The audio canary now accepts "upstream aligned OR the unsloth rewriter still matches", and an ungated `test_audio_compiler_transform_still_fixes_the_device_only_spelling` keeps the rewriter under test now that 5.15 makes the real-source canary trivially green.

## Verification

All CPU-only, no GPU.

| environment | result |
|---|---|
| transformers 5.15.0, trl 1.9.2, torch 2.10.0+cpu | 27 passed (was 1 failed / 24 passed) |
| transformers 5.14.1 (old spelling) | 27 passed |
| transformers 4.57.6, trl 0.22.2, torch 2.6.0+cpu | 22 passed, 5 skipped |

Re-confirmed independently: the pre-change file still fails on 5.15.0 in the same venv, so the fix is what moves it. Pure stdlib `ast` plus pytest, so platform- and version-agnostic.

The other three failures in that CI job are untouched and tracked separately.