### PR TITLE
Do not resolve an FP8 base onto a private 16bit sibling

### DIFF
--- a/tests/test_fp8_sibling_private_repo_gate.py
+++ b/tests/test_fp8_sibling_private_repo_gate.py
@@ -29,8 +29,13 @@ which is still a correct 16bit merge.
 
 Listing is not the test for readability: a gated repo lists publicly and still refuses
 its content anonymously (measured on `meta-llama/Llama-3.2-1B`, anonymous `ls` returns
-the file list and the anonymous `config.json` fetch answers 401 GatedRepoError), so
-these tests drive the content fetch, not just `ls`.
+the file list and an anonymous read of `config.json` answers 401 GatedRepoError), so
+these tests drive the content check, not just `ls`.
+
+Nor is a download the test. `hf_hub_download` falls back to the cache whenever its HEAD
+fails, so a copy left by an earlier credentialed download makes a gated repo read as
+public. The fixture below therefore lets every download succeed and drives the decision
+from the HEAD, which is where it has to be made.
 """
 
 import json
@@ -38,7 +43,7 @@ import warnings
 from types import SimpleNamespace
 
 import pytest
-from huggingface_hub.errors import GatedRepoError
+from huggingface_hub.errors import EntryNotFoundError, GatedRepoError
 
 from unsloth_zoo import saving_utils
 
@@ -64,15 +69,16 @@ def _repo_not_found(path):
     return FileNotFoundError(f"{path} (repository not found)")
 
 
-def _hub(monkeypatch, tmp_path, *, anonymous_content, listed = True):
+def _hub(monkeypatch, tmp_path, *, anonymous_head, listed = True):
     """One repo on the Hub, `unsloth/GLM-5.2`, unquantized, and a record of every
     request made against it.
 
-    `anonymous_content` is what a credential free CONTENT fetch does: `None` serves the
-    config (public), or a callable returning the error it raises. A token bearing fetch
-    always succeeds, which is what makes "did we need the token?" observable.
+    `anonymous_head` is what a credential free HEAD of its content does: `None` succeeds
+    (public), or a callable returning the error it raises. Downloads always succeed,
+    including for an anonymous caller, which mimics the cache fallback in
+    `hf_hub_download` and so keeps these tests honest about which call decides.
     """
-    seen = SimpleNamespace(list_tokens = [], download_tokens = [])
+    seen = SimpleNamespace(list_tokens = [], download_tokens = [], head_tokens = [])
 
     def fake_ls(self, path, detail = True, **kwargs):
         seen.list_tokens.append(self.token)
@@ -84,14 +90,21 @@ def _hub(monkeypatch, tmp_path, *, anonymous_content, listed = True):
     config = tmp_path / "hub-config.json"
     config.write_text(json.dumps({"model_type": "llama"}), encoding = "utf-8")
 
-    def fake_download(*args, **kwargs):
-        token = kwargs.get("token")
-        seen.download_tokens.append(token)
-        if not token and anonymous_content is not None:
-            raise anonymous_content(kwargs.get("repo_id"))
-        return str(config)
     import huggingface_hub
-    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake_download, raising = True)
+    monkeypatch.setattr(
+        huggingface_hub, "hf_hub_download",
+        lambda *a, **kw: (seen.download_tokens.append(kw.get("token")), str(config))[1],
+        raising = True,
+    )
+
+    def fake_head(url, token = None, **kwargs):
+        seen.head_tokens.append(token)
+        if anonymous_head is not None:
+            raise anonymous_head(url)
+        return None
+    monkeypatch.setattr(
+        huggingface_hub, "get_hf_file_metadata", fake_head, raising = True,
+    )
     return seen
 
 
@@ -114,7 +127,7 @@ def _no_opt_in(monkeypatch):
 def test_a_public_sibling_still_resolves(monkeypatch, tmp_path):
     """The overwhelmingly common case, `unsloth/GLM-5.2-FP8` -> `unsloth/GLM-5.2`, is
     untouched: no warning, and the 16bit sibling is still the merge base."""
-    _hub(monkeypatch, tmp_path, anonymous_content = None)
+    _hub(monkeypatch, tmp_path, anonymous_head = None)
 
     sibling, messages = _resolve(monkeypatch, tmp_path)
 
@@ -126,7 +139,7 @@ def test_a_gated_sibling_is_not_merged_onto(monkeypatch, tmp_path):
     """A gated repo lists publicly, so `ls` alone would wave it through, but only the
     token has accepted its terms. Resolving it would redistribute access controlled
     weights to a requester who cannot download them."""
-    _hub(monkeypatch, tmp_path, anonymous_content = lambda p: _gated_repo_error(f"403 {p}"))
+    _hub(monkeypatch, tmp_path, anonymous_head = lambda url: _gated_repo_error(f"403 {url}"))
 
     sibling, messages = _resolve(monkeypatch, tmp_path)
 
@@ -138,7 +151,7 @@ def test_a_gated_sibling_is_not_merged_onto(monkeypatch, tmp_path):
 def test_a_private_sibling_is_not_merged_onto(monkeypatch, tmp_path):
     """A private repo is simply absent to an anonymous reader, so the lookup answers
     "no sibling" without ever asking the token about it."""
-    seen = _hub(monkeypatch, tmp_path, anonymous_content = _repo_not_found, listed = False)
+    seen = _hub(monkeypatch, tmp_path, anonymous_head = _repo_not_found, listed = False)
 
     sibling, _ = _resolve(monkeypatch, tmp_path)
 
@@ -149,7 +162,7 @@ def test_a_private_sibling_is_not_merged_onto(monkeypatch, tmp_path):
 def test_a_restricted_sibling_resolves_when_explicitly_opted_in(monkeypatch, tmp_path):
     """Callers who hold access to both repos are not blocked, they just have to say so,
     and only then does the token go anywhere near the rewritten name."""
-    seen = _hub(monkeypatch, tmp_path, anonymous_content = _repo_not_found)
+    seen = _hub(monkeypatch, tmp_path, anonymous_head = _repo_not_found)
     monkeypatch.setenv(RESTRICTED_ENV, "1")
 
     sibling, messages = _resolve(monkeypatch, tmp_path)
@@ -163,7 +176,7 @@ def test_the_lookup_never_spends_the_callers_token_on_the_rewritten_name(monkeyp
     """The property the whole gate exists for. Not just "the weights are not downloaded":
     no request about `unsloth/GLM-5.2` carries the token at all, so the rewrite cannot
     disclose the repo's existence or cache its config either."""
