### PR TITLE
Spell relative imports absolutely where transformers cannot resolve them

### DIFF
--- a/tests/test_relative_imports_resolve.py
+++ b/tests/test_relative_imports_resolve.py
@@ -3,45 +3,36 @@
 
 """A relative import transformers cannot resolve breaks every remote-code save.
 
-`Paddle_OCR_(1B)_Vision` died at the trainer's first checkpoint save:
+`Paddle_OCR_(1B)_Vision` died at its first checkpoint save with
+`FileNotFoundError: .../unsloth_zoo/mlx.runtime.py`. Nothing was missing from
+the wheel, and `from .mlx.runtime import x` is valid Python: the dotted path is
+built by TRANSFORMERS, in `dynamic_module_utils`, which finds imports with a
+regex and joins the raw capture onto the directory:
 
-    FileNotFoundError: [Errno 2] No such file or directory:
-    '/usr/local/lib/python3.12/dist-packages/unsloth_zoo/mlx.runtime.py'
+    re.findall(r"^\\s*from\\s+\\.(\\S+)\\s+import", content, ...)  # plus `import .xxx`
+    f"{str(module_path / m)}.py"
 
-Nothing is missing from the wheel. The real module is `unsloth_zoo/mlx/runtime.py`
-and it imports fine. The path with a dot in it is built by TRANSFORMERS, in
-`dynamic_module_utils`:
-
-    relative_imports += re.findall(r"^\\s*from\\s+\\.(\\S+)\\s+import", content, ...)
-    ...
-    module_path / f"{imp}.py"
-
-Whatever that regex captures is pasted after the directory and `.py`. It does
-not translate dots into separators, does not strip further leading dots, and
-does not consider that the target might be a package. So three shapes break:
+`\\S+` swallows the whole dotted name, and nothing converts dots to separators,
+strips further dots, or considers that the target may be a package. So:
 
     from .mlx.runtime import x   ->  unsloth_zoo/mlx.runtime.py
     from .temporary_patches ...  ->  unsloth_zoo/temporary_patches.py  (a dir)
     from .. import __version__   ->  unsloth_zoo/mlx/..py
+    from .sibling import x       ->  a real file, so it is fine
 
-and one shape does not: `from .sibling import x`, which resolves to a real
-file. `from . import x` is also safe -- the regex needs at least one non-space
-character after the dot, so it never matches.
+(`from . import x` needs no fix either -- the regex wants a non-space after the
+dot.) Saving a remote-code model runs `custom_object_save`, which walks this
+graph recursively, so one unresolvable import anywhere crashes the save.
 
-It reaches unsloth_zoo because a remote-code model takes the `custom_object_save`
-path on save, which walks the relative imports of the module its class lives in,
-recursively. One unresolvable import anywhere in that graph is a crash at
-checkpoint time, on a code path with nothing to do with the import.
+The repair is to spell those imports absolutely: both patterns require a
+leading `.`, so an absolute import is invisible to the walk, while inside a
+package the two forms mean the same thing. Simplifying them back to relative
+form reintroduces the crash.
 
-The repair is to spell those imports absolutely. Both of transformers' patterns
-require a leading `.`, so an absolute import is invisible to the walk, and
-inside a package the two forms mean the same thing.
-
-The first pass of this fix looked only for DOTTED imports in `unsloth_zoo/*.py`
-and found 12. The end-to-end test below -- running the function that actually
-crashed -- found 24 more, in subpackages and in the two other shapes. That is
-why the regex guard here checks resolvability rather than dottedness, and why
-the walk is tested directly rather than modelled.
+A first pass looked only for DOTTED imports in `unsloth_zoo/*.py` and found 12;
+running the function that actually crashed found 24 more, in subpackages and in
+the other two shapes. Hence a guard on resolvability rather than dottedness,
+and a test of the real walk rather than a model of it.
 """
 
 from __future__ import annotations
