### PR TITLE
Cap the activation reserve per device, not by the smallest cap

### DIFF
--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1206,3 +1206,72 @@ def test_the_head_card_reserve_still_cannot_go_negative():
     )
     assert plan is not None
     assert all(v >= 0 for v in plan.activation_reserve_by_device.values())
+
+
+class _WideBlock(nn.Module):
+    """A decoder block chunky enough that the packing has real granularity.
+
+    `_Block` is a single square Linear, so on any budget the greedy walk fits at
+    the first try and the relaxation ladder below is never exercised.
+    """
+    def __init__(self, hidden, ffn, dtype):
+        super().__init__()
+        self.attn = nn.Linear(hidden, hidden, bias = False, dtype = dtype)
+        self.mlp = nn.Linear(hidden, ffn, bias = False, dtype = dtype)
+        self.down = nn.Linear(ffn, hidden, bias = False, dtype = dtype)
+
+
+class _Wide(nn.Module):
+    _no_split_modules = ["_WideBlock"]
+
+    def __init__(self, hidden, ffn, vocab, layers, dtype = torch.bfloat16):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab, hidden, dtype = dtype)
+        self.layers = nn.ModuleList(
+            [_WideBlock(hidden, ffn, dtype) for _ in range(layers)]
+        )
+        self.norm = nn.LayerNorm(hidden, dtype = dtype)
+        self.lm_head = nn.Linear(hidden, vocab, bias = False, dtype = dtype)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+
+def test_the_relaxed_reserve_is_never_below_the_old_shared_cap():
+    """Per-device reserves must not lose ground on identical cards.
+
+    The reserve is a range now, not one number, and `attempt` relaxes the
+    non-head cards from the TOP of it in 5% steps. On identical cards the top
+    sits one headroom-share above the bottom -- a fraction of a percent -- so a
+    request that misses by that fraction is answered by a whole 5% step, and the
+    cards end up keeping LESS than the single shared cap used to give them.
+
+    Measured here: 4 identical cards, a 24-layer model at ~65% of their total,
+    shared cap 3.043 GiB per card, stepping from the top alone 2.981 GiB. The
+    same shape at 4 x 80 GiB lost 1.97 GiB per card.
+    """
+    kw = dict(hidden = 4096, ffn = 16384, vocab = 152064, layers = 24)
+    with torch.device("meta"):
+        model = _Wide(**kw)
+    n, budget = 4, 6086993920
+
+    plan = plan_device_map(model, max_memory = {d: budget for d in range(n)})
+    assert plan is not None
+
+    # What a single shared `min` cap across the devices would have produced.
+    total = plan.total_weight_bytes
+    headroom = plan.headroom_bytes
+    head_bytes = model.lm_head.weight.numel() * model.lm_head.weight.element_size()
+    value = max(0, (n * budget - total - headroom) // n)
+    share = max(-(-total // n), head_bytes)
+    shared_cap = max(0, min(value, budget - share - headroom))
+    assert shared_cap > 0, "fixture no longer exercises the cap"
+
+    kept = plan.activation_reserve_by_device
+    assert min(kept.values()) >= shared_cap, (
+        f"the relaxation ladder landed below the old shared cap: kept {kept}, "
+        f"shared cap {shared_cap}"
+    )

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -267,10 +267,10 @@ class _Sized(nn.Module):
 class _Bins(nn.Module):
     _no_split_modules = ["_Sized"]
 
-    def __init__(self, sizes):
+    def __init__(self, sizes, head = 1):
         super().__init__()
         self.parts = nn.ModuleList([_Sized(n) for n in sizes])
-        self.lm_head = nn.Linear(1, 1, bias = False)
+        self.lm_head = nn.Linear(head, 1, bias = False)
 
     def get_output_embeddings(self):
         return self.lm_head
@@ -1274,4 +1274,37 @@ def test_the_relaxed_reserve_is_never_below_the_old_shared_cap():
     assert min(kept.values()) >= shared_cap, (
         f"the relaxation ladder landed below the old shared cap: kept {kept}, "
         f"shared cap {shared_cap}"
+    )
+
+
+def test_the_head_relaxation_ladder_also_keeps_the_old_shared_floor():
+    """The same loss, one ladder further down.
+
+    Merging the floor into the rungs fixed the loop that relaxes only the
+    NON-head cards. The last-resort loop below it, which relaxes the head's own
+    reserve too, kept scaling the per-device reserve from the top alone, so it
+    could still land under what a single shared cap would have kept.
+
+    Byte-exact here rather than approximated. Two units of 20 and 400 bytes and
+    an 80-byte head on budgets 300 and 590 with 22 bytes of headroom: weights
+    500, so the equal share is 250, the caps are 50 (cuda:0) and 318 (cuda:1,
+    the head) and the balanced value is 184. cuda:1 must hold the 400-byte unit,
+    which needs its reserve down to 88, so every rung of the first loop -- all of
+    which keep cuda:1 on its full 184 -- fails, and the last resort scales BOTH
+    cards down in 5% steps until cuda:1 fits. It lands at 82/22, and cuda:0 is
+    left with 22 bytes where the old shared cap of 50 fit perfectly well: the
+    placement is identical either way, so the 28 bytes bought nothing.
+    """
+    with torch.device("meta"):
+        model = _Bins([5, 100], head = 20)
+    plan = plan_device_map(
+        model,
+        max_memory = {0: 300, 1: 590},
+        headroom_bytes = 22,
+    )
+    assert plan is not None
+    assert plan.weight_bytes == {0: 20, 1: 480}
+    kept = plan.activation_reserve_by_device
+    assert min(kept.values()) >= 50, (
+        f"the last-resort ladder landed below the old shared cap of 50: {kept}"
     )

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1126,3 +1126,83 @@ def test_the_auto_reserve_relaxes_on_the_head_as_a_last_resort():
     assert plan.device_map["layers.0"] == 1
     # The headroom survives in full; only the activation reserve gave way.
     assert plan.raw_budgets[1] - plan.weight_bytes[1] >= headroom
+
+
+def _muse_shaped_budgets(model):
+    """Budgets that reproduce the Muse Glimmer arithmetic on a toy model.
+
+    The bug needs three things at once, and a model whose weights are
+    negligible against the budgets satisfies none of them:
+
+        headroom > B - W/2      the head's cap goes negative
+        headroom < 2B - W       the balanced reserve is still positive
+        B >= head + headroom    the head's card can actually hold its own
+
+    Solve for B and headroom from the model's real sizes rather than picking
+    round numbers, so the test states the condition instead of hoping for it.
+    """
+    sizes = {n: p.numel() * p.element_size()
+             for n, p in model.named_parameters()}
+    total = sum(sizes.values())
+    head = sizes["lm_head.weight"]
+    budget = 3 * total // 2
+    # Inside (budget - total/2, budget - head], which is non-empty exactly
+    # when head < total/2.
+    assert head < total // 2, "fixture no longer has a head under half the weights"
+    headroom = (budget - total // 2 + budget - head) // 2
+    assert budget - total // 2 < headroom <= budget - head
+    assert headroom < 2 * budget - total
+    return budget, headroom
+
+
+def test_a_negative_cap_on_the_head_does_not_zero_the_other_cards():
+    """The Muse Glimmer shape, in miniature.
+
+    Measured on Kaggle-Muse_Glimmer_(30B)-GRPO across 2 x 14.56 GiB: budgets
+    13.104 GiB each after the quantiser's haircut, 20.310 GiB of weights and
+    4.104 GiB of logit headroom. The balanced reserve worked out at 0.897 GiB
+    and the per-device caps at +2.949 (cuda:0) and -1.155 (cuda:1, the head).
+    Capping by the MINIMUM across devices took the head's negative cap and
+    applied it everywhere, so both cards got a 0.000 GiB reserve, cuda:0 was
+    packed to within 0.161 GiB, and training OOMed on its first 254 MiB
+    allocation while cuda:1 sat on 5.737 GiB of unused memory.
+
+    A card that does not pay the headroom must keep its own reserve.
+    """
+    model = _meta(hidden = 256, vocab = 8192, layers = 16)
+    budget, headroom = _muse_shaped_budgets(model)
+    plan = plan_device_map(
+        model,
+        max_memory = {0: budget, 1: budget},
+        headroom_bytes = headroom,
+    )
+    assert plan is not None
+    reserves = plan.activation_reserve_by_device
+    head_device = plan.device_map[
+        next(n for n in plan.device_map if n.endswith("lm_head"))
+    ]
+    others = [d for d in reserves if d != head_device]
+    assert others, "expected a non-head device to exist"
+    assert any(reserves[d] > 0 for d in others), (
+        f"every non-head card was given a zero activation reserve "
+        f"({reserves}); the head's negative cap has leaked onto them again"
+    )
+
+
+def test_the_head_card_reserve_still_cannot_go_negative():
+    """The property the shared cap was originally added for.
+
+    `attempt` only ever relaxes the reserve on the OTHER cards, so a negative
+    reserve on the head's own card makes every step infeasible and the plan is
+    refused outright. Clamping each device at zero individually has to keep
+    that from happening.
+    """
+    model = _meta(hidden = 256, vocab = 8192, layers = 16)
+    budget, headroom = _muse_shaped_budgets(model)
+    plan = plan_device_map(
+        model,
+        max_memory = {0: budget, 1: budget},
+        headroom_bytes = headroom,
+    )
+    assert plan is not None
+    assert all(v >= 0 for v in plan.activation_reserve_by_device.values())

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1138,8 +1138,8 @@ def _muse_shaped_budgets(model):
         headroom < 2B - W       the balanced reserve is still positive
         B >= head + headroom    the head's card can actually hold its own
 
-    Solve for B and headroom from the model's real sizes rather than picking
-    round numbers, so the test states the condition instead of hoping for it.
+    So solve for B and headroom from the model's real sizes rather than
+    picking round numbers and hoping.
     """
     sizes = {n: p.numel() * p.element_size()
              for n, p in model.named_parameters()}
@@ -1159,15 +1159,13 @@ def test_a_negative_cap_on_the_head_does_not_zero_the_other_cards():
     """The Muse Glimmer shape, in miniature.
 
     Measured on Kaggle-Muse_Glimmer_(30B)-GRPO across 2 x 14.56 GiB: budgets
-    13.104 GiB each after the quantiser's haircut, 20.310 GiB of weights and
-    4.104 GiB of logit headroom. The balanced reserve worked out at 0.897 GiB
-    and the per-device caps at +2.949 (cuda:0) and -1.155 (cuda:1, the head).
-    Capping by the MINIMUM across devices took the head's negative cap and
-    applied it everywhere, so both cards got a 0.000 GiB reserve, cuda:0 was
-    packed to within 0.161 GiB, and training OOMed on its first 254 MiB
-    allocation while cuda:1 sat on 5.737 GiB of unused memory.
-
-    A card that does not pay the headroom must keep its own reserve.
+    13.104 GiB each after the quantiser's haircut, 20.310 GiB of weights,
+    4.104 GiB of logit headroom, so a balanced reserve of 0.897 GiB and
+    per-device caps of +2.949 (cuda:0) and -1.155 (cuda:1, the head). Capping
+    by the MINIMUM applied the head's negative cap everywhere: both cards got
+    0.000 GiB, cuda:0 was packed to within 0.161 GiB and training OOMed on its
+    first 254 MiB allocation while cuda:1 sat on 5.737 GiB unused. A card that
+    does not pay the headroom must keep its own reserve.
     """
     model = _meta(hidden = 256, vocab = 8192, layers = 16)
     budget, headroom = _muse_shaped_budgets(model)
@@ -1193,9 +1191,8 @@ def test_the_head_card_reserve_still_cannot_go_negative():
     """The property the shared cap was originally added for.
 
     `attempt` only ever relaxes the reserve on the OTHER cards, so a negative
-    reserve on the head's own card makes every step infeasible and the plan is
-    refused outright. Clamping each device at zero individually has to keep
-    that from happening.
+    reserve on the head's own card makes every step infeasible and refuses the
+    plan outright. Clamping each device at zero has to keep that from happening.
     """
     model = _meta(hidden = 256, vocab = 8192, layers = 16)
     budget, headroom = _muse_shaped_budgets(model)
@@ -1211,8 +1208,8 @@ def test_the_head_card_reserve_still_cannot_go_negative():
 class _WideBlock(nn.Module):
     """A decoder block chunky enough that the packing has real granularity.
 
-    `_Block` is a single square Linear, so on any budget the greedy walk fits at
-    the first try and the relaxation ladder below is never exercised.
+    `_Block` is a single square Linear, so the greedy walk fits at the first
+    try and the relaxation ladder below is never exercised.
     """
     def __init__(self, hidden, ffn, dtype):
         super().__init__()
@@ -1243,15 +1240,14 @@ class _Wide(nn.Module):
 def test_the_relaxed_reserve_is_never_below_the_old_shared_cap():
     """Per-device reserves must not lose ground on identical cards.
 
-    The reserve is a range now, not one number, and `attempt` relaxes the
-    non-head cards from the TOP of it in 5% steps. On identical cards the top
-    sits one headroom-share above the bottom -- a fraction of a percent -- so a
-    request that misses by that fraction is answered by a whole 5% step, and the
-    cards end up keeping LESS than the single shared cap used to give them.
-
-    Measured here: 4 identical cards, a 24-layer model at ~65% of their total,
-    shared cap 3.043 GiB per card, stepping from the top alone 2.981 GiB. The
-    same shape at 4 x 80 GiB lost 1.97 GiB per card.
+    The reserve is a range now, and `attempt` relaxes the non-head cards from
+    the TOP of it in 5% steps. On identical cards the top sits one
+    headroom-share above the bottom -- a fraction of a percent -- so a request
+    missing by that fraction is answered by a whole 5% step and the cards keep
+    LESS than the single shared cap used to give them. Measured here: 4
+    identical cards, a 24-layer model at ~65% of their total, shared cap 3.043
+    GiB per card against 2.981 GiB stepping from the top alone. The same shape
+    at 4 x 80 GiB lost 1.97 GiB per card.
     """
     kw = dict(hidden = 4096, ffn = 16384, vocab = 152064, layers = 24)
     with torch.device("meta"):
@@ -1282,18 +1278,18 @@ def test_the_head_relaxation_ladder_also_keeps_the_old_shared_floor():
 
     Merging the floor into the rungs fixed the loop that relaxes only the
     NON-head cards. The last-resort loop below it, which relaxes the head's own
-    reserve too, kept scaling the per-device reserve from the top alone, so it
-    could still land under what a single shared cap would have kept.
+    reserve too, kept scaling from the top alone, so it could still land under
+    what a single shared cap would have kept.
 
-    Byte-exact here rather than approximated. Two units of 20 and 400 bytes and
-    an 80-byte head on budgets 300 and 590 with 22 bytes of headroom: weights
-    500, so the equal share is 250, the caps are 50 (cuda:0) and 318 (cuda:1,
-    the head) and the balanced value is 184. cuda:1 must hold the 400-byte unit,
-    which needs its reserve down to 88, so every rung of the first loop -- all of
-    which keep cuda:1 on its full 184 -- fails, and the last resort scales BOTH
-    cards down in 5% steps until cuda:1 fits. It lands at 82/22, and cuda:0 is
-    left with 22 bytes where the old shared cap of 50 fit perfectly well: the
-    placement is identical either way, so the 28 bytes bought nothing.
+    Byte-exact here. Two units of 20 and 400 bytes and an 80-byte head on
+    budgets 300 and 590 with 22 bytes of headroom: weights 500, so the equal
+    share is 250, the caps are 50 (cuda:0) and 318 (cuda:1, the head) and the
+    balanced value is 184. cuda:1 must hold the 400-byte unit, which needs its
+    reserve down to 88, so every rung of the first loop -- all keeping cuda:1
+    on its full 184 -- fails and the last resort scales BOTH cards down in 5%
+    steps until cuda:1 fits. It lands at 82/22, leaving cuda:0 with 22 bytes
+    where the old shared cap of 50 fit perfectly well: the placement is
+    identical either way, so the 28 bytes bought nothing.
     """
     with torch.device("meta"):
         model = _Bins([5, 100], head = 20)

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -1050,9 +1050,26 @@ def plan_device_map(
         constraint, so an explicit reserve either fits or the plan is refused.
         """
         reserve = reserve_for(head_device)
-        steps = 1 if reserve_is_explicit else 21
-        for step in range(steps):
-            r = _fill(head_device, reserve, max(reserve.values()) * (20 - step) // 20)
+        # Rungs for the non-head cards, from two ladders merged. The reserve is
+        # per device now, so it is a range, not one number: the top is what we
+        # would like every card to keep, the bottom is exactly what the old
+        # shared `min` cap handed all of them. Stepping only from the top can
+        # land BELOW that bottom -- a request one percent larger overshoots by a
+        # whole 5% rung -- so 4 x 80 GiB holding a 144 GiB model kept 41.72 GiB
+        # per card where the shared cap kept 43.68 GiB. Merging both ladders
+        # keeps every rung the shared cap used to try, in the same order, so the
+        # relaxed result can only be larger.
+        top, floor = max(reserve.values()), min(reserve.values())
+        if reserve_is_explicit:
+            rungs = [top]
+        else:
+            rungs = sorted(
+                {top * (20 - step) // 20 for step in range(21)} |
+                {floor * (20 - step) // 20 for step in range(21)},
+                reverse = True,
+            )
+        for other in rungs:
+            r = _fill(head_device, reserve, other)
             if r is not None:
                 return r
         if reserve_is_explicit:

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -1006,10 +1006,32 @@ def plan_device_map(
                 # is refused. A four-layer model whose head is larger than half
                 # the weights (share 24 KiB, head 32 KiB) was rejected on
                 # 2 x 8 GiB for exactly that reason.
+                # Capped PER DEVICE, not by the smallest cap across all of
+                # them. A single `min` lets the head's card -- the only one
+                # that pays the headroom, and so the only one whose cap can go
+                # negative -- drive the reserve to zero on cards that had room
+                # for one. Measured on Kaggle-Muse_Glimmer_(30B)-GRPO, 2 x
+                # 14.56 GiB: budgets 13.104 each, weights 20.310, headroom
+                # 4.104, so value 0.897 GiB and caps 2.949 (cuda:0) and -1.155
+                # (cuda:1, the head). The min was -1.155, both cards got a
+                # 0.000 GiB reserve, cuda:0 was packed to within 0.161 GiB and
+                # the run OOMed at the first training step asking for 254 MiB.
+                # cuda:1 finished with 5.737 GiB unused.
+                #
+                # Clamping each device at 0 individually keeps the property
+                # the shared cap was added for: the head's own reserve still
+                # cannot go negative, so `attempt` -- which only relaxes the
+                # OTHER cards -- is never handed an infeasible head budget.
                 share = max(-(-total // len(devices)), pinned_bytes)
-                cap = min(raw_budgets[d] - share - (headroom if d == head_device else 0)
-                          for d in devices)
-                value = int(max(0, min(value, cap)))
+                per_device = {
+                    d: int(max(0, min(
+                        value,
+                        raw_budgets[d] - share
+                        - (headroom if d == head_device else 0),
+                    )))
+                    for d in devices
+                }
+                return per_device
             else:
                 # Mirror accelerate: reserve the largest single placement unit.
                 value = max((s for _, s in units), default=0)

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -1006,22 +1006,19 @@ def plan_device_map(
                 # is refused. A four-layer model whose head is larger than half
                 # the weights (share 24 KiB, head 32 KiB) was rejected on
                 # 2 x 8 GiB for exactly that reason.
-                # Capped PER DEVICE, not by the smallest cap across all of
-                # them. A single `min` lets the head's card -- the only one
-                # that pays the headroom, and so the only one whose cap can go
-                # negative -- drive the reserve to zero on cards that had room
-                # for one. Measured on Kaggle-Muse_Glimmer_(30B)-GRPO, 2 x
-                # 14.56 GiB: budgets 13.104 each, weights 20.310, headroom
-                # 4.104, so value 0.897 GiB and caps 2.949 (cuda:0) and -1.155
-                # (cuda:1, the head). The min was -1.155, both cards got a
-                # 0.000 GiB reserve, cuda:0 was packed to within 0.161 GiB and
-                # the run OOMed at the first training step asking for 254 MiB.
-                # cuda:1 finished with 5.737 GiB unused.
-                #
-                # Clamping each device at 0 individually keeps the property
-                # the shared cap was added for: the head's own reserve still
-                # cannot go negative, so `attempt` -- which only relaxes the
-                # OTHER cards -- is never handed an infeasible head budget.
+                # Cap PER DEVICE, not by the smallest cap across all of them:
+                # a single `min` lets the head's card -- the only one paying
+                # the headroom, so the only one whose cap can go negative --
+                # zero the reserve on cards that had room for one. Measured on
+                # Kaggle-Muse_Glimmer_(30B)-GRPO, 2 x 14.56 GiB: budgets 13.104
+                # each, weights 20.310, headroom 4.104, so value 0.897 GiB and
+                # caps 2.949 (cuda:0) and -1.155 (cuda:1, the head). That min
+                # gave both cards a 0.000 GiB reserve, cuda:0 was packed to
+                # within 0.161 GiB and the run OOMed on the first training
+                # step's 254 MiB while cuda:1 left 5.737 GiB unused. Clamping
+                # each device at 0 still keeps the head's own reserve
+                # non-negative, so `attempt` -- which only relaxes the OTHER
+                # cards -- is never handed an infeasible head budget.
                 share = max(-(-total // len(devices)), pinned_bytes)
                 per_device = {
                     d: int(max(0, min(
@@ -1053,29 +1050,23 @@ def plan_device_map(
         if reserve_is_explicit:
             return _fill(head_device, reserve, max(reserve.values()))
 
-        # The reserve is per device now, so it is a range, not one number: the
-        # top is what we would like every card to keep, the floor is exactly
-        # what the old shared `min` cap handed all of them (`min` of a clamp is
-        # the clamp of the `min`). Relaxing from the top alone can therefore
-        # land BELOW what the old planner kept -- a request that misses by one
-        # percent is answered by a whole 5% rung -- so 4 x 80 GiB holding a
-        # 144 GiB model kept 41.72 GiB per card where the shared cap kept 43.68.
+        # The reserve is per device now, so it is a range: the top is what we
+        # would like every card to keep, the floor is exactly what the old
+        # shared `min` cap handed all of them (`min` of a clamp is the clamp of
+        # the `min`). Relaxing from the top alone can land BELOW that floor --
+        # a request missing by one percent is answered by a whole 5% rung -- so
+        # 4 x 80 GiB holding a 144 GiB model kept 41.72 GiB per card where the
+        # shared cap kept 43.68.
         #
-        # So try every rung EITHER planner would have tried, best first. The
-        # candidates are the reserves actually kept per device:
-        #
-        #   A  relax only the non-head cards, from the per-device range
-        #   B  the old shared ladder: every card on the floor, non-head cards
-        #      stepped down from it
-        #   C  last resort, relax the head's own reserve too, per device
-        #   D  last resort on the old shared ladder
-        #
-        # B and D are the old planner's two ladders, rung for rung, so its
-        # result is always in this set; ordering by the smallest reserve any
-        # card keeps means the accepted plan can never keep less than it did.
-        # C exists because the loop that only relaxes the OTHER cards can miss
-        # the head's card by less than its reserve and refuse a model that fits.
-        # The logit headroom is never touched by any of them.
+        # So try every rung EITHER planner would have tried, best first: the
+        # non-head cards stepped down from the per-device range and from the
+        # old shared floor, then both ladders again with the head's own reserve
+        # relaxed too. The old planner's ladders are in that set rung for rung,
+        # and ordering by the smallest reserve any card keeps means the
+        # accepted plan can never keep less than it did. The head-relaxing
+        # rungs exist because relaxing only the OTHER cards can miss the head's
+        # card by less than its reserve and refuse a model that fits. The logit
+        # headroom is never touched by any of them.
         top, floor = max(reserve.values()), min(reserve.values())
         rungs = sorted(
             {top * (20 - step) // 20 for step in range(21)} |
@@ -1100,9 +1091,8 @@ def plan_device_map(
                 continue
             seen.add(key)
             ordered.append(kept)
-        # Most-kept first: the smallest reserve on any card, then the head's own,
-        # then the total. Passing `max(kept.values())` as the non-head cap makes
-        # `_fill` keep exactly this mapping.
+        # Most-kept first. Passing `max(kept.values())` as the non-head cap
+        # makes `_fill` keep exactly this mapping.
         ordered.sort(key = lambda k: (min(k.values()), k[head_device], sum(k.values())),
                      reverse = True)
         for kept in ordered:

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -1050,38 +1050,63 @@ def plan_device_map(
         constraint, so an explicit reserve either fits or the plan is refused.
         """
         reserve = reserve_for(head_device)
-        # Rungs for the non-head cards, from two ladders merged. The reserve is
-        # per device now, so it is a range, not one number: the top is what we
-        # would like every card to keep, the bottom is exactly what the old
-        # shared `min` cap handed all of them. Stepping only from the top can
-        # land BELOW that bottom -- a request one percent larger overshoots by a
-        # whole 5% rung -- so 4 x 80 GiB holding a 144 GiB model kept 41.72 GiB
-        # per card where the shared cap kept 43.68 GiB. Merging both ladders
-        # keeps every rung the shared cap used to try, in the same order, so the
-        # relaxed result can only be larger.
+        if reserve_is_explicit:
+            return _fill(head_device, reserve, max(reserve.values()))
+
+        # The reserve is per device now, so it is a range, not one number: the
+        # top is what we would like every card to keep, the floor is exactly
+        # what the old shared `min` cap handed all of them (`min` of a clamp is
+        # the clamp of the `min`). Relaxing from the top alone can therefore
+        # land BELOW what the old planner kept -- a request that misses by one
+        # percent is answered by a whole 5% rung -- so 4 x 80 GiB holding a
+        # 144 GiB model kept 41.72 GiB per card where the shared cap kept 43.68.
+        #
+        # So try every rung EITHER planner would have tried, best first. The
+        # candidates are the reserves actually kept per device:
+        #
+        #   A  relax only the non-head cards, from the per-device range
+        #   B  the old shared ladder: every card on the floor, non-head cards
+        #      stepped down from it
+        #   C  last resort, relax the head's own reserve too, per device
+        #   D  last resort on the old shared ladder
+        #
+        # B and D are the old planner's two ladders, rung for rung, so its
+        # result is always in this set; ordering by the smallest reserve any
+        # card keeps means the accepted plan can never keep less than it did.
+        # C exists because the loop that only relaxes the OTHER cards can miss
+        # the head's card by less than its reserve and refuse a model that fits.
+        # The logit headroom is never touched by any of them.
         top, floor = max(reserve.values()), min(reserve.values())
-        if reserve_is_explicit:
-            rungs = [top]
-        else:
-            rungs = sorted(
-                {top * (20 - step) // 20 for step in range(21)} |
-                {floor * (20 - step) // 20 for step in range(21)},
-                reverse = True,
-            )
+        rungs = sorted(
+            {top * (20 - step) // 20 for step in range(21)} |
+            {floor * (20 - step) // 20 for step in range(21)},
+            reverse = True,
+        )
+        candidates = []
         for other in rungs:
-            r = _fill(head_device, reserve, other)
-            if r is not None:
-                return r
-        if reserve_is_explicit:
-            return None
-        # Last resort: relax the head's own activation reserve too. An
-        # auto-derived reserve is documented as relaxable and the loop above only
-        # ever took it off the OTHER cards, so a single atomic unit that fits
-        # nowhere else could miss the head's card by less than the reserve and
-        # the plan was refused. The logit headroom is never touched.
+            candidates.append({d: reserve[d] if d == head_device else min(reserve[d], other)
+                               for d in devices})
+            candidates.append({d: floor if d == head_device else min(floor, other)
+                               for d in devices})
         for step in range(1, 21):
-            scaled = {d: v * (20 - step) // 20 for d, v in reserve.items()}
-            r = _fill(head_device, scaled, max(scaled.values()))
+            candidates.append({d: v * (20 - step) // 20 for d, v in reserve.items()})
+            candidates.append(dict.fromkeys(devices, floor * (20 - step) // 20))
+
+        seen = set()
+        ordered = []
+        for kept in candidates:
+            key = tuple(kept[d] for d in devices)
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append(kept)
+        # Most-kept first: the smallest reserve on any card, then the head's own,
+        # then the total. Passing `max(kept.values())` as the non-head cap makes
+        # `_fill` keep exactly this mapping.
+        ordered.sort(key = lambda k: (min(k.values()), k[head_device], sum(k.values())),
+                     reverse = True)
+        for kept in ordered:
+            r = _fill(head_device, kept, max(kept.values()))
             if r is not None:
                 return r
         return None


### PR DESCRIPTION
## What

`plan_device_map_for_pretrained`'s balanced policy sizes an activation reserve and then clamps it with a single `min` across every device. Only the head's card pays the logit headroom, so only its cap can go negative, and that one negative number zeroes the reserve on every other card too, including cards with plenty of room.

## How it showed up

Measured on `Kaggle-Muse_Glimmer_(30B)-GRPO` across two 14.56 GB T4s. The planner's own printout:

```
total weights      : 20.310 GiB
output head        : lm_head -> cuda:1
head headroom      : 4.104 GiB
activation reserve : 0.000 GiB requested
  cuda:0  budget 13.10 GiB  weights 12.943 GiB  free 0.161 GiB  reserve 0.000 GiB
  cuda:1  budget 13.10 GiB  weights  7.367 GiB  free 5.737 GiB  reserve 0.000 GiB  <- output head
```

The arithmetic:

```
value = (slack - headroom) / n = (5.898 - 4.104) / 2 = 0.897 GiB
share = ceil(total / n)        = 10.155 GiB
caps  = 13.104 - 10.155 = +2.949 (cuda:0)
        13.104 - 10.155 - 4.104 = -1.155 (cuda:1, the head)
min(+2.949, -1.155) = -1.155  ->  reserve 0.000 GiB on BOTH cards
```

The model then loads fine and dies at the first training step:

```
CUDA out of memory. Tried to allocate 254.00 MiB. GPU 0 has a total capacity of
14.56 GiB of which 234.81 MiB is free.
```

which matches the 0.161 GiB the plan left. cuda:1 finished with 5.737 GiB unused.

## The fix

Clamp each device at zero individually instead of sharing one cap. This keeps the property the shared cap was added for: the head's own reserve still cannot go negative, so `attempt`, which only ever relaxes the reserve on the other cards, is never handed an infeasible head budget.

## Tests

47 pass, up from 45. The two new ones derive their budgets from the fixture's own weights, since reproducing this needs `B - W/2 < headroom < 2B - W` while the head card can still hold `lm_head + headroom`. A first version used round numbers, did not satisfy that, and passed against the unfixed planner; the committed version fails against it and passes with the fix.