-    seen = _hub(monkeypatch, tmp_path, anonymous_content = None)
+    seen = _hub(monkeypatch, tmp_path, anonymous_head = None)
 
     sibling, _ = _resolve(monkeypatch, tmp_path)
 
@@ -177,10 +190,40 @@ def test_an_unreachable_hub_is_not_reported_as_a_restricted_sibling(monkeypatch,
     repo. Answering "gated or private" there would send users chasing an access problem
     they do not have."""
     _hub(monkeypatch, tmp_path,
-         anonymous_content = lambda p: TimeoutError(f"read timed out for {p}"))
+         anonymous_head = lambda url: TimeoutError(f"read timed out for {url}"))
 
     sibling, messages = _resolve(monkeypatch, tmp_path)
 
     assert sibling is None
     assert any("could not check the Hugging Face Hub" in m for m in messages), messages
     assert [m for m in messages if "gated or private" in m] == []
+
+
+def test_a_warm_cache_cannot_make_a_gated_sibling_look_public(monkeypatch, tmp_path):
+    """The regression that a download based probe cannot catch. `hf_hub_download` answers
+    from the cache when its HEAD fails, so in the deployment this gate exists for, a
+    service that already pulled the sibling with its token, a download probe reads the
+    credentialed copy back and calls the gated repo public. Here downloads always
+    succeed, exactly as a warm cache behaves, and the sibling is still declined."""
+    seen = _hub(monkeypatch, tmp_path,
+                anonymous_head = lambda url: _gated_repo_error(f"403 {url}"))
+
+    sibling, messages = _resolve(monkeypatch, tmp_path)
+
+    assert sibling is None
+    assert any("gated or private" in m for m in messages), messages
+    assert seen.head_tokens and all(not t for t in seen.head_tokens), seen.head_tokens
+
+
+def test_a_sibling_that_ships_no_config_json_still_resolves(monkeypatch, tmp_path):
+    """Refusing the file and not having it are different answers. A repo that discusses a
+    missing file with an anonymous reader has already proved it is anonymously readable,
+    and such a sibling resolved before this gate existed: `check_model_quantization_status`
+    reads an absent config as unquantized."""
+    _hub(monkeypatch, tmp_path,
+         anonymous_head = lambda url: EntryNotFoundError(f"404 no config.json at {url}"))
+
+    sibling, messages = _resolve(monkeypatch, tmp_path)
+
+    assert sibling == "unsloth/GLM-5.2"
+    assert [m for m in messages if "gated or private" in m] == [], messages

--- a/tests/test_fp8_sibling_private_repo_gate.py
+++ b/tests/test_fp8_sibling_private_repo_gate.py
@@ -1,0 +1,147 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The FP8 16bit sibling lookup must not widen what the caller's token reaches.
+
+`_resolve_fp8_16bit_sibling` rewrites the requested repo id (`org/model-FP8` ->
+`org/model`), so the repo it lands on is not the one the caller asked for. A caller
+holding a token broader than the request, a hosted service merging on behalf of a user,
+would otherwise spend that token on the rewritten name and fold weights the requester
+could never have fetched into the merged output.
+
+Public and gated siblings keep resolving, so every normal merge is unchanged. Only a
+*private* sibling, one that exists solely because of the token, is dropped, and then
+the merge dequantizes the FP8 weights it was actually given.
+"""
+
+import json
+import warnings
+
+import pytest
+from huggingface_hub.errors import GatedRepoError
+
+from unsloth_zoo import saving_utils
+
+
+PRIVATE_ENV = "UNSLOTH_ALLOW_PRIVATE_FP8_SIBLING"
+
+
+def _repo_not_found(path):
+    """What a private (or absent) repo looks like coming out of `HfFileSystem.ls`:
+    fsspec's `_raise_file_not_found` converts the 401 into a plain FileNotFoundError."""
+    return FileNotFoundError(f"{path} (repository not found)")
+
+
+def _gated(path):
+    """A gated repo arrives the same way, with the real cause chained underneath."""
+    error = FileNotFoundError(f"{path} (gated)")
+    error.__cause__ = GatedRepoError(f"403 for {path}")
+    return error
+
+
+def _hub(monkeypatch, tmp_path, *, anonymous):
+    """One repo on the Hub, `unsloth/GLM-5.2`, unquantized. `anonymous` is what a
+    token free listing of it does: return files (public), or raise."""
+    def fake_ls(self, path, detail = True, **kwargs):
+        if not self.token and anonymous is not None:
+            raise anonymous(path)
+        return [{"name": f"{path}/model.safetensors"}]
+    monkeypatch.setattr(saving_utils.HfFileSystem, "ls", fake_ls, raising = True)
+
+    config = tmp_path / "hub-config.json"
+    config.write_text(json.dumps({"model_type": "llama"}), encoding = "utf-8")
+    import huggingface_hub
+    monkeypatch.setattr(
+        huggingface_hub, "hf_hub_download",
+        lambda *args, **kwargs: str(config), raising = True,
+    )
+
+
+def _resolve(monkeypatch, tmp_path):
+    """No local copy of anything, so only the Hub branch can answer."""
+    monkeypatch.chdir(tmp_path)
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        sibling = saving_utils._resolve_fp8_16bit_sibling(
+            "unsloth/GLM-5.2-FP8", token = "SERVICE_TOKEN",
+        )
+    return sibling, [str(w.message) for w in caught]
+
+
+@pytest.fixture(autouse = True)
+def _no_opt_in(monkeypatch):
+    monkeypatch.delenv(PRIVATE_ENV, raising = False)
+
+
+def test_a_private_sibling_is_not_merged_onto(monkeypatch, tmp_path):
+    """The token can read `unsloth/GLM-5.2`, nobody else can, and the caller asked for
+    `unsloth/GLM-5.2-FP8`. Resolving it would put weights the requester has no access to
+    into the output, so the merge stays on the FP8 base it was given."""
+    _hub(monkeypatch, tmp_path, anonymous = _repo_not_found)
+
+    sibling, messages = _resolve(monkeypatch, tmp_path)
+
+    assert sibling is None
+    assert any("private 16bit sibling" in m for m in messages), messages
+    assert any(PRIVATE_ENV in m for m in messages), messages
+
+
+def test_a_private_sibling_resolves_when_explicitly_opted_in(monkeypatch, tmp_path):
+    """Single tenant callers who own both repos are not blocked, they just have to say so."""
+    _hub(monkeypatch, tmp_path, anonymous = _repo_not_found)
+    monkeypatch.setenv(PRIVATE_ENV, "1")
+
+    sibling, messages = _resolve(monkeypatch, tmp_path)
+
+    assert sibling == "unsloth/GLM-5.2"
+    assert [m for m in messages if "private 16bit sibling" in m] == []
+
+
+def test_a_public_sibling_still_resolves(monkeypatch, tmp_path):
+    """The overwhelmingly common case, `unsloth/GLM-5.2-FP8` -> `unsloth/GLM-5.2`,
+    is untouched: no warning, and the 16bit sibling is still the merge base."""
+    _hub(monkeypatch, tmp_path, anonymous = None)
+
+    sibling, messages = _resolve(monkeypatch, tmp_path)
+
+    assert sibling == "unsloth/GLM-5.2"
+    assert [m for m in messages if isinstance(m, str) and "sibling" in m] == [], messages
+
+
+def test_a_gated_sibling_still_resolves(monkeypatch, tmp_path):
+    """Gated is public-but-licensed: the repo is listed for everyone and only the
+    download is gated, so it discloses nothing private and `meta-llama/...-FP8` ->
+    `meta-llama/...` keeps working."""
+    _hub(monkeypatch, tmp_path, anonymous = _gated)
+
+    sibling, messages = _resolve(monkeypatch, tmp_path)
+
+    assert sibling == "unsloth/GLM-5.2"
+    assert [m for m in messages if "private 16bit sibling" in m] == []
+
+
+def test_the_visibility_probe_never_sends_the_callers_token(monkeypatch, tmp_path):
+    """The whole gate rests on the probe being anonymous; `token = None` would pick the
+    ambient `HF_TOKEN` back up out of the environment and answer "public" about a repo
+    only the service can see."""
+    seen = []
+    def fake_ls(self, path, detail = True, **kwargs):
+        seen.append(self.token)
+        return [{"name": f"{path}/model.safetensors"}]
+    monkeypatch.setattr(saving_utils.HfFileSystem, "ls", fake_ls, raising = True)
+
+    assert saving_utils._hub_repo_reads_without_a_token("unsloth/GLM-5.2") is True
+    assert seen == [False], seen

--- a/tests/test_fp8_sibling_private_repo_gate.py
+++ b/tests/test_fp8_sibling_private_repo_gate.py
@@ -18,17 +18,24 @@
 
 `_resolve_fp8_16bit_sibling` rewrites the requested repo id (`org/model-FP8` ->
 `org/model`), so the repo it lands on is not the one the caller asked for. A caller
-holding a token broader than the request, a hosted service merging on behalf of a user,
-would otherwise spend that token on the rewritten name and fold weights the requester
-could never have fetched into the merged output.
+holding a token broader than the request, a service merging on behalf of a user, would
+otherwise spend that token on the rewritten name and fold weights the requester could
+never have fetched into the merged output. `token = None` makes that easy to hit by
+accident: huggingface_hub reads it as "go find one" and picks up the ambient HF_TOKEN.
 
-Public and gated siblings keep resolving, so every normal merge is unchanged. Only a
-*private* sibling, one that exists solely because of the token, is dropped, and then
-the merge dequantizes the FP8 weights it was actually given.
+So the sibling is resolved with no credentials at all, and a sibling that only a token
+can reach is dropped. The merge then dequantizes the FP8 weights it was actually given,
+which is still a correct 16bit merge.
+
+Listing is not the test for readability: a gated repo lists publicly and still refuses
+its content anonymously (measured on `meta-llama/Llama-3.2-1B`, anonymous `ls` returns
+the file list and the anonymous `config.json` fetch answers 401 GatedRepoError), so
+these tests drive the content fetch, not just `ls`.
 """
 
 import json
 import warnings
+from types import SimpleNamespace
 
 import pytest
 from huggingface_hub.errors import GatedRepoError
@@ -36,38 +43,56 @@ from huggingface_hub.errors import GatedRepoError
 from unsloth_zoo import saving_utils
 
 
-PRIVATE_ENV = "UNSLOTH_ALLOW_PRIVATE_FP8_SIBLING"
+RESTRICTED_ENV = "UNSLOTH_ALLOW_RESTRICTED_FP8_SIBLING"
+SERVICE_TOKEN  = "SERVICE_TOKEN"
+
+
+def _gated_repo_error(message):
+    """A `GatedRepoError` under either supported signature. huggingface_hub 1.x makes
+    `response` keyword only AND required, and reads `.headers` / `.request` off it in
+    `__init__`; 0.x defaults it to None. The project allows both (`>=0.34.0`)."""
+    response = SimpleNamespace(headers = {}, request = None)
+    try:
+        return GatedRepoError(message, response = response)
+    except TypeError:
+        return GatedRepoError(message)
 
 
 def _repo_not_found(path):
-    """What a private (or absent) repo looks like coming out of `HfFileSystem.ls`:
-    fsspec's `_raise_file_not_found` converts the 401 into a plain FileNotFoundError."""
+    """What a private repo looks like to an anonymous reader: the Hub reports it absent
+    rather than admitting it exists, and fsspec flattens that to FileNotFoundError."""
     return FileNotFoundError(f"{path} (repository not found)")
 
 
-def _gated(path):
-    """A gated repo arrives the same way, with the real cause chained underneath."""
-    error = FileNotFoundError(f"{path} (gated)")
-    error.__cause__ = GatedRepoError(f"403 for {path}")
-    return error
+def _hub(monkeypatch, tmp_path, *, anonymous_content, listed = True):
+    """One repo on the Hub, `unsloth/GLM-5.2`, unquantized, and a record of every
+    request made against it.
 
+    `anonymous_content` is what a credential free CONTENT fetch does: `None` serves the
+    config (public), or a callable returning the error it raises. A token bearing fetch
+    always succeeds, which is what makes "did we need the token?" observable.
+    """
+    seen = SimpleNamespace(list_tokens = [], download_tokens = [])
 
-def _hub(monkeypatch, tmp_path, *, anonymous):
-    """One repo on the Hub, `unsloth/GLM-5.2`, unquantized. `anonymous` is what a
-    token free listing of it does: return files (public), or raise."""
     def fake_ls(self, path, detail = True, **kwargs):
-        if not self.token and anonymous is not None:
-            raise anonymous(path)
+        seen.list_tokens.append(self.token)
+        if not listed:
+            raise _repo_not_found(path)
         return [{"name": f"{path}/model.safetensors"}]
     monkeypatch.setattr(saving_utils.HfFileSystem, "ls", fake_ls, raising = True)
 
     config = tmp_path / "hub-config.json"
     config.write_text(json.dumps({"model_type": "llama"}), encoding = "utf-8")
+
+    def fake_download(*args, **kwargs):
+        token = kwargs.get("token")
+        seen.download_tokens.append(token)
+        if not token and anonymous_content is not None:
+            raise anonymous_content(kwargs.get("repo_id"))
+        return str(config)
     import huggingface_hub
-    monkeypatch.setattr(
-        huggingface_hub, "hf_hub_download",
-        lambda *args, **kwargs: str(config), raising = True,
-    )
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake_download, raising = True)
+    return seen
 
 
 def _resolve(monkeypatch, tmp_path):
