### PR TITLE
Stop a broken sibling package being reported as upstream drift

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -372,6 +372,7 @@ jobs:
             tests/test_compiler_rewriter_exhaustive.py \
             tests/test_compiler_dynamic_exec.py \
             tests/test_temporary_patches_exhaustive.py \
+            tests/test_missing_parent_package_is_drift.py \
             tests/test_unsloth_zoo_lora_merge.py \
             tests/test_peft_paramwrapper_layout_drift.py \
             tests/test_transformers_moe_structure_drift.py \

--- a/tests/test_compiler_dynamic_exec.py
+++ b/tests/test_compiler_dynamic_exec.py
@@ -115,11 +115,9 @@ def _load_modeling(model_type: str):
             f"transformers, can't drive compiler"
         )
     except ImportError as exc:
-        # Present, but raising on the way in. gemma3n's config does
-        # `from timm.data import ImageNetInfo`, which a newer timm no longer
-        # exports, so the module blows up for a reason that has nothing to do
-        # with whether the rewriter emits parseable Python. Same outcome as an
-        # absent model_type -- there is nothing to drive -- but say which.
+        # Present but raising on the way in: gemma3n's config imports
+        # ImageNetInfo from timm.data, which a newer timm dropped. Nothing to
+        # drive either way, but say which.
         pytest.skip(
             f"model_type {model_type} raised on import, so the compiler cannot "
             f"be driven for it: {type(exc).__name__}: {exc}"
@@ -558,11 +556,9 @@ def _compile_and_get_cache(model_type: str, monkeypatch) -> str:
             f"transformers, can't drive compiler"
         )
     except ImportError as exc:
-        # Present, but raising on the way in. gemma3n's config does
-        # `from timm.data import ImageNetInfo`, which a newer timm no longer
-        # exports, so the module blows up for a reason that has nothing to do
-        # with whether the rewriter emits parseable Python. Same outcome as an
-        # absent model_type -- there is nothing to drive -- but say which.
+        # Present but raising on the way in: gemma3n's config imports
+        # ImageNetInfo from timm.data, which a newer timm dropped. Nothing to
+        # drive either way, but say which.
         pytest.skip(
             f"model_type {model_type} raised on import, so the compiler cannot "
             f"be driven for it: {type(exc).__name__}: {exc}"

--- a/tests/test_compiler_dynamic_exec.py
+++ b/tests/test_compiler_dynamic_exec.py
@@ -114,6 +114,16 @@ def _load_modeling(model_type: str):
             f"model_type {model_type} not present on installed "
             f"transformers, can't drive compiler"
         )
+    except ImportError as exc:
+        # Present, but raising on the way in. gemma3n's config does
+        # `from timm.data import ImageNetInfo`, which a newer timm no longer
+        # exports, so the module blows up for a reason that has nothing to do
+        # with whether the rewriter emits parseable Python. Same outcome as an
+        # absent model_type -- there is nothing to drive -- but say which.
+        pytest.skip(
+            f"model_type {model_type} raised on import, so the compiler cannot "
+            f"be driven for it: {type(exc).__name__}: {exc}"
+        )
 
 
 def _assert_parseable(rewritten: str, entry_point: str, *, dedent: bool = False):
@@ -546,6 +556,16 @@ def _compile_and_get_cache(model_type: str, monkeypatch) -> str:
         pytest.skip(
             f"model_type {model_type} not present on installed "
             f"transformers, can't drive compiler"
+        )
+    except ImportError as exc:
+        # Present, but raising on the way in. gemma3n's config does
+        # `from timm.data import ImageNetInfo`, which a newer timm no longer
+        # exports, so the module blows up for a reason that has nothing to do
+        # with whether the rewriter emits parseable Python. Same outcome as an
+        # absent model_type -- there is nothing to drive -- but say which.
+        pytest.skip(
+            f"model_type {model_type} raised on import, so the compiler cannot "
+            f"be driven for it: {type(exc).__name__}: {exc}"
         )
     if hasattr(mod, "__UNSLOTH_PATCHED__"):
         try:

