### PR TITLE
Stop double-removing packed sequence boundaries from num_items_in_batch

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -141,8 +141,8 @@ jobs:
         # file was in NO job, so `--collect-only` proved only that it imports while
         # the count double-removed every document boundary a collator had already
         # masked, inflating loss and every gradient. `.[core]` resolves trl 0.24.0
-        # here, the first release that masks labels[position_ids == 0], so this job
-        # exercises the regressed regime on every pull request.
+        # here, which masks labels[position_ids == 0] (trl added that in 0.23.1),
+        # so this job exercises the regressed regime on every pull request.
         #
         # The last two are here because `--collect-only` is exactly what missed
         # the bug they cover. `tests/` is not a package, so `from tests.x import

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -135,6 +135,15 @@ jobs:
         # test_wheel_top_level_packages pins that discovery ships unsloth_zoo and
         # nothing else; collect-only would let the packaging config regress.
         #
+        # test_loss_normalization_contract pins num_items_in_batch: the grad-accum
+        # guard, and the packed / padding-free boundary count. The second one
+        # shipped broken for the same reason this comment keeps repeating -- the
+        # file was in NO job, so `--collect-only` proved only that it imports while
+        # the count double-removed every document boundary a collator had already
+        # masked, inflating loss and every gradient. `.[core]` resolves trl 0.24.0
+        # here, the first release that masks labels[position_ids == 0], so this job
+        # exercises the regressed regime on every pull request.
+        #
         # The last two are here because `--collect-only` is exactly what missed
         # the bug they cover. `tests/` is not a package, so `from tests.x import
         # y` binds to whatever `tests` package is importable; unsloth's CI runs
@@ -147,6 +156,7 @@ jobs:
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
+            tests/test_loss_normalization_contract.py \
             tests/test_mlx_finetune_last_n_layers.py \
             tests/test_mlx_double_quant_reject.py \
             tests/test_hf_xet_fallback.py \

--- a/tests/test_loss_normalization_contract.py
+++ b/tests/test_loss_normalization_contract.py
@@ -259,6 +259,386 @@ def test_accumulated_gradient_matches_the_single_batch_gradient():
 
 
 
