### PR TITLE
Pad the GRPO log-softmax chunks so torch 2.12 can still compile them

### DIFF
--- a/tests/test_grpo_chunk_padding.py
+++ b/tests/test_grpo_chunk_padding.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Equal-chunk padding in ``chunked_hidden_states_selective_log_softmax``.
+
+The GRPO log-softmax chunks its rows with ``torch.chunk(x, chunks = N)``, which
+leaves a ragged last chunk of ``n - (N - 1)*ceil(n/N)`` rows. Inside one dynamic
+graph that tail is a symbolic expression in ``n``, and torch 2.12's Inductor
+cannot prove a vocab-wide node over it splits evenly, so the GRPO step dies with
+
+    InductorError: CantSplit: 202048*s47*s87 - 3434816*(((s47*s87 + 17)//18))
+    not divisible by s47*s87 - 17*(((s47*s87 + 17)//18))
+
+Padding the row count up to a multiple of ``chunks`` removes the ragged tail.
+These tests pin the two things that has to be true: the padding never changes a
+returned value, and the chunk sizes really are all equal.
+
+The function is lifted out with ``ast`` rather than imported, so the tests stay
+CPU-only and do not need the rest of unsloth_zoo. Decorators are stripped: the
+change is shape bookkeeping, and eager exercises it exactly.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+
+SOURCE_PATH = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "rl_replacements.py"
+FUNCTION_NAME = "chunked_hidden_states_selective_log_softmax"
+
+
+def _load_chunked_log_softmax():
+    tree = ast.parse(SOURCE_PATH.read_text(encoding = "utf-8"), filename = str(SOURCE_PATH))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == FUNCTION_NAME:
+            node.decorator_list = []
+            namespace: dict = {"torch": torch, "os": os}
+            exec(
+                compile(ast.Module(body = [node], type_ignores = []), str(SOURCE_PATH), "exec"),
+                namespace,
+            )
+            return namespace[FUNCTION_NAME]
+    raise AssertionError(f"{FUNCTION_NAME} not found in {SOURCE_PATH}")
+
+
+chunked_log_softmax = _load_chunked_log_softmax()
+
+
+def unpadded_reference(
+    hidden_states, lm_head, index, chunks,
+    logit_scale_multiply = 0.0, logit_scale_divide = 0.0,
+    logit_softcapping = 0.0, temperature = 1.0,
+):
+    """The pre-fix body: torch.chunk straight through, ragged tail and all."""
+    flat_hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
+    flat_index = index.reshape(-1)
+    out = []
+    for chunk_hidden_states, chunk_index in zip(
+        torch.chunk(flat_hidden_states, chunks = chunks, dim = 0),
+        torch.chunk(flat_index, chunks = chunks, dim = 0),
+    ):
+        chunk_hidden_states = chunk_hidden_states.to(device = lm_head.device, dtype = lm_head.dtype)
+        chunk_index = chunk_index.to(lm_head.device)
+        chunk_logits = chunk_hidden_states @ lm_head.t()
+        if logit_scale_multiply != 0.0:
+            chunk_logits = chunk_logits * logit_scale_multiply
+        if logit_scale_divide != 0.0:
+            chunk_logits = chunk_logits / logit_scale_divide
+        if logit_softcapping != 0.0:
+            chunk_logits = logit_softcapping * torch.tanh(chunk_logits / logit_softcapping)
+        chunk_logits = chunk_logits.to(torch.float32)
+        if temperature != 1.0:
+            chunk_logits = chunk_logits / temperature
+        selected = torch.gather(chunk_logits, dim = -1, index = chunk_index.unsqueeze(-1)).squeeze(-1)
+        out.append((selected - torch.logsumexp(chunk_logits, dim = -1)).to(hidden_states.device))
+    return torch.concat(out).reshape((hidden_states.shape[0], hidden_states.shape[1]))
+
+
+# (batch, seq, chunks). The Muse Glimmer shape that raised CantSplit is a
+# ragged split at 18 chunks, so ragged cases lead.
+SHAPES = [
+    (4, 137, 18),   # ragged, the reported shape
+    (5, 100,  7),   # ragged, odd chunk count
+    (1,  17, 18),   # one row short of the chunk count
+    (1,  19, 18),   # torch.chunk returns fewer chunks than asked
+    (1,   5, 18),   # rows well below the chunk count
+    (1,   1, 18),   # single row
+    (1,   1,  1),   # single row, single chunk
+    (2,  50,  1),   # one chunk, nothing to pad
+    (6,  36, 18),   # already an exact multiple
+    (4,   9,  4),   # exact multiple, small
+]
+
+SCALINGS = [
+    {},
+    {"logit_softcapping": 30.0, "temperature": 0.7},
+    {"logit_scale_multiply": 2.0},
+    {"logit_scale_divide": 4.0},
+]
+
+
+@pytest.mark.parametrize("batch, seq, chunks", SHAPES)
+@pytest.mark.parametrize("scaling", SCALINGS)
+def test_padding_never_changes_a_returned_value(batch, seq, chunks, scaling):
+    torch.manual_seed(0)
+    vocab, hidden = 512, 32
+    lm_head = torch.randn(vocab, hidden)
+    hidden_states = torch.randn(batch, seq, hidden)
+    index = torch.randint(0, vocab, (batch, seq))
+
+    got = chunked_log_softmax(hidden_states, lm_head, index, chunks, **scaling)
+    expected = unpadded_reference(hidden_states, lm_head, index, chunks, **scaling)
+
+    assert got.shape == (batch, seq)
+    # Bit-identical, not close: padding repeats a row and slices it back off,
+    # so it must not perturb any surviving value at all.
+    assert torch.equal(got, expected)
+
+
+@pytest.mark.parametrize("batch, seq, chunks", SHAPES)
+def test_every_chunk_is_the_same_size(batch, seq, chunks):
+    """The property the Inductor fix rests on, checked on the padded count."""
+    n_rows = batch * seq
+    rows_per_chunk = (n_rows + chunks - 1) // chunks
+    padded = rows_per_chunk * chunks
+
+    sizes = [c.shape[0] for c in torch.chunk(torch.empty(padded, 4), chunks = chunks, dim = 0)]
+
+    assert len(set(sizes)) == 1, f"ragged split survived: {sizes}"
+    assert len(sizes) == chunks
+    assert sum(sizes) == padded
+    assert padded - n_rows < chunks
+
+
+def test_the_unpadded_reference_really_is_ragged():
+    """Guard against the suite passing because the reference was fixed too."""
+    sizes = [c.shape[0] for c in torch.chunk(torch.empty(548, 4), chunks = 18, dim = 0)]
+    assert len(set(sizes)) > 1, "expected torch.chunk to leave a ragged tail at 548/18"
+    assert sizes[-1] != sizes[0]

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -123,6 +123,36 @@ def chunked_hidden_states_selective_log_softmax(
         chunks = max(chunks, -(-n_rows // max_rows_per_chunk))
         chunks = min(chunks, max(n_rows, 1))
 
+    # Pad the row count up to a whole multiple of `chunks` so every chunk is
+    # the same size. `torch.chunk(x, chunks = N)` otherwise gives N - 1 chunks
+    # of ceil(n/N) and a ragged last one of n - (N - 1)*ceil(n/N). Under
+    # dynamic shapes that tail is a symbolic expression in n, and Inductor has
+    # to prove a vocab-wide node over it splits evenly. torch 2.12 cannot:
+    # `SizeVarAllocator.statically_known_multiple_of` returns False there for
+    # 202048*tail over tail -- measured on a Tesla T4 with 2.12.1, and True on
+    # 2.9.1, 2.10.0 and 2.11.0 -- so the compile dies with
+    #   InductorError: CantSplit: 202048*s47*s87 - 3434816*(((s47*s87 + 17)//18))
+    #   not divisible by s47*s87 - 17*(((s47*s87 + 17)//18))
+    # which is the whole GRPO step, not a slow path. The same predicate answers
+    # True for a full chunk, ceil(n/18), on every version including 2.12.1,
+    # so equal chunks sidestep it rather than working around it.
+    #
+    # The padding repeats the last row, costs at most `chunks - 1` extra rows
+    # of a matmul that already runs over thousands, and is sliced back off
+    # below, so every returned value is unchanged. It is written without a
+    # Python `if`: `pad` is a SymInt under dynamic shapes and branching on it
+    # would either specialise the graph on n % chunks or graph-break under
+    # fullgraph. A zero-length cat is a no-op, which is the padless case.
+    n_rows = flat_hidden_states.shape[0]
+    rows_per_chunk = (n_rows + chunks - 1) // chunks
+    pad_rows = rows_per_chunk * chunks - n_rows
+    flat_hidden_states = torch.cat(
+        (flat_hidden_states, flat_hidden_states[-1:].expand(pad_rows, -1)), dim = 0,
+    )
+    flat_index = torch.cat(
+        (flat_index, flat_index[-1:].expand(pad_rows)), dim = 0,
+    )
+
     chunked_hidden_states = torch.chunk(flat_hidden_states, chunks=chunks, dim=0)
     chunked_index = torch.chunk(flat_index, chunks=chunks, dim=0)
 
@@ -161,6 +191,9 @@ def chunked_hidden_states_selective_log_softmax(
         all_per_token_logps.append(per_token_logps.to(hidden_states.device))
 
     all_per_token_logps = torch.concat(all_per_token_logps)
+    # Drop the repeated rows the equal-chunk padding added. A padless call
+    # slices [:n_rows] on exactly n_rows and is a no-op.
+    all_per_token_logps = all_per_token_logps[:n_rows]
 
     all_per_token_logps = all_per_token_logps.reshape((hidden_states.shape[0], hidden_states.shape[1]))
     return all_per_token_logps

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -52,8 +52,23 @@ def chunked_selective_log_softmax(
     temperature: float = 1.0,
     chunks: int = 4,
 ):
-    chunked_logits = torch.chunk(logits.reshape(-1, logits.shape[-1]), chunks = chunks, dim = 0)
-    chunked_index  = torch.chunk(index.reshape(-1), chunks = chunks, dim = 0)
+    flat_logits = logits.reshape(-1, logits.shape[-1])
+    flat_index  = index.reshape(-1)
+    # Equal chunks, for the reason spelled out in
+    # `chunked_hidden_states_selective_log_softmax`: the ragged last chunk of
+    # `torch.chunk(x, chunks = N)` is a symbolic expression in the row count,
+    # and torch 2.12's Inductor will not split a vocab-wide node over it,
+    # failing the whole region with `InductorError: CantSplit`. This function
+    # is the raw-logits sibling of that one and chunks the same way over the
+    # same vocab width, so it carries the same exposure. The padding repeats
+    # the last row and is sliced back off, leaving results unchanged.
+    n_rows = flat_logits.shape[0]
+    pad_rows = ((n_rows + chunks - 1) // chunks) * chunks - n_rows
+    flat_logits = torch.cat((flat_logits, flat_logits[-1:].expand(pad_rows, -1)), dim = 0)
+    flat_index  = torch.cat((flat_index,  flat_index[-1:].expand(pad_rows)),      dim = 0)
+
+    chunked_logits = torch.chunk(flat_logits, chunks = chunks, dim = 0)
+    chunked_index  = torch.chunk(flat_index,  chunks = chunks, dim = 0)
     all_per_token_logps = []
     # Per-chunk selective_log_softmax.
     for chunk_logits, chunk_index in zip(chunked_logits, chunked_index):
@@ -66,6 +81,7 @@ def chunked_selective_log_softmax(
         all_per_token_logps.append(per_token_logps)
     pass
     all_per_token_logps = torch.concat(all_per_token_logps)
+    all_per_token_logps = all_per_token_logps[:n_rows]
     all_per_token_logps = all_per_token_logps.reshape((logits.shape[0], logits.shape[1]))
     return all_per_token_logps
 pass


### PR DESCRIPTION
`chunked_hidden_states_selective_log_softmax` and `chunked_selective_log_softmax` both split their rows with `torch.chunk(x, chunks = N)`, which leaves a ragged last chunk of `n - (N - 1)*ceil(n/N)`. Inside one dynamic `fullgraph` region that tail is a symbolic expression in `n`, and Inductor has to prove a vocab-wide node over it splits evenly.

torch 2.12 cannot, so a GRPO step dies at compile time:

```
InductorError: CantSplit: 202048*s47*s87 - 3434816*(((s47*s87 + 17)//18))
not divisible by s47*s87 - 17*(((s47*s87 + 17)//18))
```

That is the whole step, not a slow path. It is also not a real indivisibility: `202048*tail` over `tail` is `202048` by inspection.

## Measured, not inferred

Feeding that exact expression to `SizeVarAllocator.statically_known_multiple_of`:

| chunk size | 2.9.1 | 2.10.0 | 2.11.0 | 2.12.1 |
|---|---|---|---|---|
| ragged tail `n - 17*ceil(n/18)` | True | True | True | **False** |
| full chunk `ceil(n/18)` | True | True | True | True |

Confirmed on a real Tesla T4 running 2.12.1, which is where it was reported, and the traceback's `simd.py:847` matches 2.12's source.

So equal chunks avoid the question rather than working around the answer. Padding the row count up to a multiple of `chunks` removes the ragged tail; the padding repeats the last row and is sliced back off.

## Both call sites

The second function is the raw-logits sibling, reached whenever the model returns logits instead of hidden states. It chunks the same way over the same vocab width inside the same kind of region, so it carries the same exposure. Found by searching every `torch.chunk` in the package rather than stopping at the traceback. The remaining call sites, the GRPO gradient chunker and the fused cross-entropy loop, chunk outside the compiled region or over non-vocab widths and are not exposed.

## Verification

- Results are unchanged: the tests assert `torch.equal`, not closeness, against the pre-fix body across ragged splits, exact multiples, single rows, one chunk, and row counts below the chunk count where `torch.chunk` returns fewer chunks than asked.
- One test asserts the reference really is ragged, so the suite cannot pass vacuously.
- Both functions compile under `fullgraph = True, dynamic = True` on 2.12.1 with no graph breaks across four different pad values. This matters because `pad_rows` is a SymInt: the code deliberately avoids a Python `if` on it, which would either specialise the graph on `n % chunks` or graph-break under `fullgraph`.
- 111 tests pass across the chunked log-softmax, device, reduction-dim, compile-disable and raw-logits-dispatch suites.

## Scope note

The fix stays inside each function on purpose. `unsloth/models/rl.py` inlines both into generated trainers with `inspect.getsource`, dumping only the one function, so a new module-level helper would `NameError` at import there. That ruled out the alternative of hoisting the chunk loop out of the compiled region.

Cost is at most `chunks - 1` extra rows through a matmul that already runs over thousands.

A live Muse Glimmer GRPO run on Kaggle 2xT4 is in flight against this branch; I will post the result here.