--- a/tests/test_missing_parent_package_is_drift.py
+++ b/tests/test_missing_parent_package_is_drift.py
@@ -1,0 +1,105 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""A removed PARENT package must read as upstream drift, not a broken dependency.
+
+Both drift suites decide "is this OUR target that vanished, or a dependency of
+it?" from `ModuleNotFoundError.name`. That name is the DEEPEST package that
+could not be found, so removing `transformers/models/siglip/` and then importing
+`transformers.models.siglip.modeling_siglip` reports
+`name == "transformers.models.siglip"` -- neither the full path nor the
+top-level package. Matching only those two read the removal as a broken
+dependency and skipped, so a hard-gate suite could pass with a production patch
+target gone.
+
+The predicate is tested directly rather than through the 23 callers: it is the
+whole decision, and driving it through a caller would need transformers itself
+mutilated on disk.
+"""
+
+import importlib
+
+import pytest
+
+from tests.test_temporary_patches_exhaustive import (
+    _names_the_target as _names_the_target_patches,
+)
+from tests.test_upstream_signatures import (
+    _names_the_target as _names_the_target_signatures,
+)
+
+PREDICATES = pytest.mark.parametrize(
+    "predicate",
+    [_names_the_target_patches, _names_the_target_signatures],
+    ids = ["temporary_patches_exhaustive", "upstream_signatures"],
+)
+
+
+def _module_not_found(name):
+    """A ModuleNotFoundError carrying `name`, built the way Python builds it."""
+    return ModuleNotFoundError(f"No module named {name!r}", name = name)
+
+
+def test_a_missing_parent_package_really_is_reported_as_the_parent():
+    """Anchors the premise on the live interpreter rather than on a docstring.
+
+    If CPython ever reported the full requested path here, the whole item would
+    be moot -- so this asserts the shape the fix is built on.
+    """
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        importlib.import_module("transformers.models.unsloth_no_such_pkg.modeling_x")
+    assert excinfo.value.name == "transformers.models.unsloth_no_such_pkg"
+
+
+@PREDICATES
+def test_removed_parent_package_counts_as_the_target(predicate):
+    """The reported bug: this was False, so the caller skipped instead of failing."""
+    exc = _module_not_found("transformers.models.siglip")
+    assert predicate(exc, "transformers.models.siglip.modeling_siglip"), (
+        "a removed parent package must be reported as the target going away, "
+        "not as a broken dependency"
+    )
+
+
+@PREDICATES
+@pytest.mark.parametrize(
+    "missing",
+    ["transformers.models.siglip.modeling_siglip", "transformers.models", "transformers"],
+)
+def test_every_package_prefix_counts_as_the_target(predicate, missing):
+    assert predicate(_module_not_found(missing), "transformers.models.siglip.modeling_siglip")
+
+
+@PREDICATES
+@pytest.mark.parametrize("missing", ["timm", "timm.data", "torchvision"])
+def test_a_broken_dependency_still_does_not_count(predicate, missing):
+    """The regression this predicate exists to prevent: gemma3n's config imports
+    `ImageNetInfo` from timm.data, which a newer timm dropped, and eight tests
+    blamed transformers for classes transformers still ships."""
+    assert not predicate(_module_not_found(missing), "transformers.models.gemma3n.configuration_gemma3n")
+
+
+@PREDICATES
+def test_a_prefix_that_is_not_a_package_boundary_does_not_count(predicate):
+    """`startswith` without the trailing dot would claim this one."""
+    assert not predicate(
+        _module_not_found("transformers.models.siglip"),
+        "transformers.models.siglipx.modeling_x",
+    )
+
+
+@PREDICATES
+def test_an_unnamed_module_not_found_does_not_count(predicate):
+    """`exc.name` is Optional; an empty name must not prefix-match everything."""
+    assert not predicate(_module_not_found(None), "transformers.models.siglip.modeling_siglip")

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import types
+
+from _pytest import outcomes as _pytest_outcomes
 import inspect
 import os
 from typing import Iterable
@@ -46,13 +49,50 @@ def _skip_if_transformers_5x(reason: str) -> None:
         )
 
 
+def _unimportable(dotted_module: str, exc: BaseException) -> str:
+    return (
+        f"{dotted_module!r} raised on import, so nothing can be said about "
+        f"upstream drift here: {type(exc).__name__}: {exc}"
+    )
+
+
 def _try_get_class(dotted_module: str, class_name: str):
     """Import ``dotted_module`` and return ``class_name`` off it (or None).
