### PR TITLE
Charge each card the weight it holds, not the flat average

### DIFF
--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1412,3 +1412,97 @@ def test_identical_cards_still_get_the_flat_average_share():
             f"{n} x 14.56 GiB moved: got {plan.activation_reserve_by_device}, "
             f"the flat-average formula gives {old}"
         )
+
+
+def _flat_average_ask(plan, pinned_bytes):
+    """What the pre-proration planner asked every device to keep."""
+    n = len(plan.raw_budgets)
+    total, headroom = plan.total_weight_bytes, plan.headroom_bytes
+    value = max(0, (sum(plan.raw_budgets.values()) - total - headroom) // n)
+    share = max(-(-total // n), pinned_bytes)
+    return {
+        d: int(max(0, min(
+            value,
+            budget - share - (headroom if d == plan.head_device else 0),
+        )))
+        for d, budget in plan.raw_budgets.items()
+    }
+
+
+def test_prorating_never_charges_the_head_card_more_than_the_flat_average():
+    """The head lands on the BIGGER card, which proration charges the most.
+
+    A symmetric proration is not a one-way improvement: it takes off the small
+    card exactly what it puts on the big one, and the big one is where the head
+    goes, so it is the only device also paying the logit headroom. Charged both,
+    its own cap goes where the small card's used to. 4 + 12 GiB carrying a
+    4-layer 8192-wide 128k-vocab model with 8 GiB of logit headroom: the flat
+    average leaves the head 1.297 GiB, the raw proportional share leaves it
+    exactly 0.000 and the first activation has nowhere to go. The 10 + 12 GiB
+    pair with 2 GiB of headroom is the same loss without the clamp, 7.297 GiB
+    down to 7.051. So the prorated share is only ever taken when it is the
+    SMALLER of the two, which makes the cap per device monotone against the old
+    planner -- no card can come out of proration with less than it had.
+    """
+    with torch.device("meta"):
+        model = _Wide(hidden = 8192, ffn = 8192, vocab = 128000, layers = 4)
+    pinned = model.lm_head.weight.numel() * model.lm_head.weight.element_size()
+
+    for small, big, hr in [(4, 12, 8), (10, 12, 2)]:
+        plan = plan_device_map(
+            model,
+            max_memory = {0: small * _GiB, 1: big * _GiB},
+            headroom_bytes = hr * _GiB,
+        )
+        assert plan is not None, f"{small} + {big} GiB was refused"
+
+        flat = _flat_average_ask(plan, pinned)
+        head = plan.head_device
+        assert plan.raw_budgets[head] > min(plan.raw_budgets.values()), (
+            f"{small} + {big} GiB: the head is not on the bigger card any more"
+        )
+        assert flat[head] > 0, "fixture no longer exercises the head's cap"
+
+        kept = plan.activation_reserve_by_device
+        assert kept[head] > 0, (
+            f"{small} + {big} GiB: the head card was given a zero activation "
+            f"reserve ({kept}); it is being charged its full proportional "
+            f"share AND the logit headroom"
+        )
+        assert kept[head] >= flat[head], (
+            f"{small} + {big} GiB: the head kept {kept[head]} where the "
+            f"flat-average planner kept {flat[head]}; proration must only "
+            f"loosen the cap, never tighten it"
+        )
+        # And the small card still gets the reserve this whole change is about.
+        assert all(v > 0 for v in kept.values()), kept
+
+
+def test_the_relaxation_ladder_still_offers_the_flat_average_rungs():
+    """A rung is 5% of the mapping it is scaled from, so the start matters.
+
+    Proration raises the non-head ask on unequal cards, and the ladder off that
+    higher start can step straight PAST a flat-average rung that fit. Byte
+    exact: units of 272 and 768 bytes and a 328-byte pinned head on budgets
+    1264 and 1354 with 3 bytes of headroom. Weights are 1368, so the flat
+    average asks 580 and 623 while proration asks 603 and 623. cuda:1 holds the
+    head and cannot also take the 768-byte unit, so cuda:0 must relax to 496 or
+    less: the flat ladder offers 580 * 17 // 20 = 493 and fits, the prorated one
+    offers 623 * 16 // 20 = 498 (too big) then 603 * 16 // 20 = 482 and gives 11
+    bytes away for nothing -- the placement is identical either way. Walking
+    both ladders keeps every rung the old planner had.
+    """
+    with torch.device("meta"):
+        model = _Bins([68, 192], head = 82)
+    plan = plan_device_map(
+        model,
+        max_memory = {0: 1264, 1: 1354},
+        headroom_bytes = 3,
+    )
+    assert plan is not None
+    assert plan.total_weight_bytes == 1368
+    assert plan.weight_bytes == {0: 768, 1: 600}
+    assert plan.activation_reserve_by_device == {0: 493, 1: 623}, (
+        f"the prorated ladder skipped the flat-average rung: "
+        f"{plan.activation_reserve_by_device}"
+    )

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1506,3 +1506,36 @@ def test_the_relaxation_ladder_still_offers_the_flat_average_rungs():
         f"the prorated ladder skipped the flat-average rung: "
         f"{plan.activation_reserve_by_device}"
     )
+
+
+def test_a_merged_ladder_rung_never_undercuts_the_flat_average_plan():
+    """The largest minimum is not the best plan when another card pays for it.
+
+    Ordering candidates by the smallest reserve any card keeps is not
+    coordinate-wise monotone, so pooling the prorated and flat-average ladders
+    can hand a card LESS than the flat-average planner did. Byte exact: free
+    units of 996, 920, 576, 812, 892 and 272 bytes and a 128-byte pinned head
+    on budgets 3050 and 3977 with 504 bytes of headroom. Weights are 4596, so
+    the flat average asks 752 and 963 while proration asks 963 and 963. cuda:1
+    holds the head and pays the headroom; 963 everywhere does not fit, the
+    prorated ladder's 963 * 19 // 20 = 914 rung does, and its larger minimum
+    sorts ahead of the still feasible 752 and 963 -- which would take 49 bytes
+    off the one card that also has to hold the logits. The fixture scales
+    linearly, so on real cards that is gigabytes.
+    """
+    with torch.device("meta"):
+        model = _Bins([249, 230, 144, 203, 223, 68], head = 32)
+    plan = plan_device_map(
+        model,
+        max_memory = {0: 3050, 1: 3977},
+        headroom_bytes = 504,
+    )
+    assert plan is not None
+    assert plan.head_device == 1
+    assert plan.total_weight_bytes == 4596
+    legacy = {0: 752, 1: 963}
+    kept = plan.activation_reserve_by_device
+    assert all(kept[d] >= legacy[d] for d in legacy), (
+        f"a merged rung kept less than the flat-average planner {legacy}: {kept}"
+    )
+    assert kept == {0: 866, 1: 963}, kept

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1539,3 +1539,34 @@ def test_a_merged_ladder_rung_never_undercuts_the_flat_average_plan():
         f"a merged rung kept less than the flat-average planner {legacy}: {kept}"
     )
     assert kept == {0: 866, 1: 963}, kept
+
+
+def test_a_small_card_is_not_charged_the_pinned_head_it_never_holds():
+    """The pinned output head is the head card's weight, nobody else's.
+
+    Byte exact: free units of 400 and 200 bytes and a 600-byte pinned head on
+    budgets 400 and 2000 with no headroom. Weights are 1200, so cuda:0's
+    capacity-proportional share is 200 bytes and cuda:1 takes the head. A
+    pinned floor charged to every card raises cuda:0's share to 600, its cap
+    400 - 600 clamps to zero, and the walk then fills all 400 bytes of that
+    card while cuda:1 leaves 1200 free -- the same zero-reserve packing the
+    proportional share exists to remove. Charged only to the head, cuda:0 keeps
+    a 200-byte reserve.
+    """
+    with torch.device("meta"):
+        model = _Bins([100, 50], head = 150)
+    plan = plan_device_map(
+        model,
+        max_memory = {0: 400, 1: 2000},
+        headroom_bytes = 0,
+    )
+    assert plan is not None
+    assert plan.head_device == 1
+    assert plan.total_weight_bytes == 1200
+    kept = plan.activation_reserve_by_device
+    assert kept[0] > 0, (
+        f"cuda:0 was charged the pinned head it does not hold: {kept}"
+    )
+    assert kept == {0: 200, 1: 600}, kept
+    free = {d: plan.raw_budgets[d] - plan.weight_bytes.get(d, 0) for d in (0, 1)}
+    assert free[0] >= kept[0], f"cuda:0 was packed below its own reserve: {free}"

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1304,3 +1304,111 @@ def test_the_head_relaxation_ladder_also_keeps_the_old_shared_floor():
     assert min(kept.values()) >= 50, (
         f"the last-resort ladder landed below the old shared cap of 50: {kept}"
     )
+
+
+def _held_bytes(model, plan):
+    """Weights each device really holds, walked from the map, not the plan."""
+    per = {d: 0 for d in plan.raw_budgets}
+    for name, device in plan.device_map.items():
+        module = model.get_submodule(name) if name else model
+        per[device] += sum(
+            p.numel() * p.element_size() for p in module.parameters(recurse = True)
+        )
+    return per
+
+
+def test_the_smaller_card_of_an_asymmetric_pair_is_not_packed_to_zero():
+    """Unequal cards were charged the FLAT AVERAGE weight, which no card holds.
+
+    The balanced cap read `raw_budgets[d] - share` with `share` the average
+    weight per device. The packing is capacity-proportional, so on a 16 + 80
+    GiB pair holding a 47 GiB model the average is larger than the whole 16 GiB
+    card: its cap went negative, `max(0, ...)` zeroed its reserve, and the walk
+    then filled it to 0.09 GiB free (99.4% full) while the 80 GiB card kept
+    16.41 GiB. The 24 + 48 pair did the same at 99.6% full. A card that does
+    not pay the headroom must keep a reserve sized to the weight IT holds.
+    """
+    with torch.device("meta"):
+        model = _Wide(hidden = 8192, ffn = 8192, vocab = 128000, layers = 110)
+
+    for small, big in [(16, 80), (24, 48), (40, 80)]:
+        max_memory = {0: small * _GiB, 1: big * _GiB}
+        plan = plan_device_map(model, max_memory = max_memory)
+        assert plan is not None, f"{small}+{big} GiB was refused"
+
+        kept = plan.activation_reserve_by_device
+        assert kept[0] > 0, (
+            f"{small}+{big} GiB: the smaller card was given a zero activation "
+            f"reserve ({kept}); it is being charged the flat average weight again"
+        )
+
+        # Reserving the small card's WHOLE budget would satisfy the line above
+        # by leaving it empty, which is not a two-GPU plan.
+        assert plan.weight_bytes[0] > 0, (
+            f"{small}+{big} GiB: the smaller card was left holding nothing "
+            f"({plan.weight_bytes})"
+        )
+
+        # The reported free space is the truth of the packing, not the ask.
+        held = _held_bytes(model, plan)
+        assert held == plan.weight_bytes, f"{small}+{big} GiB: {held} vs {plan.weight_bytes}"
+        free = plan.free_bytes
+        assert free[0] >= kept[0], (
+            f"{small}+{big} GiB: kept {kept[0]} but only {free[0]} is free"
+        )
+
+        # And it is not packed disproportionately tighter than the big card.
+        small_frac = free[0] / max_memory[0]
+        big_frac = free[1] / max_memory[1]
+        assert small_frac >= big_frac / 2, (
+            f"{small}+{big} GiB: the small card has {100 * small_frac:.1f}% free "
+            f"against {100 * big_frac:.1f}% on the big one; free {free}"
+        )
+
+
+def test_identical_cards_still_get_the_flat_average_share():
+    """Kaggle's 2 x T4 pair, and 3 and 4 of them, byte for byte.
+
+    Prorating the weight share by capacity has to be an exact no-op when the
+    capacities are equal, otherwise the measured Muse Glimmer arithmetic
+    (2 x 14.56 GiB, budgets 13.104 each, weights 20.310, headroom 4.104, so a
+    balanced value of 0.897 GiB against caps of +2.949 and -1.155) moves under
+    us. On equal cards only the HEAD's cap ever binds -- a non-head cap is
+    `b - total/n`, which is always above the balanced value `b - (total +
+    headroom)/n` -- so this pins the head's reserve. Ceiling division on both
+    sides is what makes the two expressions agree: `total * b // (n * b)`
+    floors, so a model whose byte count is not a multiple of the card count
+    (here 1778393088 bytes across 5 cards) drifts off the old `-(-total // n)`
+    and the head keeps a byte more than it used to.
+    """
+    with torch.device("meta"):
+        model = _Wide(hidden = 2048, ffn = 8192, vocab = 32768, layers = 20)
+    budget = int(14.56 * _GiB)
+
+    head_bytes = (
+        model.lm_head.weight.numel() * model.lm_head.weight.element_size()
+    )
+    for n in (2, 3, 4, 5):
+        plan = plan_device_map(model, max_memory = {d: budget for d in range(n)})
+        assert plan is not None, f"{n} x 14.56 GiB was refused"
+
+        # The pre-proration formula: one flat average share for every device,
+        # with the pinned head as its floor.
+        total = plan.total_weight_bytes
+        headroom = plan.headroom_bytes
+        value = max(0, (n * budget - total - headroom) // n)
+        share = max(-(-total // n), head_bytes)
+        old = {
+            d: int(max(0, min(
+                value,
+                budget - share - (headroom if d == plan.head_device else 0),
+            )))
+            for d in range(n)
+        }
+        assert value > 0 and old[plan.head_device] < value, (
+            f"{n} cards: fixture no longer exercises the head's cap"
+        )
+        assert plan.activation_reserve_by_device == old, (
+            f"{n} x 14.56 GiB moved: got {plan.activation_reserve_by_device}, "
+            f"the flat-average formula gives {old}"
+        )

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -1019,11 +1019,39 @@ def plan_device_map(
                 # each device at 0 still keeps the head's own reserve
                 # non-negative, so `attempt` -- which only relaxes the OTHER
                 # cards -- is never handed an infeasible head budget.
-                share = max(-(-total // len(devices)), pinned_bytes)
+                #
+                # Charge each device the weight IT holds, not the flat average.
+                # The packing is capacity-proportional, so on unequal cards the
+                # average is the weight of no device: 16 + 80 GiB holding a
+                # 62.81 GiB model gives an average of 31.41, which is larger
+                # than the whole 16 GiB card, so its cap went to -15.41 and the
+                # clamp zeroed its reserve -- and the packing then filled it to
+                # 0.09 GiB free (99.4%) while the 80 GiB card kept 16.41. Same
+                # shape at 24 + 48. Prorating by capacity keeps the cap
+                # strictly positive for every card whenever the model fits at
+                # all (the cap is `raw * (1 - total / capacity)`), and the
+                # pinned floor stays on the head, which is the only device that
+                # takes those units whole, so the four-layer big-head case
+                # above still clears.
+                #
+                # On identical cards the prorated share IS the flat average, so
+                # the Muse Glimmer arithmetic above is unchanged: 13.104 each
+                # of 26.208 gives 10.155, caps 2.949 and -1.155 exactly as
+                # measured. Ceiling division on both sides is what makes the two
+                # agree byte for byte. Single-device budgets are unchanged too
+                # (the share is the whole model either way).
+                capacity = sum(raw_budgets.values()) or 1
+                share = {
+                    d: max(
+                        -(-total * raw_budgets[d] // capacity),
+                        pinned_bytes if d == head_device else 0,
+                    )
+                    for d in devices
+                }
                 per_device = {
                     d: int(max(0, min(
                         value,
-                        raw_budgets[d] - share
+                        raw_budgets[d] - share[d]
                         - (headroom if d == head_device else 0),
                     )))
                     for d in devices

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -1118,8 +1118,8 @@ def plan_device_map(
         # non-head cards stepped down from the per-device range and from the
         # old shared floor, then both ladders again with the head's own reserve
         # relaxed too. The old planner's ladders are in that set rung for rung,
-        # and ordering by the smallest reserve any card keeps means the
-        # accepted plan can never keep less than it did. The head-relaxing
+        # and the per-card floor below is what stops a rung with a larger
+        # minimum from being taken when it keeps some card less. The head-relaxing
         # rungs exist because relaxing only the OTHER cards can miss the head's
         # card by less than its reserve and refuse a model that fits. The logit
         # headroom is never touched by any of them.
@@ -1147,31 +1147,61 @@ def plan_device_map(
         # rung that fit. Budgets 1264 + 1354, 1368 of weights and 3 of headroom
         # ask 580/623 flat and 603/623 prorated; free units of 272 and 768 make
         # the flat 493 rung fit, and the prorated ladder lands on 482 instead.
-        # A 28749 config sweep of GiB-scale budgets found no shape where this
-        # changes the answer -- the cap above already keeps the two asks equal
-        # wherever the pinned floor dominates -- so this is the cheap guarantee
-        # rather than a measured fix: candidates are only ADDED and the sort is
-        # smallest-reserve-first, so keeping every rung either planner would
-        # have tried cannot cost anything and cannot land lower than it did.
         candidates = ladder(reserve)
         flat = flat_reserve.get(head_device)
-        if flat is not None and flat != reserve:
-            candidates += ladder(flat)
+        legacy = ladder(flat) if flat is not None and flat != reserve else []
+        candidates += legacy
 
-        seen = set()
-        ordered = []
-        for kept in candidates:
-            key = tuple(kept[d] for d in devices)
-            if key in seen:
-                continue
-            seen.add(key)
-            ordered.append(kept)
-        # Most-kept first. Passing `max(kept.values())` as the non-head cap
-        # makes `_fill` keep exactly this mapping.
-        ordered.sort(key = lambda k: (min(k.values()), k[head_device], sum(k.values())),
+        def _ordered(cands):
+            # Most-kept first. Passing `max(kept.values())` as the non-head cap
+            # makes `_fill` keep exactly this mapping.
+            seen = set()
+            out = []
+            for kept in cands:
+                key = tuple(kept[d] for d in devices)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(kept)
+            out.sort(key = lambda k: (min(k.values()), k[head_device], sum(k.values())),
                      reverse = True)
-        for kept in ordered:
-            r = _fill(head_device, kept, max(kept.values()))
+            return out
+
+        filled = {}
+        def _try(kept):
+            key = tuple(kept[d] for d in devices)
+            if key not in filled:
+                filled[key] = _fill(head_device, kept, max(kept.values()))
+            return filled[key]
+
+        # What the flat-average planner would have kept: its own ladder, walked
+        # on its own. Ordering by the smallest reserve any card keeps is not
+        # coordinate-wise monotone, so merging the two ladders and taking the
+        # largest minimum can hand one card LESS than that planner did while
+        # another gains. `_Bins([249, 230, 144, 203, 223, 68], head = 32)` on
+        # budgets 3050 + 3977 with 504 of headroom asks 752/963 flat and
+        # 963/963 prorated; 963 does not fit, the prorated ladder's next rung
+        # 914/914 does, and its larger minimum sorts ahead of the still feasible
+        # 752/963 -- so the head, the card that also pays the logit headroom,
+        # comes out 49 short of what it used to keep. That fixture scales
+        # linearly, so on real cards it is gigabytes of activation reserve. A
+        # 1500 config fuzz at MiB scale put it at 58 shapes.
+        #
+        # So a candidate is only better if it is at least the legacy reserve on
+        # EVERY card. The legacy rung itself always passes that test, so this
+        # can never refuse a plan the old planner accepted, and the best rung
+        # above it is still taken: the fixture ends on 866/963, keeping the
+        # head whole AND lifting the small card 114 over the old answer.
+        legacy_kept = None
+        for kept in _ordered(legacy):
+            if _try(kept) is not None:
+                legacy_kept = kept
+                break
+
+        for kept in _ordered(candidates):
+            if legacy_kept is not None and any(kept[d] < legacy_kept[d] for d in devices):
+                continue
+            r = _try(kept)
             if r is not None:
                 return r
         return None

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -966,6 +966,10 @@ def plan_device_map(
     reserve_is_explicit = activation_reserve_bytes is not None
     requested_reserve = activation_reserve_bytes
 
+    # Per head candidate, the balanced reserve the flat-average planner asked
+    # for. `attempt` relaxes from it as well as from the prorated one.
+    flat_reserve: dict[int, dict[int, int]] = {}
+
     def reserve_for(head_device: int) -> dict[int, int]:
         """The per-device reserve to try for this head candidate.
 
@@ -1027,24 +1031,38 @@ def plan_device_map(
                 # than the whole 16 GiB card, so its cap went to -15.41 and the
                 # clamp zeroed its reserve -- and the packing then filled it to
                 # 0.09 GiB free (99.4%) while the 80 GiB card kept 16.41. Same
-                # shape at 24 + 48. Prorating by capacity keeps the cap
-                # strictly positive for every card whenever the model fits at
-                # all (the cap is `raw * (1 - total / capacity)`), and the
-                # pinned floor stays on the head, which is the only device that
-                # takes those units whole, so the four-layer big-head case
-                # above still clears.
+                # shape at 24 + 48.
                 #
-                # On identical cards the prorated share IS the flat average, so
-                # the Muse Glimmer arithmetic above is unchanged: 13.104 each
-                # of 26.208 gives 10.155, caps 2.949 and -1.155 exactly as
-                # measured. Ceiling division on both sides is what makes the two
-                # agree byte for byte. Single-device budgets are unchanged too
-                # (the share is the whole model either way).
+                # Prorating only ever LOOSENS the flat-average share, never
+                # tightens it (`min` below), and that one-sidedness is load
+                # bearing twice over. The proration is symmetric, so it charges
+                # the BIGGER card more than the average -- and the bigger card
+                # is the one the head lands on, the only one that also pays the
+                # headroom. Charged both, its own cap can go where the small
+                # card's used to: budgets 852 + 1089 with 1368 of weights, 358
+                # of headroom and a 168-byte pinned head kept 107 and 47, and
+                # the raw proportional share turns that into 107 and 0. On a
+                # real pair, 10 + 18 GiB carrying a 4-layer 8192-wide model with
+                # 12 GiB of logit headroom loses the head's whole 1.094 GiB
+                # reserve. Taking the smaller of the two shares fixes the small
+                # card without ever moving the big one: the cap is per device
+                # monotone against the flat-average planner, so no card can come
+                # out of this with less than it had.
+                #
+                # It is also what keeps identical cards byte identical. There
+                # the prorated share IS the flat average, so `min` and the
+                # pinned floor collapse onto the old expression exactly and the
+                # measured Muse Glimmer arithmetic stands: 13.104 each of
+                # 26.208 gives 10.155, caps 2.949 and -1.155. Ceiling division
+                # on both sides is what makes the two agree byte for byte.
+                # Single-device budgets are unchanged too (the share is the
+                # whole model either way).
                 capacity = sum(raw_budgets.values()) or 1
+                flat = -(-total // len(devices))
                 share = {
                     d: max(
-                        -(-total * raw_budgets[d] // capacity),
-                        pinned_bytes if d == head_device else 0,
+                        min(flat, -(-total * raw_budgets[d] // capacity)),
+                        pinned_bytes,
                     )
                     for d in devices
                 }
@@ -1052,6 +1070,16 @@ def plan_device_map(
                     d: int(max(0, min(
                         value,
                         raw_budgets[d] - share[d]
+                        - (headroom if d == head_device else 0),
+                    )))
+                    for d in devices
+                }
+                # What the flat-average planner would have asked for. `attempt`
+                # walks this ladder too, so every rung it used stays reachable.
+                flat_reserve[head_device] = {
+                    d: int(max(0, min(
+                        value,
+                        raw_budgets[d] - max(flat, pinned_bytes)
                         - (headroom if d == head_device else 0),
                     )))
                     for d in devices
@@ -1079,9 +1107,9 @@ def plan_device_map(
             return _fill(head_device, reserve, max(reserve.values()))
 
         # The reserve is per device now, so it is a range: the top is what we
-        # would like every card to keep, the floor is exactly what the old
-        # shared `min` cap handed all of them (`min` of a clamp is the clamp of
-        # the `min`). Relaxing from the top alone can land BELOW that floor --
+        # would like every card to keep, the floor the least of it (`min` of a
+        # clamp is the clamp of the `min`). Relaxing from the top alone can
+        # land BELOW that floor --
         # a request missing by one percent is answered by a whole 5% rung -- so
         # 4 x 80 GiB holding a 144 GiB model kept 41.72 GiB per card where the
         # shared cap kept 43.68.
@@ -1095,21 +1123,40 @@ def plan_device_map(
         # rungs exist because relaxing only the OTHER cards can miss the head's
         # card by less than its reserve and refuse a model that fits. The logit
         # headroom is never touched by any of them.
-        top, floor = max(reserve.values()), min(reserve.values())
-        rungs = sorted(
-            {top * (20 - step) // 20 for step in range(21)} |
-            {floor * (20 - step) // 20 for step in range(21)},
-            reverse = True,
-        )
-        candidates = []
-        for other in rungs:
-            candidates.append({d: reserve[d] if d == head_device else min(reserve[d], other)
-                               for d in devices})
-            candidates.append({d: floor if d == head_device else min(floor, other)
-                               for d in devices})
-        for step in range(1, 21):
-            candidates.append({d: v * (20 - step) // 20 for d, v in reserve.items()})
-            candidates.append(dict.fromkeys(devices, floor * (20 - step) // 20))
+        def ladder(base: dict[int, int]) -> list[dict[int, int]]:
+            top, floor = max(base.values()), min(base.values())
+            rungs = sorted(
+                {top * (20 - step) // 20 for step in range(21)} |
+                {floor * (20 - step) // 20 for step in range(21)},
+                reverse = True,
+            )
+            out = []
+            for other in rungs:
+                out.append({d: base[d] if d == head_device else min(base[d], other)
+                            for d in devices})
+                out.append({d: floor if d == head_device else min(floor, other)
+                            for d in devices})
+            for step in range(1, 21):
+                out.append({d: v * (20 - step) // 20 for d, v in base.items()})
+                out.append(dict.fromkeys(devices, floor * (20 - step) // 20))
+            return out
+
+        # Both ladders, because a rung is 5% of the mapping it is scaled from:
+        # prorating raises the non-head asks on unequal cards, and the coarser
+        # ladder off that higher start can step straight PAST a flat-average
+        # rung that fit. Budgets 1264 + 1354, 1368 of weights and 3 of headroom
+        # ask 580/623 flat and 603/623 prorated; free units of 272 and 768 make
+        # the flat 493 rung fit, and the prorated ladder lands on 482 instead.
+        # A 28749 config sweep of GiB-scale budgets found no shape where this
+        # changes the answer -- the cap above already keeps the two asks equal
+        # wherever the pinned floor dominates -- so this is the cheap guarantee
+        # rather than a measured fix: candidates are only ADDED and the sort is
+        # smallest-reserve-first, so keeping every rung either planner would
+        # have tried cannot cost anything and cannot land lower than it did.
+        candidates = ladder(reserve)
+        flat = flat_reserve.get(head_device)
+        if flat is not None and flat != reserve:
+            candidates += ladder(flat)
 
         seen = set()
         ordered = []

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -1049,20 +1049,38 @@ def plan_device_map(
                 # monotone against the flat-average planner, so no card can come
                 # out of this with less than it had.
                 #
-                # It is also what keeps identical cards byte identical. There
-                # the prorated share IS the flat average, so `min` and the
-                # pinned floor collapse onto the old expression exactly and the
-                # measured Muse Glimmer arithmetic stands: 13.104 each of
-                # 26.208 gives 10.155, caps 2.949 and -1.155. Ceiling division
-                # on both sides is what makes the two agree byte for byte.
-                # Single-device budgets are unchanged too (the share is the
-                # whole model either way).
+                # On identical cards the prorated share IS the flat average, so
+                # `min` collapses onto the old expression and the measured Muse
+                # Glimmer arithmetic stands: 13.104 each of 26.208 gives 10.155,
+                # caps 2.949 and -1.155. Ceiling division on both sides is what
+                # makes the two agree byte for byte. Single-device budgets are
+                # unchanged too (the share is the whole model either way).
+                #
+                # The pinned floor is the HEAD's alone, because the head's card
+                # is the only one that holds the pinned units. Charging it to
+                # every card is what the flat-average planner did, and it
+                # recreates on a small card exactly the zero reserve this branch
+                # exists to remove: `_Bins([100, 50], head = 150)` on budgets
+                # 400 + 2000 with no headroom has 1200 bytes of weights and a
+                # 600-byte pinned head, so cuda:0's proportional share is 200
+                # but a shared floor raises it to 600, its cap 400 - 600 clamps
+                # to zero and the in-order walk fills all 400 bytes of the card
+                # while cuda:1 leaves 1200 free. Head-only, cuda:0 keeps 200.
+                # The cap stays per device monotone against the flat-average
+                # planner either way (`min(flat, prorated) <= flat <=
+                # max(flat, pinned_bytes)`), and `attempt`'s per-card legacy
+                # floor is what guarantees the higher non-head ask can never
+                # settle BELOW the old answer: measured over 36,460 configs, 0
+                # devices anywhere come out under 7c9a7ac0, and 3 x 80 GiB on a
+                # 4-layer 8192-wide model -- the shape that regressed when the
+                # floor was head-only and that guard did not yet exist -- is
+                # byte identical.
                 capacity = sum(raw_budgets.values()) or 1
                 flat = -(-total // len(devices))
                 share = {
                     d: max(
                         min(flat, -(-total * raw_budgets[d] // capacity)),
-                        pinned_bytes,
+                        pinned_bytes if d == head_device else 0,
                     )
                     for d in devices
                 }
@@ -1076,6 +1094,10 @@ def plan_device_map(
                 }
                 # What the flat-average planner would have asked for. `attempt`
                 # walks this ladder too, so every rung it used stays reachable.
+                # It keeps the SHARED pinned floor on purpose: this mapping has
+                # to reproduce the old planner exactly, floor included, or the
+                # per-card guarantee `attempt` derives from it is not a
+                # statement about the previous release.
                 flat_reserve[head_device] = {
                     d: int(max(0, min(
                         value,


### PR DESCRIPTION
## The bug

On an asymmetric multi-GPU pair the smaller card is planned with a **zero activation reserve** and packed to the last fraction of a GiB. Measured on merged main at `7c9a7ac0` with a 62.81 GiB model:

| max_memory | kept reserve | smaller card ends up |
|---|---|---|
| 16 + 80 | `{0: 0.0, 1: 16.41}` | 0.09 GiB free, **99.4% full** |
| 24 + 48 | `{0: 0.0, 1: 4.41}` | 0.09 GiB free, **99.6% full** |
| 40 + 80 | | 78.5% full vs 39.3% on the big card |
| 80 + 16 | `{0: 16.41, 1: 0.0}` | zero reserve (latent: the walk happens not to fill it) |

A card with 92 MiB free OOMs on the first activation.

## Why

`reserve_for` capped each device with

```python
share = max(-(-total // len(devices)), pinned_bytes)   # flat average
cap   = raw_budgets[d] - share - (headroom if d == head_device else 0)
```

The comment beside it says "cap by each device's own budget less the weight it has to hold", but `share` is the flat **average** weight while the packing walk is capacity-proportional. On 16 + 80 the average is 31.41 GiB, larger than the whole 16 GiB card, so its cap goes to -15.41, `max(0, ...)` zeroes the reserve, and `_fill` is then free to pack it to 0.09 GiB.

## The fix

Charge each device the weight it actually holds, by prorating the share by capacity. The cap simplifies to `raw * (1 - total / capacity)`, which is strictly positive for every card whenever the model fits at all, so the zero-reserve outcome becomes structurally impossible rather than merely unlikely. The pinned floor moves to the head, which is the only device that takes those units whole, as the existing comment already argues.

On identical cards the prorated share **is** the flat average, byte for byte, so symmetric plans do not move. The Kaggle Muse Glimmer 2 x 14.56 GiB arithmetic in the comments is unchanged: 13.104 each of 26.208 gives 10.155, caps 2.949 and -1.155 exactly as measured.

## Evidence

- Suite `173 passed, 6 skipped` before, `175 passed, 6 skipped` after. No pre-existing test changed state, including the two that hard-code the old shared-cap formula.
- New tests: `test_the_smaller_card_of_an_asymmetric_pair_is_not_packed_to_zero`, and `test_identical_cards_still_get_the_flat_average_share` (n = 2, 3, 4, 5 identical T4s, byte-exact).
- Three mutation proofs, all red: reverting the fix fails the asymmetric test on the zero reserve; ceiling to floor division fails the symmetric test by one byte at n = 5; dropping the share entirely fails both.
- 15-shape matrix: every equal-card shape and the single-GPU decline are byte identical. Five shapes had a 0.00 GiB reserve, none do now. Worst-card fill 99.4% to 65.5% (16+80), 99.6% to 87.3% (24+48), 96.3% to 40.5% (16+24+40+80). 40 + 80 goes from 78.5/39.3 to 52.4/52.4. Nothing got worse and nothing newly refuses.

## Not fixed here, deliberately

The reserve *target* is still an equal split `(slack - headroom) / n`, while activation demand scales with the layers a card holds. A proportional target is arguably more correct on unequal cards, but it would move symmetric plans, the docstring already flags the equal split as a known heuristic with a per-device escape hatch, and it is not the bug measured here. Worth a separate look.

One caveat stated plainly: the symmetric test cannot go red on a plain revert, because it pins behaviour the old code also had. Its mutation proofs are mutations of the fix rather than a revert.
