### PR TITLE
Detect the logit transforms the device map planner sizes for

### DIFF
--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -30,6 +30,7 @@ import torch.nn as nn
 
 from unsloth_zoo.device_map_planner import (
     DeviceMapInfeasible,
+    detect_logit_transforms,
     _auto_class_for,
     _compute_module_sizes,
     _from_config_remote_aware,
@@ -1570,3 +1571,140 @@ def test_a_small_card_is_not_charged_the_pinned_head_it_never_holds():
     assert kept == {0: 200, 1: 600}, kept
     free = {d: plan.raw_budgets[d] - plan.weight_bytes.get(d, 0) for d in (0, 1)}
     assert free[0] >= kept[0], f"cuda:0 was packed below its own reserve: {free}"
+
+
+# --------------------------------------------------------------------------- #
+# logit transform detection
+# --------------------------------------------------------------------------- #
+class _Cfg:
+    """A model config stands in as a plain attribute holder."""
+
+    def __init__(self, **fields):
+        self.__dict__.update(fields)
+
+
+class _MethodOnlyTextConfig:
+    """A config whose text settings are only reachable through a method.
+
+    T5Gemma is shaped like this: no `text_config` attribute, so anything that
+    only reads the top level and `.text_config` sees no soft cap at all.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    def get_text_config(self):
+        return self._inner
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        # Gemma 2/3/3n, T5Gemma, VaultGemma.
+        (_Cfg(final_logit_softcapping = 30.0), (30.0, 0.0, 0.0)),
+        # RecurrentGemma spells the same knob differently.
+        (_Cfg(logits_soft_cap = 30.0), (30.0, 0.0, 0.0)),
+        # Cohere and Cohere 2 multiply; the default is not 1.
+        (_Cfg(logit_scale = 0.0625), (0.0, 0.0625, 0.0)),
+        # Granite and its MoE variants divide.
+        (_Cfg(logits_scaling = 16.0), (0.0, 0.0, 16.0)),
+        # Llama and friends transform nothing.
+        (_Cfg(), (0.0, 0.0, 0.0)),
+    ],
+)
+def test_detects_the_transform_each_family_applies(config, expected):
+    found = detect_logit_transforms(config)
+    assert (
+        found["logit_softcapping"],
+        found["logit_scale_multiply"],
+        found["logit_scale_divide"],
+    ) == expected
+
+
+def test_reads_a_nested_text_config():
+    """Gemma 3 puts the soft cap on the text sub-config, not the top level."""
+    config = _Cfg(text_config = _Cfg(final_logit_softcapping = 20.0))
+    assert detect_logit_transforms(config)["logit_softcapping"] == 20.0
+
+
+def test_reads_a_text_config_only_reachable_by_method():
+    """The T5Gemma shape. Reading `.text_config` alone reports no soft cap and
+    under-reserves the head's card by the tanh temporary plus the retained
+    term, which is the larger of the two."""
+    config = _MethodOnlyTextConfig(_Cfg(final_logit_softcapping = 30.0))
+    assert detect_logit_transforms(config)["logit_softcapping"] == 30.0
+
+
+def test_a_contrastive_logit_scale_is_not_an_output_head_transform():
+    """CLIP-family models carry a `logit_scale`, but it scales image-text
+    similarity, not an output head. Its config spells it `logit_scale_init_value`,
+    and reserving for it would be reserving for a tensor nobody allocates."""
+    from transformers.models.clip import CLIPConfig
+
+    found = detect_logit_transforms(CLIPConfig())
+    assert found == {
+        "logit_softcapping": 0.0,
+        "logit_scale_multiply": 0.0,
+        "logit_scale_divide": 0.0,
+    }
+
+
+def test_detection_never_raises():
+    """An unreadable or remote-code config reports nothing, which leaves the
+    caller on the behaviour it had before detection existed."""
+    class _Hostile:
+        def __getattr__(self, name):
+            raise ValueError(name)
+
+    for config in (None, object(), _Hostile(), _MethodOnlyTextConfig(None)):
+        assert detect_logit_transforms(config) == {
+            "logit_softcapping": 0.0,
+            "logit_scale_multiply": 0.0,
+            "logit_scale_divide": 0.0,
+        }
+
+
+def test_the_planner_sizes_a_detected_soft_cap_without_being_told():
+    """The point of the detection: the same model plans the same either way."""
+    model = _meta(vocab = 512)
+    model.config = _Cfg(final_logit_softcapping = 30.0)
+    auto = plan_device_map(model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB})
+    told = plan_device_map(
+        model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB}, softcapped = True,
+    )
+    assert auto is not None and told is not None
+    assert auto.headroom_bytes == told.headroom_bytes
+
+
+def test_the_planner_sizes_a_detected_logit_scale_without_being_told():
+    model = _meta(vocab = 512)
+    model.config = _Cfg(logits_scaling = 16.0)
+    auto = plan_device_map(model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB})
+    told = plan_device_map(
+        model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB}, logit_scaled = True,
+    )
+    assert auto is not None and told is not None
+    assert auto.headroom_bytes == told.headroom_bytes
+    # And it really is bigger than the un-scaled reserve, or the flag is inert.
+    plain = plan_device_map(
+        model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB}, logit_scaled = False,
+    )
+    assert auto.headroom_bytes > plain.headroom_bytes
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_an_explicit_flag_still_wins_over_detection(flag):
+    """Backwards compatible: only `None` asks for detection."""
+    model = _meta(vocab = 512)
+    model.config = _Cfg(final_logit_softcapping = 30.0, logits_scaling = 16.0)
+    told = plan_device_map(
+        model,
+        max_memory = {0: 8 * _GiB, 1: 8 * _GiB},
+        softcapped = flag,
+        logit_scaled = flag,
+    )
+    expected = logit_headroom_bytes(
+        512, 128, logit_dtype = model.lm_head.weight.dtype,
+        softcapped = flag, logit_scaled = flag,
+    )
+    assert told.headroom_bytes == expected

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1710,3 +1710,61 @@ def test_an_explicit_flag_still_wins_over_detection(flag):
         softcapped = flag, logit_scaled = flag,
     )
     assert told.headroom_bytes == expected
+
+
+@pytest.mark.parametrize(
+    "error", [RuntimeError, KeyError, OSError, ImportError, RecursionError],
+)
+def test_a_config_that_raises_anything_does_not_abort_planning(error):
+    """`getattr`'s default only swallows `AttributeError`, so a remote-code
+    config raising anything else used to escape detection and take the whole
+    plan down with it, even for a caller that asked for no detection at all."""
+    class _Attribute:
+        def __getattr__(self, name):
+            raise error(name)
+
+    class _Property:
+        @property
+        def text_config(self):
+            raise error("text_config")
+
+    class _Method:
+        text_config = None
+        def get_text_config(self):
+            raise error("get_text_config")
+
+    for config in (_Attribute(), _Property(), _Method()):
+        assert detect_logit_transforms(config) == {
+            "logit_softcapping": 0.0,
+            "logit_scale_multiply": 0.0,
+            "logit_scale_divide": 0.0,
+        }
+
+    model = _meta(vocab = 512)
+    model.config = _Property()
+    plan = plan_device_map(model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB})
+    assert plan is not None
+
+
+def test_an_interrupt_is_not_swallowed():
+    """Detection absorbs config errors, not the user's Ctrl-C."""
+    class _Interrupting:
+        def __getattr__(self, name):
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        detect_logit_transforms(_Interrupting())
+
+
+def test_one_unreadable_field_does_not_discard_the_readable_ones():
+    """A field that is present but not a number is skipped on its own. Zeroing
+    the whole result would drop a soft cap the old flag-free path did detect."""
+    config = _Cfg(final_logit_softcapping = 30.0, logit_scale = ["not a number"])
+    found = detect_logit_transforms(config)
+    assert found["logit_softcapping"] == 30.0
+    assert found["logit_scale_multiply"] == 0.0
+
+
+def test_a_non_numeric_alias_falls_through_to_the_next_one():
+    config = _Cfg(final_logit_softcapping = object(), logits_soft_cap = 20.0)
+    assert detect_logit_transforms(config)["logit_softcapping"] == 20.0

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1907,6 +1907,19 @@ def test_logits_scaling_multiplies_for_hyperclovax_and_divides_for_granite():
     assert detect_logit_transforms(clova)["logit_scale_divide"] == 0.0
 
 
+@pytest.mark.parametrize("tied", [True, False])
+def test_falcon_h1_multiplies_whether_or_not_the_head_is_tied(tied):
+    """`FalconH1ForCausalLM.forward` has one head line and it is unconditional:
+    `logits = self.lm_head(...) * self.model.lm_head_multiplier`. No
+    `tie_word_embeddings` branch exists in the file, and the config defaults the
+    flag to False, so gating on tied would drop the reserve for the common case.
+    (The tied gate in `mlx/utils.py` is the MLX fused-CCE path, a different
+    runtime and a different contract.)"""
+    config = _Cfg(model_type = "falcon_h1", lm_head_multiplier = 4.0,
+                  tie_word_embeddings = tied)
+    assert detect_logit_transforms(config)["logit_scale_multiply"] == 4.0
+
+
 def test_minicpm3_logits_scaling_is_not_a_logit_transform():
     """MiniCPM3 exposes `logits_scaling` as a property that divides the HIDDEN
     STATES before the head (`hidden_states = hidden_states / ...`), so no logits

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1608,6 +1608,8 @@ class _MethodOnlyTextConfig:
         (_Cfg(logit_scale = 0.0625), (0.0, 0.0625, 0.0)),
         # Granite and its MoE variants divide.
         (_Cfg(logits_scaling = 16.0), (0.0, 0.0, 16.0)),
+        # Falcon-H1 multiplies, on the lm_head call line rather than after it.
+        (_Cfg(lm_head_multiplier = 4.0), (0.0, 4.0, 0.0)),
         # Llama and friends transform nothing.
         (_Cfg(), (0.0, 0.0, 0.0)),
     ],

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1770,6 +1770,37 @@ def test_a_non_numeric_alias_falls_through_to_the_next_one():
     assert detect_logit_transforms(config)["logit_softcapping"] == 20.0
 
 
+@pytest.mark.parametrize(
+    "junk",
+    [
+        ["not a number"],                    # TypeError
+        "twenty",                            # ValueError
+        10 ** 400,                           # OverflowError, not a ValueError
+        torch.tensor([1.0, 2.0]),            # ValueError from torch
+    ],
+)
+def test_no_conversion_error_discards_the_fields_already_read(junk):
+    config = _Cfg(final_logit_softcapping = 30.0, logit_scale = junk)
+    found = detect_logit_transforms(config)
+    assert found["logit_softcapping"] == 30.0
+    assert found["logit_scale_multiply"] == 0.0
+
+
+@pytest.mark.parametrize("value", [0.0, 0, -0.0, False])
+def test_a_zero_scale_reserves_nothing(value):
+    """The headroom sizes the chunked loss, and that loss guards every transform
+    on `!= 0.0` (`rl_replacements.py`, `if logit_scale_multiply != 0.0`). At zero
+    it allocates no scaled copy, so reserving one would reserve for nothing. The
+    `bool` cast is what keeps the two in step."""
+    model = _meta(vocab = 512)
+    model.config = _Cfg(logit_scale = value)
+    auto = plan_device_map(model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB})
+    off = plan_device_map(
+        model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB}, logit_scaled = False,
+    )
+    assert auto.headroom_bytes == off.headroom_bytes
+
+
 def test_the_xlstm_spelling_of_the_soft_cap():
     """xLSTM calls it `output_logit_soft_cap`, defaults it to 30.0 and applies it
     unguarded (`modeling_xlstm.py`, `logits = soft_cap(logits, ...)`), so

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1881,6 +1881,44 @@ def test_a_wrapped_model_still_reports_its_transforms(wrapper):
     assert detect_logit_transforms(outer)["logit_softcapping"] == 30.0
 
 
+def test_the_muse_glimmer_multiplier():
+    """Muse Glimmer pre-scales by `output_multiplier` and then soft caps, so it
+    owes BOTH buffers; only the cap was detected. The composite applies it in its
+    own forward (`logits = logits * self.config.text_config.output_multiplier`),
+    and the name appears in no other config, so matching it risks nothing."""
+    config = _Cfg(text_config = _Cfg(output_multiplier = 0.19611613513818404,
+                                     final_logit_softcapping = 20.0))
+    found = detect_logit_transforms(config)
+    assert found["logit_scale_multiply"] == 0.19611613513818404
+    assert found["logit_softcapping"] == 20.0
+
+
+def test_logits_scaling_multiplies_for_hyperclovax_and_divides_for_granite():
+    """The same spelling, opposite operations. transformers says so on the line:
+    "MuP: multiply logits by logits_scaling (cf. GraniteForCausalLM which
+    divides)". Bucketing HyperCLOVA X as a divide reports the wrong magnitude to
+    anything that applies the transform rather than just sizing it."""
+    granite = _Cfg(model_type = "granite", logits_scaling = 8.0)
+    assert detect_logit_transforms(granite)["logit_scale_divide"] == 8.0
+    assert detect_logit_transforms(granite)["logit_scale_multiply"] == 0.0
+
+    clova = _Cfg(model_type = "hyperclovax", logits_scaling = 8.0)
+    assert detect_logit_transforms(clova)["logit_scale_multiply"] == 8.0
+    assert detect_logit_transforms(clova)["logit_scale_divide"] == 0.0
+
+
+def test_minicpm3_logits_scaling_is_not_a_logit_transform():
+    """MiniCPM3 exposes `logits_scaling` as a property that divides the HIDDEN
+    STATES before the head (`hidden_states = hidden_states / ...`), so no logits
+    temporary exists and reserving one reserves for nothing."""
+    config = _Cfg(model_type = "minicpm3", logits_scaling = 10.0)
+    assert detect_logit_transforms(config) == {
+        "logit_softcapping": 0.0,
+        "logit_scale_multiply": 0.0,
+        "logit_scale_divide": 0.0,
+    }
+
+
 def test_a_config_that_hands_back_itself_terminates():
     class _Circular:
         final_logit_softcapping = 20.0

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1768,3 +1768,55 @@ def test_one_unreadable_field_does_not_discard_the_readable_ones():
 def test_a_non_numeric_alias_falls_through_to_the_next_one():
     config = _Cfg(final_logit_softcapping = object(), logits_soft_cap = 20.0)
     assert detect_logit_transforms(config)["logit_softcapping"] == 20.0
+
+
+def test_the_xlstm_spelling_of_the_soft_cap():
+    """xLSTM calls it `output_logit_soft_cap`, defaults it to 30.0 and applies it
+    unguarded (`modeling_xlstm.py`, `logits = soft_cap(logits, ...)`), so
+    NX-AI/xLSTM-7b was under-reserved by a whole logits temporary. The name is
+    unique to xLSTM across transformers, so matching it costs no false positive."""
+    assert detect_logit_transforms(
+        _Cfg(output_logit_soft_cap = 30.0))["logit_softcapping"] == 30.0
+
+
+def test_reads_a_decoder_sub_config():
+    """T5Gemma keeps the cap on `config.decoder`, and on transformers 4.56.x its
+    `get_text_config` is overridden to return `self`, so neither `.text_config`
+    nor the method reaches it. `decoder` is one of the names `get_text_config`
+    searches itself, so following it directly covers both spellings."""
+    class _SelfReturning:
+        def __init__(self, decoder):
+            self.decoder = decoder
+        def get_text_config(self, *args, **kwargs):
+            return self
+
+    config = _SelfReturning(_Cfg(final_logit_softcapping = 30.0))
+    assert detect_logit_transforms(config)["logit_softcapping"] == 30.0
+
+
+def test_a_decoder_that_transforms_nothing_stays_inert():
+    """Following `decoder` must not invent a transform for the encoder-decoder
+    models that simply have one."""
+    config = _Cfg(decoder = _Cfg(vocab_size = 32000), text_encoder = _Cfg())
+    assert detect_logit_transforms(config) == {
+        "logit_softcapping": 0.0,
+        "logit_scale_multiply": 0.0,
+        "logit_scale_divide": 0.0,
+    }
+
+
+def test_a_sub_config_left_as_a_dict_is_still_read():
+    """A composite whose class declares no sub-config type keeps whatever the
+    checkpoint's JSON held, and `getattr` on a dict never sees the keys."""
+    config = _Cfg(text_config = {"final_logit_softcapping": 30.0})
+    assert detect_logit_transforms(config)["logit_softcapping"] == 30.0
+
+
+def test_a_config_that_hands_back_itself_terminates():
+    class _Circular:
+        final_logit_softcapping = 20.0
+        @property
+        def text_config(self):
+            return self
+
+    assert detect_logit_transforms(_Circular())["logit_softcapping"] == 20.0

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1584,11 +1584,8 @@ class _Cfg:
 
 
 class _MethodOnlyTextConfig:
-    """A config whose text settings are only reachable through a method.
-
-    T5Gemma is shaped like this: no `text_config` attribute, so anything that
-    only reads the top level and `.text_config` sees no soft cap at all.
-    """
+    """The T5Gemma shape: no `text_config` attribute, so a reader that only
+    checks the top level and `.text_config` sees no soft cap at all."""
 
     def __init__(self, inner):
         self._inner = inner
@@ -1604,11 +1601,11 @@ class _MethodOnlyTextConfig:
         (_Cfg(final_logit_softcapping = 30.0), (30.0, 0.0, 0.0)),
         # RecurrentGemma spells the same knob differently.
         (_Cfg(logits_soft_cap = 30.0), (30.0, 0.0, 0.0)),
-        # Cohere and Cohere 2 multiply; the default is not 1.
+        # Cohere and Cohere 2 multiply.
         (_Cfg(logit_scale = 0.0625), (0.0, 0.0625, 0.0)),
         # Granite and its MoE variants divide.
         (_Cfg(logits_scaling = 16.0), (0.0, 0.0, 16.0)),
-        # Falcon-H1 multiplies, on the lm_head call line rather than after it.
+        # Falcon-H1 multiplies, on the lm_head call line itself.
         (_Cfg(lm_head_multiplier = 4.0), (0.0, 4.0, 0.0)),
         # Llama and friends transform nothing.
         (_Cfg(), (0.0, 0.0, 0.0)),
@@ -1630,17 +1627,15 @@ def test_reads_a_nested_text_config():
 
 
 def test_reads_a_text_config_only_reachable_by_method():
-    """The T5Gemma shape. Reading `.text_config` alone reports no soft cap and
-    under-reserves the head's card by the tanh temporary plus the retained
-    term, which is the larger of the two."""
+    """Reading `.text_config` alone reports no soft cap, under-reserving the
+    head's card by the tanh temporary plus the retained term."""
     config = _MethodOnlyTextConfig(_Cfg(final_logit_softcapping = 30.0))
     assert detect_logit_transforms(config)["logit_softcapping"] == 30.0
 
 
 def test_a_contrastive_logit_scale_is_not_an_output_head_transform():
-    """CLIP-family models carry a `logit_scale`, but it scales image-text
-    similarity, not an output head. Its config spells it `logit_scale_init_value`,
-    and reserving for it would be reserving for a tensor nobody allocates."""
+    """CLIP carries a `logit_scale` (spelled `logit_scale_init_value` in its
+    config), but it scales image-text similarity, not an output head."""
     from transformers.models.clip import CLIPConfig
 
     found = detect_logit_transforms(CLIPConfig())
@@ -1652,8 +1647,8 @@ def test_a_contrastive_logit_scale_is_not_an_output_head_transform():
 
 
 def test_detection_never_raises():
-    """An unreadable or remote-code config reports nothing, which leaves the
-    caller on the behaviour it had before detection existed."""
+    """An unreadable config reports nothing, leaving the caller on the
+    behaviour it had before detection existed."""
     class _Hostile:
         def __getattr__(self, name):
             raise ValueError(name)
@@ -1687,7 +1682,7 @@ def test_the_planner_sizes_a_detected_logit_scale_without_being_told():
     )
     assert auto is not None and told is not None
     assert auto.headroom_bytes == told.headroom_bytes
