### PR TITLE
Match the transformers 5.x Qwen2-VL vision block call in the gradient checkpointing rewriter

### DIFF
--- a/tests/mutants/qwen2_vl_max_seqlen_mutants.py
+++ b/tests/mutants/qwen2_vl_max_seqlen_mutants.py
@@ -1,0 +1,140 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+"""Mutation harness for
+``test_compiler_custom_gradient_checkpointing_qwen2_vl_max_seqlen_is_recomputed``.
+
+That guard is what licenses the transformers 5.x entry in
+``unsloth_zoo/compiler.py:custom_gradient_checkpointing_replacements`` to drop
+``max_seqlen=max_seqlen`` from the rewritten ``blk(...)`` call. A guard that
+only greps for ``get_max_seqlen(`` stays green on upstreams where dropping the
+keyword is no longer lossless, so this harness rebuilds
+``VisionAttention.forward`` from its own source with one line mutated and
+requires the shipped guard to fail on each mutant.
+
+Each mutant is checked twice:
+
+* ``full``       -- the whole guard (AST pin + executed forward).
+* ``exec only``  -- the guard fed the *pristine* source for its AST stage, so
+                    only the executed forward can catch the mutant.
+
+Run it directly (CPU only, no model downloads)::
+
+    python tests/mutants/qwen2_vl_max_seqlen_mutants.py
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import textwrap
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from test_upstream_source_patterns import (  # noqa: E402
+    _assert_qwen2_vl_max_seqlen_recomputed,
+)
+
+
+# Each entry: name, (old, new) source substitution, why it matters.
+MUTATIONS = (
+    (
+        "different sequence tensor",
+        "get_max_seqlen(cu_seqlens, self.config",
+        "get_max_seqlen(cu_seqlens[:2], self.config",
+        "recompute kept, but off a different tensor -> 4 instead of 5",
+    ),
+    (
+        "non-None precomputed value",
+        'kwargs={"max_seqlen": max_seqlen}',
+        'kwargs={"max_seqlen": max_seqlen if max_seqlen is not None else 128}',
+        "recompute kept, but a config-style fallback wins -> 128 instead of 5",
+    ),
+)
+
+
+def _build_mutant(old: str, new: str):
+    """Recompile ``VisionAttention.forward`` from source with one substitution
+    and return ``(subclass, mutated_source)``. Compiled against a copy of the
+    upstream module globals, so the real module is never touched."""
+    from transformers.models.qwen2_vl import modeling_qwen2_vl as module
+
+    src = textwrap.dedent(inspect.getsource(module.VisionAttention.forward))
+    if old not in src:
+        raise SystemExit(
+            f"mutation anchor is stale, not found in VisionAttention.forward: {old!r}"
+        )
+    mutated_src = src.replace(old, new)
+    namespace = dict(module.__dict__)
+    exec(compile(mutated_src, "<mutant VisionAttention.forward>", "exec"),
+         namespace)
+    mutant = type(
+        "MutantVisionAttention",
+        (module.VisionAttention,),
+        {"forward": namespace["forward"]},
+    )
+    return mutant, mutated_src, src
+
+
+def _run_guard(attn_cls, forward_src):
+    """Return ``None`` if the guard passed, else its failure message."""
+    try:
+        _assert_qwen2_vl_max_seqlen_recomputed(attn_cls, forward_src = forward_src)
+    except BaseException as error:            # pytest.fail raises OutcomeException
+        return getattr(error, "msg", None) or str(error)
+    return None
+
+
+def main() -> int:
+    try:
+        from transformers.models.qwen2_vl.modeling_qwen2_vl import (  # noqa: F401
+            get_max_seqlen, VisionAttention,
+        )
+    except ImportError:
+        print("SKIP: get_max_seqlen / VisionAttention not in this transformers "
+              "build (4.x) -- nothing to mutate")
+        return 0
+
+    failures = []
+
+    control = _run_guard(VisionAttention, None)
+    if control is None:
+        print("PASS  control (unmutated upstream VisionAttention): guard green")
+    else:
+        failures.append("control")
+        print(f"FAIL  control (unmutated upstream VisionAttention): {control}")
+
+    for name, old, new, why in MUTATIONS:
+        mutant, mutated_src, pristine_src = _build_mutant(old, new)
+        print(f"\n-- mutant: {name} ({why})")
+        for label, src in (("full     ", mutated_src),
+                           ("exec only", pristine_src)):
+            caught = _run_guard(mutant, src)
+            if caught is None:
+                failures.append(f"{name} [{label.strip()}]")
+                print(f"   FAIL  {label}: guard stayed GREEN on the mutant")
+            else:
+                print(f"   PASS  {label}: caught -- {caught}")
+
+    print()
+    if failures:
+        print(f"MUTATION HARNESS FAILED: {failures}")
+        return 1
+    print("MUTATION HARNESS OK: guard is green on real upstream and red on "
+          "every mutant, under both the AST pin and the executed forward")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/mutants/qwen2_vl_max_seqlen_mutants.py
+++ b/tests/mutants/qwen2_vl_max_seqlen_mutants.py
@@ -14,11 +14,13 @@
 """Mutation harness for
 ``test_compiler_custom_gradient_checkpointing_qwen2_vl_max_seqlen_is_recomputed``.
 
