### PR TITLE
Degrade to eager when Inductor cannot generate code, instead of ending the run

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -157,6 +157,11 @@ jobs:
             tests/test_python39_compatibility.py \
             tests/test_checkpoint_modes.py \
             tests/test_wheel_top_level_packages.py \
+            tests/test_inductor_codegen_fallback.py \
+            tests/test_eager_fallback_latch.py \
+            tests/test_recompile_limit_fallback.py \
+            tests/test_checkpoint_compile_mix.py \
+            tests/test_disabled_hook_graph_break.py \
             -v
 
       - name: pytest MLX adapter-filter gate (HARD GATE)

--- a/tests/test_disabled_hook_graph_break.py
+++ b/tests/test_disabled_hook_graph_break.py
@@ -245,15 +245,40 @@ def test_the_compiled_callable_stays_reachable():
     assert hasattr(w, "get_compiler_config")
 
 
-def test_it_degrades_to_the_compiled_function_when_torch_offers_neither():
+def test_it_degrades_to_the_compiled_function_when_torch_offers_none_of_them():
     """On a torch with no such exceptions at all, wrapping buys nothing and
-    must not add a layer."""
+    must not add a layer.
+
+    All THREE families have to be absent. The wrapper now also catches Inductor
+    codegen refusals, and `_backend_compile_errors()` is non-empty on every
+    supported torch, so mocking only the two recompile families left the third
+    live and the wrapper rightly kept its layer -- this asserted "no exceptions
+    at all" while one family was still there.
+    """
     import unittest.mock as mock
+    with mock.patch.object(U, "_recompile_limit_errors", lambda: ()), \
+         mock.patch.object(U, "_disabled_hook_graph_break_error", lambda: ()), \
+         mock.patch.object(U, "_backend_compile_errors", lambda: ()):
+        sentinel = object()
+        assert U._fall_back_to_eager_on_recompile_limit(
+            sentinel, lambda: None, "x") is sentinel
+
+
+def test_backend_errors_alone_are_enough_to_keep_the_wrapper():
+    """The other half of the contract, and the reason the test above changed.
+
+    A torch that reports no recompile-limit exception and no graph-break
+    exception can still refuse to generate code, so the layer has to stay --
+    otherwise the codegen fallback would silently not exist there.
+    """
+    import unittest.mock as mock
+    if not U._backend_compile_errors():
+        pytest.skip("this torch exposes no backend compile exception")
     with mock.patch.object(U, "_recompile_limit_errors", lambda: ()), \
          mock.patch.object(U, "_disabled_hook_graph_break_error", lambda: ()):
         sentinel = object()
         assert U._fall_back_to_eager_on_recompile_limit(
-            sentinel, lambda: None, "x") is sentinel
+            sentinel, lambda: None, "x") is not sentinel
 
 
 if __name__ == "__main__":

--- a/tests/test_eager_fallback_latch.py
+++ b/tests/test_eager_fallback_latch.py
@@ -127,9 +127,14 @@ def test_an_unrelated_exception_still_propagates():
 
 
 def test_no_wrapper_at_all_when_torch_has_no_such_errors(monkeypatch):
-    """On a torch with neither exception there is nothing to catch, and the
-    compiled callable must be returned untouched rather than wrapped."""
+    """On a torch with none of these exceptions there is nothing to catch, and
+    the compiled callable must be returned untouched rather than wrapped.
+
+    `_backend_compile_errors` is stubbed too: the wrapper also catches Inductor
+    codegen failures now, so leaving that tuple populated gives it a real reason
+    to exist and the assertion below would be testing the wrong thing."""
     monkeypatch.setattr(U, "_recompile_limit_errors", lambda: ())
+    monkeypatch.setattr(U, "_backend_compile_errors", lambda: ())
     compiled, eager, _ = _pair()
     assert U._fall_back_to_eager_on_recompile_limit(
         compiled, eager, "M.f") is compiled

--- a/tests/test_inductor_codegen_fallback.py
+++ b/tests/test_inductor_codegen_fallback.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Inductor codegen failures degrade to eager instead of ending the run.
+
+torch 2.12 refuses to generate code for the ragged tail of
+``torch.chunk(x, chunks = N)`` under dynamic shapes:
+
+    InductorError: CantSplit: 202048*s47*s87 - 3434816*(((s47*s87 + 17)//18))
+    not divisible by s47*s87 - 17*(((s47*s87 + 17)//18))
+
+That is arithmetic which is true by inspection, and which the same predicate
+answers correctly on 2.9, 2.10 and 2.11. A backend simplifier gap should cost
+speed, not kill a GRPO run, so ``_fall_back_to_eager_on_recompile_limit`` now
+catches it the way it already catches cache exhaustion.
+
+These tests drive the wrapper directly with a compiled callable that raises,
+rather than trying to provoke Inductor, so they run on CPU and stay valid on
+torch versions where the real expression compiles fine.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from unsloth_zoo.temporary_patches import utils as patch_utils
+
+
+@pytest.fixture(autouse = True)
+def _clear_latches():
+    """The latch is process-global and keyed by label, so tests must not leak."""
+    patch_utils._LATCHED_EAGER_LABELS.clear()
+    patch_utils._PENDING_EAGER_LABELS.clear()
+    yield
+    patch_utils._LATCHED_EAGER_LABELS.clear()
+    patch_utils._PENDING_EAGER_LABELS.clear()
+
+
+def _inductor_error(message = "CantSplit: 202048*s47*s87 not divisible by s47*s87"):
+    """Build whichever backend exception this torch has.
+
+    The constructors disagree across versions: 2.12's `InductorError` takes
+    `(inner_exception, first_useful_frame)`, `BackendCompilerFailed` takes
+    `(backend_fn, exc)`, and older builds accept a bare message. Try the
+    shapes rather than pinning one, so the test tracks the tuple the wrapper
+    actually catches instead of a single release's signature.
+    """
+    errors = patch_utils._backend_compile_errors()
+    if not errors:
+        pytest.skip("this torch exposes no backend compile exception")
+    cls = errors[0]
+    inner = RuntimeError(message)
+    for args in ((inner, None), (inner, inner), (message,), (inner,)):
+        try:
+            return cls(*args)
+        except TypeError:
+            continue
+    pytest.skip(f"cannot construct {cls.__name__} on this torch")
+
+
+def test_the_backend_error_tuple_is_not_empty_on_this_torch():
+    """If this ever goes empty the fallback silently stops existing."""
+    assert patch_utils._backend_compile_errors(), (
+        "no InductorError or BackendCompilerFailed found; the wrapper would "
+        "pass a codegen failure straight through"
+    )
+
+
+def test_a_codegen_failure_falls_back_to_eager():
+    calls = {"compiled": 0, "eager": 0}
+
+    def compiled(x):
+        calls["compiled"] += 1
+        raise _inductor_error()
+
+    def eager(x):
+        calls["eager"] += 1
+        return x * 2
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, eager, "test-codegen",
+    )
+
+    assert wrapped(21) == 42
+    assert calls == {"compiled": 1, "eager": 1}
+
+
+def test_the_fallback_latches_so_the_backend_is_not_retried():
+    """A codegen refusal is deterministic; retrying pays the compile twice."""
+    calls = {"compiled": 0, "eager": 0}
+
+    def compiled(x):
+        calls["compiled"] += 1
+        raise _inductor_error()
+
+    def eager(x):
+        calls["eager"] += 1
+        return x + 1
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, eager, "test-latch",
+    )
+
+    assert [wrapped(1), wrapped(2), wrapped(3)] == [2, 3, 4]
+    assert calls["compiled"] == 1, "the compiled path was retried after latching"
+    assert calls["eager"] == 3
+
+
+def test_only_this_label_latches():
+    """Unlike cache exhaustion, a codegen refusal is local to one graph."""
+    def compiled_bad(x):
+        raise _inductor_error()
+
+    def compiled_good(x):
+        return "compiled"
+
+    bad = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled_bad, lambda x: "eager", "test-bad",
+    )
+    good = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled_good, lambda x: "eager", "test-good",
+    )
+
+    assert bad(1) == "eager"
+    assert good(1) == "compiled", "an unrelated region was knocked eager"
+    assert "test-good" not in patch_utils._LATCHED_EAGER_LABELS
+
+
+def test_a_real_runtime_error_still_raises():
+    """The net must be narrow: only backend codegen, never the user's bug."""
+    def compiled(x):
+        raise ValueError("a real bug in the model")
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-runtime",
+    )
+
+    with pytest.raises(ValueError, match = "a real bug"):
+        wrapped(1)
+
+
+def test_the_hard_switch_lets_the_error_escape(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_HARD_BACKEND_FAILURE", "1")
+    errors = patch_utils._backend_compile_errors()
+    if not errors:
+        pytest.skip("this torch exposes no backend compile exception")
+
+    def compiled(x):
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-hard",
+    )
+
+    with pytest.raises(errors[0]):
+        wrapped(1)
+
+
+def test_the_switch_is_read_live_not_at_import(monkeypatch):
+    """A test setting the variable after import must still be honoured."""
+    monkeypatch.delenv("UNSLOTH_HARD_BACKEND_FAILURE", raising = False)
+    assert patch_utils._wants_hard_backend_failure() is False
+    monkeypatch.setenv("UNSLOTH_HARD_BACKEND_FAILURE", "1")
+    assert patch_utils._wants_hard_backend_failure() is True

--- a/tests/test_inductor_codegen_fallback.py
+++ b/tests/test_inductor_codegen_fallback.py
@@ -877,36 +877,59 @@ def test_an_unknown_answer_does_not_latch_the_process_wide_marker(monkeypatch):
         "an unknown must not latch the process-wide marker"
 
 
-def test_the_budgeted_probe_stops_walking_and_answers_unknown(monkeypatch):
-    """`budgeted = True` puts the frame walk on the step's miss budget.
+def test_a_spent_walk_budget_does_not_invent_checkpoint_history(monkeypatch):
+    """An exhausted probe budget must not mark uncheckpointed calls as packed.
 
