### PR TITLE
Do not let a broken bitsandbytes take down the whole unsloth_zoo import

### DIFF
--- a/unsloth_zoo/temporary_patches/moe_bnb.py
+++ b/unsloth_zoo/temporary_patches/moe_bnb.py
@@ -37,7 +37,11 @@ try:
     from bitsandbytes.nn import Params4bit
     from bitsandbytes.functional import dequantize_4bit
     HAS_BNB = True
-except ImportError:
+except Exception:
+    # Not just ImportError: a bitsandbytes built against a different torch
+    # raises AttributeError from its own import (for example
+    # torch._C._cuda_getCurrentRawStream missing on a CPU torch). Degrading
+    # to HAS_BNB = False beats taking the whole of unsloth_zoo down with it.
     HAS_BNB = False
     Params4bit = None
 

--- a/unsloth_zoo/temporary_patches/moe_bnb.py
+++ b/unsloth_zoo/temporary_patches/moe_bnb.py
@@ -38,10 +38,7 @@ try:
     from bitsandbytes.functional import dequantize_4bit
     HAS_BNB = True
 except Exception:
-    # Not just ImportError: a bitsandbytes built against a different torch
-    # raises AttributeError from its own import (for example
-    # torch._C._cuda_getCurrentRawStream missing on a CPU torch). Degrading
-    # to HAS_BNB = False beats taking the whole of unsloth_zoo down with it.
+    # Not just ImportError: a bitsandbytes mismatched with torch fails its own import with AttributeError.
     HAS_BNB = False
     Params4bit = None
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -32,7 +32,11 @@ try:
     import bitsandbytes as bnb
     from bitsandbytes.nn import Params4bit
     HAS_BNB = True
-except ImportError:
+except Exception:
+    # Not just ImportError: a bitsandbytes built against a different torch
+    # raises AttributeError from its own import (for example
+    # torch._C._cuda_getCurrentRawStream missing on a CPU torch). Degrading to
+    # HAS_BNB = False beats taking the whole of unsloth_zoo down with it.
     HAS_BNB = False
     Params4bit = None
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -33,10 +33,7 @@ try:
     from bitsandbytes.nn import Params4bit
     HAS_BNB = True
 except Exception:
-    # Not just ImportError: a bitsandbytes built against a different torch
-    # raises AttributeError from its own import (for example
-    # torch._C._cuda_getCurrentRawStream missing on a CPU torch). Degrading to
-    # HAS_BNB = False beats taking the whole of unsloth_zoo down with it.
+    # Not just ImportError: a bitsandbytes mismatched with torch fails its own import with AttributeError.
     HAS_BNB = False
     Params4bit = None
 

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -41,10 +41,7 @@ try:
     from bitsandbytes.nn import Params4bit
     HAS_BNB = True
 except Exception:
-    # Not just ImportError: a bitsandbytes built against a different torch
-    # raises AttributeError from its own import (for example
-    # torch._C._cuda_getCurrentRawStream missing on a CPU torch). Degrading
-    # to HAS_BNB = False beats taking the whole of unsloth_zoo down with it.
+    # Not just ImportError: a bitsandbytes mismatched with torch fails its own import with AttributeError.
     HAS_BNB = False
     Params4bit = None
 

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -40,7 +40,11 @@ try:
     import bitsandbytes as bnb
     from bitsandbytes.nn import Params4bit
     HAS_BNB = True
-except ImportError:
+except Exception:
+    # Not just ImportError: a bitsandbytes built against a different torch
+    # raises AttributeError from its own import (for example
+    # torch._C._cuda_getCurrentRawStream missing on a CPU torch). Degrading
+    # to HAS_BNB = False beats taking the whole of unsloth_zoo down with it.
     HAS_BNB = False
     Params4bit = None
 


### PR DESCRIPTION
### What breaks

`import unsloth_zoo` dies outright when the installed `bitsandbytes` does not match the installed torch:

```
  File "unsloth_zoo/temporary_patches/moe_utils.py", line 32, in <module>
    import bitsandbytes as bnb
  File ".../bitsandbytes/__init__.py", line 36, in <module>
    from .backends.cuda import ops as cuda_ops
  File ".../bitsandbytes/backends/cuda/ops.py", line 69, in <module>
    _get_raw_stream = torch._C._cuda_getCurrentRawStream
AttributeError: module 'torch._C' has no attribute '_cuda_getCurrentRawStream'
```

The three module-level guards already intend to tolerate this, but they catch `ImportError` only, and bitsandbytes fails with `AttributeError`. So a mismatched bitsandbytes takes down every import path, not just the 4bit ones that actually need it.

### Where it shows up

`tests/test_temporary_patches_imports.py::test_xet_submodule_import_does_not_query_free_device_memory` and `::test_flex_attention_import_does_not_query_free_device_memory`. Both spawn a subprocess that stubs `torch.cuda.is_available` to True; on a CPU torch, bitsandbytes then takes its CUDA import path and hits the missing symbol. These are the only 2 failures in the suite (`2 failed, 4870 passed, 303 skipped`) and they turn every `Core` cell red in `unslothai/unsloth`.

### Fix

Catch `Exception` in the three module-level guards so a broken bitsandbytes degrades to `HAS_BNB = False`, exactly as a missing one already does.

### Verification

Clean venv, torch 2.10.0+cpu and bitsandbytes 0.50.1, the combination on the runners:

| | before | after |
| --- | --- | --- |
| the two tests' inline scripts | `AttributeError`, rc=1 | `IMPORT_OK`, rc=0 |
| `HAS_BNB` with a healthy bitsandbytes | True | True (`moe_utils`, `moe_bnb`, `moe_utils_bnb4bit`) |

The success path is untouched; only the set of caught exceptions widens.