-    # And it really is bigger than the un-scaled reserve, or the flag is inert.
+    # And bigger than the un-scaled reserve, or the flag is inert.
     plain = plan_device_map(
         model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB}, logit_scaled = False,
     )
@@ -1717,8 +1712,7 @@ def test_an_explicit_flag_still_wins_over_detection(flag):
 )
 def test_a_config_that_raises_anything_does_not_abort_planning(error):
     """`getattr`'s default only swallows `AttributeError`, so a remote-code
-    config raising anything else used to escape detection and take the whole
-    plan down with it, even for a caller that asked for no detection at all."""
+    config raising anything else used to take the whole plan down with it."""
     class _Attribute:
         def __getattr__(self, name):
             raise error(name)
@@ -1757,8 +1751,8 @@ def test_an_interrupt_is_not_swallowed():
 
 
 def test_one_unreadable_field_does_not_discard_the_readable_ones():
-    """A field that is present but not a number is skipped on its own. Zeroing
-    the whole result would drop a soft cap the old flag-free path did detect."""
+    """A non-numeric field is skipped on its own; zeroing the whole result
+    would drop a soft cap the old flag-free path did detect."""
     config = _Cfg(final_logit_softcapping = 30.0, logit_scale = ["not a number"])
     found = detect_logit_transforms(config)
     assert found["logit_softcapping"] == 30.0
@@ -1788,10 +1782,9 @@ def test_no_conversion_error_discards_the_fields_already_read(junk):
 
 @pytest.mark.parametrize("value", [0.0, 0, -0.0, False])
 def test_a_zero_scale_reserves_nothing(value):
-    """The headroom sizes the chunked loss, and that loss guards every transform
-    on `!= 0.0` (`rl_replacements.py`, `if logit_scale_multiply != 0.0`). At zero
-    it allocates no scaled copy, so reserving one would reserve for nothing. The
-    `bool` cast is what keeps the two in step."""
+    """The chunked loss guards every transform on `!= 0.0`
+    (`rl_replacements.py`, `if logit_scale_multiply != 0.0`), so at zero it
+    allocates no scaled copy. The `bool` cast keeps the two in step."""
     model = _meta(vocab = 512)
     model.config = _Cfg(logit_scale = value)
     auto = plan_device_map(model, max_memory = {0: 8 * _GiB, 1: 8 * _GiB})
@@ -1802,19 +1795,17 @@ def test_a_zero_scale_reserves_nothing(value):
 
 
 def test_the_xlstm_spelling_of_the_soft_cap():
-    """xLSTM calls it `output_logit_soft_cap`, defaults it to 30.0 and applies it
-    unguarded (`modeling_xlstm.py`, `logits = soft_cap(logits, ...)`), so
-    NX-AI/xLSTM-7b was under-reserved by a whole logits temporary. The name is
-    unique to xLSTM across transformers, so matching it costs no false positive."""
+    """xLSTM calls it `output_logit_soft_cap`, defaults it to 30.0 and applies
+    it unguarded (`modeling_xlstm.py`, `logits = soft_cap(logits, ...)`), so
+    NX-AI/xLSTM-7b was under-reserved. The name is unique to xLSTM."""
     assert detect_logit_transforms(
         _Cfg(output_logit_soft_cap = 30.0))["logit_softcapping"] == 30.0
 
 
 def test_reads_a_decoder_sub_config():
-    """T5Gemma keeps the cap on `config.decoder`, and on transformers 4.56.x its
-    `get_text_config` is overridden to return `self`, so neither `.text_config`
-    nor the method reaches it. `decoder` is one of the names `get_text_config`
-    searches itself, so following it directly covers both spellings."""
+    """T5Gemma keeps the cap on `config.decoder`, and on transformers 4.56.x
+    overrides `get_text_config` to return `self`, so neither `.text_config` nor
+    the method reaches it. Following `decoder` directly does."""
     class _SelfReturning:
         def __init__(self, decoder):
             self.decoder = decoder
@@ -1826,7 +1817,7 @@ def test_reads_a_decoder_sub_config():
 
 
 def test_a_decoder_that_transforms_nothing_stays_inert():
-    """Following `decoder` must not invent a transform for the encoder-decoder
+    """Following `decoder` must not invent a transform for encoder-decoder
     models that simply have one."""
     config = _Cfg(decoder = _Cfg(vocab_size = 32000), text_encoder = _Cfg())
     assert detect_logit_transforms(config) == {
@@ -1837,19 +1828,18 @@ def test_a_decoder_that_transforms_nothing_stays_inert():
 
 
 def test_a_sub_config_left_as_a_dict_is_still_read():
-    """A composite whose class declares no sub-config type keeps whatever the
-    checkpoint's JSON held, and `getattr` on a dict never sees the keys."""
+    """A composite declaring no sub-config type keeps the checkpoint's raw
+    JSON, and `getattr` on a dict never sees the keys."""
     config = _Cfg(text_config = {"final_logit_softcapping": 30.0})
     assert detect_logit_transforms(config)["logit_softcapping"] == 30.0
 
 
 @pytest.mark.parametrize("model_type", ["aya_vision", "cohere2_vision"])
 def test_a_wrapper_that_re_heads_its_text_tower_claims_no_transform(model_type):
-    """Aya Vision and Cohere 2 Vision build a bare `AutoModel` text tower and put
-    their own `nn.Linear` lm_head on top, so `logits = self.lm_head(...)` with no
-    scale; `logit_scale` does not appear in either modeling file. The Cohere 2
-    config they carry still declares it, and crediting it reserves a temporary
-    nobody allocates."""
+    """Aya Vision and Cohere 2 Vision put their own `nn.Linear` lm_head on a
+    bare `AutoModel` tower, so `logits = self.lm_head(...)` with no scale;
+    `logit_scale` does not appear in either modeling file. The Cohere 2 config
+    they carry still declares it, so crediting it reserves nothing real."""
     from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
     config = CONFIG_MAPPING[model_type]()
@@ -1860,8 +1850,7 @@ def test_a_wrapper_that_re_heads_its_text_tower_claims_no_transform(model_type):
 def test_a_wrapper_that_reuses_the_causal_lm_head_keeps_its_transform():
     """The other half of the rule. Granite Speech builds an
     `AutoModelForCausalLM`, so the divide happens inside the text model and the
-    reserve is still owed, even though `logits_scaling` never appears in Granite
-    Speech's own file."""
+    reserve is still owed, though `logits_scaling` is absent from its own file."""
     from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
     config = CONFIG_MAPPING["granite_speech"]()
@@ -1871,9 +1860,9 @@ def test_a_wrapper_that_reuses_the_causal_lm_head_keeps_its_transform():
 
 @pytest.mark.parametrize("wrapper", ["module", "_orig_mod"])
 def test_a_wrapped_model_still_reports_its_transforms(wrapper):
-    """`nn.Module.__getattr__` resolves submodules and parameters, not plain
-    attributes, so DistributedDataParallel and torch.compile wrappers have no
-    `.config` and the model inside would read as transform-free."""
+    """`nn.Module.__getattr__` resolves submodules, not plain attributes, so
+    DDP and torch.compile wrappers have no `.config` and the model inside would
+    read as transform-free."""
     inner = nn.Module()
     inner.config = _Cfg(final_logit_softcapping = 30.0)
     outer = nn.Module()
@@ -1883,9 +1872,9 @@ def test_a_wrapped_model_still_reports_its_transforms(wrapper):
 
 def test_the_muse_glimmer_multiplier():
     """Muse Glimmer pre-scales by `output_multiplier` and then soft caps, so it
-    owes BOTH buffers; only the cap was detected. The composite applies it in its
-    own forward (`logits = logits * self.config.text_config.output_multiplier`),
-    and the name appears in no other config, so matching it risks nothing."""
+    owes BOTH buffers; only the cap was detected. Applied in the composite's own
+    forward (`logits = logits * self.config.text_config.output_multiplier`), and
+    the name appears in no other config."""
     config = _Cfg(text_config = _Cfg(output_multiplier = 0.19611613513818404,
                                      final_logit_softcapping = 20.0))
     found = detect_logit_transforms(config)
@@ -1894,10 +1883,10 @@ def test_the_muse_glimmer_multiplier():
 
 
 def test_logits_scaling_multiplies_for_hyperclovax_and_divides_for_granite():
-    """The same spelling, opposite operations. transformers says so on the line:
+    """Same spelling, opposite operations, as transformers says on the line:
     "MuP: multiply logits by logits_scaling (cf. GraniteForCausalLM which
-    divides)". Bucketing HyperCLOVA X as a divide reports the wrong magnitude to
-    anything that applies the transform rather than just sizing it."""
+    divides)". Bucketing HyperCLOVA X as a divide reports the wrong magnitude
+    to anything that applies the transform rather than just sizing it."""
     granite = _Cfg(model_type = "granite", logits_scaling = 8.0)
     assert detect_logit_transforms(granite)["logit_scale_divide"] == 8.0
     assert detect_logit_transforms(granite)["logit_scale_multiply"] == 0.0