-    Without it a torch with no accessor pays an unbounded stack walk on every
-    successful compiled call for the whole run, which is exactly the cost
-    `_probe_walk`'s budget exists to cap for the pre-call probe. A spent budget
-    has to answer None rather than False: "stopped asking" is not "no region".
+    A budgeted post-call probe has to answer something once the budget is gone,
+    and both answers are wrong somewhere. Answering None and recording it is the
+    dangerous one: on a torch with no hook accessor, a generation-heavy GRPO
+    step spends the budget on uncheckpointed inference calls, every later
+    success gets recorded as a possible compiled pack, and the first codegen
+    refusal inside the training checkpoint is then re-raised as though an
+    earlier compiled pack existed -- which ends the run this module exists to
+    keep alive. So the probe stays unbudgeted and answers definitely.
     """
     monkeypatch.setattr(patch_utils, "_saved_tensor_hook_accessor",
                         lambda: None)
-    walks = {"n": 0}
-
-    def _counting_walk():
-        walks["n"] += 1
-        return False
-
+    # No checkpoint anywhere: the walk always answers a definite False.
     monkeypatch.setattr(patch_utils, "_walk_for_checkpoint_frame",
-                        _counting_walk)
-    monkeypatch.setattr(patch_utils, "_CHECKPOINT_PROBE_MISSES", 0)
+                        lambda: False)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    # The budget is already spent, as it would be after a long generation pass.
+    monkeypatch.setattr(patch_utils, "_CHECKPOINT_PROBE_MISSES",
+                        patch_utils._CHECKPOINT_PROBE_MISS_BUDGET)
 
-    budget = patch_utils._CHECKPOINT_PROBE_MISS_BUDGET
-    for _ in range(budget + 25):
-        patch_utils._in_non_reentrant_checkpoint(budgeted = True)
-
-    assert walks["n"] == budget, (
-        f"the walk should stop at the {budget}-miss budget; it ran "
-        f"{walks['n']} times"
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        lambda x: "compiled", lambda x: "eager", "test-spent-budget",
     )
-    assert patch_utils._in_non_reentrant_checkpoint(budgeted = True) is None, \
-        "a spent budget means 'stopped asking', not 'no region'"
-    # The uncapped form is unchanged: the give-up paths still get a real answer.
-    assert patch_utils._in_non_reentrant_checkpoint() is False
-    assert walks["n"] == budget + 1
+    for _ in range(5):
+        assert wrapped(1) == "compiled"
+
+    assert "test-spent-budget" not in patch_utils._COMPILED_OK_LABELS, (
+        "an exhausted budget must not turn definitely-uncheckpointed calls "
+        "into checkpoint history"
+    )
+    assert patch_utils._in_non_reentrant_checkpoint() is False, \
+        "the probe must keep giving a definite answer, not None"
+
+
+def test_releasing_borrowed_budget_keeps_compiled_pack_history(monkeypatch):
+    """`_restore_recompile_limits` is not a step boundary, so it must not clear.
+
+    `_release_borrowed_budget` calls it mid-step, after a caught exception, as
+    soon as no live wrapper still needs its bump. Clearing the history there
+    erases another wrapper's record of having packed compiled under a still-open
+    checkpoint, and that wrapper's next refusal then latches eager and lets the
+    pack be recomputed eagerly. Only `apply_pending_eager_fallbacks`, the real
+    step boundary, may clear it.
+    """
+    patch_utils._COMPILED_OK_LABELS.add("test-packed-earlier")
+    patch_utils._restore_recompile_limits()
+    assert "test-packed-earlier" in patch_utils._COMPILED_OK_LABELS, (
+        "handing back the recompile budget mid-step erased a wrapper's record "
+        "of having packed compiled activations"
+    )
+    # The genuine step boundary still clears it.
+    patch_utils.apply_pending_eager_fallbacks()
+    assert "test-packed-earlier" not in patch_utils._COMPILED_OK_LABELS, \
+        "the step boundary must still reset the history"

--- a/tests/test_inductor_codegen_fallback.py
+++ b/tests/test_inductor_codegen_fallback.py
@@ -38,26 +38,74 @@ def _clear_latches():
     patch_utils._COMPILED_OK_LABELS.clear()
 
 
+def _inductor_backend_fn(gm, example_inputs):
+    """Stands in for the backend object torch hands `BackendCompilerFailed`.
+
+    `BackendCompilerFailed.__init__` stores `getattr(backend_fn, "__name__",
+    "?")` as `backend_name`, and torch passes `OutputGraph.compiler_fn`, whose
+    `__name__` is `inductor`. Verified by execution on torch 2.9.1: making
+    `torch._inductor.compile_fx.compile_fx` raise a bare `RuntimeError` under
+    `torch.compile(backend = "inductor")` produces a `BackendCompilerFailed`
+    with `backend_name == "inductor"`.
+    """
+    return gm
+_inductor_backend_fn.__name__ = "inductor"
+
+
 def _inductor_error(message = "CantSplit: 202048*s47*s87 not divisible by s47*s87"):
-    """Build whichever backend exception this torch has.
+    """Build whichever backend exception this torch has, WITH an Inductor identity.
 
     The constructors disagree across versions: 2.12's `InductorError` takes
     `(inner_exception, first_useful_frame)`, `BackendCompilerFailed` takes
-    `(backend_fn, exc)`, and older builds accept a bare message. Try the
-    shapes rather than pinning one, so the test tracks the tuple the wrapper
-    actually catches instead of a single release's signature.
+    `(backend_fn, inner_exception)` up to 2.8 and `(backend_fn,
+    inner_exception, first_useful_frame)` from 2.9. Try the shapes rather than
+    pinning one, so the test tracks the tuple the wrapper actually catches
+    instead of a single release's signature.
+
+    Every candidate has to carry an Inductor identity, and the result is
+    checked for one. On torch 2.6 `InductorError` does not exist, so
+    `_backend_compile_errors()[0]` is `BackendCompilerFailed` and the old
+    `(inner, None)` shape fitted its two-argument signature -- producing an
+    exception whose backend was the RuntimeError (`backend_name == "?"`) and
+    whose `inner_exception` was `None`. `_is_inductor_codegen_failure` rightly
+    rejects that, so every fallback test below asserted the OPPOSITE of the
+    behaviour it was written for on exactly the version where the wrapped form
+    is the only form.
     """
     errors = patch_utils._backend_compile_errors()
     if not errors:
         pytest.skip("this torch exposes no backend compile exception")
     cls = errors[0]
     inner = RuntimeError(message)
-    for args in ((inner, None), (inner, inner), (message,), (inner,)):
+    for args in (
+        (inner, None),                              # InductorError, 2.7+
+        (_inductor_backend_fn, inner, None),        # BackendCompilerFailed, 2.9+
+        (_inductor_backend_fn, inner),              # BackendCompilerFailed, <= 2.8
+    ):
         try:
-            return cls(*args)
+            built = cls(*args)
         except TypeError:
             continue
-    pytest.skip(f"cannot construct {cls.__name__} on this torch")
+        if patch_utils._is_inductor_codegen_failure(built):
+            return built
+    pytest.skip(f"cannot construct an Inductor-identified {cls.__name__}")
+
+
+class _Torch26BackendCompilerFailed(RuntimeError):
+    """torch 2.6's `BackendCompilerFailed`, reproduced attribute for attribute.
+
+    2.6 is in the supported range and is the version with no `InductorError`,
+    so the wrapped form is the ONLY form the fallback can see there. Standing
+    it in is the only way to exercise that path from a newer torch, and it is a
+    faithful copy of the 2.6.0 source rather than an approximation.
+    """
+    def __init__(self, backend_fn, inner_exception):
+        self.backend_name = getattr(backend_fn, "__name__", "?")
+        self.inner_exception = inner_exception
+        super().__init__(
+            f"backend={self.backend_name!r} raised:\n"
+            f"{type(inner_exception).__name__}: {inner_exception}"
+        )
 
 
 def test_the_backend_error_tuple_is_not_empty_on_this_torch():
@@ -194,7 +242,14 @@ def test_a_later_refusal_after_a_successful_compile_still_raises(monkeypatch):
 
     Here the pack was compiled and the recompute would be eager, which either
     aborts the backward or returns wrong gradients, so the step must end.
+
+    The successful call has to happen INSIDE the checkpoint, which is what
+    makes it a compiled pack. Entering the region only for the refusal, as this
+    test used to, describes a different situation entirely -- a compiled call
+    somewhere else in the step -- and that one is safe to fall back from.
     """
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     calls = {"n": 0}
 
     def compiled(x):
@@ -209,8 +264,6 @@ def test_a_later_refusal_after_a_successful_compile_still_raises(monkeypatch):
 
     assert wrapped(1) == "compiled"
 
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
-    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     errors = patch_utils._backend_compile_errors()
     with pytest.raises(errors):
         wrapped(2)
@@ -271,7 +324,7 @@ def test_a_refusal_in_a_later_step_falls_back(monkeypatch):
     assert wrapped(2) == "eager", "a new step re-raised on its first refusal"
 
 
-def test_a_successful_budget_retry_is_recorded_as_compiled():
+def test_a_successful_budget_retry_is_recorded_as_compiled(monkeypatch):
     """A retry that compiles has packed compiled activations, so record it.
 
     The retry returns from the exception branch and never reaches the `else:`
@@ -284,7 +337,13 @@ def test_a_successful_budget_retry_is_recorded_as_compiled():
     The record still has to be right -- it is the process-wide answer to "did
     this label pack something compiled in this step" -- but the pack/recompute
     divergence this guards against is not reachable through this path today.