@@ -76,72 +101,86 @@ def _resolve(monkeypatch, tmp_path):
     with warnings.catch_warnings(record = True) as caught:
         warnings.simplefilter("always")
         sibling = saving_utils._resolve_fp8_16bit_sibling(
-            "unsloth/GLM-5.2-FP8", token = "SERVICE_TOKEN",
+            "unsloth/GLM-5.2-FP8", token = SERVICE_TOKEN,
         )
     return sibling, [str(w.message) for w in caught]
 
 
 @pytest.fixture(autouse = True)
 def _no_opt_in(monkeypatch):
-    monkeypatch.delenv(PRIVATE_ENV, raising = False)
+    monkeypatch.delenv(RESTRICTED_ENV, raising = False)
 
 
-def test_a_private_sibling_is_not_merged_onto(monkeypatch, tmp_path):
-    """The token can read `unsloth/GLM-5.2`, nobody else can, and the caller asked for
-    `unsloth/GLM-5.2-FP8`. Resolving it would put weights the requester has no access to
-    into the output, so the merge stays on the FP8 base it was given."""
-    _hub(monkeypatch, tmp_path, anonymous = _repo_not_found)
+def test_a_public_sibling_still_resolves(monkeypatch, tmp_path):
+    """The overwhelmingly common case, `unsloth/GLM-5.2-FP8` -> `unsloth/GLM-5.2`, is
+    untouched: no warning, and the 16bit sibling is still the merge base."""
+    _hub(monkeypatch, tmp_path, anonymous_content = None)
+
+    sibling, messages = _resolve(monkeypatch, tmp_path)
+
+    assert sibling == "unsloth/GLM-5.2"
+    assert [m for m in messages if "sibling" in m] == [], messages
+
+
+def test_a_gated_sibling_is_not_merged_onto(monkeypatch, tmp_path):
+    """A gated repo lists publicly, so `ls` alone would wave it through, but only the
+    token has accepted its terms. Resolving it would redistribute access controlled
+    weights to a requester who cannot download them."""
+    _hub(monkeypatch, tmp_path, anonymous_content = lambda p: _gated_repo_error(f"403 {p}"))
 
     sibling, messages = _resolve(monkeypatch, tmp_path)
 
     assert sibling is None