@@ -1910,11 +1899,11 @@ def test_logits_scaling_multiplies_for_hyperclovax_and_divides_for_granite():
 @pytest.mark.parametrize("tied", [True, False])
 def test_falcon_h1_multiplies_whether_or_not_the_head_is_tied(tied):
     """`FalconH1ForCausalLM.forward` has one head line and it is unconditional:
-    `logits = self.lm_head(...) * self.model.lm_head_multiplier`. No
-    `tie_word_embeddings` branch exists in the file, and the config defaults the
-    flag to False, so gating on tied would drop the reserve for the common case.
-    (The tied gate in `mlx/utils.py` is the MLX fused-CCE path, a different
-    runtime and a different contract.)"""
+    `logits = self.lm_head(...) * self.model.lm_head_multiplier`. There is no
+    `tie_word_embeddings` branch in the file and the config defaults the flag to
+    False, so gating on tied would drop the reserve for the common case. (The
+    tied gate in `mlx/utils.py` is the MLX fused-CCE path, a different
+    contract.)"""
     config = _Cfg(model_type = "falcon_h1", lm_head_multiplier = 4.0,
                   tie_word_embeddings = tied)
     assert detect_logit_transforms(config)["logit_scale_multiply"] == 4.0
@@ -1923,7 +1912,7 @@ def test_falcon_h1_multiplies_whether_or_not_the_head_is_tied(tied):
 def test_minicpm3_logits_scaling_is_not_a_logit_transform():
     """MiniCPM3 exposes `logits_scaling` as a property that divides the HIDDEN
     STATES before the head (`hidden_states = hidden_states / ...`), so no logits