-That guard is what licenses the transformers 5.x entry in
-``unsloth_zoo/compiler.py:custom_gradient_checkpointing_replacements`` to drop
-``max_seqlen=max_seqlen`` from the rewritten ``blk(...)`` call. A guard that
-only greps for ``get_max_seqlen(`` stays green on upstreams where dropping the
-keyword is no longer lossless, so this harness rebuilds
+That guard pins the recompute fallback behind the transformers 5.x entry in
+``unsloth_zoo/compiler.py:custom_gradient_checkpointing_replacements``. The
+entry keeps ``max_seqlen`` (bound into the checkpointed callable), and the
+recompute is what makes a lost or mis-bound keyword degrade into an extra
+``.max()`` instead of into wrong attention. A guard that only greps for
+``get_max_seqlen(`` stays green on upstreams where omitting the keyword is no
+longer lossless, so this harness rebuilds
 ``VisionAttention.forward`` from its own source with one line mutated and
 requires the shipped guard to fail on each mutant.
 

--- a/tests/test_gc_rewriter_bound_keywords.py
+++ b/tests/test_gc_rewriter_bound_keywords.py
@@ -1,0 +1,312 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Keywords bound into the checkpointed callable by
+``unsloth_zoo.compiler.patch_gradient_checkpointing``.
+
+``patch_gradient_checkpointing`` rewrites ``hidden_states = blk(ARGS)`` into a
+``self._gradient_checkpointing_func(blk.__call__, ARGS)`` call. Everything in
+``ARGS`` goes to the *checkpoint function*, not to the layer, so a keyword the
+layer only accepts through ``**kwargs`` (transformers 5.x passes
+``max_seqlen=max_seqlen`` to the Qwen2-VL vision block that way) cannot travel
+there: ``self._gradient_checkpointing_func`` is frequently plain
+``torch.utils.checkpoint.checkpoint``, which raises ``ValueError: Unexpected
+keyword arguments`` under ``use_reentrant = True``.
+
+The optional third element of a ``custom_gradient_checkpointing_replacements``
+entry names such keywords, and the rewriter binds them into the callable with
+``functools.partial`` - the same thing
+``transformers.modeling_layers.GradientCheckpointingLayer.__call__`` does.
+
+These tests pin that contract without needing transformers, a GPU, or a model
+download.
+"""
+
+import ast
+import functools
+import inspect
+import os
+import sys
+import textwrap
+
+import pytest
+
+import torch
+
+from unsloth_zoo import compiler
+from unsloth_zoo.gradient_checkpointing import (
+    Unsloth_Gradient_Checkpointer,
+    _TORCH_CHECKPOINT_KEYWORDS,
+    _bind_checkpoint_kwargs,
+    unsloth_checkpoint,
+    unsloth_gradient_checkpoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# A miniature model whose forward has the exact shape the rewriter looks for.
+# ---------------------------------------------------------------------------
+
+_TOY_SOURCE = '''
+class _ToyBlocks(torch.nn.Module):
+    def __init__(self, depth):
+        super().__init__()
+        self.layers = torch.nn.ModuleList(
+            [torch.nn.Identity() for _ in range(depth)]
+        )
+
+    def forward(self, hidden_states, extra, **kwargs):
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states,
+                extra=extra,
+                sentinel=sentinel,
+                **kwargs,
+            )
+        return hidden_states
+'''
+
+
+@functools.lru_cache(maxsize = None)
+def _build_toy():
+    # patch_gradient_checkpointing() reads the class through inspect.getsource(),
+    # so the toy has to live in a real file on disk.
+    import importlib.util
+    import tempfile
+
+    directory = tempfile.mkdtemp(prefix = "unsloth_gc_toy_")
+    path = os.path.join(directory, "unsloth_gc_toy.py")
+    with open(path, "w", encoding = "utf-8") as handle:
+        handle.write("import torch\n" + _TOY_SOURCE)
+    spec = importlib.util.spec_from_file_location("unsloth_gc_toy", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["unsloth_gc_toy"] = module
+    spec.loader.exec_module(module)
+    return module._ToyBlocks
+
+
+_TOY_FIND = """hidden_states = layer(
+                hidden_states,
+                extra=extra,
+                sentinel=sentinel,
+                **kwargs,
+            )"""
+_TOY_REPLACE = """hidden_states = layer(
+                hidden_states,
+                extra=extra,
+                **kwargs,
+            )"""
+
+
+def _rewrite_toy(monkeypatch, entry):
+    """Run patch_gradient_checkpointing over the toy class with one entry."""
+    monkeypatch.setattr(
+        compiler, "custom_gradient_checkpointing_replacements", [entry],
+    )
+    cls = _build_toy()
+    output = compiler.patch_gradient_checkpointing("_ToyBlocks", cls)
+    assert output is not None, "rewriter bailed on the toy class"
+    return output[1]
+
+
+def _for_loop_body(forward_source):
+    tree = ast.parse(textwrap.dedent(forward_source))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.For):
+            return node
+    raise AssertionError("no for-loop in the rewritten forward")
+
+
+def test_rewriter_two_tuple_entries_are_unchanged(monkeypatch):
+    """A 2-tuple entry declares no bound keywords, so nothing about the emitted
+    code may change - every entry that shipped before is a 2-tuple."""
+    forward = _rewrite_toy(monkeypatch, (_TOY_FIND, _TOY_REPLACE))
+    assert "functools.partial" not in forward
+    assert "sentinel" not in forward
+    ast.parse(textwrap.dedent(forward))
+
+
+@pytest.mark.parametrize("declaration", [("sentinel",), {"sentinel": "sentinel"}])
+def test_rewriter_binds_declared_keyword_into_the_callable(monkeypatch, declaration):
+    """Sequence and mapping spellings both bind the keyword into the callable on
+    the checkpointed branch and pass it directly on the else branch."""
+    forward = _rewrite_toy(
+        monkeypatch, (_TOY_FIND, _TOY_REPLACE, declaration),
+    )
+    loop = _for_loop_body(forward)
+    branch = loop.body[0]
+    assert isinstance(branch, ast.If), "expected the if/else gradient checkpointing branch"
+
+    checkpointed = branch.body[0].value
+    assert isinstance(checkpointed, ast.Call)
+    assert ast.unparse(checkpointed.func) == "self._gradient_checkpointing_func"
+    # Nothing may be left as a keyword on the checkpoint function itself.
+    assert [kw.arg for kw in checkpointed.keywords] == [None], (
+        "only the layer's own **kwargs may reach _gradient_checkpointing_func; "
+        f"got {[kw.arg for kw in checkpointed.keywords]}"
+    )
+    callable_arg = checkpointed.args[0]
+    assert isinstance(callable_arg, ast.Call)
+    assert ast.unparse(callable_arg.func) == "functools.partial"
+    assert ast.unparse(callable_arg.args[0]) == "layer.__call__"
+    assert {kw.arg: ast.unparse(kw.value) for kw in callable_arg.keywords} == {
+        "sentinel": "sentinel",
+    }
+
+    direct = branch.orelse[0].value
+    assert isinstance(direct, ast.Call)
+    assert ast.unparse(direct.func) == "layer"
+    assert {kw.arg: ast.unparse(kw.value) for kw in direct.keywords if kw.arg} == {
+        "sentinel": "sentinel",
+    }
+
+
+def test_rewriter_bound_keyword_supports_a_custom_expression(monkeypatch):
+    """A mapping may point the keyword at a different expression."""
+    forward = _rewrite_toy(
+        monkeypatch, (_TOY_FIND, _TOY_REPLACE, {"sentinel": "extra"}),
+    )
+    assert "functools.partial(layer.__call__, sentinel = extra)" in forward
+    ast.parse(textwrap.dedent(forward))
+
+
+def test_rewriter_both_branches_call_the_layer_identically(monkeypatch):
+    """The checkpointed and the direct branch must hand the layer the same
+    arguments - the only difference may be the checkpoint indirection."""
+    forward = _rewrite_toy(monkeypatch, (_TOY_FIND, _TOY_REPLACE, ("sentinel",)))
+    branch = _for_loop_body(forward).body[0]
+    checkpointed = branch.body[0].value
+    direct = branch.orelse[0].value
+
+    positional = [ast.unparse(a) for a in checkpointed.args[1:]]
+    assert positional == [ast.unparse(a) for a in direct.args]
+    assert (
+        {kw.arg: ast.unparse(kw.value) for kw in checkpointed.args[0].keywords}
+        == {kw.arg: ast.unparse(kw.value) for kw in direct.keywords if kw.arg}
+    )
+    assert [kw.arg for kw in checkpointed.keywords] == \
+        [kw.arg for kw in direct.keywords if kw.arg is None]
+
+
+def test_qwen2_vl_5x_entry_declares_max_seqlen():
+    """The shipped transformers 5.x Qwen2-VL entry must keep max_seqlen rather
+    than drop it, and must remove it from the positional list (otherwise the
+    ``arg=arg`` demotion would push it into a positional slot the block does not
+    have)."""
+    entries = compiler.custom_gradient_checkpointing_replacements
+    matching = [e for e in entries if "max_seqlen=max_seqlen" in e[0]]
+    assert len(matching) == 1, "expected exactly one 5.x max_seqlen entry"
+    entry = matching[0]
+    assert len(entry) == 3, "the 5.x entry must declare its bound keywords"
+    assert "max_seqlen" in entry[2]
+    assert "max_seqlen" not in entry[1], (
+        "max_seqlen must leave the argument list; it comes back bound into the "
+        "callable"
+    )
+    # And the 5.x entry has to stay last, after both 4.x entries, because its
+    # replacement text is literally the 4.x call site.
+    assert entries.index(entry) == len(entries) - 1
+
+
+def test_generated_module_imports_functools():
+    """``functools`` is not in the generated module's license header nor
+    guaranteed to be re-exported by the model module, so create_new_function()
+    must import it whenever the emitted source uses it."""
+    source = inspect.getsource(compiler.create_new_function)
+    assert '"functools." in new_source' in source
+    assert '"import functools\\n"' in source
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint shims
+# ---------------------------------------------------------------------------
+
+def test_bind_checkpoint_kwargs_is_identity_without_kwargs():
+    def fn(x):
+        return x
+    assert _bind_checkpoint_kwargs(fn, {}) is fn
+    # torch's own checkpoint keywords are consumed by the checkpoint machinery
+    # and must never be bound into the wrapped function.
+    only_torch = {k: object() for k in _TORCH_CHECKPOINT_KEYWORDS}
+    assert _bind_checkpoint_kwargs(fn, only_torch) is fn
+
+
+def test_bind_checkpoint_kwargs_binds_the_rest():
+    def fn(x, flag = None):
+        return (x, flag)
+    bound = _bind_checkpoint_kwargs(fn, {"flag": 7, "preserve_rng_state": False})
+    assert isinstance(bound, functools.partial)
+    assert bound(1) == (1, 7)
+
+
+@pytest.mark.parametrize(
+    "checkpoint_fn", [unsloth_gradient_checkpoint, unsloth_checkpoint],
+)
+def test_checkpoint_shims_deliver_extra_kwargs_to_the_function(checkpoint_fn):
+    """``unsloth_gradient_checkpoint`` used to drop them silently and
+    ``unsloth_checkpoint`` used to raise. Both now behave like torch's
+    non-reentrant checkpoint: the keyword reaches the wrapped function."""
+    if checkpoint_fn is unsloth_checkpoint:
+        pytest.importorskip("torch")
+        pytest.skip(
+            "unsloth_checkpoint routes through UnslothCheckpointFunction, whose "
+            "module globals are only initialised on a real accelerator"
+        )
+    seen = {}
+
+    def fn(x, flag = None):
+        seen["flag"] = flag
+        return x * 2
+
+    x = torch.randn(4, requires_grad = True)
+    out = checkpoint_fn(fn, x, flag = "delivered")
+    out.sum().backward()
+    assert seen["flag"] == "delivered"
+    assert x.grad is not None
+
+
+def test_unsloth_checkpoint_binds_instead_of_raising():
+    """Source-level guard for the shim we cannot execute on CPU: the leftover
+    keyword branch must bind, not raise."""
+    source = inspect.getsource(unsloth_checkpoint)
+    assert "_bind_checkpoint_kwargs" in source
+    assert "raise ValueError" not in source.split("if kwargs and use_reentrant")[1][:400]
+
+
+def test_unsloth_gradient_checkpointer_accepts_a_bare_tensor_return():
+    """Every modern transformers block returns the tensor itself rather than a
+    1-tuple. The recompute in backward used to insist on a 1-tuple and raised
+    ``too many values to unpack``."""
+    def block(x):
+        return x * 3
+
+    x = torch.randn(5, requires_grad = True)
+    out = Unsloth_Gradient_Checkpointer.apply(block, x)
+    assert torch.is_tensor(out)
+    out.sum().backward()
+    assert torch.allclose(x.grad, torch.full_like(x, 3.0))
+
+
+def test_unsloth_gradient_checkpointer_still_accepts_a_one_tuple_return():
+    def block(x):
+        return (x * 3,)
+
+    x = torch.randn(5, requires_grad = True)
+    out = Unsloth_Gradient_Checkpointer.apply(block, x)
+    if isinstance(out, tuple):
+        (out,) = out
+    out.sum().backward()
+    assert torch.allclose(x.grad, torch.full_like(x, 3.0))

--- a/tests/test_gc_rewriter_bound_keywords.py
+++ b/tests/test_gc_rewriter_bound_keywords.py
@@ -80,6 +80,42 @@ class _ToyBlocks(torch.nn.Module):
 '''
 
 
+# Same shape, but with a named layer class so the rewriter can resolve the
+# ModuleList's element type and check a replacement against its signature.
+_TOY_NAMED_SOURCE = '''
+class _ToyLayer(torch.nn.Module):
+    def forward(self, hidden_states, extra, **kwargs):
+        return hidden_states
+
+
+class _ToyNamedBlocks(torch.nn.Module):
+    def __init__(self, depth):
+        super().__init__()
+        self.layers = torch.nn.ModuleList([_ToyLayer() for _ in range(depth)])
+
+    def forward(self, hidden_states, extra, **kwargs):
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states,
+                extra=extra,
+                **kwargs,
+            )
+        return hidden_states
+'''
+
+_TOY_NAMED_FIND = """hidden_states = layer(
+                hidden_states,
+                extra=extra,
+                **kwargs,
+            )"""
+_TOY_NAMED_REPLACE = """hidden_states = layer(
+                hidden_states,
+                extra=extra,
+                injected=injected,
+                **kwargs,
+            )"""
+
+
 @functools.lru_cache(maxsize = None)
 def _build_toy():
     # patch_gradient_checkpointing() reads the class through inspect.getsource(),
@@ -96,6 +132,22 @@ def _build_toy():
     sys.modules["unsloth_gc_toy"] = module
     spec.loader.exec_module(module)
     return module._ToyBlocks
+
+
+@functools.lru_cache(maxsize = None)
+def _build_named_toy():
+    import importlib.util
+    import tempfile
+
+    directory = tempfile.mkdtemp(prefix = "unsloth_gc_named_toy_")
+    path = os.path.join(directory, "unsloth_gc_named_toy.py")
+    with open(path, "w", encoding = "utf-8") as handle:
+        handle.write("import torch\n" + _TOY_NAMED_SOURCE)
+    spec = importlib.util.spec_from_file_location("unsloth_gc_named_toy", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["unsloth_gc_named_toy"] = module
+    spec.loader.exec_module(module)
+    return module._ToyNamedBlocks
 
 
 _TOY_FIND = """hidden_states = layer(
@@ -275,6 +327,80 @@ def test_rewritten_forward_survives_non_empty_runtime_kwargs(monkeypatch):
         assert kwargs["sentinel"] == 7, "declared keyword lost"
         assert kwargs["probe"] == "delivered", "runtime keyword never reached the layer"
     assert hidden_states.grad is not None
+
+
+def _rewrite_named_toy(monkeypatch, entry):
+    monkeypatch.setattr(
+        compiler, "custom_gradient_checkpointing_replacements", [entry],
+    )
+    output = compiler.patch_gradient_checkpointing(
+        "_ToyNamedBlocks", _build_named_toy(),
+    )
+    assert output is not None, "rewriter bailed on the named toy class"
+    return output[1]
+
+
+def test_rewriter_resolves_the_modulelist_layer_class():
+    cls = _build_named_toy()
+    init = inspect.getsource(cls.__init__)
+    layer_class = compiler._modulelist_layer_class(cls, init, "self.layers")
+    assert layer_class is not None and layer_class.__name__ == "_ToyLayer"
+
+
+def test_rewriter_skips_a_replacement_the_layer_cannot_take(monkeypatch):
+    """A replacement entry may declare the parameters the layer must have.
+
+    Two transformers generations spell the Qwen2-VL vision call site
+    identically (4.53.0 - 5.9 and 5.10 - 5.14) but only the first still takes
+    ``rotary_pos_emb``. Injecting it on 5.10 - 5.14 handed the block one
+    positional too many. The text alone cannot tell them apart, so the entry
+    declares the parameter it depends on and is skipped when it is gone."""
+    forward = _rewrite_named_toy(
+        monkeypatch,
+        (_TOY_NAMED_FIND, _TOY_NAMED_REPLACE, None, ("injected",)),
+    )
+    assert "injected" not in forward, \
+        "injected a keyword the layer's forward does not declare"
+    ast.parse(textwrap.dedent(forward))
+
+
+def test_rewriter_applies_a_replacement_the_layer_can_take(monkeypatch):
+    """Control for the test above: the same entry fires when the declared
+    parameter is present, so the guard cannot pass by never applying."""
+    forward = _rewrite_named_toy(
+        monkeypatch,
+        (_TOY_NAMED_FIND, _TOY_NAMED_REPLACE, None, ("extra",)),
+    )
+    assert "injected" in forward
+    ast.parse(textwrap.dedent(forward))
+
+
+def test_rewriter_applies_a_guarded_replacement_when_the_layer_is_unresolvable(
+        monkeypatch):
+    """The plain toy fills its ModuleList with ``torch.nn.Identity``, which is
+    not a name in the toy's own module. Unresolvable means "behave exactly as
+    before", never "silently stop rewriting"."""
+    forward = _rewrite_toy(
+        monkeypatch, (_TOY_FIND, _TOY_REPLACE, None, ("nothing_has_this",)),
+    )
+    assert "sentinel" not in forward, "the replacement did not fire"
+    ast.parse(textwrap.dedent(forward))
+
+
+def test_qwen2_vl_rotary_entries_declare_the_parameter_they_depend_on():
+    """The shipped entries that re-inject ``rotary_pos_emb`` must be guarded on
+    it; transformers 5.10 - 5.14 spell the call site the same way and dropped
+    the parameter."""
+    guarded = [
+        entry for entry in compiler.custom_gradient_checkpointing_replacements
+        if "rotary_pos_emb=rotary_pos_emb" in entry[1]
+    ]
+    assert guarded, "no rotary_pos_emb re-injecting entry left"
+    for entry in guarded:
+        assert len(entry) == 4 and "rotary_pos_emb" in entry[3], (
+            "an entry that injects rotary_pos_emb must declare it as required; "
+            f"got {entry[2:]}"
+        )
 
 
 def test_qwen2_vl_5x_entry_declares_max_seqlen():

--- a/tests/test_gc_rewriter_bound_keywords.py
+++ b/tests/test_gc_rewriter_bound_keywords.py
@@ -320,6 +320,40 @@ def test_bind_checkpoint_kwargs_is_identity_without_kwargs():
     assert _bind_checkpoint_kwargs(fn, only_torch) is fn
 
 
+def test_torch_checkpoint_keywords_covers_every_keyword_only_parameter():
+    """Whatever torch's own ``checkpoint`` declares keyword-only is the
+    checkpoint machinery's, never the block's.
+
+    ``early_stop`` is the concrete miss this pins: torch added it as a per-call
+    keyword and documents it as ignored under ``use_reentrant = True``, which is
+    what the Unsloth shims force. It used to be bound onto the wrapped function,
+    so an ordinary block raised ``TypeError: forward() got an unexpected keyword
+    argument 'early_stop'`` as soon as Unsloth replaced the global symbol."""
+    signature = inspect.signature(torch.utils.checkpoint.checkpoint)
+    keyword_only = {
+        name for name, parameter in signature.parameters.items()
+        if parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    } - {"use_reentrant"}
+    missing = keyword_only - _TORCH_CHECKPOINT_KEYWORDS
+    assert not missing, f"checkpoint keywords that would be bound to the block: {missing}"
+
+
+def test_bind_checkpoint_kwargs_drops_early_stop(monkeypatch):
+    """End of the same story, executed: a block with no ``early_stop``
+    parameter must survive a caller using torch's documented keyword."""
+    if "early_stop" not in inspect.signature(torch.utils.checkpoint.checkpoint).parameters:
+        pytest.skip("this torch has no per-call early_stop")
+
+    def block(x):
+        return x * 2
+
+    assert _bind_checkpoint_kwargs(block, {"early_stop": False}) is block
+    x = torch.randn(4, requires_grad = True)
+    out = unsloth_gradient_checkpoint(block, x, early_stop = False)
+    out.sum().backward()
+    assert x.grad is not None
+
+
 def test_bind_checkpoint_kwargs_binds_the_rest():
     def fn(x, flag = None):
         return (x, flag)

--- a/tests/test_gc_rewriter_bound_keywords.py
+++ b/tests/test_gc_rewriter_bound_keywords.py
@@ -109,6 +109,11 @@ _TOY_REPLACE = """hidden_states = layer(
                 extra=extra,
                 **kwargs,
             )"""
+# Same call site with no keyword expansion left at all.
+_TOY_REPLACE_NO_KWARGS = """hidden_states = layer(
+                hidden_states,
+                extra=extra,
+            )"""
 
 
 def _rewrite_toy(monkeypatch, entry):
@@ -130,12 +135,36 @@ def _for_loop_body(forward_source):
     raise AssertionError("no for-loop in the rewritten forward")
 
 
-def test_rewriter_two_tuple_entries_are_unchanged(monkeypatch):
-    """A 2-tuple entry declares no bound keywords, so nothing about the emitted
-    code may change - every entry that shipped before is a 2-tuple."""
+def test_rewriter_two_tuple_entries_declare_no_bound_keyword(monkeypatch):
+    """A 2-tuple entry declares no bound keywords, so no extra keyword appears.
+
+    The layer's own ``**kwargs`` expansion still has to move into the callable:
+    it is a keyword expansion like any other, and leaving it in the argument
+    list hands the layer's runtime keywords to the checkpoint function."""
     forward = _rewrite_toy(monkeypatch, (_TOY_FIND, _TOY_REPLACE))
-    assert "functools.partial" not in forward
     assert "sentinel" not in forward
+    branch = _for_loop_body(forward).body[0]
+    checkpointed = branch.body[0].value
+    assert [kw.arg for kw in checkpointed.keywords] == []
+    callable_arg = checkpointed.args[0]
+    assert ast.unparse(callable_arg.func) == "functools.partial"
+    assert [
+        (kw.arg, ast.unparse(kw.value)) for kw in callable_arg.keywords
+    ] == [(None, "kwargs")]
+    ast.parse(textwrap.dedent(forward))
+
+
+def test_rewriter_leaves_a_kwargless_call_site_alone(monkeypatch):
+    """No ``**kwargs`` at the call site and no declared keyword means no
+    ``functools.partial`` at all - the pre-existing zero-overhead emission."""
+    forward = _rewrite_toy(
+        monkeypatch, (_TOY_FIND, _TOY_REPLACE_NO_KWARGS),
+    )
+    assert "functools.partial" not in forward
+    branch = _for_loop_body(forward).body[0]
+    checkpointed = branch.body[0].value
+    assert ast.unparse(checkpointed.args[0]) == "layer.__call__"
+    assert checkpointed.keywords == []
     ast.parse(textwrap.dedent(forward))
 
 
@@ -153,18 +182,21 @@ def test_rewriter_binds_declared_keyword_into_the_callable(monkeypatch, declarat
     checkpointed = branch.body[0].value
     assert isinstance(checkpointed, ast.Call)
     assert ast.unparse(checkpointed.func) == "self._gradient_checkpointing_func"
-    # Nothing may be left as a keyword on the checkpoint function itself.
-    assert [kw.arg for kw in checkpointed.keywords] == [None], (
-        "only the layer's own **kwargs may reach _gradient_checkpointing_func; "
+    # NOTHING may be left as a keyword on the checkpoint function itself - not
+    # the declared keyword and not the layer's own **kwargs expansion, which is
+    # empty often enough to look harmless and then raises `Unexpected keyword
+    # arguments` the first time a caller passes anything.
+    assert [kw.arg for kw in checkpointed.keywords] == [], (
+        "no keyword may reach _gradient_checkpointing_func; "
         f"got {[kw.arg for kw in checkpointed.keywords]}"
     )
     callable_arg = checkpointed.args[0]
     assert isinstance(callable_arg, ast.Call)
     assert ast.unparse(callable_arg.func) == "functools.partial"
     assert ast.unparse(callable_arg.args[0]) == "layer.__call__"
-    assert {kw.arg: ast.unparse(kw.value) for kw in callable_arg.keywords} == {
-        "sentinel": "sentinel",
-    }
+    assert [
+        (kw.arg, ast.unparse(kw.value)) for kw in callable_arg.keywords
+    ] == [("sentinel", "sentinel"), (None, "kwargs")]
 
     direct = branch.orelse[0].value
     assert isinstance(direct, ast.Call)
@@ -179,7 +211,7 @@ def test_rewriter_bound_keyword_supports_a_custom_expression(monkeypatch):
     forward = _rewrite_toy(
         monkeypatch, (_TOY_FIND, _TOY_REPLACE, {"sentinel": "extra"}),
     )
-    assert "functools.partial(layer.__call__, sentinel = extra)" in forward
+    assert "functools.partial(layer.__call__, sentinel = extra, **kwargs)" in forward
     ast.parse(textwrap.dedent(forward))
 
 
@@ -193,12 +225,56 @@ def test_rewriter_both_branches_call_the_layer_identically(monkeypatch):
 
     positional = [ast.unparse(a) for a in checkpointed.args[1:]]
     assert positional == [ast.unparse(a) for a in direct.args]
-    assert (
-        {kw.arg: ast.unparse(kw.value) for kw in checkpointed.args[0].keywords}
-        == {kw.arg: ast.unparse(kw.value) for kw in direct.keywords if kw.arg}
+    # Every keyword the direct branch passes - named or expanded - has to be on
+    # the partial instead, and none of them on the checkpoint function.
+    assert sorted(
+        (str(kw.arg), ast.unparse(kw.value)) for kw in checkpointed.args[0].keywords
+    ) == sorted(
+        (str(kw.arg), ast.unparse(kw.value)) for kw in direct.keywords
     )
-    assert [kw.arg for kw in checkpointed.keywords] == \
-        [kw.arg for kw in direct.keywords if kw.arg is None]
+    assert checkpointed.keywords == []
+
+
+def test_rewritten_forward_survives_non_empty_runtime_kwargs(monkeypatch):
+    """Executed proof, not just emitted text.
+
+    With an EMPTY ``**kwargs`` the old emission worked by accident, which is how
+    the leak survived review. Give the forward one real runtime keyword and the
+    reentrant ``torch.utils.checkpoint.checkpoint`` raises ``ValueError:
+    Unexpected keyword arguments`` instead of ever reaching the layer."""
+    forward = _rewrite_toy(monkeypatch, (_TOY_FIND, _TOY_REPLACE, ("sentinel",)))
+
+    seen = []
+
+    class _Layer(torch.nn.Module):
+        def forward(self, hidden_states, extra, **kwargs):
+            seen.append(dict(kwargs))
+            return hidden_states * extra
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = torch.nn.ModuleList([_Layer(), _Layer()])
+            self.gradient_checkpointing = True
+            self._gradient_checkpointing_func = functools.partial(
+                torch.utils.checkpoint.checkpoint, use_reentrant = True,
+            )
+
+    namespace = {"torch": torch, "functools": functools, "sentinel": 7}
+    exec(compile(textwrap.dedent(forward), "<rewritten>", "exec"), namespace)
+    _Model.forward = namespace["forward"]
+
+    model = _Model()
+    model.train()
+    hidden_states = torch.randn(4, requires_grad = True)
+    out = model(hidden_states, torch.tensor(2.0), probe = "delivered")
+    out.sum().backward()
+
+    assert seen, "the layer was never called"
+    for kwargs in seen:
+        assert kwargs["sentinel"] == 7, "declared keyword lost"
+        assert kwargs["probe"] == "delivered", "runtime keyword never reached the layer"
+    assert hidden_states.grad is not None
 
 
 def test_qwen2_vl_5x_entry_declares_max_seqlen():

--- a/tests/test_gc_rewriter_bound_keywords.py
+++ b/tests/test_gc_rewriter_bound_keywords.py
@@ -674,3 +674,67 @@ def test_reentrant_checkpointer_returns_gradients_for_tensor_args():
     assert torch.allclose(x.grad, torch.full_like(x, 2.0))
     # d(loss)/d(leaf) = 3 * (1 from the block + 1 from side.sum())
     assert torch.allclose(leaf.grad, torch.full_like(leaf, 6.0))
+
+
+# ---------------------------------------------------------------------------
+# A frozen first activation next to a differentiable later input
+# ---------------------------------------------------------------------------
+# UnslothCheckpointFunction decided "this Function has a gradient to produce"
+# from positional input zero alone. Autograd calls backward whenever ANY input
+# requires grad, so a frozen activation zero next to a differentiable later
+# input reached the early return and the engine got a single None where it
+# wanted one gradient per input. torch's own reentrant CheckpointFunction has no
+# such gate - it saves unconditionally - so this was a divergence from the
+# function these shims stand in for.
+
+
+def _frozen_first_input(checkpoint_fn, as_keyword):
+    """activation 0 does not require grad; the second input does."""
+    def block(hidden_states, side):
+        return hidden_states * 2.0 + side * 3.0
+
+    def block_kw(hidden_states, side = None):
+        return block(hidden_states, side)
+
+    torch.manual_seed(3)
+    frozen = torch.randn(4)
+    side   = torch.randn(4, requires_grad = True)
+    if checkpoint_fn is None:
+        out = block(frozen, side)
+    elif as_keyword:
+        out = checkpoint_fn(block_kw, frozen, side = side)
+    else:
+        out = checkpoint_fn(block, frozen, side)
+    out.sum().backward()
+    return side.grad
+
+
+@pytest.mark.parametrize("as_keyword", [False, True])
+@pytest.mark.parametrize(
+    "checkpoint_fn", [unsloth_checkpoint, unsloth_gradient_checkpoint],
+)
+def test_frozen_first_activation_still_propagates(
+    checkpoint_fn, as_keyword, cpu_offload_globals,
+):
+    reference = _frozen_first_input(None, as_keyword)
+    got = _frozen_first_input(checkpoint_fn, as_keyword)
+    assert got is not None, "the differentiable input received no gradient"
+    assert torch.equal(got, reference)
+
+
+def test_frozen_first_activation_matches_torchs_own_reentrant_checkpoint(
+        cpu_offload_globals):
+    """The behaviour above is not an Unsloth invention: pristine torch, on the
+    reentrant path these shims force, already propagates here."""
+    pristine = getattr(
+        torch.utils.checkpoint, "_unsloth_pristine_checkpoint", None,
+    ) or torch.utils.checkpoint.checkpoint
+
+    def block(hidden_states, side):
+        return hidden_states * 2.0 + side * 3.0
+
+    torch.manual_seed(3)
+    frozen = torch.randn(4)
+    side   = torch.randn(4, requires_grad = True)
+    pristine(block, frozen, side, use_reentrant = True).sum().backward()
+    assert torch.equal(side.grad, _frozen_first_input(unsloth_checkpoint, False))

--- a/tests/test_gc_rewriter_bound_keywords.py
+++ b/tests/test_gc_rewriter_bound_keywords.py
@@ -439,11 +439,11 @@ def test_generated_module_imports_functools():
 def test_bind_checkpoint_kwargs_is_identity_without_kwargs():
     def fn(x):
         return x
-    assert _bind_checkpoint_kwargs(fn, {}) is fn
+    assert _bind_checkpoint_kwargs(fn, {}) == (fn, ())
     # torch's own checkpoint keywords are consumed by the checkpoint machinery
     # and must never be bound into the wrapped function.
     only_torch = {k: object() for k in _TORCH_CHECKPOINT_KEYWORDS}
-    assert _bind_checkpoint_kwargs(fn, only_torch) is fn
+    assert _bind_checkpoint_kwargs(fn, only_torch) == (fn, ())
 
 
 def test_torch_checkpoint_keywords_covers_every_keyword_only_parameter():
@@ -473,7 +473,7 @@ def test_bind_checkpoint_kwargs_drops_early_stop(monkeypatch):
     def block(x):
         return x * 2
 
-    assert _bind_checkpoint_kwargs(block, {"early_stop": False}) is block
+    assert _bind_checkpoint_kwargs(block, {"early_stop": False}) == (block, ())
     x = torch.randn(4, requires_grad = True)
     out = unsloth_gradient_checkpoint(block, x, early_stop = False)
     out.sum().backward()
@@ -483,8 +483,11 @@ def test_bind_checkpoint_kwargs_drops_early_stop(monkeypatch):
 def test_bind_checkpoint_kwargs_binds_the_rest():
     def fn(x, flag = None):
         return (x, flag)
-    bound = _bind_checkpoint_kwargs(fn, {"flag": 7, "preserve_rng_state": False})
+    bound, extra = _bind_checkpoint_kwargs(fn, {"flag": 7, "preserve_rng_state": False})
+    # Nothing differentiable here, so the cheap partial is kept and no extra
+    # positional input is handed to the checkpoint Function.
     assert isinstance(bound, functools.partial)
+    assert extra == ()
     assert bound(1) == (1, 7)
 
 
@@ -546,3 +549,128 @@ def test_unsloth_gradient_checkpointer_still_accepts_a_one_tuple_return():
         (out,) = out
     out.sum().backward()
     assert torch.allclose(x.grad, torch.full_like(x, 3.0))
+
+
+# ---------------------------------------------------------------------------
+# Tensor keywords stay visible to autograd
+# ---------------------------------------------------------------------------
+# A keyword whose value is a non-leaf tensor that requires grad cannot be closed
+# over by functools.partial: the checkpoint autograd.Function would never see it
+# as an input, so its gradient could only arrive as a side effect of the nested
+# torch.autograd.backward() the reentrant recompute performs. When that tensor is
+# shared - handed to more than one checkpointed layer, or also feeding the loss -
+# the first nested backward frees the shared history and the next traversal dies
+# with "Trying to backward through the graph a second time".
+
+
+@pytest.fixture
+def cpu_offload_globals(monkeypatch):
+    """Let UnslothCheckpointFunction run on CPU.
+
+    Its module globals are normally seeded by
+    ``initialize_unsloth_gradient_checkpointing()``, which needs pinned memory,
+    streams and a device count. MINIMUM_SIZE above any tensor in these tests
+    keeps the offload branch off, so the plain recompute path runs."""
+    from unsloth_zoo import gradient_checkpointing as gc_module
+    for name, value in (
+        ("FIRST_PASS", False), ("LAST_GC_INDEX", 0), ("CURRENT_GC_INDEX", 0),
+        ("MINIMUM_SIZE", 1 << 40), ("CPU_INDEX", 0),
+        ("CPU_BUFFERS", [torch.empty(0)]), ("BACKWARD_PASS", False),
+        ("USE_DOUBLE_BUFFER", False), ("GPU_BUFFERS", []), ("GPU_BUFFERS_B", None),
+    ):
+        monkeypatch.setattr(gc_module, name, value, raising = False)
+    return gc_module
+
+
+class _SideLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.eye(4) * 0.5)
+
+    def forward(self, hidden_states, side = None, flag = False):
+        out = hidden_states @ self.weight
+        if side is not None:
+            out = out + side
+        if flag:
+            out = out * 1.0
+        return out
+
+
+def _run_shared_keyword(checkpoint_fn):
+    """Two checkpointed layers fed the same non-leaf tensor keyword, which also
+    contributes to the loss. Returns the gradients."""
+    torch.manual_seed(0)
+    layers = torch.nn.ModuleList([_SideLayer(), _SideLayer()])
+    torch.manual_seed(1)
+    x    = torch.randn(2, 4, requires_grad = True)
+    leaf = torch.randn(2, 4, requires_grad = True)
+    side = leaf * 2.0                     # non-leaf, requires grad, shared
+
+    hidden_states = x
+    for layer in layers:
+        if checkpoint_fn is None:
+            hidden_states = layer(hidden_states, side = side, flag = True)
+        else:
+            hidden_states = checkpoint_fn(layer, hidden_states, side = side, flag = True)
+    (hidden_states.sum() + side.sum()).backward()
+    return {
+        "x": x.grad, "leaf": leaf.grad,
+        "w0": layers[0].weight.grad, "w1": layers[1].weight.grad,
+    }
+
+
+@pytest.mark.parametrize(
+    "checkpoint_fn", [unsloth_gradient_checkpoint, unsloth_checkpoint],
+)
+def test_shared_tensor_keyword_matches_the_uncheckpointed_reference(
+    checkpoint_fn, cpu_offload_globals,
+):
+    reference = _run_shared_keyword(None)
+    got = _run_shared_keyword(checkpoint_fn)
+    for name, expected in reference.items():
+        assert got[name] is not None, f"{name} received no gradient"
+        assert torch.equal(got[name], expected), (
+            f"{name}: {(got[name] - expected).abs().max().item()}"
+        )
+
+
+def test_bind_checkpoint_kwargs_routes_differentiable_tensors_positionally():
+    """The tensor keyword becomes a positional input of the checkpoint Function
+    and is put back into keyword position before the block is called."""
+    def block(x, side = None, flag = None):
+        return (x, side, flag)
+
+    side = (torch.randn(3, requires_grad = True) * 2.0)
+    bound, extra = _bind_checkpoint_kwargs(block, {"side": side, "flag": 7})
+    assert not isinstance(bound, functools.partial)
+    assert extra == (side,)
+    x = torch.zeros(3)
+    seen_x, seen_side, seen_flag = bound(x, *extra)
+    assert seen_x is x and seen_side is side and seen_flag == 7
+
+
+def test_non_differentiable_tensor_keyword_keeps_the_cheap_partial():
+    """Only tensors that require grad need to be visible to autograd."""
+    def block(x, mask = None):
+        return x
+
+    mask = torch.ones(3)
+    bound, extra = _bind_checkpoint_kwargs(block, {"mask": mask})
+    assert isinstance(bound, functools.partial)
+    assert extra == ()
+
+
+def test_reentrant_checkpointer_returns_gradients_for_tensor_args():
+    """Positional tensor args got the same treatment: the recompute ran on the
+    still-attached tensor and the Function returned None for it."""
+    def block(hidden_states, side):
+        return hidden_states * 2.0 + side
+
+    leaf = torch.randn(4, requires_grad = True)
+    side = leaf * 3.0
+    x = torch.randn(4, requires_grad = True)
+    out = Unsloth_Gradient_Checkpointer.apply(block, x, side)
+    (out.sum() + side.sum()).backward()
+    assert torch.allclose(x.grad, torch.full_like(x, 2.0))
+    # d(loss)/d(leaf) = 3 * (1 from the block + 1 from side.sum())
+    assert torch.allclose(leaf.grad, torch.full_like(leaf, 6.0))

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -479,13 +479,21 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
         "                **kwargs,\n"
         "            )"
     )
-    # 4.51.3 - 4.52.x spell the whole call on one line. The rewriter has no entry
-    # for that form at all, so there is no pinned string to have drifted; failing
-    # here would report drift where the truth is "never covered".
-    if "hidden_states = blk(hidden_states," in src:
+    # 4.51.3 - 4.52.x spell the whole call on one line, and the same forward
+    # already calls ``self._gradient_checkpointing_func`` itself. That is the
+    # first thing patch_gradient_checkpointing() tests
+    # (``if "_gradient_checkpointing_func" in forward: return None``), so on
+    # those versions it returns None before the replacement list, before the
+    # ``for blk in ...`` regex and before the generic ``arg=arg`` demotion -
+    # nothing is rewritten and there is no pinned string that could have
+    # drifted. Skip on the early-return condition itself rather than on the
+    # one-line spelling, so this stays tied to the code path and not to a
+    # guess about how upstream formats the call.
+    if "_gradient_checkpointing_func" in src:
         pytest.skip(
-            "transformers <= 4.52 spells the call on one line; "
-            "custom_gradient_checkpointing_replacements has no entry for it"
+            "upstream forward already implements gradient checkpointing "
+            "(transformers <= 4.52); patch_gradient_checkpointing() returns "
+            "None before touching this call site"
         )
     if not any(n in src for n in (needle_4x, needle_4x_attention_mask, needle_5x)):
         _drift(
@@ -504,7 +512,18 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
     ``(hidden_states, cu_seqlens, [rotary_pos_emb,] position_embeddings)``
     in that order. A reorder / rename binds arguments to the wrong
     parameters instead of no-op'ing, so guard it separately from the
-    call-site string."""
+    call-site string.
+
+    Names and order alone are not enough. Upstream can make
+    ``position_embeddings`` keyword-only without touching either: the name
+    list and its order are unchanged, so a name-only allowlist still passes
+    while the rewritten call keeps passing the tensor positionally and the
+    block raises ``TypeError``. So check ``Parameter.kind`` too - every named
+    parameter has to stay bindable positionally and ``kwargs`` has to stay a
+    real ``**kwargs``. Positional-only is accepted alongside
+    positional-or-keyword because the rewritten call site passes everything
+    positionally; only kinds that cannot take a positional argument
+    (keyword-only, ``*args``) break it."""
     pytest.importorskip("transformers")
     try:
         from transformers.models.qwen2_vl.modeling_qwen2_vl import (
@@ -512,12 +531,13 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
         )
     except ImportError:
         pytest.skip("Qwen2VLVisionBlock not in this build")
-    params = list(inspect.signature(Qwen2VLVisionBlock.forward).parameters)
+    parameters = inspect.signature(Qwen2VLVisionBlock.forward).parameters
+    params = list(parameters)
     accepted = (
         # transformers 4.51.3 - 4.52.x -- no **kwargs on the block yet
         ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
          "position_embeddings"],
-        # transformers 4.53.0 / 4.54 - 4.57
+        # transformers 4.53.0 / 4.54 - 4.57 / 5.0 - 5.5
         ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
          "position_embeddings", "kwargs"],
         # transformers 4.53.1 - 4.53.3 -- attention_mask added as the fifth
@@ -526,7 +546,8 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
         # targets. Gone again by 4.54.
         ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
          "position_embeddings", "attention_mask", "kwargs"],
-        # transformers 5.x -- rotary_pos_emb dropped, max_seqlen rides in kwargs
+        # transformers 5.15 -- rotary_pos_emb dropped, max_seqlen rides in
+        # kwargs
         ["self", "hidden_states", "cu_seqlens", "position_embeddings",
          "kwargs"],
     )
@@ -538,6 +559,24 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
             "transformers.models.qwen2_vl.modeling_qwen2_vl."
             f"Qwen2VLVisionBlock.forward signature (got {params})",
         )
+    positional_kinds = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    for name, parameter in parameters.items():
+        expected = (
+            (inspect.Parameter.VAR_KEYWORD,) if name == "kwargs"
+            else positional_kinds
+        )
+        if parameter.kind not in expected:
+            _drift(
+                "unsloth_zoo/compiler.py:2779-2848 "
+                "(custom_gradient_checkpointing_replacements)",
+                f"{name} as " + " OR ".join(str(k) for k in expected),
+                "transformers.models.qwen2_vl.modeling_qwen2_vl."
+                f"Qwen2VLVisionBlock.forward signature (got {name} as "
+                f"{parameter.kind})",
+            )
 
 
 _UNSET = object()

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -492,9 +492,18 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
         pytest.skip("Qwen2VLVisionBlock not in this build")
     params = list(inspect.signature(Qwen2VLVisionBlock.forward).parameters)
     accepted = (
-        # transformers 4.x
+        # transformers 4.51.3 - 4.52.x -- no **kwargs on the block yet
+        ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
+         "position_embeddings"],
+        # transformers 4.53.0 / 4.54 - 4.57
         ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
          "position_embeddings", "kwargs"],