@@ -53,8 +44,8 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1] / "unsloth_zoo"
 
-# Transformers' own two patterns, copied rather than approximated, because what
-# matters is exactly what IT matches -- not what looks like an import.
+# Transformers' own patterns, copied not approximated: what matters is exactly
+# what IT matches, not what looks like an import.
 RELATIVE_FROM = re.compile(r"^\s*from\s+\.(\S+)\s+import", re.MULTILINE)
 RELATIVE_IMPORT = re.compile(r"^\s*import\s+\.(\S+)\s*$", re.MULTILINE)
 
@@ -80,16 +71,15 @@ def test_every_relative_import_transformers_sees_resolves_to_a_file(path):
 
 
 def test_resolvable_relative_imports_are_left_alone():
-    """The guard must not have been read as 'no relative imports'. Sibling
-    imports resolve to a real file, cost nothing, and are the normal spelling.
-    A rewrite that removed them all would be a far larger change than the bug."""
+    """The guard is not 'no relative imports': sibling imports resolve to a real
+    file and are the normal spelling, so removing them all would be a far larger
+    change than the bug."""
     sources = "\n".join(p.read_text(encoding = "utf-8") for p in _modules())
     assert len(re.findall(r"^\s*from \.\w+ import", sources, re.MULTILINE)) > 100
 
 
 def test_the_transformers_patterns_are_the_ones_we_copied():
-    """If upstream changes its regexes, this guard is checking the wrong thing
-    and should be updated rather than trusted."""
+    """If upstream changes its regexes, this guard checks the wrong thing."""
     dynamic = pytest.importorskip("transformers.dynamic_module_utils")
     import inspect
 
@@ -99,10 +89,8 @@ def test_the_transformers_patterns_are_the_ones_we_copied():
 
 
 def test_transformers_can_walk_the_package_without_raising():
-    """The end-to-end version: run the function that crashed, on the files it
-    crashes from. A regex guard can go green on a rewrite that resolves to a
-    different nonexistent path; this cannot. It is also what found the 24 sites
-    the first pass missed."""
+    """Runs the function that crashed. A regex guard can go green on a rewrite
+    that resolves to a different nonexistent path; this cannot."""
     dynamic = pytest.importorskip("transformers.dynamic_module_utils")
 
     for name in ("__init__.py", "device_type.py", "saving_utils.py", "loss_utils.py"):