+
+    Under a checkpoint, because that is the only place a compiled return packs
+    something that will be recomputed, and therefore the only place the record
+    means anything.
     """
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     calls = {"n": 0}
 
     def compiled(x):
@@ -413,3 +472,286 @@ def test_restoring_the_marker_cannot_erase_an_earlier_compiled_pack(monkeypatch)
     assert patch_utils._PACKED_COMPILED_IN_CHECKPOINT is True, (
         "the restore erased an earlier region's compiled pack"
     )
+
+
+# ---- what the second review round found ------------------------------------
+#
+# Five more, all of them the same shape as the first four: a path where the
+# wrapper either re-raises where the fallback was safe, or never sees the
+# refusal at all.
+
+
+def test_the_wrapped_form_is_recognised_by_its_recorded_backend_name():
+    """`BackendCompilerFailed` records `backend_name`; nothing records `backend`.
+
+    This is the shape torch actually produces when Inductor raises something
+    that is not an `InductorError` -- confirmed on 2.9.1 by making `compile_fx`
+    raise a bare `RuntimeError`: `backend_name == "inductor"`, no `backend`
+    attribute, and `inner_exception` a `builtins.RuntimeError` whose module
+    tells the caller nothing. Reading the attribute that never exists made this
+    branch dead code, so the wrapped form `_backend_compile_errors()` goes out
+    of its way to catch was re-raised anyway.
+    """
+    built = _Torch26BackendCompilerFailed(
+        _inductor_backend_fn, RuntimeError("CantSplit: not divisible"))
+    assert built.backend_name == "inductor"
+    assert not hasattr(built, "backend"), "no torch has ever set `backend`"
+    assert patch_utils._is_inductor_codegen_failure(built), (
+        "an Inductor refusal recorded under `backend_name` was not recognised"
+    )
+
+
+def test_a_non_inductor_backend_name_is_still_rejected():
+    """The `backend_name` read must not widen the net to every backend."""
+    def my_backend(gm, example_inputs): return gm
+    built = _Torch26BackendCompilerFailed(
+        my_backend, ValueError("my custom backend is misconfigured"))
+    assert built.backend_name == "my_backend"
+    assert not patch_utils._is_inductor_codegen_failure(built)
+
+
+def test_a_torch_2_6_shaped_refusal_falls_back_to_eager(monkeypatch):
+    """2.6 has no `InductorError`, so the wrapped form is the only form.
+
+    Stand in the 2.6 exception and drive the real wrapper with it: without the
+    `backend_name` read this re-raises, which on 2.6 means the fallback does
+    not exist at all.
+    """
+    monkeypatch.setattr(
+        patch_utils, "_backend_compile_errors",
+        lambda: (_Torch26BackendCompilerFailed,),
+    )
+
+    def compiled(x):
+        raise _Torch26BackendCompilerFailed(
+            _inductor_backend_fn, RuntimeError("CantSplit: not divisible"))
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-torch26-shape",
+    )
+    assert wrapped(1) == "eager"
+
+
+def test_a_refusal_from_the_budget_retry_falls_back(monkeypatch):
+    """Cache exhaustion first, then Inductor refuses once the budget is bumped.
+
+    `_retry_with_more_budget` calls `compiled_func` inside its own `try`, and
+    its `except BaseException` re-raises. Python does not route that to the
+    wrapper's sibling `except backend_errors`, so the refusal escaped and ended
+    the run -- the exact outcome the fallback exists to prevent, reached by the
+    one path where the compiler had to be given more budget before it got as
+    far as refusing.
+    """
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: False)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _recompile_limit_error()
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-retry-refusal",
+    )
+    if not patch_utils._recompile_limit_errors():
+        pytest.skip("this torch exposes no recompile-limit exception")
+    assert wrapped(1) == "eager", (
+        "a codegen refusal raised by the budget retry escaped the wrapper"
+    )
+    assert "test-retry-refusal" in patch_utils._LATCHED_EAGER_LABELS
+
+
+def test_a_refusal_from_the_budget_retry_is_not_recorded_as_compiled(monkeypatch):
+    """It ran EAGER, so it must not count as a compiled pack.
+
+    Guards the sentinel: returning the eager value down the ordinary
+    retry-succeeded path would record this label as having packed something
+    compiled, which is the lie that ends a later step for no reason -- or, in a
+    checkpoint, the one that recomputes in the wrong mode.
+    """
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _recompile_limit_error()
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-retry-refusal-record",
+    )
+    if not patch_utils._recompile_limit_errors():
+        pytest.skip("this torch exposes no recompile-limit exception")
+    assert wrapped(1) == "eager"
+    assert "test-retry-refusal-record" not in patch_utils._COMPILED_OK_LABELS
+
+
+def test_a_legacy_budget_retry_is_recorded_as_compiled(monkeypatch):
+    """torch 2.4 reaches the retry through the graph-break arm, not the typed one.
+
+    Cache exhaustion has no exception class there, so it arrives as
+    `Unsupported` and is matched by message. That arm returned the retry's
+    result without recording it, so 2.4 took the opposite decision from 2.7+
+    when a backend refusal followed in the same step.
+    """
+    graph_break_errors = patch_utils._disabled_hook_graph_break_error()
+    if not graph_break_errors:
+        pytest.skip("this torch exposes no graph-break exception")
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            try:
+                raise graph_break_errors[0]("recompile_limit reached")
+            except TypeError:
+                raise graph_break_errors[0]()
+        return "retried"
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-legacy-retry",
+    )
+    if wrapped(1) != "retried":
+        pytest.skip("this torch does not take the legacy budget-retry path")
+    assert "test-legacy-retry" in patch_utils._COMPILED_OK_LABELS, (
+        "a legacy retry that compiled and returned was not recorded as compiled"
+    )
+
+
+def test_a_compiled_call_outside_a_checkpoint_is_not_a_compiled_pack(monkeypatch):
+    """GRPO generates with the same patched kernels it then trains with.
+
+    A compiled call made outside a non-reentrant checkpoint packs nothing that
+    is ever recomputed, so it cannot desynchronise a pack from a recompute and
+    must not stop the fallback. Recording every compiled return made the first
+    refusal of the training pass end the step because the generation pass had
+    succeeded earlier in the same step.
+    """
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: False)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "compiled"
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-uncheckpointed-success",
+    )
+    assert wrapped(1) == "compiled"           # generation: no region open
+    assert "test-uncheckpointed-success" not in patch_utils._COMPILED_OK_LABELS
+
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    assert wrapped(2) == "eager", (
+        "a compiled call made outside any checkpoint blocked the fallback"
+    )
+
+
+def test_an_unknown_checkpoint_answer_still_counts_as_packed(monkeypatch):
+    """`None` is "torch cannot say", and that has to count as yes.
+
+    Before 2.8 there is no hook accessor, and a user's own
+    `saved_tensors_hooks` can sit above ours on any version. Over-recording
+    ends a step that `force_eager_fallback` retries; under-recording recomputes
+    a compiled pack eagerly and hands back wrong gradients, so the unknown
+    answer must take the expensive side.
+
+    Only the RECORD is asserted here, which is what `_note_compiled_ok` owns.
+    Whether `_give_up_on_backend` then raises is a separate decision, and on an
+    unknown answer it leans on the marker -- so the marker is set for the
+    refusal, matching a step where some region is known to have packed.
+    """
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: None)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "compiled"
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-unknown-checkpoint",
+    )
+    assert wrapped(1) == "compiled"
+    assert "test-unknown-checkpoint" in patch_utils._COMPILED_OK_LABELS, (
+        "an unknown checkpoint answer was read as 'no region', which is the "
+        "direction that recomputes a compiled pack eagerly"
+    )
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
+    errors = patch_utils._backend_compile_errors()
+    with pytest.raises(errors):
+        wrapped(2)
+
+
+def test_a_backend_refusal_is_evidence_for_force_eager_fallback(monkeypatch):
+    """The transition has to be recorded where `force_eager_fallback` reads it.
+
+    It deliberately does not read `_LATCHED_EAGER_LABELS` -- that set is
+    permanent, so a discarded model's labels would answer for this one -- and
+    otherwise asks the LIVE wrappers. GRPO's `accumulate_chunk` is built inside
+    the forward and collected before the backward that calls this, so with only
+    the permanent latch recorded the call returns 0, the caller reads that as
+    "no compile-mode flip happened" and re-raises the failure it was asked to
+    retry past. Every other give-up path already writes `_RECENT_EAGER_LABELS`.
+    """
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
+    monkeypatch.setattr(patch_utils, "_RECENT_EAGER_LABELS", set())
+    monkeypatch.setattr(patch_utils, "_EAGER_FALLBACK_WRAPPERS", [])
+
+    def _transient():
+        """Built inside the forward and dropped before backward, like GRPO's."""
+        calls = {"n": 0}
+        def compiled(x):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return "compiled"
+            raise _inductor_error()
+        w = patch_utils._fall_back_to_eager_on_recompile_limit(
+            compiled, lambda x: "eager", "test-transient-evidence",
+        )
+        assert w(1) == "compiled"
+        with pytest.raises(patch_utils._backend_compile_errors()):
+            w(2)
+
+    _transient()
+    import gc; gc.collect()
+
+    assert "test-transient-evidence" in patch_utils._RECENT_EAGER_LABELS
+    assert patch_utils.force_eager_fallback() > 0, (
+        "the backend fallback left no evidence, so the caller would re-raise"
+    )
+
+
+def test_the_error_builder_produces_an_inductor_identity_on_a_2_6_shaped_torch(
+        monkeypatch):
+    """The builder must not hand the tests an unrecognisable exception.
+
+    On a torch with no `InductorError`, `_backend_compile_errors()[0]` is
+    `BackendCompilerFailed`, whose two-argument signature happily accepts
+    `(inner, None)` -- producing `backend_name == "?"` and
+    `inner_exception is None`. Every fallback test above then drove the wrapper
+    with something `_is_inductor_codegen_failure` correctly rejects, so on 2.6
+    they asserted eager fallback against an exception that re-raises by design.
+    """
+    monkeypatch.setattr(
+        patch_utils, "_backend_compile_errors",
+        lambda: (_Torch26BackendCompilerFailed,),
+    )
+    built = _inductor_error()
+    assert isinstance(built, _Torch26BackendCompilerFailed)
+    assert built.backend_name == "inductor", (
+        f"the builder produced backend_name={built.backend_name!r}"
+    )
+    assert isinstance(built.inner_exception, RuntimeError)
+    assert patch_utils._is_inductor_codegen_failure(built)

--- a/tests/test_inductor_codegen_fallback.py
+++ b/tests/test_inductor_codegen_fallback.py
@@ -162,3 +162,73 @@ def test_the_switch_is_read_live_not_at_import(monkeypatch):
     assert patch_utils._wants_hard_backend_failure() is False
     monkeypatch.setenv("UNSLOTH_HARD_BACKEND_FAILURE", "1")
     assert patch_utils._wants_hard_backend_failure() is True
+
+
+# ---- the checkpoint distinction -------------------------------------------
+#
+# `_give_up` must re-raise inside a non-reentrant checkpoint, because it latches
+# every borrower and some of them packed activations compiled. The backend path
+# latches one label, so the only pack that can desynchronise is this function's
+# own -- and a first-call codegen refusal means it packed nothing compiled.
+
+
+def test_a_first_compile_refusal_falls_back_even_under_a_checkpoint(monkeypatch):
+    """The Muse Glimmer case: Inductor refuses before anything was ever packed."""
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
+
+    def compiled(x):
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-first-compile",
+    )
+
+    assert wrapped(1) == "eager", "a first-call refusal should not end the step"
+
+
+def test_a_later_refusal_after_a_successful_compile_still_raises(monkeypatch):
+    """A new dynamic shape refusing after an earlier one packed compiled.
+
+    Here the pack was compiled and the recompute would be eager, which either
+    aborts the backward or returns wrong gradients, so the step must end.
+    """
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "compiled"
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-later-refusal",
+    )
+
+    assert wrapped(1) == "compiled"
+
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
+    errors = patch_utils._backend_compile_errors()
+    with pytest.raises(errors):
+        wrapped(2)
+
+
+def test_outside_a_checkpoint_a_later_refusal_still_falls_back(monkeypatch):
+    """Nothing is packed, so there is no pack/recompute pair to protect."""
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: False)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "compiled"
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-no-checkpoint",
+    )
+
+    assert wrapped(1) == "compiled"
+    assert wrapped(2) == "eager"

--- a/tests/test_inductor_codegen_fallback.py
+++ b/tests/test_inductor_codegen_fallback.py
@@ -31,9 +31,11 @@ def _clear_latches():
     """The latch is process-global and keyed by label, so tests must not leak."""
     patch_utils._LATCHED_EAGER_LABELS.clear()
     patch_utils._PENDING_EAGER_LABELS.clear()
+    patch_utils._COMPILED_OK_LABELS.clear()
     yield
     patch_utils._LATCHED_EAGER_LABELS.clear()
     patch_utils._PENDING_EAGER_LABELS.clear()
+    patch_utils._COMPILED_OK_LABELS.clear()
 
 
 def _inductor_error(message = "CantSplit: 202048*s47*s87 not divisible by s47*s87"):
@@ -232,3 +234,151 @@ def test_outside_a_checkpoint_a_later_refusal_still_falls_back(monkeypatch):
 
     assert wrapped(1) == "compiled"
     assert wrapped(2) == "eager"
+
+
+# ---- what the review round found ------------------------------------------
+#
+# Four holes in the checkpoint gate above, all of them cases where the wrapper
+# either re-raises when the fallback was safe, or falls back when it was not.
+
+
+def test_a_refusal_in_a_later_step_falls_back(monkeypatch):
+    """`compiled_ok` must not answer for a step that is already over.
+
+    Held per wrapper it stays true forever, so the first refusal in ANY later
+    step re-raises even though nothing compiled has been packed in that step.
+    That defeats the fallback for exactly the long-running GRPO case it exists
+    for.
+    """
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "compiled"
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-later-step",
+    )
+    assert wrapped(1) == "compiled"
+
+    # The step boundary. This is what `apply_pending_eager_fallbacks` does.
+    patch_utils._COMPILED_OK_LABELS.clear()
+
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
+    assert wrapped(2) == "eager", "a new step re-raised on its first refusal"
+
+
+def test_a_successful_budget_retry_is_recorded_as_compiled():
+    """A retry that compiles has packed compiled activations, so record it.
+
+    The retry returns from the exception branch and never reaches the `else:`
+    clause that normally does the recording, which left the wrapper believing
+    nothing compiled had run.
+
+    Worth being precise about the consequence, because it is narrower than it
+    looks: the retry also latches this label eager, so the SAME wrapper never
+    makes another compiled call and cannot itself hit a later backend refusal.
+    The record still has to be right -- it is the process-wide answer to "did
+    this label pack something compiled in this step" -- but the pack/recompute
+    divergence this guards against is not reachable through this path today.
+    """
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _recompile_limit_error()
+        return "retried"
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-retry-counts",
+    )
+    if wrapped(1) != "retried":
+        pytest.skip("this torch does not take the budget-retry path")
+    assert "test-retry-counts" in patch_utils._COMPILED_OK_LABELS, (
+        "a retry that compiled and returned was not recorded as compiled"
+    )
+
+
+def test_the_compiled_pack_marker_is_restored_after_a_refusal(monkeypatch):
+    """Nothing compiled ran, so the process-wide marker must not stay set.
+
+    Left set, an unrelated wrapper exhausting its budget in the same checkpoint
+    reads it as evidence of a compiled pack and ends the step for no reason.
+    """
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    # The real one sets the marker, which is precisely what has to be undone.
+    monkeypatch.setattr(
+        patch_utils, "_note_packed_under_checkpoint",
+        lambda: setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True),
+    )
+
+    def compiled(x):
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-marker-restored",
+    )
+    assert wrapped(1) == "eager"
+    assert patch_utils._PACKED_COMPILED_IN_CHECKPOINT is False, (
+        "a refusal that ran no compiled code left the compiled-pack marker set"
+    )
+
+
+def test_a_non_inductor_backend_failure_still_raises():
+    """`BackendCompilerFailed` wraps any backend, not only Inductor.
+
+    `torch_compile_with_fallback(..., backend = custom)` is supported, and
+    swallowing a custom backend's exception would hide a configuration or
+    programming error behind a permanent silent switch to eager.
+    """
+    try:
+        from torch._dynamo.exc import BackendCompilerFailed
+    except Exception:
+        pytest.skip("this torch has no BackendCompilerFailed")
+
+    inner = ValueError("my custom backend is misconfigured")
+    built = None
+    def _backend_fn(gm, example_inputs): return gm
+    for args in (
+        (_backend_fn, inner, None),   # 2.9+: (backend_fn, inner, first_useful_frame)
+        (_backend_fn, inner),
+        (inner, None),
+        (inner,),
+    ):
+        try:
+            built = BackendCompilerFailed(*args)
+        except TypeError:
+            continue
+        break
+    if built is None:
+        pytest.skip("cannot construct BackendCompilerFailed on this torch")
+    if patch_utils._is_inductor_codegen_failure(built):
+        pytest.skip("this torch gives the wrapper no usable backend identity")
+
+    def compiled(x):
+        raise built
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-custom-backend",
+    )
+    with pytest.raises(BackendCompilerFailed):
+        wrapped(1)
+    assert "test-custom-backend" not in patch_utils._LATCHED_EAGER_LABELS
+
+
+def _recompile_limit_error():
+    errors = patch_utils._recompile_limit_errors()
+    if not errors:
+        pytest.skip("this torch exposes no recompile-limit exception")
+    cls = errors[0]
+    for args in (("recompile limit reached",), ()):
+        try:
+            return cls(*args)
+        except TypeError:
+            continue
+    pytest.skip(f"cannot construct {cls.__name__}")