+# Packed / padding-free boundary counting.
+#
+# Packing N documents into a flat row leaves N-1 internal boundaries whose next
+# token prediction crosses a document, so the count has to exclude them. Doing
+# that by subtracting N-1 from the total double counts every boundary a collator
+# had already masked with -100, which under-counts num_items_in_batch and so
+# inflates loss and every gradient. TRL >= 0.24 masks them (labels[position_ids
+# == 0] = -100) and completion_only_loss / assistant_masks mask them on every TRL
+# version including 0.22.2, so the arithmetic must be idempotent, not version
+# detected. unsloth's enable_padding_free_metadata attaches packed_seq_lengths
+# even when packing is off, one entry per example, so this reaches ordinary LoRA
+# runs with per_device_train_batch_size > 1.
+
+
+def _padding_free_batch(lengths, premask_starts = False, completion_only = 0):
+    """One flattened padding-free row holding len(lengths) documents.
+
+    premask_starts reproduces TRL >= 0.24, which writes -100 at every
+    position_ids == 0 slot. completion_only masks the first N tokens of each
+    document, which is what completion_only_loss and assistant_masks do on every
+    TRL version, and which also lands -100 on the document starts. Synthesising
+    both regimes here is what lets one installed TRL stand in for all of them.
+    """
+    torch = pytest.importorskip("torch")
+    total = int(sum(int(x) for x in lengths))
+    g = torch.Generator().manual_seed(11)
+    ids = torch.randint(1, 11, (1, total), generator = g)
+    labels = ids.clone()
+    offset = 0
+    for length in lengths:
+        length = int(length)
+        if length <= 0: continue
+        if premask_starts:
+            labels[0, offset] = -100
+        for i in range(min(completion_only, length)):
+            labels[0, offset + i] = -100
+        offset += length
+    # Padding-free batches carry no attention_mask; unsloth's collator pops it.
+    return {
+        "input_ids": ids,
+        "labels": labels,
+        "packed_seq_lengths": torch.tensor([int(x) for x in lengths], dtype = torch.int32),
+    }
+
+
+def _true_target_count(labels, lengths):
+    """Truth by an independent method, so a bug cannot hide in the oracle.
+
+    Walks the batch in Python lists rather than reusing any of the tensor
+    arithmetic under test. A shifted slot is a target when its label is not -100
+    and the token it predicts is not the first token of a document (which
+    includes the first token of a row, dropped by the labels[..., 1:] slice).
+    """
+    rows = labels.tolist()
+    if not isinstance(rows[0], list): rows = [rows]
+    width = len(rows[0])
+    starts = set()
+    offset = 0
+    for length in lengths:
+        length = int(length)
+        if length <= 0: continue
+        starts.add(offset)
+        offset += length
+    count = 0
+    for r, row in enumerate(rows):
+        for col in range(1, width):
+            if (r * width + col) in starts: continue
+            if row[col] == -100: continue
+            count += 1
+    return count
+
+
+def _counted(batch, model = None):
+    """num_items_in_batch as _unsloth_get_batch_samples reports it for one batch.
+
+    ALLOWED_NUM_ITEMS_IN_BATCH is keyed on the model class name and a stale entry
+    makes the counting branch not run at all, so every test clears it first or
+    passes vacuously.
+    """
+    mod = _loss_utils()
+    fn = getattr(mod, "_unsloth_get_batch_samples", None)
+    if fn is None: pytest.skip("_unsloth_get_batch_samples not present")
+    mod.ALLOWED_NUM_ITEMS_IN_BATCH.clear()
+    _, count = fn(_fake_trainer(model if model is not None else _tiny_model(), True), iter([batch]), 1)
+    return None if count is None else int(count)
+
+
+def _normalizer():
+    mod = _loss_utils()
+    fn = getattr(mod, "_normalize_packed_seq_lengths", None)
+    if fn is None: pytest.fail("_normalize_packed_seq_lengths is gone; the counting path relies on it")
+    return fn
+
+
+def test_normalize_accepts_every_shape_a_collator_can_emit():
+    torch = pytest.importorskip("torch")
+    normalize = _normalizer()
+    expected = [4, 3, 3]
+    candidates = [
+        torch.tensor(expected, dtype = torch.int32),
+        torch.tensor(expected, dtype = torch.int64),
+        list(expected),
+        tuple(expected),
+    ]
+    numpy = pytest.importorskip("numpy")
+    candidates.append(numpy.array(expected, dtype = "int32"))
+    for candidate in candidates:
+        out = normalize(candidate)
+        assert out is not None, f"{type(candidate).__name__} was rejected"
+        assert out.dtype == torch.int64 and out.device.type == "cpu"
+        assert out.tolist() == expected
+
+
+def test_normalize_treats_unusable_metadata_as_absent():
+    """It must degrade, never raise: the caller counts inside a try that re-raises
+    as RuntimeError, which turns a bad batch into a dead training run."""
+    normalize = _normalizer()
+    for junk in (None, "not lengths", object(), [[1, 2], [3]], {"a": 1}):
+        assert normalize(junk) is None, f"{junk!r} should have been treated as absent"
+
+
+def test_normalize_drops_nonpositive_and_short_circuits_one_document():
+    torch = pytest.importorskip("torch")
+    normalize = _normalizer()
+    assert normalize(torch.tensor([4, 0, 3, 0, 3])).tolist() == [4, 3, 3]
+    # One document has no internal boundary, so there is nothing to drop.
+    assert normalize(torch.tensor([7])) is None
+    assert normalize(torch.tensor([7, 0, 0])) is None
+    assert normalize(torch.tensor([], dtype = torch.int64)) is None
+    assert normalize(torch.tensor(7)) is None
+
+
+def test_count_is_identical_whether_or_not_the_collator_premasked():
+    """The headline property. TRL >= 0.24 masks the document starts and earlier
+    versions do not, and completion-only masking does it on every version. The
+    count must not depend on which of those produced the batch."""
+    lengths = [4, 3, 3]
+    plain = _counted(_padding_free_batch(lengths))
+    masked = _counted(_padding_free_batch(lengths, premask_starts = True))
+    assert plain == masked == 7, (
+        f"pre-masked batch counted {masked} against {plain} unmasked; the boundary "
+        "slots are being removed twice on whichever collator already masked them"
+    )
+
+
+def test_count_equals_total_tokens_minus_document_count():
+    for lengths in ([4, 3, 3], [8] * 4, [256, 256], [5, 1, 9, 2]):
+        total = sum(lengths)
+        for premask in (False, True):
+            batch = _padding_free_batch(lengths, premask_starts = premask)
+            counted = _counted(batch)
+            assert counted == _true_target_count(batch["labels"], lengths)
+            assert counted == total - len(lengths), (
+                f"lengths={lengths} premask={premask}: counted {counted}, "
+                f"expected {total - len(lengths)}"
+            )
+
+
+def test_completion_only_masking_is_not_double_subtracted():
+    """completion_only_loss puts -100 on the document starts on every TRL version,
+    which is why a version gate would leave the commonest SFT config broken."""
+    lengths = [5, 5, 5, 5]
+    batch = _padding_free_batch(lengths, completion_only = 3)
+    counted = _counted(batch)
+    assert counted == _true_target_count(batch["labels"], lengths)
+    # 4 documents x 5 tokens, first 3 of each masked, minus the boundary targets
+    # that are already inside the masked prefixes.
+    assert counted == 8, f"counted {counted}, expected 8"
+
+
+def test_single_document_batch_is_untouched():
+    """N = 1 has no internal boundary. Provable no-op, not an approximate one."""
+    lengths = [12]
+    batch = _padding_free_batch(lengths)
+    counted = _counted(batch)
+    assert counted == _true_target_count(batch["labels"], lengths) == 11
+
+
+def test_zero_length_entries_are_ignored():
+    torch = pytest.importorskip("torch")
+    lengths = [4, 0, 3, 0, 3]
+    batch = _padding_free_batch(lengths)
+    assert batch["input_ids"].shape[-1] == 10
+    counted = _counted(batch)
+    assert counted == _true_target_count(batch["labels"], lengths) == 7
+
+
+def test_lengths_overrunning_the_batch_do_not_kill_live_targets():
+    """Metadata is trusted to describe the row, so guard the case where it does
+    not. Boundaries past the end of the batch must be dropped, not wrapped onto a
+    row that is really there."""
+    torch = pytest.importorskip("torch")
+    # 5 puts a boundary at flat 15, past the end of a 10 token batch and NOT on a
+    # row start, so only the rows < n_rows filter can catch it. Without it this
+    # raises IndexError inside the try that re-raises as RuntimeError.
+    for overrun in ([4, 3, 3, 5, 50], [4, 3, 3, 50, 50], [4, 3, 3, 1]):
+        batch = _padding_free_batch([4, 3, 3])
+        batch["packed_seq_lengths"] = torch.tensor(overrun, dtype = torch.int32)
+        counted = _counted(batch)
+        assert counted == 7, f"lengths={overrun}: counted {counted}, expected 7"
+
+
+def test_metadata_shorter_than_the_batch_never_targets_the_trailing_boundary():
+    """cumsum(...)[:-1] rather than the full cumsum: the trailing boundary of a
+    truncated description is a live target, and truncated metadata must not eat
+    it."""
+    torch = pytest.importorskip("torch")
+    batch = _padding_free_batch([4, 3, 3])
+    batch["packed_seq_lengths"] = torch.tensor([4, 3], dtype = torch.int32)
+    counted = _counted(batch)
+    assert counted == 8, f"counted {counted}, expected 8 (10 tokens, 1 row start, 1 boundary)"
+
+
+def test_a_document_starting_at_a_row_boundary_is_not_dropped_twice():
+    """A document that begins exactly at a row start was already dropped by the
+    labels[..., 1:] slice, so it must not be zeroed again."""
+    torch = pytest.importorskip("torch")
+    g = torch.Generator().manual_seed(3)
+    ids = torch.randint(1, 11, (2, 6), generator = g)
+    lengths = [6, 6]
+    batch = {
+        "input_ids": ids,
+        "labels": ids.clone(),
+        "packed_seq_lengths": torch.tensor(lengths, dtype = torch.int32),
+    }
+    counted = _counted(batch)
+    assert counted == _true_target_count(batch["labels"], lengths) == 10, (
+        f"counted {counted}, expected 10: both rows keep all 5 shifted targets"
+    )
+
+
+def test_multi_row_boundaries_map_row_major():
+    """Documents tile the flattened batch row-major, so a boundary at flat index s
+    lands at row s // width, column s % width."""
+    torch = pytest.importorskip("torch")
+    g = torch.Generator().manual_seed(5)
+    ids = torch.randint(1, 11, (3, 4), generator = g)
+    lengths = [3, 5, 4]
+    batch = {
+        "input_ids": ids,
+        "labels": ids.clone(),
+        "packed_seq_lengths": torch.tensor(lengths, dtype = torch.int32),
+    }
+    counted = _counted(batch)
+    # 12 tokens, 3 row starts dropped by the slice, boundaries at flat 3 and 8.
+    # Flat 8 is a row start (row 2 column 0) and is already gone, so only flat 3
+    # is a live boundary to remove.
+    assert counted == _true_target_count(batch["labels"], lengths) == 8, (
+        f"counted {counted}, expected 8"
+    )
+
+
+def test_applying_the_boundary_removal_twice_is_idempotent():
+    """The property that makes a version check unnecessary, asserted directly on
+    the counting path rather than inferred from the two-collator comparison."""
+    torch = pytest.importorskip("torch")
+    lengths = [4, 3, 3]
+    # Pre-masked, so the boundary slots are already gone before the counting path
+    # touches them: removing them a second time is exactly the bug.
+    batch = _padding_free_batch(lengths, premask_starts = True)
+    first = _counted(batch)
+    second = _counted(batch)
+    assert first == second == 7, f"first {first}, second {second}"
+    # And the caller's batch must come back unharmed.
+    assert int((batch["labels"] != -100).sum()) == 7, (
+        "the counting path mutated the caller's labels"
+    )
+
+
+def test_batch_without_packed_seq_lengths_is_unchanged():
+    """The no-metadata path must be bit identical to before the fix."""
+    torch = pytest.importorskip("torch")
+    g = torch.Generator().manual_seed(9)
+    ids = torch.randint(1, 11, (4, 7), generator = g)
+    labels = ids.clone()
+    labels[0, 3] = -100
+    counted = _counted({"input_ids": ids, "labels": labels})
+    assert counted == int((labels[..., 1:] != -100).sum()) == 23
+
+
+def test_a_plain_list_of_lengths_does_not_kill_the_run():
+    """`seq_lengths > 0` raises on a list, and the enclosing except re-raises as
+    RuntimeError, so this used to be a dead training run rather than a bad count."""
+    lengths = [4, 3, 3]
+    batch = _padding_free_batch(lengths)
+    batch["packed_seq_lengths"] = list(lengths)
+    assert _counted(batch) == 7
+
+
+def test_int32_metadata_counts_like_int64():
+    torch = pytest.importorskip("torch")
+    lengths = [4, 3, 3]
+    counted = []
+    for dtype in (torch.int32, torch.int64):
+        batch = _padding_free_batch(lengths)
+        batch["packed_seq_lengths"] = torch.tensor(lengths, dtype = dtype)
+        counted.append(_counted(batch))
+    assert counted == [7, 7], f"int32 and int64 metadata disagreed: {counted}"
+
+
+def test_unusable_metadata_degrades_instead_of_raising():
+    batch = _padding_free_batch([4, 3, 3])
+    batch["packed_seq_lengths"] = "garbage"
+    # Falls back to the plain shifted count rather than raising RuntimeError.
+    assert _counted(batch) == 9
+
+
+def test_the_real_installed_trl_collator_is_counted_correctly():
+    """One end-to-end pass through whatever TRL is installed, so the synthesised
+    regimes above cannot drift away from a real collator's output."""
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("trl")
+    # Moved between trl.trainer.utils and trl.trainer.sft_trainer across releases.
+    cls = None
+    for module in ("trl.trainer.sft_trainer", "trl.trainer.utils"):
+        try: candidate = __import__(module, fromlist = ["DataCollatorForLanguageModeling"])
+        except Exception: continue
+        cls = getattr(candidate, "DataCollatorForLanguageModeling", None)
+        if cls is not None: break
+    if cls is None: pytest.skip("this TRL has no DataCollatorForLanguageModeling")
+    # return_position_ids only exists on some releases; padding_free implies it on
+    # the rest.
+    collator = None
+    for kwargs in ({"return_position_ids": True}, {}):
+        try:
+            collator = cls(pad_token_id = 0, padding_free = True, **kwargs)
+            break
+        except TypeError:
+            continue
+    if collator is None: pytest.skip("this TRL's collator does not take padding_free")
+
+    lengths = [4, 3, 3]
+    examples = [{"input_ids": list(range(1, n + 1))} for n in lengths]
+    batch = collator(examples)
+    if "position_ids" not in batch: pytest.skip("collator returned no position_ids")
+    if batch["labels"].shape[-1] != sum(lengths): pytest.skip("collator did not flatten the batch")
+    batch = dict(batch)
+    batch.pop("attention_mask", None)
+    batch["packed_seq_lengths"] = torch.tensor(lengths, dtype = torch.int32)
+
+    counted = _counted(batch)
+    assert counted == _true_target_count(batch["labels"], lengths), (
+        f"counted {counted} against an independently computed "
+        f"{_true_target_count(batch['labels'], lengths)} on the real collator"
+    )
+    assert counted == 7, (
+        f"counted {counted}, expected 10 tokens minus 3 document starts"
+    )
+
+
+def test_the_counting_path_never_branches_on_the_trl_version():
+    """Locks in the architectural decision. Feature detection answers the wrong
+    question (what matters is whether these exact slots are already -100, which
+    completion-only masking also decides), inspects a class the batch may never
+    have come from, and inspect.getsource raises on frozen, zipped, -OO or wrapped
+    installs, inside the try that turns it into a hard crash."""
+    import ast
+
+    mod = _loss_utils()
+    src = inspect.getsource(mod)
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.split(".")[0] == "trl", "loss_utils must not import trl"
+        elif isinstance(node, ast.ImportFrom):
+            assert not (node.module or "").split(".")[0] == "trl", "loss_utils must not import trl"
+
+    counting = inspect.getsource(mod._unsloth_get_batch_samples)
+    counting += inspect.getsource(mod._normalize_packed_seq_lengths)
+    # Strip comments: the rationale above is allowed to name versions, the code is not.
+    code = "\n".join(line.split("#", 1)[0] for line in counting.splitlines())
+    for banned in ("__version__", "Version(", "getsource", "trl"):
+        assert banned not in code, (
+            f"the packed-boundary count branches on {banned!r}; it must be "
+            "idempotent instead, because completion-only masking regresses the "
+            "same slots on every TRL version"
+        )
+
+
 def _stock_counts_shifted_labels(stock):
     """Does the installed transformers count over `labels[..., 1:]` rather than `labels`?
 

--- a/tests/test_loss_normalization_contract.py
+++ b/tests/test_loss_normalization_contract.py
@@ -265,7 +265,7 @@ def test_accumulated_gradient_matches_the_single_batch_gradient():
 # token prediction crosses a document, so the count has to exclude them. Doing
 # that by subtracting N-1 from the total double counts every boundary a collator
 # had already masked with -100, which under-counts num_items_in_batch and so
-# inflates loss and every gradient. TRL >= 0.24 masks them (labels[position_ids
+# inflates loss and every gradient. TRL >= 0.23.1 masks them (labels[position_ids
 # == 0] = -100) and completion_only_loss / assistant_masks mask them on every TRL
 # version including 0.22.2, so the arithmetic must be idempotent, not version
 # detected. unsloth's enable_padding_free_metadata attaches packed_seq_lengths
@@ -276,7 +276,7 @@ def test_accumulated_gradient_matches_the_single_batch_gradient():
 def _padding_free_batch(lengths, premask_starts = False, completion_only = 0):
     """One flattened padding-free row holding len(lengths) documents.
 
