### PR TITLE
Read the Gemma4 merge dtype from the definition that reaches it

### DIFF
--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -16,6 +16,7 @@ The real-source canaries import the real transformers gemma4 module and skip
 cleanly when it is absent; when present (transformers >= 5.5.0, as on CI) they
 catch upstream source drift that would silently disable the patch.
 """
+import ast
 import inspect
 import re
 
@@ -195,13 +196,113 @@ def _gemma4_modeling_source():
     return pathlib.Path(inspect.getsourcefile(real_gemma4)).read_text()
 
 
-def _feature_assignments(src, modality):
-    """Every line in ``src`` that BINDS ``<modality>_features``, stripped."""
-    return [
-        line.strip()
-        for line in src.splitlines()
-        if re.match(rf"\s*{modality}_features\s*=", line)
-    ]
+def _mentions(node, name):
+    """Does the expression ``node`` read the local ``name`` anywhere inside it?"""
+    return any(
+        isinstance(n, ast.Name) and n.id == name for n in ast.walk(node)
+    )
+
+
+def _carries_inputs_embeds_dtype(node):
+    """Does ``node`` carry ``inputs_embeds.dtype``?
+
+    Covers both spellings upstream uses: the positional `.to(device, dtype)`
+    overload and the keyword `dtype=inputs_embeds.dtype` one.
+    """
+    for n in ast.walk(node):
+        if (
+            isinstance(n, ast.Attribute)
+            and n.attr == "dtype"
+            and isinstance(n.value, ast.Name)
+            and n.value.id == "inputs_embeds"
+        ):
+            return True
+    return False
+
+
+def _merge_calls(tree, modality):
+    """Every ``masked_scatter`` call that scatters ``<modality>_features``.
+
+    Returns (call_node, source_argument) pairs. The source argument is the
+    scattered VALUE (the second positional arg, or `source=`), which is the
+    tensor whose dtype has to line up with the destination.
+    """
+    name = f"{modality}_features"
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr in ("masked_scatter", "masked_scatter_")):
+            continue
+        args = list(node.args) + [kw.value for kw in node.keywords if kw.arg in (None, "source")]
+        for arg in args:
+            if _mentions(arg, name):
+                found.append((node, arg))
+                break
+    return found
+
+
+def _last_binding_before(tree, name, lineno):
+    """The last assignment to ``name`` that can reach line ``lineno``.
+
+    Textually last wins, which is what a straight-line merge block gives us.
+    Both `x = ...` and `x: T = ...` count, as does a tuple/starred target that
+    includes ``name``.
+    """
+    best = None
+    for node in ast.walk(tree):
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+        else:
+            continue
+        binds = any(
+            isinstance(t, ast.Name) and t.id == name
+            for target in targets
+            for t in ast.walk(target)
+        )
+        if not binds or node.lineno >= lineno:
+            continue
+        if best is None or node.lineno > best.lineno:
+            best = node
+    return best
+
+
+def _merge_is_dtype_aligned(src, modality):
+    """Is the ``<modality>_features`` tensor that reaches the merge dtype-aligned?
+
+    Structural, not textual: find the masked_scatter that consumes the tensor,
+    then ask whether ``inputs_embeds.dtype`` is applied EITHER in the scattered
+    expression itself OR in the last assignment that reaches it. Answering from
+    the reaching definition (rather than from any mention of the name anywhere
+    in the file) is what stops a later device-only rebinding, or a cast in some
+    unrelated method, from standing in for the cast that actually runs.
+
+    Returns (ok, detail) so a failure can say what it saw.
+    """
+    tree = ast.parse(src)
+    merges = _merge_calls(tree, modality)
+    if not merges:
+        return False, f"no masked_scatter consuming {modality}_features"
+    for call, arg in merges:
+        if _carries_inputs_embeds_dtype(arg):
+            continue
+        binding = _last_binding_before(tree, f"{modality}_features", call.lineno)
+        if binding is None:
+            return False, (
+                f"{modality}_features is scattered at line {call.lineno} with no "
+                f"assignment reaching it"
+            )
+        if not _carries_inputs_embeds_dtype(binding.value):
+            return False, (
+                f"the {modality}_features binding reaching the merge at line "
+                f"{call.lineno} does not cast to inputs_embeds.dtype: "
+                f"{ast.unparse(binding).strip()!r}"
+            )
+    return True, f"{len(merges)} merge(s) dtype-aligned"
 
 
 @requires_gemma4
@@ -224,45 +325,115 @@ def test_real_gemma4_image_and_video_merges_still_cast_dtype(modality):
     # Regression anchor: image/video have always cast dtype; if upstream ever
     # drops it there too, that is a new modality that also needs patching.
     #
-    # Asked of the ASSIGNMENTS rather than of one exact call spelling. Upstream
-    # reshaped the image branch to
+    # Asked of the tensor that REACHES the merge rather than of one exact call
+    # spelling. transformers 5.15.0 reshaped the image branch to
     #
     #   image_features = torch.cat(image_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
+    #   ...
+    #   inputs_embeds = inputs_embeds.masked_scatter(image_mask.to(...), image_features.to(inputs_embeds.device))
     #
     # which still casts, but no longer contains the literal
-    # "image_features.to(inputs_embeds.device, inputs_embeds.dtype)". Only the
-    # spelling moved, so a substring match failed on a file that is still
-    # correct -- the guard fired at the wrong thing. What actually matters is
-    # that SOMETHING binds <modality>_features to a value carrying
-    # inputs_embeds.dtype before the masked_scatter, and that survives a
+    # "image_features.to(inputs_embeds.device, inputs_embeds.dtype)" the guard
+    # used to grep for. Only the spelling moved, so the substring match went red
+    # on a file that is still correct. What matters is that the value the
+    # masked_scatter consumes carries inputs_embeds.dtype, and that survives a
     # rename of whatever produced the tensor.
-    assignments = _feature_assignments(_gemma4_modeling_source(), modality)
-    assert assignments, f"no {modality}_features assignment found at all"
-    assert any("inputs_embeds.dtype" in line for line in assignments), (
-        f"Gemma4 {modality} merge no longer casts to inputs_embeds.dtype: "
-        f"{assignments}. That is a modality the unsloth dtype patches do not "
-        f"cover, and masked_scatter will raise on a dtype mismatch."
+    ok, detail = _merge_is_dtype_aligned(_gemma4_modeling_source(), modality)
+    assert ok, (
+        f"Gemma4 {modality} merge no longer casts to inputs_embeds.dtype: {detail}. "
+        f"That is a modality the unsloth dtype patches do not cover, and "
+        f"masked_scatter will raise on a dtype mismatch."
     )
 
 
-def test_the_dtype_cast_guard_can_actually_fail():
-    """The guard above is a search, so it is worth proving it does not always find.
+# Spellings the guard above has to keep straight. Kept out of the gemma4-only
+# section on purpose: these run everywhere, so the guard cannot quietly go
+# vacuous on the hosts that do not have a gemma4 to read.
+_MERGE_SHAPES = {
+    # transformers 5.15.0: the cast moved into the torch.cat that builds the tensor.
+    "cat_then_merge": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).pooler_output
+    image_features = torch.cat(image_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
+    inputs_embeds = inputs_embeds.masked_scatter(
+        image_mask.to(inputs_embeds.device), image_features.to(inputs_embeds.device)
+    )
+""", True),
+    # transformers 5.5.0: cast on a plain rebinding of the same name.
+    "rebind_then_merge": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).pooler_output
+    image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+    inputs_embeds = inputs_embeds.masked_scatter(
+        image_mask.to(inputs_embeds.device), image_features.to(inputs_embeds.device)
+    )
+""", True),
+    # Cast written at the merge itself (what the audio branch does since 5.15.0).
+    "cast_at_merge": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).pooler_output
+    inputs_embeds = inputs_embeds.masked_scatter(
+        image_mask.to(inputs_embeds.device), image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+    )
+""", True),
+    # Keyword dtype= instead of the positional overload.
+    "keyword_dtype": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).to(dtype=inputs_embeds.dtype)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", True),
+    # The regression itself: device only, dtype dropped.
+    "device_only": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).pooler_output
+    image_features = image_features.to(inputs_embeds.device)
+    inputs_embeds = inputs_embeds.masked_scatter(
+        image_mask.to(inputs_embeds.device), image_features.to(inputs_embeds.device)
+    )
+""", False),
+    # A good cast that a later device-only rebinding undoes before the merge.
+    # This is the case a "does the cast appear anywhere" search gets wrong.
+    "cast_then_undone": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).to(inputs_embeds.device, inputs_embeds.dtype)
+    image_features = postprocess(image_features).to(inputs_embeds.device)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", False),
+    # A cast that lives in a different method entirely must not count either.
+    "cast_in_another_method": ("""
+def get_image_features(self, pixel_values, inputs_embeds):
+    return self.vision_tower(pixel_values).to(inputs_embeds.device, inputs_embeds.dtype)
+
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values, inputs_embeds)
+    image_features = image_features.to(inputs_embeds.device)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", False),
+    # No merge at all is a drift we want to hear about, not a silent pass.
+    "no_merge": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).to(inputs_embeds.device, inputs_embeds.dtype)
+    return image_features
+""", False),
+}
+
+
+@pytest.mark.parametrize("shape", sorted(_MERGE_SHAPES))
+def test_the_dtype_cast_guard_reads_the_reaching_definition(shape):
+    """Prove the guard accepts every spelling upstream has shipped, and still fails.
 
     Runs without gemma4 installed, unlike the guard itself, which is the point: a
     guard that only ever runs on hosts with the newest transformers is one nobody
     notices going vacuous."""