-    Used to skip 5.0+-gated tests on a 4.x install."""
+    Used to skip 5.0+-gated tests on a 4.x install.
+
+    ``None`` now means one thing only: the module imported and the attribute is
+    not on it. That is the real drift signal, and it is the one 15 of the 23
+    callers below turn into a DRIFT failure.
+
+    A module that RAISES on import is a different question. The signal is not
+    lost: a ``ModuleNotFoundError`` naming the module we asked for still answers
+    ``None``, because an upstream module that has genuinely gone away is drift.
+    What is now separated out is a module that exists but blows up on the way
+    in, which says nothing about upstream at all. Swallowing every exception
+    made the two indistinguishable, and the resulting message
+
+        DRIFT DETECTED: gemma3n.py:53 helper expects Gemma3nRMSNorm but it is
+        missing on transformers 4.57.6
+
+    named the wrong component: transformers 4.57.6 does ship that class. What
+    actually happened was that ``configuration_gemma3n`` imports
+    ``ImageNetInfo`` from ``timm.data``, which a newer timm no longer exports,
+    so the whole module raised ImportError and every gemma3n class looked
+    deleted. Eight tests reported upstream drift for a broken sibling package.
+    """
     try:
         mod = importlib.import_module(dotted_module)
-    except Exception:
-        return None
+    except ModuleNotFoundError as exc:
+        # The target module itself is absent. That IS drift (or a version gate),
+        # and it is what the callers were always judging, so it still answers
+        # None and they still decide. Only a miss on the module we asked for
+        # counts: a ModuleNotFoundError naming something else is a broken
+        # dependency, and falls through to the skip below.
+        if (exc.name or "") in (dotted_module, dotted_module.split(".")[0]):
+            return None
+        pytest.skip(_unimportable(dotted_module, exc))
+    except Exception as exc:
+        pytest.skip(_unimportable(dotted_module, exc))
     return getattr(mod, class_name, None)
 
 
@@ -2490,3 +2530,45 @@ def test_temporary_patches_directory_has_expected_files():
             f"DRIFT DETECTED: temporary_patches/ is missing files {missing}; "
             f"either they were renamed or dropped without updating the test"
         )
+
+
+def test_a_broken_dependency_is_not_reported_as_upstream_drift():
+    """The two ways an import can fail are not the same finding.
+
+    A module that has gone away upstream is drift and must still reach the
+    caller as None so it can fail. A module that exists but raises on the way
+    in says nothing about upstream: gemma3n did exactly this, where
+    configuration_gemma3n imports ImageNetInfo from timm.data and a newer timm
+    no longer exports it, so eight tests announced
+
+        DRIFT DETECTED: ... missing on transformers 4.57.6
+
+    about classes transformers 4.57.6 ships perfectly well.
+    """
+    # Genuinely absent module: still None, so the callers still judge it.
+    assert _try_get_class("transformers.models.not_a_real_model_xyz", "Whatever") is None
+
+    # Present but raising, on a dependency of its own: skipped, not blamed.
+    module_name = "_zoo_probe_broken_import"
+    module = types.ModuleType(module_name)
+
+    def _explode():
+        raise ImportError("cannot import name 'ImageNetInfo' from 'timm.data'")
+
+    module.__getattr__ = lambda name: _explode()
+    real_import = importlib.import_module
+
+    def fake_import(name, *args, **kwargs):
+        if name == module_name:
+            raise ImportError("cannot import name 'ImageNetInfo' from 'timm.data'")
+        return real_import(name, *args, **kwargs)
+
+    importlib.import_module = fake_import
+    try:
+        # Skipped derives from BaseException, so `pytest.raises(Exception)`
+        # would let it through and silently skip THIS test instead.
+        with pytest.raises(_pytest_outcomes.Skipped) as caught:
+            _try_get_class(module_name, "Anything")
+        assert "nothing can be said about upstream drift" in str(caught.value)
+    finally:
+        importlib.import_module = real_import

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -56,6 +56,26 @@ def _unimportable(dotted_module: str, exc: BaseException) -> str:
     )
 
 