-    premask_starts reproduces TRL >= 0.24, which writes -100 at every
+    premask_starts reproduces TRL >= 0.23.1, which writes -100 at every
     position_ids == 0 slot. completion_only masks the first N tokens of each
     document, which is what completion_only_loss and assistant_masks do on every
     TRL version, and which also lands -100 on the document starts. Synthesising
@@ -392,7 +392,7 @@ def test_normalize_drops_nonpositive_and_short_circuits_one_document():
 
 
 def test_count_is_identical_whether_or_not_the_collator_premasked():
-    """The headline property. TRL >= 0.24 masks the document starts and earlier
+    """The headline property. TRL >= 0.23.1 masks the document starts and earlier
     versions do not, and completion-only masking does it on every version. The
     count must not depend on which of those produced the batch."""
     lengths = [4, 3, 3]
@@ -564,6 +564,84 @@ def test_unusable_metadata_degrades_instead_of_raising():
     batch["packed_seq_lengths"] = "garbage"
     # Falls back to the plain shifted count rather than raising RuntimeError.
     assert _counted(batch) == 9
+
+
+def test_normalize_does_not_raise_when_the_length_filter_cannot_run():
+    """Dropping the non-positive lengths is a boolean mask, so it lowers to
+    aten.nonzero, whose output shape is data dependent. Under FakeTensorMode that
+    raises DynamicOutputShapeException. The whole body therefore has to sit inside
+    the try: the caller counts inside `except Exception: raise RuntimeError(...)`,
+    so an escape here is a dead training run, not the missing correction this
+    helper exists to degrade to."""
+    torch = pytest.importorskip("torch")
+    fake = pytest.importorskip("torch._subclasses.fake_tensor")
+    normalize = _normalizer()
+    with fake.FakeTensorMode():
+        # Positive lengths only, so this is metadata the helper would normally
+        # accept: the raise comes from the filter, not from rejecting the input.
+        assert normalize(torch.tensor([4, 3, 3])) is None
+
+
+def test_the_counting_path_does_not_raise_on_a_traced_tensor():
+    """The same escape, observed where it actually hurts: through the public
+    counting entry point, whose except clause converts anything that gets out into
+    a RuntimeError that ends the run."""
+    torch = pytest.importorskip("torch")
+    fake = pytest.importorskip("torch._subclasses.fake_tensor")
+    mod = _loss_utils()
+    fn = getattr(mod, "_unsloth_get_batch_samples", None)
+    if fn is None: pytest.skip("_unsloth_get_batch_samples not present")
+    with fake.FakeTensorMode():
+        ids = torch.randint(1, 11, (1, 10))
+        batch = {
+            "input_ids": ids,
+            "labels": ids.clone(),
+            "packed_seq_lengths": torch.tensor([4, 3, 3], dtype = torch.int32),
+        }
+        mod.ALLOWED_NUM_ITEMS_IN_BATCH.clear()
+        # Called directly rather than through _counted, which ends in int(count):
+        # that is a .item() and raises on a fake tensor all by itself, which would
+        # make this test fail for a reason that has nothing to do with the code
+        # under test. No assertion on the number either, since under a fake tensor
+        # there is no number. The contract is only that it does not end the run.
+        fn(_fake_trainer(_tiny_model(), True), iter([batch]), 1)
+
+
+def test_the_count_can_never_go_negative():
+    """Subtracting N-1 had no lower bound. On a batch whose live targets number
+    fewer than N, the old arithmetic returned zero or a negative num_items_in_batch,
+    so the loss divided by zero or changed sign and the gradients ascended. Zeroing
+    slots that may already be False is bounded below by construction, and this
+    pins that.
+
+    Every case here has real trainable targets, so declining to count is not an
+    acceptable answer either.
+    """
+    torch = pytest.importorskip("torch")
+    # (lengths, completion_only, premask, true target count)
+    cases = [
+        ([4, 3, 3],    3, False, 1),
+        ([1, 1, 2],    1, True,  1),
+        ([5, 3],       4, False, 1),
+        ([2, 5, 2],    4, False, 1),
+        ([1, 5, 6, 3, 3], 4, True, 3),
+        ([5, 3, 4, 2], 3, False, 3),
+    ]
+    for lengths, completion_only, premask, expected in cases:
+        batch = _padding_free_batch(
+            lengths, premask_starts = premask, completion_only = completion_only,
+        )
+        counted = _counted(batch)
+        assert counted == _true_target_count(batch["labels"], lengths)
+        assert counted == expected, (
+            f"lengths={lengths} completion_only={completion_only}: "
+            f"counted {counted}, expected {expected}"
+        )
+        assert counted >= 0, (
+            f"lengths={lengths} completion_only={completion_only}: num_items_in_batch "
+            f"came back {counted}. A non-positive count makes the loss divide by zero "
+            "or flip sign, which is what subtracting an unbounded N-1 allowed"
+        )
 
 
 def test_the_real_installed_trl_collator_is_counted_correctly():

--- a/tests/test_loss_normalization_contract.py
+++ b/tests/test_loss_normalization_contract.py
@@ -180,12 +180,10 @@ def _fake_trainer(model, accepts, compute_loss_func = None):
     t.accelerator = Accelerator()
     t.model_accepts_loss_kwargs = accepts
     t.compute_loss_func = compute_loss_func
-    # transformers 5.x reads this INSIDE the try that counts labels, and the except
-    # swallows AttributeError. A stand-in without it therefore does not measure stock's
-    # decision at all: stock raises on the first list comprehension, returns None, and a
-    # differential test reads that as "stock declined to count". Every real Trainer sets
-    # it in __init__. True is the value for this fixture's model, which shifts labels
-    # internally like any causal LM, which is exactly the case the flag selects.
+    # transformers 5.x reads this inside the try that counts labels, and the except
+    # swallows the AttributeError, so a stand-in without it makes stock look like it
+    # declined to count. Every real Trainer sets it; True matches this fixture's model,
+    # which shifts labels internally like any causal LM.
     t._loss_shifts_labels = True
     return t
 
@@ -261,16 +259,13 @@ def test_accumulated_gradient_matches_the_single_batch_gradient():
 
 # Packed / padding-free boundary counting.
 #
-# Packing N documents into a flat row leaves N-1 internal boundaries whose next
-# token prediction crosses a document, so the count has to exclude them. Doing
-# that by subtracting N-1 from the total double counts every boundary a collator
-# had already masked with -100, which under-counts num_items_in_batch and so
-# inflates loss and every gradient. TRL >= 0.23.1 masks them (labels[position_ids
-# == 0] = -100) and completion_only_loss / assistant_masks mask them on every TRL
-# version including 0.22.2, so the arithmetic must be idempotent, not version
-# detected. unsloth's enable_padding_free_metadata attaches packed_seq_lengths
-# even when packing is off, one entry per example, so this reaches ordinary LoRA
-# runs with per_device_train_batch_size > 1.
+# The N-1 internal boundaries of a packed row are not training positions, but
+# subtracting N-1 double counts every boundary a collator already masked with
+# -100 (TRL >= 0.23.1 labels[position_ids == 0] = -100, completion_only_loss /
+# assistant_masks on every version), under-counting num_items_in_batch and
+# inflating loss and grads. So the arithmetic must be idempotent, not version
+# detected. unsloth attaches packed_seq_lengths even when packing is off, so
+# this reaches ordinary LoRA runs with per_device_train_batch_size > 1.
 
 
 def _padding_free_batch(lengths, premask_starts = False, completion_only = 0):
@@ -424,8 +419,8 @@ def test_completion_only_masking_is_not_double_subtracted():
     batch = _padding_free_batch(lengths, completion_only = 3)
     counted = _counted(batch)
     assert counted == _true_target_count(batch["labels"], lengths)
-    # 4 documents x 5 tokens, first 3 of each masked, minus the boundary targets
-    # that are already inside the masked prefixes.
+    # 4 documents x 5 tokens, first 3 of each masked; the boundary targets are
+    # already inside those masked prefixes.
     assert counted == 8, f"counted {counted}, expected 8"
 
 
@@ -451,9 +446,9 @@ def test_lengths_overrunning_the_batch_do_not_kill_live_targets():
     not. Boundaries past the end of the batch must be dropped, not wrapped onto a
     row that is really there."""
     torch = pytest.importorskip("torch")