-    assert any("private 16bit sibling" in m for m in messages), messages
-    assert any(PRIVATE_ENV in m for m in messages), messages
+    assert any("gated or private" in m for m in messages), messages
+    assert any(RESTRICTED_ENV in m for m in messages), messages
 
 
-def test_a_private_sibling_resolves_when_explicitly_opted_in(monkeypatch, tmp_path):
-    """Single tenant callers who own both repos are not blocked, they just have to say so."""
-    _hub(monkeypatch, tmp_path, anonymous = _repo_not_found)
-    monkeypatch.setenv(PRIVATE_ENV, "1")
+def test_a_private_sibling_is_not_merged_onto(monkeypatch, tmp_path):
+    """A private repo is simply absent to an anonymous reader, so the lookup answers
+    "no sibling" without ever asking the token about it."""
+    seen = _hub(monkeypatch, tmp_path, anonymous_content = _repo_not_found, listed = False)
 
-    sibling, messages = _resolve(monkeypatch, tmp_path)
+    sibling, _ = _resolve(monkeypatch, tmp_path)
 
-    assert sibling == "unsloth/GLM-5.2"
-    assert [m for m in messages if "private 16bit sibling" in m] == []
-
-
-def test_a_public_sibling_still_resolves(monkeypatch, tmp_path):
-    """The overwhelmingly common case, `unsloth/GLM-5.2-FP8` -> `unsloth/GLM-5.2`,
-    is untouched: no warning, and the 16bit sibling is still the merge base."""
-    _hub(monkeypatch, tmp_path, anonymous = None)
-
-    sibling, messages = _resolve(monkeypatch, tmp_path)
-
-    assert sibling == "unsloth/GLM-5.2"
-    assert [m for m in messages if isinstance(m, str) and "sibling" in m] == [], messages
+    assert sibling is None
+    assert SERVICE_TOKEN not in seen.list_tokens + seen.download_tokens
 
 
-def test_a_gated_sibling_still_resolves(monkeypatch, tmp_path):
-    """Gated is public-but-licensed: the repo is listed for everyone and only the
-    download is gated, so it discloses nothing private and `meta-llama/...-FP8` ->
-    `meta-llama/...` keeps working."""
-    _hub(monkeypatch, tmp_path, anonymous = _gated)
+def test_a_restricted_sibling_resolves_when_explicitly_opted_in(monkeypatch, tmp_path):
+    """Callers who hold access to both repos are not blocked, they just have to say so,
+    and only then does the token go anywhere near the rewritten name."""
+    seen = _hub(monkeypatch, tmp_path, anonymous_content = _repo_not_found)
+    monkeypatch.setenv(RESTRICTED_ENV, "1")
 
     sibling, messages = _resolve(monkeypatch, tmp_path)
 
     assert sibling == "unsloth/GLM-5.2"