--- a/tests/test_relative_imports_resolve.py
+++ b/tests/test_relative_imports_resolve.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""A relative import transformers cannot resolve breaks every remote-code save.
+
+`Paddle_OCR_(1B)_Vision` died at the trainer's first checkpoint save:
+
+    FileNotFoundError: [Errno 2] No such file or directory:
+    '/usr/local/lib/python3.12/dist-packages/unsloth_zoo/mlx.runtime.py'
+
+Nothing is missing from the wheel. The real module is `unsloth_zoo/mlx/runtime.py`
+and it imports fine. The path with a dot in it is built by TRANSFORMERS, in
+`dynamic_module_utils`:
+
+    relative_imports += re.findall(r"^\\s*from\\s+\\.(\\S+)\\s+import", content, ...)
+    ...
+    module_path / f"{imp}.py"
+
+Whatever that regex captures is pasted after the directory and `.py`. It does
+not translate dots into separators, does not strip further leading dots, and
+does not consider that the target might be a package. So three shapes break:
+
+    from .mlx.runtime import x   ->  unsloth_zoo/mlx.runtime.py
+    from .temporary_patches ...  ->  unsloth_zoo/temporary_patches.py  (a dir)
+    from .. import __version__   ->  unsloth_zoo/mlx/..py
+
+and one shape does not: `from .sibling import x`, which resolves to a real
+file. `from . import x` is also safe -- the regex needs at least one non-space
+character after the dot, so it never matches.
+
+It reaches unsloth_zoo because a remote-code model takes the `custom_object_save`
+path on save, which walks the relative imports of the module its class lives in,
+recursively. One unresolvable import anywhere in that graph is a crash at
+checkpoint time, on a code path with nothing to do with the import.
+
+The repair is to spell those imports absolutely. Both of transformers' patterns
+require a leading `.`, so an absolute import is invisible to the walk, and
+inside a package the two forms mean the same thing.
+
+The first pass of this fix looked only for DOTTED imports in `unsloth_zoo/*.py`
+and found 12. The end-to-end test below -- running the function that actually
+crashed -- found 24 more, in subpackages and in the two other shapes. That is
+why the regex guard here checks resolvability rather than dottedness, and why
+the walk is tested directly rather than modelled.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1] / "unsloth_zoo"
+
+# Transformers' own two patterns, copied rather than approximated, because what
+# matters is exactly what IT matches -- not what looks like an import.
+RELATIVE_FROM = re.compile(r"^\s*from\s+\.(\S+)\s+import", re.MULTILINE)
+RELATIVE_IMPORT = re.compile(r"^\s*import\s+\.(\S+)\s*$", re.MULTILINE)
+
+
+def _modules():
+    return sorted(ROOT.rglob("*.py"))
+
+
+def _rel(p):
+    return str(p.relative_to(ROOT))
+
+
+@pytest.mark.parametrize("path", _modules(), ids = _rel)
+def test_every_relative_import_transformers_sees_resolves_to_a_file(path):
+    source = path.read_text(encoding = "utf-8")
+    seen = RELATIVE_FROM.findall(source) + RELATIVE_IMPORT.findall(source)
+    broken = [imp for imp in seen if not (path.parent / f"{imp}.py").is_file()]
+    assert not broken, (
+        f"{_rel(path)}: transformers would try to open "
+        f"{_rel(path.parent)}/{broken[0]}.py during custom_object_save and "
+        f"fail. Spell these absolutely: {broken}"
+    )
+
+
+def test_resolvable_relative_imports_are_left_alone():
+    """The guard must not have been read as 'no relative imports'. Sibling
+    imports resolve to a real file, cost nothing, and are the normal spelling.
+    A rewrite that removed them all would be a far larger change than the bug."""
+    sources = "\n".join(p.read_text(encoding = "utf-8") for p in _modules())
+    assert len(re.findall(r"^\s*from \.\w+ import", sources, re.MULTILINE)) > 100
+
+
+def test_the_transformers_patterns_are_the_ones_we_copied():
+    """If upstream changes its regexes, this guard is checking the wrong thing
+    and should be updated rather than trusted."""
+    dynamic = pytest.importorskip("transformers.dynamic_module_utils")
+    import inspect
+
+    source = inspect.getsource(dynamic.get_relative_imports)
+    assert r"from\s+\.(\S+)\s+import" in source
+    assert r"import\s+\.(\S+)\s*$" in source
+
+
+def test_transformers_can_walk_the_package_without_raising():
+    """The end-to-end version: run the function that crashed, on the files it
+    crashes from. A regex guard can go green on a rewrite that resolves to a
+    different nonexistent path; this cannot. It is also what found the 24 sites
+    the first pass missed."""
+    dynamic = pytest.importorskip("transformers.dynamic_module_utils")
+
+    for name in ("__init__.py", "device_type.py", "saving_utils.py", "loss_utils.py"):
+        files = dynamic.get_relative_import_files(str(ROOT / name))
+        missing = [f for f in files if not Path(f).is_file()]
+        assert not missing, f"walking {name} produced unopenable paths: {missing}"
+
+
+def test_the_import_it_died_on_is_actually_gone():
+    """The one the Paddle OCR run died on, named rather than implied."""
+    for name in ("__init__.py", "device_type.py"):
+        source = (ROOT / name).read_text(encoding = "utf-8")
+        assert "from .mlx.runtime import" not in source
+        assert "from unsloth_zoo.mlx.runtime import" in source
+
+
+def test_the_module_it_could_not_find_exists_and_is_nested():
+    """Confirms the diagnosis: nothing was missing from the wheel."""
+    assert (ROOT / "mlx" / "runtime.py").is_file()
+    assert not (ROOT / "mlx.runtime.py").exists()

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -150,7 +150,7 @@ if (os.environ.get("UNSLOTH_COMPILE_DEBUG", "0") == "1"):
 
 
 from importlib.util import find_spec
