### PR TITLE
Read the Gemma4 merge dtype from the definition that reaches it

### DIFF
--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -195,6 +195,15 @@ def _gemma4_modeling_source():
     return pathlib.Path(inspect.getsourcefile(real_gemma4)).read_text()
 
 
+def _feature_assignments(src, modality):
+    """Every line in ``src`` that BINDS ``<modality>_features``, stripped."""
+    return [
+        line.strip()
+        for line in src.splitlines()
+        if re.match(rf"\s*{modality}_features\s*=", line)
+    ]
+
+
 @requires_gemma4
 def test_real_gemma4_audio_merge_site_is_recognized():
     src = _gemma4_modeling_source()
@@ -210,12 +219,50 @@ def test_real_gemma4_audio_merge_site_is_recognized():
 
 
 @requires_gemma4
-def test_real_gemma4_image_and_video_merges_still_cast_dtype():
+@pytest.mark.parametrize("modality", ["image", "video"])
+def test_real_gemma4_image_and_video_merges_still_cast_dtype(modality):
     # Regression anchor: image/video have always cast dtype; if upstream ever
     # drops it there too, that is a new modality that also needs patching.
-    src = _gemma4_modeling_source()
-    assert "image_features.to(inputs_embeds.device, inputs_embeds.dtype)" in src
-    assert "video_features.to(inputs_embeds.device, inputs_embeds.dtype)" in src
+    #
+    # Asked of the ASSIGNMENTS rather than of one exact call spelling. Upstream
+    # reshaped the image branch to
+    #
+    #   image_features = torch.cat(image_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
+    #
+    # which still casts, but no longer contains the literal
+    # "image_features.to(inputs_embeds.device, inputs_embeds.dtype)". Only the
+    # spelling moved, so a substring match failed on a file that is still
+    # correct -- the guard fired at the wrong thing. What actually matters is
+    # that SOMETHING binds <modality>_features to a value carrying
+    # inputs_embeds.dtype before the masked_scatter, and that survives a
+    # rename of whatever produced the tensor.
+    assignments = _feature_assignments(_gemma4_modeling_source(), modality)
+    assert assignments, f"no {modality}_features assignment found at all"
+    assert any("inputs_embeds.dtype" in line for line in assignments), (
+        f"Gemma4 {modality} merge no longer casts to inputs_embeds.dtype: "
+        f"{assignments}. That is a modality the unsloth dtype patches do not "
+        f"cover, and masked_scatter will raise on a dtype mismatch."
+    )
+
+
+def test_the_dtype_cast_guard_can_actually_fail():
+    """The guard above is a search, so it is worth proving it does not always find.
+
+    Runs without gemma4 installed, unlike the guard itself, which is the point: a
+    guard that only ever runs on hosts with the newest transformers is one nobody
+    notices going vacuous."""
+    casts = "    image_features = torch.cat(x, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)\n"
+    older = "    image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
+    device_only = "    image_features = image_features.to(inputs_embeds.device)\n"
+
+    def _ok(src):
+        found = _feature_assignments(src, "image")
+        return bool(found) and any("inputs_embeds.dtype" in line for line in found)
+
+    assert _ok(casts), "the current upstream spelling must pass"
+    assert _ok(older), "the spelling this guard used to match must still pass"
+    assert not _ok(device_only), "a device-only merge must fail"
+    assert not _feature_assignments(device_only, "video"), "and it must not match another modality"
 
 
 @requires_gemma4


### PR DESCRIPTION
Core (HF=latest + TRL=latest) is red on main:

```
FAILED tests/test_gemma4_dtype_drift_guards.py::test_real_gemma4_image_and_video_merges_still_cast_dtype
```

### What broke

The guard is a substring search for

```
image_features.to(inputs_embeds.device, inputs_embeds.dtype)
```

and transformers reshaped that branch. `Gemma4Model.forward` at v5.15.0 reads

```python
image_features = self.get_image_features(pixel_values, image_position_ids, return_dict=True).pooler_output
image_features = torch.cat(image_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
...
inputs_embeds = inputs_embeds.masked_scatter(
    image_mask.to(inputs_embeds.device), image_features.to(inputs_embeds.device)
)
```

The cast is still there, it just moved into the `torch.cat` that builds the
tensor, so the literal the guard grepped for is gone. Only the spelling moved.

Checked against the versions rather than assumed:

| transformers | image | video | audio |
| --- | --- | --- | --- |
| 5.5.0 | `image_features = image_features.to(device, dtype)` | same shape | device only, the known upstream bug |
| 5.15.0 | cast folded into `torch.cat(...)` | unchanged | now casts dtype at the merge |

That is exactly the observed failure: at v5.15.0 the old substring is absent
for image and present for video, so the first assert goes red and the second
would have passed. Nothing is wrong with the file, and nothing is wrong with
the patches. Audio, which is what these guards were written for, is now fixed
upstream, and `test_real_gemma4_audio_merge_site_is_recognized` already accepts
either form.

### What the fix does

The guard is about the tensor that reaches the merge, not about one call
spelling, so it now asks that structurally. Walk the AST, find the
`masked_scatter` that consumes `<modality>_features`, and check whether
`inputs_embeds.dtype` is applied either in the scattered expression itself or
in the last assignment that reaches it. Positional `.to(device, dtype)` and
keyword `dtype=` both count. A merge that cannot be found at all is a failure,
not a silent pass.

Reading the reaching definition rather than searching the file is what keeps
this a real guard: a good cast that a later device-only rebinding undoes, or a
cast that lives in some other method, does not satisfy it.

Parametrised over image and video so a failure names the modality instead of
leaving two asserts in one test.

`_MERGE_SHAPES` pins the behaviour on eight small sources and runs WITHOUT
gemma4 installed, which is the point: a guard that only runs on hosts with the
newest transformers is one nobody notices going vacuous. It covers the 5.5.0
shape, the 5.15.0 `torch.cat` shape, a cast written at the merge, the keyword
form, and the four ways this should go red.

### Verified

- `tests/test_gemma4_dtype_drift_guards.py`: 35 passed on transformers 5.5.0
  and 35 passed on 5.15.0. On main the same file is 25 passed on 5.5.0 and
  1 failed / 24 passed on 5.15.0.
- Negative check on the real file: dropping `inputs_embeds.dtype` from the
  v5.15.0 `torch.cat` line makes the guard fail with
  `the image_features binding reaching the merge at line 2336 does not cast to
  inputs_embeds.dtype`, then passes again once restored.
- Full `tests/` on transformers 5.15.0 + trl 1.9.2: 4470 passed, 297 skipped,
  9 failed. All 9 fail identically on unmodified main in this environment
  (they need `unsloth` installed and a generated trainer), and none of them
  touch gemma4.
