### PR TITLE
Reach a sibling test by path, not through the `tests.` package

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -134,6 +134,16 @@ jobs:
         # raising requires-python relaxes it rather than making it lie.
         # test_wheel_top_level_packages pins that discovery ships unsloth_zoo and
         # nothing else; collect-only would let the packaging config regress.
+        #
+        # The last two are here because `--collect-only` is exactly what missed
+        # the bug they cover. `tests/` is not a package, so `from tests.x import
+        # y` binds to whatever `tests` package is importable; unsloth's CI runs
+        # these files with its own repo root on sys.path and it DOES ship
+        # `tests/__init__.py`, so the import resolved there and took the module
+        # out at collection, ending that job at exit 2 on every unsloth pull
+        # request. Collecting the drift file here proves it still imports under
+        # a plain root, and the sweep is a stdlib-only grep that refuses the
+        # pattern anywhere in the suite.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
@@ -162,6 +172,8 @@ jobs:
             tests/test_recompile_limit_fallback.py \
             tests/test_checkpoint_compile_mix.py \
             tests/test_disabled_hook_graph_break.py \
+            tests/test_missing_parent_package_is_drift.py \
+            tests/test_sibling_imports_do_not_go_through_a_tests_package.py \
             -v
 
       - name: pytest MLX adapter-filter gate (HARD GATE)

