### PR TITLE
Stop Dynamo compiling weakref's dictionary writes, which is what exhausts the recompile budget under gradient checkpointing

### DIFF
--- a/tests/test_weak_dictionary_writes_not_compiled.py
+++ b/tests/test_weak_dictionary_writes_not_compiled.py
@@ -1,0 +1,156 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Dynamo must not compile the standard library's weak-dictionary writes.
+
+Fine-tuning gemma-4-E2B-it on a T4 dies in the second step with
+
+    AssertionError: Something went unexpectedly wrong in activation checkpoint
+
+and the recompile budget is why, but not the way it looks. The budget that runs
+out belongs to `weakref.__setitem__`, compiled 1030 times in that one step
+against a limit of 1024, while the gemma4 RMSNorm kernel Unsloth does compile
+was compiled six times in the whole run. Activation checkpointing's saved-tensor
+bookkeeping reaches those writes from inside a compiled region and hands Dynamo
+a fresh key object per checkpointed region, so every one of them is a
+compilation that can never be reused.
+
+Kaggle T4 `danielhanchen/unsloth-t4-ci-e29ca7f0`: with these four code objects
+marked skipped and nothing else changed, the run that had been asserting
+completes, still compiled.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from unsloth_zoo import patching_utils as P  # noqa: E402
+
+
+def test_every_weak_dictionary_writer_is_marked():
+    """All four, because all four are what the T4 run was measured with."""
+    marked = []
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr("torch._dynamo.eval_frame.skip_code",
+                      lambda code: marked.append(code))
+        count = P.stop_compiling_weak_dictionary_writes()
+    import weakref
+    expected = {
+        weakref.WeakKeyDictionary.__setitem__.__code__,
+        weakref.WeakKeyDictionary.__delitem__.__code__,
+        weakref.WeakValueDictionary.__setitem__.__code__,
+        weakref.WeakValueDictionary.__delitem__.__code__,
+    }
+    assert count == 4
+    assert set(marked) == expected
+
+
+def test_the_marked_frames_are_never_compiled():
+    """No Dynamo cache entry for any of the four, through the real accessor.
+
+    This is a weaker statement than it looks anywhere but a T4. Whether Dynamo
+    intercepts these frames at all depends on how they are reached -- on the
+    failing kernel it is from the saved-tensor bookkeeping of a checkpoint
+    recompute, on an autograd worker thread, with a compiled region on the
+    stack, and that arrangement has not been reproduced anywhere else. What this
+    pins is the invariant either way: after the mark, nothing compiles them.
+    """
+    import weakref
+    from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+
+    class Key:
+        pass
+
+    assert P.stop_compiling_weak_dictionary_writes() == 4
+    box, keys = weakref.WeakKeyDictionary(), [Key() for _ in range(3)]
+    compiled = torch.compile(weakref.WeakKeyDictionary.__setitem__,
+                             backend = "eager")
+    for index, key in enumerate(keys):
+        compiled(box, key, index)
+    assert len(box) == 3, "the skipped frame did not run"
+    for owner_name, method_name in P._WEAK_DICTIONARY_WRITERS:
+        code = getattr(getattr(weakref, owner_name), method_name).__code__
+        assert _debug_get_cache_entry_list(code) == []
+
+
+def test_a_skipped_write_still_works():
+    """A skipped frame runs in the interpreter, which is what it did before
+    anyone thought to compile it. Nothing about the dictionary changes."""
+    import weakref
+
+    class Key:
+        pass
+
+    P.stop_compiling_weak_dictionary_writes()
+    kept, box = Key(), weakref.WeakKeyDictionary()
+    box[kept] = "value"
+    assert box[kept] == "value"
+    dropped = Key()
+    box[dropped] = "gone"
+    del box[dropped]
+    assert len(box) == 1
+
+
+def test_it_is_safe_to_call_twice():
+    """`patch_torch_compile` is not guaranteed to run once, and marking an
+    already-marked code object must not be an error."""
+    assert P.stop_compiling_weak_dictionary_writes() == 4
+    assert P.stop_compiling_weak_dictionary_writes() == 4
+
+
+def test_a_torch_without_the_accessor_is_not_an_error():
+    """This runs from `patch_torch_compile`, at import. A torch that cannot be
+    asked has to mean "nothing marked", never a failed import."""
+    with pytest.MonkeyPatch.context() as patch:
+        patch.delattr("torch._dynamo.eval_frame.skip_code")
+        assert P.stop_compiling_weak_dictionary_writes() == 0
+
+
+def test_one_refusal_does_not_stop_the_others():
+    refused = []
+
+    def flaky(code):
+        if not refused:
+            refused.append(code)
+            raise RuntimeError("no")
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr("torch._dynamo.eval_frame.skip_code", flaky)
+        assert P.stop_compiling_weak_dictionary_writes() == 3
+
+
+def test_a_missing_weak_dictionary_is_skipped_quietly():
+    """Named through `weakref` rather than imported, so a python that has moved
+    one of them leaves the other three marked."""
+    import weakref
+    with pytest.MonkeyPatch.context() as patch:
+        patch.delattr(weakref, "WeakValueDictionary")
+        assert P.stop_compiling_weak_dictionary_writes() == 2
+
+
+def test_patching_torch_compile_marks_them():
+    """The wiring, not just the function: nothing else calls it, so a
+    `patch_torch_compile` that forgets it is the bug back again."""
+    called = []
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(P, "stop_compiling_weak_dictionary_writes",
+                      lambda: called.append(True) or 4)
+        P.patch_torch_compile()
+    assert called == [True]