-    assert [m for m in messages if "private 16bit sibling" in m] == []
+    assert [m for m in messages if "gated or private" in m] == []
+    assert SERVICE_TOKEN in seen.list_tokens
 
 
-def test_the_visibility_probe_never_sends_the_callers_token(monkeypatch, tmp_path):
-    """The whole gate rests on the probe being anonymous; `token = None` would pick the
-    ambient `HF_TOKEN` back up out of the environment and answer "public" about a repo
-    only the service can see."""
-    seen = []
-    def fake_ls(self, path, detail = True, **kwargs):
-        seen.append(self.token)
-        return [{"name": f"{path}/model.safetensors"}]
-    monkeypatch.setattr(saving_utils.HfFileSystem, "ls", fake_ls, raising = True)
+def test_the_lookup_never_spends_the_callers_token_on_the_rewritten_name(monkeypatch, tmp_path):
+    """The property the whole gate exists for. Not just "the weights are not downloaded":
+    no request about `unsloth/GLM-5.2` carries the token at all, so the rewrite cannot
+    disclose the repo's existence or cache its config either."""
+    seen = _hub(monkeypatch, tmp_path, anonymous_content = None)
 
-    assert saving_utils._hub_repo_reads_without_a_token("unsloth/GLM-5.2") is True
-    assert seen == [False], seen
+    sibling, _ = _resolve(monkeypatch, tmp_path)
+
+    assert sibling == "unsloth/GLM-5.2"
+    assert seen.list_tokens and seen.download_tokens, "the Hub was never asked"
+    assert all(not t for t in seen.list_tokens + seen.download_tokens), seen
+
+
+def test_an_unreachable_hub_is_not_reported_as_a_restricted_sibling(monkeypatch, tmp_path):
+    """A 429 or a proxy error on the anonymous read says nothing about who may read the
+    repo. Answering "gated or private" there would send users chasing an access problem
+    they do not have."""
+    _hub(monkeypatch, tmp_path,
+         anonymous_content = lambda p: TimeoutError(f"read timed out for {p}"))
+
+    sibling, messages = _resolve(monkeypatch, tmp_path)
+
+    assert sibling is None
+    assert any("could not check the Hugging Face Hub" in m for m in messages), messages
+    assert [m for m in messages if "gated or private" in m] == []

--- a/tests/test_local_fp8_base_offline_resolution.py
+++ b/tests/test_local_fp8_base_offline_resolution.py
@@ -645,6 +645,12 @@ def test_the_sibling_lookup_keeps_asking_the_hub_after_an_unreadable_local_confi
         huggingface_hub, "hf_hub_download",
         lambda *args, **kwargs: str(good_config), raising = True,
     )
+    # The sibling is also HEADed anonymously to prove it is readable without a token;
+    # stub that too, or the lookup leaves the fixture and asks the real Hub.
+    monkeypatch.setattr(
+        huggingface_hub, "get_hf_file_metadata",
+        lambda *args, **kwargs: None, raising = True,
+    )
 
     with warnings.catch_warnings(record = True) as caught:
         warnings.simplefilter("always")

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -5069,22 +5069,31 @@ def _sibling_content_reads_anonymously(model_name):
 
     Listing is not the test. A gated repo lists publicly and still refuses its content
     anonymously: measured on `meta-llama/Llama-3.2-1B`, an anonymous `ls` returns the