+def _names_the_target(exc: ModuleNotFoundError, dotted_module: str) -> bool:
+    """Did the import fail because OUR target is gone, rather than a dependency?
+
+    ``exc.name`` is the deepest package that could not be found, which for a
+    removed model package is the PARENT, not the module we asked for: dropping
+    ``transformers/models/siglip/`` makes importing
+    ``transformers.models.siglip.modeling_siglip`` raise with
+    ``name == "transformers.models.siglip"``. Comparing only against the full
+    path and the top-level package therefore read a removed target as a broken
+    dependency and skipped, so the hard gate passed while the patch target had
+    disappeared. Any package prefix of the target counts.
+
+    The trailing dot is what keeps this a PACKAGE prefix: without it
+    ``transformers.models.siglip`` would also claim
+    ``transformers.models.siglipx.modeling_x``.
+    """
+    name = exc.name or ""
+    return bool(name) and (dotted_module == name or dotted_module.startswith(name + "."))
+
+
 def _try_get_class(dotted_module: str, class_name: str):
     """Import ``dotted_module`` and return ``class_name`` off it (or None).
     Used to skip 5.0+-gated tests on a 4.x install.
@@ -74,7 +94,7 @@ def _try_get_class(dotted_module: str, class_name: str):
     except ModuleNotFoundError as exc:
         # An absent target module IS drift, so callers still get None and judge.
         # One naming something else is a broken dependency: skip below.
-        if (exc.name or "") in (dotted_module, dotted_module.split(".")[0]):
+        if _names_the_target(exc, dotted_module):
             return None
         pytest.skip(_unimportable(dotted_module, exc))
     except Exception as exc:

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -60,34 +60,20 @@ def _try_get_class(dotted_module: str, class_name: str):
     """Import ``dotted_module`` and return ``class_name`` off it (or None).
     Used to skip 5.0+-gated tests on a 4.x install.
 
-    ``None`` now means one thing only: the module imported and the attribute is
-    not on it. That is the real drift signal, and it is the one 15 of the 23
-    callers below turn into a DRIFT failure.
-
-    A module that RAISES on import is a different question. The signal is not
-    lost: a ``ModuleNotFoundError`` naming the module we asked for still answers
-    ``None``, because an upstream module that has genuinely gone away is drift.
-    What is now separated out is a module that exists but blows up on the way
-    in, which says nothing about upstream at all. Swallowing every exception
-    made the two indistinguishable, and the resulting message
-
-        DRIFT DETECTED: gemma3n.py:53 helper expects Gemma3nRMSNorm but it is
-        missing on transformers 4.57.6
-
-    named the wrong component: transformers 4.57.6 does ship that class. What
-    actually happened was that ``configuration_gemma3n`` imports
-    ``ImageNetInfo`` from ``timm.data``, which a newer timm no longer exports,
-    so the whole module raised ImportError and every gemma3n class looked
-    deleted. Eight tests reported upstream drift for a broken sibling package.
+    ``None`` means drift, and 15 of the 23 callers below fail on it: either the
+    module imported without the attribute, or a ``ModuleNotFoundError`` named
+    the module we asked for. A module that exists but RAISES on the way in says
+    nothing about upstream, so it skips instead. Swallowing every exception
+    conflated the two and reported "Gemma3nRMSNorm missing on transformers
+    4.57.6" for a class transformers 4.57.6 ships: configuration_gemma3n imports
+    ImageNetInfo from timm.data, which a newer timm dropped, so every gemma3n
+    class looked deleted and eight tests blamed transformers.
     """
     try:
         mod = importlib.import_module(dotted_module)
     except ModuleNotFoundError as exc:
-        # The target module itself is absent. That IS drift (or a version gate),
-        # and it is what the callers were always judging, so it still answers
-        # None and they still decide. Only a miss on the module we asked for
-        # counts: a ModuleNotFoundError naming something else is a broken
-        # dependency, and falls through to the skip below.
+        # An absent target module IS drift, so callers still get None and judge.
+        # One naming something else is a broken dependency: skip below.
         if (exc.name or "") in (dotted_module, dotted_module.split(".")[0]):
             return None
         pytest.skip(_unimportable(dotted_module, exc))
@@ -2533,19 +2519,13 @@ def test_temporary_patches_directory_has_expected_files():
 
 
 def test_a_broken_dependency_is_not_reported_as_upstream_drift():
-    """The two ways an import can fail are not the same finding.
-
-    A module that has gone away upstream is drift and must still reach the
-    caller as None so it can fail. A module that exists but raises on the way
-    in says nothing about upstream: gemma3n did exactly this, where
-    configuration_gemma3n imports ImageNetInfo from timm.data and a newer timm
-    no longer exports it, so eight tests announced
-
-        DRIFT DETECTED: ... missing on transformers 4.57.6
-
-    about classes transformers 4.57.6 ships perfectly well.
+    """A module gone upstream is drift and must still reach the caller as None;
+    a module that raises on its own dependency is not. gemma3n conflated them:
+    configuration_gemma3n imports ImageNetInfo from timm.data, which a newer
+    timm dropped, so eight tests announced "missing on transformers 4.57.6"
+    about classes transformers 4.57.6 ships.
     """