--- a/tests/test_weak_dictionary_writes_not_compiled.py
+++ b/tests/test_weak_dictionary_writes_not_compiled.py
@@ -16,21 +16,16 @@
 
 """Dynamo must not compile the standard library's weak-dictionary writes.
 
-Fine-tuning gemma-4-E2B-it on a T4 dies in the second step with
-
-    AssertionError: Something went unexpectedly wrong in activation checkpoint
-
-and the recompile budget is why, but not the way it looks. The budget that runs
-out belongs to `weakref.__setitem__`, compiled 1030 times in that one step
-against a limit of 1024, while the gemma4 RMSNorm kernel Unsloth does compile
-was compiled six times in the whole run. Activation checkpointing's saved-tensor
-bookkeeping reaches those writes from inside a compiled region and hands Dynamo
-a fresh key object per checkpointed region, so every one of them is a
-compilation that can never be reused.
+Fine-tuning gemma-4-E2B-it on a T4 dies in the second step with "AssertionError:
+Something went unexpectedly wrong in activation checkpoint". The exhausted
+recompile budget is `weakref.__setitem__`'s -- 1030 compiles against a limit of
+1024 in that step -- not the gemma4 RMSNorm kernel the warning names, which
+compiles six times in the whole run. Checkpointing's saved-tensor bookkeeping
+reaches those writes from inside a compiled region with a fresh key object per
+region, so none of those compilations can ever be reused.
 
 Kaggle T4 `danielhanchen/unsloth-t4-ci-e29ca7f0`: with these four code objects
-marked skipped and nothing else changed, the run that had been asserting
-completes, still compiled.
+skipped and nothing else changed, the asserting run completes, still compiled.
 """
 
 import sys
@@ -45,7 +40,7 @@ from unsloth_zoo import patching_utils as P  # noqa: E402
 
 
 def test_every_weak_dictionary_writer_is_marked():
