### PR TITLE
Give the loss-contract fake trainer the attribute transformers 5.x reads

### DIFF
--- a/tests/test_loss_normalization_contract.py
+++ b/tests/test_loss_normalization_contract.py
@@ -180,6 +180,13 @@ def _fake_trainer(model, accepts, compute_loss_func = None):
     t.accelerator = Accelerator()
     t.model_accepts_loss_kwargs = accepts
     t.compute_loss_func = compute_loss_func
+    # transformers 5.x reads this INSIDE the try that counts labels, and the except
+    # swallows AttributeError. A stand-in without it therefore does not measure stock's
+    # decision at all: stock raises on the first list comprehension, returns None, and a
+    # differential test reads that as "stock declined to count". Every real Trainer sets
+    # it in __init__. True is the value for this fixture's model, which shifts labels
+    # internally like any causal LM, which is exactly the case the flag selects.
+    t._loss_shifts_labels = True
     return t
 
 
@@ -251,6 +258,19 @@ def test_accumulated_gradient_matches_the_single_batch_gradient():
     )
 
 
+
+def _stock_counts_shifted_labels(stock):
+    """Does the installed transformers count over `labels[..., 1:]` rather than `labels`?
+
+    Read off the source rather than the version, so a backport or a fork lands on the
+    right branch and this does not need a table of version numbers.
+    """
+    import inspect
+    try:
+        return "_loss_shifts_labels" in inspect.getsource(stock)
+    except (OSError, TypeError):
+        return False
+
 def test_guard_returns_a_count_exactly_when_stock_transformers_would():
     """Same decision as Trainer._get_num_items_in_batch, for every flag pairing, and
     the answer to "why not keep the count and normalise per token across
@@ -279,3 +299,13 @@ def test_guard_returns_a_count_exactly_when_stock_transformers_would():
                 f"accepts={accepts} compute_loss_func={loss_func is not None}: "
                 f"we returned {ours!r} where stock returned {theirs!r}"
             )
+            # Where stock counts over labels[..., 1:] the COUNT has to agree too, not
+            # just whether one was produced. transformers adopted that rule in 5.x
+            # (position 0 of a row is never a prediction target for a causal LM); zoo
+            # has always counted that way, so before 5.x the two legitimately differ by
+            # one token per row and only the nullity above is a shared contract.
+            if _stock_counts_shifted_labels(stock) and ours is not None:
+                assert int(ours) == int(theirs), (
+                    f"accepts={accepts} compute_loss_func={loss_func is not None}: "
+                    f"counted {int(ours)} where stock counted {int(theirs)}"
+                )


### PR DESCRIPTION
## The red

`tests/test_loss_normalization_contract.py::test_guard_returns_a_count_exactly_when_stock_transformers_would` fails on zoo main against **HF=latest**:

```
AssertionError: accepts=True compute_loss_func=False: we returned tensor(20) where stock returned None
```

This is on zoo main, so `Core (HF=latest + TRL=latest)` is red on **every open unsloth PR**, since that job runs zoo main's full suite.

## It is the fixture, not the guard

transformers 5.x reads `self._loss_shifts_labels` **inside** the `try` that counts labels, and the `except` swallows `AttributeError`:

```python
try:
    labels_for_count = [
        batch["shift_labels"] if "shift_labels" in batch
        else batch["labels"][..., 1:] if self._loss_shifts_labels
        else batch["labels"]
        for batch in batch_samples
    ]
    num_items_in_batch = sum(labels.ne(-100).sum() for labels in labels_for_count)
except (TypeError, AttributeError):
    pass
```

`_fake_trainer` never set it. So stock raised on the first comprehension and returned `None`, and the differential test read that as "stock declined to count" when stock had not reached a decision at all. Every real `Trainer` sets it in `__init__` (transformers 5.15.0, `trainer.py:525`).

Measured against 5.15.0's counting body, all four flag pairings:

| accepts | compute_loss_func | ours | stock, before | stock, after |
|---|---|---|---|---|
| True | False | 20 | **None** | 20 |
| True | True | 20 | **None** | 20 |
| False | False | None | None | None |
| False | True | 20 | **None** | 20 |

Three of the four disagreed. CI reported only the first because the loop asserts as it goes.

## The guard is right, and upstream came round to it

transformers 5.x now counts over `labels[..., 1:]` for a causal LM, with this reasoning in its own source:

> Causal LM losses shift labels internally (predictions at position i target label[i+1]), so position 0 of each row is never a prediction target.

That is what `_unsloth_get_batch_samples` has always done. Before 5.x stock counted the full label tensor, so the two legitimately differ by one token per row on 4.x and only nullity is a shared contract there.

So the new value assertion is gated on whether the installed stock actually reads `_loss_shifts_labels`, read off its source rather than a version table, so a backport or a fork lands on the right branch.

`True` is the correct value for this fixture: `TinyForCausalLM` shifts labels internally like any causal LM, which is exactly the case the flag selects.

## Tests

`tests/test_loss_normalization_contract.py`: 7 passed, 1 skipped on transformers 4.57.6.

## Not covered

Not executed against a real transformers 5.x install; the 5.15.0 comparison above runs that release's counting body verbatim against these fixtures rather than importing it. Encoder-decoder models, `shift_labels` from a padding-free collator, and the multi-GPU / `average_tokens_across_devices` branches are untouched by this change and unmeasured here.
