### PR TITLE
tests: anchor the GGUF retry cleanup assertion to the OOM branch

### DIFF
--- a/tests/test_gguf_oom_temp_file_retry.py
+++ b/tests/test_gguf_oom_temp_file_retry.py
@@ -214,8 +214,16 @@ def test_the_paths_include_the_file_and_its_shards(tmp_path):
 
 
 def test_the_retry_clears_the_old_output_first():
+    # Anchored on the OOM branch. The loop grew a second `command = retry`, for
+    # a converter that rejects --no-mtp, and a bare index() finds that one
+    # first. That retry re-runs the same command minus one flag, keeps
+    # --split-max-size and so overwrites the same paths, which is why it has no
+    # cleanup; only the OOM retry drops --split-max-size and can leave the
+    # killed run's shards behind. Searching from the kill check keeps the
+    # assertion on the branch that actually needs it.
     body = _loop_src()
-    assert body.index("_remove_gguf_outputs(output_file)") < body.index("command = retry")
+    oom = body.index("_converter_was_oom_killed(e)")
+    assert body.index("_remove_gguf_outputs(output_file)", oom) < body.index("command = retry", oom)
 
 
 def test_a_failed_projector_is_removed_and_stops_claiming_vlm():


### PR DESCRIPTION
## Problem

`tests/test_gguf_oom_temp_file_retry.py::test_the_retry_clears_the_old_output_first` fails on `main`, which red-lines the `Core` job on every `unslothai/unsloth` PR:

```
assert body.index("_remove_gguf_outputs(output_file)") < body.index("command = retry")
E   assert 3469 < 2472
```

The code is correct; the assertion is looking at the wrong branch. The run loop now has two `command = retry` sites, and a bare `index()` finds the first one:

- `llama_cpp.py:2711` retries when the converter rejects `--no-mtp`. It re-runs the same command minus that flag, keeps `--split-max-size`, and so overwrites the same output paths. There is nothing to clean up.
- `llama_cpp.py:2720` is the OOM retry. It swaps in `--use-temp-file` and drops `--split-max-size`, so the killed run's shards would linger beside the good file and be uploaded with it. This is the branch that must clear the old output first, and it does.

So the test measures the `--no-mtp` retry, which was added above it, and fails on correct code.

## Fix

Search from the kill check, so the assertion stays on the OOM branch regardless of what else the loop grows above it.

## Testing

- `pytest tests/test_gguf_oom_temp_file_retry.py` : 25 passed.
- Confirmed it still catches the regression it exists for: deleting `_remove_gguf_outputs(output_file)` from the OOM branch makes the test fail again. A fix that only turned the assertion green would not be worth having.