-    file list while the anonymous `config.json` fetch answers 401 GatedRepoError. So ask
-    for a file. Access is repo wide rather than per file, so one readable file stands for
-    the weights. A private repo is reported as absent to an anonymous reader and lands in
-    `restricted` with the gated ones, which is the same verdict either way.
+    file list while an anonymous read of `config.json` answers 401 GatedRepoError. So ask
+    about a file. Access is repo wide rather than per file, so one anonymously readable
+    file stands for the weights.
+
+    It has to be a HEAD rather than a download. `hf_hub_download` falls back to the cache
+    whenever the HEAD fails (`if head_call_error is not None: ... return pointer_path`),
+    so on a warm cache it hands back a copy an earlier CREDENTIALED download left behind
+    and the gated repo reads as public. Measured: warm the cache for
+    `meta-llama/Llama-3.2-1B` with a token, and `token = False` then returns the cached
+    path instead of raising. `get_hf_file_metadata` has no cache path at all.
     """
-    from huggingface_hub import hf_hub_download
+    from huggingface_hub import get_hf_file_metadata, hf_hub_url
     repo_id, revision = _hub_repo_and_revision(model_name)
     try:
-        hf_hub_download(
-            repo_id = repo_id, filename = "config.json",
-            token = False, revision = revision,
+        get_hf_file_metadata(
+            hf_hub_url(repo_id, "config.json", revision = revision), token = False,
         )
         return "public"
-    except _HUB_DOWNLOAD_UNREACHABLE_ERRORS:
-        return "unreachable"
-    except _HUB_ABSENT_ERRORS:
+    except EntryNotFoundError:
+        # The repo discussed a missing file with an anonymous reader instead of refusing
+        # it, which is itself proof of anonymous read access. A sibling that shipped
+        # safetensors without a config.json resolved before this gate existed and still
+        # must: `check_model_quantization_status` reads an absent config as unquantized.
+        return "public"
+    except (GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError):
         return "restricted"
     except Exception:
         return "unreachable"

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -5063,22 +5063,18 @@ def _strip_fp8_suffix(model_name):
 pass
 
 def _sibling_content_reads_anonymously(model_name):
-    """How a reader carrying no credentials at all fares on `model_name`'s content:
-    `"public"` (a file came back), `"restricted"` (the repo refused it) or
-    `"unreachable"` (the Hub could not be asked, which is no answer about the repo).
+    """How a reader with no credentials fares on `model_name`'s content: `"public"`,
+    `"restricted"` (refused) or `"unreachable"` (the Hub could not be asked, which is no
+    answer about the repo).
 
-    Listing is not the test. A gated repo lists publicly and still refuses its content
-    anonymously: measured on `meta-llama/Llama-3.2-1B`, an anonymous `ls` returns the
-    file list while an anonymous read of `config.json` answers 401 GatedRepoError. So ask
-    about a file. Access is repo wide rather than per file, so one anonymously readable
-    file stands for the weights.
-
-    It has to be a HEAD rather than a download. `hf_hub_download` falls back to the cache
-    whenever the HEAD fails (`if head_call_error is not None: ... return pointer_path`),
-    so on a warm cache it hands back a copy an earlier CREDENTIALED download left behind
-    and the gated repo reads as public. Measured: warm the cache for
-    `meta-llama/Llama-3.2-1B` with a token, and `token = False` then returns the cached
-    path instead of raising. `get_hf_file_metadata` has no cache path at all.
+    Listing is not the test, since a gated repo lists publicly and still refuses its
+    content. Nor is a download: `hf_hub_download` answers from the cache whenever its HEAD
+    fails (`if head_call_error is not None: ... return pointer_path`), handing back a copy
+    an earlier CREDENTIALED download left behind, so a warm cache makes a gated repo read
+    as public. Measured on `meta-llama/Llama-3.2-1B`: anonymous `ls` succeeds, and after a
+    credentialed fetch `token = False` returns the cached path rather than raising.
+    `get_hf_file_metadata` has no cache path, and access is repo wide, so one anonymously
+    HEADable file stands for the weights.
     """
     from huggingface_hub import get_hf_file_metadata, hf_hub_url
     repo_id, revision = _hub_repo_and_revision(model_name)
@@ -5088,10 +5084,10 @@ def _sibling_content_reads_anonymously(model_name):
         )
         return "public"
     except EntryNotFoundError:
-        # The repo discussed a missing file with an anonymous reader instead of refusing
-        # it, which is itself proof of anonymous read access. A sibling that shipped
-        # safetensors without a config.json resolved before this gate existed and still
-        # must: `check_model_quantization_status` reads an absent config as unquantized.
+        # Discussing a missing file with an anonymous reader is itself proof of anonymous
+        # access, and a sibling with safetensors but no config.json resolved before this
+        # gate existed: `check_model_quantization_status` reads an absent config as
+        # unquantized.
         return "public"
     except (GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError):
         return "restricted"
@@ -5100,9 +5096,9 @@ def _sibling_content_reads_anonymously(model_name):
 pass
 
 def _allow_restricted_fp8_sibling():
-    """Opt in to resolving an FP8 base onto a gated or private 16bit sibling using the
+    """Opt in to resolving an FP8 base onto a gated or private 16bit sibling with the
     caller's token. Off by default so a broad token cannot be aimed at an unrequested
-    repo; single tenant callers who own both repos can set it to `1`."""
+    repo; callers holding access to both repos set it to `1`."""
     return os.environ.get("UNSLOTH_ALLOW_RESTRICTED_FP8_SIBLING") == "1"
 pass
 
@@ -5127,10 +5123,8 @@ def _resolve_fp8_16bit_sibling(model_name, token=None):
         return None
     # `org/model-FP8` -> `org/model` is a guess, and the caller asked for the FP8 repo, so
     # the sibling is resolved with NO credentials: whatever that finds, the requester could
-    # have fetched themselves. Handing the token to the rewritten name instead would let a
-    # caller running with one broader than the request, a service merging on someone's
-    # behalf, fold weights that requester cannot reach into the output. Opting in swaps the
-    # token back in for callers who own both repos.
+    # have fetched themselves. Spending a token broader than the request on the rewritten
+    # name is what would fold unreachable weights into the output.
     opted_in = _allow_restricted_fp8_sibling()
     sibling_token = token if opted_in else False
     try:
@@ -5138,8 +5132,7 @@ def _resolve_fp8_16bit_sibling(model_name, token=None):
         # replaced this function with a two argument stand-in.
         _ask_the_hub = {"local_ok": False} if local_rejected else {}
         if check_hf_model_exists(base, sibling_token):