+        # transformers 4.53.1 - 4.53.3 -- attention_mask added as the fifth
+        # positional parameter (and passed by the call site); this is the
+        # variant the 4.x + attention_mask replacement entry in compiler.py
+        # targets. Gone again by 4.54.
+        ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
+         "position_embeddings", "attention_mask", "kwargs"],
         # transformers 5.x -- rotary_pos_emb dropped, max_seqlen rides in kwargs
         ["self", "hidden_states", "cu_seqlens", "position_embeddings",
          "kwargs"],

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -688,7 +688,9 @@ def _assert_qwen2_vl_max_seqlen_recomputed(attn_cls, forward_src = None):
             _QWEN2_VL_MAX_SEQLEN_ZOO_SITE,
             "get_max_seqlen(..., kwargs = {'max_seqlen': max_seqlen}) -- the "
             "precomputed slot must be the block's own parameter, which is None "
-            "exactly because the rewriter dropped the keyword",
+            "is the block's own parameter, which the rewriter now binds "
+                "into the checkpointed callable (and which is None whenever a "
+                "caller omits it)",
             _QWEN2_VL_ATTN_PATH,
             f"(got kwargs = {precomputed})",
         )
@@ -725,7 +727,7 @@ def _assert_qwen2_vl_max_seqlen_recomputed(attn_cls, forward_src = None):
         attn, hidden_states, cu_seqlens, position_embeddings,
         max_seqlen = caller_max_seqlen,
     )