-    # Genuinely absent module: still None, so the callers still judge it.
+    # Absent module: still None, so the callers still judge it.
     assert _try_get_class("transformers.models.not_a_real_model_xyz", "Whatever") is None
 
     # Present but raising, on a dependency of its own: skipped, not blamed.
@@ -2565,8 +2545,8 @@ def test_a_broken_dependency_is_not_reported_as_upstream_drift():
 
     importlib.import_module = fake_import
     try:
-        # Skipped derives from BaseException, so `pytest.raises(Exception)`
-        # would let it through and silently skip THIS test instead.
+        # Skipped derives from BaseException: pytest.raises(Exception) would
+        # let it through and silently skip THIS test.
         with pytest.raises(_pytest_outcomes.Skipped) as caught:
             _try_get_class(module_name, "Anything")
         assert "nothing can be said about upstream drift" in str(caught.value)

--- a/tests/test_upstream_signatures.py
+++ b/tests/test_upstream_signatures.py
@@ -45,6 +45,25 @@ def _skip_if_transformers_5x(reason: str) -> None:
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _names_the_target(exc: ModuleNotFoundError, dotted_module: str) -> bool:
+    """Did the import fail because OUR target is gone, rather than a dependency?
+
+    ``exc.name`` is the deepest package that could not be found, which for a
+    removed model package is the PARENT, not the module we asked for: dropping
+    ``transformers/models/siglip/`` makes importing
+    ``transformers.models.siglip.modeling_siglip`` raise with
+    ``name == "transformers.models.siglip"``. Comparing only against the full
+    path and the top-level package therefore read a removed target as a broken
+    dependency and skipped, hiding real drift. Any package prefix counts.
+
+    The trailing dot keeps this a PACKAGE prefix: without it
+    ``transformers.models.siglip`` would also claim
+    ``transformers.models.siglipx.modeling_x``.
+    """
+    name = exc.name or ""
+    return bool(name) and (dotted_module == name or dotted_module.startswith(name + "."))
+
+
 def _import_or_skip(dotted_module: str, *names):
     """Import ``names`` from ``dotted_module``, or skip with the real reason.
 
@@ -61,7 +80,7 @@ def _import_or_skip(dotted_module: str, *names):
     try:
         mod = importlib.import_module(dotted_module)
     except ModuleNotFoundError as exc:
-        if (exc.name or "") in (dotted_module, dotted_module.split(".")[0]):
+        if _names_the_target(exc, dotted_module):
             raise
         pytest.skip(
             f"{dotted_module!r} raised on import, so nothing can be said about "

--- a/tests/test_upstream_signatures.py
+++ b/tests/test_upstream_signatures.py
@@ -48,19 +48,15 @@ def _skip_if_transformers_5x(reason: str) -> None:
 def _import_or_skip(dotted_module: str, *names):
     """Import ``names`` from ``dotted_module``, or skip with the real reason.
 