-from .mlx.runtime import is_mlx_available
+from unsloth_zoo.mlx.runtime import is_mlx_available
 from .model_lists import FORCE_FLOAT32
 
 # Import-time fixes live in ``unsloth/import_fixes.py`` and run at ``import
@@ -184,9 +184,9 @@ else:
 # instead of a hard ImportError. Inert in the download child, which never touches them.
 # On a normal CUDA/CPU run _SKIP_GPU_INIT is False and the real modules are untouched.
 if _SKIP_GPU_INIT:
-    from .stubs.triton_stub import inject_into_sys_modules as _inject_triton
+    from unsloth_zoo.stubs.triton_stub import inject_into_sys_modules as _inject_triton
     _inject_triton()
-    from .stubs.bitsandbytes_stub import inject_into_sys_modules as _inject_bnb
+    from unsloth_zoo.stubs.bitsandbytes_stub import inject_into_sys_modules as _inject_bnb
     _inject_bnb()
     del _inject_triton, _inject_bnb
 
@@ -503,14 +503,14 @@ if not _SKIP_GPU_INIT:
     # Log Unsloth-Zoo Utilities
     os.environ["UNSLOTH_ZOO_IS_PRESENT"] = "1"
 
-    from .temporary_patches import (
+    from unsloth_zoo.temporary_patches import (
         encode_conversations_with_harmony,
     )
 
     # Fused lm_head + cross_entropy auto-installer. On by default; set
     # UNSLOTH_FUSED_FORWARD=0 to disable.
     try:
-        from .fused_losses.forward_install import install_modeling_import_hook as _install_fused_forward
+        from unsloth_zoo.fused_losses.forward_install import install_modeling_import_hook as _install_fused_forward
         _install_fused_forward()
         del _install_fused_forward
     except Exception:

--- a/unsloth_zoo/_vendored/fla/utils/_decorators.py
+++ b/unsloth_zoo/_vendored/fla/utils/_decorators.py
@@ -18,7 +18,7 @@ from typing import Any
 import torch
 from packaging import version as package_version
 
-from .. import __version__
+from unsloth_zoo._vendored.fla import __version__
 from ._config import FLA_DISABLE_TENSOR_CACHE, FLA_TENSOR_CACHE_SIZE
 from ._device import custom_device_ctx
 

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -55,7 +55,7 @@ from importlib.metadata import version as importlib_version
 import functools
 from .compiler_replacements import compiler_replacements
 from . import DEVICE_TYPE
-from .temporary_patches.common import get_torch_compile_options
+from unsloth_zoo.temporary_patches.common import get_torch_compile_options
 from .hf_utils import get_transformers_model_type
 
 try:

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -689,7 +689,7 @@ def train_on_responses_only(
     # All Unsloth Zoo code licensed under LGPLv3
     if trainer is not None:
         try:
-            from .mlx.trainer import (
+            from unsloth_zoo.mlx.trainer import (
                 MLXTrainer,
                 train_on_responses_only as _mlx_train_on_responses_only,
             )

--- a/unsloth_zoo/device_type.py
+++ b/unsloth_zoo/device_type.py
@@ -31,7 +31,7 @@ __all__ = [
 
 import functools
 from .utils import Version
-from .mlx.runtime import is_mlx_available
+from unsloth_zoo.mlx.runtime import is_mlx_available
 import inspect
 import os
 import re

--- a/unsloth_zoo/flex_attention/utils.py
+++ b/unsloth_zoo/flex_attention/utils.py
@@ -35,7 +35,7 @@ __all__ = [
 
 import torch
 import functools
-from ..temporary_patches.common import torch_compile, _torch_compile
+from unsloth_zoo.temporary_patches.common import torch_compile, _torch_compile
 FLEX_ATTENTION_KV_INCREMENT = 512
 
 try:

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -26,8 +26,8 @@ import inspect
 import functools
 import math
 import os
-from ..temporary_patches.common import UNSLOTH_ENABLE_LOGGING, torch_compile_options, logger
-from ..device_type import DEVICE_TYPE
+from unsloth_zoo.temporary_patches.common import UNSLOTH_ENABLE_LOGGING, torch_compile_options, logger
+from unsloth_zoo.device_type import DEVICE_TYPE
         
 
 TARGET_GB = os.environ.get("UNSLOTH_CE_LOSS_TARGET_GB", None)

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -23,7 +23,7 @@ from typing import Optional
 torch_nn_functional_cross_entropy = torch.nn.functional.cross_entropy
 from triton import __version__ as triton_version
 from . import DEVICE_TYPE
-from .temporary_patches.common import UNSLOTH_ENABLE_LOGGING, torch_compile_options, logger
+from unsloth_zoo.temporary_patches.common import UNSLOTH_ENABLE_LOGGING, torch_compile_options, logger
 import inspect
 
 global HAS_CUT_CROSS_ENTROPY
@@ -74,7 +74,7 @@ __all__ = [
     "unsloth_fused_ce_loss",
 ]
 
-from .fused_losses import unsloth_fused_ce_loss
+from unsloth_zoo.fused_losses import unsloth_fused_ce_loss
 
 def patch_loss_functions(_fast_cross_entropy_loss, torch_compile = True):
     # All Unsloth Zoo code licensed under LGPLv3

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -105,7 +105,7 @@ def _is_force_float32_arch(model_type: str) -> bool:
     (strips ``-``/``_``; trailing comma marks an exact-match entry)."""
     if not model_type:
         return False
-    from ..model_lists import FORCE_FLOAT32
+    from unsloth_zoo.model_lists import FORCE_FLOAT32
     def _norm(s: str) -> str:
         return s.lower().replace("-", "").replace("_", "")
     norm_input = _norm(model_type)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4639,13 +4639,13 @@ class MLXTrainer:
                 from .loader import _fix_qwen35_attention_cache, _disable_fused_mrope
                 _fix_qwen35_attention_cache(model)
                 _disable_fused_mrope(model)
-                from ..gated_delta_vjp import patch_gated_delta, patch_gated_delta_vlm
+                from unsloth_zoo.gated_delta_vjp import patch_gated_delta, patch_gated_delta_vlm
                 patch_gated_delta()
                 patch_gated_delta_vlm()
                 gated_delta_patched = True
             # Structural check: qwen3_next / kimi_linear also need the VJP.
             if not gated_delta_patched and model_has_gated_delta_layers(model):
-                from ..gated_delta_vjp import patch_gated_delta
+                from unsloth_zoo.gated_delta_vjp import patch_gated_delta
                 patch_gated_delta()
             # Qwen2/2.5/3-VL language towers share the fused MRoPE kernel with
             # no VJP; flip it off so training takes the differentiable fallback.
@@ -8439,7 +8439,7 @@ def train_on_responses_only(
     Returns:
         The trainer (for chaining), or the closure if return_function=True.
     """
-    from ..dataset_utils import (
+    from unsloth_zoo.dataset_utils import (
         train_on_responses_only as _hf_train_on_responses_only,
     )
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -58,8 +58,8 @@ from typing import NamedTuple
 from packaging.version import Version as _Version
 
 
-from .cce import _get_runtime_cce
-from .cce.runtime_cce import _normalize_label_smoothing
+from unsloth_zoo.mlx.cce import _get_runtime_cce
+from unsloth_zoo.mlx.cce.runtime_cce import _normalize_label_smoothing
 
 
 _LLAMA_CPP_PATCHER_ENV_LOCK = threading.Lock()
@@ -1574,7 +1574,7 @@ def make_baseline_loss_fn(label_smoothing=0.0):
 # Image/vision/audio special tokens that should never contribute to loss.
 # Single source of truth shared with the CUDA collator (unsloth_zoo/vlm_tokens.py),
 # so the two backends cannot drift apart.
-from ..vlm_tokens import VLM_PLACEHOLDER_TOKENS
+from unsloth_zoo.vlm_tokens import VLM_PLACEHOLDER_TOKENS
 _IMAGE_TOKEN_STRINGS = tuple(VLM_PLACEHOLDER_TOKENS)
 
 
@@ -5566,7 +5566,7 @@ def _extract_vlm_images(
 
     if not images and isinstance(messages, list):
         try:
-            from ..vision_utils import process_vision_info
+            from unsloth_zoo.vision_utils import process_vision_info
 
             extracted = process_vision_info(messages, return_video_kwargs=True)
             if isinstance(extracted, tuple) and extracted:
@@ -5596,7 +5596,7 @@ def _extract_vlm_pc_images(item, prompt_messages, completion_messages, image_siz
 
     if isinstance(item, dict) and "images" in item:
         try:
-            from ..vision_utils import process_vision_info
+            from unsloth_zoo.vision_utils import process_vision_info
 
             raw_images = item["images"]
             vision_infos = [{"image": raw_images[i]} for i in range(len(raw_images))]
@@ -14518,7 +14518,7 @@ def _install_llama_cpp_macos(llama_cpp_folder="llama.cpp"):
         # Reuse the same guards the generic installer uses so a user-pointed
         # UNSLOTH_LLAMA_CPP_PATH that happens to be a non-source directory is
         # never wiped out from under the caller.
-        from ..llama_cpp import _is_safe_to_delete, UNSLOTH_PREBUILT_INFO_FILENAME
+        from unsloth_zoo.llama_cpp import _is_safe_to_delete, UNSLOTH_PREBUILT_INFO_FILENAME
         is_prebuilt_install = os.path.isfile(
             os.path.join(llama_cpp_folder, UNSLOTH_PREBUILT_INFO_FILENAME)
         )
@@ -14632,7 +14632,7 @@ def save_pretrained_gguf(
             compresses it to ``quantization_method``. Pass ``"f32"`` /
             ``"f16"`` / ``"bf16"`` to force a specific intermediate
     """
-    from ..llama_cpp import (
+    from unsloth_zoo.llama_cpp import (
         convert_to_gguf,
         quantize_gguf,
         check_llama_cpp,

--- a/unsloth_zoo/patch_torch_functions.py
+++ b/unsloth_zoo/patch_torch_functions.py
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 import os
-from .temporary_patches.common import torch_compile, UNSLOTH_ENABLE_LOGGING
+from unsloth_zoo.temporary_patches.common import torch_compile, UNSLOTH_ENABLE_LOGGING
 from .log import logger
 from torch import Tensor
 import torch

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -26,7 +26,7 @@ import logging
 import numpy as np
 from typing import Union, Callable, Optional, List, Dict
 from .device_type import DEVICE_TYPE, device_synchronize
-from .temporary_patches.common import (
+from unsloth_zoo.temporary_patches.common import (
     torch_compile_options,
     _maybe_compile,
 )

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -24,7 +24,7 @@ from .peft_utils import get_lora_layer_modules
 from .utils import _get_dtype, Version
 from .hf_utils import dtype_from_config
 from .device_type import DEVICE_TYPE, DEVICE_TYPE_TORCH, device_empty_cache
-from .temporary_patches.common import UNSLOTH_ENABLE_LOGGING, logger
+from unsloth_zoo.temporary_patches.common import UNSLOTH_ENABLE_LOGGING, logger
 from collections import defaultdict
 
 # Import each independently: convert_moe_packed_tensors_cpu is injected at runtime by Unsloth's

--- a/unsloth_zoo/temporary_patches/amd_aiter.py
+++ b/unsloth_zoo/temporary_patches/amd_aiter.py
@@ -95,7 +95,7 @@ def aiter_attention_forward(
     # Registration is AMD gated, but this is exported, directly callable, and the
     # gate behind it is cached at import. Re-check per call: `is_hip` is uncached
     # and cheap, and ROCm tensors report device.type "cuda", so both are needed.
-    from ..device_type import is_hip
+    from unsloth_zoo.device_type import is_hip
     if not is_hip() or not query.is_cuda:
         return _fallback()
 
@@ -115,7 +115,7 @@ def aiter_attention_forward(
                 and kwarg_value is not None and kwarg_value is not False):
             return _fallback()
 
-    from ..device_type import get_amd_flash_attn_func
+    from unsloth_zoo.device_type import get_amd_flash_attn_func
     flash_attn_func = get_amd_flash_attn_func()
     if flash_attn_func is None:
         return _fallback()
@@ -166,7 +166,7 @@ def aiter_attention_forward(
 def patch_amd_aiter_attention():
     """Register `aiter` as an attention backend when the hardware supports it."""
     try:
-        from ..device_type import get_amd_attention_implementation
+        from unsloth_zoo.device_type import get_amd_attention_implementation
         if get_amd_attention_implementation() != "amd_aiter":
             return  # NVIDIA, Intel, CPU, MLX, ROCm < 7, or an unsupported arch
         from transformers.modeling_utils import AttentionInterface

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -35,7 +35,7 @@ __all__ = [
 import os
 import sys
 import logging
-from ..log import logger
+from unsloth_zoo.log import logger
 import functools
 UNSLOTH_ENABLE_LOGGING  = os.environ.get("UNSLOTH_ENABLE_LOGGING",  "0") == "1"
 UNSLOTH_COMPILE_DISABLE = os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") in ("1", "partial",)

--- a/unsloth_zoo/temporary_patches/deepseek_v3_moe.py
+++ b/unsloth_zoo/temporary_patches/deepseek_v3_moe.py
@@ -38,7 +38,7 @@ from .utils import (
     Cache,
     process_return,
 )
-from ..hf_utils import dtype_from_config
+from unsloth_zoo.hf_utils import dtype_from_config
 from .moe_utils import (
     patch_param_wrapper_for_moe,
     get_forward_moe_backend,

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -31,7 +31,7 @@ from .common import (
     logger,
 )
 from importlib.metadata import version as importlib_version
-from ..utils import Version
+from unsloth_zoo.utils import Version
 transformers_version = Version(importlib_version("transformers"))
 has_static_cache = transformers_version >= Version("4.56.0.dev0")
 from .utils import (
@@ -44,7 +44,7 @@ from .utils import (
     Cache,
     process_return,
 )
-from ..hf_utils import dtype_from_config
+from unsloth_zoo.hf_utils import dtype_from_config
 torch_cuda_device = torch.cuda.device
 
 # UNSLOTH_MXFP4_NO_DEQUANTIZE=1 keeps MXFP4 quantized (needs triton_kernels); else dequantized to bf16 for LoRA.
@@ -1386,7 +1386,7 @@ TEMPORARY_PATCHES.append(patch_gpt_oss_bnb4bit_auto)
 
 
 # Combo kernels uses too much VRAM for low memory GPUs
-from ..device_type import DEVICE_TYPE
+from unsloth_zoo.device_type import DEVICE_TYPE
 
 # UNSLOTH_ALLOW_CPU=1 keeps DEVICE_TYPE="cuda" on GPU-less hosts, so guard
 # with is_available() like device_synchronize() does.
@@ -2079,7 +2079,7 @@ def patch_GptOssAttention():
     if UNSLOTH_COMPILE_DISABLE: return
     if "gpt_oss" not in _normalized_unsloth_model_name(): return
     try:
-        from ..flex_attention import (
+        from unsloth_zoo.flex_attention import (
             flex_attention_with_sink,
             is_flex_attention_decoding,
             flex_attention_with_sink_decoding,
@@ -2519,7 +2519,7 @@ def patch_GptOssModel():
             mk["cache_position"] = cache_position
         return mk
 
-    from ..flex_attention import (
+    from unsloth_zoo.flex_attention import (
         is_flex_attention_decoding,
         flex_attention_with_sink_decoding,
         flex_attention_add_sinks,

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -26,7 +26,7 @@ import functools
 # `unsloth_zoo.temporary_patches.misc`, where a two-level relative import
 # raises "attempted relative import beyond top-level package".
 try:
-    from ..log import logger
+    from unsloth_zoo.log import logger
 except (ImportError, ValueError):
     import logging
     logger = logging.getLogger("unsloth_zoo.log")

--- a/unsloth_zoo/temporary_patches/moe_bnb.py
+++ b/unsloth_zoo/temporary_patches/moe_bnb.py
@@ -27,7 +27,7 @@ import torch.nn.functional as F
 from typing import Optional, List, Any, Tuple
 import os
 import warnings
-from ..log import logger
+from unsloth_zoo.log import logger
 
 UNSLOTH_ENABLE_LOGGING = os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1"
 

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -54,7 +54,7 @@ try:
 except:
     from typing_extensions import _TypedDictMeta as t_TypedDictMeta
 
-from ..utils import Version
+from unsloth_zoo.utils import Version
 from .common import UNSLOTH_ENABLE_LOGGING, UNSLOTH_COMPILE_DISABLE, torch_compile_options, logger, unwrap_already_compiled
 
 EMPTY = inspect._empty

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -60,7 +60,7 @@ from .hf_utils import (
     set_dtype_in_config,
 )
 from .patching_utils import patch_model_and_tokenizer
-from .temporary_patches.common import (
+from unsloth_zoo.temporary_patches.common import (
     get_torch_compile_options,
     UNSLOTH_ENABLE_LOGGING,
 )


### PR DESCRIPTION
`Paddle_OCR_(1B)_Vision` dies at the trainer's first checkpoint save:

```
FileNotFoundError: [Errno 2] No such file or directory:
'/usr/local/lib/python3.12/dist-packages/unsloth_zoo/mlx.runtime.py'
```

Nothing is missing from the wheel. That path is built by transformers, in `dynamic_module_utils.get_relative_imports`, which pastes whatever its regex captures after the directory and `.py`. It does not translate dots into separators, does not strip further leading dots, and does not consider that the target might be a package. Three shapes break:

| written | transformers opens |
|---|---|
| `from .mlx.runtime import x` | `unsloth_zoo/mlx.runtime.py` |
| `from .temporary_patches import x` | `unsloth_zoo/temporary_patches.py` (a directory) |
| `from .. import __version__` | `unsloth_zoo/mlx/..py` |

It reaches unsloth_zoo because a remote-code model takes the `custom_object_save` path on save, which walks relative imports recursively. One unresolvable import anywhere in that graph is a crash at checkpoint time, on a code path with nothing to do with the import.

36 sites across 18 files are now absolute. `from . import x` is untouched: the regex needs at least one non-space character after the dot, so it never matches it, and `from .sibling import x` resolves to a file that exists.

### Tests

`tests/test_relative_imports_resolve.py` asserts resolvability rather than dottedness, and runs `get_relative_import_files` itself against the package entry points. That end-to-end check is what found the 24 sites a dotted-only pass had missed.

Suite: 4726 passed. The 8 Gemma3n failures and 3 order-dependent rmsnorm recompile-budget failures are present on main and unaffected by this change.