-    # What patch_gradient_checkpointing actually runs: keyword dropped.
+    # The fallback: keyword absent, value recomputed from cu_seqlens.
     dropped = _qwen2_vl_run_vision_attention(
         attn, hidden_states, cu_seqlens, position_embeddings,
     )
@@ -751,23 +753,29 @@ def _assert_qwen2_vl_max_seqlen_recomputed(attn_cls, forward_src = None):
 
 
 def test_compiler_custom_gradient_checkpointing_qwen2_vl_max_seqlen_is_recomputed():
-    """The transformers 5.x entry in
-    ``unsloth_zoo/compiler.py:custom_gradient_checkpointing_replacements``
-    drops ``max_seqlen=max_seqlen`` from the rewritten ``blk(...)`` call: the
-    block's three positional slots are already taken and anything left as a
-    keyword binds to ``self._gradient_checkpointing_func`` instead of to the
-    block (``unsloth_checkpoint`` then raises ``Unexpected keyword
-    arguments``).
+    """Safety net behind the transformers 5.x entry in
+    ``unsloth_zoo/compiler.py:custom_gradient_checkpointing_replacements``.
 
-    That is only lossless while ``VisionAttention.forward`` itself recomputes
-    the value off the same ``cu_seqlens`` the rewritten call still passes, with
-    the precomputed slot left empty. Merely finding a ``get_max_seqlen(`` call
-    somewhere in the forward proves nothing: upstream could keep the call and
-    feed it a different tensor, a config-derived cap, or a non-``None``
-    precomputed value, and dropping the keyword would then silently change
-    attention. So pin the call expression AND execute the forward twice on CPU
-    -- once as upstream calls it, once as the rewriter calls it -- and require
-    the packed-sequence lengths and the attention output to be identical."""
+    The entry no longer drops ``max_seqlen=max_seqlen``: it removes it from the
+    positional argument list (where the ``arg=arg`` demotion would push it into
+    a slot the block does not have, and where it would bind to
+    ``self._gradient_checkpointing_func`` - which is often plain
+    ``torch.utils.checkpoint.checkpoint`` and raises ``Unexpected keyword
+    arguments``) and re-adds it bound into the callable with
+    ``functools.partial``. That the value now ARRIVES at the block is pinned by
+    ``tests/test_gc_rewriter_bound_keywords.py``.
+
+    This guard pins the fallback that made dropping it survivable in the first
+    place, and it is still load-bearing: it is what makes a mis-bound or lost
+    ``max_seqlen`` degrade into a recompute rather than into wrong attention.
+    ``VisionAttention.forward`` must keep recomputing the value off the same
+    ``cu_seqlens`` the rewritten call passes, with the precomputed slot honoured.
+    Merely finding a ``get_max_seqlen(`` call somewhere in the forward proves
+    nothing: upstream could keep the call and feed it a different tensor, a
+    config-derived cap, or ignore the precomputed value. So pin the call
+    expression AND execute the forward twice on CPU -- once with the keyword,
+    once without -- and require the packed-sequence lengths and the attention
+    output to be identical."""
     pytest.importorskip("transformers")
     pytest.importorskip("torch")
     try:

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -436,7 +436,10 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
     ``max_seqlen=max_seqlen`` (cu_seqlens/max_seqlen moved into
     ``get_vision_attention_seqlens``) and dropped ``rotary_pos_emb`` from
     ``Qwen2VLVisionBlock.forward``. The rewriter carries one entry per
-    spelling; pass if either is still present, fail if neither is."""
+    spelling; pass if either is still present, fail if neither is.
+
+    The 5.x replacement drops ``max_seqlen`` (see
+    ``test_..._max_seqlen_is_recomputed`` below for why that is lossless)."""
     pytest.importorskip("transformers")
     try:
         from transformers.models.qwen2_vl.modeling_qwen2_vl import (
@@ -503,6 +506,53 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
             " OR ".join(str(a) for a in accepted),
             "transformers.models.qwen2_vl.modeling_qwen2_vl."
             f"Qwen2VLVisionBlock.forward signature (got {params})",
+        )
+
+
+def test_compiler_custom_gradient_checkpointing_qwen2_vl_max_seqlen_is_recomputed():
+    """The transformers 5.x entry in
+    ``unsloth_zoo/compiler.py:custom_gradient_checkpointing_replacements``
+    drops ``max_seqlen=max_seqlen`` from the rewritten ``blk(...)`` call: the
+    block's three positional slots are already taken and anything left as a
+    keyword binds to ``self._gradient_checkpointing_func`` instead of to the
+    block (``unsloth_checkpoint`` then raises ``Unexpected keyword
+    arguments``).
+
+    That is only lossless while ``VisionAttention.forward`` recomputes the
+    value through ``get_max_seqlen(cu_seqlens, config, kwargs=...)``, which
+    returns ``(cu_seqlens[1:] - cu_seqlens[:-1]).max()`` when no precomputed
+    value is supplied. If upstream stops recomputing it, dropping it becomes a
+    silent numerical change, so guard it here."""
+    pytest.importorskip("transformers")
+    torch = pytest.importorskip("torch")
+    try:
+        from transformers.models.qwen2_vl.modeling_qwen2_vl import (
+            get_max_seqlen, VisionAttention,
+        )
+    except ImportError:
+        pytest.skip("get_max_seqlen / VisionAttention not in this build (4.x)")
+
+    attn_src = inspect.getsource(VisionAttention.forward)
+    if "get_max_seqlen(" not in attn_src:
+        _drift(
+            "unsloth_zoo/compiler.py (custom_gradient_checkpointing_replacements, 5.x entry)",
+            "get_max_seqlen(",
+            "transformers.models.qwen2_vl.modeling_qwen2_vl.VisionAttention.forward",
+        )
+
+    class _FlashCfg:
+        _attn_implementation = "flash_attention_2"
+
+    cu_seqlens = torch.tensor([0, 4, 9], dtype = torch.int32)
+    expected = int((cu_seqlens[1:] - cu_seqlens[:-1]).max())
+    # no precomputed value -> must recompute the same number the caller had
+    got = get_max_seqlen(cu_seqlens, _FlashCfg(), kwargs = {"max_seqlen": None})
+    if got != expected:
+        _drift(
+            "unsloth_zoo/compiler.py (custom_gradient_checkpointing_replacements, 5.x entry)",
+            f"get_max_seqlen(...) == {expected} when max_seqlen is absent",
+            "transformers.models.qwen2_vl.modeling_qwen2_vl.get_max_seqlen "
+            f"(got {got})",
         )
 
 

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -427,6 +427,64 @@ def test_compiler_cross_entropy_find_3_shift_logits_pattern():
             )
 
 