--- a/tests/test_inductor_codegen_fallback.py
+++ b/tests/test_inductor_codegen_fallback.py
@@ -382,3 +382,34 @@ def _recompile_limit_error():
         except TypeError:
             continue
     pytest.skip(f"cannot construct {cls.__name__}")
+
+
+def test_restoring_the_marker_cannot_erase_an_earlier_compiled_pack(monkeypatch):
+    """The restore writes a process-wide global, so it must not clear too much.
+
+    If another region already packed something compiled inside this checkpoint,
+    the marker was true BEFORE this call and has to stay true: clearing it would
+    tell a later `_give_up` the checkpoint is clean when it is not, and that is
+    the direction that returns wrong gradients rather than merely ending a step.
+    Restoring the prior value rather than assigning False is what makes this
+    safe, and this test is the difference between the two.
+    """
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    # An earlier region in this same checkpoint already packed compiled.
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
+    monkeypatch.setattr(
+        patch_utils, "_note_packed_under_checkpoint",
+        lambda: setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True),
+    )
+
+    def compiled(x):
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-marker-not-erased",
+    )
+    # This label itself never compiled, so it falls back rather than raising.
+    assert wrapped(1) == "eager"
+    assert patch_utils._PACKED_COMPILED_IN_CHECKPOINT is True, (
+        "the restore erased an earlier region's compiled pack"
+    )

--- a/tests/test_inductor_codegen_fallback.py
+++ b/tests/test_inductor_codegen_fallback.py
@@ -22,6 +22,7 @@ torch versions where the real expression compiles fine.
 from __future__ import annotations
 
 import pytest
+import torch
 
 from unsloth_zoo.temporary_patches import utils as patch_utils
 
@@ -933,3 +934,66 @@ def test_releasing_borrowed_budget_keeps_compiled_pack_history(monkeypatch):
     patch_utils.apply_pending_eager_fallbacks()
     assert "test-packed-earlier" not in patch_utils._COMPILED_OK_LABELS, \
         "the step boundary must still reset the history"
+
+def test_generation_does_not_pay_the_success_probe(monkeypatch):
+    """Inference mode saves nothing for backward, so there is nothing to ask.
+
+    This is the O(1) exit that keeps the frame walk off GRPO's generation pass
+    on a torch with no hook accessor, where the walk is the only signal.
+    Inference mode and NOT `is_grad_enabled()`: `autograd.Function.forward`
+    runs with grad off and Unsloth's gradient checkpointing IS one, so grad-off
+    is true in the exact place the record has to be made.
+    """
+    monkeypatch.setattr(patch_utils, "_saved_tensor_hook_accessor",
+                        lambda: None)
+    walks = {"n": 0}
+
+    def _counting_walk():
+        walks["n"] += 1
+        return False
+
+    monkeypatch.setattr(patch_utils, "_walk_for_checkpoint_frame",
+                        _counting_walk)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    monkeypatch.setattr(patch_utils, "_CHECKPOINT_PROBE_MISSES", 0)
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        lambda x: "compiled", lambda x: "eager", "test-generation-free",
+    )
+    with torch.inference_mode():
+        for _ in range(200):
+            assert wrapped(1) == "compiled"
+
+    assert walks["n"] == 0, (
+        f"generation walked the stack {walks['n']} times for an answer that "
+        f"cannot matter: inference mode packs nothing that is recomputed"
+    )
+    assert "test-generation-free" not in patch_utils._COMPILED_OK_LABELS
+
+
+def test_a_recorded_label_is_not_probed_again(monkeypatch):
+    """The record is idempotent, so the second probe cannot change anything.
+
+    With the marker branch, this is what bounds the success-path cost: a label
+    is probed until its answer is known, not once per call forever.
+    """
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    probes = {"n": 0}
+
+    def _counting_probe(*_, **__):
+        probes["n"] += 1
+        return None                      # unknown: records without latching
+
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        _counting_probe)
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        lambda x: "compiled", lambda x: "eager", "test-probe-once",
+    )
+    for _ in range(50):
+        assert wrapped(1) == "compiled"
+
+    assert "test-probe-once" in patch_utils._COMPILED_OK_LABELS
+    assert probes["n"] == 1, (
+        f"an already-recorded label was probed {probes['n']} times"
+    )

--- a/tests/test_inductor_codegen_fallback.py
+++ b/tests/test_inductor_codegen_fallback.py
@@ -224,7 +224,8 @@ def test_the_switch_is_read_live_not_at_import(monkeypatch):
 
 def test_a_first_compile_refusal_falls_back_even_under_a_checkpoint(monkeypatch):
     """The Muse Glimmer case: Inductor refuses before anything was ever packed."""
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
 
     def compiled(x):
@@ -248,7 +249,8 @@ def test_a_later_refusal_after_a_successful_compile_still_raises(monkeypatch):
     test used to, describes a different situation entirely -- a compiled call
     somewhere else in the step -- and that one is safe to fall back from.
     """
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     calls = {"n": 0}
 
@@ -271,7 +273,8 @@ def test_a_later_refusal_after_a_successful_compile_still_raises(monkeypatch):
 
 def test_outside_a_checkpoint_a_later_refusal_still_falls_back(monkeypatch):
     """Nothing is packed, so there is no pack/recompute pair to protect."""
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: False)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: False)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
     calls = {"n": 0}
 
@@ -319,7 +322,8 @@ def test_a_refusal_in_a_later_step_falls_back(monkeypatch):
     # The step boundary. This is what `apply_pending_eager_fallbacks` does.
     patch_utils._COMPILED_OK_LABELS.clear()
 
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     assert wrapped(2) == "eager", "a new step re-raised on its first refusal"
 
@@ -342,7 +346,8 @@ def test_a_successful_budget_retry_is_recorded_as_compiled(monkeypatch):
     something that will be recomputed, and therefore the only place the record
     means anything.
     """
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     calls = {"n": 0}
 
@@ -369,7 +374,8 @@ def test_the_compiled_pack_marker_is_restored_after_a_refusal(monkeypatch):
     reads it as evidence of a compiled pack and ends the step for no reason.
     """
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     # The real one sets the marker, which is precisely what has to be undone.
     monkeypatch.setattr(
         patch_utils, "_note_packed_under_checkpoint",
@@ -453,7 +459,8 @@ def test_restoring_the_marker_cannot_erase_an_earlier_compiled_pack(monkeypatch)
     Restoring the prior value rather than assigning False is what makes this
     safe, and this test is the difference between the two.
     """
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     # An earlier region in this same checkpoint already packed compiled.
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     monkeypatch.setattr(
@@ -542,7 +549,8 @@ def test_a_refusal_from_the_budget_retry_falls_back(monkeypatch):
     one path where the compiler had to be given more budget before it got as
     far as refusing.
     """
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: False)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: False)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
     calls = {"n": 0}
 
@@ -571,7 +579,8 @@ def test_a_refusal_from_the_budget_retry_is_not_recorded_as_compiled(monkeypatch
     compiled, which is the lie that ends a later step for no reason -- or, in a
     checkpoint, the one that recomputes in the wrong mode.
     """
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     calls = {"n": 0}
 
@@ -601,7 +610,8 @@ def test_a_legacy_budget_retry_is_recorded_as_compiled(monkeypatch):
     graph_break_errors = patch_utils._disabled_hook_graph_break_error()
     if not graph_break_errors:
         pytest.skip("this torch exposes no graph-break exception")
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     calls = {"n": 0}
 
@@ -633,7 +643,8 @@ def test_a_compiled_call_outside_a_checkpoint_is_not_a_compiled_pack(monkeypatch
     refusal of the training pass end the step because the generation pass had
     succeeded earlier in the same step.
     """
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: False)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: False)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
     calls = {"n": 0}
 
@@ -649,7 +660,8 @@ def test_a_compiled_call_outside_a_checkpoint_is_not_a_compiled_pack(monkeypatch
     assert wrapped(1) == "compiled"           # generation: no region open
     assert "test-uncheckpointed-success" not in patch_utils._COMPILED_OK_LABELS
 
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     assert wrapped(2) == "eager", (
         "a compiled call made outside any checkpoint blocked the fallback"
     )
@@ -669,7 +681,8 @@ def test_an_unknown_checkpoint_answer_still_counts_as_packed(monkeypatch):
     unknown answer it leans on the marker -- so the marker is set for the
     refusal, matching a step where some region is known to have packed.
     """
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: None)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: None)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
     calls = {"n": 0}
 