-    # 5 puts a boundary at flat 15, past the end of a 10 token batch and NOT on a
-    # row start, so only the rows < n_rows filter can catch it. Without it this
-    # raises IndexError inside the try that re-raises as RuntimeError.
+    # 5 puts a boundary at flat 15: past a 10 token batch and not on a row start,
+    # so only the rows < n_rows filter catches it. Without it, IndexError inside
+    # the try that re-raises as RuntimeError.
     for overrun in ([4, 3, 3, 5, 50], [4, 3, 3, 50, 50], [4, 3, 3, 1]):
         batch = _padding_free_batch([4, 3, 3])
         batch["packed_seq_lengths"] = torch.tensor(overrun, dtype = torch.int32)
@@ -504,8 +499,7 @@ def test_multi_row_boundaries_map_row_major():
     }
     counted = _counted(batch)
     # 12 tokens, 3 row starts dropped by the slice, boundaries at flat 3 and 8.
-    # Flat 8 is a row start (row 2 column 0) and is already gone, so only flat 3
-    # is a live boundary to remove.
+    # Flat 8 is a row start and already gone, so only flat 3 is live.
     assert counted == _true_target_count(batch["labels"], lengths) == 8, (
         f"counted {counted}, expected 8"
     )
@@ -599,11 +593,9 @@ def test_the_counting_path_does_not_raise_on_a_traced_tensor():
             "packed_seq_lengths": torch.tensor([4, 3, 3], dtype = torch.int32),
         }
         mod.ALLOWED_NUM_ITEMS_IN_BATCH.clear()