-    temporary exists and reserving one reserves for nothing."""
+    temporary exists to reserve."""
     config = _Cfg(model_type = "minicpm3", logits_scaling = 10.0)
     assert detect_logit_transforms(config) == {
         "logit_softcapping": 0.0,

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -1812,6 +1812,44 @@ def test_a_sub_config_left_as_a_dict_is_still_read():
     assert detect_logit_transforms(config)["logit_softcapping"] == 30.0
 
 
+@pytest.mark.parametrize("model_type", ["aya_vision", "cohere2_vision"])
+def test_a_wrapper_that_re_heads_its_text_tower_claims_no_transform(model_type):
+    """Aya Vision and Cohere 2 Vision build a bare `AutoModel` text tower and put
+    their own `nn.Linear` lm_head on top, so `logits = self.lm_head(...)` with no
+    scale; `logit_scale` does not appear in either modeling file. The Cohere 2
+    config they carry still declares it, and crediting it reserves a temporary
+    nobody allocates."""
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    config = CONFIG_MAPPING[model_type]()
+    assert getattr(config.text_config, "logit_scale", None)   # the trap is real
+    assert detect_logit_transforms(config)["logit_scale_multiply"] == 0.0
+
+
+def test_a_wrapper_that_reuses_the_causal_lm_head_keeps_its_transform():
+    """The other half of the rule. Granite Speech builds an
+    `AutoModelForCausalLM`, so the divide happens inside the text model and the
+    reserve is still owed, even though `logits_scaling` never appears in Granite
+    Speech's own file."""
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    config = CONFIG_MAPPING["granite_speech"]()
+    assert detect_logit_transforms(config)["logit_scale_divide"] == \
+        config.text_config.logits_scaling
+
+
+@pytest.mark.parametrize("wrapper", ["module", "_orig_mod"])
+def test_a_wrapped_model_still_reports_its_transforms(wrapper):
+    """`nn.Module.__getattr__` resolves submodules and parameters, not plain
+    attributes, so DistributedDataParallel and torch.compile wrappers have no
+    `.config` and the model inside would read as transform-free."""
+    inner = nn.Module()
+    inner.config = _Cfg(final_logit_softcapping = 30.0)
+    outer = nn.Module()
+    setattr(outer, wrapper, inner)
+    assert detect_logit_transforms(outer)["logit_softcapping"] == 30.0
+
+
 def test_a_config_that_hands_back_itself_terminates():
     class _Circular:
         final_logit_softcapping = 20.0

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -224,6 +224,28 @@ def _model_config(model_or_config):
 # the soft cap in its own ``forward``; neither belongs here.
 _OWN_UNTRANSFORMED_HEAD = frozenset({"aya_vision", "cohere2_vision"})
 
+# Config field -> which magnitude it contributes, by default.
+_TRANSFORM_FIELDS = (
+    ("logit_softcapping",
+     ("final_logit_softcapping", "logits_soft_cap", "output_logit_soft_cap")),
+    ("logit_scale_multiply",
+     ("logit_scale", "lm_head_multiplier", "output_multiplier")),
+    ("logit_scale_divide", ("logits_scaling",)),
+)
+
+# ``logits_scaling`` is not one knob. Granite divides the logits by it, but
+# HyperCLOVA X multiplies, and transformers says so on the line itself: "MuP:
+# multiply logits by logits_scaling (cf. GraniteForCausalLM which divides)".
+# MiniCPM3 spells the same name as a property that scales the HIDDEN STATES
+# before the head (``hidden_states = hidden_states / self.config.logits_scaling``),
+# so it makes no logits temporary at all and maps to nothing. Keyed on the
+# ``model_type`` of the config the field was read from, so a composite wrapping
+# one of these towers is judged by the tower.
+_BUCKET_OVERRIDES = {
+    ("logits_scaling", "hyperclovax"): "logit_scale_multiply",
+    ("logits_scaling", "minicpm3"): None,
+}
+
 
 def _text_configs(config):
     """``config`` and every text sub-config it exposes, outermost first.
@@ -265,8 +287,11 @@ def detect_logit_transforms(model_or_config) -> dict:
       ``output_logit_soft_cap``.
     * ``logit_scale`` multiplies the logits (Cohere, Cohere 2).
     * ``lm_head_multiplier`` multiplies them too (Falcon-H1, which applies it on
-      the ``lm_head`` call itself rather than on a following line).
-    * ``logits_scaling`` divides them (Granite and its MoE variants).
+      the ``lm_head`` call itself rather than on a following line), as does
+      ``output_multiplier`` (Muse Glimmer, which then soft caps as well).
+    * ``logits_scaling`` divides them (Granite and its MoE variants), except in
+      HyperCLOVA X where it multiplies, and in MiniCPM3 where it scales the
+      hidden states before the head and so is not a logit transform at all.
 
     Both scale fields are applied unguarded in their ``forward``, so the buffer
     exists whatever the value. CLIP-style models also carry a ``logit_scale``,
@@ -295,21 +320,18 @@ def detect_logit_transforms(model_or_config) -> dict:
         for holder in _text_configs(config):
             if own_head and holder is not config:
                 continue
-            for key, names in (
-                ("logit_softcapping",
-                 ("final_logit_softcapping", "logits_soft_cap",
-                  "output_logit_soft_cap")),
-                ("logit_scale_multiply", ("logit_scale", "lm_head_multiplier")),
-                ("logit_scale_divide", ("logits_scaling",)),
-            ):
-                if found[key]:
-                    continue
+            model_type = _config_attr(holder, "model_type")
+            for key, names in _TRANSFORM_FIELDS:
                 for name in names:
+                    # Same spelling, different meaning in some families.
+                    bucket = _BUCKET_OVERRIDES.get((name, model_type), key)
+                    if bucket is None or found[bucket]:
+                        continue
                     value = _config_attr(holder, name)
                     if value is None:
                         continue
                     try:
-                        found[key] = float(value)
+                        found[bucket] = float(value)
                     except Exception:
                         # Anything at all: a huge int raises OverflowError, not
                         # ValueError, and falling through to the outer handler

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -164,6 +164,20 @@ class _SearchExhausted(Exception):
 # --------------------------------------------------------------------------- #
 # logit transform detection
 # --------------------------------------------------------------------------- #
+def _config_attr(holder, name, default = None):
+    """``getattr`` that a hostile config cannot break out of.
+
+    ``getattr``'s default only swallows ``AttributeError``. A remote-code config
+    is free to raise ``KeyError``, ``OSError`` or anything else from a property
+    or from ``__getattr__``, and that would escape a detection this module
+    documents as never raising.
+    """
+    try:
+        return getattr(holder, name, default)
+    except Exception:
+        return default
+
+
 def _text_configs(config):
     """``config`` and every text sub-config it exposes, innermost last.
 
@@ -172,13 +186,13 @@ def _text_configs(config):
     Reading just the top level misses both.
     """
     seen = [config]
-    text_config = getattr(config, "text_config", None)
+    text_config = _config_attr(config, "text_config")
     if text_config is None:
-        get_text_config = getattr(config, "get_text_config", None)
+        get_text_config = _config_attr(config, "get_text_config")
         if callable(get_text_config):
             try:
                 text_config = get_text_config()
-            except (TypeError, ValueError):
+            except Exception:
                 text_config = None
     if text_config is not None and text_config is not config:
         seen.append(text_config)
@@ -207,8 +221,11 @@ def detect_logit_transforms(model_or_config) -> dict:
     but it scales image-text similarity rather than an output head, and they are
     never what the planner is asked about.
 
-    Never raises: an unreadable or remote-code config reports no transforms,
-    which leaves the caller on the behaviour it had before this existed.
+    Never raises, short of ``KeyboardInterrupt`` and friends: an unreadable or
+    remote-code config reports the transforms it could read and zero for the
+    rest, which leaves the caller on the behaviour it had before this existed.
+    A field that is present but not a number is skipped on its own, without
+    discarding the fields that did read cleanly.
     """
     zero = {
         "logit_softcapping": 0.0,
@@ -216,7 +233,7 @@ def detect_logit_transforms(model_or_config) -> dict:
         "logit_scale_divide": 0.0,
     }
     try:
-        config = getattr(model_or_config, "config", model_or_config)
+        config = _config_attr(model_or_config, "config", model_or_config)
         if config is None:
             return zero
         found = dict(zero)
@@ -229,13 +246,16 @@ def detect_logit_transforms(model_or_config) -> dict:
                 if found[key]:
                     continue
                 for name in names:
-                    value = getattr(holder, name, None)
+                    value = _config_attr(holder, name)
                     if value is None:
                         continue
-                    found[key] = float(value)
+                    try:
+                        found[key] = float(value)
+                    except (TypeError, ValueError):
+                        continue
                     break
         return found
-    except (TypeError, ValueError, AttributeError):
+    except Exception:
         return zero
 
 
@@ -448,9 +468,9 @@ def resolve_head_width(model: nn.Module, head: nn.Module | None) -> int:
         weight = getattr(head, "weight", None)
         if weight is not None and weight.dim() >= 1:
             return int(weight.shape[0])
-    cfg = getattr(model, "config", None)
-    for holder in (getattr(cfg, "text_config", None), cfg):
-        v = getattr(holder, "vocab_size", None)
+    cfg = _config_attr(model, "config")
+    for holder in (_config_attr(cfg, "text_config"), cfg):
+        v = _config_attr(holder, "vocab_size")
         if isinstance(v, int) and v > 0:
             return v
     return 0
@@ -458,9 +478,9 @@ def resolve_head_width(model: nn.Module, head: nn.Module | None) -> int:
 
 def head_is_tied(model: nn.Module, head: nn.Module | None) -> bool:
     """True when the output head shares storage with the input embedding."""
-    cfg = getattr(model, "config", None)
-    for holder in (cfg, getattr(cfg, "text_config", None)):
-        flag = getattr(holder, "tie_word_embeddings", None)
+    cfg = _config_attr(model, "config")
+    for holder in (cfg, _config_attr(cfg, "text_config")):
+        flag = _config_attr(holder, "tie_word_embeddings")
         if flag is True:
             return True
     if head is None:
@@ -478,10 +498,10 @@ def head_is_tied(model: nn.Module, head: nn.Module | None) -> bool:
 
 def _model_dtype(model: nn.Module) -> Any:
     """The dtype the checkpoint will be loaded in, as the config declares it."""
-    cfg = getattr(model, "config", None)
-    for holder in (cfg, getattr(cfg, "text_config", None)):
+    cfg = _config_attr(model, "config")
+    for holder in (cfg, _config_attr(cfg, "text_config")):
         for attr in ("dtype", "torch_dtype"):
-            d = getattr(holder, attr, None)
+            d = _config_attr(holder, attr)
             if isinstance(d, torch.dtype):
                 return d
     for t in model.parameters():

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -167,15 +167,10 @@ class _SearchExhausted(Exception):
 def _config_attr(holder, name, default = None):
     """``getattr`` that a hostile config cannot break out of.
 
-    ``getattr``'s default only swallows ``AttributeError``. A remote-code config
-    is free to raise ``KeyError``, ``OSError`` or anything else from a property
-    or from ``__getattr__``, and that would escape a detection this module
-    documents as never raising.
+    ``getattr``'s default only swallows ``AttributeError``, but a remote-code
+    config can raise anything. Sub-configs left as plain dicts are read as dicts.
     """
     try:
-        # A sub-config is not always a config object. A composite whose class
-        # declares no sub-config type keeps whatever the checkpoint's JSON held,
-        # and `getattr` on a plain dict never sees the keys.
         if isinstance(holder, Mapping):
             return holder.get(name, default)
         return getattr(holder, name, default)
@@ -183,22 +178,18 @@ def _config_attr(holder, name, default = None):
         return default
 
 
-# The sub-config names ``PretrainedConfig.get_text_config`` searches, in its own
-# order. Asking the method instead is not enough on its own: T5Gemma overrides it
-# to return ``self`` on transformers 4.56.x, which hides the 30.0 soft cap that
-# lives on ``config.decoder``.
+# The names ``PretrainedConfig.get_text_config`` searches, in its order. Asking
+# the method is not enough: T5Gemma overrides it to return ``self`` on
+# transformers 4.56.x, hiding the soft cap on ``config.decoder``.
 _TEXT_CONFIG_ATTRS = ("text_config", "decoder", "text_encoder")
 
 
 def _model_config(model_or_config):
     """The config, through the wrappers a training model arrives in.
 
-    ``nn.Module.__getattr__`` resolves submodules and parameters, not plain
-    attributes, so a ``DistributedDataParallel`` or a ``torch.compile`` wrapper
-    has no ``.config`` of its own and the transforms of the model inside would
-    read as none at all. PEFT already forwards ``config``, so unwrapping the two
-    that do not is enough. Anything that is already a config falls straight
-    through, since it has no ``.config`` either.
+    ``nn.Module.__getattr__`` resolves submodules, not plain attributes, so DDP
+    and ``torch.compile`` wrappers have no ``.config``; unwrap those two. PEFT
+    already forwards ``config``, and a config itself falls straight through.
     """
     obj = model_or_config
     for _ in range(4):
@@ -214,14 +205,13 @@ def _model_config(model_or_config):
     return model_or_config
 
 
-# Composite wrappers that build their own ``lm_head`` over a bare ``AutoModel``
-# text tower instead of reusing the family's ``*ForCausalLM``. The tower's config
-# still carries the family's scale, but the wrapper's ``forward`` never applies
-# it, so crediting it reserves a temporary nobody allocates. Both were confirmed
-# against ``modeling_aya_vision.py`` / ``modeling_cohere2_vision.py``, where
-# ``logit_scale`` does not appear at all. Contrast Granite Speech, which builds
-# an ``AutoModelForCausalLM`` and so does divide, and Gemma 3n, which re-applies
-# the soft cap in its own ``forward``; neither belongs here.
+# Composites that build their own ``lm_head`` over a bare ``AutoModel`` tower
+# instead of the family's ``*ForCausalLM``. The tower's config still declares the
+# scale but the wrapper's ``forward`` never applies it (``logit_scale`` does not
+# appear in ``modeling_aya_vision.py`` / ``modeling_cohere2_vision.py``), so
+# crediting it reserves a temporary nobody allocates. Not here: Granite Speech
+# (builds an ``AutoModelForCausalLM``, so it does divide) and Gemma 3n
+# (re-applies the cap in its own ``forward``).
 _OWN_UNTRANSFORMED_HEAD = frozenset({"aya_vision", "cohere2_vision"})
 
 # Config field -> which magnitude it contributes, by default.
@@ -233,14 +223,12 @@ _TRANSFORM_FIELDS = (
     ("logit_scale_divide", ("logits_scaling",)),
 )
 
-# ``logits_scaling`` is not one knob. Granite divides the logits by it, but
-# HyperCLOVA X multiplies, and transformers says so on the line itself: "MuP:
-# multiply logits by logits_scaling (cf. GraniteForCausalLM which divides)".
-# MiniCPM3 spells the same name as a property that scales the HIDDEN STATES
-# before the head (``hidden_states = hidden_states / self.config.logits_scaling``),
-# so it makes no logits temporary at all and maps to nothing. Keyed on the
-# ``model_type`` of the config the field was read from, so a composite wrapping
-# one of these towers is judged by the tower.
+# ``logits_scaling`` is not one knob. Granite divides the logits by it;
+# HyperCLOVA X multiplies, as transformers notes on the line itself ("MuP:
+# multiply logits by logits_scaling (cf. GraniteForCausalLM which divides)");
+# MiniCPM3 scales the HIDDEN STATES before the head, so it is not a logit
+# transform at all. Keyed on the ``model_type`` of the config the field came
+# from, so a composite is judged by the tower it wraps.
 _BUCKET_OVERRIDES = {
     ("logits_scaling", "hyperclovax"): "logit_scale_multiply",
     ("logits_scaling", "minicpm3"): None,
@@ -250,10 +238,9 @@ _BUCKET_OVERRIDES = {
 def _text_configs(config):
     """``config`` and every text sub-config it exposes, outermost first.
 
-    Composite models put the head's settings on a sub-config: Gemma 3 on
-    ``config.text_config``, T5Gemma on ``config.decoder``. Reading only the top
-    level misses both, and the first holder to report a transform wins, so the
-    order here is the precedence order.
+    Composites put the head's settings on a sub-config (Gemma 3 on
+    ``text_config``, T5Gemma on ``decoder``). First holder to report a transform
+    wins, so this order is the precedence order.
     """
     seen = [config]
     candidates = [_config_attr(config, name) for name in _TEXT_CONFIG_ATTRS]
@@ -264,8 +251,7 @@ def _text_configs(config):
         except Exception:
             pass
     for candidate in candidates:
-        # Identity, not equality: two sub-configs can compare equal, and a
-        # config that hands back itself must not be visited twice.
+        # Identity, not equality: two sub-configs can compare equal.
         if candidate is None or any(candidate is s for s in seen):
             continue
         seen.append(candidate)
@@ -275,34 +261,31 @@ def _text_configs(config):
 def detect_logit_transforms(model_or_config) -> dict:
     """What the loss will do to the logits, read off the model config.
 
-    The head's card has to hold a temporary for each of these, so the planner
-    sizes them; the GRPO loss applies them. Both derive from here, or the
-    reserve stops matching the allocation it is reserving for.
+    The planner sizes a temporary for each of these and the GRPO loss applies
+    them; both derive from here, or the reserve stops matching the allocation.
 
     Returns ``logit_softcapping``, ``logit_scale_multiply`` and
     ``logit_scale_divide``, ``0.0`` when the architecture does not use one:
 
     * ``final_logit_softcapping`` (Gemma 2/3/3n, T5Gemma, VaultGemma), its
-      RecurrentGemma spelling ``logits_soft_cap``, and its xLSTM spelling
+      RecurrentGemma spelling ``logits_soft_cap`` and its xLSTM spelling
       ``output_logit_soft_cap``.
-    * ``logit_scale`` multiplies the logits (Cohere, Cohere 2).
-    * ``lm_head_multiplier`` multiplies them too (Falcon-H1, which applies it on
-      the ``lm_head`` call itself rather than on a following line), as does
-      ``output_multiplier`` (Muse Glimmer, which then soft caps as well).
-    * ``logits_scaling`` divides them (Granite and its MoE variants), except in
-      HyperCLOVA X where it multiplies, and in MiniCPM3 where it scales the
-      hidden states before the head and so is not a logit transform at all.
+    * ``logit_scale`` multiplies (Cohere, Cohere 2), as do ``lm_head_multiplier``
+      (Falcon-H1, on the ``lm_head`` call itself) and ``output_multiplier``
+      (Muse Glimmer, which then soft caps as well).
+    * ``logits_scaling`` divides (Granite and its MoE variants), except in
+      HyperCLOVA X where it multiplies and MiniCPM3 where it scales the hidden
+      states before the head and so is not a logit transform.
 
-    Both scale fields are applied unguarded in their ``forward``, so the buffer
-    exists whatever the value. CLIP-style models also carry a ``logit_scale``,
-    but it scales image-text similarity rather than an output head, and they are
-    never what the planner is asked about.
+    Every scale field is applied unguarded in its ``forward``, so a no-op value
+    like ``1.0`` still allocates the buffer and still owes the reserve.
 
-    Never raises, short of ``KeyboardInterrupt`` and friends: an unreadable or
-    remote-code config reports the transforms it could read and zero for the
-    rest, which leaves the caller on the behaviour it had before this existed.
-    A field that is present but not a number is skipped on its own, without
-    discarding the fields that did read cleanly.
+    CLIP-style models also carry a ``logit_scale``, but it scales image-text
+    similarity, not an output head, and is never what the planner is asked about.
+
+    Never raises, short of ``KeyboardInterrupt`` and friends: an unreadable
+    config or field is skipped on its own and reported as zero, leaving the
+    caller on the behaviour it had before this existed.
     """
     zero = {
         "logit_softcapping": 0.0,
@@ -314,8 +297,8 @@ def detect_logit_transforms(model_or_config) -> dict:
         if config is None:
             return zero
         found = dict(zero)
-        # A wrapper that re-heads its text tower carries the tower's config, and
-        # so its transforms, without ever applying them.
+        # A re-heading wrapper carries the tower's transforms without applying
+        # them, so only its own top-level config counts.
         own_head = _config_attr(config, "model_type") in _OWN_UNTRANSFORMED_HEAD
         for holder in _text_configs(config):
             if own_head and holder is not config:
@@ -333,9 +316,9 @@ def detect_logit_transforms(model_or_config) -> dict:
                     try:
                         found[bucket] = float(value)
                     except Exception:
-                        # Anything at all: a huge int raises OverflowError, not
-                        # ValueError, and falling through to the outer handler
-                        # would discard the fields already read.
+                        # Anything at all: a huge int raises OverflowError, and
+                        # the outer handler would discard the fields already
+                        # read.
                         continue
                     break
         return found
@@ -942,11 +925,10 @@ def plan_device_map(
         vocab_size: override the detected head width.
         logit_dtype: dtype of the logits; defaults to the head's dtype.
         softcapped: whether a non-zero ``logit_softcapping`` is in play.
-            ``None`` (default) detects it from the config, including the
-            RecurrentGemma alias and composite text sub-configs.
+            ``None`` (default) detects it from the config, aliases and text
+            sub-configs included.
         logit_scaled: whether the logits are multiplied or divided before the
-            loss. ``None`` (default) detects it: ``logit_scale`` (Cohere) and
-            ``logits_scaling`` (Granite). See ``detect_logit_transforms``.
+            loss. ``None`` (default) detects it. See ``detect_logit_transforms``.
         temperature_scaled: whether the caller divides by a temperature != 1.
         headroom_bytes: bypass the formula entirely.
         safety_bytes: slack added to the headroom.
@@ -1016,8 +998,8 @@ def plan_device_map(
         logit_dtype = w.dtype if w is not None and w.dtype.is_floating_point else torch.bfloat16
 
     if softcapped is None or logit_scaled is None:
-        # Whatever the loss will really apply. Missing a transform drops its
-        # temporary from the headroom and under-reserves the head's card.
+        # Missing a transform drops its temporary from the headroom and
+        # under-reserves the head's card.
         transforms = detect_logit_transforms(model)
         if softcapped is None:
             softcapped = bool(transforms["logit_softcapping"])

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -198,6 +198,8 @@ def detect_logit_transforms(model_or_config) -> dict:
     * ``final_logit_softcapping`` (Gemma 2/3/3n, T5Gemma, VaultGemma) and its
       RecurrentGemma spelling ``logits_soft_cap``.
     * ``logit_scale`` multiplies the logits (Cohere, Cohere 2).
+    * ``lm_head_multiplier`` multiplies them too (Falcon-H1, which applies it on
+      the ``lm_head`` call itself rather than on a following line).
     * ``logits_scaling`` divides them (Granite and its MoE variants).
 
     Both scale fields are applied unguarded in their ``forward``, so the buffer
@@ -221,7 +223,7 @@ def detect_logit_transforms(model_or_config) -> dict:
         for holder in _text_configs(config):
             for key, names in (
                 ("logit_softcapping", ("final_logit_softcapping", "logits_soft_cap")),
-                ("logit_scale_multiply", ("logit_scale",)),
+                ("logit_scale_multiply", ("logit_scale", "lm_head_multiplier")),
                 ("logit_scale_divide", ("logits_scaling",)),
             ):
                 if found[key]:

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -173,29 +173,45 @@ def _config_attr(holder, name, default = None):
     documents as never raising.
     """
     try:
+        # A sub-config is not always a config object. A composite whose class
+        # declares no sub-config type keeps whatever the checkpoint's JSON held,
+        # and `getattr` on a plain dict never sees the keys.
+        if isinstance(holder, Mapping):
+            return holder.get(name, default)
         return getattr(holder, name, default)
     except Exception:
         return default
 
 
-def _text_configs(config):
-    """``config`` and every text sub-config it exposes, innermost last.
+# The sub-config names ``PretrainedConfig.get_text_config`` searches, in its own
+# order. Asking the method instead is not enough on its own: T5Gemma overrides it
+# to return ``self`` on transformers 4.56.x, which hides the 30.0 soft cap that
+# lives on ``config.decoder``.
+_TEXT_CONFIG_ATTRS = ("text_config", "decoder", "text_encoder")
 
-    Composite models put the head's settings on a sub-config. Gemma 3 reaches it
-    as ``config.text_config``; T5Gemma only through ``config.get_text_config()``.
-    Reading just the top level misses both.
+
+def _text_configs(config):
+    """``config`` and every text sub-config it exposes, outermost first.
+
+    Composite models put the head's settings on a sub-config: Gemma 3 on
+    ``config.text_config``, T5Gemma on ``config.decoder``. Reading only the top
+    level misses both, and the first holder to report a transform wins, so the
+    order here is the precedence order.
     """
     seen = [config]
-    text_config = _config_attr(config, "text_config")
-    if text_config is None:
-        get_text_config = _config_attr(config, "get_text_config")
-        if callable(get_text_config):
-            try:
-                text_config = get_text_config()
-            except Exception:
-                text_config = None
-    if text_config is not None and text_config is not config:
-        seen.append(text_config)
+    candidates = [_config_attr(config, name) for name in _TEXT_CONFIG_ATTRS]
+    get_text_config = _config_attr(config, "get_text_config")
+    if callable(get_text_config):
+        try:
+            candidates.append(get_text_config())
+        except Exception:
+            pass
+    for candidate in candidates:
+        # Identity, not equality: two sub-configs can compare equal, and a
+        # config that hands back itself must not be visited twice.
+        if candidate is None or any(candidate is s for s in seen):
+            continue
+        seen.append(candidate)
     return seen
 
 
@@ -209,8 +225,9 @@ def detect_logit_transforms(model_or_config) -> dict:
     Returns ``logit_softcapping``, ``logit_scale_multiply`` and
     ``logit_scale_divide``, ``0.0`` when the architecture does not use one:
 
-    * ``final_logit_softcapping`` (Gemma 2/3/3n, T5Gemma, VaultGemma) and its
-      RecurrentGemma spelling ``logits_soft_cap``.
+    * ``final_logit_softcapping`` (Gemma 2/3/3n, T5Gemma, VaultGemma), its
+      RecurrentGemma spelling ``logits_soft_cap``, and its xLSTM spelling
+      ``output_logit_soft_cap``.
     * ``logit_scale`` multiplies the logits (Cohere, Cohere 2).
     * ``lm_head_multiplier`` multiplies them too (Falcon-H1, which applies it on
       the ``lm_head`` call itself rather than on a following line).
@@ -239,7 +256,9 @@ def detect_logit_transforms(model_or_config) -> dict:
         found = dict(zero)
         for holder in _text_configs(config):
             for key, names in (
-                ("logit_softcapping", ("final_logit_softcapping", "logits_soft_cap")),
+                ("logit_softcapping",
+                 ("final_logit_softcapping", "logits_soft_cap",
+                  "output_logit_soft_cap")),
                 ("logit_scale_multiply", ("logit_scale", "lm_head_multiplier")),
                 ("logit_scale_divide", ("logits_scaling",)),
             ):

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -190,6 +190,41 @@ def _config_attr(holder, name, default = None):
 _TEXT_CONFIG_ATTRS = ("text_config", "decoder", "text_encoder")
 
 
+def _model_config(model_or_config):
+    """The config, through the wrappers a training model arrives in.
+
+    ``nn.Module.__getattr__`` resolves submodules and parameters, not plain
+    attributes, so a ``DistributedDataParallel`` or a ``torch.compile`` wrapper
+    has no ``.config`` of its own and the transforms of the model inside would
+    read as none at all. PEFT already forwards ``config``, so unwrapping the two
+    that do not is enough. Anything that is already a config falls straight
+    through, since it has no ``.config`` either.
+    """
+    obj = model_or_config
+    for _ in range(4):
+        config = _config_attr(obj, "config")
+        if config is not None:
+            return config
+        inner = _config_attr(obj, "module")
+        if inner is None:
+            inner = _config_attr(obj, "_orig_mod")
+        if inner is None or inner is obj:
+            break
+        obj = inner
+    return model_or_config
+
+
+# Composite wrappers that build their own ``lm_head`` over a bare ``AutoModel``
+# text tower instead of reusing the family's ``*ForCausalLM``. The tower's config
+# still carries the family's scale, but the wrapper's ``forward`` never applies
+# it, so crediting it reserves a temporary nobody allocates. Both were confirmed
+# against ``modeling_aya_vision.py`` / ``modeling_cohere2_vision.py``, where
+# ``logit_scale`` does not appear at all. Contrast Granite Speech, which builds
+# an ``AutoModelForCausalLM`` and so does divide, and Gemma 3n, which re-applies
+# the soft cap in its own ``forward``; neither belongs here.
+_OWN_UNTRANSFORMED_HEAD = frozenset({"aya_vision", "cohere2_vision"})
+
+
 def _text_configs(config):
     """``config`` and every text sub-config it exposes, outermost first.
 
@@ -250,11 +285,16 @@ def detect_logit_transforms(model_or_config) -> dict:
         "logit_scale_divide": 0.0,
     }
     try:
-        config = _config_attr(model_or_config, "config", model_or_config)
+        config = _model_config(model_or_config)
         if config is None:
             return zero
         found = dict(zero)
+        # A wrapper that re-heads its text tower carries the tower's config, and
+        # so its transforms, without ever applying them.
+        own_head = _config_attr(config, "model_type") in _OWN_UNTRANSFORMED_HEAD
         for holder in _text_configs(config):
+            if own_head and holder is not config:
+                continue
             for key, names in (
                 ("logit_softcapping",
                  ("final_logit_softcapping", "logits_soft_cap",

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -143,6 +143,7 @@ import torch.nn as nn
 __all__ = [
     "DeviceMapInfeasible",
     "DeviceMapPlan",
+    "detect_logit_transforms",
     "logit_headroom_bytes",
     "plan_device_map",
     "plan_device_map_for_pretrained",
@@ -158,6 +159,82 @@ class DeviceMapInfeasible(RuntimeError):
 
 class _SearchExhausted(Exception):
     """Internal: the bounded exact-packing search hit its node budget."""
+
+
+# --------------------------------------------------------------------------- #
+# logit transform detection
+# --------------------------------------------------------------------------- #
+def _text_configs(config):
+    """``config`` and every text sub-config it exposes, innermost last.
+
+    Composite models put the head's settings on a sub-config. Gemma 3 reaches it
+    as ``config.text_config``; T5Gemma only through ``config.get_text_config()``.
+    Reading just the top level misses both.
+    """
+    seen = [config]
+    text_config = getattr(config, "text_config", None)
+    if text_config is None:
+        get_text_config = getattr(config, "get_text_config", None)
+        if callable(get_text_config):
+            try:
+                text_config = get_text_config()
+            except (TypeError, ValueError):
+                text_config = None
+    if text_config is not None and text_config is not config:
+        seen.append(text_config)
+    return seen
+
+
+def detect_logit_transforms(model_or_config) -> dict:
+    """What the loss will do to the logits, read off the model config.
+
+    The head's card has to hold a temporary for each of these, so the planner
+    sizes them; the GRPO loss applies them. Both derive from here, or the
+    reserve stops matching the allocation it is reserving for.
+
+    Returns ``logit_softcapping``, ``logit_scale_multiply`` and
+    ``logit_scale_divide``, ``0.0`` when the architecture does not use one:
+
+    * ``final_logit_softcapping`` (Gemma 2/3/3n, T5Gemma, VaultGemma) and its
+      RecurrentGemma spelling ``logits_soft_cap``.
+    * ``logit_scale`` multiplies the logits (Cohere, Cohere 2).
+    * ``logits_scaling`` divides them (Granite and its MoE variants).
+
+    Both scale fields are applied unguarded in their ``forward``, so the buffer
+    exists whatever the value. CLIP-style models also carry a ``logit_scale``,
+    but it scales image-text similarity rather than an output head, and they are
+    never what the planner is asked about.
+
+    Never raises: an unreadable or remote-code config reports no transforms,
+    which leaves the caller on the behaviour it had before this existed.
+    """
+    zero = {
+        "logit_softcapping": 0.0,
+        "logit_scale_multiply": 0.0,
+        "logit_scale_divide": 0.0,
+    }
+    try:
+        config = getattr(model_or_config, "config", model_or_config)
+        if config is None:
+            return zero
+        found = dict(zero)
+        for holder in _text_configs(config):
+            for key, names in (
+                ("logit_softcapping", ("final_logit_softcapping", "logits_soft_cap")),
+                ("logit_scale_multiply", ("logit_scale",)),
+                ("logit_scale_divide", ("logits_scaling",)),
+            ):
+                if found[key]:
+                    continue
+                for name in names:
+                    value = getattr(holder, name, None)
+                    if value is None:
+                        continue
+                    found[key] = float(value)
+                    break
+        return found
+    except (TypeError, ValueError, AttributeError):
+        return zero
 
 
 # --------------------------------------------------------------------------- #
@@ -737,7 +814,7 @@ def plan_device_map(
     vocab_size: int | None = None,
     logit_dtype: torch.dtype | None = None,
     softcapped: bool | None = None,
-    logit_scaled: bool = False,
+    logit_scaled: bool | None = None,
     temperature_scaled: bool = False,
     headroom_bytes: int | None = None,
     safety_bytes: int = 256 * 1024 ** 2,
@@ -759,10 +836,11 @@ def plan_device_map(
         vocab_size: override the detected head width.
         logit_dtype: dtype of the logits; defaults to the head's dtype.
         softcapped: whether a non-zero ``logit_softcapping`` is in play.
-            ``None`` (default) reads ``final_logit_softcapping`` (or its
-            RecurrentGemma alias ``logits_soft_cap``) off the config.
-        logit_scaled: whether the caller passes a non-zero
-            ``logit_scale_multiply`` or ``logit_scale_divide``.
+            ``None`` (default) detects it from the config, including the
+            RecurrentGemma alias and composite text sub-configs.
+        logit_scaled: whether the logits are multiplied or divided before the
+            loss. ``None`` (default) detects it: ``logit_scale`` (Cohere) and
+            ``logits_scaling`` (Granite). See ``detect_logit_transforms``.
         temperature_scaled: whether the caller divides by a temperature != 1.
         headroom_bytes: bypass the formula entirely.
         safety_bytes: slack added to the headroom.
@@ -831,17 +909,16 @@ def plan_device_map(
         w = getattr(head_mod, "weight", None)
         logit_dtype = w.dtype if w is not None and w.dtype.is_floating_point else torch.bfloat16
 
-    if softcapped is None:
-        cfg = getattr(model, "config", None)
-        # `logits_soft_cap` is the RecurrentGemma spelling of the same knob, and
-        # the repository's own `_detect_logit_softcap` already treats them as
-        # aliases. Missing it drops the tanh temporary and the retained soft-cap
-        # buffer from the headroom, so the head's card is under-reserved.
-        softcapped = any(
-            bool(getattr(h, name, None))
-            for h in (cfg, getattr(cfg, "text_config", None))
-            for name in ("final_logit_softcapping", "logits_soft_cap")
-        )
+    if softcapped is None or logit_scaled is None:
+        # Whatever the loss will really apply. Missing a transform drops its
+        # temporary from the headroom and under-reserves the head's card.
+        transforms = detect_logit_transforms(model)
+        if softcapped is None:
+            softcapped = bool(transforms["logit_softcapping"])
+        if logit_scaled is None:
+            logit_scaled = bool(
+                transforms["logit_scale_multiply"] or transforms["logit_scale_divide"]
+            )
 
     if headroom_bytes is None:
         headroom = logit_headroom_bytes(
@@ -1663,7 +1740,7 @@ def plan_device_map_for_pretrained(
     retained_rows: int = 0,
     vocab_size: int | None = None,
     softcapped: bool | None = None,
-    logit_scaled: bool = False,
+    logit_scaled: bool | None = None,
     temperature_scaled: bool = False,
     headroom_bytes: int | None = None,
     safety_bytes: int = 256 * 1024 ** 2,

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -310,7 +310,10 @@ def detect_logit_transforms(model_or_config) -> dict:
                         continue
                     try:
                         found[key] = float(value)
-                    except (TypeError, ValueError):
+                    except Exception:
+                        # Anything at all: a huge int raises OverflowError, not
+                        # ValueError, and falling through to the outer handler
+                        # would discard the fields already read.
                         continue
                     break
         return found


### PR DESCRIPTION
`plan_device_map_for_pretrained` reserves headroom for the temporaries the loss allocates over the logits. Two of those depend on what the architecture does to the logits before the loss sees them: a soft cap, and a logit scale. Until now the planner only inferred the soft cap, and the scale had to be passed in by hand as `logit_scaled = True`.

That is a fact about the checkpoint, not about the caller, and getting it wrong is silent. A missed transform drops its temporary from the headroom and under-reserves the head's card, which surfaces later as an OOM in the loss rather than as a planning error.

## What it is worth, and what it risks

A missed scale drops exactly one chunk-sized logits buffer, `rows_per_chunk * vocab * itemsize`:

| model | vocab | rows/chunk | logit dtype | under-reserved by |
| --- | --- | --- | --- | --- |
| Cohere Command-R | 256000 | 128 | bf16 | 62.5 MiB |
| Cohere Command-R | 256000 | 512 | bf16 | 250 MiB |
| Cohere Command-R | 256000 | 512 | fp32 | 500 MiB |
| Granite 3.1 2B | 49155 | 128 | bf16 | 12 MiB |
| Falcon-H1 1.5B | 32784 | 128 | bf16 | 8 MiB |

It closes an OOM cliff at the margin rather than being a headline saving, and it only bites when the plan was already tight.

The blast radius is small enough to check rather than assert. Both flags are keyword-only, so no positional caller exists and an explicit `True` or `False` still wins. The planner has no callers outside its own tests: nothing in `unsloth`, in `unsloth_zoo/__init__.py` or in Studio imports `plan_device_map`, `plan_device_map_for_pretrained` or `logit_headroom_bytes`, there is no star-import of the module, and nothing introspects these signatures. `plan_device_map` returns `None` for fewer than two usable devices before any detection runs, so CPU-only, single-GPU and ROCm callers never reach the new code at all. The detection itself touches no `os`, `platform` or device API, so Linux, macOS and Windows behave identically by construction.

## What changed

New `detect_logit_transforms(model_or_config)` in `device_map_planner.py`, returning the three magnitudes:

```python
{"logit_softcapping": 20.0, "logit_scale_multiply": 0.0, "logit_scale_divide": 0.0}
```

The fields it reads, from a sweep of `transformers/models/*/modeling_*.py` across 4.56.x through the latest 5.x:

| field | families | effect |
| --- | --- | --- |
| `final_logit_softcapping` | gemma2, gemma3, t5gemma | soft cap |
| `logits_soft_cap` | recurrentgemma | soft cap |
| `logit_scale` | cohere, cohere2 | multiply |
| `lm_head_multiplier` | falcon_h1 | multiply |
| `logits_scaling` | granite, granitemoe and variants | divide |
| `output_multiplier` | muse_glimmer | multiply |
| `output_logit_soft_cap` | xlstm | soft cap |

`logit_scaled` on the two planner entry points becomes `bool | None`, defaulting to `None` (detect). An explicit `True` or `False` still wins, so nothing that passes it today changes behaviour. `softcapped` keeps the same contract it already had.

Two things the sweep turned up that the detection has to get right:

- Composite configs. Gemma 3 puts the cap on `config.text_config`; T5Gemma keeps it on `config.decoder`. Detection follows the sub-config names `PretrainedConfig.get_text_config` searches itself, `text_config` then `decoder` then `text_encoder`, and collects the method's own answer alongside them. Asking the method alone is not enough: on transformers 4.56.x, which is inside the supported range, `T5GemmaConfig.get_text_config` is overridden to return `self`, so the cap is invisible to both the attribute and the method. A sub-config that stayed a plain `dict`, which is what a composite whose class declares no sub-config type keeps, is read too.
- CLIP-family models have a `logit_scale`, but it is the contrastive image-text temperature, not an output head transform. Its config field is `logit_scale_init_value`, so reading the exact names above already excludes it. There is a test pinning that.

`logits_scaling` is not one knob, so the bucket is resolved per family. Granite divides the logits by it; HyperCLOVA X multiplies, and transformers says so on the line itself ("MuP: multiply logits by logits_scaling (cf. GraniteForCausalLM which divides)"); MiniCPM3 spells the same name as a property that divides the **hidden states** before the head, so it makes no logits temporary and maps to nothing. Overrides key on the `model_type` of the config the field was read from, so a composite is judged by its tower.

Aya Vision and Cohere 2 Vision are excluded for the opposite reason to CLIP: they really do carry a Cohere 2 `logit_scale`, but they build their text tower with `AutoModel.from_config` and put their own `nn.Linear` head on top, so `logit_scale` appears nowhere in either modeling file. Granite Speech, which builds an `AutoModelForCausalLM`, and Gemma 3n, which re-applies the cap in its own `forward`, both stay detected. The rule is whether the wrapper reuses the family's causal-LM head, not whether the field is present.

Models arrive wrapped, so the config is read through `DistributedDataParallel` and `torch.compile`. `nn.Module.__getattr__` resolves submodules and parameters, not plain attributes, so those wrappers have no `.config` of their own and the model inside read as transform-free. PEFT already forwards `config`.

There is no transformers ceiling in play. Neither package constrains transformers in its core dependency table, so a plain install leaves it unpinned and users reach 5.9+ and 5.15 for real; the families above were judged on their merits rather than filed as out of range.

Detection never raises, short of `KeyboardInterrupt` and friends. `getattr`'s default only swallows `AttributeError`, and a remote-code config is free to raise `KeyError` or `OSError` from a property or `__getattr__`, so every config read on the planning path goes through one helper that returns the default on any `Exception`. A field that is present but not a number is skipped on its own rather than discarding the fields that did read cleanly.

## Tests

39 new tests in `tests/test_device_map_planner.py`; 98 pass in that file. They cover each family, nested / dict / method-only / `decoder` sub-configs, the CLIP and Aya Vision exclusions against the Granite Speech and Gemma 3n inclusions, the HyperCLOVA X and MiniCPM3 bucket overrides, DDP and `torch.compile` wrappers, the never-raises contract across `RuntimeError` / `KeyError` / `OSError` / `ImportError` / `RecursionError` with interrupts still propagating, conversion failures including `OverflowError` not discarding sibling fields, a zero scale reserving nothing, and explicit-flag precedence both ways.

Checked against real checkpoints, not only synthetic configs, on transformers 4.56.2 and 4.57.6: gemma-2-9b-it, gemma-3-4b-it, t5gemma-2b-2b-prefixlm-it, aya-expanse-8b, granite-3.1-2b-instruct, Falcon-H1-1.5B-Instruct and xLSTM-7b all report what their own `forward` really does, and clip-vit-base-patch32, siglip-base-patch16-224, Llama-3.2-1B, Qwen2-VL-2B-Instruct and llava-1.5-7b-hf all stay inert.

The decisive check is a sweep of **every instantiable config class** in the library, before and after, on three versions: 394 on 4.56.2, 411 on 4.57.6, 679 on 5.15.0. Seven results move in total and each is intended and tested: aya_vision and cohere2_vision drop to zero, xlstm and (on 4.56.2) t5gemma gain their cap, hyperclovax crosses buckets, minicpm3 drops to zero, and muse_glimmer and muse_glimmer_text gain 0.196. Nothing else in the library changes.

Cross-platform CI on ubuntu-latest, macos-14 and windows-latest, plus the repo suite on Python 3.10 through 3.13.