@@ -704,7 +717,8 @@ def test_a_backend_refusal_is_evidence_for_force_eager_fallback(monkeypatch):
     "no compile-mode flip happened" and re-raises the failure it was asked to
     retry past. Every other give-up path already writes `_RECENT_EAGER_LABELS`.
     """
-    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint", lambda: True)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: True)
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     monkeypatch.setattr(patch_utils, "_RECENT_EAGER_LABELS", set())
     monkeypatch.setattr(patch_utils, "_EAGER_FALLBACK_WRAPPERS", [])
@@ -755,3 +769,144 @@ def test_the_error_builder_produces_an_inductor_identity_on_a_2_6_shaped_torch(
     )
     assert isinstance(built.inner_exception, RuntimeError)
     assert patch_utils._is_inductor_codegen_failure(built)
+
+
+# ---- what the SECOND review round found -----------------------------------
+#
+# The post-call `_note_compiled_ok` probe runs on the SUCCESS path, so unlike
+# every probe above it is paid by runs that never fall back at all. Two
+# consequences, one a cost and one a correctness hole, and the same one-line
+# marker latch closes both.
+
+
+def test_a_successful_call_does_not_reprobe_once_the_marker_has_latched(
+        monkeypatch):
+    """The success-path probe must read the cheap global BEFORE the walk.
+
+    `_note_compiled_ok` asked `_in_non_reentrant_checkpoint() is False and not
+    _PACKED_COMPILED_IN_CHECKPOINT`, and Python evaluates the left operand of
+    `and` first, so the probe was paid on EVERY successful compiled call even
+    after the marker had latched and the answer could not change. On a torch
+    with no saved-tensor-hook accessor that probe is an uncapped walk to the
+    root of the Python stack, which the module itself prices at ~15us against
+    ~0.1us for the wrapper -- a per-call cost on runs that compile cleanly and
+    never touch the fallback at all.
+    """
+    probes = {"n": 0}
+
+    def _counting_probe(**_):
+        probes["n"] += 1
+        return True
+
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        _counting_probe)
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        lambda x: "compiled", lambda x: "eager", "test-no-reprobe",
+    )
+    for _ in range(20):
+        assert wrapped(1) == "compiled"
+
+    assert "test-no-reprobe" in patch_utils._COMPILED_OK_LABELS, \
+        "the observation itself must survive the short-circuit"
+    assert probes["n"] == 0, (
+        f"the marker was already latched, so the checkpoint probe should never "
+        f"have run; it ran {probes['n']} times"
+    )
+
+
+def test_the_success_probe_latches_the_marker_when_it_finds_a_checkpoint(
+        monkeypatch):
+    """A definite yes from the post-call probe is process-wide news, not local.
+
+    The pre-call probe can miss a region this one then finds -- on a torch with
+    no accessor its `_probe_walk` budget may already be spent by earlier
+    uncheckpointed calls. Recording only the label left
+    `_PACKED_COMPILED_IN_CHECKPOINT` false, so a later refusal by this same
+    wrapper OUTSIDE the region read `packed` as false, latched eager, and left
+    the compiled activations this call had just packed to be recomputed
+    eagerly: a checkpoint abort, or silently wrong gradients.
+    """
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    inside = {"yes": True}
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: inside["yes"])
+    calls = {"n": 0}
+
+    def compiled(x):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "compiled"
+        raise _inductor_error()
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda x: "eager", "test-latch-marker",
+    )
+
+    assert wrapped(1) == "compiled"
+    assert patch_utils._PACKED_COMPILED_IN_CHECKPOINT is True, (
+        "a definite yes from the post-call probe must latch the process-wide "
+        "marker, not only the per-label history"
+    )
+
+    # The layer has returned, so the region is closed -- but its compiled pack
+    # is still owed a recompute.
+    inside["yes"] = False
+    with pytest.raises(patch_utils._backend_compile_errors()):
+        wrapped(2)
+
+
+def test_an_unknown_answer_does_not_latch_the_process_wide_marker(monkeypatch):
+    """`None` counts as packed for THIS label, but must not speak for others.
+
+    The marker is read by every other wrapper's give-up path, so latching it on
+    a guess would end steps that had nothing compiled packed anywhere.
+    """
+    monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", False)
+    monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
+                        lambda **_: None)
+
+    wrapped = patch_utils._fall_back_to_eager_on_recompile_limit(
+        lambda x: "compiled", lambda x: "eager", "test-unknown-no-latch",
+    )
+    assert wrapped(1) == "compiled"
+
+    assert "test-unknown-no-latch" in patch_utils._COMPILED_OK_LABELS
+    assert patch_utils._PACKED_COMPILED_IN_CHECKPOINT is False, \
+        "an unknown must not latch the process-wide marker"
+
+
+def test_the_budgeted_probe_stops_walking_and_answers_unknown(monkeypatch):
+    """`budgeted = True` puts the frame walk on the step's miss budget.
+
+    Without it a torch with no accessor pays an unbounded stack walk on every
+    successful compiled call for the whole run, which is exactly the cost
+    `_probe_walk`'s budget exists to cap for the pre-call probe. A spent budget
+    has to answer None rather than False: "stopped asking" is not "no region".
+    """
+    monkeypatch.setattr(patch_utils, "_saved_tensor_hook_accessor",
+                        lambda: None)
+    walks = {"n": 0}
+
+    def _counting_walk():
+        walks["n"] += 1
+        return False
+
+    monkeypatch.setattr(patch_utils, "_walk_for_checkpoint_frame",
+                        _counting_walk)
+    monkeypatch.setattr(patch_utils, "_CHECKPOINT_PROBE_MISSES", 0)
+
+    budget = patch_utils._CHECKPOINT_PROBE_MISS_BUDGET
+    for _ in range(budget + 25):
+        patch_utils._in_non_reentrant_checkpoint(budgeted = True)
+
+    assert walks["n"] == budget, (
+        f"the walk should stop at the {budget}-miss budget; it ran "
+        f"{walks['n']} times"
+    )
+    assert patch_utils._in_non_reentrant_checkpoint(budgeted = True) is None, \
+        "a spent budget means 'stopped asking', not 'no region'"
+    # The uncapped form is unchanged: the give-up paths still get a real answer.
+    assert patch_utils._in_non_reentrant_checkpoint() is False
+    assert walks["n"] == budget + 1

--- a/tests/test_recompile_limit_fallback.py
+++ b/tests/test_recompile_limit_fallback.py
@@ -208,13 +208,15 @@ def test_no_wrapper_when_torch_exposes_no_such_errors(monkeypatch):
     # Older torch without these names: return the compiled function
     # unchanged rather than guessing at which exception to catch.
     #
-    # BOTH sources must be empty now. The wrapper also catches the graph
+    # ALL THREE sources must be empty now. The wrapper also catches the graph
     # break Unsloth causes itself by registering a `torch.compiler.disable`d
     # gradient-checkpointing hook inside a fullgraph region, so a torch that
     # has `Unsupported` but no recompile-limit errors still needs wrapping.
+    # Inductor codegen failures are the third such reason.
     import unsloth_zoo.temporary_patches.utils as u
     monkeypatch.setattr(u, "_recompile_limit_errors", lambda: ())
     monkeypatch.setattr(u, "_disabled_hook_graph_break_error", lambda: ())
+    monkeypatch.setattr(u, "_backend_compile_errors", lambda: ())
     c, e, _ = _pair()
     assert u._fall_back_to_eager_on_recompile_limit(c, e, "M.forward") is c
 

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -858,7 +858,7 @@ def _is_checkpoint_pack_hook(pack):
                 ("_checkpoint_hook", "_recomputation_hook")))
 
 
-def _in_non_reentrant_checkpoint(budgeted = False):
+def _in_non_reentrant_checkpoint():
     """Are we inside a `use_reentrant = False` region? None when torch cannot say.
 
     The only saved-tensor hooks `torch.utils.checkpoint` installs are the
@@ -873,15 +873,15 @@ def _in_non_reentrant_checkpoint(budgeted = False):
     ours, so an unrecognised hook is "cannot tell from here", not "no region":
     ask the frames instead.
 
-    `budgeted` puts that frame walk on the step's `_probe_walk` budget, for the
-    one caller that runs on EVERY successful compiled call rather than once per
-    failure. The give-up paths must keep the default uncapped walk: they are
-    reached once, and their answer decides whether a compiled pack would be
-    recomputed eagerly, so ~15us there buys correctness outright. Paying it per
-    call instead defeats the very budget `_note_packed_under_checkpoint` pays
-    into and adds the walk to every compiled kernel invocation for the life of a
-    run on a torch with no accessor. A spent budget answers None, not False:
-    "stopped asking" is not "no region", and an unknown still counts as packed.
+    The walk is deliberately NOT put on `_probe_walk`'s miss budget, even though
+    `_note_compiled_ok` calls this on every successful compiled call. Budgeting
+    it means a spent budget has to answer something, and both answers are wrong
+    somewhere: False loses a compiled pack that really was under a checkpoint,
+    and None gets recorded as a possible pack, which on a generation-heavy GRPO
+    step marks uncheckpointed inference calls as packed and re-raises on the
+    first codegen refusal -- the exact failure this module exists to prevent.
+    A definite answer per call is worth the walk; the cost is instead removed by
+    not asking, see `_note_compiled_ok`.
     """
     top = _saved_tensor_hook_accessor()
     if top is not None:
@@ -892,12 +892,7 @@ def _in_non_reentrant_checkpoint(budgeted = False):
         if hooks is not _UNKNOWN:
             if not hooks: return False
             if _is_checkpoint_pack_hook(hooks[0]): return True
-    if not budgeted: return _walk_for_checkpoint_frame()
-    # Asked before walking, not after: `_probe_walk` increments the miss count
-    # itself, so reading it afterwards would report the walk it just did as a
-    # walk that was skipped.
-    if _CHECKPOINT_PROBE_MISSES >= _CHECKPOINT_PROBE_MISS_BUDGET: return None
-    return True if _probe_walk() else False
+    return _walk_for_checkpoint_frame()
 
 
 # Set when a compiled call ran with a non-reentrant checkpoint's pack hook on
@@ -1310,7 +1305,13 @@ def _restore_recompile_limits():
     # A new step packs its own activations; last step's are long since freed.
     _PACKED_COMPILED_IN_CHECKPOINT = False
     _CHECKPOINT_PROBE_MISSES = 0
-    _COMPILED_OK_LABELS.clear()
+    # `_COMPILED_OK_LABELS` is deliberately NOT cleared here. This runs whenever
+    # the last borrowed bump is handed back, which `_release_borrowed_budget`
+    # does mid-step after a caught exception, not only at a step boundary. One
+    # wrapper releasing budget would then erase another wrapper's record of
+    # having packed compiled under a still-open checkpoint, and that wrapper's
+    # next refusal would latch eager and let its pack be recomputed eagerly.
+    # The genuine step boundary, `apply_pending_eager_fallbacks`, clears it.
     if not _ORIGINAL_RECOMPILE_LIMITS:
         return 0
     try:
@@ -1799,7 +1800,12 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             # on the call that actually packs. The marker was the only thing
             # worth reading here and it is already known False above.
             return
-        answer = _in_non_reentrant_checkpoint(budgeted = True)
+        if label in _COMPILED_OK_LABELS:
+            # Already recorded this step, so the probe cannot change anything.
+            # Together with the marker branch above this is what bounds the
+            # cost: a label is probed until its answer is known, not forever.
+            return
+        answer = _in_non_reentrant_checkpoint()
         if answer is False:
             return
         if answer:

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1059,8 +1059,21 @@ def _is_inductor_codegen_failure(e):
         module = type(inner).__module__ or ""
         if module.startswith("torch._inductor"):
             return True
-    # Last resort, the backend name the wrapper records.
-    backend = getattr(e, "backend", None)
+    # Last resort, the backend name the wrapper records. `backend_name`, not
+    # `backend`: `BackendCompilerFailed.__init__` has stored
+    # `getattr(backend_fn, "__name__", "?")` under `backend_name` on every
+    # supported version (checked in torch 2.4.0, 2.6.0, 2.9.1 and main), and
+    # `InductorError` carries `backend_name = "inductor"` as a class attribute.
+    # No torch has ever set `backend`, so reading it answered "" for every
+    # exception and this branch could never fire -- which is exactly the branch
+    # the 2.6-era bare `RuntimeError` above depends on, since its module is
+    # `builtins` and the module test cannot see Inductor in it. Verified by
+    # making `compile_fx` raise a bare `RuntimeError` under
+    # `torch.compile(backend = "inductor")` on 2.9.1: torch raises
+    # `BackendCompilerFailed` with `backend_name == "inductor"`, no `backend`
+    # attribute, and `inner_exception` a plain `builtins.RuntimeError`.
+    backend = getattr(e, "backend_name", None)
+    if backend is None: backend = getattr(e, "backend", None)
     name = getattr(backend, "__name__", None) or (backend if isinstance(backend, str) else "")
     return name == "inductor"
 
@@ -1393,7 +1406,9 @@ _PENDING_EAGER_LABELS: set = set()
 # one says "in this step", which is the question being asked.
 _RECENT_EAGER_LABELS: set = set()
 
-# Labels whose compiled callable returned at least once SINCE THE LAST SETTLE.
+# Labels whose compiled callable returned at least once UNDER A CHECKPOINT,
+# SINCE THE LAST SETTLE. Both qualifiers earn their place: see `_note_compiled_ok`
+# for why an uncheckpointed compiled call must not go in here.
 # `_give_up_on_backend` reads this to decide whether going eager could
 # desynchronise a pack from its recompute, and that question is only ever about
 # the step being executed: last step's activations are long since freed. Holding
@@ -1401,6 +1416,19 @@ _RECENT_EAGER_LABELS: set = set()
 # backwards -- it would re-raise on a first refusal in a later step, where
 # nothing compiled has been packed and the fallback is safe.
 _COMPILED_OK_LABELS: set = set()
+
+
+class _EagerFallbackTaken:
+    """Carries the eager result back out of the budget retry.
+
+    The retry has three outcomes, not two: it compiled and returned, it ran out
+    of road (`_NO_RESULT`), or the compiler REFUSED and the backend fallback
+    already ran the call eagerly. The third has to be distinguishable from the
+    first, because a value that came back eager must not be recorded as a
+    compiled pack, and `None` is a valid return value so no sentinel VALUE
+    works. A one-field box does."""
+    __slots__ = ("value",)
+    def __init__(self, value): self.value = value
 
 
 def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
@@ -1658,6 +1686,18 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         _PACKED_COMPILED_IN_CHECKPOINT = marker_before
         state["eager"] = True
         _LATCHED_EAGER_LABELS.add(label)
+        # And as current-step EVIDENCE, which is a different question from the
+        # permanent latch and the reason `_latch_all_to_eager` writes both.
+        # `force_eager_fallback` deliberately refuses to read
+        # `_LATCHED_EAGER_LABELS` -- it is permanent, so a previous model's
+        # labels would answer for this one -- and falls back to asking the live
+        # wrappers. The wrapper that fails here need not be one: GRPO builds
+        # `accumulate_chunk` inside the forward, so it is collected before the
+        # backward that calls `force_eager_fallback`. With no live wrapper and
+        # no recent label the call returns 0, the caller reads that as "no
+        # compile-mode flip happened" and re-raises the very failure it was
+        # asked to retry past.
+        _RECENT_EAGER_LABELS.add(label)
         _warn(
             f"Unsloth: torch.compile could not generate code for {label}; "
             f"running it eagerly from here. Training is unaffected apart from "
@@ -1669,6 +1709,75 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             _CHECKPOINT_SETTLE_ATTEMPTS = 0
             raise e
         return eager_func(*args, **kwargs)
+
+    def _is_backend_refusal_we_handle(e):
+        """The gate the wrapper's own backend arm applies, in one place."""
+        if _wants_hard_backend_failure():
+            return False
+        return _is_inductor_codegen_failure(e)
+
+    def _retry_catching_backend_refusal(args, kwargs, marker_before):
+        """`_retry_with_more_budget`, with a codegen refusal FROM THE RETRY caught.
+
+        The wrapper's `except backend_errors` arm only ever sees the first
+        `compiled_func` call. `_retry_with_more_budget` calls `compiled_func`
+        again inside its own `try`, and Python does not route an exception
+        raised inside one `except` block to a sibling `except` on the same
+        `try` -- so a refusal there escaped the wrapper entirely and ended the
+        run, which is the one outcome this whole function exists to prevent.
+        Reachable whenever a dynamic graph exhausts the recompile cache first
+        and only then exposes the refusal, once the bumped budget lets the
+        compile get as far as codegen.
+
+        The retry's own `except BaseException` has already handed the borrowed
+        bump back by the time this sees the exception, so there is nothing to
+        release here.
+        """
+        try:
+            return _retry_with_more_budget(args, kwargs)
+        except backend_errors as e:
+            if not _is_backend_refusal_we_handle(e):
+                raise
+            return _EagerFallbackTaken(
+                _give_up_on_backend(e, args, kwargs, marker_before))
+
+    def _note_compiled_ok():
+        """Record that this label packed something COMPILED in this step.
+
+        Only calls made under a non-reentrant checkpoint count. The question
+        `_give_up_on_backend` asks of this set is whether going eager now could
+        leave a compiled pack to be RECOMPUTED eagerly, and a compiled call
+        outside a checkpoint region packs nothing that is ever recomputed --
+        generation, inference, or an uncheckpointed stretch of the step. GRPO
+        is exactly that shape: it generates with the same patched kernels it
+        then trains with, so recording the generation pass made the first
+        refusal of the training pass end the step for no reason.
+
+        `None` means torch could not say -- no hook accessor before 2.8, or a
+        user's own `saved_tensors_hooks` sitting above ours -- and that has to
+        count as yes. The asymmetry is the whole point: over-recording ends a
+        step that `force_eager_fallback` retries, while under-recording
+        recomputes a compiled pack eagerly and returns wrong gradients. Same
+        conservative test `_retry_with_more_budget` uses to decide whether
+        anything is half-packed, and for the same reason.
+        """
+        if _dynamo_is_tracing():
+            # The accessor `_in_non_reentrant_checkpoint` reaches for is a
+            # pybind builtin Dynamo refuses to enter, and under
+            # `fullgraph = True` that is fatal rather than a graph break -- the
+            # failure `_note_packed_under_checkpoint` documents, which killed
+            # Gemma4_(E2B)-Vision at cell 15. This runs in the wrapper body, so
+            # a nested compiled region traces it. Nothing is lost: the answer is
+            # meaningless mid-trace, and the same wrapper is entered from eager
+            # on the call that actually packs. Fall back to the marker, which is
+            # a plain global read.
+            if _PACKED_COMPILED_IN_CHECKPOINT:
+                _COMPILED_OK_LABELS.add(label)
+            return
+        if _in_non_reentrant_checkpoint() is False and \
+            not _PACKED_COMPILED_IN_CHECKPOINT:
+            return
+        _COMPILED_OK_LABELS.add(label)
 
     @functools.wraps(eager_func)
     def wrapper(*args, **kwargs):