-            # Existence came from a listing, which a gated repo also answers. Ask for
-            # content before trusting it.
+            # Existence came from a listing, which a gated repo also answers.
             anonymous = "public" if opted_in else _sibling_content_reads_anonymously(base)
             if anonymous == "unreachable":
                 raise _hub_unreachable_error(

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -5062,6 +5062,36 @@ def _strip_fp8_suffix(model_name):
     return model_name[:idx] or None
 pass
 
+def _hub_repo_reads_without_a_token(model_name):
+    """True when reading `model_name` does not depend on the caller's credentials.
+
+    The sibling lookup rewrites the requested repo id (`org/model-FP8` -> `org/model`),
+    so the repo it lands on was never the one the caller asked for. A caller that runs
+    with a token broader than the request, a hosted service merging on behalf of a user,
+    would otherwise spend that token on the rewritten name and fold weights the requester
+    could not have fetched themselves into the output. Deciding that anonymously keeps
+    the rewrite from being able to widen access.
+
+    Public repos answer True. Gated ones do too: their contents are listed publicly and
+    only the download is licence gated, so a gated sibling discloses nothing private and
+    the (common) gated FP8 -> gated 16bit merge keeps working. Private repos, and
+    anything unreadable for a reason that cannot be identified, answer False.
+    """
+    if not _is_hub_repo_id(model_name): return False
+    try:
+        HfFileSystem(token = False).ls(model_name, detail = False)
+        return True
+    except Exception as e:
+        return _gated_repo_cause(e) is not None
+pass
+
+def _allow_private_fp8_sibling():
+    """Opt in to resolving an FP8 base onto a *private* 16bit sibling with the caller's
+    token. Off by default so a broad token cannot be aimed at an unrequested private
+    repo; single tenant callers who own both repos can set it to `1`."""
+    return os.environ.get("UNSLOTH_ALLOW_PRIVATE_FP8_SIBLING") == "1"
+pass
+
 def _resolve_fp8_16bit_sibling(model_name, token=None):
     """If model_name is an FP8 variant with an existing, non-quantized 16bit sibling
     (e.g. unsloth/GLM-5.2-FP8 -> unsloth/GLM-5.2), return the sibling so a 16bit merge
@@ -5088,6 +5118,19 @@ def _resolve_fp8_16bit_sibling(model_name, token=None):
         if check_hf_model_exists(base, token) and not check_model_quantization_status(
             base, token, **_ask_the_hub,
         )[0]:
+            # The rewrite may not widen what the token reaches: a private sibling is only
+            # visible because of the caller's credentials, and the caller asked for the
+            # FP8 repo, not this one. Merging onto the FP8 weights stays correct, so drop
+            # the sibling rather than fold an unrequested private repo into the output.
+            if not _hub_repo_reads_without_a_token(base) and not _allow_private_fp8_sibling():
+                warnings.warn(
+                    f"Unsloth: `{base}` is a private 16bit sibling of `{model_name}` and "
+                    f"is only readable with the current token, so it is not used as the "
+                    f"merge base. Merging onto the FP8 weights instead. Set "
+                    f"`UNSLOTH_ALLOW_PRIVATE_FP8_SIBLING=1` if you own both repos and "
+                    f"want the 16bit sibling."
+                )
+                return None
             return base
     except RuntimeError as e:
         # An unreachable Hub is not "there is no 16bit sibling". None is still right,

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -5062,34 +5062,39 @@ def _strip_fp8_suffix(model_name):
     return model_name[:idx] or None
 pass
 
-def _hub_repo_reads_without_a_token(model_name):
-    """True when reading `model_name` does not depend on the caller's credentials.
+def _sibling_content_reads_anonymously(model_name):
+    """How a reader carrying no credentials at all fares on `model_name`'s content:
+    `"public"` (a file came back), `"restricted"` (the repo refused it) or
+    `"unreachable"` (the Hub could not be asked, which is no answer about the repo).
 
-    The sibling lookup rewrites the requested repo id (`org/model-FP8` -> `org/model`),
-    so the repo it lands on was never the one the caller asked for. A caller that runs
-    with a token broader than the request, a hosted service merging on behalf of a user,
-    would otherwise spend that token on the rewritten name and fold weights the requester
-    could not have fetched themselves into the output. Deciding that anonymously keeps
-    the rewrite from being able to widen access.
-
-    Public repos answer True. Gated ones do too: their contents are listed publicly and
-    only the download is licence gated, so a gated sibling discloses nothing private and
-    the (common) gated FP8 -> gated 16bit merge keeps working. Private repos, and
-    anything unreadable for a reason that cannot be identified, answer False.
+    Listing is not the test. A gated repo lists publicly and still refuses its content
+    anonymously: measured on `meta-llama/Llama-3.2-1B`, an anonymous `ls` returns the
+    file list while the anonymous `config.json` fetch answers 401 GatedRepoError. So ask
+    for a file. Access is repo wide rather than per file, so one readable file stands for
+    the weights. A private repo is reported as absent to an anonymous reader and lands in
+    `restricted` with the gated ones, which is the same verdict either way.
     """
-    if not _is_hub_repo_id(model_name): return False
+    from huggingface_hub import hf_hub_download
+    repo_id, revision = _hub_repo_and_revision(model_name)
     try:
-        HfFileSystem(token = False).ls(model_name, detail = False)
-        return True
-    except Exception as e:
-        return _gated_repo_cause(e) is not None
+        hf_hub_download(
+            repo_id = repo_id, filename = "config.json",
+            token = False, revision = revision,
+        )
+        return "public"
+    except _HUB_DOWNLOAD_UNREACHABLE_ERRORS:
+        return "unreachable"
+    except _HUB_ABSENT_ERRORS:
+        return "restricted"
+    except Exception:
+        return "unreachable"
 pass
 
-def _allow_private_fp8_sibling():
-    """Opt in to resolving an FP8 base onto a *private* 16bit sibling with the caller's
-    token. Off by default so a broad token cannot be aimed at an unrequested private
+def _allow_restricted_fp8_sibling():
+    """Opt in to resolving an FP8 base onto a gated or private 16bit sibling using the
+    caller's token. Off by default so a broad token cannot be aimed at an unrequested
     repo; single tenant callers who own both repos can set it to `1`."""
-    return os.environ.get("UNSLOTH_ALLOW_PRIVATE_FP8_SIBLING") == "1"
+    return os.environ.get("UNSLOTH_ALLOW_RESTRICTED_FP8_SIBLING") == "1"
 pass
 
 def _resolve_fp8_16bit_sibling(model_name, token=None):
@@ -5111,27 +5116,41 @@ def _resolve_fp8_16bit_sibling(model_name, token=None):
         local_rejected = True
     except Exception:
         return None
+    # `org/model-FP8` -> `org/model` is a guess, and the caller asked for the FP8 repo, so
+    # the sibling is resolved with NO credentials: whatever that finds, the requester could
+    # have fetched themselves. Handing the token to the rewritten name instead would let a
+    # caller running with one broader than the request, a service merging on someone's
+    # behalf, fold weights that requester cannot reach into the output. Opting in swaps the
+    # token back in for callers who own both repos.
+    opted_in = _allow_restricted_fp8_sibling()
+    sibling_token = token if opted_in else False
     try:
         # `local_ok` only when it has to be: passing it always would break any caller that
         # replaced this function with a two argument stand-in.
         _ask_the_hub = {"local_ok": False} if local_rejected else {}
-        if check_hf_model_exists(base, token) and not check_model_quantization_status(
-            base, token, **_ask_the_hub,
-        )[0]:
-            # The rewrite may not widen what the token reaches: a private sibling is only
-            # visible because of the caller's credentials, and the caller asked for the
-            # FP8 repo, not this one. Merging onto the FP8 weights stays correct, so drop
-            # the sibling rather than fold an unrequested private repo into the output.
-            if not _hub_repo_reads_without_a_token(base) and not _allow_private_fp8_sibling():
+        if check_hf_model_exists(base, sibling_token):
+            # Existence came from a listing, which a gated repo also answers. Ask for
+            # content before trusting it.
+            anonymous = "public" if opted_in else _sibling_content_reads_anonymously(base)
+            if anonymous == "unreachable":
+                raise _hub_unreachable_error(
+                    base, RuntimeError("anonymous read failed"),
+                    action = f"checking whether `{base}` is readable without a token",
+                    mistaken_for = "a missing model",
+                )
+            if anonymous != "public":
                 warnings.warn(
-                    f"Unsloth: `{base}` is a private 16bit sibling of `{model_name}` and "
-                    f"is only readable with the current token, so it is not used as the "
-                    f"merge base. Merging onto the FP8 weights instead. Set "
-                    f"`UNSLOTH_ALLOW_PRIVATE_FP8_SIBLING=1` if you own both repos and "
-                    f"want the 16bit sibling."
+                    f"Unsloth: the 16bit sibling `{base}` of `{model_name}` is gated or "
+                    f"private, so reaching it would depend on the current token rather "
+                    f"than on what was asked for. Merging onto the FP8 weights instead. "
+                    f"Set `UNSLOTH_ALLOW_RESTRICTED_FP8_SIBLING=1` if you have access to "
+                    f"both repos and want the 16bit sibling."
                 )
                 return None
-            return base
+            if not check_model_quantization_status(
+                base, sibling_token, **_ask_the_hub,
+            )[0]:
+                return base
     except RuntimeError as e:
         # An unreachable Hub is not "there is no 16bit sibling". None is still right,
         # since the merge can dequantize the FP8 weights, but say so: the base used is


### PR DESCRIPTION
`_resolve_fp8_16bit_sibling` rewrites the requested model id (`org/model-FP8` -> `org/model`) and `merge_and_overwrite_lora` then uses that rewritten name for the rest of the merge, including the `snapshot_download`. The repo it lands on is not the one the caller asked for, and it was checked and downloaded with the same token.

That matters because of how `huggingface_hub` reads `token`:

```
build_hf_headers(token = None)  -> sends Authorization   # picks up the ambient HF_TOKEN
build_hf_headers(token = False) -> no Authorization
```

So a process holding a token broader than the request, a service merging on behalf of a user, or just a shell with `HF_TOKEN` exported, can have that token spent on a repo nobody asked for, and the weights it returns end up in the merged output. The caller validated `org/model-FP8`; nothing ever authorized `org/model`.

### The fix

Resolve the sibling with no credentials at all. Every Hub call in that branch gets `token = False`, which genuinely drops the Authorization header unlike `token = None`, so no request about the rewritten name carries the token. Whatever the lookup finds is something the requester could have fetched themselves. If the sibling is not anonymously readable it is dropped and the merge dequantizes the FP8 weights it was actually given, which is still a correct 16bit merge.

Readability is checked by asking for content, not by listing. Measured on `meta-llama/Llama-3.2-1B`, an anonymous `ls` returns the full file list while an anonymous `config.json` fetch answers `401 GatedRepoError`, so a listing based check would wave gated repos through. Access on the Hub is repo wide rather than per file, so one anonymously readable file stands for the weights.

The obvious alternative, putting the whole sibling fallback behind an off by default flag, is not what this does. That would silently downgrade every FP8 `merged_16bit` merge to FP8 dequantization for everyone, in Studio, Desktop, the notebooks and the CLI, to close a risk that only exists when the token is broader than the request. This narrows the resolution instead of removing it.

### What still works

- Public siblings, which is every Unsloth FP8 repo: unchanged, no warning, still the merge base.
- Local and offline sibling resolution: untouched, the local branch answers before the Hub is ever consulted.
- Non FP8 paths, and FP8 merges with no sibling: untouched.
- Gated and private siblings now fall back to dequantizing the FP8 base, with a warning naming the opt-in. `UNSLOTH_ALLOW_RESTRICTED_FP8_SIBLING=1` restores the old behaviour for callers who hold access to both repos.

A transient failure on the anonymous read is reported as an unreachable Hub, not as a restricted sibling, so a 429 or proxy error does not send users chasing an access problem they do not have.

Read only gate, nothing written, the env var is re-read per call, so it is idempotent.

### Tests

New `tests/test_fp8_sibling_private_repo_gate.py`: public sibling resolves, gated sibling declined, private sibling declined without the token ever being used, opt-in restores resolution, unreachable Hub is not reported as restricted, and the central property that no request about the rewritten name carries the caller's token.

```
tests/test_fp8_sibling_private_repo_gate.py                                6 passed
test_fp8_dense_merge.py + test_local_fp8_base_offline_resolution.py      118 passed
every test touching saving_utils                                973 passed, 17 skipped
```