-    casts = "    image_features = torch.cat(x, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)\n"
-    older = "    image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
-    device_only = "    image_features = image_features.to(inputs_embeds.device)\n"
+    src, expected = _MERGE_SHAPES[shape]
+    ok, detail = _merge_is_dtype_aligned(src, "image")
+    assert ok is expected, f"{shape}: expected ok={expected}, got {ok} ({detail})"
 
-    def _ok(src):
-        found = _feature_assignments(src, "image")
-        return bool(found) and any("inputs_embeds.dtype" in line for line in found)
 
-    assert _ok(casts), "the current upstream spelling must pass"
-    assert _ok(older), "the spelling this guard used to match must still pass"
-    assert not _ok(device_only), "a device-only merge must fail"
-    assert not _feature_assignments(device_only, "video"), "and it must not match another modality"
+def test_the_dtype_cast_guard_does_not_confuse_modalities():
+    src, _ = _MERGE_SHAPES["cat_then_merge"]
+    ok, detail = _merge_is_dtype_aligned(src, "video")
+    assert not ok and "no masked_scatter" in detail, detail
 
 
 @requires_gemma4

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -203,106 +203,326 @@ def _mentions(node, name):
     )
 
 
-def _carries_inputs_embeds_dtype(node):
-    """Does ``node`` carry ``inputs_embeds.dtype``?
+def _is_attr(node, owner, attr):
+    """``<owner>.<attr>`` as an AST node, e.g. ``inputs_embeds.dtype``."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == attr
+        and isinstance(node.value, ast.Name)
+        and node.value.id == owner
+    )
 