@@ -1682,25 +1791,29 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             # Before the recompile-limit clause: these are disjoint classes, but
             # the ordering states the intent, which is that a backend refusal is
             # never a budget problem and must not consume budget.
-            if _wants_hard_backend_failure():
-                raise
-            if not _is_inductor_codegen_failure(e):
-                # Some other backend refused. Only Inductor's simplifier gaps
-                # are known-benign enough to run through eagerly; a custom
-                # backend raising is a configuration or programming error and
-                # hiding it would cost the user their diagnosis.
+            if not _is_backend_refusal_we_handle(e):
+                # Either the caller asked for a hard failure, or some other
+                # backend refused. Only Inductor's simplifier gaps are
+                # known-benign enough to run through eagerly; a custom backend
+                # raising is a configuration or programming error and hiding it
+                # would cost the user their diagnosis.
                 raise
             return _give_up_on_backend(e, args, kwargs, marker_before)
         except errors as e:
             if _wants_hard_recompile_failure():
                 raise
-            result = _retry_with_more_budget(args, kwargs)
+            result = _retry_catching_backend_refusal(args, kwargs, marker_before)
+            if type(result) is _EagerFallbackTaken:
+                # The retry hit a codegen refusal and already ran eager. Hand
+                # that value straight back: recording it as compiled would be a
+                # lie in the direction that recomputes a pack in the wrong mode.
+                return result.value
             if result is not _NO_RESULT:
-                # The retry COMPILED and returned, so this region has now packed
-                # compiled activations. Without this the `else:` below is never
-                # reached on the retry path and a later backend refusal in the
-                # same step would fall back to eager against a compiled pack.
-                _COMPILED_OK_LABELS.add(label)
+                # The retry COMPILED and returned, so this region may now have
+                # packed compiled activations. Without this the `else:` below is
+                # never reached on the retry path and a later backend refusal in
+                # the same step would fall back to eager against a compiled pack.
+                _note_compiled_ok()
                 return result
             return _give_up(e, args, kwargs)
         except graph_break_errors as e:
@@ -1708,8 +1821,18 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             # (2.4), then our own `torch.compiler.disable` hook. Anything else
             # is a real graph break and must keep raising.
             if _is_recompile_limit_unsupported(e):
-                result = _retry_with_more_budget(args, kwargs)
+                # The 2.4 route to the same place as the typed arm above, so it
+                # needs the same two things: a refusal from the retry must reach
+                # the backend fallback, and a retry that COMPILED must be
+                # recorded as having packed compiled. Neither happened here, so
+                # cache exhaustion on 2.4 followed by a codegen refusal in the
+                # same step took the opposite decision from 2.7+.
+                result = _retry_catching_backend_refusal(
+                    args, kwargs, marker_before)
+                if type(result) is _EagerFallbackTaken:
+                    return result.value
                 if result is not _NO_RESULT:
+                    _note_compiled_ok()
                     return result
                 return _give_up(e, args, kwargs)
             if not _is_our_own_disabled_hook(e):
@@ -1723,11 +1846,11 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             )
             return eager_func(*args, **kwargs)
         else:
-            # The compiled callable returned, so anything it packs from here is
-            # packed compiled. Only `_give_up_on_backend` reads this, to decide
-            # whether switching to eager could desynchronise a pack from its
-            # recompute.
-            _COMPILED_OK_LABELS.add(label)
+            # The compiled callable returned, so anything it packed under a
+            # checkpoint is packed compiled. Only `_give_up_on_backend` reads
+            # this, to decide whether switching to eager could desynchronise a
+            # pack from its recompute.
+            _note_compiled_ok()
             return result
 
     # Keep the compiled callable reachable for anything that unwraps it, and

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1011,6 +1011,68 @@ def _disabled_hook_graph_break_error():
     return ()
 
 
+def _wants_hard_backend_failure():
+    """Did the caller ask for a backend codegen failure to be fatal?
+
+    Its own switch rather than a reuse of `_wants_hard_recompile_failure`:
+    that one reads a Dynamo config flag about the recompile budget, which says
+    nothing about codegen. Off by default, so the shipped behaviour is the
+    fallback; on, so this repo's tests can assert the exception still escapes
+    and a user chasing a backend bug can see it.
+
+    `os` is imported inside the function: this module has no module-level
+    `import os`, and the read has to be live anyway, since a test that sets the
+    variable after import must still be seen.
+    """
+    import os
+    return os.environ.get("UNSLOTH_HARD_BACKEND_FAILURE", "0") == "1"
+
+
+def _backend_compile_errors():
+    """Inductor's own codegen failures, if this torch exposes them.
+
+    Categorically different from a graph break. The frame traced fine and the
+    backend then refused to generate code for the graph it was handed, so the
+    eager result is the same result and only speed is lost. A graph break means
+    Dynamo could not represent the code at all, which is a bug worth raising.
+
+    The live example is torch 2.12 refusing the ragged tail of
+    `torch.chunk(x, chunks = N)` under dynamic shapes:
+
+        InductorError: CantSplit: 202048*s47*s87 - 3434816*(((s47*s87 + 17)//18))
+        not divisible by s47*s87 - 17*(((s47*s87 + 17)//18))
+
+    which is arithmetic that is true by inspection -- `202048*tail` over `tail`
+    is `202048` -- and which `statically_known_multiple_of` answers correctly on
+    2.9, 2.10 and 2.11. A version-specific simplifier gap in the backend should
+    cost speed, not end the run.
+
+    Looked up by name, like the recompile-limit and graph-break tuples above:
+    `InductorError` does not exist before 2.6 and the import must not be able to
+    stop the tuple from being built.
+    """
+    found = []
+    try:
+        from torch._inductor.exc import InductorError as _inductor_error
+    except Exception:
+        pass
+    else:
+        if isinstance(_inductor_error, type) and issubclass(_inductor_error, BaseException):
+            found.append(_inductor_error)
+    try:
+        import torch._dynamo.exc as _exc
+    except Exception:
+        pass
+    else:
+        # What Dynamo wraps a backend failure in when it does not surface the
+        # Inductor class directly. Not a superset: on some versions only one of
+        # the two ever reaches the caller, so both are needed.
+        _e = getattr(_exc, "BackendCompilerFailed", None)
+        if isinstance(_e, type) and issubclass(_e, BaseException):
+            found.append(_e)
+    return tuple(found)
+
+
 def _is_recompile_limit_unsupported(exc):
     """Cache exhaustion reported as a plain graph break.
 
@@ -1307,7 +1369,8 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     """
     errors = _recompile_limit_errors()
     graph_break_errors = _disabled_hook_graph_break_error()
-    if not errors and not graph_break_errors:
+    backend_errors = _backend_compile_errors()
+    if not errors and not graph_break_errors and not backend_errors:
         return compiled_func
 
     # Warn once. The condition repeats every call, and the log should not.
@@ -1489,6 +1552,39 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             raise e
         return eager_func(*args, **kwargs)
 
+    def _give_up_on_backend(e, args, kwargs):
+        """Inductor refused to generate code. Run eager, and stay there.
+
+        No budget retry: cache exhaustion is a resource problem that more
+        budget can genuinely fix, but a codegen refusal is deterministic. The
+        same graph regenerates the same failure, so retrying only pays the
+        compile twice before landing here anyway.
+
+        Only THIS label latches, unlike `_give_up`. Exhaustion is process-wide
+        and takes the other borrowers with it; a codegen refusal is a property
+        of one region's graph, so knocking unrelated regions eager would cost
+        their compilation for nothing.
+
+        The checkpoint rule from `_give_up` still applies unchanged: inside a
+        non-reentrant region, anything already packed compiled this step owes a
+        backward that would now recompute eagerly, which either aborts or hands
+        back wrong gradients. End the step instead and let the caller retry.
+        """
+        packed = _in_non_reentrant_checkpoint() or _PACKED_COMPILED_IN_CHECKPOINT
+        state["eager"] = True
+        _LATCHED_EAGER_LABELS.add(label)
+        _warn(
+            f"Unsloth: torch.compile could not generate code for {label}; "
+            f"running it eagerly from here. Training is unaffected apart from "
+            f"speed. ({type(e).__name__})"
+        )
+        if packed:
+            global _RAISED_INSIDE_CHECKPOINT, _CHECKPOINT_SETTLE_ATTEMPTS
+            _RAISED_INSIDE_CHECKPOINT = True
+            _CHECKPOINT_SETTLE_ATTEMPTS = 0
+            raise e
+        return eager_func(*args, **kwargs)
+
     @functools.wraps(eager_func)
     def wrapper(*args, **kwargs):
         if state["eager"]:
@@ -1496,6 +1592,13 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         try:
             _note_packed_under_checkpoint()
             return compiled_func(*args, **kwargs)
+        except backend_errors as e:
+            # Before the recompile-limit clause: these are disjoint classes, but
+            # the ordering states the intent, which is that a backend refusal is
+            # never a budget problem and must not consume budget.
+            if _wants_hard_backend_failure():
+                raise
+            return _give_up_on_backend(e, args, kwargs)
         except errors as e:
             if _wants_hard_recompile_failure():
                 raise

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1079,14 +1079,27 @@ def _backend_compile_errors():
         InductorError: CantSplit: 202048*s47*s87 - 3434816*(((s47*s87 + 17)//18))
         not divisible by s47*s87 - 17*(((s47*s87 + 17)//18))
 
-    which is arithmetic that is true by inspection -- `202048*tail` over `tail`
-    is `202048` -- and which `statically_known_multiple_of` answers correctly on
-    2.9, 2.10 and 2.11. A version-specific simplifier gap in the backend should
-    cost speed, not end the run.
+    which is arithmetic that is true by inspection: `202048*tail` over `tail`
+    is `202048`. A backend that cannot see that should cost speed, not end the
+    run.
 
-    Looked up by name, like the recompile-limit and graph-break tuples above:
-    `InductorError` does not exist before 2.6 and the import must not be able to
-    stop the tuple from being built.
+    Deliberately NOT claiming which torch versions answer the underlying
+    divisibility question correctly. A standalone `statically_known_multiple_of`
+    probe does not reproduce the refusal: driving it with an unbacked symint
+    answers False on 2.6 through 2.10 and on 2.12, and True only on 2.11, which
+    tracks neither the versions nor the hardware where the compile actually
+    fails. What IS measured: the same expression compiles cleanly under torch
+    2.12.1 on CPU Inductor and on an sm_100 B200, and refuses on an sm_75 T4,
+    where the reduction has to be split in the first place. So the trigger is a
+    tiling decision, not a version constant, and this net is written to catch
+    the refusal wherever it appears rather than to encode a version range.
+
+    Looked up by name, like the recompile-limit and graph-break tuples above.
+    Measured across CPU builds 2.6.0, 2.7.1, 2.8.0, 2.10.0, 2.11.0, 2.12.1 and
+    2.9.1+cu128: `InductorError` is absent on 2.6 and present from 2.7, while
+    `BackendCompilerFailed` is present on all of them, so the tuple is non-empty
+    everywhere in the supported range and the import must not be able to stop it
+    from being built.
     """
     found = []
     try:

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1800,6 +1800,15 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             # on the call that actually packs. The marker was the only thing
             # worth reading here and it is already known False above.
             return
+        if torch.is_inference_mode_enabled():
+            # Inference mode saves nothing for backward, so this call cannot
+            # have packed anything that is ever recomputed and the answer is
+            # known without asking. Inference mode, NOT `is_grad_enabled()`:
+            # `autograd.Function.forward` runs with grad off and Unsloth's
+            # gradient checkpointing IS one, so grad-off is true in the exact
+            # place the record has to be made -- the same trap
+            # `_note_packed_under_checkpoint` documents.
+            return
         if label in _COMPILED_OK_LABELS:
             # Already recorded this step, so the probe cannot change anything.
             # Together with the marker branch above this is what bounds the
@@ -2105,6 +2114,11 @@ def apply_pending_eager_fallbacks() -> int:
     _LATCHED_EAGER_LABELS.update(_PENDING_EAGER_LABELS)
     _PENDING_EAGER_LABELS.clear()
     _RECENT_EAGER_LABELS.clear()
+    # A genuine settlement: everything is eager now, so the step is being
+    # abandoned and the compiled-pack history answers for nobody.
+    # `_restore_recompile_limits` deliberately does NOT do this, because it also
+    # runs mid-step when a borrower hands its bump back.
+    _COMPILED_OK_LABELS.clear()
     # Everything that borrowed headroom is eager now, so hand the budget back
     # rather than leaving the process permanently raised.
     _restore_recompile_limits()

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1028,6 +1028,43 @@ def _wants_hard_backend_failure():
     return os.environ.get("UNSLOTH_HARD_BACKEND_FAILURE", "0") == "1"
 
 
+def _is_inductor_codegen_failure(e):
+    """True only when Inductor itself refused to generate code.
+
+    `_backend_compile_errors` has to include `BackendCompilerFailed` to catch
+    the refusal on torch versions that wrap it, but that class wraps ANY
+    backend. `torch_compile_with_fallback(..., backend = custom)` is supported,
+    and swallowing a custom backend's exception would turn a configuration or
+    programming error into a silent permanent switch to eager -- the user would
+    lose both the speed and the diagnosis.
+
+    So a wrapper is only accepted when what it wraps is an Inductor error.
+    `InductorError` raised directly is accepted as itself.
+    """
+    try:
+        from torch._inductor.exc import InductorError as _inductor_error
+    except Exception:
+        _inductor_error = None
+    if _inductor_error is not None and isinstance(e, _inductor_error):
+        return True
+    # `BackendCompilerFailed` keeps the original under one of these, depending on
+    # the version; `__cause__` is the one that survives `raise ... from`.
+    for attribute in ("inner_exception", "__cause__", "__context__"):
+        inner = getattr(e, attribute, None)
+        if inner is None: continue
+        if _inductor_error is not None and isinstance(inner, _inductor_error):
+            return True
+        # 2.6-era builds raise a bare RuntimeError out of the scheduler rather
+        # than an `InductorError`, so fall back to where it was raised from.
+        module = type(inner).__module__ or ""
+        if module.startswith("torch._inductor"):
+            return True
+    # Last resort, the backend name the wrapper records.
+    backend = getattr(e, "backend", None)
+    name = getattr(backend, "__name__", None) or (backend if isinstance(backend, str) else "")
+    return name == "inductor"
+
+
 def _backend_compile_errors():
     """Inductor's own codegen failures, if this torch exposes them.
 
@@ -1232,6 +1269,7 @@ def _restore_recompile_limits():
     # A new step packs its own activations; last step's are long since freed.
     _PACKED_COMPILED_IN_CHECKPOINT = False
     _CHECKPOINT_PROBE_MISSES = 0
+    _COMPILED_OK_LABELS.clear()
     if not _ORIGINAL_RECOMPILE_LIMITS:
         return 0
     try:
@@ -1342,6 +1380,15 @@ _PENDING_EAGER_LABELS: set = set()
 # one says "in this step", which is the question being asked.
 _RECENT_EAGER_LABELS: set = set()
 
+# Labels whose compiled callable returned at least once SINCE THE LAST SETTLE.
+# `_give_up_on_backend` reads this to decide whether going eager could
+# desynchronise a pack from its recompute, and that question is only ever about
+# the step being executed: last step's activations are long since freed. Holding
+# it per wrapper instead would answer for a step that is over, which is exactly
+# backwards -- it would re-raise on a first refusal in a later step, where
+# nothing compiled has been packed and the fallback is safe.
+_COMPILED_OK_LABELS: set = set()
+
 
 def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     """Run eager instead of dying when the recompile cache is exhausted.
@@ -1379,13 +1426,12 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     # it cannot be hoisted) dies with that forward and the registry holds it
     # weakly, so latching it bought nothing -- the next step compiled a fresh
     # one, borrowed again, and the bounded transition to eager never happened.
-    # `compiled_ok` records whether the compiled callable has ever returned for
-    # this wrapper. Only the backend-codegen path reads it, to tell a first
-    # compile that never packed anything from a later one that did. See
-    # `_give_up_on_backend`.
+    # Whether the compiled callable has returned is deliberately NOT held here:
+    # it lives in the module-level `_COMPILED_OK_LABELS`, which is cleared at
+    # every step boundary. See that set for why the answer has to be per step
+    # rather than per wrapper.
     state = {"warned": False, "eager": label in _LATCHED_EAGER_LABELS,
-             "pending_eager": label in _PENDING_EAGER_LABELS, "bumps": 0,
-             "compiled_ok": False}
+             "pending_eager": label in _PENDING_EAGER_LABELS, "bumps": 0}
 
     def _warn(message):
         if not state["warned"]:
@@ -1557,7 +1603,7 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             raise e
         return eager_func(*args, **kwargs)
 
-    def _give_up_on_backend(e, args, kwargs):
+    def _give_up_on_backend(e, args, kwargs, marker_before):
         """Inductor refused to generate code. Run eager, and stay there.
 
         No budget retry: cache exhaustion is a resource problem that more
@@ -1586,10 +1632,17 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         was compiled and the recompute would be eager, which either aborts or
         returns wrong gradients, so end the step instead.
         """
+        global _PACKED_COMPILED_IN_CHECKPOINT
         packed = (
             (_in_non_reentrant_checkpoint() or _PACKED_COMPILED_IN_CHECKPOINT)
-            and state["compiled_ok"]
+            and label in _COMPILED_OK_LABELS
         )
+        # `_note_packed_under_checkpoint` ran before the compiled call and set
+        # the process-wide marker, but the call refused at compile time so no
+        # compiled code ran and nothing compiled was packed. Leaving the marker
+        # set would make an unrelated wrapper's `_give_up` believe this
+        # checkpoint holds a compiled pack and end the step for no reason.
+        _PACKED_COMPILED_IN_CHECKPOINT = marker_before
         state["eager"] = True
         _LATCHED_EAGER_LABELS.add(label)
         _warn(
@@ -1608,6 +1661,7 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     def wrapper(*args, **kwargs):
         if state["eager"]:
             return eager_func(*args, **kwargs)
+        marker_before = _PACKED_COMPILED_IN_CHECKPOINT
         try:
             _note_packed_under_checkpoint()
             result = compiled_func(*args, **kwargs)
@@ -1617,12 +1671,23 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             # never a budget problem and must not consume budget.
             if _wants_hard_backend_failure():
                 raise
-            return _give_up_on_backend(e, args, kwargs)
+            if not _is_inductor_codegen_failure(e):
+                # Some other backend refused. Only Inductor's simplifier gaps
+                # are known-benign enough to run through eagerly; a custom
+                # backend raising is a configuration or programming error and
+                # hiding it would cost the user their diagnosis.
+                raise
+            return _give_up_on_backend(e, args, kwargs, marker_before)
         except errors as e:
             if _wants_hard_recompile_failure():
                 raise
             result = _retry_with_more_budget(args, kwargs)
             if result is not _NO_RESULT:
+                # The retry COMPILED and returned, so this region has now packed
+                # compiled activations. Without this the `else:` below is never
+                # reached on the retry path and a later backend refusal in the
+                # same step would fall back to eager against a compiled pack.
+                _COMPILED_OK_LABELS.add(label)
                 return result
             return _give_up(e, args, kwargs)
         except graph_break_errors as e:
@@ -1649,7 +1714,7 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             # packed compiled. Only `_give_up_on_backend` reads this, to decide
             # whether switching to eager could desynchronise a pack from its
             # recompute.
-            state["compiled_ok"] = True
+            _COMPILED_OK_LABELS.add(label)
             return result
 
     # Keep the compiled callable reachable for anything that unwraps it, and
@@ -1811,6 +1876,7 @@ def apply_pending_eager_fallbacks() -> int:
     global _PACKED_COMPILED_IN_CHECKPOINT, _CHECKPOINT_PROBE_MISSES
     _PACKED_COMPILED_IN_CHECKPOINT = False
     _CHECKPOINT_PROBE_MISSES = 0             # a new step, a new probe budget
+    _COMPILED_OK_LABELS.clear()              # and a new compiled-pack history
     _settled = _settle_abandoned_checkpoint_generator()
     if _RAISED_INSIDE_CHECKPOINT and not _settled:
         # Still rooted, so its saved-tensor hooks are still on the stack and the

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1379,8 +1379,13 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     # it cannot be hoisted) dies with that forward and the registry holds it
     # weakly, so latching it bought nothing -- the next step compiled a fresh
     # one, borrowed again, and the bounded transition to eager never happened.
+    # `compiled_ok` records whether the compiled callable has ever returned for
+    # this wrapper. Only the backend-codegen path reads it, to tell a first
+    # compile that never packed anything from a later one that did. See
+    # `_give_up_on_backend`.
     state = {"warned": False, "eager": label in _LATCHED_EAGER_LABELS,
-             "pending_eager": label in _PENDING_EAGER_LABELS, "bumps": 0}
+             "pending_eager": label in _PENDING_EAGER_LABELS, "bumps": 0,
+             "compiled_ok": False}
 
     def _warn(message):
         if not state["warned"]:
@@ -1565,12 +1570,26 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         of one region's graph, so knocking unrelated regions eager would cost
         their compilation for nothing.
 
-        The checkpoint rule from `_give_up` still applies unchanged: inside a
-        non-reentrant region, anything already packed compiled this step owes a
-        backward that would now recompute eagerly, which either aborts or hands
-        back wrong gradients. End the step instead and let the caller retry.
+        The checkpoint rule from `_give_up` applies, but only when THIS wrapper
+        has actually run compiled at some point in this step. That extra
+        condition is the difference between recovering and not.
+
+        `_give_up` has to assume the worst because it latches every borrower,
+        including regions that did pack activations compiled. This path latches
+        one label, so the only pack/recompute pair that can desynchronise is
+        this function's own. Inductor refuses at compile time, so a first-call
+        refusal means this region has packed nothing compiled: the eager call
+        below packs eagerly and the backward recomputes eagerly, which agree.
+
+        The case that does need the raise is a later compile for a new dynamic
+        shape, after an earlier shape already compiled and packed. Then the pack
+        was compiled and the recompute would be eager, which either aborts or
+        returns wrong gradients, so end the step instead.
         """
-        packed = _in_non_reentrant_checkpoint() or _PACKED_COMPILED_IN_CHECKPOINT
+        packed = (
+            (_in_non_reentrant_checkpoint() or _PACKED_COMPILED_IN_CHECKPOINT)
+            and state["compiled_ok"]
+        )
         state["eager"] = True
         _LATCHED_EAGER_LABELS.add(label)
         _warn(
@@ -1591,7 +1610,7 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             return eager_func(*args, **kwargs)
         try:
             _note_packed_under_checkpoint()
-            return compiled_func(*args, **kwargs)
+            result = compiled_func(*args, **kwargs)
         except backend_errors as e:
             # Before the recompile-limit clause: these are disjoint classes, but
             # the ordering states the intent, which is that a backend refusal is
@@ -1625,6 +1644,13 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
                 f"unaffected apart from speed."
             )
             return eager_func(*args, **kwargs)
+        else:
+            # The compiled callable returned, so anything it packs from here is
+            # packed compiled. Only `_give_up_on_backend` reads this, to decide
+            # whether switching to eager could desynchronise a pack from its
+            # recompute.
+            state["compiled_ok"] = True
+            return result
 
     # Keep the compiled callable reachable for anything that unwraps it, and
     # keep `get_compiler_config` present so the unwrap check below still sees

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -858,7 +858,7 @@ def _is_checkpoint_pack_hook(pack):
                 ("_checkpoint_hook", "_recomputation_hook")))
 
 
-def _in_non_reentrant_checkpoint():
+def _in_non_reentrant_checkpoint(budgeted = False):
     """Are we inside a `use_reentrant = False` region? None when torch cannot say.
 
     The only saved-tensor hooks `torch.utils.checkpoint` installs are the
@@ -872,6 +872,16 @@ def _in_non_reentrant_checkpoint():
     `saved_tensors_hooks`/`save_on_cpu` entered inside the region sits above
     ours, so an unrecognised hook is "cannot tell from here", not "no region":
     ask the frames instead.
+
+    `budgeted` puts that frame walk on the step's `_probe_walk` budget, for the
+    one caller that runs on EVERY successful compiled call rather than once per
+    failure. The give-up paths must keep the default uncapped walk: they are
+    reached once, and their answer decides whether a compiled pack would be
+    recomputed eagerly, so ~15us there buys correctness outright. Paying it per
+    call instead defeats the very budget `_note_packed_under_checkpoint` pays
+    into and adds the walk to every compiled kernel invocation for the life of a
+    run on a torch with no accessor. A spent budget answers None, not False:
+    "stopped asking" is not "no region", and an unknown still counts as packed.
     """
     top = _saved_tensor_hook_accessor()
     if top is not None:
@@ -882,7 +892,12 @@ def _in_non_reentrant_checkpoint():
         if hooks is not _UNKNOWN:
             if not hooks: return False
             if _is_checkpoint_pack_hook(hooks[0]): return True
-    return _walk_for_checkpoint_frame()
+    if not budgeted: return _walk_for_checkpoint_frame()
+    # Asked before walking, not after: `_probe_walk` increments the miss count
+    # itself, so reading it afterwards would report the walk it just did as a
+    # walk that was skipped.
+    if _CHECKPOINT_PROBE_MISSES >= _CHECKPOINT_PROBE_MISS_BUDGET: return None
+    return True if _probe_walk() else False
 
 
 # Set when a compiled call ran with a non-reentrant checkpoint's pack hook on
@@ -1761,22 +1776,48 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         conservative test `_retry_with_more_budget` uses to decide whether
         anything is half-packed, and for the same reason.
         """
+        global _PACKED_COMPILED_IN_CHECKPOINT
+        # The marker FIRST, because it is a plain global read and everything
+        # below it can cost a full stack walk. Written as one `and` it read
+        # `_in_non_reentrant_checkpoint() is False and not marker`, and Python
+        # evaluates the left operand first, so the probe was paid on every
+        # successful compiled call even once the marker had latched and the
+        # answer was a foregone conclusion -- on 2.4-2.7, where there is no hook
+        # accessor, that is an uncapped ~15us frame walk per compiled kernel
+        # invocation for the rest of the run.
+        if _PACKED_COMPILED_IN_CHECKPOINT:
+            _COMPILED_OK_LABELS.add(label)
+            return
         if _dynamo_is_tracing():
-            # The accessor `_in_non_reentrant_checkpoint` reaches for is a
-            # pybind builtin Dynamo refuses to enter, and under
-            # `fullgraph = True` that is fatal rather than a graph break -- the
-            # failure `_note_packed_under_checkpoint` documents, which killed
+            # The accessor the probe reaches for is a pybind builtin Dynamo
+            # refuses to enter, and under `fullgraph = True` that is fatal
+            # rather than a graph break -- the failure
+            # `_note_packed_under_checkpoint` documents, which killed
             # Gemma4_(E2B)-Vision at cell 15. This runs in the wrapper body, so
             # a nested compiled region traces it. Nothing is lost: the answer is
             # meaningless mid-trace, and the same wrapper is entered from eager
-            # on the call that actually packs. Fall back to the marker, which is
-            # a plain global read.
-            if _PACKED_COMPILED_IN_CHECKPOINT:
-                _COMPILED_OK_LABELS.add(label)
+            # on the call that actually packs. The marker was the only thing
+            # worth reading here and it is already known False above.
             return
-        if _in_non_reentrant_checkpoint() is False and \
-            not _PACKED_COMPILED_IN_CHECKPOINT:
+        answer = _in_non_reentrant_checkpoint(budgeted = True)
+        if answer is False:
             return
+        if answer:
+            # Latch the process-wide marker too, not just this label. The
+            # pre-call probe can miss a region the post-call one then finds --
+            # on 2.4-2.7 its budget may already be spent -- and leaving the
+            # marker False lets a later refusal by this same wrapper OUTSIDE the
+            # region read `packed` as false, latch eager, and leave the compiled
+            # activations this call just packed to be recomputed eagerly, which
+            # aborts the backward or returns wrong gradients.
+            #
+            # It also makes this probe self-limiting, which is the other half of
+            # the cost fix above: once the marker is set the branch at the top
+            # short-circuits and no further call walks anything.
+            _PACKED_COMPILED_IN_CHECKPOINT = True
+        # `answer is None` falls through to here deliberately: torch could not
+        # say, and an unknown has to count as packed (see the docstring), but it
+        # must NOT latch the process-wide marker on a guess.
         _COMPILED_OK_LABELS.add(label)
 
     @functools.wraps(eager_func)


### PR DESCRIPTION
## The problem

torch 2.12 refuses to generate code for the ragged tail of `torch.chunk(x, chunks = N)` under dynamic shapes, and the refusal kills the run:

```
InductorError: CantSplit: 202048*s47*s87 - 3434816*(((s47*s87 + 17)//18))
               not divisible by s47*s87 - 17*(((s47*s87 + 17)//18))
```

`3434816 == 202048 * 17`, so this is the last chunk of an 18-way split of a symbolic row count `n = s47*s87`: every full chunk is `ceil(n/18)` rows and the tail is `n - 17*ceil(n/18)`. Asking whether `vocab * tail` is a multiple of `tail` is true by inspection, and the backend refuses to see it.

An earlier version of this description added "torch 2.9, 2.10 and 2.11 all answer it correctly; 2.12 does not". That is withdrawn: probing `statically_known_multiple_of` directly across CPU builds 2.6.0, 2.7.1, 2.8.0, 2.10.0, 2.11.0, 2.12.1 and 2.9.1+cu128 returns False everywhere except 2.11, which tracks neither the versions nor the hardware where the compile actually fails. Driving the predicate by hand does not reconstruct the context Inductor has when it asks, so the observed compile behaviour below is the evidence, not the predicate.

This is what stops `Muse_Glimmer_(30B)-GRPO` from training on Kaggle 2xT4. It reaches `chunked_hidden_states_selective_log_softmax` and dies at the first optimizer step.

Scope of the trigger, which is narrower than the error suggests: torch 2.12.1 compiles the same expression cleanly on CPU Inductor and on an sm_100 B200. It only fails on the T4, where the reduction has to be split in the first place. So it is a backend simplifier gap reachable on exactly the hardware most users run GRPO on.

## The change

A backend simplifier gap should cost speed, not end a run, so `_fall_back_to_eager_on_recompile_limit` now catches Inductor codegen failures the way it already catches recompile-cache exhaustion: warn once, run the region eagerly, latch so the compile is not paid again.

Three details worth flagging for review:

- **The latch is per-label.** Cache exhaustion is a process-wide budget, so it knocks every borrower eager. A codegen refusal is a property of one graph, so only that label latches; unrelated compiled regions keep their speed.
- **The net is narrow.** Only `InductorError` and `BackendCompilerFailed`, and only if this torch actually exposes them, discovered at wrap time rather than assumed. A real `ValueError` from the model still propagates. `UNSLOTH_HARD_BACKEND_FAILURE=1` re-raises instead, so a debugging session can still see the original error.
- **The non-reentrant checkpoint case.** Falling back mid-step is only safe when this region has not already packed a compiled activation, because an eager recompute against a compiled pack either aborts the backward or returns wrong gradients. Inductor refuses at compile time, so a first-call refusal means nothing compiled was ever packed: the pack and the recompute are both eager and they agree. A refusal that arrives *after* a successful compile does end the step, deliberately.

## Verification

`Muse_Glimmer_(30B)-GRPO` on real Kaggle 2xT4 hardware, which is where the failure lives:

- Before: `CONFIRMED_REGRESSION` at cell 17, `InductorError: CantSplit`.
- After: `PASS`, loss `0.0 -> 0.0853`, 105 tokens of coherent inference, kernel state `COMPLETE`.

The executed notebook contains the warning exactly once, naming the region, and contains no `CantSplit` anywhere:

```
Unsloth: torch.compile could not generate code for chunked_hidden_states_selective_log_softmax;
running it eagerly from here. Training is unaffected apart from speed. (InductorError)
```

That is the causal link rather than a coincidental pass: the error was raised, caught, and the region ran eagerly.

115 tests pass, including 10 new ones driving the wrapper with a callable that raises so they stay valid on torch versions where the real expression compiles fine. The backend exception is constructed version-tolerantly, since 2.12's `InductorError` takes `(inner, first_useful_frame)` while older builds accept a bare message. Measured over the same seven builds, `InductorError` is absent on 2.6 and present from 2.7, while `BackendCompilerFailed` is present on all of them, so the caught tuple is non-empty across the whole supported range. One test asserts the caught tuple is non-empty on this torch, so the fallback cannot silently stop existing.