### PR TITLE
Avoid persistent CUDA context creation during Zoo imports

### DIFF
--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -127,7 +127,7 @@ def test_temporary_patches_submodule_list_is_complete():
 
 def test_gpt_oss_imports_without_visible_gpus():
     """gpt_oss.py computes device_memory at import; with UNSLOTH_ALLOW_CPU=1
-    DEVICE_TYPE stays "cuda" on GPU-less hosts, so mem_get_info must be
+    DEVICE_TYPE stays "cuda" on GPU-less hosts, so the capacity lookup must be
     guarded. Subprocess so conftest's mem_get_info stub cannot mask it."""
     import os
     import subprocess
@@ -142,6 +142,56 @@ def test_gpt_oss_imports_without_visible_gpus():
     result = subprocess.run(
         [sys.executable, "-c",
          "import unsloth_zoo.temporary_patches.gpt_oss; print('IMPORT_OK')"],
+        env=env, capture_output=True, text=True, timeout=600,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert "IMPORT_OK" in result.stdout
+
+
+def test_xet_submodule_import_does_not_query_free_device_memory():
+    """Importing a download helper must not create an accelerator context.
+
+    gpt_oss only needs total capacity to select combo-kernel options. Device
+    properties provide that without the context-creating mem_get_info call.
+    """
+    import os
+    import subprocess
+    import sys
+
+    script = r'''
+import torch
+
+class Props:
+    major = 8
+    minor = 9
+    total_memory = 48 * 1024**3
+    multi_processor_count = 108
+    name = "stub"
+
+def forbidden(*args, **kwargs):
+    raise AssertionError("mem_get_info was called during import")
+
+torch.cuda.is_available = lambda: True
+torch.cuda.device_count = lambda: 1
+torch.cuda.current_device = lambda: 0
+torch.cuda.get_device_capability = lambda *args, **kwargs: (8, 9)
+torch.cuda.get_device_properties = lambda *args, **kwargs: Props()
+torch.cuda.mem_get_info = forbidden
+torch.cuda.memory.mem_get_info = forbidden
+
+import unsloth_zoo.hf_xet_fallback
+from unsloth_zoo.temporary_patches import gpt_oss
+assert gpt_oss.device_memory == Props.total_memory
+assert gpt_oss.use_combo_kernels is True
+print("IMPORT_OK")
+'''
+    env = {
+        **os.environ,
+        "UNSLOTH_IS_PRESENT": "1",
+        "UNSLOTH_ALLOW_CPU": "1",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
         env=env, capture_output=True, text=True, timeout=600,
     )
     assert result.returncode == 0, result.stderr[-2000:]

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -196,3 +196,53 @@ print("IMPORT_OK")
     )
     assert result.returncode == 0, result.stderr[-2000:]
     assert "IMPORT_OK" in result.stdout