-    Covers both spellings upstream uses: the positional `.to(device, dtype)`
-    overload and the keyword `dtype=inputs_embeds.dtype` one.
+
+def _is_embeds_dtype(node):
+    return _is_attr(node, "inputs_embeds", "dtype")
+
+
+def _is_device_expr(node):
+    """``x.device``, ``"cuda"`` or ``torch.device(...)``: a device, not a dtype."""
+    if isinstance(node, ast.Attribute) and node.attr == "device":
+        return True
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return True
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "device"
+    )
+
+
+def _is_dtype_bearing(node):
+    """Can ``node`` be a dtype argument (``torch.float32``, ``other.dtype``)?"""
+    if isinstance(node, ast.Attribute) and node.attr == "dtype":
+        return True
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "torch"
+    )
+
+
+def _is_embeds_tensor(node):
+    return isinstance(node, ast.Name) and node.id == "inputs_embeds"
+
+
+def _call_aligns_dtype(call):
+    """Does this call land the tensor ON ``inputs_embeds``' dtype?
+
+    Three spellings count. `.to(inputs_embeds.device, inputs_embeds.dtype)` and
+    `.to(dtype = inputs_embeds.dtype)` name the dtype; `.to(inputs_embeds)` and
+    `.type_as(inputs_embeds)` take it from the tensor itself, which torch
+    documents as returning a tensor with the same dtype (and, for `.to`, device)
+    as the argument. Only a dtype ARGUMENT counts, so a bare mention of
+    `inputs_embeds.dtype` somewhere else in the expression proves nothing.
     """