-        # Called directly rather than through _counted, which ends in int(count):
-        # that is a .item() and raises on a fake tensor all by itself, which would
-        # make this test fail for a reason that has nothing to do with the code
-        # under test. No assertion on the number either, since under a fake tensor
-        # there is no number. The contract is only that it does not end the run.
+        # Called directly, not through _counted: its int(count) is a .item() that
+        # raises on a fake tensor by itself. No number exists under a fake tensor
+        # either, so the only contract here is that it does not end the run.
         fn(_fake_trainer(_tiny_model(), True), iter([batch]), 1)
 
 
@@ -632,10 +624,8 @@ def test_the_count_can_never_go_negative():
             lengths, premask_starts = premask, completion_only = completion_only,
         )
         counted = _counted(batch)
-        # The bound first. Asserting it after the equality below would make it dead:
-        # every expected value here is >= 1, so the equality can never leave a
-        # negative count for this to catch, and the invariant the test is named for
-        # would never actually be exercised.
+        # The bound first: after the equality below it would be dead, since every
+        # expected value here is >= 1 and no negative count could ever reach it.
         assert counted is not None and counted > 0, (
             f"lengths={lengths} completion_only={completion_only}: num_items_in_batch "
             f"came back {counted}. A non-positive count makes the loss divide by zero "
@@ -661,8 +651,7 @@ def test_the_real_installed_trl_collator_is_counted_correctly():
         cls = getattr(candidate, "DataCollatorForLanguageModeling", None)
         if cls is not None: break
     if cls is None: pytest.skip("this TRL has no DataCollatorForLanguageModeling")
-    # return_position_ids only exists on some releases; padding_free implies it on
-    # the rest.
+    # return_position_ids only exists on some releases; padding_free implies it elsewhere.
     collator = None
     for kwargs in ({"return_position_ids": True}, {}):
         try:
@@ -761,11 +750,10 @@ def test_guard_returns_a_count_exactly_when_stock_transformers_would():
                 f"accepts={accepts} compute_loss_func={loss_func is not None}: "
                 f"we returned {ours!r} where stock returned {theirs!r}"
             )