+
+
+def test_flex_attention_import_does_not_query_free_device_memory():
+    """The same probe pattern in flex_attention/utils.py.
+
+    It only needs total capacity, like gpt_oss, and gpt_oss imports it, so leaving
+    mem_get_info() here would put back the context the gpt_oss fix removes for anyone
+    who reaches the flex-attention path.
+    """
+    import os
+    import subprocess
+    import sys
+
+    script = r'''
+import torch
+
+class Props:
+    major = 8
+    minor = 9
+    total_memory = 48 * 1024**3
+    multi_processor_count = 108
+    name = "stub"
+
+def forbidden(*args, **kwargs):
+    raise AssertionError("mem_get_info was called during import")
+
+torch.cuda.is_available = lambda: True
+torch.cuda.device_count = lambda: 1
+torch.cuda.current_device = lambda: 0
+torch.cuda.get_device_capability = lambda *args, **kwargs: (8, 9)
+torch.cuda.get_device_properties = lambda *args, **kwargs: Props()
+torch.cuda.mem_get_info = forbidden
+torch.cuda.memory.mem_get_info = forbidden
+
+from unsloth_zoo.flex_attention import utils
+# 48 GB is above the 16 GB threshold, so the low-memory kernel options stay off.
+assert utils.kernel_options is None, utils.kernel_options
+print("IMPORT_OK")
+'''
+    env = {
+        **os.environ,
+        "UNSLOTH_IS_PRESENT": "1",
+        "UNSLOTH_ALLOW_CPU": "1",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env, capture_output=True, text=True, timeout=600,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert "IMPORT_OK" in result.stdout

--- a/unsloth_zoo/flex_attention/utils.py
+++ b/unsloth_zoo/flex_attention/utils.py
@@ -51,7 +51,9 @@ try:
     # InductorError: RuntimeError: No valid triton configs. OutOfMemoryError: out of resource: triton_tem_fused_0 Required: 65536 Hardware limit:65536 Reducing block sizes or `num_stages` may help.
     # See https://github.com/pytorch/pytorch/issues/133254#issuecomment-2408710459
     # https://github.com/pytorch/pytorch/issues/133254#issuecomment-2539969593
-    vram_of_gpu = min(torch.cuda.memory.mem_get_info(i)[-1]/1024/1024/1024 for i in range(torch.cuda.device_count()))
+    # Total capacity, like the gpt_oss probe: mem_get_info() would create a device
+    # context at import time and leave an otherwise idle process holding it.
+    vram_of_gpu = min(torch.cuda.get_device_properties(i).total_memory/1024/1024/1024 for i in range(torch.cuda.device_count()))
     kernel_options = None
     if vram_of_gpu <= 16:
         kernel_options = {

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1391,9 +1391,11 @@ from ..device_type import DEVICE_TYPE
 # UNSLOTH_ALLOW_CPU=1 keeps DEVICE_TYPE="cuda" on GPU-less hosts, so guard
 # with is_available() like device_synchronize() does.
 if DEVICE_TYPE == "xpu" and hasattr(torch, "xpu") and torch.xpu.is_available():
-    device_memory = torch.xpu.memory.mem_get_info(0)[-1]
+    # Only total capacity is needed. mem_get_info() can create a device context at
+    # import time, leaving otherwise idle processes with persistent device memory.
+    device_memory = torch.xpu.get_device_properties(0).total_memory
 elif DEVICE_TYPE in ("cuda", "hip") and torch.cuda.is_available():
-    device_memory = torch.cuda.memory.mem_get_info(0)[-1]
+    device_memory = torch.cuda.get_device_properties(0).total_memory
 else:
     device_memory = 0
 use_combo_kernels = False if device_memory/1024/1024/1024 <= 40 else True


### PR DESCRIPTION
## Context

Unsloth Studio uses `unsloth_zoo.hf_xet_fallback` for Xet download health, tuning, watchdog, and HTTP fallback behavior. Importing that submodule first executes Zoo's package initializer, which imports `temporary_patches.gpt_oss`.

`gpt_oss.py` only needs total device capacity to configure combo kernels, but used `mem_get_info()`. That call creates a CUDA context which remains allocated for the lifetime of Studio's backend, even though Xet itself does not use the GPU.

## Change

Read total capacity from device properties instead. This returns the same value and preserves combo-kernel selection without creating the persistent context.

## Live measurements

Measured with Studio's Python environment, PyTorch 2.10.0+cu130, Zoo 2026.8.10, and an NVIDIA RTX 6000 Ada:

| Probe | `nvidia-smi` usage | Torch allocated / reserved |
| --- | ---: | ---: |
| Import Torch | No process | 0 / 0 |
| `torch.cuda.get_device_properties(0)` | No process | 0 / 0 |
| `torch.cuda.mem_get_info(0)` | 426 MiB | 0 / 0 |
| Import `unsloth_zoo.hf_xet_fallback` on `main` | 426 MiB | 0 / 0 |
| Import `unsloth_zoo.hf_xet_fallback` with this change | No process | 0 / 0 |

Both capacity APIs returned exactly `50,865,307,648` bytes.

## Testing

- Added an import regression that forbids `mem_get_info()` and verifies combo-kernel selection is preserved.
- Temporary-patches suite: 39 passed.
- Ruff and compile checks passed.