-    for n in ast.walk(node):
-        if (
-            isinstance(n, ast.Attribute)
-            and n.attr == "dtype"
-            and isinstance(n.value, ast.Name)
-            and n.value.id == "inputs_embeds"
-        ):
-            return True
-    return False
+    method = call.func.attr
+    if method == "type_as":
+        return bool(call.args) and _is_embeds_tensor(call.args[0])
+    if method != "to":
+        return False
+    if any(_is_embeds_dtype(a) for a in call.args):
+        return True
+    if any(kw.arg == "dtype" and _is_embeds_dtype(kw.value) for kw in call.keywords):
+        return True
+    # torch spells the tensor overload positionally only; there is no `other=`.
+    return bool(call.args) and _is_embeds_tensor(call.args[0])
 
 
-def _merge_calls(tree, modality):
-    """Every ``masked_scatter`` call that scatters ``<modality>_features``.
+def _to_call_is_device_only(call):
+    """Is this ``.to(...)`` a pure device move, which keeps the dtype?
 
-    Returns (call_node, source_argument) pairs. The source argument is the
-    scattered VALUE (the second positional arg, or `source=`), which is the
-    tensor whose dtype has to line up with the destination.
+    `to(device = None, dtype = None, ...)` infers `dtype` from `self` when it is
+    not given, so `features.to(inputs_embeds.device)` cannot retype anything.
     """
-    name = f"{modality}_features"
+    for arg in call.args:
+        if not _is_device_expr(arg):
+            return False
+    for kw in call.keywords:
+        if kw.arg in ("non_blocking", "copy", "memory_format"):
+            continue
+        if kw.arg == "device" and _is_device_expr(kw.value):
+            continue
+        return False
+    return True
+
+
+# Methods that reshape or relocate a tensor without retyping it, so the dtype the
+# merge sees is still the one its reaching definition established.
+_DTYPE_PRESERVING_METHODS = frozenset({
+    "clone", "contiguous", "detach", "cpu", "cuda",
+    "view", "reshape", "flatten", "squeeze", "unsqueeze",
+    "expand", "expand_as", "transpose", "permute", "narrow",
+})
+
+
+def _expr_alignment(node, name):
+    """Alignment of the value ``node`` produces, for the tensor called ``name``.
+
+    True  -> the expression itself casts to inputs_embeds' dtype.
+    None  -> it only moves/reshapes ``name``, so its dtype is whatever reached it.
+    False -> anything else, including an expression that retypes (`.float()`) or
+             one built from some other tensor entirely.
+    """
+    while True:
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            method = node.func.attr
+            if _call_aligns_dtype(node):
+                return True
+            if method == "to":
+                if not _to_call_is_device_only(node):
+                    return False
+            elif method in _DTYPE_PRESERVING_METHODS:
+                values = list(node.args) + [kw.value for kw in node.keywords]
+                if any(_is_dtype_bearing(v) for v in values):
+                    return False
+            else:
+                return False
+            node = node.func.value
+            continue
+        if isinstance(node, ast.Subscript):
+            node = node.value
+            continue
+        if isinstance(node, ast.Name):
+            return None if node.id == name else False
+        return False
+
+
+def _bound_names(target):
+    """Every plain local name an assignment target binds.
+
+    `image_features[0] = ...` and `self.image_features = ...` are NOT bindings:
+    the name keeps referring to the same object, so the RHS of a slice write is
+    not the definition that reaches the merge.
+    """
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return [n for elt in target.elts for n in _bound_names(elt)]
+    if isinstance(target, ast.Starred):
+        return _bound_names(target.value)
+    return []
+
+
+_SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+
+
+def _walk_own_scope(root, descend = True):
+    """``ast.walk`` restricted to the code ``root``'s own scope executes.
+
+    A nested `def` / `class` / `lambda` has its own locals, so a cast written in
+    another method says nothing about the tensor this one scatters. The nested
+    node itself is still yielded, only its body is skipped.
+    """
+    if isinstance(root, _SCOPE_NODES) and not descend:
+        yield root
+        return
+    todo = [root]
+    while todo:
+        node = todo.pop(0)
+        yield node
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, _SCOPE_NODES):
+                yield child
+            else:
+                todo.append(child)
+
+
+def _child_blocks(stmt):
+    """Every nested statement list of ``stmt`` (if/else, loop bodies, try)."""
+    blocks = []
+    for field in ("body", "orelse", "finalbody"):
+        value = getattr(stmt, field, None)
+        if isinstance(value, list) and value and all(isinstance(s, ast.stmt) for s in value):
+            blocks.append(value)
+    for handler in getattr(stmt, "handlers", None) or []:
+        blocks.append(handler.body)
+    return blocks
+
+
+def _enclosing_blocks(scope, target):
+    """``[(block, index)]`` from the scope body inwards to the stmt holding ``target``.
+
+    Only these statement lists run on the path to ``target``. A cast stranded in
+    a branch the merge does not run under is not a reaching definition, however
+    late in the file it is written.
+    """
+    chain = []
+
+    def holds(node):
+        return any(n is target for n in _walk_own_scope(node, descend = False))
+
+    def descend(block):
+        for index, stmt in enumerate(block):
+            if not holds(stmt):
+                continue
+            chain.append((block, index))
+            for inner in _child_blocks(stmt):
+                if any(holds(s) for s in inner):
+                    descend(inner)
+                    break
+            return
+
+    descend(scope.body)
+    return chain
+
+
+def _rebinding_values(stmt, name):
+    """The value expressions every rebinding of ``name`` inside ``stmt`` gives it."""
+    values = []
+    for node in _walk_own_scope(stmt, descend = False):
+        if isinstance(node, ast.Assign):
+            pairs = [(t, node.value) for t in node.targets]
+        elif isinstance(node, (ast.AnnAssign, ast.NamedExpr)) and node.value is not None:
+            pairs = [(node.target, node.value)]
+        else:
+            continue
+        for target, value in pairs:
+            if name in _bound_names(target):
+                values.append(value)
+    return values
+
+
+def _reaching_alignment(scope, name, target):
+    """Fold the statements that reach ``target`` into "is ``name`` dtype-aligned?".
+
+    Every rebinding on the way has to leave the tensor aligned. A rebinding that
+    only moves or reshapes it inherits the running verdict, so a device move
+    hoisted out of the merge call does not read as a regression; one that can
+    retype it, or that is stranded in a branch alongside an unaligned sibling,
+    makes the whole thing unaligned.
+    """
+    state, seen = False, False
+    for block, index in _enclosing_blocks(scope, target):
+        for stmt in block[:index]:
+            values = _rebinding_values(stmt, name)
+            if not values:
+                continue
+            seen = True
+            resolved = [_expr_alignment(v, name) for v in values]
+            state = all(state if r is None else r for r in resolved)
+    return state, seen
+
+
+def _feature_merges(scope, name):
+    """Every ``inputs_embeds.masked_scatter[_](mask, <name> ...)`` in ``scope``.
+
+    The receiver has to reference `inputs_embeds`: an auxiliary scatter into some
+    other tensor is not the merge these guards protect, and letting one in makes
+    the canary answer for the wrong call in both directions. Only the SOURCE
+    operand is inspected, since that is the tensor whose dtype `masked_scatter`
+    requires to match; the mask is a bool tensor and its dtype is irrelevant.
+    """
     found = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
+    for node in _walk_own_scope(scope):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("masked_scatter", "masked_scatter_")
+        ):
             continue
-        func = node.func
-        if not (isinstance(func, ast.Attribute) and func.attr in ("masked_scatter", "masked_scatter_")):
+        if not _mentions(node.func.value, "inputs_embeds"):
             continue
-        args = list(node.args) + [kw.value for kw in node.keywords if kw.arg in (None, "source")]
-        for arg in args:
-            if _mentions(arg, name):
-                found.append((node, arg))
-                break
+        source = node.args[1] if len(node.args) >= 2 else None
+        if source is None:
+            source = next((kw.value for kw in node.keywords if kw.arg == "source"), None)
+        if source is not None and _mentions(source, name):
+            found.append((node, source))
     return found
 
 
-def _last_binding_before(tree, name, lineno):
-    """The last assignment to ``name`` that can reach line ``lineno``.
-
-    Textually last wins, which is what a straight-line merge block gives us.
-    Both `x = ...` and `x: T = ...` count, as does a tuple/starred target that
-    includes ``name``.
-    """
-    best = None
+def _scopes(tree):
+    """The module plus every function body, each as its own name scope."""
+    yield tree
     for node in ast.walk(tree):
-        targets = []
-        if isinstance(node, ast.Assign):
-            targets = node.targets
-        elif isinstance(node, ast.AnnAssign) and node.value is not None:
-            targets = [node.target]
-        else:
-            continue
-        binds = any(
-            isinstance(t, ast.Name) and t.id == name
-            for target in targets
-            for t in ast.walk(target)
-        )
-        if not binds or node.lineno >= lineno:
-            continue
-        if best is None or node.lineno > best.lineno:
-            best = node
-    return best
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
 
 
 def _merge_is_dtype_aligned(src, modality):
     """Is the ``<modality>_features`` tensor that reaches the merge dtype-aligned?
 
