### PR TITLE
Stop an unreadable optional path aborting collection of the whole suite

### DIFF
--- a/tests/test_upstream_pinned_symbols_trl_vllm.py
+++ b/tests/test_upstream_pinned_symbols_trl_vllm.py
@@ -75,27 +75,17 @@ TRL_ANCHOR_TAGS = ("v0.22.2", "v0.27.1", "v1.0.0")
 # without failing.
 # ---------------------------------------------------------------------------
 def _try_load_fetch_shim():
-    """Locate ``_postmerge_audit/tests/version_compat/_fetch.py`` and
-    return its (fetch_text, has_def) helpers. Returns ``None`` if the
-    shim isn't present on this machine; the parametrized fetch-based
-    tests then ``pytest.skip`` instead of crashing on import.
+    """Return ``_fetch.py``'s (fetch_text, has_def) helpers, or ``None`` so the
+    fetch-based tests skip.
 
-    Two things this has to survive, both learned by watching it not:
-
-    * The shim is optional and lives OUTSIDE the repo, so the only
-      admissible location is one derived from this file. An absolute path
-      naming a particular machine's home used to sit at the top of this
-      list; it made collection of the whole suite depend on a directory
-      that exists on exactly one box.
-    * ``is_file()`` raises rather than returning False when a parent
-      directory denies traversal. That turned "shim not available, skip"
-      into ``PermissionError`` during collection, which pytest reports as
-      an error for the entire session -- 10 skipped, 1 error, no tests run.
-      Hence ``OSError`` is swallowed per candidate.
+    The shim lives outside the repo, so its path must be derived from
+    ``__file__``; a hardcoded absolute path made collection depend on one
+    machine. ``is_file()`` raises rather than returning False when a parent
+    directory denies traversal, turning "not present, skip" into a
+    ``PermissionError`` that pytest treats as a fatal collection error for the
+    whole session -- hence ``OSError`` is swallowed per candidate.
     """
     candidates = [
-        # zoo_clone/.. sibling. Derived from this file, so it cannot depend
-        # on where the checkout happens to live.
         Path(__file__).resolve().parents[2] / "_postmerge_audit/tests/version_compat/_fetch.py",
     ]
     for path in candidates:

--- a/tests/test_upstream_pinned_symbols_trl_vllm.py
+++ b/tests/test_upstream_pinned_symbols_trl_vllm.py
@@ -78,15 +78,32 @@ def _try_load_fetch_shim():
     """Locate ``_postmerge_audit/tests/version_compat/_fetch.py`` and
     return its (fetch_text, has_def) helpers. Returns ``None`` if the
     shim isn't present on this machine; the parametrized fetch-based
-    tests then ``pytest.skip`` instead of crashing on import."""
+    tests then ``pytest.skip`` instead of crashing on import.
+
+    Two things this has to survive, both learned by watching it not:
+
+    * The shim is optional and lives OUTSIDE the repo, so the only
+      admissible location is one derived from this file. An absolute path
+      naming a particular machine's home used to sit at the top of this
+      list; it made collection of the whole suite depend on a directory
+      that exists on exactly one box.
+    * ``is_file()`` raises rather than returning False when a parent
+      directory denies traversal. That turned "shim not available, skip"
+      into ``PermissionError`` during collection, which pytest reports as
+      an error for the entire session -- 10 skipped, 1 error, no tests run.
+      Hence ``OSError`` is swallowed per candidate.
+    """
     candidates = [
-        # Sister workspace layout the parent agent uses
-        Path("/mnt/disks/unslothai/ubuntu/workspace_6/_postmerge_audit/tests/version_compat/_fetch.py"),
-        # Generic relative layout (zoo_clone/.. sibling)
+        # zoo_clone/.. sibling. Derived from this file, so it cannot depend
+        # on where the checkout happens to live.
         Path(__file__).resolve().parents[2] / "_postmerge_audit/tests/version_compat/_fetch.py",
     ]
     for path in candidates:
-        if path.is_file():
+        try:
+            reachable = path.is_file()
+        except OSError:
+            continue
+        if reachable:
             spec_dir = str(path.parent)
             if spec_dir not in sys.path:
                 sys.path.insert(0, spec_dir)


### PR DESCRIPTION
`tests/test_upstream_pinned_symbols_trl_vllm.py` could not be collected on this machine:

    ERROR tests/test_upstream_pinned_symbols_trl_vllm.py
      PermissionError: [Errno 13] Permission denied:
      '/mnt/disks/unslothai/ubuntu/workspace_6/_postmerge_audit/tests/version_compat/_fetch.py'
    Interrupted: 1 error during collection
    10 skipped, 1 error in 7.37s

That is not one file failing. Pytest treats a collection error as fatal for the session, so the **entire suite ran zero tests** -- which is worse than a failure, because a suite that collects nothing looks a lot like a suite that passed.

Two causes, both inside `_try_load_fetch_shim`.

**A machine-specific absolute path was checked into the repo.** The shim is optional and lives outside the repo, so the only admissible location is one derived from `__file__`. The hardcoded candidate made collection of this repo's tests depend on a directory that exists on exactly one box, under a different user.

**The guard did not do what its own docstring promised.** It says it returns `None` when the shim is absent so the fetch-based tests skip. `Path.is_file()` raises rather than returning False when a parent directory denies traversal, so "not available, skip" turned into `PermissionError`. `OSError` is now swallowed per candidate, which is what the docstring always described.

CI never saw this: its runners have no such directory, so `is_file()` answered False cleanly. It bites where the path exists and is not readable, which is any workspace on a host shared with another user.

## Measured

| | before | after |
|---|---|---|
| this file | 1 collection error | 5 passed, 11 skipped |
| full suite | 0 tests run | **4895 passed, 202 skipped** |

I file-searched `_postmerge_audit` and the absolute path across the repo: this one file is the only place either appears.

## The 8 remaining failures are not from this change

All gemma3n, and they reproduce identically at `1935aafa` -- before the four PRs that merged today -- so they predate this and are not a regression from those merges. Their cause is local rather than repo: this venv's `timm` no longer exports `ImageNetInfo`, so `transformers` 4.57.6's `configuration_gemma3n` raises `ImportError` and every gemma3n class then looks absent.

Worth recording separately, though I have not changed it here: the guard reports `DRIFT DETECTED: ... missing on transformers 4.57.6`, which blames transformers for what is an unrelated ImportError further down the chain. That message will mislead the next person who hits it.