--- a/tests/test_missing_parent_package_is_drift.py
+++ b/tests/test_missing_parent_package_is_drift.py
@@ -29,13 +29,22 @@ mutilated on disk.
 """
 
 import importlib
+import pathlib
+import sys
 
 import pytest
 
-from tests.test_temporary_patches_exhaustive import (
+# By path, not through `tests.`: this repo's `tests/` is not a package, so that
+# name binds to whatever `tests` package is importable instead. Unsloth's own
+# CI runs these files with its repo root on sys.path, and unsloth DOES ship
+# `tests/__init__.py`, so the absolute form resolved to a sibling project's
+# package and the whole module failed to collect.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from test_temporary_patches_exhaustive import (  # noqa: E402
     _names_the_target as _names_the_target_patches,
 )
-from tests.test_upstream_signatures import (
+from test_upstream_signatures import (  # noqa: E402
     _names_the_target as _names_the_target_signatures,
 )
 

--- a/tests/test_sibling_imports_do_not_go_through_a_tests_package.py
+++ b/tests/test_sibling_imports_do_not_go_through_a_tests_package.py
@@ -64,16 +64,34 @@ def test_the_pattern_is_recognized():
     assert _imports_through_the_tests_package("from a import tests") == []
 
 
-def test_no_test_file_imports_a_sibling_through_the_tests_package():
+def _scan_the_suite() -> dict:
+    """Every file under `tests/` that reaches a sibling through `tests.`.
+
+    This file is scanned too. Its own examples are string literals and parse to
+    no import node, so there is nothing to exempt - and exempting it would have
+    let the one module whose whole job is refusing this pattern be the one
+    module allowed to carry it.
+    """
     offenders = {}
     for path in sorted(TESTS.rglob("*.py")):
-        if path == pathlib.Path(__file__).resolve():
-            continue
         hits = _imports_through_the_tests_package(
             path.read_text(encoding = "utf-8", errors = "replace")
         )
         if hits:
             offenders[path.relative_to(TESTS).as_posix()] = hits
+    return offenders
+
+
+def test_the_guard_scans_itself():
+    """The examples above are literals, so scanning this file finds nothing."""
+    here = pathlib.Path(__file__).resolve()
+    assert _imports_through_the_tests_package(here.read_text(encoding = "utf-8")) == []
+    # And it really is in the walk, rather than passing by being skipped.
+    assert here in set(TESTS.rglob("*.py"))
+
+
+def test_no_test_file_imports_a_sibling_through_the_tests_package():
+    offenders = _scan_the_suite()
     assert not offenders, (
         "these reach a sibling through `tests.`, which binds to another "
         f"project's package under unsloth's CI: {offenders}. Import the module "

--- a/tests/test_sibling_imports_do_not_go_through_a_tests_package.py
+++ b/tests/test_sibling_imports_do_not_go_through_a_tests_package.py
@@ -1,0 +1,81 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""A test file may not reach a sibling through the `tests.` package.
+
+This repo's `tests/` carries no `__init__.py`, so `tests.foo` does not name
+anything here: it names whatever `tests` package is importable, and there is
+one. Unsloth's Core CI runs these files with its own repo root on `sys.path`,
+and unsloth DOES ship `tests/__init__.py`, so `from tests.x import y` bound to
+that project's package and raised `ModuleNotFoundError: No module named
+'tests.x'` -- taking the whole module out at collection and failing the job
+with exit 2, on every unsloth pull request rather than on anything zoo changed.
+
+A grep, because the import only misbehaves under a `sys.path` this suite does
+not control, so no amount of running the files from this repo would catch it.
+"""
+
+import ast
+import pathlib
+
+TESTS = pathlib.Path(__file__).resolve().parent
+
+
+def _imports_through_the_tests_package(source: str) -> list:
+    """Every `import tests.x` / `from tests.x import y` in `source`."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    found = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            # `level` is the number of leading dots: a relative import names
+            # this directory and is not the failure mode.
+            if not node.level and (node.module or "").split(".")[0] == "tests":
+                found.append(f"from {node.module} import ...")
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] == "tests":
+                    found.append(f"import {alias.name}")
+    return found
+
+
+def test_the_pattern_is_recognized():
+    """The grep can fail, which is what makes the sweep below mean something."""
+    assert _imports_through_the_tests_package("from tests.a import b") == [
+        "from tests.a import ..."
+    ]
+    assert _imports_through_the_tests_package("import tests.a") == ["import tests.a"]
+    # A relative import and an unrelated one are both fine.
+    assert _imports_through_the_tests_package("from .a import b") == []
+    assert _imports_through_the_tests_package("from testsuite import b") == []
+    assert _imports_through_the_tests_package("from a import tests") == []
+
+
+def test_no_test_file_imports_a_sibling_through_the_tests_package():
+    offenders = {}
+    for path in sorted(TESTS.rglob("*.py")):
+        if path == pathlib.Path(__file__).resolve():
+            continue
+        hits = _imports_through_the_tests_package(
+            path.read_text(encoding = "utf-8", errors = "replace")
+        )
+        if hits:
+            offenders[path.relative_to(TESTS).as_posix()] = hits
+    assert not offenders, (
+        "these reach a sibling through `tests.`, which binds to another "
+        f"project's package under unsloth's CI: {offenders}. Import the module "
+        "by name after putting this directory on sys.path instead."
+    )


### PR DESCRIPTION
Every open unsloth pull request is currently red on a zoo collection error.

`tests/` in this repo carries no `__init__.py`, so `tests.x` does not name anything here. It names whatever `tests` package happens to be importable, and under unsloth's Core CI there is one: the zoo checkout lands in `$RUNNER_TEMP/unsloth-zoo` while unsloth's own repo root is on `sys.path`, and unsloth **does** ship `tests/__init__.py`. So the two imports added in #1057 resolved against that project's package:

```
ModuleNotFoundError: No module named 'tests.test_temporary_patches_exhaustive'
ERROR ../../_temp/unsloth-zoo/tests/test_missing_parent_package_is_drift.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
5129 tests collected, 1 error in 11.87s
##[error]Process completed with exit code 2.
```

One module failing to import ends the whole job, so 5129 collected tests run zero of them and the pull request reads as broken by whatever it happened to change.

### The fix

The imports go by module name with this file's own directory on `sys.path`. Same file either way, and it no longer depends on which `tests` package wins the name.

### Why the grep

Running these files from this repo cannot catch it. `tests/test_missing_parent_package_is_drift.py` collects and passes here today, on the unfixed code, because pytest puts the rootdir first and `tests.x` resolves locally. It only misbehaves under a `sys.path` this suite does not control.

Reproduced by putting an empty `tests/__init__.py` package ahead of this repo on `PYTHONPATH`, which is the shape unsloth's CI produces:

- before: `ModuleNotFoundError: No module named 'tests.test_temporary_patches_exhaustive'`, no tests collected, 1 error
- after: 19 passed

The new `test_no_test_file_imports_a_sibling_through_the_tests_package` is red at `3f72f667` naming both offending lines, and green here. It also tests its own predicate, so a grep that silently stops matching does not pass by accident. This is the only file in the suite that had the pattern.