-    A bare ``from transformers.models.X.modeling_X import Y`` inside a test
-    turns any failure on the way in into a test failure, and this file's whole
-    purpose is to report UPSTREAM SIGNATURE DRIFT. Those are not the same
-    finding. gemma3n showed the difference: its config module does
-    ``from timm.data import ImageNetInfo``, a newer timm no longer exports that,
-    and four signature tests failed here for a reason that has nothing to do
-    with the signatures they check or with the transformers version installed.
+    A bare inline import turns any failure on the way in into a signature-drift
+    failure, and those are different findings. gemma3n showed it: its config
+    does ``from timm.data import ImageNetInfo``, which a newer timm dropped, and
+    four signature tests failed here for a reason unrelated to the signatures
+    they check or to the transformers version installed. A module that has
+    genuinely gone away still raises, since that IS drift; only a module that
+    exists and raises is skipped.
 
-    A module that has genuinely gone away is still allowed through as an error,
-    since that IS drift; only a module that exists and raises is skipped.
-
-    Any other direct import in this file has the same latent shape and can be
-    routed through here when it bites.
+    Other direct imports in this file have the same shape and can move here.
     """
     try:
         mod = importlib.import_module(dotted_module)
@@ -78,7 +74,6 @@ def _import_or_skip(dotted_module: str, *names):
         )
     got = tuple(getattr(mod, name) for name in names)
     return got[0] if len(got) == 1 else got
-
 
 
 def _param_names(func) -> list[str]:

--- a/tests/test_upstream_signatures.py
+++ b/tests/test_upstream_signatures.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import inspect
 from typing import Iterable
 
+import importlib
+
 import pytest
 
 try:
@@ -42,6 +44,42 @@ def _skip_if_transformers_5x(reason: str) -> None:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _import_or_skip(dotted_module: str, *names):
+    """Import ``names`` from ``dotted_module``, or skip with the real reason.
+
+    A bare ``from transformers.models.X.modeling_X import Y`` inside a test
+    turns any failure on the way in into a test failure, and this file's whole
+    purpose is to report UPSTREAM SIGNATURE DRIFT. Those are not the same
+    finding. gemma3n showed the difference: its config module does
+    ``from timm.data import ImageNetInfo``, a newer timm no longer exports that,
+    and four signature tests failed here for a reason that has nothing to do
+    with the signatures they check or with the transformers version installed.
+
+    A module that has genuinely gone away is still allowed through as an error,
+    since that IS drift; only a module that exists and raises is skipped.
+
+    Any other direct import in this file has the same latent shape and can be
+    routed through here when it bites.
+    """
+    try:
+        mod = importlib.import_module(dotted_module)
+    except ModuleNotFoundError as exc:
+        if (exc.name or "") in (dotted_module, dotted_module.split(".")[0]):
+            raise
+        pytest.skip(
+            f"{dotted_module!r} raised on import, so nothing can be said about "
+            f"signature drift here: {type(exc).__name__}: {exc}"
+        )
+    except Exception as exc:
+        pytest.skip(
+            f"{dotted_module!r} raised on import, so nothing can be said about "
+            f"signature drift here: {type(exc).__name__}: {exc}"
+        )
+    got = tuple(getattr(mod, name) for name in names)
+    return got[0] if len(got) == 1 else got
+
+
 
 def _param_names(func) -> list[str]:
     try:
@@ -587,8 +625,8 @@ def test_Gemma3Attention_forward_signature():
 def test_Gemma3nMultimodalEmbedder_forward_signature():
     """gemma3n.py:88 patches
     ``Gemma3nMultimodalEmbedder.forward(self, input_ids, inputs_embeds)``."""
-    from transformers.models.gemma3n.modeling_gemma3n import (
-        Gemma3nMultimodalEmbedder,
+    Gemma3nMultimodalEmbedder = _import_or_skip(
+        "transformers.models.gemma3n.modeling_gemma3n", "Gemma3nMultimodalEmbedder",
     )
     _assert_params_superset(
         Gemma3nMultimodalEmbedder.forward,
@@ -600,7 +638,9 @@ def test_Gemma3nMultimodalEmbedder_forward_signature():
 def test_Gemma3nTextAltUp_predict_signature():
     """gemma3n.py:122 patches
     ``Gemma3nTextAltUp.predict(self, hidden_states)``."""
-    from transformers.models.gemma3n.modeling_gemma3n import Gemma3nTextAltUp
+    Gemma3nTextAltUp = _import_or_skip(
+        "transformers.models.gemma3n.modeling_gemma3n", "Gemma3nTextAltUp",
+    )
     sig = inspect.signature(Gemma3nTextAltUp.predict)
     params = [p.name for p in sig.parameters.values() if p.name != "self"]
     if "hidden_states" not in params:
@@ -614,7 +654,9 @@ def test_Gemma3nTextAltUp_predict_signature():
 def test_Gemma3nTextAltUp_correct_signature():
     """gemma3n.py:146 patches
     ``Gemma3nTextAltUp.correct(self, predictions, activated)``."""
-    from transformers.models.gemma3n.modeling_gemma3n import Gemma3nTextAltUp
+    Gemma3nTextAltUp = _import_or_skip(
+        "transformers.models.gemma3n.modeling_gemma3n", "Gemma3nTextAltUp",
+    )
     _assert_params_superset(
         Gemma3nTextAltUp.correct,
         required=["predictions", "activated"],
@@ -625,7 +667,9 @@ def test_Gemma3nTextAltUp_correct_signature():
 def test_Gemma3nModel_get_placeholder_mask_signature():
     """gemma3n.py:201 patches ``Gemma3nModel.get_placeholder_mask`` with
     match_level='relaxed'."""
-    from transformers.models.gemma3n.modeling_gemma3n import Gemma3nModel
+    Gemma3nModel = _import_or_skip(
+        "transformers.models.gemma3n.modeling_gemma3n", "Gemma3nModel",
+    )
     _assert_params_superset(
         Gemma3nModel.get_placeholder_mask,
         required=["input_ids", "inputs_embeds"],


### PR DESCRIPTION
Eight tests on main announce upstream drift for something upstream did not do:

    DRIFT DETECTED: gemma3n.py:53 helper expects Gemma3nRMSNorm but it is
    missing on transformers 4.57.6

transformers 4.57.6 ships `Gemma3nRMSNorm` perfectly well. What actually happens is that `configuration_gemma3n` does

    from timm.data import ImageNetInfo, infer_imagenet_subset

and a newer `timm` no longer exports `ImageNetInfo`, so the whole gemma3n module raises `ImportError` and every class on it looks deleted. The message names transformers, which is the one component not at fault, and it names a version, which invites someone to go bisect transformers over a timm problem.

## Three places conflated two different findings

| where | before | after |
|---|---|---|
| `_try_get_class`, `test_temporary_patches_exhaustive.py` | swallowed every exception, returned `None`; 15 of its 23 callers turn `None` into a DRIFT failure | `None` only for a `ModuleNotFoundError` naming the module asked for; skip with the real exception otherwise |
| four gemma3n tests, `test_upstream_signatures.py` | inline `from ... import X`, so an ImportError surfaced as signature drift | routed through a new `_import_or_skip` with the same rule |
| `_load_modeling` and `_compile_and_get_cache`, `test_compiler_dynamic_exec.py` | caught only `ModuleNotFoundError`, so a raising module failed the parseable-cache test | skip on `ImportError` too, saying which |

**The drift signal is deliberately preserved.** A module that has genuinely gone away upstream is still reported, because that really is drift. Only a module that exists and raises on the way in is skipped, since it says nothing about upstream at all.

## Proving the distinction rather than assuming it

The new test builds both cases by hand rather than relying on the environment to supply one, so it stays meaningful after timm is fixed: an absent module still comes back as `None` so callers can fail on it, and a module that raises on a dependency is skipped.

One trap worth recording, since it silently produced a green result at first: pytest's `Skipped` derives from `BaseException`, so `pytest.raises(Exception)` lets it through and skips the asserting test itself. The test caught 25 skips instead of a pass until it asserted on `_pytest.outcomes.Skipped` directly.

## Measured

    test_temporary_patches_exhaustive.py
    + test_upstream_signatures.py
    + test_compiler_dynamic_exec.py      236 passed, 31 skipped

Before this change, 8 of those failed. No production code changes; this is test diagnostics only.

Sits on top of #1056, which fixes a different way this suite failed to report honestly (a collection error that ran zero tests while looking like a pass).