-            # Where stock counts over labels[..., 1:] the COUNT has to agree too, not
-            # just whether one was produced. transformers adopted that rule in 5.x
-            # (position 0 of a row is never a prediction target for a causal LM); zoo
-            # has always counted that way, so before 5.x the two legitimately differ by
-            # one token per row and only the nullity above is a shared contract.
+            # Where stock counts over labels[..., 1:] the count must agree too, not
+            # just whether one was produced. transformers adopted that rule in 5.x;
+            # zoo always counted that way, so before 5.x the two legitimately differ
+            # by one token per row and only the nullity above is shared.
             if _stock_counts_shifted_labels(stock) and ours is not None:
                 assert int(ours) == int(theirs), (
                     f"accepts={accepts} compute_loss_func={loss_func is not None}: "

--- a/tests/test_loss_normalization_contract.py
+++ b/tests/test_loss_normalization_contract.py
@@ -620,27 +620,31 @@ def test_the_count_can_never_go_negative():
     torch = pytest.importorskip("torch")
     # (lengths, completion_only, premask, true target count)
     cases = [
-        ([4, 3, 3],    3, False, 1),
-        ([1, 1, 2],    1, True,  1),
-        ([5, 3],       4, False, 1),
-        ([2, 5, 2],    4, False, 1),
-        ([1, 5, 6, 3, 3], 4, True, 3),
-        ([5, 3, 4, 2], 3, False, 3),
+        ([4, 3, 3],       3, False, 1),
+        ([1, 1, 2],       1, True,  1),
+        ([5, 3],          4, False, 1),
+        ([2, 5, 2],       4, False, 1),
+        ([1, 5, 6, 3, 3], 4, True,  3),
+        ([5, 3, 4, 2],    3, False, 3),
     ]
     for lengths, completion_only, premask, expected in cases:
         batch = _padding_free_batch(
             lengths, premask_starts = premask, completion_only = completion_only,
         )
         counted = _counted(batch)
+        # The bound first. Asserting it after the equality below would make it dead:
+        # every expected value here is >= 1, so the equality can never leave a
+        # negative count for this to catch, and the invariant the test is named for
+        # would never actually be exercised.
+        assert counted is not None and counted > 0, (
+            f"lengths={lengths} completion_only={completion_only}: num_items_in_batch "
+            f"came back {counted}. A non-positive count makes the loss divide by zero "
+            "or flip sign, which is what subtracting an unbounded N-1 allowed"
+        )
         assert counted == _true_target_count(batch["labels"], lengths)
         assert counted == expected, (
             f"lengths={lengths} completion_only={completion_only}: "
             f"counted {counted}, expected {expected}"
-        )
-        assert counted >= 0, (
-            f"lengths={lengths} completion_only={completion_only}: num_items_in_batch "
-            f"came back {counted}. A non-positive count makes the loss divide by zero "
-            "or flip sign, which is what subtracting an unbounded N-1 allowed"
         )
 
 

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -266,12 +266,21 @@ def _normalize_packed_seq_lengths(seq_lengths):
             lengths = seq_lengths.detach().to(device = "cpu", dtype = torch.long)
         else:
             lengths = torch.as_tensor(seq_lengths, dtype = torch.long)
+        if lengths.ndim != 1:
+            lengths = lengths.reshape(-1)
+        # Everything through the last read stays inside the try. Dropping the
+        # non-positive entries is a boolean mask, so it lowers to aten.nonzero,
+        # whose output shape is data dependent: under FakeTensorMode it raises
+        # DynamicOutputShapeException and under vmap it raises outright. Left
+        # outside, those escape into the caller's `except Exception: raise
+        # RuntimeError(...)`, which is a dead training run rather than the
+        # missing correction this helper promises. Filtering is not optional --
+        # a zero-length entry would otherwise duplicate a start, and a negative
+        # one would corrupt every later cumsum.
+        lengths = lengths[lengths > 0]
+        if lengths.numel() <= 1: return None
     except Exception:
         return None
-    if lengths.ndim != 1:
-        lengths = lengths.reshape(-1)
-    lengths = lengths[lengths > 0]
-    if lengths.numel() <= 1: return None
     return lengths
 pass
 
@@ -360,10 +369,17 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
                     # subtracting N-1 from the total: whatever already wrote -100
                     # there would otherwise be charged for them twice, which
                     # under-counts num_items_in_batch and inflates loss and grads.
-                    # Collators that already mask them include TRL >= 0.24, which
-                    # sets labels[position_ids == 0] = -100, plus completion_only_loss
-                    # and assistant_masks on every TRL version. So the arithmetic has
-                    # to be idempotent rather than version detected.
+                    # Collators that already mask them include TRL >= 0.23.1, which
+                    # sets labels[position_ids == 0] = -100, transformers'
+                    # DataCollatorWithFlattening on every version, and
+                    # completion_only_loss / assistant_masks on every TRL version.
+                    # So the arithmetic has to be idempotent rather than version
+                    # detected.
+                    #
+                    # Subtracting also had no lower bound: on a batch whose live
+                    # targets number fewer than N, the old count went to zero or
+                    # negative, so the loss divided by zero or changed sign. Zeroing
+                    # slots that may already be False cannot go below zero.
                     #
                     # labels[..., 1:] above already dropped the first token of every
                     # row, so a document starting at flat index s sits at column s - 1

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -269,15 +269,11 @@ def _normalize_packed_seq_lengths(seq_lengths):
             lengths = torch.as_tensor(seq_lengths, dtype = torch.long)
         if lengths.ndim != 1:
             lengths = lengths.reshape(-1)
-        # Everything through the last read stays inside the try. Dropping the
-        # non-positive entries is a boolean mask, so it lowers to aten.nonzero,
-        # whose output shape is data dependent: under FakeTensorMode it raises
-        # DynamicOutputShapeException and under vmap it raises outright. Left
-        # outside, those escape into the caller's `except Exception: raise
-        # RuntimeError(...)`, which is a dead training run rather than the
-        # missing correction this helper promises. Filtering is not optional --
-        # a zero-length entry would otherwise duplicate a start, and a negative
-        # one would corrupt every later cumsum.
+        # Filtering is mandatory (a 0 length duplicates a start, a negative one
+        # corrupts every later cumsum) and must stay inside the try: the mask
+        # lowers to aten.nonzero, which raises DynamicOutputShapeException under
+        # FakeTensorMode and raises under vmap. Escaping into the caller's
+        # `except Exception: raise RuntimeError(...)` kills the run.
         lengths = lengths[lengths > 0]
         if lengths.numel() <= 1: return None
     except Exception:
@@ -365,36 +361,26 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
                     mark_dynamic(token_type_ids, 1)
                 seq_lengths = _normalize_packed_seq_lengths(x.get("packed_seq_lengths"))
                 if seq_lengths is not None and token_count.ndim in (1, 2) and token_count.shape[-1] != 0:
-                    # Packing N documents leaves N-1 internal boundaries that are not
-                    # valid training positions. Zero those exact slots instead of
-                    # subtracting N-1 from the total: whatever already wrote -100
-                    # there would otherwise be charged for them twice, which
-                    # under-counts num_items_in_batch and inflates loss and grads.
-                    # Collators that already mask them include TRL >= 0.23.1, which
-                    # sets labels[position_ids == 0] = -100, transformers'
-                    # DataCollatorWithFlattening on every version, and
-                    # completion_only_loss / assistant_masks on every TRL version.
-                    # So the arithmetic has to be idempotent rather than version
-                    # detected.
+                    # Packing N documents leaves N-1 internal boundaries that are
+                    # not valid training positions. Zero those exact slots rather
+                    # than subtract N-1: many collators already mask them (TRL
+                    # >= 0.23.1 labels[position_ids == 0] = -100, transformers'
+                    # DataCollatorWithFlattening, completion_only_loss /
+                    # assistant_masks), so subtracting double counts them and
+                    # inflates loss and grads. Zeroing is idempotent and cannot
+                    # go below zero; subtracting had no lower bound and drove the
+                    # count to zero or negative on small batches.
                     #
-                    # Subtracting also had no lower bound: on a batch whose live
-                    # targets number fewer than N, the old count went to zero or
-                    # negative, so the loss divided by zero or changed sign. Zeroing
-                    # slots that may already be False cannot go below zero.
+                    # labels[..., 1:] already dropped column 0 of every row, so a
+                    # document starting at flat index s sits at column s - 1, and
+                    # one starting at a row boundary is already gone. cumsum[:-1]
+                    # drops the trailing boundary, making a single document a
+                    # provable no-op and keeping truncated metadata harmless.
                     #
-                    # labels[..., 1:] above already dropped the first token of every
-                    # row, so a document starting at flat index s sits at column s - 1
-                    # of its row here, and a document starting at a row boundary
-                    # (col 0) was eaten by that slice already. cumsum(...)[:-1] leaves
-                    # out the trailing boundary, which makes a single document a
-                    # provable no-op and stops truncated metadata from ever killing a
-                    # live target.
-                    #
-                    # This block has its own unprotected data-dependent reads
-                    # (rows[keep], then rows.numel()). They are safe only because
-                    # _normalize_packed_seq_lengths returns None first under any
-                    # mode that cannot evaluate them, so nothing here ever runs on
-                    # a tensor whose shape is unbacked. Keep that ordering.
+                    # The data-dependent reads below (rows[keep], rows.numel())
+                    # are unprotected, and safe only because
+                    # _normalize_packed_seq_lengths already returned None under
+                    # any mode that cannot evaluate them. Keep that ordering.
                     n_shift = token_count.shape[-1]
                     n_rows  = token_count.numel() // n_shift
                     starts  = torch.cumsum(seq_lengths, dim = 0)[:-1]

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -243,6 +243,39 @@ from transformers.training_args import ParallelMode
 mark_static  = torch._dynamo.mark_static
 mark_dynamic = torch._dynamo.mark_dynamic
 
+
+def _normalize_packed_seq_lengths(seq_lengths):
+    # All Unsloth Zoo code licensed under LGPLv3
+    """Coerce collator supplied packed sequence lengths to a 1D int64 CPU tensor.
+
+    Returns None when the metadata is missing, unusable, or describes a single
+    document, since one document has no internal boundary to drop. Kept on CPU:
+    these are tens of elements, it avoids MPS / XPU integer op gaps, and it keeps
+    the counting path free of a device sync.
+
+    Deliberately duplicated from unsloth/utils/packing.py rather than imported.
+    The dependency arrow runs unsloth -> unsloth_zoo and must never run back.
+
+    Anything unconvertible is treated as absent rather than raised: the caller
+    counts inside a try that re-raises as RuntimeError, so a plain list of ints
+    used to end the run outright.
+    """
+    if seq_lengths is None: return None
+    try:
+        if isinstance(seq_lengths, torch.Tensor):
+            lengths = seq_lengths.detach().to(device = "cpu", dtype = torch.long)
+        else:
+            lengths = torch.as_tensor(seq_lengths, dtype = torch.long)
+    except Exception:
+        return None
+    if lengths.ndim != 1:
+        lengths = lengths.reshape(-1)
+    lengths = lengths[lengths > 0]
+    if lengths.numel() <= 1: return None
+    return lengths
+pass
+
+
 def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None, *args, **kwargs):
     # All Unsloth Zoo code licensed under LGPLv3
     batch_samples = []
@@ -320,12 +353,42 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
                     token_type_ids = x["token_type_ids"]
                     mark_static (token_type_ids, 0)
                     mark_dynamic(token_type_ids, 1)
+                seq_lengths = _normalize_packed_seq_lengths(x.get("packed_seq_lengths"))
+                if seq_lengths is not None and token_count.ndim in (1, 2) and token_count.shape[-1] != 0:
+                    # Packing N documents leaves N-1 internal boundaries that are not
+                    # valid training positions. Zero those exact slots instead of
+                    # subtracting N-1 from the total: whatever already wrote -100
+                    # there would otherwise be charged for them twice, which
+                    # under-counts num_items_in_batch and inflates loss and grads.
+                    # Collators that already mask them include TRL >= 0.24, which
+                    # sets labels[position_ids == 0] = -100, plus completion_only_loss
+                    # and assistant_masks on every TRL version. So the arithmetic has
+                    # to be idempotent rather than version detected.
+                    #
+                    # labels[..., 1:] above already dropped the first token of every
+                    # row, so a document starting at flat index s sits at column s - 1
+                    # of its row here, and a document starting at a row boundary
+                    # (col 0) was eaten by that slice already. cumsum(...)[:-1] leaves
+                    # out the trailing boundary, which makes a single document a
+                    # provable no-op and stops truncated metadata from ever killing a
+                    # live target.
+                    n_shift = token_count.shape[-1]
+                    n_rows  = token_count.numel() // n_shift
+                    starts  = torch.cumsum(seq_lengths, dim = 0)[:-1]
+                    rows    = torch.div(starts, n_shift + 1, rounding_mode = "floor")
+                    cols    = starts - rows * (n_shift + 1)
+                    keep    = (cols > 0) & (rows < n_rows)
+                    rows, cols = rows[keep], cols[keep]
+                    if rows.numel() != 0:
+                        if rows.device != token_count.device:
+                            rows = rows.to(token_count.device)
+                            cols = cols.to(token_count.device)
+                        # Reassign: reshape can copy on a non contiguous input.
+                        token_count = token_count.reshape(n_rows, n_shift)
+                        token_count[rows, cols - 1] = False
+                    pass
+                pass
                 count = token_count.sum()
