### PR TITLE
Fix Qwen3.5 GGUF export when MTP config is nested under text_config

### DIFF
--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -223,3 +223,61 @@ def test_convert_to_gguf_rejects_malformed_layer_count_before_rewrite(llama_cpp,
         )
 
     assert json.loads(config_path.read_text(encoding = "utf-8")) == config
+
+
+@pytest.mark.parametrize("has_mtp", (False, True))
+def test_convert_to_gguf_hoists_nested_text_config_keys_for_converter(llama_cpp, tmp_path, has_mtp):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_path = model_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForCausalLM"],
+                "model_type": "qwen3_5",
+                "text_config": {
+                    "num_hidden_layers": 24,
+                    "mtp_num_hidden_layers": 1,
+                    "unsloth_fixed_mtp": True,
+                },
+            }
+        ),
+        encoding = "utf-8",
+    )
+    tensor_name = (
+        "model.layers.24.eh_proj.weight"
+        if has_mtp
+        else "model.layers.23.self_attn.q_proj.weight"
+    )
+    _write_index(model_dir, tensor_name)
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(tmp_path / "output.gguf"),
+        input_folder = str(model_dir),
+        converter_location = str(_write_converter(tmp_path)),
+        quantization_type = "bf16",
+    )
+
+    updated = json.loads(config_path.read_text(encoding = "utf-8"))
+    assert updated["num_hidden_layers"] == 24
+    assert ("mtp_num_hidden_layers" in updated) is has_mtp
+    if has_mtp:
+        assert updated["mtp_num_hidden_layers"] == 1
+    assert "unsloth_fixed_mtp" not in updated
+    assert "unsloth_fixed_mtp" not in updated["text_config"]
+
+
+def test_hoist_text_config_keys_for_gguf_converter_is_noop_without_text_config(llama_cpp):
+    config = {"num_hidden_layers": 24}
+    assert llama_cpp._hoist_text_config_keys_for_gguf_converter(config) is False
+    assert config == {"num_hidden_layers": 24}
+
+
+def test_hoist_text_config_keys_for_gguf_converter_does_not_override_top_level(llama_cpp):
+    config = {
+        "num_hidden_layers": 32,
+        "text_config": {"num_hidden_layers": 24, "mtp_num_hidden_layers": 1},
+    }
+    assert llama_cpp._hoist_text_config_keys_for_gguf_converter(config) is True
+    assert config["num_hidden_layers"] == 32
+    assert config["mtp_num_hidden_layers"] == 1

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2318,6 +2318,30 @@ def _has_mtp_weight_tensors(input_folder, num_layers):
     return False
 
 
+_GGUF_CONVERTER_TEXT_CONFIG_KEYS = (
+    "num_hidden_layers",
+    "mtp_num_hidden_layers",
+)
+
+
+def _hoist_text_config_keys_for_gguf_converter(config_file):
+    """Copy nested text_config keys the llama.cpp Qwen MTP converter reads only at top level.
+
+    ``convert_hf_to_gguf``'s Qwen MTP mixin merges ``text_config`` in ``index_tensors`` but
+    not in ``__init__``, so checkpoints that only nest MTP hyperparameters under
+    ``text_config`` fail GGUF export with ``assert self.opt_num_mtp_layers != 0``.
+    """
+    text_config = config_file.get("text_config")
+    if not isinstance(text_config, dict):
+        return False
+    changed = False
+    for key in _GGUF_CONVERTER_TEXT_CONFIG_KEYS:
+        if key in text_config and key not in config_file:
+            config_file[key] = text_config[key]
+            changed = True
+    return changed
+
+
 def _find_bitsandbytes_quantization(config, _path = "config.json"):
     """Where a bitsandbytes `quantization_config` sits, or None.
 
@@ -2489,6 +2513,8 @@ def convert_to_gguf(
             if _key in _cfg:
                 _cfg.pop(_key)
                 _changed = True
+    if _hoist_text_config_keys_for_gguf_converter(config_file):
+        _changed = True
     if _changed:
         with open(config_path, "w", encoding = "utf-8") as f:
             json.dump(config_file, f, indent = 2)


### PR DESCRIPTION
## Summary

Fixes unslothai/unsloth#8443

Qwen3.5 GGUF export fails with `assert self.opt_num_mtp_layers != 0` when `num_hidden_layers` and `mtp_num_hidden_layers` live only under `text_config`.

llama.cpp's Qwen MTP converter merges `text_config` in `index_tensors`, but its `__init__` reads those hyperparameters from the top level only. Unsloth already reconciles MTP keys against the weight index, but did not hoist the nested values the converter needs.

## Changes

- `unsloth_zoo/llama_cpp.py`: hoist `num_hidden_layers` and `mtp_num_hidden_layers` from `text_config` to the top level before writing `config.json` for conversion
- `tests/test_convert_to_gguf_mtp_reconcile.py`: cover nested-only configs and helper edge cases

## Test plan

- [x] `pytest tests/test_convert_to_gguf_mtp_reconcile.py`