-    Structural, not textual: find the masked_scatter that consumes the tensor,
-    then ask whether ``inputs_embeds.dtype`` is applied EITHER in the scattered
-    expression itself OR in the last assignment that reaches it. Answering from
-    the reaching definition (rather than from any mention of the name anywhere
-    in the file) is what stops a later device-only rebinding, or a cast in some
-    unrelated method, from standing in for the cast that actually runs.
+    Structural, not textual: find the `inputs_embeds.masked_scatter` that
+    consumes the tensor, then ask whether it lands on ``inputs_embeds.dtype``
+    either in the scattered expression itself or in the definitions that reach
+    it along the merge's own control-flow path, inside the merge's own scope.
+    Answering from the reaching definition (rather than from any mention of the
+    name anywhere in the file) is what stops a later retyping rebinding, or a
+    cast in some unrelated method or untaken branch, from standing in for the
+    cast that actually runs.
 
     Returns (ok, detail) so a failure can say what it saw.
     """
     tree = ast.parse(src)
-    merges = _merge_calls(tree, modality)
-    if not merges:
-        return False, f"no masked_scatter consuming {modality}_features"
-    for call, arg in merges:
-        if _carries_inputs_embeds_dtype(arg):
-            continue
-        binding = _last_binding_before(tree, f"{modality}_features", call.lineno)
-        if binding is None:
-            return False, (
-                f"{modality}_features is scattered at line {call.lineno} with no "
-                f"assignment reaching it"
-            )
-        if not _carries_inputs_embeds_dtype(binding.value):
-            return False, (
-                f"the {modality}_features binding reaching the merge at line "
-                f"{call.lineno} does not cast to inputs_embeds.dtype: "
-                f"{ast.unparse(binding).strip()!r}"
-            )
-    return True, f"{len(merges)} merge(s) dtype-aligned"
+    name = f"{modality}_features"
+    total = 0
+    for scope in _scopes(tree):
+        for call, source in _feature_merges(scope, name):
+            total += 1
+            at_call = _expr_alignment(source, name)
+            if at_call is True:
+                continue
+            if at_call is False:
+                # The scattered expression rebuilds or retypes the tensor, so
+                # whatever the reaching definition established no longer holds.
+                return False, (
+                    f"the expression scattered at line {call.lineno} does not "
+                    f"reach inputs_embeds.dtype: {ast.unparse(source).strip()!r}"
+                )
+            aligned, seen = _reaching_alignment(scope, name, call)
+            if not seen:
+                return False, (
+                    f"{name} is scattered at line {call.lineno} with no "
+                    f"assignment reaching it"
+                )
+            if not aligned:
+                return False, (
+                    f"the {name} binding reaching the merge at line "
+                    f"{call.lineno} does not cast to inputs_embeds.dtype: "
+                    f"{ast.unparse(source).strip()!r}"
+                )
+    if not total:
+        return False, f"no masked_scatter consuming {name}"
+    return True, f"{total} merge(s) dtype-aligned"
 
 
 @requires_gemma4
@@ -408,6 +628,78 @@ def forward(self, inputs_embeds):
     image_features = self.get_image_features(pixel_values, inputs_embeds)
     image_features = image_features.to(inputs_embeds.device)
     inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", False),
+    # torch's tensor overload: `.to(other)` takes other's dtype AND device, so
+    # this is aligned even though it never spells `inputs_embeds.dtype`.
+    "tensor_overload": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).to(inputs_embeds)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", True),
+    # `.type_as` is the dtype-only spelling of the same thing.
+    "type_as": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).type_as(inputs_embeds)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", True),
+    # A device move hoisted OUT of the merge call keeps the earlier cast: `.to()`
+    # infers dtype from self when none is given, so this cannot retype anything.
+    "device_move_after_cast": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).pooler_output
+    image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+    image_features = image_features.to(inputs_embeds.device)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", True),
+    # An auxiliary scatter into some OTHER tensor is not the merge we protect,
+    # and must not be able to fail the guard on a correct inputs_embeds merge.
+    "auxiliary_scatter_elsewhere": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).to(inputs_embeds.device, inputs_embeds.dtype)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+    scratch = torch.zeros_like(inputs_embeds)
+    image_features = image_features.float()
+    scratch = scratch.masked_scatter(image_mask, image_features)
+""", True),
+    # A mention of inputs_embeds.dtype that is not a cast argument proves nothing.
+    "dtype_mentioned_but_not_applied": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).to(inputs_embeds.device) if inputs_embeds.dtype is not None else image_features
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", False),
+    # A cast in the branch the merge does NOT come through is not a definition
+    # that reaches it.
+    "cast_in_untaken_branch": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).pooler_output
+    if fast_path:
+        image_features = image_features.to(inputs_embeds.device)
+    else:
+        image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", False),
+    # The mask operand's dtype is irrelevant; only the source has to line up.
+    "cast_on_the_mask_only": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).to(inputs_embeds.device)
+    inputs_embeds = inputs_embeds.masked_scatter(
+        image_features.to(inputs_embeds.dtype).bool(), image_features
+    )
+""", False),
+    # A slice write does not rebind the name, so its RHS is not the definition
+    # that reaches the merge.
+    "subscript_write_is_not_a_binding": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).to(inputs_embeds.device)
+    image_features[0] = replacement.to(inputs_embeds.dtype)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+""", False),
+    # The scattered expression retypes the tensor, so an earlier good cast is
+    # already spent by the time masked_scatter sees it.
+    "source_overrides_the_dtype": ("""
+def forward(self, inputs_embeds):
+    image_features = self.get_image_features(pixel_values).to(inputs_embeds.device, inputs_embeds.dtype)
+    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features.float())
 """, False),
     # No merge at all is a drift we want to hear about, not a silent pass.
     "no_merge": ("""


### PR DESCRIPTION
Follow-up to #1046, which fixed the red `Core (HF=latest + TRL=latest)` cell:

```
FAILED tests/test_gemma4_dtype_drift_guards.py::test_real_gemma4_image_and_video_merges_still_cast_dtype
```

#1046 replaced the substring search with a line search over assignments to
`<modality>_features`. That is correct on both transformers versions we run,
but it accepts a cast written anywhere in `modeling_gemma4.py`, which is looser
than the thing the guard exists to protect. Two files that are broken at the
merge still pass it:

```python
# a good cast that a later rebinding undoes
image_features = self.get_image_features(pixel_values).to(inputs_embeds.device, inputs_embeds.dtype)
image_features = postprocess(image_features).to(inputs_embeds.device)
inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
```

```python
# a cast that lives in a different method
def get_image_features(self, pixel_values, inputs_embeds):
    return self.vision_tower(pixel_values).to(inputs_embeds.device, inputs_embeds.dtype)

def forward(self, inputs_embeds):
    image_features = self.get_image_features(pixel_values, inputs_embeds)
    image_features = image_features.to(inputs_embeds.device)
    inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
```

### What this does

Reads the reaching definition instead of searching the file. Walk the AST, find
the `masked_scatter` that consumes `<modality>_features`, and check whether
`inputs_embeds.dtype` is applied in the scattered expression itself or in the
last assignment that reaches it. Both spellings upstream uses count, the
positional `.to(device, dtype)` overload and the keyword `dtype=`. A merge that
cannot be found at all is a failure rather than a silent pass.

That is what makes the later device-only rebinding win over the earlier good
cast, which is what actually runs, and what keeps a cast in an unrelated method
from standing in for one that is missing.

Robust across the versions we support rather than pinned to one upstream
spelling, which is what put the original guard on the floor:

| transformers | image | video | audio |
| --- | --- | --- | --- |
| 5.5.0 | `image_features = image_features.to(device, dtype)` | same shape | device only, the known upstream bug |
| 5.15.0 | cast folded into `torch.cat(image_features, dim=0).to(device, dtype)` | unchanged | now casts dtype at the merge |

Both shapes are dtype-aligned at the merge and both pass. Audio is unchanged
here: `test_real_gemma4_audio_merge_site_is_recognized` already accepts either
the device-only form or the fixed one, and upstream fixed it at 5.15.0.

`_MERGE_SHAPES` pins the behaviour on eight small sources and runs WITHOUT
gemma4 installed, which is the point: a guard that only runs on hosts with the
newest transformers is one nobody notices going vacuous. It covers the 5.5.0
shape, the 5.15.0 `torch.cat` shape, a cast written at the merge, the keyword
form, and the four ways this should go red, including the two cases above.

### Verified

- `tests/test_gemma4_dtype_drift_guards.py`: 35 passed on transformers 5.5.0
  and 35 passed on 5.15.0.
- Negative check on the real file: dropping `inputs_embeds.dtype` from the
  v5.15.0 `torch.cat` line makes the guard fail with `the image_features
  binding reaching the merge at line 2336 does not cast to inputs_embeds.dtype`,
  and it passes again once restored.
- Full `tests/` on transformers 5.15.0 + trl 1.9.2: 4470 passed, 297 skipped,
  9 failed. All 9 fail identically on unmodified main in this environment
  (they need `unsloth` installed and a generated trainer) and none touch gemma4.

Tests only, no runtime change.