-                seq_lengths = x.get("packed_seq_lengths")
-                if seq_lengths is not None:
-                    # Packing N sequences has N-1 internal boundaries that
-                    # aren't valid training positions.
-                    count -= torch.count_nonzero(seq_lengths > 0).item() - 1
                 token_counts.append(count)
             pass
             num_items_in_batch = sum(token_counts)

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -248,8 +248,9 @@ def _normalize_packed_seq_lengths(seq_lengths):
     # All Unsloth Zoo code licensed under LGPLv3
     """Coerce collator supplied packed sequence lengths to a 1D int64 CPU tensor.
 
-    Returns None when the metadata is missing, unusable, or describes a single
-    document, since one document has no internal boundary to drop. Kept on CPU:
+    Returns None when the metadata is missing, unusable, describes a single
+    document (one document has no internal boundary to drop), or when the running
+    execution mode cannot evaluate the filter below. Kept on CPU:
     these are tens of elements, it avoids MPS / XPU integer op gaps, and it keeps
     the counting path free of a device sync.
 
@@ -388,6 +389,12 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
                     # out the trailing boundary, which makes a single document a
                     # provable no-op and stops truncated metadata from ever killing a
                     # live target.
+                    #
+                    # This block has its own unprotected data-dependent reads
+                    # (rows[keep], then rows.numel()). They are safe only because
+                    # _normalize_packed_seq_lengths returns None first under any
+                    # mode that cannot evaluate them, so nothing here ever runs on
+                    # a tensor whose shape is unbacked. Keep that ordering.
                     n_shift = token_count.shape[-1]
                     n_rows  = token_count.numel() // n_shift
                     starts  = torch.cumsum(seq_lengths, dim = 0)[:-1]


### PR DESCRIPTION
## The bug

`_unsloth_get_batch_samples` builds the target mask over `labels[..., 1:]`, then subtracts a constant for the internal boundaries of a packed or padding-free batch:

```python
token_count = (labels[..., 1:] != -100)     # loss_utils.py:309
...
count = token_count.sum()
seq_lengths = x.get("packed_seq_lengths")
if seq_lengths is not None:
    count -= torch.count_nonzero(seq_lengths > 0).item() - 1
```

`position_ids == 0` marks each document's first flat token. The `[..., 1:]` slice has already dropped document 1's start, so the remaining `N-1` starts sit at shifted indices `cumsum(lengths)[:-1] - 1`, which are exactly the slots the subtraction is aiming at. Whenever something had already masked them, they come off twice, `num_items_in_batch` comes back low, and loss and every gradient are scaled up by `(T - N) / (T - 2N + 1)`.

They are already masked by TRL >= 0.23.1, which does `labels[position_ids == 0] = -100` (`sft_trainer.py:208` in 0.25.1, still there verbatim in 1.10.0), by transformers' own `DataCollatorWithFlattening` on **every** transformers version, and by `completion_only_loss` / `assistant_masks` on **every** TRL version including 0.22.2. That second path is why this is fixed idempotently rather than behind a version check: a version gate would leave the most common SFT configuration broken.

`enable_padding_free_metadata` in unsloth attaches `packed_seq_lengths` even when packing is off, one entry per example, and unsloth auto-enables padding-free, so this also reaches ordinary LoRA runs with `per_device_train_batch_size > 1`, where `N = B`.

## Magnitude, stated honestly

This is not a 1.4x error in general. The ratio is `(T - N) / (T - 2N + 1)`, so it is under 1% for typical long-sequence SFT and only becomes material for short sequences with large batches, or under completion-only masking.

| config | T | correct | reported today | inflation |
|---|---|---|---|---|
| B=2, L=1024 | 2048 | 2046 | 2045 | 1.0005x |
| B=8, L=512 | 4096 | 4088 | 4081 | 1.0017x |
| B=16, L=32 (short chat) | 512 | 496 | 481 | 1.031x |
| packing, N=8 docs of 256 | 2048 | 2040 | 2033 | 1.0034x |
| completion-only, 8 examples x 5-token completions | - | 40 | 33 | 1.21x |
| toy repro, 3 docs of 4/3/3 | 10 | 7 | 5 | 1.4x |

`B = 1` is unaffected, since `N - 1 = 0`.

## The fix

Two hunks in `unsloth_zoo/loss_utils.py`.

**A. `_normalize_packed_seq_lengths`**, a new module-level helper returning a 1-D int64 **CPU** tensor of the positive lengths, or `None` when the metadata is missing, unusable, or describes a single document. It accepts a tensor, list, tuple or numpy array; anything unconvertible is treated as absent. That last point is a fix in itself: today a plain list raises on `seq_lengths > 0` inside the `try` whose `except` re-raises as `RuntimeError`, so a list-valued entry ends the run rather than mis-counting. Mirrors `_normalize_packed_lengths` in `unsloth/utils/packing.py`, but duplicated rather than imported, because the dependency arrow runs unsloth -> zoo and must never run back.

**B. Boundary zeroing** in place of the subtraction. Compute `starts = cumsum(lengths)[:-1]`, map to `rows, cols` by row-major divmod against `n_shift + 1`, drop `cols == 0` (a row start, already eaten by the slice) and `rows >= n_rows` (metadata overruns the batch), set those slots `False`, then sum. Guarded on `token_count.ndim in (1, 2)`.

Notes on the choices:

- The index maths stays on CPU. These are tens of elements, it sidesteps MPS/XPU integer-op coverage, and it **removes** the `.item()` device sync the old line performed, so the packed path is marginally faster.
- `[:-1]` rather than the full cumsum is deliberate: it makes `N == 1` a provable no-op and stops truncated metadata from ever killing a live target.
- `count` stays a 0-dim tensor, so the `accelerator.gather`, `.to(device)` and DataParallel `repeat` below are untouched, and the function still ends `return batch_samples, num_items_in_batch`, which `unsloth/models/_utils.py` asserts on before swapping the method in.
- Batches with no `packed_seq_lengths` take exactly the path they took before.
- No TRL symbol is imported or inspected. Feature-detecting the collator was considered and rejected: it answers the wrong question (what matters is whether *these slots* are already `-100`, which completion-only masking also decides), it inspects a class the batch may never have come from (unsloth wraps whatever collator the user passed), and `inspect.getsource` raises on frozen, zipped, `-OO` or wrapped installs, inside the `try` that converts that into a hard crash.

## Tests

`tests/test_loss_normalization_contract.py` grows two helpers and 18 tests. `_padding_free_batch` synthesises both TRL regimes (pre-masked starts, and completion-only masking) so one installed TRL stands in for all of them, and `_true_target_count` computes truth by walking Python lists, independent of the arithmetic under test, so a bug cannot hide in the oracle. Every test clears `ALLOWED_NUM_ITEMS_IN_BATCH` first: that cache is keyed on the model class name and a stale entry makes the counting branch not run at all, which would make the whole file pass vacuously.

Coverage: identical count whether or not the collator pre-masked; count equals `T - N`; completion-only not double-subtracted; `N = 1` untouched; zero-length entries; lengths overrunning the batch; metadata shorter than the batch; a document starting exactly at a row boundary; multi-row row-major mapping; idempotence; a plain list accepted without `RuntimeError`; int32 normalised; unconvertible metadata degrading instead of raising; no `packed_seq_lengths` unchanged; a pass through the **real installed TRL collator**; and one test asserting the counting path never branches on the TRL version, which locks in the architectural decision above.

### Every test proven discriminating

Each production hunk was reverted or mutated in turn, and the intended tests fail. Transcript:

```
### BASELINE (both hunks present)
26 passed, 1 skipped

### HUNK B REVERTED (subtract N-1 instead of zeroing the boundary slots)
FAILED test_count_is_identical_whether_or_not_the_collator_premasked
FAILED test_count_equals_total_tokens_minus_document_count
FAILED test_completion_only_masking_is_not_double_subtracted
FAILED test_lengths_overrunning_the_batch_do_not_kill_live_targets
FAILED test_a_document_starting_at_a_row_boundary_is_not_dropped_twice
FAILED test_multi_row_boundaries_map_row_major
FAILED test_applying_the_boundary_removal_twice_is_idempotent
FAILED test_a_plain_list_of_lengths_does_not_kill_the_run
FAILED test_unusable_metadata_degrades_instead_of_raising
FAILED test_the_real_installed_trl_collator_is_counted_correctly
10 failed, 16 passed, 1 skipped

### HUNK A REVERTED (_normalize_packed_seq_lengths removed, raw metadata)
FAILED test_normalize_accepts_every_shape_a_collator_can_emit
FAILED test_normalize_treats_unusable_metadata_as_absent
FAILED test_normalize_drops_nonpositive_and_short_circuits_one_document
FAILED test_a_plain_list_of_lengths_does_not_kill_the_run
FAILED test_unusable_metadata_degrades_instead_of_raising
FAILED test_the_counting_path_never_branches_on_the_trl_version
6 failed, 20 passed, 1 skipped

### HUNK B MUTATED: cumsum without [:-1] (targets the trailing boundary)
FAILED test_metadata_shorter_than_the_batch_never_targets_the_trailing_boundary
1 failed, 25 passed, 1 skipped

### HUNK B MUTATED: cols > 0 filter dropped (row starts eaten twice)
FAILED test_a_document_starting_at_a_row_boundary_is_not_dropped_twice
FAILED test_multi_row_boundaries_map_row_major
2 failed, 24 passed, 1 skipped

### HUNK B MUTATED: rows < n_rows filter dropped (metadata overrun)
FAILED test_lengths_overrunning_the_batch_do_not_kill_live_targets
1 failed, 25 passed, 1 skipped
```

Three tests do not move under any of those mutations, and that is on purpose rather than an oversight: `test_single_document_batch_is_untouched`, `test_zero_length_entries_are_ignored` and `test_batch_without_packed_seq_lengths_is_unchanged` pin the paths that were already correct and must stay bit-identical.

## The CI gap, which mattered as much as the arithmetic

`tests/test_loss_normalization_contract.py` was in **no** workflow. `consolidated-tests-ci.yml` names files explicitly in the CPU hard-gate list, and `pytest tests/ --collect-only` (which is also `continue-on-error`) proves only that a file imports. That is exactly how this shipped. The file now runs in the `repo-tests-cpu` "behavioral gates (HARD GATE)" step, which is not `continue-on-error`, and `.[core]` resolves `trl<=0.24.0` there, so CI exercises the regressed regime on every pull request. (The masking first shipped in the 0.23.1 patch, from huggingface/trl#4170 merged 2025-09-30, not in 0.24.0.)

Full local replay of every suite that workflow names, with `CUDA_VISIBLE_DEVICES=""` since CI is CPU-only:

```
tests/security (HARD GATE)                          15 passed
behavioral gates (HARD GATE)                      1045 passed, 3 skipped
MLX adapter-filter gate (HARD GATE)                 44 passed
mlx_module_exports + zoo-specific CPU tests        118 passed
upstream-regression suite                          785 passed, 55 skipped
```

## GPU evidence

Qwen3-0.6B, LoRA r=8, bf16, one GPU, a deterministic synthetic pre-tokenized corpus, 20 steps. `learning_rate = 0` freezes the parameters, so both arms replay the same batches against the same weights and the per-step loss ratio is a deterministic prediction rather than a trend. The zoo build is selected by `PYTHONPATH` and every result JSON records `unsloth_zoo.__file__`, the sha256 of `loss_utils.py` and whether the fix is present, because the venv install is not editable and a run that silently resolves to site-packages measures neither arm.

torch 2.9.1+cu128, transformers 4.57.6, trl 0.25.1.

**Arm 1, packing on**, `max_length = 256`, documents of 8 tokens, so N = 32 per row:

| | num_items_in_batch | step-1 loss | loss ratio (before / after) |
|---|---|---|---|
| before | 193 (49 on short rows) | 13.894458770751953 | |
| after | 224 (56 on short rows) | 11.971564292907715 | |
| predicted | 224 / 193 | | 1.160622 |
| measured | | | 1.160622 on all 18 full rows, 1.142857 (= 56/49) on the 2 short rows |

The after-arm was run twice: the two runs are bitwise identical on all 20 steps, so the noise floor is exactly zero.

**Arm 2, padding-free without packing**, B=16, rows of 16 tokens (deliberately short: at B=2, L=1024 the ratio is 1.0005 and would prove nothing):

| | num_items_in_batch | step-1 loss | loss ratio |
|---|---|---|---|
| before | 225 | 12.892023086547852 | |
| after | 240 | 12.086272239685059 | |
| predicted | 240 / 225 | | 1.066667 |
| measured | | | 1.066667 on every one of the 20 steps |

**Arm 4, isolation**: packing off and padding-free off, so no `packed_seq_lengths` is attached. `num_items_in_batch` is integer-identical (240 on every step) and the losses are **bitwise** identical across all 20 steps before and after.

One extra result worth recording: after the fix, arm 2 (padding-free) is bitwise identical to arm 4 (padding-free off) on all 20 steps, which is the invariant you want, since the two paths see the same tokens. Before the fix they were not.

## Version pairing

- Old unsloth + new zoo is safe: no `packed_seq_lengths` is attached, so the branch never fires.
- New unsloth + **old** zoo is today's broken state and stays broken.

So the zoo version should be bumped and unsloth's `unsloth_zoo>=` floor raised in a paired release. A resumed run's loss curve will visibly step down at the version boundary; that belongs in the release notes.

## Risks

1. Everything rests on `packed_seq_lengths` truthfully describing the row. The fix now *indexes* with those lengths rather than subtracting a scalar, so bad metadata mis-targets slots. The `cols > 0` and `rows < n_rows` filters and the `[:-1]` choice bound the damage, and both are pinned by tests, but this is the top residual risk.
2. The multi-row mapping assumes documents tile contiguously with no per-row padding. No in-repo producer emits that shape, and today's code is also wrong there, so it is a strict improvement, but it is an interpretation pinned by one test.
3. `token_count.ndim` outside `(1, 2)` now takes no boundary adjustment at all, where the old code still subtracted `N-1`. No producer emits that shape, and a scalar subtraction against an unknown layout was not defensible.
4. Multi-GPU runs with `average_tokens_across_devices` will see loss curves shift by the ratio above. More correct, not less, but user-visible.