+_QWEN2_VL_NEEDLE_4X = (
+    "hidden_states = blk(\n"
+    "                hidden_states,\n"
+    "                cu_seqlens=cu_seqlens,\n"
+    "                position_embeddings=position_embeddings,\n"
+    "                **kwargs,\n"
+    "            )"
+)
+# 4.53.1 - 4.53.3 pass attention_mask at the call site. compiler.py carries
+# its own entry for that spelling; leaving it out here failed the guard on a
+# supported version while the rewriter was working fine.
+_QWEN2_VL_NEEDLE_4X_ATTENTION_MASK = (
+    "hidden_states = blk(\n"
+    "                hidden_states,\n"
+    "                cu_seqlens=cu_seqlens,\n"
+    "                position_embeddings=position_embeddings,\n"
+    "                attention_mask=attention_mask,\n"
+    "                **kwargs,\n"
+    "            )"
+)
+_QWEN2_VL_NEEDLE_5X = (
+    "hidden_states = blk(\n"
+    "                hidden_states,\n"
+    "                cu_seqlens=cu_seqlens,\n"
+    "                max_seqlen=max_seqlen,\n"
+    "                position_embeddings=position_embeddings,\n"
+    "                **kwargs,\n"
+    "            )"
+)
+
+_QWEN2_VL_SIG_ROTARY = [
+    "self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
+    "position_embeddings", "kwargs",
+]
+_QWEN2_VL_SIG_ROTARY_ATTENTION_MASK = [
+    "self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
+    "position_embeddings", "attention_mask", "kwargs",
+]
+_QWEN2_VL_SIG_NO_ROTARY = [
+    "self", "hidden_states", "cu_seqlens", "position_embeddings", "kwargs",
+]
+
+# (label, call-site spelling, block signature) triples the rewriter handles.
+# The call spelling ALONE does not determine the rewrite: transformers
+# 4.53.0 / 4.54 - 5.9 and 5.10 - 5.14 write the call identically and need
+# different treatment, because 5.10 dropped rotary_pos_emb from the block.
+_QWEN2_VL_VARIANTS = (
+    ("4.53.0 / 4.54 - 5.9  (rotary re-injected)",
+     _QWEN2_VL_NEEDLE_4X, _QWEN2_VL_SIG_ROTARY),
+    ("4.53.1 - 4.53.3  (rotary re-injected, attention_mask at the call site)",
+     _QWEN2_VL_NEEDLE_4X_ATTENTION_MASK, _QWEN2_VL_SIG_ROTARY_ATTENTION_MASK),
+    ("5.10 - 5.14  (no entry fires; the arg=arg demotion already fits)",
+     _QWEN2_VL_NEEDLE_4X, _QWEN2_VL_SIG_NO_ROTARY),
+    ("5.15+  (max_seqlen bound into the checkpointed callable)",
+     _QWEN2_VL_NEEDLE_5X, _QWEN2_VL_SIG_NO_ROTARY),
+)
+
+
 def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
     """``unsloth_zoo/compiler.py:2779-2848`` pins the Qwen2-VL multiline
     raw strings ``hidden_states = blk(\\n hidden_states,\\n
@@ -450,35 +508,9 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
     except ImportError:
         pytest.skip("Qwen2VisionTransformerPretrainedModel not in this build")
     src = inspect.getsource(Qwen2VisionTransformerPretrainedModel.forward)
-    needle_4x = (
-        "hidden_states = blk(\n"
-        "                hidden_states,\n"
-        "                cu_seqlens=cu_seqlens,\n"
-        "                position_embeddings=position_embeddings,\n"
-        "                **kwargs,\n"
-        "            )"
-    )
-    # 4.53.1 - 4.53.3 pass attention_mask at the call site. compiler.py carries
-    # its own entry for that spelling; leaving it out here failed the guard on a
-    # supported version while the rewriter was working fine.
-    needle_4x_attention_mask = (
-        "hidden_states = blk(\n"
-        "                hidden_states,\n"
-        "                cu_seqlens=cu_seqlens,\n"
-        "                position_embeddings=position_embeddings,\n"
-        "                attention_mask=attention_mask,\n"
-        "                **kwargs,\n"
-        "            )"
-    )
-    needle_5x = (
-        "hidden_states = blk(\n"
-        "                hidden_states,\n"
-        "                cu_seqlens=cu_seqlens,\n"
-        "                max_seqlen=max_seqlen,\n"
-        "                position_embeddings=position_embeddings,\n"
-        "                **kwargs,\n"
-        "            )"
-    )
+    needle_4x = _QWEN2_VL_NEEDLE_4X
+    needle_4x_attention_mask = _QWEN2_VL_NEEDLE_4X_ATTENTION_MASK
+    needle_5x = _QWEN2_VL_NEEDLE_5X
     # 4.51.3 - 4.52.x spell the whole call on one line, and the same forward
     # already calls ``self._gradient_checkpointing_func`` itself. That is the
     # first thing patch_gradient_checkpointing() tests
@@ -537,19 +569,16 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
         # transformers 4.51.3 - 4.52.x -- no **kwargs on the block yet
         ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
          "position_embeddings"],
-        # transformers 4.53.0 / 4.54 - 4.57 / 5.0 - 5.5
-        ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
-         "position_embeddings", "kwargs"],
+        # transformers 4.53.0 / 4.54 - 4.57 / 5.0 - 5.9
+        _QWEN2_VL_SIG_ROTARY,
         # transformers 4.53.1 - 4.53.3 -- attention_mask added as the fifth
         # positional parameter (and passed by the call site); this is the
         # variant the 4.x + attention_mask replacement entry in compiler.py
         # targets. Gone again by 4.54.
-        ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
-         "position_embeddings", "attention_mask", "kwargs"],
-        # transformers 5.15 -- rotary_pos_emb dropped, max_seqlen rides in
-        # kwargs
-        ["self", "hidden_states", "cu_seqlens", "position_embeddings",
-         "kwargs"],
+        _QWEN2_VL_SIG_ROTARY_ATTENTION_MASK,
+        # transformers 5.10+ -- rotary_pos_emb dropped; from 5.15 max_seqlen
+        # rides in kwargs
+        _QWEN2_VL_SIG_NO_ROTARY,
     )
     if params not in accepted:
         _drift(
@@ -577,6 +606,63 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
                 f"Qwen2VLVisionBlock.forward signature (got {name} as "
                 f"{parameter.kind})",
             )
+
+
+def test_compiler_qwen2_vl_call_site_and_block_signature_are_a_known_pair():
+    """The two guards above accept any known call spelling and any known block
+    signature INDEPENDENTLY, and that is not enough.
+
+    transformers 5.10.0 - 5.14.1 shipped the 4.x call spelling together with the
+    5.x no-rotary block signature. Both guards above pass on those releases,
+    while the rewriter re-injected ``rotary_pos_emb`` and the rewritten forward
+    died with ``TypeError: Qwen2VLVisionBlock.forward() takes from 3 to 4
+    positional arguments but 5 were given``. Only the PAIR is diagnostic, so
+    pin the pair."""
+    pytest.importorskip("transformers")
+    try:
+        from transformers.models.qwen2_vl.modeling_qwen2_vl import (
+            Qwen2VisionTransformerPretrainedModel,
+            Qwen2VLVisionBlock,
+        )
+    except ImportError:
+        pytest.skip("Qwen2-VL vision classes not in this build")
+    src = inspect.getsource(Qwen2VisionTransformerPretrainedModel.forward)
+    if "_gradient_checkpointing_func" in src:
+        pytest.skip(
+            "upstream forward already implements gradient checkpointing "
+            "(transformers <= 4.52); patch_gradient_checkpointing() returns "
+            "None before touching this call site"
+        )
+    params = list(inspect.signature(Qwen2VLVisionBlock.forward).parameters)
+    matched = [
+        label for label, needle, signature in _QWEN2_VL_VARIANTS
+        if needle in src and params == signature
+    ]
+    if not matched:
+        present = [
+            label for label, needle, _sig in _QWEN2_VL_VARIANTS if needle in src
+        ] or ["<no known call spelling>"]
+        _drift(
+            "unsloth_zoo/compiler.py "
+            "(custom_gradient_checkpointing_replacements, call site paired "
+            "with Qwen2VLVisionBlock.forward)",
+            " OR ".join(label for label, _n, _s in _QWEN2_VL_VARIANTS),
+            "transformers.models.qwen2_vl.modeling_qwen2_vl: call site matches "
+            f"{present} but the block signature is {params}",
+        )
+
+
+def test_qwen2_vl_variant_table_is_the_pairing_the_rewriter_implements():
+    """Documents which pairs are supported, so the table above cannot silently
+    grow back into an "any call spelling with any signature" allowlist."""
+    pairs = {(needle, tuple(sig)) for _label, needle, sig in _QWEN2_VL_VARIANTS}
+    # 5.10 - 5.14: 4.x spelling, no rotary in the block. Supported because
+    # compiler.py now skips the rotary re-injection when the block dropped it.
+    assert (_QWEN2_VL_NEEDLE_4X, tuple(_QWEN2_VL_SIG_NO_ROTARY)) in pairs
+    # Never shipped and never handled: max_seqlen at the call site while the
+    # block still takes rotary_pos_emb. The 5.x entry removes max_seqlen and
+    # nothing re-adds rotary_pos_emb, so the block would lose a positional.
+    assert (_QWEN2_VL_NEEDLE_5X, tuple(_QWEN2_VL_SIG_ROTARY)) not in pairs
 
 
 _UNSET = object()

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -456,6 +456,18 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
         "                **kwargs,\n"
         "            )"
     )
+    # 4.53.1 - 4.53.3 pass attention_mask at the call site. compiler.py carries
+    # its own entry for that spelling; leaving it out here failed the guard on a
+    # supported version while the rewriter was working fine.
+    needle_4x_attention_mask = (
+        "hidden_states = blk(\n"
+        "                hidden_states,\n"
+        "                cu_seqlens=cu_seqlens,\n"
+        "                position_embeddings=position_embeddings,\n"
+        "                attention_mask=attention_mask,\n"
+        "                **kwargs,\n"
+        "            )"
+    )
     needle_5x = (
         "hidden_states = blk(\n"
         "                hidden_states,\n"
@@ -465,11 +477,19 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
         "                **kwargs,\n"
         "            )"
     )
-    if not any(n in src for n in (needle_4x, needle_5x)):
+    # 4.51.3 - 4.52.x spell the whole call on one line. The rewriter has no entry
+    # for that form at all, so there is no pinned string to have drifted; failing
+    # here would report drift where the truth is "never covered".
+    if "hidden_states = blk(hidden_states," in src:
+        pytest.skip(
+            "transformers <= 4.52 spells the call on one line; "
+            "custom_gradient_checkpointing_replacements has no entry for it"
+        )
+    if not any(n in src for n in (needle_4x, needle_4x_attention_mask, needle_5x)):
         _drift(
             "unsloth_zoo/compiler.py:2779-2848 "
             "(custom_gradient_checkpointing_replacements)",
-            " OR ".join((needle_4x, needle_5x)),
+            " OR ".join((needle_4x, needle_4x_attention_mask, needle_5x)),
             "transformers.models.qwen2_vl.modeling_qwen2_vl."
             "Qwen2VisionTransformerPretrainedModel.forward",
         )

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -22,8 +22,10 @@ its pinned pattern is gone.
 
 from __future__ import annotations
 
+import ast
 import inspect
 import re
+import textwrap
 
 import pytest
 
@@ -538,6 +540,177 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
         )
 
 
+_UNSET = object()
+
+_QWEN2_VL_MAX_SEQLEN_ZOO_SITE = (
+    "unsloth_zoo/compiler.py "
+    "(custom_gradient_checkpointing_replacements, 5.x entry)"
+)
+_QWEN2_VL_ATTN_PATH = (
+    "transformers.models.qwen2_vl.modeling_qwen2_vl.VisionAttention.forward"
+)
+
+
+def _qwen2_vl_max_seqlen_recompute_call(forward_src: str):
+    """Return the ``ast.Call`` for the ``max_seqlen = get_max_seqlen(...)``
+    recompute inside ``VisionAttention.forward``, or ``None``."""
+    tree = ast.parse(textwrap.dedent(forward_src))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not (len(node.targets) == 1 and
+                isinstance(node.targets[0], ast.Name) and
+                node.targets[0].id == "max_seqlen"):
+            continue
+        call = node.value
+        if (isinstance(call, ast.Call) and
+                isinstance(call.func, ast.Name) and
+                call.func.id == "get_max_seqlen"):
+            return call
+    return None
+
+
+def _qwen2_vl_run_vision_attention(attn, hidden_states, cu_seqlens,
+                                   position_embeddings,
+                                   max_seqlen = _UNSET):
+    """Execute the real ``VisionAttention.forward`` on CPU and report the
+    packed-sequence lengths it handed to the attention backend.
+
+    The backend is swapped for a recorder by rebinding
+    ``ALL_ATTENTION_FUNCTIONS`` in the globals of the forward under test, so
+    this needs no flash-attn build and no GPU, and leaves the global attention
+    registry untouched. Passing ``max_seqlen`` reproduces the upstream call
+    site; omitting it reproduces the call the zoo rewriter emits.
+
+    Returns ``(max_length_q, max_length_k, attn_output)``."""
+    seen = {}
+
+    class _Recorder:
+        def get_interface(self, attn_implementation, default):
+            def _record(module, query, key, value, attention_mask = None,
+                        **kwargs):
+                seen.update(kwargs)
+                seq_length = query.shape[2]
+                return query.transpose(1, 2).reshape(1, seq_length, -1), None
+            return _record
+
+    forward_globals = type(attn).forward.__globals__
+    old = forward_globals["ALL_ATTENTION_FUNCTIONS"]
+    forward_globals["ALL_ATTENTION_FUNCTIONS"] = _Recorder()
+    try:
+        if max_seqlen is _UNSET:
+            out = attn(hidden_states, cu_seqlens, position_embeddings)
+        else:
+            out = attn(hidden_states, cu_seqlens, position_embeddings,
+                       max_seqlen = max_seqlen)
+    finally:
+        forward_globals["ALL_ATTENTION_FUNCTIONS"] = old
+    return seen.get("max_length_q"), seen.get("max_length_k"), out
+
+
+def _assert_qwen2_vl_max_seqlen_recomputed(attn_cls, forward_src = None):
+    """The guard body, factored out so a mutated ``VisionAttention`` can be
+    pushed through exactly the checks that ship (see
+    ``tests/mutants/qwen2_vl_max_seqlen_mutants.py``)."""
+    import torch
+    from transformers.models.qwen2_vl.modeling_qwen2_vl import (
+        get_vision_attention_seqlens,
+    )
+    from transformers.models.qwen2_vl.configuration_qwen2_vl import (
+        Qwen2VLVisionConfig,
+    )
+    if forward_src is None:
+        forward_src = inspect.getsource(attn_cls.forward)
+
+    # (1) Pin the call expression itself, not just the presence of the name.
+    call = _qwen2_vl_max_seqlen_recompute_call(forward_src)
+    if call is None:
+        _drift(
+            _QWEN2_VL_MAX_SEQLEN_ZOO_SITE,
+            "max_seqlen = get_max_seqlen(...)",
+            _QWEN2_VL_ATTN_PATH,
+        )
+    receiver = ast.unparse(call.args[0]) if call.args else "<no arguments>"
+    if receiver != "cu_seqlens":
+        _drift(
+            _QWEN2_VL_MAX_SEQLEN_ZOO_SITE,
+            "get_max_seqlen(cu_seqlens, ...) -- recomputed from the very "
+            "cu_seqlens the rewritten blk(...) call still passes positionally",
+            _QWEN2_VL_ATTN_PATH,
+            f"(got get_max_seqlen({receiver}, ...))",
+        )
+    keywords = {kw.arg: kw.value for kw in call.keywords}
+    precomputed = (
+        ast.unparse(keywords["kwargs"]) if "kwargs" in keywords
+        else "<no kwargs= argument>"
+    )
+    if precomputed != "{'max_seqlen': max_seqlen}":
+        _drift(
+            _QWEN2_VL_MAX_SEQLEN_ZOO_SITE,
+            "get_max_seqlen(..., kwargs = {'max_seqlen': max_seqlen}) -- the "
+            "precomputed slot must be the block's own parameter, which is None "
+            "exactly because the rewriter dropped the keyword",
+            _QWEN2_VL_ATTN_PATH,
+            f"(got kwargs = {precomputed})",
+        )
+
+    # (2) Execute the path. Flash attention is the only branch that consumes
+    # max_seqlen, so request it; the backend itself is stubbed out.
+    config = Qwen2VLVisionConfig(embed_dim = 8, num_heads = 2, hidden_size = 8)
+    config._attn_implementation = "flash_attention_2"
+    torch.manual_seed(0)
+    attn = attn_cls(config)
+
+    # Two ragged images -> 4 and 5 tokens, so max_seqlen (5) differs from both
+    # the token count (9) and the first segment (4): a recompute off the wrong
+    # tensor cannot coincidentally match.
+    grid_thw = torch.tensor([[1, 2, 2], [1, 1, 5]], dtype = torch.long)
+    cu_seqlens, caller_max_seqlen = get_vision_attention_seqlens(
+        grid_thw, config, kwargs = {},
+    )
+    assert caller_max_seqlen == 5, (
+        "test fixture is stale: get_vision_attention_seqlens returned "
+        f"{caller_max_seqlen} for grid {grid_thw.tolist()}, expected 5"
+    )
+    seq_length = int(cu_seqlens[-1])
+    head_dim = config.embed_dim // config.num_heads
+    hidden_states = torch.randn(seq_length, config.embed_dim)
+    angles = torch.arange(seq_length, dtype = torch.float32).unsqueeze(1) * 0.1
+    position_embeddings = (
+        torch.cos(angles).expand(seq_length, head_dim).contiguous(),
+        torch.sin(angles).expand(seq_length, head_dim).contiguous(),
+    )
+
+    # Upstream's own call site: max_seqlen precomputed and forwarded.
+    kept = _qwen2_vl_run_vision_attention(
+        attn, hidden_states, cu_seqlens, position_embeddings,
+        max_seqlen = caller_max_seqlen,
+    )
+    # What patch_gradient_checkpointing actually runs: keyword dropped.
+    dropped = _qwen2_vl_run_vision_attention(
+        attn, hidden_states, cu_seqlens, position_embeddings,
+    )
+    for label, (got_q, got_k, _) in (("with max_seqlen", kept),
+                                     ("with max_seqlen dropped", dropped)):
+        if (got_q, got_k) != (caller_max_seqlen, caller_max_seqlen):
+            _drift(
+                _QWEN2_VL_MAX_SEQLEN_ZOO_SITE,
+                f"max_length_q/max_length_k == {caller_max_seqlen} "
+                f"({label})",
+                _QWEN2_VL_ATTN_PATH,
+                f"(got max_length_q={got_q}, max_length_k={got_k}; dropping "
+                "max_seqlen from the rewritten blk(...) call would silently "
+                "change vision attention)",
+            )
+    if not torch.equal(kept[2], dropped[2]):
+        _drift(
+            _QWEN2_VL_MAX_SEQLEN_ZOO_SITE,
+            "identical VisionAttention output with and without max_seqlen",
+            _QWEN2_VL_ATTN_PATH,
+            "(outputs diverge -- dropping the keyword is no longer lossless)",
+        )
+
+
 def test_compiler_custom_gradient_checkpointing_qwen2_vl_max_seqlen_is_recomputed():
     """The transformers 5.x entry in
     ``unsloth_zoo/compiler.py:custom_gradient_checkpointing_replacements``
@@ -547,42 +720,27 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_max_seqlen_is_recompute
     block (``unsloth_checkpoint`` then raises ``Unexpected keyword
     arguments``).
 
-    That is only lossless while ``VisionAttention.forward`` recomputes the
-    value through ``get_max_seqlen(cu_seqlens, config, kwargs=...)``, which
-    returns ``(cu_seqlens[1:] - cu_seqlens[:-1]).max()`` when no precomputed
-    value is supplied. If upstream stops recomputing it, dropping it becomes a
-    silent numerical change, so guard it here."""
+    That is only lossless while ``VisionAttention.forward`` itself recomputes
+    the value off the same ``cu_seqlens`` the rewritten call still passes, with
+    the precomputed slot left empty. Merely finding a ``get_max_seqlen(`` call
+    somewhere in the forward proves nothing: upstream could keep the call and
+    feed it a different tensor, a config-derived cap, or a non-``None``
+    precomputed value, and dropping the keyword would then silently change
+    attention. So pin the call expression AND execute the forward twice on CPU
+    -- once as upstream calls it, once as the rewriter calls it -- and require
+    the packed-sequence lengths and the attention output to be identical."""
     pytest.importorskip("transformers")
-    torch = pytest.importorskip("torch")
+    pytest.importorskip("torch")
     try:
-        from transformers.models.qwen2_vl.modeling_qwen2_vl import (
-            get_max_seqlen, VisionAttention,
+        # Imported for existence only -- 4.x has neither helper, and the
+        # rewriter entry these guard is 5.x-only.
+        from transformers.models.qwen2_vl.modeling_qwen2_vl import (  # noqa: F401
+            get_max_seqlen, get_vision_attention_seqlens, VisionAttention,
         )
     except ImportError:
         pytest.skip("get_max_seqlen / VisionAttention not in this build (4.x)")
 
-    attn_src = inspect.getsource(VisionAttention.forward)
-    if "get_max_seqlen(" not in attn_src:
-        _drift(
-            "unsloth_zoo/compiler.py (custom_gradient_checkpointing_replacements, 5.x entry)",
-            "get_max_seqlen(",
-            "transformers.models.qwen2_vl.modeling_qwen2_vl.VisionAttention.forward",
-        )
-
-    class _FlashCfg:
-        _attn_implementation = "flash_attention_2"
-
-    cu_seqlens = torch.tensor([0, 4, 9], dtype = torch.int32)
-    expected = int((cu_seqlens[1:] - cu_seqlens[:-1]).max())
-    # no precomputed value -> must recompute the same number the caller had
-    got = get_max_seqlen(cu_seqlens, _FlashCfg(), kwargs = {"max_seqlen": None})
-    if got != expected:
-        _drift(
-            "unsloth_zoo/compiler.py (custom_gradient_checkpointing_replacements, 5.x entry)",
-            f"get_max_seqlen(...) == {expected} when max_seqlen is absent",
-            "transformers.models.qwen2_vl.modeling_qwen2_vl.get_max_seqlen "
-            f"(got {got})",
-        )
+    _assert_qwen2_vl_max_seqlen_recomputed(VisionAttention)
 
 
 def test_compiler_moe_routing_weights_cast_pattern():

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -426,10 +426,17 @@ def test_compiler_cross_entropy_find_3_shift_logits_pattern():
 
 
 def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
-    """``unsloth_zoo/compiler.py:2192-2207`` pins the Qwen2-VL multiline
-    raw string ``hidden_states = blk(\\n hidden_states,\\n
-    cu_seqlens=cu_seqlens,\\n position_embeddings=position_embeddings,\\n
-    **kwargs,\\n )``. A re-indent silently no-ops."""
+    """``unsloth_zoo/compiler.py:2779-2848`` pins the Qwen2-VL multiline
+    raw strings ``hidden_states = blk(\\n hidden_states,\\n
+    cu_seqlens=cu_seqlens,\\n [max_seqlen=max_seqlen,\\n]
+    position_embeddings=position_embeddings,\\n **kwargs,\\n )``.
+    A re-indent silently no-ops.
+
+    transformers 4.x and 5.x spell the call differently: 5.x added
+    ``max_seqlen=max_seqlen`` (cu_seqlens/max_seqlen moved into
+    ``get_vision_attention_seqlens``) and dropped ``rotary_pos_emb`` from
+    ``Qwen2VLVisionBlock.forward``. The rewriter carries one entry per
+    spelling; pass if either is still present, fail if neither is."""
     pytest.importorskip("transformers")
     try:
         from transformers.models.qwen2_vl.modeling_qwen2_vl import (
@@ -438,7 +445,7 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
     except ImportError:
         pytest.skip("Qwen2VisionTransformerPretrainedModel not in this build")
     src = inspect.getsource(Qwen2VisionTransformerPretrainedModel.forward)
-    needle = (
+    needle_4x = (
         "hidden_states = blk(\n"
         "                hidden_states,\n"
         "                cu_seqlens=cu_seqlens,\n"
@@ -446,11 +453,57 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
         "                **kwargs,\n"
         "            )"
     )
-    _assert_in_source(
-        needle, src,
-        "unsloth_zoo/compiler.py:2194-2199 (custom_gradient_checkpointing_replacements[0])",
-        "transformers.models.qwen2_vl.modeling_qwen2_vl.Qwen2VisionTransformerPretrainedModel.forward",
+    needle_5x = (
+        "hidden_states = blk(\n"
+        "                hidden_states,\n"
+        "                cu_seqlens=cu_seqlens,\n"
+        "                max_seqlen=max_seqlen,\n"
+        "                position_embeddings=position_embeddings,\n"
+        "                **kwargs,\n"
+        "            )"
     )
+    if not any(n in src for n in (needle_4x, needle_5x)):
+        _drift(
+            "unsloth_zoo/compiler.py:2779-2848 "
+            "(custom_gradient_checkpointing_replacements)",
+            " OR ".join((needle_4x, needle_5x)),
+            "transformers.models.qwen2_vl.modeling_qwen2_vl."
+            "Qwen2VisionTransformerPretrainedModel.forward",
+        )
+
+
+def test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature():
+    """The rewriter in ``unsloth_zoo/compiler.py:2779-2848`` demotes every
+    ``arg=arg`` keyword to a positional, so the rewritten ``blk(...)`` call
+    only works if ``Qwen2VLVisionBlock.forward`` still takes
+    ``(hidden_states, cu_seqlens, [rotary_pos_emb,] position_embeddings)``
+    in that order. A reorder / rename binds arguments to the wrong
+    parameters instead of no-op'ing, so guard it separately from the
+    call-site string."""
+    pytest.importorskip("transformers")
+    try:
+        from transformers.models.qwen2_vl.modeling_qwen2_vl import (
+            Qwen2VLVisionBlock,
+        )
+    except ImportError:
+        pytest.skip("Qwen2VLVisionBlock not in this build")
+    params = list(inspect.signature(Qwen2VLVisionBlock.forward).parameters)
+    accepted = (
+        # transformers 4.x
+        ["self", "hidden_states", "cu_seqlens", "rotary_pos_emb",
+         "position_embeddings", "kwargs"],
+        # transformers 5.x -- rotary_pos_emb dropped, max_seqlen rides in kwargs
+        ["self", "hidden_states", "cu_seqlens", "position_embeddings",
+         "kwargs"],
+    )
+    if params not in accepted:
+        _drift(
+            "unsloth_zoo/compiler.py:2779-2848 "
+            "(custom_gradient_checkpointing_replacements)",
+            " OR ".join(str(a) for a in accepted),
+            "transformers.models.qwen2_vl.modeling_qwen2_vl."
+            f"Qwen2VLVisionBlock.forward signature (got {params})",
+        )
 
 
 def test_compiler_moe_routing_weights_cast_pattern():

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2787,7 +2787,13 @@ pass
 #   self._gradient_checkpointing_func(
 #       functools.partial(blk.__call__, max_seqlen = max_seqlen), ...)
 # in the checkpointed branch and `blk(..., max_seqlen = max_seqlen)` in the else
-# branch. Binding into the callable is exactly what transformers itself does in
+# branch. The same reasoning applies to the `**kwargs` expansion the call site
+# already had on EVERY version, 4.x included: it is a keyword expansion, so it
+# is moved out of the argument list and into the same partial. It looks harmless
+# only because it is usually empty; `output_hidden_states = True` reaches the
+# vision tower's **kwargs on transformers 5.x and is enough to trip the same
+# `Unexpected keyword arguments` error.
+# Binding into the callable is exactly what transformers itself does in
 # `GradientCheckpointingLayer.__call__`, so it works with every checkpoint
 # implementation - reentrant or not, Unsloth's or torch's - and the value still
 # reaches the block on both branches.
@@ -2952,15 +2958,47 @@ def patch_gradient_checkpointing(module, source):
     # Gradient checkpointing calling must remove arg=arg convention
     args = re.sub(r"([^\s]{1,})[\s]?\=[\s]?\1", r"\1", args)
 
+    # Everything left in `ARGS` is forwarded verbatim to
+    # `self._gradient_checkpointing_func`, which is frequently plain
+    # `torch.utils.checkpoint.checkpoint`. Positionals are fine there - that is
+    # exactly what checkpointing is for - but KEYWORDS are not: reentrant
+    # `torch.utils.checkpoint.checkpoint` raises `Unexpected keyword arguments`
+    # on anything it does not recognise, and Unsloth's own reentrant shims can
+    # only forward positionals. So every keyword has to be bound into the
+    # checkpointed callable instead, the way
+    # `transformers.modeling_layers.GradientCheckpointingLayer.__call__` does
+    # it upstream.
+    #
+    # Two sources of keywords:
+    #   1. `bound_keywords` - declared by a replacement entry (Qwen2-VL's
+    #      `max_seqlen`, which the 5.x block only accepts through **kwargs).
+    #   2. A `**kwargs` expansion the upstream call site already had. This one
+    #      is the layer's own runtime keywords; leaving it in `ARGS` hands them
+    #      to the checkpoint function. Empty at runtime it looks harmless, which
+    #      is why it survived - `output_hidden_states = True` on transformers
+    #      5.x is enough to make it non-empty and blow up.
+    # The `else` branch calls the layer directly, so there they all stay
+    # ordinary keywords and `ARGS` is used unchanged.
+    star_kwargs = re.findall(r"\*\*[\s]*([A-Za-z_][A-Za-z_0-9]*)", args)
+    checkpoint_args = args
+    if star_kwargs:
+        checkpoint_args = re.sub(
+            r"\*\*[\s]*[A-Za-z_][A-Za-z_0-9]*[\s]*\,?", "", args
+        )
+    partial_keywords = [
+        f"{name} = {value}" for name, value in bound_keywords.items()
+    ] + [f"**{name}" for name in star_kwargs]
+
+    if partial_keywords:
+        replacer = replacer.replace(
+            "LAYER.__call__, ARGS",
+            "functools.partial(LAYER.__call__, "
+            + ", ".join(partial_keywords)
+            + "), " + checkpoint_args,
+        )
+    pass
+
     if bound_keywords:
-        # Keywords the block only takes through **kwargs. `ARGS` is forwarded
-        # verbatim to `self._gradient_checkpointing_func`, so putting them there
-        # would bind them to the checkpoint function instead of to the layer -
-        # and `torch.utils.checkpoint.checkpoint` raises on unknown keywords
-        # under `use_reentrant = True`, as does Unsloth's `unsloth_checkpoint`.
-        # Bind them into the callable instead, like
-        # `GradientCheckpointingLayer.__call__` does upstream. The `else` branch
-        # calls the layer directly, so there they stay ordinary keywords.
         keywords = ", ".join(
             f"{name} = {value}" for name, value in bound_keywords.items()
         )
@@ -2971,10 +3009,6 @@ def patch_gradient_checkpointing(module, source):
             if not args_with_keywords.endswith(","):
                 args_with_keywords += ","
             args_with_keywords += " " + keywords
-        replacer = replacer.replace(
-            "LAYER.__call__, ARGS",
-            "functools.partial(LAYER.__call__, " + keywords + "), ARGS",
-        )
         replacer = replacer.replace(
             "hidden_states = LAYER(ARGS)",
             "hidden_states = LAYER(" + args_with_keywords + ")",

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2766,16 +2766,33 @@ pass
 #                              position_embeddings=None, **kwargs)
 # and added `max_seqlen=max_seqlen` to the call site (transformers 5.x moved the
 # cu_seqlens/max_seqlen computation into get_vision_attention_seqlens()).
-# `max_seqlen` is NOT a named parameter of the block - it rides along in
-# **kwargs down to the attention. Left alone the `arg=arg` demotion would turn
-# it into the third positional and it would silently be bound to
-# `position_embeddings`, so it is rewritten into an explicit
-# `**{"max_seqlen": max_seqlen}` mapping, which has no `arg=arg` spelling for
-# the demotion regex to match and therefore stays a keyword. The mapping is kept
-# inside the call (rather than hoisted into `kwargs` before the loop) so the
-# `for ... in ...:\n<spaces>hidden_states = <layer>(...)` finder regex below,
-# which requires the call to be the first statement of the loop body, still
-# matches.
+# `max_seqlen` is NOT a named parameter of the block, and there is nowhere for it
+# to go in the rewritten call: the three positional slots are already taken, and
+# anything left as a keyword is bound to `self._gradient_checkpointing_func`
+# rather than to the block - Unsloth's smart `unsloth_checkpoint` rejects leftover
+# keywords outright ("Unexpected keyword arguments: max_seqlen") and
+# `unsloth_gradient_checkpoint` silently drops them.
+#
+# So the 5.x entry simply drops `max_seqlen` from the call. This is lossless:
+# `VisionAttention.forward` recomputes it via
+#   get_max_seqlen(cu_seqlens, self.config, kwargs = {"max_seqlen": max_seqlen})
+# which, when the caller-supplied value is None, returns
+# `(cu_seqlens[1:] - cu_seqlens[:-1]).max().item()` under flash-attention and
+# None otherwise - exactly what `get_vision_attention_seqlens` computed from the
+# same `cu_seqlens`. The only cost is recomputing that max per layer.
+#
+# Order matters: the 5.x entries must stay AFTER the 4.x ones. The 5.x
+# replacement is textually the 4.x call, and the replacement list is applied in a
+# single pass, so entry 0 (which would inject `rotary_pos_emb` that 5.x blocks no
+# longer accept) has already run by the time this fires.
+#
+# There is deliberately no 5.x + `attention_mask` entry. The `attention_mask=`
+# spelling only ever existed in transformers 4.53.x (where the block named it as
+# its fifth positional parameter, which is why the 4.x entry below demotes it);
+# it was gone by 4.54 and no 5.x release pairs it with `max_seqlen`. In 5.x the
+# vision attention has no `attention_mask` parameter at all and passes
+# `attention_mask = None` to the attention interface itself, so any guessed
+# rewrite would be untestable and wrong either way.
 custom_gradient_checkpointing_replacements = [
     (
         """hidden_states = blk(
@@ -2809,8 +2826,8 @@ custom_gradient_checkpointing_replacements = [
                 **kwargs,
             )""",
     ),
-    # transformers >= 5.0 spellings. `max_seqlen` is a **kwargs-only argument of
-    # the vision block, so it must survive as a keyword.
+    # transformers >= 5.0 spelling. `max_seqlen` is dropped - the vision
+    # attention recomputes it from `cu_seqlens`. Must stay after the 4.x entries.
     (
         """hidden_states = blk(
                 hidden_states,
@@ -2823,25 +2840,6 @@ custom_gradient_checkpointing_replacements = [
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 position_embeddings=position_embeddings,
-                **{"max_seqlen": max_seqlen},
-                **kwargs,
-            )""",
-    ),
-    (
-        """hidden_states = blk(
-                hidden_states,
-                cu_seqlens=cu_seqlens,
-                max_seqlen=max_seqlen,
-                position_embeddings=position_embeddings,
-                attention_mask=attention_mask,
-                **kwargs,
-            )""",
-        """hidden_states = blk(
-                hidden_states,
-                cu_seqlens=cu_seqlens,
-                position_embeddings=position_embeddings,
-                attention_mask=attention_mask,
-                **{"max_seqlen": max_seqlen},
                 **kwargs,
             )""",
     ),

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1181,6 +1181,12 @@ def create_new_function(
         imports += "from unsloth_zoo.temporary_patches.common import _maybe_compile\n"
     if "KWARGS_TYPE" in new_source:
         imports += "from unsloth_zoo.temporary_patches.utils import KWARGS_TYPE\n"
+    if "functools." in new_source:
+        # patch_gradient_checkpointing() emits `functools.partial(layer.__call__,
+        # ...)` for keywords the layer only accepts through **kwargs, and copied
+        # upstream source can reference functools too. Neither the license header
+        # nor the model module's own imports are guaranteed to provide it.
+        imports += "import functools\n"
     if (
         "forward_moe_backend" in new_source
         or "select_moe_backend" in new_source
@@ -2766,20 +2772,31 @@ pass
 #                              position_embeddings=None, **kwargs)
 # and added `max_seqlen=max_seqlen` to the call site (transformers 5.x moved the
 # cu_seqlens/max_seqlen computation into get_vision_attention_seqlens()).
-# `max_seqlen` is NOT a named parameter of the block, and there is nowhere for it
-# to go in the rewritten call: the three positional slots are already taken, and
-# anything left as a keyword is bound to `self._gradient_checkpointing_func`
-# rather than to the block - Unsloth's smart `unsloth_checkpoint` rejects leftover
-# keywords outright ("Unexpected keyword arguments: max_seqlen") and
-# `unsloth_gradient_checkpoint` silently drops them.
+# `max_seqlen` is NOT a named parameter of the block - it only rides in through
+# **kwargs - so it cannot be demoted to a positional, and it must not be left as
+# a bare keyword either: in the rewritten call everything after the callable is
+# handed to `self._gradient_checkpointing_func`, not to the block. That function
+# is not necessarily Unsloth's. It is whatever transformers installed, i.e. very
+# often plain `torch.utils.checkpoint.checkpoint` (or a `functools.partial` of
+# it), which raises `ValueError: Unexpected keyword arguments: max_seqlen` under
+# `use_reentrant = True`. Unsloth's own `unsloth_checkpoint` raises the same way.
 #
-# So the 5.x entry simply drops `max_seqlen` from the call. This is lossless:
-# `VisionAttention.forward` recomputes it via
-#   get_max_seqlen(cu_seqlens, self.config, kwargs = {"max_seqlen": max_seqlen})
-# which, when the caller-supplied value is None, returns
-# `(cu_seqlens[1:] - cu_seqlens[:-1]).max().item()` under flash-attention and
-# None otherwise - exactly what `get_vision_attention_seqlens` computed from the
-# same `cu_seqlens`. The only cost is recomputing that max per layer.
+# So the 5.x entry drops `max_seqlen` from the positional argument list and asks
+# for it back as a *bound* keyword via the optional third element of the entry.
+# `patch_gradient_checkpointing()` then emits
+#   self._gradient_checkpointing_func(
+#       functools.partial(blk.__call__, max_seqlen = max_seqlen), ...)
+# in the checkpointed branch and `blk(..., max_seqlen = max_seqlen)` in the else
+# branch. Binding into the callable is exactly what transformers itself does in
+# `GradientCheckpointingLayer.__call__`, so it works with every checkpoint
+# implementation - reentrant or not, Unsloth's or torch's - and the value still
+# reaches the block on both branches.
+#
+# (Were the keyword dropped instead, `VisionAttention.forward` would recompute it
+# via get_max_seqlen(cu_seqlens, self.config, kwargs = {"max_seqlen": max_seqlen})
+# and return the same number, so nothing breaks - but that costs a
+# `.max().item()` device sync per vision layer under flash attention, which is
+# why the keyword is preserved instead.)
 #
 # Order matters: the 5.x entries must stay AFTER the 4.x ones. The 5.x
 # replacement is textually the 4.x call, and the replacement list is applied in a
@@ -2826,8 +2843,9 @@ custom_gradient_checkpointing_replacements = [
                 **kwargs,
             )""",
     ),
-    # transformers >= 5.0 spelling. `max_seqlen` is dropped - the vision
-    # attention recomputes it from `cu_seqlens`. Must stay after the 4.x entries.
+    # transformers >= 5.0 spelling. `max_seqlen` leaves the positional argument
+    # list and comes back as a keyword bound into the checkpointed callable (the
+    # third element below). Must stay after the 4.x entries.
     (
         """hidden_states = blk(
                 hidden_states,
@@ -2842,6 +2860,7 @@ custom_gradient_checkpointing_replacements = [
                 position_embeddings=position_embeddings,
                 **kwargs,
             )""",
+        ("max_seqlen",),
     ),
 ]
 replace_gradient_checkpointing = """
@@ -2853,6 +2872,31 @@ $    )
 $else:
 $    hidden_states = LAYER(ARGS)
 """
+
+
+def _bound_keywords_of_replacement(replacement):
+    """Optional third element of a ``custom_gradient_checkpointing_replacements``
+    entry: keyword arguments the rewritten call must keep as keywords.
+
+    They cannot travel in ``ARGS`` - everything there is forwarded to
+    ``self._gradient_checkpointing_func``, which is frequently plain
+    ``torch.utils.checkpoint.checkpoint`` and rejects unknown keywords. They are
+    bound into the checkpointed callable instead, the way
+    ``transformers.modeling_layers.GradientCheckpointingLayer.__call__`` does it.
+
+    Accepts a mapping ``{keyword: expression}`` or a plain sequence of names
+    (shorthand for ``{name: name}``). A 2-tuple entry declares none, so every
+    pre-existing entry keeps behaving exactly as before.
+    """
+    # All Unsloth Zoo code licensed under LGPLv3
+    if len(replacement) <= 2:
+        return {}
+    extra = replacement[2]
+    if extra is None:
+        return {}
+    if isinstance(extra, dict):
+        return dict(extra)
+    return {name: name for name in extra}
 
 
 def patch_gradient_checkpointing(module, source):
@@ -2871,8 +2915,13 @@ def patch_gradient_checkpointing(module, source):
         return None
 
     # Fix Qwen2 missing None for gradient checkpointing
-    for custom_find, custom_replace in custom_gradient_checkpointing_replacements:
+    bound_keywords = {}
+    for replacement in custom_gradient_checkpointing_replacements:
+        custom_find, custom_replace = replacement[0], replacement[1]
+        if custom_find not in forward:
+            continue
         forward = forward.replace(custom_find, custom_replace)
+        bound_keywords.update(_bound_keywords_of_replacement(replacement))
     pass
 
     # No gradient checkpointing?
@@ -2902,6 +2951,35 @@ def patch_gradient_checkpointing(module, source):
 
     # Gradient checkpointing calling must remove arg=arg convention
     args = re.sub(r"([^\s]{1,})[\s]?\=[\s]?\1", r"\1", args)
+
+    if bound_keywords:
+        # Keywords the block only takes through **kwargs. `ARGS` is forwarded
+        # verbatim to `self._gradient_checkpointing_func`, so putting them there
+        # would bind them to the checkpoint function instead of to the layer -
+        # and `torch.utils.checkpoint.checkpoint` raises on unknown keywords
+        # under `use_reentrant = True`, as does Unsloth's `unsloth_checkpoint`.
+        # Bind them into the callable instead, like
+        # `GradientCheckpointingLayer.__call__` does upstream. The `else` branch
+        # calls the layer directly, so there they stay ordinary keywords.
+        keywords = ", ".join(
+            f"{name} = {value}" for name, value in bound_keywords.items()
+        )
+        args_with_keywords = args.rstrip()
+        if args_with_keywords.strip() == "":
+            args_with_keywords = keywords
+        else:
+            if not args_with_keywords.endswith(","):
+                args_with_keywords += ","
+            args_with_keywords += " " + keywords
+        replacer = replacer.replace(
+            "LAYER.__call__, ARGS",
+            "functools.partial(LAYER.__call__, " + keywords + "), ARGS",
+        )
+        replacer = replacer.replace(
+            "hidden_states = LAYER(ARGS)",
+            "hidden_states = LAYER(" + args_with_keywords + ")",
+        )
+    pass
 
     replacer = (
         replacer.replace("LAYER", layer)

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2831,6 +2831,11 @@ custom_gradient_checkpointing_replacements = [
                 position_embeddings=position_embeddings,
                 **kwargs,
             )""",
+        None,
+        # transformers 5.10 - 5.14 spell the call site exactly like 4.53.0 - 5.9
+        # but dropped rotary_pos_emb from the block, so this entry must only
+        # fire while the block still takes it. See _replacement_fits_the_layer.
+        ("rotary_pos_emb",),
     ),
     (
         """hidden_states = blk(
@@ -2848,6 +2853,8 @@ custom_gradient_checkpointing_replacements = [
                 attention_mask=attention_mask,
                 **kwargs,
             )""",
+        None,
+        ("rotary_pos_emb",),
     ),
     # transformers >= 5.0 spelling. `max_seqlen` leaves the positional argument
     # list and comes back as a keyword bound into the checkpointed callable (the
@@ -2905,6 +2912,65 @@ def _bound_keywords_of_replacement(replacement):
     return {name: name for name in extra}
 
 
+def _modulelist_layer_class(source, init, modulelist_item):
+    """The class the ``nn.ModuleList`` is filled with, or ``None``.
+
+    ``self.blocks = nn.ModuleList([Qwen2VLVisionBlock(config) for _ in ...])``
+    names it, and it is defined in the same module as ``source``. Returned so a
+    replacement entry can be checked against the signature it is rewriting the
+    call for, instead of trusting the call site's spelling alone.
+    """
+    # All Unsloth Zoo code licensed under LGPLv3
+    match = re.search(
+        re.escape(modulelist_item)
+        + r"[\s]*\=[\s]*.*?nn\.ModuleList\([\s]*\[?[\s]*([A-Za-z_][A-Za-z_0-9]*)[\s]*\(",
+        init, flags = re.DOTALL,
+    )
+    if match is None:
+        return None
+    return getattr(
+        sys.modules.get(getattr(source, "__module__", None), None),
+        match.group(1), None,
+    )
+
+
+def _replacement_fits_the_layer(replacement, layer_class):
+    """Optional 4th element: parameter names the layer's ``forward`` must have
+    for the replacement to be correct.
+
+    Two different transformers generations can spell the call site IDENTICALLY
+    and still need different rewrites. transformers 4.53.0 - 5.9 and 5.10 - 5.14
+    both write
+
+        hidden_states = blk(hidden_states, cu_seqlens=cu_seqlens,
+                            position_embeddings=position_embeddings, **kwargs)
+
+    but 5.10 dropped ``rotary_pos_emb`` from ``Qwen2VLVisionBlock.forward``. The
+    entry that re-injects ``rotary_pos_emb`` (needed on <= 5.9, where the block
+    still takes it as its third positional and the un-rewritten call relies on
+    keyword binding) therefore has to be skipped on >= 5.10, where injecting it
+    hands the block one positional too many:
+    ``TypeError: Qwen2VLVisionBlock.forward() takes from 3 to 4 positional
+    arguments but 5 were given``. On >= 5.10 no entry is needed at all - the
+    generic ``arg=arg`` demotion already produces a call the block accepts.
+
+    Unresolvable layer / signature means "behave exactly as before".
+    """
+    # All Unsloth Zoo code licensed under LGPLv3
+    if len(replacement) <= 3:
+        return True
+    required = replacement[3]
+    if not required:
+        return True
+    if layer_class is None:
+        return True
+    try:
+        parameters = inspect.signature(layer_class.forward).parameters
+    except (TypeError, ValueError):
+        return True
+    return all(name in parameters for name in required)
+
+
 def patch_gradient_checkpointing(module, source):
     # All Unsloth Zoo code licensed under LGPLv3
     try:
@@ -2920,21 +2986,24 @@ def patch_gradient_checkpointing(module, source):
     if "_gradient_checkpointing_func" in forward:
         return None
 
-    # Fix Qwen2 missing None for gradient checkpointing
-    bound_keywords = {}
-    for replacement in custom_gradient_checkpointing_replacements:
-        custom_find, custom_replace = replacement[0], replacement[1]
-        if custom_find not in forward:
-            continue
-        forward = forward.replace(custom_find, custom_replace)
-        bound_keywords.update(_bound_keywords_of_replacement(replacement))
-    pass
-
     # No gradient checkpointing?
     modulelist_items = re.findall(r"(self\.[^\s]{1,}) = .*?nn\.ModuleList\(", init)
     if len(modulelist_items) != 1:
         return None
     modulelist_item = modulelist_items[0]
+
+    # Fix Qwen2 missing None for gradient checkpointing
+    layer_class = _modulelist_layer_class(source, init, modulelist_item)
+    bound_keywords = {}
+    for replacement in custom_gradient_checkpointing_replacements:
+        custom_find, custom_replace = replacement[0], replacement[1]
+        if custom_find not in forward:
+            continue
+        if not _replacement_fits_the_layer(replacement, layer_class):
+            continue
+        forward = forward.replace(custom_find, custom_replace)
+        bound_keywords.update(_bound_keywords_of_replacement(replacement))
+    pass
 
     # Check in forward source
     finder = (

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2744,6 +2744,38 @@ pass
 
 # We need to manually replace some items
 # For example HF 4.53.1 breaks Qwen2VL since None wasn't provided
+#
+# patch_gradient_checkpointing() below rewrites `hidden_states = blk(...)` into
+# a `self._gradient_checkpointing_func(blk.__call__, ...)` call, and on the way
+# it demotes every `arg=arg` keyword to a positional (the
+# `re.sub(r"([^\s]{1,})[\s]?\=[\s]?\1", ...)` a few lines further down). So the
+# rewritten argument list has to line up positionally with the vision block's
+# own signature, and anything the block only accepts through **kwargs has to
+# stay a keyword.
+#
+# transformers <= 4.57 spells the block as
+#   Qwen2VLVisionBlock.forward(self, hidden_states, cu_seqlens,
+#                              rotary_pos_emb=None, position_embeddings=None,
+#                              **kwargs)
+# while the caller passes only cu_seqlens + position_embeddings, so
+# `rotary_pos_emb=rotary_pos_emb` is injected to fill the third positional slot
+# (that is the "missing None" HF 4.53.1 broke).
+#
+# transformers >= 5.0 dropped `rotary_pos_emb` from the block signature
+#   Qwen2VLVisionBlock.forward(self, hidden_states, cu_seqlens,
+#                              position_embeddings=None, **kwargs)
+# and added `max_seqlen=max_seqlen` to the call site (transformers 5.x moved the
+# cu_seqlens/max_seqlen computation into get_vision_attention_seqlens()).
+# `max_seqlen` is NOT a named parameter of the block - it rides along in
+# **kwargs down to the attention. Left alone the `arg=arg` demotion would turn
+# it into the third positional and it would silently be bound to
+# `position_embeddings`, so it is rewritten into an explicit
+# `**{"max_seqlen": max_seqlen}` mapping, which has no `arg=arg` spelling for
+# the demotion regex to match and therefore stays a keyword. The mapping is kept
+# inside the call (rather than hoisted into `kwargs` before the loop) so the
+# `for ... in ...:\n<spaces>hidden_states = <layer>(...)` finder regex below,
+# which requires the call to be the first statement of the loop body, still
+# matches.
 custom_gradient_checkpointing_replacements = [
     (
         """hidden_states = blk(
@@ -2774,6 +2806,42 @@ custom_gradient_checkpointing_replacements = [
                 rotary_pos_emb=rotary_pos_emb,
                 position_embeddings=position_embeddings,
                 attention_mask=attention_mask,
+                **kwargs,
+            )""",
+    ),
+    # transformers >= 5.0 spellings. `max_seqlen` is a **kwargs-only argument of
+    # the vision block, so it must survive as a keyword.
+    (
+        """hidden_states = blk(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )""",
+        """hidden_states = blk(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                position_embeddings=position_embeddings,
+                **{"max_seqlen": max_seqlen},
+                **kwargs,
+            )""",
+    ),
+    (
+        """hidden_states = blk(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                position_embeddings=position_embeddings,
+                attention_mask=attention_mask,
+                **kwargs,
+            )""",
+        """hidden_states = blk(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                position_embeddings=position_embeddings,
+                attention_mask=attention_mask,
+                **{"max_seqlen": max_seqlen},
                 **kwargs,
             )""",
     ),

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2809,6 +2809,16 @@ pass
 # single pass, so entry 0 (which would inject `rotary_pos_emb` that 5.x blocks no
 # longer accept) has already run by the time this fires.
 #
+# Ordering alone is not enough, though, and that is what the optional FOURTH
+# element is for. transformers 5.10 - 5.14 spell the call site exactly like
+# 4.53.0 - 5.9 while the block has already lost `rotary_pos_emb`, so entry 0
+# matched on its own and produced
+#   TypeError: Qwen2VLVisionBlock.forward() takes from 3 to 4 positional
+#   arguments but 5 were given
+# Entries that inject a parameter therefore declare it, and
+# _replacement_fits_the_layer() checks it against the real block signature
+# before the entry is allowed to fire.
+#
 # There is deliberately no 5.x + `attention_mask` entry. The `attention_mask=`
 # spelling only ever existed in transformers 4.53.x (where the block named it as
 # its fifth positional parameter, which is why the 4.x entry below demotes it);

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -220,6 +220,42 @@ def _gradient_checkpoint_recompute_marker():
         _GC_RECOMPUTE_TLS.active = previous
 
 
+def _detach_checkpoint_args(args):
+    """Detach the differentiable tensors in ``args`` for a reentrant recompute.
+
+    ``ctx.args`` are the tensors as they were handed to ``Function.apply``; a
+    Python ``autograd.Function`` does not strip their ``grad_fn``. Re-running the
+    block on them under ``torch.enable_grad()`` and calling
+    ``torch.autograd.backward`` on the result therefore walks straight into the
+    history *behind* those tensors from inside this backward - a nested backward
+    over a graph the outer engine still intends to visit, which frees it early
+    ("Trying to backward through the graph a second time") and delivers the
+    gradient as a side effect rather than as this Function's output.
+
+    Detaching stops the traversal at the recompute boundary, exactly as
+    ``UnslothCheckpointFunction`` and torch's own reentrant checkpoint do, and
+    the caller returns the collected ``.grad`` so the engine keeps propagating.
+
+    Returns ``(recompute_args, grad_holders)`` where ``grad_holders[i]`` is the
+    detached tensor to read a gradient off, or ``None`` for inputs that take no
+    gradient.
+    """
+    # All Unsloth Zoo code licensed under LGPLv3
+    recompute_args = []
+    grad_holders   = []
+    for arg in args:
+        if torch.is_tensor(arg) and arg.requires_grad:
+            detached = arg.detach()
+            detached.requires_grad_(True)
+            recompute_args.append(detached)
+            grad_holders  .append(detached)
+        else:
+            recompute_args.append(arg)
+            grad_holders  .append(None)
+    return recompute_args, grad_holders
+pass
+
+
 class Unsloth_Offloaded_Gradient_Checkpointer(torch.autograd.Function):
     """
     All Unsloth Zoo code licensed under LGPLv3
@@ -245,8 +281,9 @@ class Unsloth_Offloaded_Gradient_Checkpointer(torch.autograd.Function):
         (hidden_states,) = ctx.saved_tensors
         hidden_states = hidden_states.to(ctx.device, non_blocking = True).detach()
         hidden_states.requires_grad_(True)
+        recompute_args, grad_holders = _detach_checkpoint_args(ctx.args)
         with torch.enable_grad(), _gradient_checkpoint_recompute_marker():
-            output = ctx.forward_function(hidden_states, *ctx.args)
+            output = ctx.forward_function(hidden_states, *recompute_args)
         # Layers that return a 1-tuple keep unpacking exactly as before. Layers
         # that return the tensor itself (Qwen2-VL's vision block, and every
         # transformers block since the tuple returns were retired) used to raise
@@ -255,7 +292,11 @@ class Unsloth_Offloaded_Gradient_Checkpointer(torch.autograd.Function):
         if isinstance(output, tuple):
             (output,) = output
         torch.autograd.backward(output, dY)
-        return (None, hidden_states.grad,) + (None,)*len(ctx.args)
+        # Gradients for the extra inputs are returned to the engine instead of
+        # being left to accumulate as a side effect of the nested backward.
+        return (None, hidden_states.grad,) + tuple(
+            None if holder is None else holder.grad for holder in grad_holders
+        )
     pass
 pass
 
@@ -282,8 +323,9 @@ class Unsloth_Gradient_Checkpointer(torch.autograd.Function):
         (hidden_states,) = ctx.saved_tensors
         hidden_states = hidden_states.detach()
         hidden_states.requires_grad_(True)
+        recompute_args, grad_holders = _detach_checkpoint_args(ctx.args)
         with torch.enable_grad(), _gradient_checkpoint_recompute_marker():
-            output = ctx.forward_function(hidden_states, *ctx.args)
+            output = ctx.forward_function(hidden_states, *recompute_args)
         # Layers that return a 1-tuple keep unpacking exactly as before. Layers
         # that return the tensor itself (Qwen2-VL's vision block, and every
         # transformers block since the tuple returns were retired) used to raise
@@ -292,7 +334,11 @@ class Unsloth_Gradient_Checkpointer(torch.autograd.Function):
         if isinstance(output, tuple):
             (output,) = output
         torch.autograd.backward(output, dY)
-        return (None, hidden_states.grad,) + (None,)*len(ctx.args)
+        # Gradients for the extra inputs are returned to the engine instead of
+        # being left to accumulate as a side effect of the nested backward.
+        return (None, hidden_states.grad,) + tuple(
+            None if holder is None else holder.grad for holder in grad_holders
+        )
     pass
 pass
 
@@ -352,6 +398,46 @@ def _torch_checkpoint_keywords():
 _TORCH_CHECKPOINT_KEYWORDS = _torch_checkpoint_keywords()
 
 
+class _KeywordArgumentCall:
+    """Re-form keyword arguments from trailing positional arguments.
+
+    ``functools.partial(function, **extra)`` is the obvious way to turn a
+    keyword call into the positional-only call an ``autograd.Function`` can
+    make, but a tensor closed over that way is invisible to autograd: it never
+    appears in the Function's input list, so the Function cannot return a
+    gradient for it. The reentrant checkpointers re-run the wrapped block under
+    ``torch.enable_grad()`` and then call ``torch.autograd.backward`` on the
+    recomputed output, so a captured non-leaf tensor is walked *through* - its
+    own history is traversed inside the nested backward. When that history is
+    shared (the same tensor handed to several checkpointed layers, or also
+    feeding the loss) the first nested backward frees it and the next traversal
+    raises ``Trying to backward through the graph a second time``; when it does
+    not raise, the gradient arrives as a side effect of the nested call instead
+    of as a Function output.
+
+    So tensors are passed as ordinary positional inputs to the Function - which
+    is what makes them visible to autograd - and this callable puts them back
+    into keyword position, taking them off the tail of the positional list.
+    Non-tensor keywords have no gradient and stay bound directly.
+    """
+    # All Unsloth Zoo code licensed under LGPLv3
+    __slots__ = ("function", "keys", "constants",)
+
+    def __init__(self, function, keys, constants):
+        self.function  = function
+        self.keys      = keys
+        self.constants = constants
+    pass
+
+    def __call__(self, *args):
+        split = len(args) - len(self.keys)
+        kwargs = dict(self.constants)
+        kwargs.update(zip(self.keys, args[split:]))
+        return self.function(*args[:split], **kwargs)
+    pass
+pass
+
+
 def _bind_checkpoint_kwargs(function, kwargs):
     """Bind leftover keyword arguments into ``function``.
 
@@ -367,23 +453,35 @@ def _bind_checkpoint_kwargs(function, kwargs):
     ``unsloth_checkpoint`` raised ``Unexpected keyword arguments``. Binding makes
     all three agree and never turns a working call into an error.
 
-    Returns ``function`` unchanged when there is nothing to bind, so the ordinary
-    empty-kwargs path allocates nothing.
+    Returns ``(callable, extra_positional_args)``. The extra arguments are the
+    keyword values that require grad; the caller must append them to the
+    Function's positional inputs so autograd can see them, and
+    ``_KeywordArgumentCall`` moves them back into keyword position before the
+    block is called. Returns ``function`` unchanged with an empty tuple when
+    there is nothing to bind, so the ordinary empty-kwargs path allocates
+    nothing and the no-tensor path keeps the cheap ``functools.partial``.
     """
     # All Unsloth Zoo code licensed under LGPLv3
     if not kwargs:
-        return function
+        return function, ()
     extra = {k : v for k, v in kwargs.items() if k not in _TORCH_CHECKPOINT_KEYWORDS}
     if not extra:
-        return function
-    return functools.partial(function, **extra)
+        return function, ()
+    keys = tuple(
+        k for k, v in extra.items() if torch.is_tensor(v) and v.requires_grad
+    )
+    if not keys:
+        return functools.partial(function, **extra), ()
+    constants = {k : v for k, v in extra.items() if k not in keys}
+    return _KeywordArgumentCall(function, keys, constants), \
+        tuple(extra[k] for k in keys)
 pass
 
 
 @torch._disable_dynamo
 def unsloth_gradient_checkpoint(function, *args, use_reentrant = None, **kwargs):
-    function = _bind_checkpoint_kwargs(function, kwargs)
-    return Unsloth_Gradient_Checkpointer.apply(function, *args)
+    function, tensor_args = _bind_checkpoint_kwargs(function, kwargs)
+    return Unsloth_Gradient_Checkpointer.apply(function, *args, *tensor_args)
 pass
 
 
@@ -975,7 +1073,8 @@ def unsloth_checkpoint(
         # Unsloth's smart gradient checkpointing is installed. Bind them into
         # the callable instead - same observable behaviour, no keyword reaches
         # UnslothCheckpointFunction. See _bind_checkpoint_kwargs.
-        function = _bind_checkpoint_kwargs(function, kwargs)
+        function, extra_args = _bind_checkpoint_kwargs(function, kwargs)
+        args = args + extra_args
         kwargs = {}
 
     if use_reentrant:
@@ -1176,8 +1275,8 @@ def unsloth_offloaded_gradient_checkpoint(function, *args, use_reentrant = None,
     global CPU_BUFFERS
     if len(CPU_BUFFERS) == 0:
         initialize_unsloth_gradient_checkpointing(args[0].dtype)
-    function = _bind_checkpoint_kwargs(function, kwargs)
-    return UnslothCheckpointFunction.apply(function, *args)
+    function, tensor_args = _bind_checkpoint_kwargs(function, kwargs)
+    return UnslothCheckpointFunction.apply(function, *args, *tensor_args)
 pass
 
 # Unsloth Zoo - Utilities for Unsloth

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -730,10 +730,25 @@ class UnslothCheckpointFunction(torch.autograd.Function):
         ctx.tensor_indices = []
         tensor_inputs = []
         ctx._requires_gradient = False
+        # Read unconditionally in backward, so it needs a value on every path
+        # that never takes the offload branch below.
+        ctx._saved_metadata = (None, None, None, None, None, None, None,)
         use_gpu_buffer = False
 
         for i, arg in enumerate(args):
             if torch.is_tensor(arg):
+                # ANY differentiable input means this Function has a gradient to
+                # produce, exactly as torch's own reentrant CheckpointFunction
+                # (which saves unconditionally) does. Keying this off input zero
+                # alone made backward bail out early - and it is reached, since
+                # autograd only calls backward when some input requires grad -
+                # so the engine got a single None instead of one gradient per
+                # input and raised `returned an incorrect number of gradients`.
+                # A frozen first activation next to a differentiable later one
+                # is ordinary: an untrained embedding feeding layer 0 alongside
+                # a learned positional/query tensor, or a tensor keyword routed
+                # positionally by _bind_checkpoint_kwargs.
+                if arg.requires_grad: ctx._requires_gradient = True
 
                 if i == 0 and arg.requires_grad:
                     global FIRST_PASS
@@ -747,7 +762,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                     global CURRENT_GC_INDEX
                     CURRENT_GC_INDEX += 1
 
-                    ctx._requires_gradient = True
                     new_size = arg.numel()
 
                     global MINIMUM_SIZE

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -245,7 +245,14 @@ class Unsloth_Offloaded_Gradient_Checkpointer(torch.autograd.Function):
         hidden_states = hidden_states.to(ctx.device, non_blocking = True).detach()
         hidden_states.requires_grad_(True)
         with torch.enable_grad(), _gradient_checkpoint_recompute_marker():
-            (output,) = ctx.forward_function(hidden_states, *ctx.args)
+            output = ctx.forward_function(hidden_states, *ctx.args)
+        # Layers that return a 1-tuple keep unpacking exactly as before. Layers
+        # that return the tensor itself (Qwen2-VL's vision block, and every
+        # transformers block since the tuple returns were retired) used to raise
+        # `ValueError: too many values to unpack` here, because forward() stored
+        # whatever the layer returned while backward() insisted on a 1-tuple.
+        if isinstance(output, tuple):
+            (output,) = output
         torch.autograd.backward(output, dY)
         return (None, hidden_states.grad,) + (None,)*len(ctx.args)
     pass
@@ -275,7 +282,14 @@ class Unsloth_Gradient_Checkpointer(torch.autograd.Function):
         hidden_states = hidden_states.detach()
         hidden_states.requires_grad_(True)
         with torch.enable_grad(), _gradient_checkpoint_recompute_marker():
-            (output,) = ctx.forward_function(hidden_states, *ctx.args)
+            output = ctx.forward_function(hidden_states, *ctx.args)
+        # Layers that return a 1-tuple keep unpacking exactly as before. Layers
+        # that return the tensor itself (Qwen2-VL's vision block, and every
+        # transformers block since the tuple returns were retired) used to raise
+        # `ValueError: too many values to unpack` here, because forward() stored
+        # whatever the layer returned while backward() insisted on a 1-tuple.
+        if isinstance(output, tuple):
+            (output,) = output
         torch.autograd.backward(output, dY)
         return (None, hidden_states.grad,) + (None,)*len(ctx.args)
     pass
@@ -288,8 +302,49 @@ pass
 # pass
 
 
+# Keywords that belong to the checkpoint machinery itself rather than to the
+# wrapped function. torch.utils.checkpoint.checkpoint names all four; the Unsloth
+# reentrant checkpointers below never honoured them, and that is deliberately
+# left as-is so callers passing only these see exactly today's behaviour.
+_TORCH_CHECKPOINT_KEYWORDS = frozenset({
+    "preserve_rng_state",
+    "context_fn",
+    "determinism_check",
+    "debug",
+})
+
+
+def _bind_checkpoint_kwargs(function, kwargs):
+    """Bind leftover keyword arguments into ``function``.
+
+    ``checkpoint(fn, *args, **kwargs)`` means "call ``fn(*args, **kwargs)``";
+    that is what torch's non-reentrant path does. The Unsloth checkpointers are
+    ``torch.autograd.Function`` subclasses and can only forward positionals, so
+    the keywords are bound into the callable instead - the same trick
+    ``transformers.modeling_layers.GradientCheckpointingLayer.__call__`` uses.
+
+    Before this, ``unsloth_gradient_checkpoint`` /
+    ``unsloth_offloaded_gradient_checkpoint`` dropped them silently (the wrapped
+    block then ran with different arguments and no diagnostic) while
+    ``unsloth_checkpoint`` raised ``Unexpected keyword arguments``. Binding makes
+    all three agree and never turns a working call into an error.
+
+    Returns ``function`` unchanged when there is nothing to bind, so the ordinary
+    empty-kwargs path allocates nothing.
+    """
+    # All Unsloth Zoo code licensed under LGPLv3
+    if not kwargs:
+        return function
+    extra = {k : v for k, v in kwargs.items() if k not in _TORCH_CHECKPOINT_KEYWORDS}
+    if not extra:
+        return function
+    return functools.partial(function, **extra)
+pass
+
+
 @torch._disable_dynamo
 def unsloth_gradient_checkpoint(function, *args, use_reentrant = None, **kwargs):
+    function = _bind_checkpoint_kwargs(function, kwargs)
     return Unsloth_Gradient_Checkpointer.apply(function, *args)
 pass
 
@@ -875,9 +930,15 @@ def unsloth_checkpoint(
     # Hack to mix *args with **kwargs in a python 2.7-compliant way
     preserve = kwargs.pop("preserve_rng_state", True)
     if kwargs and use_reentrant:
-        raise ValueError(
-            "Unexpected keyword arguments: " + ",".join(arg for arg in kwargs)
-        )
+        # torch raises here, but only because *the caller* asked for the
+        # reentrant path. We force use_reentrant = True above, so raising would
+        # turn a call that works on unpatched torch (non-reentrant checkpoint
+        # forwards **kwargs straight to `function`) into a crash the moment
+        # Unsloth's smart gradient checkpointing is installed. Bind them into
+        # the callable instead - same observable behaviour, no keyword reaches
+        # UnslothCheckpointFunction. See _bind_checkpoint_kwargs.
+        function = _bind_checkpoint_kwargs(function, kwargs)
+        kwargs = {}
 
     if use_reentrant:
         if context_fn is not noop_context_fn or debug is not False:
@@ -1077,6 +1138,7 @@ def unsloth_offloaded_gradient_checkpoint(function, *args, use_reentrant = None,
     global CPU_BUFFERS
     if len(CPU_BUFFERS) == 0:
         initialize_unsloth_gradient_checkpointing(args[0].dtype)
+    function = _bind_checkpoint_kwargs(function, kwargs)
     return UnslothCheckpointFunction.apply(function, *args)
 pass
 

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -20,6 +20,7 @@ from typing import Union, Optional, List, Any, Callable, Tuple
 from contextlib import contextmanager, nullcontext
 import os
 import functools
+import inspect
 import warnings
 import gc
 import threading
@@ -303,15 +304,52 @@ pass
 
 
 # Keywords that belong to the checkpoint machinery itself rather than to the
-# wrapped function. torch.utils.checkpoint.checkpoint names all four; the Unsloth
-# reentrant checkpointers below never honoured them, and that is deliberately
-# left as-is so callers passing only these see exactly today's behaviour.
-_TORCH_CHECKPOINT_KEYWORDS = frozenset({
+# wrapped function. The Unsloth reentrant checkpointers below never honoured
+# them, and that is deliberately left as-is so callers passing only these see
+# exactly today's behaviour. What must NOT happen is binding one of them onto
+# the wrapped block: the block has no such parameter and raises TypeError, so a
+# call that works against unpatched torch would start failing the moment Unsloth
+# swaps torch.utils.checkpoint.checkpoint out from under it.
+#
+# `early_stop` is the one that was missing: torch grew it as a per-call keyword
+# (present on 2.10 and 2.13 here) and documents it as ignored when
+# use_reentrant = True - which is exactly what these shims force - so dropping
+# it is the faithful behaviour.
+_TORCH_CHECKPOINT_KEYWORDS_LITERAL = frozenset({
     "preserve_rng_state",
     "context_fn",
     "determinism_check",
     "debug",
+    "early_stop",
 })
+
+
+def _torch_checkpoint_keywords():
+    """The literal set above, widened by whatever torch's own ``checkpoint``
+    actually declares.
+
+    Read off the live signature so a keyword a later torch adds (the same way it
+    added ``early_stop``) is dropped rather than bound onto the block. Falls back
+    to the literal set if the signature cannot be read, and unions rather than
+    replaces so a signature already replaced by one of the shims below can only
+    ever widen the set. ``use_reentrant`` is excluded because every shim names it
+    explicitly, so it never reaches ``**kwargs``."""
+    # All Unsloth Zoo code licensed under LGPLv3
+    names = set(_TORCH_CHECKPOINT_KEYWORDS_LITERAL)
+    try:
+        checkpoint = getattr(
+            torch.utils.checkpoint, "_unsloth_pristine_checkpoint", None,
+        ) or torch.utils.checkpoint.checkpoint
+        for name, parameter in inspect.signature(checkpoint).parameters.items():
+            if parameter.kind is inspect.Parameter.KEYWORD_ONLY:
+                names.add(name)
+    except Exception:
+        pass
+    names.discard("use_reentrant")
+    return frozenset(names)
+
+
+_TORCH_CHECKPOINT_KEYWORDS = _torch_checkpoint_keywords()
 
 
 def _bind_checkpoint_kwargs(function, kwargs):


### PR DESCRIPTION
`Core (HF=latest + TRL=latest)` is red on unsloth main. One of its four failures is this zoo guard:

```
FAILED tests/test_upstream_source_patterns.py::test_compiler_custom_gradient_checkpointing_qwen2_vl_blk
  DRIFT DETECTED: zoo source-rewriter at unsloth_zoo/compiler.py:2194-2199
```

## What upstream changed

`Qwen2VisionTransformerPretrainedModel.forward`, transformers 4.57.6 vs 5.15.0 (`cu_seqlens`/`max_seqlen` moved into `get_vision_attention_seqlens()`):

```python
# 4.57.6
hidden_states = blk(hidden_states, cu_seqlens=cu_seqlens, position_embeddings=position_embeddings, **kwargs)
# 5.15.0
hidden_states = blk(hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen, position_embeddings=position_embeddings, **kwargs)
```

The block signature also lost `rotary_pos_emb`. The same change hit `qwen3_vl`, `qwen3_vl_moe` and `glm4v` with identical spelling.

## What the drift actually costs

The rewriter does not silently no-op. It silently emits **broken** code:

```
replacement[0] matches upstream 5.15: False
patch_gradient_checkpointing -> None?  False        <- it still rewrites
emitted: blk(hidden_states, cu_seqlens, max_seqlen, position_embeddings, **kwargs)
running it: TypeError: Qwen2VLVisionBlock.forward() takes from 3 to 4 positional arguments but 5 were given
```

`max_seqlen` is a `**kwargs`-only argument of the block, but the rewriter demotes every `arg=arg` to a positional, so it takes `position_embeddings`' slot and pushes the real one past the end.

**No live regression today.** The caller gates on the modeling file containing `(GradientCheckpointingLayer)`, which `modeling_qwen2_vl.py` does on both versions, so `patch_gradient_checkpointing` is never invoked for it and upstream's own `GradientCheckpointingLayer` handles checkpointing. If that gate ever flipped, this would crash rather than quietly degrade. The red test is real drift over latent-but-wrong code.

## The fix

Two transformers-5.x entries added to `custom_gradient_checkpointing_replacements`; the 4.x entries are untouched, so both versions match.

```python
**{"max_seqlen": max_seqlen},
```

The mapping form has no `arg=arg` spelling for the demotion regex to match, so `max_seqlen` stays a keyword and still reaches attention through the block's `**kwargs`. It is kept inside the call rather than hoisted before the loop because the finder regex requires the call to be the loop body's first statement; hoisting makes the whole patch return `None`. PEP 448, valid on Python 3.9+.

The guard now accepts either the 4.x or the 5.x spelling and fails if neither is present, matching the existing "pass on either" precedent in that file (`test_compiler_attn_weights_attention_mask_dict_pattern`). It is not softened to a skip. Added `test_compiler_custom_gradient_checkpointing_qwen2_vl_block_signature`, pinning `Qwen2VLVisionBlock.forward`'s parameter order: that ordering is the invariant the positional demotion depends on, it is what silently broke, and nothing guarded it.

Grepped both repos for `custom_gradient_checkpointing_replacements`, `rotary_pos_emb=rotary_pos_emb`, `max_seqlen=max_seqlen` and `cu_seqlens=cu_seqlens`: the only other non-vendored hits are in `unsloth_zoo/mlx/compile.py`, a separate MLX path with its own literals. Nothing in `unslothai/unsloth` references these names.

## Verification

CPU-only, no GPU.

Executing the rewritten source on a tiny CPU model (depth 2, embed_dim 32, 16 patches):

| | 4.57.6 | 5.15.0 |
|---|---|---|
| max abs diff vs upstream | 0.0 | 0.0 |
| `_gradient_checkpointing_func` calls | 2 of 2 layers | 2 of 2 layers |
| kwargs forwarded to checkpoint | none | `['max_seqlen']` |
| gradient flowed | yes | yes |

`tests/test_upstream_source_patterns.py`: 35 passed on 4.57.6, 31 passed / 4 skipped on 5.15.0. Related compiler suites: 94 passed / 4 skipped on 4.57.6, 83 passed / 15 skipped on 5.15.0, with one `test_unsloth_trainer_exec_marker` failure confirmed pre-existing.

## Left alone deliberately

`qwen2_5_vl` spells the call `cu_seqlens=cu_seqlens_now, max_seqlen=max_seqlen_now`, which no entry matches on either version, so the rewriter bails and returns `None`. Adding an entry would enable patching for a model that has never been patched - a behaviour change rather than a drift fix, and dead code behind the same gate.