### PR TITLE
Sanitize TokenizersBackend in exported tokenizer configs

### DIFF
--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14125,6 +14125,12 @@ def save_merged_model(model, tokenizer, path, dequantize=False):
 
     # Save tokenizer
     tokenizer.save_pretrained(str(path))
+    try:
+        from unsloth_zoo.saving_utils import sanitize_tokenizer_class_in_config
+
+        sanitize_tokenizer_class_in_config(tokenizer, path)
+    except Exception:
+        pass
 
     src_path = _get_src_path(model)
     if src_path is not None:
@@ -14412,6 +14418,9 @@ def save_pretrained_merged(
             save_lora_adapters(model, save_directory)
         try:
             tokenizer.save_pretrained(str(save_directory))
+            from unsloth_zoo.saving_utils import sanitize_tokenizer_class_in_config
+
+            sanitize_tokenizer_class_in_config(tokenizer, save_directory)
         except Exception:
             pass
     else:

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2814,6 +2814,62 @@ def _remove_transformers_version(config_path: Path):
     pass
 pass
 
+_UNLOADABLE_TOKENIZER_CLASSES = frozenset({"TokenizersBackend"})
+
+
+def _exportable_tokenizer_class(tokenizer, saved_folder):
+    """Return a HuggingFace-loadable tokenizer_class for tokenizer_config.json."""
+    source = tokenizer
+    if tokenizer is not None and hasattr(tokenizer, "tokenizer"):
+        source = tokenizer.tokenizer
+    if source is not None:
+        class_name = type(source).__name__
+        if class_name not in _UNLOADABLE_TOKENIZER_CLASSES:
+            return class_name
+
+    saved_folder = str(saved_folder)
+    if os.path.isfile(os.path.join(saved_folder, "tokenizer.json")):
+        return "PreTrainedTokenizerFast"
+    return None
+
+
+def sanitize_tokenizer_class_in_config(tokenizer, saved_folder, filename_prefix = None):
+    """Rewrite internal tokenizer_class names that AutoTokenizer cannot load.
+
+    Transformers 5.x fast tokenizers can serialize as ``TokenizersBackend``, which is
+    an internal wrapper rather than a registered tokenizer class. Downstream tools
+    (``AutoTokenizer``, llama.cpp, mlx_lm) need a loadable value such as
+    ``PreTrainedTokenizerFast`` when ``tokenizer.json`` is present.
+    """
+    if saved_folder is None:
+        return
+
+    tokenizer_config_name = (
+        f"{filename_prefix}-tokenizer_config.json" if filename_prefix else "tokenizer_config.json"
+    )
+    tokenizer_config_path = os.path.join(str(saved_folder), tokenizer_config_name)
+    if not os.path.isfile(tokenizer_config_path):
+        return
+
+    replacement = _exportable_tokenizer_class(tokenizer, saved_folder)
+    if replacement is None:
+        return
+
+    try:
+        with open(tokenizer_config_path, "r", encoding = "utf-8") as file:
+            config = json.load(file)
+        if config.get("tokenizer_class") not in _UNLOADABLE_TOKENIZER_CLASSES:
+            return
+        if config.get("tokenizer_class") == replacement:
+            return
+        config["tokenizer_class"] = replacement
+        with open(tokenizer_config_path, "w", encoding = "utf-8") as file:
+            json.dump(config, file, indent = 2, ensure_ascii = False)
+            file.write("\n")
+    except Exception:
+        pass
+
+
 def fix_tokenizer_config_json(tokenizer, saved_folder):
     # Add "chat_template" to tokenizer_config.json
     tokenizer_config_path = os.path.join(saved_folder, "tokenizer_config.json")
@@ -2842,6 +2898,7 @@ def fix_tokenizer_config_json(tokenizer, saved_folder):
         except:
             pass
     pass
+    sanitize_tokenizer_class_in_config(tokenizer, saved_folder)
     # Fix config.json using torch_dtype / dtype
     config_file_path = os.path.join(saved_folder, "config.json")
     if os.path.exists(config_file_path):


### PR DESCRIPTION
## Summary

Companion fix for unslothai/unsloth#8444.

Adds `sanitize_tokenizer_class_in_config` and wires it into:
- `fix_tokenizer_config_json` (zoo save paths)
- MLX merged export (`save_merged_model` and LoRA save)

This covers Studio MLX exports, which call `tokenizer.save_pretrained` directly rather than through Unsloth's patched save hook.

## Test plan

- [x] Covered by tests added in the unsloth PR (`tests/saving/test_sanitize_tokenizer_class_in_config.py`)