-    """All four, because all four are what the T4 run was measured with."""
+    """All four, as measured on the T4 run."""
     marked = []
     with pytest.MonkeyPatch.context() as patch:
         patch.setattr("torch._dynamo.eval_frame.skip_code",
@@ -65,12 +60,10 @@ def test_every_weak_dictionary_writer_is_marked():
 def test_the_marked_frames_are_never_compiled():
     """No Dynamo cache entry for any of the four, through the real accessor.
 
-    This is a weaker statement than it looks anywhere but a T4. Whether Dynamo
-    intercepts these frames at all depends on how they are reached -- on the
-    failing kernel it is from the saved-tensor bookkeeping of a checkpoint
-    recompute, on an autograd worker thread, with a compiled region on the
-    stack, and that arrangement has not been reproduced anywhere else. What this
-    pins is the invariant either way: after the mark, nothing compiles them.
+    Weaker than it looks off a T4: whether Dynamo intercepts these frames at all
+    depends on how they are reached, and the failing arrangement (checkpoint
+    recompute on an autograd thread under a compiled region) has not been
+    reproduced elsewhere. The invariant holds either way.
     """
     import weakref
     from torch._dynamo.eval_frame import _debug_get_cache_entry_list
@@ -91,8 +84,7 @@ def test_the_marked_frames_are_never_compiled():
 
 
 def test_a_skipped_write_still_works():
-    """A skipped frame runs in the interpreter, which is what it did before
-    anyone thought to compile it. Nothing about the dictionary changes."""
+    """A skipped frame runs in the interpreter; the dictionary is unchanged."""
     import weakref
 
     class Key:
@@ -109,15 +101,14 @@ def test_a_skipped_write_still_works():
 
 
 def test_it_is_safe_to_call_twice():
-    """`patch_torch_compile` is not guaranteed to run once, and marking an
-    already-marked code object must not be an error."""
+    """`patch_torch_compile` is not guaranteed to run only once."""
     assert P.stop_compiling_weak_dictionary_writes() == 4
     assert P.stop_compiling_weak_dictionary_writes() == 4
 
 
 def test_a_torch_without_the_accessor_is_not_an_error():
-    """This runs from `patch_torch_compile`, at import. A torch that cannot be
-    asked has to mean "nothing marked", never a failed import."""
+    """This runs at import, so a torch that cannot be asked must mean
+    "nothing marked", never a failed import."""
     with pytest.MonkeyPatch.context() as patch:
         patch.delattr("torch._dynamo.eval_frame.skip_code")
         assert P.stop_compiling_weak_dictionary_writes() == 0
@@ -137,8 +128,7 @@ def test_one_refusal_does_not_stop_the_others():
 
 
 def test_a_missing_weak_dictionary_is_skipped_quietly():
-    """Named through `weakref` rather than imported, so a python that has moved
-    one of them leaves the other three marked."""
+    """Named through `weakref`, so a python missing one still marks the rest."""
     import weakref
     with pytest.MonkeyPatch.context() as patch:
         patch.delattr(weakref, "WeakValueDictionary")
@@ -146,8 +136,8 @@ def test_a_missing_weak_dictionary_is_skipped_quietly():
 
 
 def test_patching_torch_compile_marks_them():
-    """The wiring, not just the function: nothing else calls it, so a
-    `patch_torch_compile` that forgets it is the bug back again."""
+    """Nothing else calls it, so a `patch_torch_compile` that forgets it is the
+    bug back again."""
     called = []
     with pytest.MonkeyPatch.context() as patch:
         patch.setattr(P, "stop_compiling_weak_dictionary_writes",

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -24,6 +24,7 @@ __all__ = [
     "patch_compiling_bitsandbytes",
     "patch_layernorm",
     "patch_torch_compile",
+    "stop_compiling_weak_dictionary_writes",
     "patch_model_and_tokenizer",
     "patch_compiled_autograd",
 ]
@@ -101,6 +102,73 @@ def patch_layernorm(fast_layernorm):
         torch.nn.LayerNorm = Unsloth_LayerNorm
     return
 pass
+
+
+# The stdlib weak-dictionary mutators. Dynamo inlines the standard library by
+# default and will happily compile these, and the saved-tensor bookkeeping of
+# activation checkpointing reaches them from inside a compiled region.
+_WEAK_DICTIONARY_WRITERS = (
+    ("WeakKeyDictionary",   "__setitem__"),
+    ("WeakKeyDictionary",   "__delitem__"),
+    ("WeakValueDictionary", "__setitem__"),
+    ("WeakValueDictionary", "__delitem__"),
+)
+
+
+def stop_compiling_weak_dictionary_writes():
+    """Ask Dynamo to leave `weakref`'s dictionary writes alone. Returns how many.
+
+    Fine-tuning gemma-4-E2B-it on a T4 dies in the second step with
+
+        AssertionError: Something went unexpectedly wrong in activation
+        checkpoint
+
+    and the recompile budget is why, but not the way it looks. The budget that
+    runs out does not belong to any kernel Unsloth compiles: measured on the
+    kernel that fails, `weakref.__setitem__` was compiled 1030 times in that one
+    step against a `recompile_limit` of 1024, while the gemma4 RMSNorm kernel
+    Unsloth does compile was compiled six times in the whole run.
+
+    Non-reentrant activation checkpointing recomputes each packed forward during
+    backward and saves the intermediates through weakly-keyed bookkeeping. That
+    bookkeeping runs on the autograd thread with a compiled region on the stack,
+    so Dynamo intercepts it, and it sees a fresh key object per checkpointed
+    region -- one compilation each, thousands of them, none of which can ever be
+    reused. When the budget finally runs out, the failure surfaces inside
+    whichever compiled kernel was running, AFTER that kernel has already run and
+    its activations have been packed. The eager fallback then retries the call
+    with a little more budget, the retry packs the same activations a second
+    time, and torch's recomputation hook asserts on the duplicate.
+
+    Compiling a weak-dictionary insert buys nothing whatsoever, so the fix is to
+    stop doing it. The budget is then never touched, no retry happens, nothing is
+    packed twice, and the model stays compiled -- unlike every workaround that
+    turns compilation off to get the run to finish.
+
+    A one-time mark on four code objects. It changes no behaviour of its own:
+    a skipped frame runs in the interpreter, which is what it did before anyone
+    thought to compile it.
+    """
+    try:
+        import weakref
+        from torch._dynamo.eval_frame import skip_code
+    except Exception:
+        # Older torch without the accessor, or no Dynamo at all. Nothing to do,
+        # and nothing here is worth failing an import over.
+        return 0
+    marked = 0
+    for owner_name, method_name in _WEAK_DICTIONARY_WRITERS:
+        owner = getattr(weakref, owner_name, None)
+        method = getattr(owner, method_name, None)
+        code = getattr(method, "__code__", None)
+        if code is None:
+            continue
+        try:
+            skip_code(code)
+        except Exception:
+            continue
+        marked += 1
+    return marked
 
 
 def patch_torch_compile(debug = False, O3 = False, ignore_errors = True):
@@ -230,6 +298,9 @@ def patch_torch_compile(debug = False, O3 = False, ignore_errors = True):
         try:    exec(_try_dynamo_argument)
         except: pass
     pass
+    # Here because this is where Dynamo is configured, and because it has to
+    # happen before anything compiles. See the function for what it is for.
+    stop_compiling_weak_dictionary_writes()
 pass
 
 def get_model(model):

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -104,9 +104,7 @@ def patch_layernorm(fast_layernorm):
 pass
 
 
-# The stdlib weak-dictionary mutators. Dynamo inlines the standard library by
-# default and will happily compile these, and the saved-tensor bookkeeping of
-# activation checkpointing reaches them from inside a compiled region.
+# Dynamo inlines the stdlib, so checkpointing's bookkeeping gets these compiled.
 _WEAK_DICTIONARY_WRITERS = (
     ("WeakKeyDictionary",   "__setitem__"),
     ("WeakKeyDictionary",   "__delitem__"),
@@ -116,45 +114,30 @@ _WEAK_DICTIONARY_WRITERS = (
 
 
 def stop_compiling_weak_dictionary_writes():
-    """Ask Dynamo to leave `weakref`'s dictionary writes alone. Returns how many.
+    """Mark `weakref`'s dictionary writes never-compile. Returns how many.
 
     Fine-tuning gemma-4-E2B-it on a T4 dies in the second step with
+    "AssertionError: Something went unexpectedly wrong in activation
+    checkpoint". The exhausted recompile budget is `weakref.__setitem__`'s --
+    1030 compiles against a `recompile_limit` of 1024 in that step -- NOT the
+    gemma4 RMSNorm kernel the warning names, which compiles six times in the
+    whole run and is only named because the failure surfaces inside whichever
+    compiled kernel is on the stack.
 
-        AssertionError: Something went unexpectedly wrong in activation
-        checkpoint
+    Non-reentrant checkpointing saves recomputed intermediates through weakly
+    keyed bookkeeping, which runs on the autograd thread under a compiled
+    region with a fresh key object per region: one unusable compilation each.
+    The budget runs out after the kernel has packed its activations, so the
+    eager retry packs them again and torch's recomputation hook asserts.
 
-    and the recompile budget is why, but not the way it looks. The budget that
-    runs out does not belong to any kernel Unsloth compiles: measured on the
-    kernel that fails, `weakref.__setitem__` was compiled 1030 times in that one
-    step against a `recompile_limit` of 1024, while the gemma4 RMSNorm kernel
-    Unsloth does compile was compiled six times in the whole run.
-
-    Non-reentrant activation checkpointing recomputes each packed forward during
-    backward and saves the intermediates through weakly-keyed bookkeeping. That
-    bookkeeping runs on the autograd thread with a compiled region on the stack,
-    so Dynamo intercepts it, and it sees a fresh key object per checkpointed
-    region -- one compilation each, thousands of them, none of which can ever be
-    reused. When the budget finally runs out, the failure surfaces inside
-    whichever compiled kernel was running, AFTER that kernel has already run and
-    its activations have been packed. The eager fallback then retries the call
-    with a little more budget, the retry packs the same activations a second
-    time, and torch's recomputation hook asserts on the duplicate.
-
-    Compiling a weak-dictionary insert buys nothing whatsoever, so the fix is to
-    stop doing it. The budget is then never touched, no retry happens, nothing is
-    packed twice, and the model stays compiled -- unlike every workaround that
-    turns compilation off to get the run to finish.
-
-    A one-time mark on four code objects. It changes no behaviour of its own:
-    a skipped frame runs in the interpreter, which is what it did before anyone
-    thought to compile it.
+    Compiling a weak-dictionary insert buys nothing, so skipping these four
+    code objects costs nothing and keeps the model compiled.
     """
     try:
         import weakref
         from torch._dynamo.eval_frame import skip_code
     except Exception:
-        # Older torch without the accessor, or no Dynamo at all. Nothing to do,
-        # and nothing here is worth failing an import over.
+        # Older torch, or no Dynamo: not worth failing an import over.
         return 0
     marked = 0
     for owner_name, method_name in _WEAK_DICTIONARY_WRITERS:
@@ -298,8 +281,7 @@ def patch_torch_compile(debug = False, O3 = False, ignore_errors = True):
         try:    exec(_try_dynamo_argument)
         except: pass
     pass
-    # Here because this is where Dynamo is configured, and because it has to
-    # happen before anything compiles. See the function for what it is for.
+    # Must happen before anything compiles.
     stop_compiling_weak_dictionary_writes()
 pass
 


### PR DESCRIPTION
## The symptom

Fine-tuning `unsloth/gemma-4-E2B-it` on a T4 with `use_gradient_checkpointing = "unsloth"` dies in the second step:

```
AssertionError: Something went unexpectedly wrong in activation checkpoint.
Please report this bug by filing an issue to PyTorch.
```

Shortly before it, unsloth_zoo prints its own warning naming `Gemma4RMSNorm.forward (scaled)` as having run out of recompilation cache. That warning is a red herring, and chasing it is what made this take a while.

## The mechanism

The recompile budget is the mechanism, but the budget that runs out belongs to no kernel we compile. Instrumenting torch's own `exceeds_recompile_limit` on the failing kernel:

```
EXHAUST reason=recompile_limit code=__setitem__ @/usr/lib/python3.12/weakref.py:427
        entries=1024 frame_id=11 frame_compile_id=1024 limit=1024 thread=Dummy-5

FINAL-TOP [('__setitem__ @weakref.py:427', 1030),
           ('_gemma4_rms_norm_scaled @gemma4_float32.py:296', 6),
           ('Gemma4ClippableLinear_forward', 4), ('apply_rotary_pos_emb', 4), ...]
```

`weakref.__setitem__` was compiled **1030 times in that one step** against a `recompile_limit` of 1024. The gemma4 RMSNorm kernel the warning names was compiled **six times in the whole run**.

Non-reentrant activation checkpointing recomputes each packed forward during backward and tracks the saved intermediates through weakly-keyed bookkeeping. That runs on the autograd thread with a compiled region on the stack, so Dynamo intercepts it, and it sees a fresh key object per checkpointed region: one compilation each, a thousand of them, not one of which can ever be reused. When the budget finally goes, the failure surfaces inside whichever compiled kernel was running, **after** that kernel has already run and its activations have been packed. `_retry_with_more_budget` then buys 16 more and re-invokes the same call, the retry packs the same activations a second time, and torch's recomputation hook trips `_internal_assert` on the duplicate.

That also explains the 62 to 72 second first step: most of it is spent compiling weak-dictionary inserts.

## The fix

Ask Dynamo not to compile them. `stop_compiling_weak_dictionary_writes()` marks four code objects skipped through `torch._dynamo.eval_frame.skip_code`, and `patch_torch_compile` calls it where Dynamo is already being configured and before anything compiles:

```
WeakKeyDictionary.__setitem__      WeakKeyDictionary.__delitem__
WeakValueDictionary.__setitem__    WeakValueDictionary.__delitem__
```

A skipped frame runs in the interpreter, which is what it did before anything thought to compile it, so this has no semantics of its own. Compiling a weak-dictionary insert buys nothing in the first place. Every failure to read torch's internals degrades to "nothing marked" rather than an error, since this runs at import.

The budget is then never touched, no retry happens, nothing is packed twice, and **the model stays compiled**. That is what separates this from the two workarounds that get the run to finish by turning compilation off.

## Two designs I tried first, and why they lose

Both assume the exhausted budget belongs to a kernel we compile. It does not.

**Raise the budget.** It is already 1024, raised from torch's default of 8 by `patching_utils`, and the demand was 1030 in a single step. The demand is one compilation per checkpointed region, so it scales with depth and sequence length. No fixed cap is enough, and a cap that were enough would still be paying for a thousand compilations nobody wants.

**Predict the exhaustion at a step boundary and go eager before it.** I built this and measured it on the T4. It never fired, and the run asserted exactly as before: the frame that overruns is created **during** the failing step and reaches 1024 compiles inside it, so nothing measured at the previous boundary can see it coming. The premise that 504 RMSNorm instances make the collision knowable in advance is also wrong, since those 504 instances share one code object that compiles six times.

## Evidence

One Kaggle T4 image throughout: `torch 2.10.0+cu128`, capability (7,5), `bf16 = false`, transformers 5.5.0, three steps of `unsloth/LaTeX_OCR`.

| kernel | zoo under test | result |
|---|---|---|
| `unsloth-t4-ci-7b86fbd2` | main | ASSERTED |
| `unsloth-t4-ci-a6eb18b9` | main | ASSERTED |
| `unsloth-t4-ci-934d681d` | main, instrumented | ASSERTED, named `weakref.__setitem__` x1030 |
| `unsloth-t4-ci-e29ca7f0` | main plus the skip only | COMPLETED, `[5.1565, 3.4462, 3.2893]` |
| `unsloth-t4-ci-8bbcc702` | this branch | COMPLETED, `[5.1565, 3.4462, 3.2885]`, 77.0 s |

Reference losses with `UNSLOTH_COMPILE_DISABLE=1`: `[5.1558, 3.4465, 3.3079]`. In the passing runs the per-frame compile counts are identical at every step boundary and `weakref.__setitem__` is absent entirely, so compilation is intact.

## Healthy path

`unsloth/gemma-3-270m-it`, LoRA, unsloth gradient checkpointing, 20 steps, ragged lengths, one B200. Three alternating pairs, warmup dropped, steady-state step time:

| | mean step (s) | median step (s) |
|---|---|---|
| main | 0.1662, 0.1709, 0.1690 | 0.1694, 0.1740, 0.1729 |
| this branch | 0.1660, 0.1659, 0.1669 | 0.1704, 0.1698, 0.1708 |

Mean of means 0.1687 against 0.1663. Losses identical to four decimals, and `eager_fallback_state()` reports nothing eager and nothing latched on either side, so no compilation was lost. The change costs nothing per step by construction: one mark on four code objects at import.

## Tests

`tests/test_weak_dictionary_writes_not_compiled.py`, 8 tests, CPU, milliseconds. All 8 fail on `main` and pass here. They pin which code objects are marked, that the writes still work, idempotence, that one refusal does not stop the others, that a torch without the accessor is not an import error, and that `patch_torch_compile` is wired to call it.

Full suite on this branch: 4969 passed, 212 skipped, exit 0.

## Known gap, worth a follow-up

The retry in `_retry_with_more_budget` is unsafe under a checkpoint in general: a recompile-limit failure can be raised for somebody else's frame after our own call has already packed activations, and re-invoking the call packs them twice. This removes the only trigger seen in the wild, but the same double-pack would happen for any other frame Dynamo intercepts from a saved-tensor hook.

## Not verified

Dynamo compiling `weakref.__setitem__` has only been observed on the T4, inside a checkpoint recompute on an autograd thread. Compiling that method directly on a local B200 produces no cache entries with or without the mark, so the tests pin the invariant after the mark rather than the failure itself. The offending line is `weakref.py:427` on python 3.12, which is `WeakKeyDictionary.__setitem__`; the other three are marked because they are the same class of thing and because that is the set the passing run was measured with.
