### PR TITLE
Finish the job #1063 started on a bitsandbytes that is not importable

### DIFF
--- a/tests/test_broken_bitsandbytes_import.py
+++ b/tests/test_broken_bitsandbytes_import.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2023-present the Unsloth team. All rights reserved.
+"""A bitsandbytes that fails its own import with something other than ImportError
+must not take the whole unsloth_zoo import down with it.
+
+A bitsandbytes wheel built against a different torch raises out of its own module
+scope, and not as an ImportError:
+
+  bitsandbytes/backends/cuda/ops.py:69
+  _get_raw_stream = torch._C._cuda_getCurrentRawStream
+  AttributeError: module 'torch._C' has no attribute '_cuda_getCurrentRawStream'
+
+Two module-scope sites let that through. `patching_utils` reaches bitsandbytes second
+hand: its dynamic-4bit patch imports `transformers.integrations.bitsandbytes`, and that
+transformers module does a bare module-scope `import bitsandbytes as bnb` of its own.
+`vllm_utils` reaches it directly, behind an `importlib.util.find_spec` gate that only
+proves the wheel is on disk. Either one put the AttributeError on the `import unsloth`
+path, breaking 16bit and full finetuning on a host whose only real problem was a 4bit dep.
+
+Both have a no-bnb path already, and that is where a broken wheel now goes. The healthy
+path is pinned here too, so a guard cannot buy the fix by turning 4bit off for everybody.
+
+The dep is faked with a one-line module on `sys.path`, never a real wheel and never the
+network, and every case runs in a fresh interpreter so the poisoned `bitsandbytes` cannot
+leak into the rest of the suite.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# The message the mismatched wheel actually dies with, reproduced verbatim so a
+# guard narrowed back to ImportError fails here rather than passing vacuously.
+_BREAKAGE = "module 'torch._C' has no attribute '_cuda_getCurrentRawStream'"
+
+_STUB = f'raise AttributeError("{_BREAKAGE}")\n'
+
+
+def _run(code, *, poisoned):
+    """Run `code` in a fresh interpreter, optionally with the broken dep first
+    on the path. The repo root goes on PYTHONPATH so the child imports the tree
+    under test rather than an installed unsloth_zoo."""
+    path = [str(_ROOT)]
+    if poisoned:
+        path.insert(0, str(poisoned))
+    if os.environ.get("PYTHONPATH"):
+        path.append(os.environ["PYTHONPATH"])
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output = True,
+        text = True,
+        env = dict(
+            os.environ,
+            PYTHONPATH = os.pathsep.join(path),
+            UNSLOTH_ALLOW_CPU = "1",
+        ),
+        timeout = 900,
+    )
+
+
+@pytest.fixture
+def poisoned_bitsandbytes(tmp_path):
+    (tmp_path / "bitsandbytes.py").write_text(_STUB)
+    return tmp_path
+
+
+def test_the_stub_really_breaks_the_import(poisoned_bitsandbytes):
+    """Without this, every other case in the file could pass on a host that
+    simply resolved the real bitsandbytes and never saw the stub at all."""
+    out = _run(
+        "try:\n"
+        "    import bitsandbytes\n"
+        "except AttributeError as e:\n"
+        "    print('RAISED', type(e).__name__, e)\n"
+        "else:\n"
+        "    print('NOT_RAISED', bitsandbytes.__file__)\n",
+        poisoned = poisoned_bitsandbytes,
+    )
+    assert out.returncode == 0, out.stderr[-3000:]
+    assert "RAISED AttributeError" in out.stdout, out.stdout
+    assert _BREAKAGE in out.stdout, out.stdout
+
+
+def test_patching_utils_imports_when_bitsandbytes_cannot(poisoned_bitsandbytes):
+    """The regression. `patching_utils` is on the path `import unsloth` walks,
+    via `unsloth/models/_utils.py`, so this failing takes the whole import down."""
+    out = _run(
+        "import sys, importlib\n"
+        # Establish that transformers really does try to load the poisoned dep on
+        # this version. Where it does not, patching_utils was never at risk and
+        # the case has nothing to prove.
+        "try:\n"
+        "    importlib.import_module('transformers.integrations.bitsandbytes')\n"
+        "except AttributeError:\n"
+        "    print('PRECONDITION poisoned')\n"
+        "except Exception as e:\n"
+        "    print('PRECONDITION other', type(e).__name__)\n"
+        "else:\n"
+        "    print('PRECONDITION unreached')\n"
+        "import unsloth_zoo.patching_utils as p\n"
+        "print('IMPORT_OK')\n"
+        "print('PATCH_APPLIED', '_unsloth_replace_with_bnb_linear' in vars(p))\n"
+        "print('INTEGRATION_LOADED', 'transformers.integrations.bitsandbytes' in sys.modules)\n",
+        poisoned = poisoned_bitsandbytes,
+    )
+    if "PRECONDITION unreached" in out.stdout:
+        pytest.skip("transformers did not import bitsandbytes, so nothing could break")
+    assert "PRECONDITION poisoned" in out.stdout, out.stdout
+    assert out.returncode == 0, out.stderr[-3000:]
+    assert "IMPORT_OK" in out.stdout, out.stdout
+    # The AttributeError must not merely be caught somewhere and re-raised later.
+    assert _BREAKAGE not in out.stderr, out.stderr[-3000:]
+    # The no-bnb path: the dynamic-4bit patch needs the source of a function it
+    # cannot reach, so it is skipped rather than half-applied.
+    assert "PATCH_APPLIED False" in out.stdout, out.stdout
+    assert "INTEGRATION_LOADED False" in out.stdout, out.stdout
+
+
+def test_vllm_utils_takes_the_no_bnb_path_when_bitsandbytes_cannot_import(poisoned_bitsandbytes):
+    """`vllm_utils` gated its bitsandbytes block on `importlib.util.find_spec`, which only
+    proves the wheel is on disk. A mismatched wheel is on disk, so the gate opened and the
+    module-scope `import bitsandbytes.functional` behind it raised. The `else:` branch of
+    that same gate already defines no-op stand-ins, so there was a no-bnb path to take.
+
+    peft carries an `except ImportError` guard of its own and dies first on a genuinely
+    broken wheel. That is upstream and not what this pins, so the child loads peft while
+    the real wheel is still reachable and only then puts the stub on the path.
+    """
+    out = _run(
+        "import importlib, sys\n"
+        "import peft\n"
+        "for _m in [m for m in sys.modules if m == 'bitsandbytes' or m.startswith('bitsandbytes.')]:\n"
+        "    del sys.modules[_m]\n"
+        f"sys.path.insert(0, {str(poisoned_bitsandbytes)!r})\n"
+        "importlib.invalidate_caches()\n"
+        "try:\n"
+        "    import bitsandbytes\n"
+        "except AttributeError:\n"
+        "    print('PRECONDITION poisoned')\n"
+        "else:\n"
+        "    print('PRECONDITION unreached')\n"
+        "for _m in [m for m in sys.modules if m == 'bitsandbytes' or m.startswith('bitsandbytes.')]:\n"
+        "    del sys.modules[_m]\n"
+        "import unsloth_zoo.vllm_utils as v\n"
+        "print('IMPORT_OK')\n"
+        "print('LINEAR4BIT_DEFINED', hasattr(v, 'Linear4bit'))\n"
+        # The no-op stand-in is a bare `return` and so touches no globals at all; the
+        # real one reassigns bitsandbytes.functional.QuantState.from_dict and Linear4bit.
+        "print('HELPER_TOUCHES_BNB', bool(v.patch_bitsandbytes_quant_state.__code__.co_names))\n"
+        "v.patch_bitsandbytes_quant_state()\n"
+        "print('HELPER_CALLABLE_OK')\n",
+        poisoned = None,
+    )
+    if "PRECONDITION unreached" in out.stdout:
+        pytest.skip("the stub did not take over bitsandbytes, so nothing could break")
+    assert out.returncode == 0, out.stderr[-3000:]
+    assert "IMPORT_OK" in out.stdout, out.stdout
+    assert _BREAKAGE not in out.stderr, out.stderr[-3000:]
+    # The gate has to close, not half-open: Linear4bit subclasses a bitsandbytes class
+    # that is not there, and the callers of the patch helpers get the no-op stand-ins.
+    assert "LINEAR4BIT_DEFINED False" in out.stdout, out.stdout
+    assert "HELPER_TOUCHES_BNB False" in out.stdout, out.stdout
+    # The stand-in has to survive being called, which is what callers at vllm_utils.py:803
+    # and :3629 do unconditionally.
+    assert "HELPER_CALLABLE_OK" in out.stdout, out.stdout
+
+
+def test_a_healthy_bitsandbytes_still_gets_the_dynamic_4bit_patch():
+    """The guard degrades only when the dep is genuinely unusable. With the real
+    wheel installed the patch still has to land, or the guard has quietly turned
+    dynamic 4bit off for everybody."""
+    out = _run(
+        "import unsloth_zoo.patching_utils as p\n"
+        "import transformers.integrations.bitsandbytes as tib\n"
+        "print('PATCH_APPLIED', '_unsloth_replace_with_bnb_linear' in vars(p))\n"
+        "print('HOOKED', getattr(getattr(tib, '_replace_with_bnb_linear', None),"
+        " '__name__', 'ABSENT'))\n",
+        poisoned = None,
+    )
+    if out.returncode != 0:
+        pytest.skip("no usable bitsandbytes on this host: " + out.stderr[-500:])
+    if "HOOKED ABSENT" in out.stdout:
+        # transformers 5.x dropped _replace_with_bnb_linear; the should_convert_module
+        # patch covers that branch instead and is not what this case pins.
+        pytest.skip("transformers has no _replace_with_bnb_linear to patch")
+    assert "PATCH_APPLIED True" in out.stdout, out.stdout
+    assert "HOOKED _unsloth_replace_with_bnb_linear" in out.stdout, out.stdout
+
+
+def test_a_healthy_bitsandbytes_still_opens_the_vllm_utils_gate():
+    """The other half of the same bargain: swapping `find_spec` for a real import probe
+    must not close the gate on a host where bitsandbytes works."""
+    out = _run(
+        "import unsloth_zoo.vllm_utils as v\n"
+        "import bitsandbytes.nn.modules\n"
+        "print('LINEAR4BIT_DEFINED', hasattr(v, 'Linear4bit'))\n"
+        "print('LINEAR4BIT_BASE', v.Linear4bit.__mro__[1].__module__)\n"
+        "print('HELPER_TOUCHES_BNB', bool(v.patch_bitsandbytes_quant_state.__code__.co_names))\n"
+        "v.patch_bitsandbytes_quant_state()\n"
+        "print('QUANT_STATE_PATCHED', bitsandbytes.nn.modules.Linear4bit is v.Linear4bit)\n",
+        poisoned = None,
+    )
+    if out.returncode != 0:
+        pytest.skip("no usable bitsandbytes on this host: " + out.stderr[-500:])
+    assert "LINEAR4BIT_DEFINED True" in out.stdout, out.stdout
+    assert "LINEAR4BIT_BASE bitsandbytes.nn.modules" in out.stdout, out.stdout
+    assert "HELPER_TOUCHES_BNB True" in out.stdout, out.stdout
+    # The gate being open is only worth anything if the patch behind it still lands.
+    assert "QUANT_STATE_PATCHED True" in out.stdout, out.stdout

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -730,13 +730,19 @@ class WrapRecursiveCall(ast.NodeTransformer):
 
 # Patch for dynamic 4bit quantization
 import inspect
-import transformers.integrations.bitsandbytes
-if hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") and \
-    (transformers.integrations.bitsandbytes._replace_with_bnb_linear.__name__ != "_unsloth_replace_with_bnb_linear"):
+try:
+    import transformers.integrations.bitsandbytes as _transformers_bnb
+except Exception:
+    # Not just ImportError: this transformers module imports bitsandbytes at its own module
+    # scope, and a bitsandbytes mismatched with torch fails its own import with AttributeError.
+    _transformers_bnb = None
+if _transformers_bnb is not None and \
+    hasattr(_transformers_bnb, "_replace_with_bnb_linear") and \
+    (_transformers_bnb._replace_with_bnb_linear.__name__ != "_unsloth_replace_with_bnb_linear"):
 
     # All Unsloth Zoo code licensed under LGPLv3
-    source = inspect.getsource(transformers.integrations.bitsandbytes._replace_with_bnb_linear)
-    functions = dir(transformers.integrations.bitsandbytes)
+    source = inspect.getsource(_transformers_bnb._replace_with_bnb_linear)
+    functions = dir(_transformers_bnb)
     functions = [x for x in functions if f" {x}" in source or f"{x}." in source or f"{x}(" in source]
     functions = [x for x in functions if x != "_replace_with_bnb_linear"]
     x = ", ".join(functions)
@@ -804,7 +810,7 @@ if hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") a
     source = re.sub(pattern, add_score_code, source, flags=re.MULTILINE)
 
     exec(source, globals())
-    transformers.integrations.bitsandbytes._replace_with_bnb_linear = _unsloth_replace_with_bnb_linear
+    _transformers_bnb._replace_with_bnb_linear = _unsloth_replace_with_bnb_linear
 pass
 
 # Patch for transformers 5.x: should_convert_module uses re.match + endswith
@@ -813,7 +819,10 @@ pass
 # 4.x patches _replace_with_bnb_linear (substring matching); on 5.x that no
 # longer exists, so patch should_convert_module instead.
 import transformers.quantizers.quantizers_utils as _quantizers_utils
-if not hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") and \
+# A bitsandbytes too broken to import leaves _transformers_bnb None, which rules out 4.x's
+# _replace_with_bnb_linear the same way 5.x does. should_convert_module below is the marker
+# that actually separates the two, so the 5.x patch still applies instead of being skipped.
+if (_transformers_bnb is None or not hasattr(_transformers_bnb, "_replace_with_bnb_linear")) and \
     hasattr(_quantizers_utils, "should_convert_module") and \
     getattr(_quantizers_utils.should_convert_module, "__name__", "") != "_unsloth_should_convert_module":
 
@@ -833,8 +842,8 @@ if not hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear
 
     _quantizers_utils.should_convert_module = _unsloth_should_convert_module
     # Also patch the imported reference in bitsandbytes module
-    if hasattr(transformers.integrations.bitsandbytes, "should_convert_module"):
-        transformers.integrations.bitsandbytes.should_convert_module = _unsloth_should_convert_module
+    if _transformers_bnb is not None and hasattr(_transformers_bnb, "should_convert_module"):
+        _transformers_bnb.should_convert_module = _unsloth_should_convert_module
 pass
 
 # Unsloth Zoo - Utilities for Unsloth

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -417,7 +417,20 @@ else:
 pass
 
 
-if importlib.util.find_spec("bitsandbytes") is not None:
+def _bitsandbytes_is_usable():
+    # find_spec only proves the wheel is on disk. One built against a different torch is
+    # on disk and still fails its own import with AttributeError, so import it and see.
+    if importlib.util.find_spec("bitsandbytes") is None:
+        return False
+    try:
+        import bitsandbytes
+    except Exception:
+        return False
+    return True
+pass
+
+
+if _bitsandbytes_is_usable():
     import bitsandbytes.functional
     from bitsandbytes.utils import pack_dict_to_tensor, unpack_tensor_to_dict
 


### PR DESCRIPTION
#1063 widened three module-scope `bitsandbytes` guards from `ImportError` to `Exception`, because a wheel built against a different torch fails its own import with

```
bitsandbytes/backends/cuda/ops.py:69
_get_raw_stream = torch._C._cuda_getCurrentRawStream
AttributeError: module 'torch._C' has no attribute '_cuda_getCurrentRawStream'
```

Those three were not the whole chain. Two more module-scope sites reach `bitsandbytes` without a guard that catches this, and `import unsloth` still died on both.

### The two sites

**1. `unsloth_zoo/patching_utils.py:733`** imported `transformers.integrations.bitsandbytes` with no guard at all, and on transformers 4.x that module does a bare module-scope `import bitsandbytes as bnb` of its own.

```
File "unsloth_zoo/patching_utils.py", line 733, in <module>
  import transformers.integrations.bitsandbytes
File "transformers/integrations/bitsandbytes.py", line 20, in <module>
  import bitsandbytes as bnb
AttributeError: module 'torch._C' has no attribute '_cuda_getCurrentRawStream'
```

Guarding only the import turns the crash into a `NameError`. The `import transformers.integrations.bitsandbytes` statement is what binds `transformers` in this module, and the transformers 5.x block below reads the same module twice more. So all four reference sites move together onto one alias that is `None` when the dep is unusable.

**2. `unsloth_zoo/vllm_utils.py:420`** gated its whole `bitsandbytes` block on `importlib.util.find_spec("bitsandbytes") is not None`. A mismatched wheel is on disk, so `find_spec` says yes and the `import bitsandbytes.functional` behind the gate raises:

```
File "unsloth_zoo/vllm_utils.py", line 421, in <module>
  import bitsandbytes.functional
AttributeError: module 'torch._C' has no attribute '_cuda_getCurrentRawStream'
```

The gate now imports the package to decide, which is the only answer `find_spec` cannot give.

### Neither site invents a new fallback

`patching_utils` skips a dynamic-4bit patch that needs `inspect.getsource` of a function it cannot reach. `vllm_utils` takes the `else:` branch of its own gate, the one that already defines the no-op `patch_bitsandbytes_quant_state` / `patch_bitsandbytes_compute_dtype` / `unpatch_bitsandbytes_compute_dtype` stand-ins for a host with no `bitsandbytes`.

The transformers 5.x `should_convert_module` branch does **not** get skipped. It is gated on `quantizers_utils.should_convert_module`, which is the marker that actually separates 4.x from 5.x and needs no `bitsandbytes` to read, so a broken wheel still gets that patch.

### The healthy path is byte-for-byte unchanged

With the real wheel installed (`bitsandbytes` 0.50.0, transformers 4.57.6), before and after this branch:

| | parent 848fd15f | this branch |
|---|---|---|
| patched source sha256 | `759f6abb...` | `759f6abb...` |
| bytecode sha256 | `6c0a7043...` | `6c0a7043...` |
| `tib._replace_with_bnb_linear.__name__` | `_unsloth_replace_with_bnb_linear` | same |
| `mark_parent_error` | `False` | `False` |
| names exec'd into globals | `Conv1D, bnb, init_empty_weights, nn, replace_with_bnb_linear, signature` | same |
| `vllm_utils.Linear4bit` base | `bitsandbytes.nn.modules.Linear4bit` | same |

The 5.x `should_convert_module` branch, which this host's transformers 4.57 never reaches, was exercised by simulating 5.x (drop `_replace_with_bnb_linear`, add `quantizers_utils.should_convert_module`) and lands identically on both.

### Tests

`tests/test_broken_bitsandbytes_import.py` fakes the dep with a one-line stub module on `sys.path`, in a subprocess. No network, no real broken wheel, and nothing leaks into the rest of the suite.

- `test_patching_utils_imports_when_bitsandbytes_cannot` and `test_vllm_utils_takes_the_no_bnb_path_when_bitsandbytes_cannot_import` fail at 848fd15f and pass here.
- `test_the_stub_really_breaks_the_import` keeps the other cases from passing vacuously on a host that quietly resolved the real wheel.
- `test_a_healthy_bitsandbytes_still_gets_the_dynamic_4bit_patch` and `test_a_healthy_bitsandbytes_still_opens_the_vllm_utils_gate` pass on both, so a guard cannot buy the fix by turning 4bit off for everybody.

Related suites, all green:

```
tests/test_broken_bitsandbytes_import.py tests/test_temporary_patches_imports.py
tests/test_allow_cpu_import_driverless.py tests/test_compiler_rewriter_exhaustive.py
tests/test_extended_dep_api_pins.py tests/test_weak_dictionary_writes_not_compiled.py
tests/test_zoo_source_upstream_refs.py tests/test_upstream_signatures.py
tests/test_upstream_pinned_symbols_transformers.py tests/test_zoo_history_regressions.py
tests/test_zoo_history_regressions_deep.py tests/test_gguf_bitsandbytes_guard.py
tests/test_vllm_to_hf_conversion.py tests/test_fp8_dense_merge.py

521 passed, 17 skipped in 113.86s
```

### One thing this cannot fix from here

`peft/helpers.py` has the same `except ImportError` on `bitsandbytes` and sits right behind these two, reached from `unsloth_zoo/training_utils.py:22` (`from transformers import Trainer`) and `unsloth_zoo/vllm_utils.py:3100`. So a genuinely broken wheel still needs that fixed upstream before `import unsloth` completes. Simulating the upstream one-word fix locally, the import completes and reports the expected `bitsandbytes is not installed - 4bit QLoRA unallowed, but 16bit and full finetuning works!`.

### Sweep

I AST-scanned every module-scope import in `unsloth_zoo/` for the same class. Everything demonstrably broken is fixed above. Not fixed, because I could not make them fail here, listed so they are on the record:

- `vllm_utils.py:176` `import vllm.model_executor.layers.quantization.bitsandbytes` behind `find_spec("vllm")`, unguarded. Does not import `bitsandbytes` at module scope with the installed vLLM, so a broken wheel passes straight through it.
- `loss_utils.py:24` `from triton import __version__` and `compiler.py:51` `import triton`, both fully unguarded and both on the `import unsloth` path. A triton mismatched with torch fails the same way. Left alone: triton is not optional on the CUDA path, and the MLX and skip-GPU-init hosts already get `stubs/triton_stub.py`.
- `vllm_lora_worker_manager.py` (8 imports), `vllm_lora_request.py:10`, `vllm_utils.py:112,115`: `except ImportError` around `vllm.*`. Importing any `vllm.*` runs the whole vLLM init, which raises `RuntimeError` / `OSError` on a torch or CUDA-lib mismatch more often than `ImportError`.
- `mlx/cce/__init__.py:22` `import mlx.core` under `except ImportError`; an mlx wheel on the wrong arch fails with a dylib `OSError`. Note the ~13 other module-scope `mlx` imports in the package are unguarded, so the guard here is already inconsistent rather than load-bearing.
- `saving_utils.py:35,39` `except (ImportError, ModuleNotFoundError)` on `transformers.integrations.mxfp4`. Safe against the pinned transformers, which has no module-scope `triton_kernels` import there, but narrow if a newer one adds it.
- `patching_utils.py:821` `import transformers.quantizers.quantizers_utils`, unguarded. Verified that module has no module-scope `bitsandbytes` or `triton` import.

`patching_utils.py` is the only module-scope importer of `transformers.integrations.bitsandbytes` in the package, and `integrations/bitsandbytes.py` is the only installed transformers module with an unguarded module-scope `import bitsandbytes`.
