### PR TITLE
fix: stub torch.float8_e8m0fnu before transformers import

### DIFF
--- a/scripts/verify_e8m0_import.py
+++ b/scripts/verify_e8m0_import.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Manual integration verification for unslothai/unsloth#8933."""
+
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+STUDIO_TRANSFORMERS_ROOT = os.path.expanduser(
+    "~/.unsloth/studio/.venv_t5_510"
+)
+
+
+def _banner(title: str) -> None:
+    print(f"\n=== {title} ===")
+
+
+def test_old_transformers_fails_without_stub() -> bool:
+    _banner("1. Studio finegrained_fp8 bind WITHOUT stub (expect fail)")
+    import torch
+
+    assert not hasattr(torch, "float8_e8m0fnu"), "need torch < 2.7 for this check"
+    try:
+        ns = {"torch": torch}
+        exec("_UE8M0_SF_DTYPE = torch.float8_e8m0fnu", ns)  # noqa: S102
+        print("UNEXPECTED: bind succeeded without stub")
+        return False
+    except AttributeError as exc:
+        if "float8_e8m0fnu" in str(exc):
+            print("OK: failed as expected:", exc)
+            return True
+        print("FAIL: wrong AttributeError:", exc)
+        return False
+
+
+def _load_ensure_helper():
+    import ast
+
+    path = os.path.join(ROOT, "unsloth_zoo", "temporary_patches", "utils.py")
+    tree = ast.parse(open(path, encoding="utf-8").read())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_ensure_torch_float8_e8m0fnu":
+            ns = {"torch": __import__("torch")}
+            exec(compile(ast.Module([node], []), "<utils>", "exec"), ns)
+            return ns["_ensure_torch_float8_e8m0fnu"]
+    raise RuntimeError("helper not found")
+
+
+def test_old_transformers_succeeds_with_stub() -> bool:
+    _banner("2. Studio finegrained_fp8 bind WITH stub (expect pass)")
+    import torch
+
+    ensure = _load_ensure_helper()
+    ensure()
+    assert torch.float8_e8m0fnu is torch.float8_e4m3fn
+
+    try:
+        ns = {"torch": torch}
+        exec("_UE8M0_SF_DTYPE = torch.float8_e8m0fnu", ns)  # noqa: S102
+        assert ns["_UE8M0_SF_DTYPE"] is torch.float8_e4m3fn
+        print("OK: Studio bind line succeeds after stub")
+        return True
+    except Exception as exc:
+        print("FAIL:", exc)
+        traceback.print_exc()
+        return False
+
+
+def test_temporary_patches_utils_import() -> bool:
+    _banner("3. unsloth_zoo.temporary_patches.utils import on torch 2.6")
+    import subprocess
+
+    code = r'''
+import os, sys, types
+os.environ["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+root = os.environ["UNSLOTH_ZOO_ROOT"]
+sys.path.insert(0, root)
+
+import torch
+assert not hasattr(torch, "float8_e8m0fnu")
+assert hasattr(torch, "float8_e4m3fn")
+
+# conftest-style device_type preload
+import importlib.util
+pkg = "unsloth_zoo"
+pkg_path = os.path.join(root, pkg)
+pkg_mod = types.ModuleType(pkg)
+pkg_mod.__path__ = [pkg_path]
+pkg_mod.__package__ = pkg
+sys.modules[pkg] = pkg_mod
+for prereq in ("utils",):
+    full = f"{pkg}.{prereq}"
+    path = os.path.join(pkg_path, f"{prereq}.py")
+    spec = importlib.util.spec_from_file_location(full, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[full] = mod
+    spec.loader.exec_module(mod)
+dt_path = os.path.join(pkg_path, "device_type.py")
+dt_spec = importlib.util.spec_from_file_location(f"{pkg}.device_type", dt_path)
+dt_mod = importlib.util.module_from_spec(dt_spec)
+sys.modules[f"{pkg}.device_type"] = dt_mod
+_orig = torch.cuda.is_available
+torch.cuda.is_available = lambda: True
+try:
+    dt_spec.loader.exec_module(dt_mod)
+finally:
+    torch.cuda.is_available = _orig
+
+from unsloth_zoo.temporary_patches.utils import Unpack
+assert torch.float8_e8m0fnu is torch.float8_e4m3fn
+print("ok")
+'''
+    env = dict(os.environ)
+    env["UNSLOTH_ZOO_ROOT"] = ROOT
+    # Load utils.py directly (same entry point as the Studio crash) without
+    # pulling every temporary_patches submodule.
+    code = code.replace(
+        "from unsloth_zoo.temporary_patches import utils as tp_utils\n"
+        "assert torch.float8_e8m0fnu is torch.float8_e4m3fn\n"
+        "assert hasattr(tp_utils, \"Unpack\")",
+        "utils_path = os.path.join(pkg_path, \"temporary_patches\", \"utils.py\")\n"
+        "utils_spec = importlib.util.spec_from_file_location(\n"
+        "    \"unsloth_zoo.temporary_patches.utils\", utils_path,\n"
+        "    submodule_search_locations=[os.path.join(pkg_path, \"temporary_patches\")],\n"
+        ")\n"
+        "utils_mod = importlib.util.module_from_spec(utils_spec)\n"
+        "sys.modules[\"unsloth_zoo.temporary_patches.utils\"] = utils_mod\n"
+        "utils_spec.loader.exec_module(utils_mod)\n"
+        "assert torch.float8_e8m0fnu is torch.float8_e4m3fn\n"
+        "assert hasattr(utils_mod, \"Unpack\")",
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and "ok" in result.stdout:
+        print("OK: temporary_patches.utils imported with Unpack")
+        return True
+    print("FAIL:", result.stderr or result.stdout)
+    return False
+
+
+def test_ue8m0_on_capable_torch() -> bool:
+    _banner("4. UE8M0 dtype available on torch 2.12+ (Studio FP8 path)")
+    import subprocess
+
+    code = """
+import torch
+from transformers.integrations import finegrained_fp8 as fg
+if hasattr(torch, "float8_e8m0fnu"):
+    getter = getattr(fg, "_get_ue8m0_dtype", None)
+    if getter is not None:
+        dtype = getter()
+        assert dtype is torch.float8_e8m0fnu
+        print("ok getter")
+    elif hasattr(fg, "_UE8M0_SF_DTYPE"):
+        assert fg._UE8M0_SF_DTYPE is torch.float8_e8m0fnu
+        print("ok module bind")
+    else:
+        print("skip no ue8m0 hook")
+else:
+    raise RuntimeError("torch lacks float8_e8m0fnu on a build that should have it")
+"""
+    py = "/home/ubuntu/workspace/unsloth/.venv/bin/python"
+    if not os.path.isfile(py):
+        print("SKIP: unsloth venv not available")
+        return True
+    result = subprocess.run([py, "-c", code], capture_output=True, text=True)
+    if result.returncode == 0:
+        print("OK:", (result.stdout or "").strip())
+        return True
+    print("FAIL:", result.stderr or result.stdout)
+    return False
+
+
+def main() -> int:
+    os.environ.setdefault("UNSLOTH_ZOO_DISABLE_GPU_INIT", "1")
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    import torch
+
+    print("torch", torch.__version__)
+    print("e8m0", hasattr(torch, "float8_e8m0fnu"))
+    print("e4m3", hasattr(torch, "float8_e4m3fn"))
+    print("studio transformers root:", STUDIO_TRANSFORMERS_ROOT)
+
+    results = [
+        test_old_transformers_fails_without_stub(),
+        test_old_transformers_succeeds_with_stub(),
+        test_temporary_patches_utils_import(),
+    ]
+
+    # UE8M0-capable torch check uses the workspace torch 2.12 venv.
+    results.append(test_ue8m0_on_capable_torch())
+
+    passed = sum(results)
+    total = len(results)
+    print(f"\n=== SUMMARY: {passed}/{total} passed ===")
+    return 0 if passed == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_e8m0_import.py
+++ b/scripts/verify_e8m0_import.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 import os
+
+os.environ.setdefault("UNSLOTH_ZOO_DISABLE_GPU_INIT", "1")
+
+import subprocess
 import sys
 import traceback
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-STUDIO_TRANSFORMERS_ROOT = os.path.expanduser(
-    "~/.unsloth/studio/.venv_t5_510"
-)
 
 
 def _banner(title: str) -> None:
@@ -21,7 +22,9 @@ def test_old_transformers_fails_without_stub() -> bool:
     _banner("1. Studio finegrained_fp8 bind WITHOUT stub (expect fail)")
     import torch
 
-    assert not hasattr(torch, "float8_e8m0fnu"), "need torch < 2.7 for this check"
+    if hasattr(torch, "float8_e8m0fnu"):
+        print("SKIP: need torch < 2.7")
+        return True
     try:
         ns = {"torch": torch}
         exec("_UE8M0_SF_DTYPE = torch.float8_e8m0fnu", ns)  # noqa: S102
@@ -35,32 +38,51 @@ def test_old_transformers_fails_without_stub() -> bool:
         return False
 
 
-def _load_ensure_helper():
-    import ast
-
-    path = os.path.join(ROOT, "unsloth_zoo", "temporary_patches", "utils.py")
-    tree = ast.parse(open(path, encoding="utf-8").read())
-    for node in tree.body:
-        if isinstance(node, ast.FunctionDef) and node.name == "_ensure_torch_float8_e8m0fnu":
-            ns = {"torch": __import__("torch")}
-            exec(compile(ast.Module([node], []), "<utils>", "exec"), ns)
-            return ns["_ensure_torch_float8_e8m0fnu"]
-    raise RuntimeError("helper not found")
-
-
 def test_old_transformers_succeeds_with_stub() -> bool:
-    _banner("2. Studio finegrained_fp8 bind WITH stub (expect pass)")
+    _banner("2. Studio finegrained_fp8 bind WITH temporary stub (expect pass)")
+    import ast
     import torch
 
-    ensure = _load_ensure_helper()
-    ensure()
-    assert torch.float8_e8m0fnu is torch.float8_e4m3fn
+    if hasattr(torch, "float8_e8m0fnu"):
+        print("SKIP: need torch < 2.7")
+        return True
+
+    utils_path = os.path.join(ROOT, "unsloth_zoo", "temporary_patches", "utils.py")
+    tree = ast.parse(open(utils_path, encoding="utf-8").read())
+    ns = {
+        "torch": torch,
+        "contextlib": __import__("contextlib"),
+        "_E8M0_IMPORT_STUB_ACTIVE": False,
+    }
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in (
+            "torch_supports_float8_e8m0fnu",
+            "require_native_float8_e8m0fnu",
+            "_temporary_float8_e8m0fnu_import_stub",
+        ):
+            exec(compile(ast.Module([node], []), "<utils>", "exec"), ns)
+    if "require_native_float8_e8m0fnu" not in ns:
+        print("FAIL: could not load require_native_float8_e8m0fnu from utils.py")
+        return False
+    temporary_stub = ns["_temporary_float8_e8m0fnu_import_stub"]
+    require_native = ns["require_native_float8_e8m0fnu"]
 
     try:
-        ns = {"torch": torch}
-        exec("_UE8M0_SF_DTYPE = torch.float8_e8m0fnu", ns)  # noqa: S102
-        assert ns["_UE8M0_SF_DTYPE"] is torch.float8_e4m3fn
-        print("OK: Studio bind line succeeds after stub")
+        with temporary_stub() as used:
+            assert used is True
+            bind_ns = {"torch": torch}
+            exec("_UE8M0_SF_DTYPE = torch.float8_e8m0fnu", bind_ns)  # noqa: S102
+            assert bind_ns["_UE8M0_SF_DTYPE"] is torch.float8_e4m3fn
+        assert not hasattr(torch, "float8_e8m0fnu")
+        try:
+            require_native()
+            print("FAIL: require_native should raise after stub exits")
+            return False
+        except RuntimeError as exc:
+            if "PyTorch >= 2.7" not in str(exc):
+                print("FAIL: unexpected error:", exc)
+                return False
+        print("OK: temporary bind works; UE8M0 rejected after import")
         return True
     except Exception as exc:
         print("FAIL:", exc)
@@ -70,21 +92,17 @@ def test_old_transformers_succeeds_with_stub() -> bool:
 
 def test_temporary_patches_utils_import() -> bool:
     _banner("3. unsloth_zoo.temporary_patches.utils import on torch 2.6")
-    import subprocess
+    venv_py = os.path.join(ROOT, ".test-e8m0-venv", "bin", "python")
+    if not os.path.isfile(venv_py):
+        print("SKIP: .test-e8m0-venv not found")
+        return True
 
     code = r'''
-import os, sys, types
+import os, sys, types, importlib.util
 os.environ["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
-os.environ["TOKENIZERS_PARALLELISM"] = "false"
 root = os.environ["UNSLOTH_ZOO_ROOT"]
 sys.path.insert(0, root)
-
 import torch
-assert not hasattr(torch, "float8_e8m0fnu")
-assert hasattr(torch, "float8_e4m3fn")
-
-# conftest-style device_type preload
-import importlib.util
 pkg = "unsloth_zoo"
 pkg_path = os.path.join(root, pkg)
 pkg_mod = types.ModuleType(pkg)
@@ -108,36 +126,20 @@ try:
     dt_spec.loader.exec_module(dt_mod)
 finally:
     torch.cuda.is_available = _orig
-
-from unsloth_zoo.temporary_patches.utils import Unpack
-assert torch.float8_e8m0fnu is torch.float8_e4m3fn
+utils_path = os.path.join(pkg_path, "temporary_patches", "utils.py")
+utils_spec = importlib.util.spec_from_file_location(
+    "unsloth_zoo.temporary_patches.utils", utils_path,
+    submodule_search_locations=[os.path.join(pkg_path, "temporary_patches")],
+)
+utils_mod = importlib.util.module_from_spec(utils_spec)
+sys.modules["unsloth_zoo.temporary_patches.utils"] = utils_mod
+utils_spec.loader.exec_module(utils_mod)
+assert not utils_mod.torch_supports_float8_e8m0fnu()
+assert hasattr(utils_mod, "Unpack")
 print("ok")
 '''
-    env = dict(os.environ)
-    env["UNSLOTH_ZOO_ROOT"] = ROOT
-    # Load utils.py directly (same entry point as the Studio crash) without
-    # pulling every temporary_patches submodule.
-    code = code.replace(
-        "from unsloth_zoo.temporary_patches import utils as tp_utils\n"
-        "assert torch.float8_e8m0fnu is torch.float8_e4m3fn\n"
-        "assert hasattr(tp_utils, \"Unpack\")",
-        "utils_path = os.path.join(pkg_path, \"temporary_patches\", \"utils.py\")\n"
-        "utils_spec = importlib.util.spec_from_file_location(\n"
-        "    \"unsloth_zoo.temporary_patches.utils\", utils_path,\n"
-        "    submodule_search_locations=[os.path.join(pkg_path, \"temporary_patches\")],\n"
-        ")\n"
-        "utils_mod = importlib.util.module_from_spec(utils_spec)\n"
-        "sys.modules[\"unsloth_zoo.temporary_patches.utils\"] = utils_mod\n"
-        "utils_spec.loader.exec_module(utils_mod)\n"
-        "assert torch.float8_e8m0fnu is torch.float8_e4m3fn\n"
-        "assert hasattr(utils_mod, \"Unpack\")",
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        env=env,
-        capture_output=True,
-        text=True,
-    )
+    env = {**os.environ, "UNSLOTH_ZOO_ROOT": ROOT, "UNSLOTH_ZOO_DISABLE_GPU_INIT": "1"}
+    result = subprocess.run([venv_py, "-c", code], env=env, capture_output=True, text=True)
     if result.returncode == 0 and "ok" in result.stdout:
         print("OK: temporary_patches.utils imported with Unpack")
         return True
@@ -147,60 +149,50 @@ print("ok")
 
 def test_ue8m0_on_capable_torch() -> bool:
     _banner("4. UE8M0 dtype available on torch 2.12+ (Studio FP8 path)")
-    import subprocess
-
-    code = """
-import torch
-from transformers.integrations import finegrained_fp8 as fg
-if hasattr(torch, "float8_e8m0fnu"):
-    getter = getattr(fg, "_get_ue8m0_dtype", None)
-    if getter is not None:
-        dtype = getter()
-        assert dtype is torch.float8_e8m0fnu
-        print("ok getter")
-    elif hasattr(fg, "_UE8M0_SF_DTYPE"):
-        assert fg._UE8M0_SF_DTYPE is torch.float8_e8m0fnu
-        print("ok module bind")
-    else:
-        print("skip no ue8m0 hook")
-else:
-    raise RuntimeError("torch lacks float8_e8m0fnu on a build that should have it")
-"""
     py = "/home/ubuntu/workspace/unsloth/.venv/bin/python"
     if not os.path.isfile(py):
         print("SKIP: unsloth venv not available")
         return True
-    result = subprocess.run([py, "-c", code], capture_output=True, text=True)
+    code = """
+import torch
+from transformers.integrations import finegrained_fp8 as fg
+assert hasattr(torch, "float8_e8m0fnu")
+getter = getattr(fg, "_get_ue8m0_dtype", None)
+if getter is not None:
+    assert getter() is torch.float8_e8m0fnu
+    print("ok getter")
+elif hasattr(fg, "_UE8M0_SF_DTYPE"):
+    assert fg._UE8M0_SF_DTYPE is torch.float8_e8m0fnu
+    print("ok module bind")
+else:
+    print("skip no ue8m0 hook")
+"""
+    env = {**os.environ}
+    result = subprocess.run([py, "-c", code], env=env, capture_output=True, text=True)
     if result.returncode == 0:
-        print("OK:", (result.stdout or "").strip())
+        out = (result.stdout or "").strip()
+        print("OK:", out or "passed")
         return True
     print("FAIL:", result.stderr or result.stdout)
     return False
 
 
 def main() -> int:
-    os.environ.setdefault("UNSLOTH_ZOO_DISABLE_GPU_INIT", "1")
-    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    sys.path.insert(0, ROOT)
     import torch
 
     print("torch", torch.__version__)
-    print("e8m0", hasattr(torch, "float8_e8m0fnu"))
-    print("e4m3", hasattr(torch, "float8_e4m3fn"))
-    print("studio transformers root:", STUDIO_TRANSFORMERS_ROOT)
+    print("e8m0 native", hasattr(torch, "float8_e8m0fnu"))
 
     results = [
         test_old_transformers_fails_without_stub(),
         test_old_transformers_succeeds_with_stub(),
         test_temporary_patches_utils_import(),
+        test_ue8m0_on_capable_torch(),
     ]
-
-    # UE8M0-capable torch check uses the workspace torch 2.12 venv.
-    results.append(test_ue8m0_on_capable_torch())
-
     passed = sum(results)
-    total = len(results)
-    print(f"\n=== SUMMARY: {passed}/{total} passed ===")
-    return 0 if passed == total else 1
+    print(f"\n=== SUMMARY: {passed}/{len(results)} passed ===")
+    return 0 if passed == len(results) else 1
 
 
 if __name__ == "__main__":

--- a/tests/test_torch_float8_e8m0fnu_stub.py
+++ b/tests/test_torch_float8_e8m0fnu_stub.py
@@ -73,5 +73,22 @@ def test_attribute_error_branch_names_e8m0():
     assert '"float8_e8m0fnu" in e_str and "has no attribute" in e_str' in src
 
 
+@pytest.mark.integration
+def test_old_transformers_module_bind_succeeds_after_stub():
+    """Mimic pinned transformers that bind _UE8M0_SF_DTYPE at import time."""
+    pytest.importorskip("torch")
+    import torch
+
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch build lacks float8_e4m3fn")
+
+    if hasattr(torch, "float8_e8m0fnu"):
+        del torch.float8_e8m0fnu
+
+    _run_ensure(torch)
+    _UE8M0_SF_DTYPE = torch.float8_e8m0fnu  # noqa: N806 — mirrors transformers
+    assert _UE8M0_SF_DTYPE is torch.float8_e4m3fn
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_torch_float8_e8m0fnu_stub.py
+++ b/tests/test_torch_float8_e8m0fnu_stub.py
@@ -30,15 +30,24 @@ import pytest
 UTILS = (Path(__file__).resolve().parents[1] / "unsloth_zoo"
          / "temporary_patches" / "utils.py")
 
+_HELPER_NAMES = (
+    "torch_supports_float8_e8m0fnu",
+    "_temporary_float8_e8m0fnu_import_stub",
+    "require_native_float8_e8m0fnu",
+)
 
-def _load_helpers():
+
+def _helper_namespace(torch_mod, *, include_require_native: bool = False):
+    """Extract e8m0 helpers with the same module globals they expect at runtime."""
     tree = ast.parse(UTILS.read_text(encoding="utf-8"))
-    wanted = {
-        "_temporary_float8_e8m0fnu_import_stub",
-        "torch_supports_float8_e8m0fnu",
-        "require_native_float8_e8m0fnu",
+    wanted = set(_HELPER_NAMES)
+    if not include_require_native:
+        wanted.discard("require_native_float8_e8m0fnu")
+    ns: dict = {
+        "torch": torch_mod,
+        "contextlib": __import__("contextlib"),
+        "_E8M0_IMPORT_STUB_ACTIVE": False,
     }
-    ns: dict = {"contextlib": __import__("contextlib")}
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name in wanted:
             exec(compile(ast.Module([node], []), "<utils>", "exec"), ns)
@@ -47,31 +56,9 @@ def _load_helpers():
     return ns
 
 
-HELPERS = _load_helpers()
-temporary_stub = HELPERS["_temporary_float8_e8m0fnu_import_stub"]
-supports = HELPERS["torch_supports_float8_e8m0fnu"]
-require_native = HELPERS["require_native_float8_e8m0fnu"]
-
-
-def _run_temporary_stub(torch_mod):
-    tree = ast.parse(UTILS.read_text(encoding="utf-8"))
-    ns = {
-        "torch": torch_mod,
-        "contextlib": __import__("contextlib"),
-        "_E8M0_IMPORT_STUB_ACTIVE": False,
-    }
-    for node in tree.body:
-        if isinstance(node, ast.FunctionDef) and node.name in (
-            "torch_supports_float8_e8m0fnu",
-            "_temporary_float8_e8m0fnu_import_stub",
-        ):
-            exec(compile(ast.Module([node], []), "<utils>", "exec"), ns)
-    return ns["_temporary_float8_e8m0fnu_import_stub"]
-
-
 def test_temporary_stub_aliases_e4m3_only_during_context():
     torch_mod = types.SimpleNamespace(float8_e4m3fn = object())
-    stub = _run_temporary_stub(torch_mod)
+    stub = _helper_namespace(torch_mod)["_temporary_float8_e8m0fnu_import_stub"]
     with stub() as used:
         assert used is True
         assert torch_mod.float8_e8m0fnu is torch_mod.float8_e4m3fn
@@ -81,7 +68,7 @@ def test_temporary_stub_aliases_e4m3_only_during_context():
 def test_temporary_stub_is_noop_when_e8m0_already_exists():
     sentinel = object()
     torch_mod = types.SimpleNamespace(float8_e8m0fnu = sentinel)
-    stub = _run_temporary_stub(torch_mod)
+    stub = _helper_namespace(torch_mod)["_temporary_float8_e8m0fnu_import_stub"]
     with stub() as used:
         assert used is False
         assert torch_mod.float8_e8m0fnu is sentinel
@@ -121,6 +108,9 @@ def test_require_native_raises_when_e8m0_missing():
     if hasattr(torch, "float8_e8m0fnu"):
         pytest.skip("need torch without native e8m0 for this check")
 
+    require_native = _helper_namespace(
+        torch, include_require_native = True,
+    )["require_native_float8_e8m0fnu"]
     with pytest.raises(RuntimeError, match="PyTorch >= 2.7"):
         require_native()
 
@@ -136,7 +126,9 @@ def test_old_transformers_bind_inside_temporary_stub():
     if hasattr(torch, "float8_e8m0fnu"):
         pytest.skip("need torch without native e8m0 for this check")
 
-    stub = _run_temporary_stub(torch)
+    helpers = _helper_namespace(torch, include_require_native = True)
+    stub = helpers["_temporary_float8_e8m0fnu_import_stub"]
+    require_native = helpers["require_native_float8_e8m0fnu"]
     with stub():
         _UE8M0_SF_DTYPE = torch.float8_e8m0fnu  # noqa: N806
         assert _UE8M0_SF_DTYPE is torch.float8_e4m3fn

--- a/tests/test_torch_float8_e8m0fnu_stub.py
+++ b/tests/test_torch_float8_e8m0fnu_stub.py
@@ -1,0 +1,77 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""torch.float8_e8m0fnu must be stubbed before transformers imports finegrained_fp8.
+
+Studio users on torch < 2.7 hit:
+    module 'torch' has no attribute 'float8_e8m0fnu'
+during `import unsloth` even when they are not training UE8M0 FP8 models.
+"""
+
+import ast
+import types
+from pathlib import Path
+
+import pytest
+
+UTILS = (Path(__file__).resolve().parents[1] / "unsloth_zoo"
+         / "temporary_patches" / "utils.py")
+
+
+def _run_ensure(torch_mod):
+    tree = ast.parse(UTILS.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_ensure_torch_float8_e8m0fnu":
+            ns = {"torch": torch_mod}
+            exec(compile(ast.Module([node], []), "<utils>", "exec"), ns)
+            ns["_ensure_torch_float8_e8m0fnu"]()
+            return
+    raise AssertionError("_ensure_torch_float8_e8m0fnu not found in utils.py")
+
+
+def test_stub_aliases_e4m3_when_e8m0_missing():
+    torch_mod = types.SimpleNamespace(float8_e4m3fn = object())
+    _run_ensure(torch_mod)
+    assert torch_mod.float8_e8m0fnu is torch_mod.float8_e4m3fn
+
+
+def test_stub_is_a_noop_when_e8m0_already_exists():
+    sentinel = object()
+    torch_mod = types.SimpleNamespace(float8_e8m0fnu = sentinel, float8_e4m3fn = object())
+    _run_ensure(torch_mod)
+    assert torch_mod.float8_e8m0fnu is sentinel
+
+
+def test_stub_leaves_torch_alone_when_no_fp8_dtypes_exist():
+    torch_mod = types.SimpleNamespace()
+    _run_ensure(torch_mod)
+    assert not hasattr(torch_mod, "float8_e8m0fnu")
+
+
+def test_the_helper_runs_before_the_unpack_import():
+    src = UTILS.read_text(encoding="utf-8")
+    stub = src.index("_ensure_torch_float8_e8m0fnu()")
+    unpack = src.index("from transformers.processing_utils import Unpack")
+    assert stub < unpack, "the stub must run before transformers is imported"
+
+
+def test_attribute_error_branch_names_e8m0():
+    src = UTILS.read_text(encoding="utf-8")
+    assert '"float8_e8m0fnu" in e_str and "has no attribute" in e_str' in src
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_torch_float8_e8m0fnu_stub.py
+++ b/tests/test_torch_float8_e8m0fnu_stub.py
@@ -31,41 +31,82 @@ UTILS = (Path(__file__).resolve().parents[1] / "unsloth_zoo"
          / "temporary_patches" / "utils.py")
 
 
-def _run_ensure(torch_mod):
+def _load_helpers():
     tree = ast.parse(UTILS.read_text(encoding="utf-8"))
+    wanted = {
+        "_temporary_float8_e8m0fnu_import_stub",
+        "torch_supports_float8_e8m0fnu",
+        "require_native_float8_e8m0fnu",
+    }
+    ns: dict = {"contextlib": __import__("contextlib")}
     for node in tree.body:
-        if isinstance(node, ast.FunctionDef) and node.name == "_ensure_torch_float8_e8m0fnu":
-            ns = {"torch": torch_mod}
+        if isinstance(node, ast.FunctionDef) and node.name in wanted:
             exec(compile(ast.Module([node], []), "<utils>", "exec"), ns)
-            ns["_ensure_torch_float8_e8m0fnu"]()
-            return
-    raise AssertionError("_ensure_torch_float8_e8m0fnu not found in utils.py")
+    missing = wanted - set(ns)
+    assert not missing, f"helpers not found in utils.py: {missing}"
+    return ns
 
 
-def test_stub_aliases_e4m3_when_e8m0_missing():
+HELPERS = _load_helpers()
+temporary_stub = HELPERS["_temporary_float8_e8m0fnu_import_stub"]
+supports = HELPERS["torch_supports_float8_e8m0fnu"]
+require_native = HELPERS["require_native_float8_e8m0fnu"]
+
+
+def _run_temporary_stub(torch_mod):
+    tree = ast.parse(UTILS.read_text(encoding="utf-8"))
+    ns = {
+        "torch": torch_mod,
+        "contextlib": __import__("contextlib"),
+        "_E8M0_IMPORT_STUB_ACTIVE": False,
+    }
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in (
+            "torch_supports_float8_e8m0fnu",
+            "_temporary_float8_e8m0fnu_import_stub",
+        ):
+            exec(compile(ast.Module([node], []), "<utils>", "exec"), ns)
+    return ns["_temporary_float8_e8m0fnu_import_stub"]
+
+
+def test_temporary_stub_aliases_e4m3_only_during_context():
     torch_mod = types.SimpleNamespace(float8_e4m3fn = object())
-    _run_ensure(torch_mod)
-    assert torch_mod.float8_e8m0fnu is torch_mod.float8_e4m3fn
-
-
-def test_stub_is_a_noop_when_e8m0_already_exists():
-    sentinel = object()
-    torch_mod = types.SimpleNamespace(float8_e8m0fnu = sentinel, float8_e4m3fn = object())
-    _run_ensure(torch_mod)
-    assert torch_mod.float8_e8m0fnu is sentinel
-
-
-def test_stub_leaves_torch_alone_when_no_fp8_dtypes_exist():
-    torch_mod = types.SimpleNamespace()
-    _run_ensure(torch_mod)
+    stub = _run_temporary_stub(torch_mod)
+    with stub() as used:
+        assert used is True
+        assert torch_mod.float8_e8m0fnu is torch_mod.float8_e4m3fn
     assert not hasattr(torch_mod, "float8_e8m0fnu")
 
 
-def test_the_helper_runs_before_the_unpack_import():
-    src = UTILS.read_text(encoding="utf-8")
-    stub = src.index("_ensure_torch_float8_e8m0fnu()")
-    unpack = src.index("from transformers.processing_utils import Unpack")
-    assert stub < unpack, "the stub must run before transformers is imported"
+def test_temporary_stub_is_noop_when_e8m0_already_exists():
+    sentinel = object()
+    torch_mod = types.SimpleNamespace(float8_e8m0fnu = sentinel)
+    stub = _run_temporary_stub(torch_mod)
+    with stub() as used:
+        assert used is False
+        assert torch_mod.float8_e8m0fnu is sentinel
+
+
+def test_the_import_context_runs_before_unpack_import():
+    tree = ast.parse(UTILS.read_text(encoding="utf-8"))
+    with_line = None
+    unpack_line = None
+    for node in tree.body:
+        if isinstance(node, ast.With):
+            for item in node.items:
+                ctx = item.context_expr
+                if isinstance(ctx, ast.Call) and isinstance(ctx.func, ast.Name):
+                    if ctx.func.id == "_temporary_float8_e8m0fnu_import_stub":
+                        with_line = node.lineno
+        if isinstance(node, ast.With):
+            for child in ast.walk(node):
+                if isinstance(child, ast.ImportFrom) and child.module == "transformers.processing_utils":
+                    for alias in child.names:
+                        if alias.name == "Unpack":
+                            unpack_line = child.lineno
+    assert with_line is not None, "import context manager not found"
+    assert unpack_line is not None, "Unpack import not found"
+    assert with_line < unpack_line
 
 
 def test_attribute_error_branch_names_e8m0():
@@ -73,21 +114,35 @@ def test_attribute_error_branch_names_e8m0():
     assert '"float8_e8m0fnu" in e_str and "has no attribute" in e_str' in src
 
 
+def test_require_native_raises_when_e8m0_missing():
+    pytest.importorskip("torch")
+    import torch
+
+    if hasattr(torch, "float8_e8m0fnu"):
+        pytest.skip("need torch without native e8m0 for this check")
+
+    with pytest.raises(RuntimeError, match="PyTorch >= 2.7"):
+        require_native()
+
+
 @pytest.mark.integration
-def test_old_transformers_module_bind_succeeds_after_stub():
+def test_old_transformers_bind_inside_temporary_stub():
     """Mimic pinned transformers that bind _UE8M0_SF_DTYPE at import time."""
     pytest.importorskip("torch")
     import torch
 
     if not hasattr(torch, "float8_e4m3fn"):
         pytest.skip("torch build lacks float8_e4m3fn")
-
     if hasattr(torch, "float8_e8m0fnu"):
-        del torch.float8_e8m0fnu
+        pytest.skip("need torch without native e8m0 for this check")
 
-    _run_ensure(torch)
-    _UE8M0_SF_DTYPE = torch.float8_e8m0fnu  # noqa: N806 — mirrors transformers
-    assert _UE8M0_SF_DTYPE is torch.float8_e4m3fn
+    stub = _run_temporary_stub(torch)
+    with stub():
+        _UE8M0_SF_DTYPE = torch.float8_e8m0fnu  # noqa: N806
+        assert _UE8M0_SF_DTYPE is torch.float8_e4m3fn
+    assert not hasattr(torch, "float8_e8m0fnu")
+    with pytest.raises(RuntimeError, match="PyTorch >= 2.7"):
+        require_native()
 
 
 if __name__ == "__main__":

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -315,6 +315,24 @@ def _torchao_torch_mismatch_message(message):
     )
 
 
+def _ensure_torch_float8_e8m0fnu():
+    """Let transformers import on torch builds before float8_e8m0fnu existed.
+
+    Older transformers releases bind ``torch.float8_e8m0fnu`` at import time inside
+    ``integrations.finegrained_fp8``. PyTorch added that dtype in 2.7, so a plain
+    ``import unsloth`` dies on earlier torch even when the run will never touch
+    UE8M0 FP8 checkpoints. Aliasing to ``torch.float8_e4m3fn`` is enough for the
+    import to succeed; UE8M0 models still fail later with transformers' own error.
+    """
+    if hasattr(torch, "float8_e8m0fnu"):
+        return
+    fallback = getattr(torch, "float8_e4m3fn", None)
+    if fallback is not None:
+        torch.float8_e8m0fnu = fallback  # type: ignore[attr-defined]
+
+
+_ensure_torch_float8_e8m0fnu()
+
 try:
     from transformers.processing_utils import Unpack
     assert \
@@ -360,6 +378,14 @@ except Exception as e:
     # The nms arm above, for the case that never arrives as an ImportError: a
     # torchvision whose compiled ops do not match torch fails inside
     # `_meta_registrations` at `register_fake("torchvision::nms")`, a RuntimeError.
+    if "float8_e8m0fnu" in e_str and "has no attribute" in e_str:
+        raise RuntimeError(
+            f"***** Unsloth: your transformers build needs torch.float8_e8m0fnu "
+            f"(PyTorch >= 2.7), but torch {torch.__version__} does not provide it. "
+            f"Upgrade torch to use UE8M0 FP8 checkpoints, or update unsloth_zoo if "
+            f"you are on an older torch and only training non-FP8 models. "
+            f"Original error: {e_str} *****"
+        ) from None
     if "torchvision::nms does not exist" in e_str:
         raise RuntimeError(_TORCHVISION_BROKE)
     if "numpy" in e_str and ("_blas" in e_str or "_multiarray" in e_str):

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -45,6 +45,7 @@ __all__ = [
 import functools
 import inspect
 import weakref
+import contextlib
 import typing as t
 import torch
 from textwrap import dedent
@@ -315,88 +316,142 @@ def _torchao_torch_mismatch_message(message):
     )
 
 
-def _ensure_torch_float8_e8m0fnu():
-    """Let transformers import on torch builds before float8_e8m0fnu existed.
+_E8M0_IMPORT_STUB_ACTIVE = False
 
-    Older transformers releases bind ``torch.float8_e8m0fnu`` at import time inside
-    ``integrations.finegrained_fp8``. PyTorch added that dtype in 2.7, so a plain
-    ``import unsloth`` dies on earlier torch even when the run will never touch
-    UE8M0 FP8 checkpoints. Aliasing to ``torch.float8_e4m3fn`` is enough for the
-    import to succeed; UE8M0 models still fail later with transformers' own error.
-    """
-    if hasattr(torch, "float8_e8m0fnu"):
+
+def torch_supports_float8_e8m0fnu() -> bool:
+    """True when torch natively provides ``float8_e8m0fnu`` (not our import alias)."""
+    return hasattr(torch, "float8_e8m0fnu") and not _E8M0_IMPORT_STUB_ACTIVE
+
+
+def require_native_float8_e8m0fnu(
+    feature: str = "UE8M0 FP8 checkpoints",
+) -> None:
+    """Raise when a UE8M0 FP8 path is taken on torch without the real dtype."""
+    if torch_supports_float8_e8m0fnu():
+        return
+    raise RuntimeError(
+        f"***** Unsloth: {feature} require torch.float8_e8m0fnu, which is only "
+        f"available in PyTorch >= 2.7 (found {torch.__version__}). Upgrade torch "
+        f"to use UE8M0 FP8 checkpoints. *****"
+    )
+
+
+class _UE8M0RuntimeUnavailable:
+    """Dropped into finegrained_fp8 after a stubbed import on torch < 2.7."""
+
+    def __repr__(self) -> str:
+        return "torch.float8_e8m0fnu (unavailable; upgrade PyTorch >= 2.7)"
+
+
+@contextlib.contextmanager
+def _temporary_float8_e8m0fnu_import_stub():
+    """Stub ``torch.float8_e8m0fnu`` only while transformers is importing."""
+    global _E8M0_IMPORT_STUB_ACTIVE
+    if torch_supports_float8_e8m0fnu():
+        yield False
         return
     fallback = getattr(torch, "float8_e4m3fn", None)
-    if fallback is not None:
-        torch.float8_e8m0fnu = fallback  # type: ignore[attr-defined]
+    if fallback is None:
+        yield False
+        return
+    _E8M0_IMPORT_STUB_ACTIVE = True
+    torch.float8_e8m0fnu = fallback  # type: ignore[attr-defined]
+    try:
+        yield True
+    finally:
+        _E8M0_IMPORT_STUB_ACTIVE = False
+        if hasattr(torch, "float8_e8m0fnu"):
+            del torch.float8_e8m0fnu
 
 
-_ensure_torch_float8_e8m0fnu()
+def _install_finegrained_fp8_ue8m0_guard() -> None:
+    """After a stubbed import, stop UE8M0 from using the import-time alias."""
+    if torch_supports_float8_e8m0fnu():
+        return
+    try:
+        import transformers.integrations.finegrained_fp8 as fg
+    except Exception:
+        return
 
-try:
-    from transformers.processing_utils import Unpack
-    assert \
-        type(Unpack) is type(t_Unpack), \
-        "Unsloth: Unpack type changed! Please file a bug report asap!"
-except ImportError as e:
-    e = str(e)
-    if "cannot import name '_center' from 'numpy._core.umath'" in e:
+    unavailable = _UE8M0RuntimeUnavailable()
+    if hasattr(fg, "_UE8M0_SF_DTYPE"):
+        fg._UE8M0_SF_DTYPE = unavailable  # type: ignore[attr-defined]
+
+    getter = getattr(fg, "_get_ue8m0_dtype", None)
+    if getter is None:
+        return
+
+    def _guarded_get_ue8m0_dtype():
+        require_native_float8_e8m0fnu()
+
+    try:
+        fg._get_ue8m0_dtype = functools.cache(_guarded_get_ue8m0_dtype)  # type: ignore[attr-defined]
+    except Exception:
+        fg._get_ue8m0_dtype = _guarded_get_ue8m0_dtype  # type: ignore[attr-defined]
+
+
+_STUBBED_TRANSFORMERS_IMPORT = False
+
+with _temporary_float8_e8m0fnu_import_stub() as _stubbed_transformers_import:
+    _STUBBED_TRANSFORMERS_IMPORT = _stubbed_transformers_import
+    try:
+        from transformers.processing_utils import Unpack
+        assert \
+            type(Unpack) is type(t_Unpack), \
+            "Unsloth: Unpack type changed! Please file a bug report asap!"
+    except ImportError as e:
+        e = str(e)
+        if "cannot import name '_center' from 'numpy._core.umath'" in e:
+            raise RuntimeError(
+                f"***** You might have used uv to install packages, and they broke numpy. Try restarting your runtime. *****"
+            )
+        elif "torchvision::nms does not exist" in e:
+            raise RuntimeError(_TORCHVISION_BROKE)
+        elif "No module named 'torchvision.io.video'" in e or \
+             "No module named 'torchvision.io._video'" in e:
+            raise RuntimeError(
+                f"***** Your torchvision install is incomplete: `torchvision.io` "
+                f"imports a `video` module that is not there. Please run "
+                f"`pip install --upgrade --force-reinstall --no-cache-dir torchvision` "
+                f"then restart your runtime/kernel. Original error = {e} *****"
+            )
+        elif "PIL" in e or "_Ink" in e or "Pillow" in e:
+            raise RuntimeError(
+                f"***** Your Pillow (PIL) version is incompatible with torchvision. "
+                f"Please run `pip install --upgrade --force-reinstall Pillow` then restart your runtime/kernel. *****"
+            )
+        elif _torchao_is_newer_than_torch(e):
+            raise RuntimeError(_torchao_torch_mismatch_message(e)) from None
+        elif "Unpack" not in e:
+            raise Exception(e)
         raise RuntimeError(
-            f"***** You might have used uv to install packages, and they broke numpy. Try restarting your runtime. *****"
+            f"Unsloth: Unpack has been moved! Other error = {str(e)}.\n"\
+            "Please file a bug report asap!"
         )
-    elif "torchvision::nms does not exist" in e:
-        raise RuntimeError(_TORCHVISION_BROKE)
-    elif "No module named 'torchvision.io.video'" in e or \
-         "No module named 'torchvision.io._video'" in e:
-        # A half-installed torchvision, like the nms arm above. No release raises
-        # this alone (0.25 ships `io/video.py`, 0.26 dropped it with its importer),
-        # so only a tree partly overwritten by a venv install gets here.
-        # The MISSING-MODULE form only: `cannot import name 'read_video' from
-        # 'torchvision.io.video'` carries the same substring while the module is
-        # right there, and the message below would then be a lie.
-        raise RuntimeError(
-            f"***** Your torchvision install is incomplete: `torchvision.io` "
-            f"imports a `video` module that is not there. Please run "
-            f"`pip install --upgrade --force-reinstall --no-cache-dir torchvision` "
-            f"then restart your runtime/kernel. Original error = {e} *****"
-        )
-    elif "PIL" in e or "_Ink" in e or "Pillow" in e:
-        raise RuntimeError(
-            f"***** Your Pillow (PIL) version is incompatible with torchvision. "
-            f"Please run `pip install --upgrade --force-reinstall Pillow` then restart your runtime/kernel. *****"
-        )
-    elif _torchao_is_newer_than_torch(e):
-        raise RuntimeError(_torchao_torch_mismatch_message(e)) from None
-    elif "Unpack" not in e:
-        raise Exception(e)
-    raise RuntimeError(
-        f"Unsloth: Unpack has been moved! Other error = {str(e)}.\n"\
-        "Please file a bug report asap!"
-    )
-except Exception as e:
-    e_str = str(e)
-    # The nms arm above, for the case that never arrives as an ImportError: a
-    # torchvision whose compiled ops do not match torch fails inside
-    # `_meta_registrations` at `register_fake("torchvision::nms")`, a RuntimeError.
-    if "float8_e8m0fnu" in e_str and "has no attribute" in e_str:
-        raise RuntimeError(
-            f"***** Unsloth: your transformers build needs torch.float8_e8m0fnu "
-            f"(PyTorch >= 2.7), but torch {torch.__version__} does not provide it. "
-            f"Upgrade torch to use UE8M0 FP8 checkpoints, or update unsloth_zoo if "
-            f"you are on an older torch and only training non-FP8 models. "
-            f"Original error: {e_str} *****"
-        ) from None
-    if "torchvision::nms does not exist" in e_str:
-        raise RuntimeError(_TORCHVISION_BROKE)
-    if "numpy" in e_str and ("_blas" in e_str or "_multiarray" in e_str):
-        raise RuntimeError(
-            f"***** numpy was likely upgraded mid-session without restarting the kernel. "
-            f"numpy C extensions cannot be reloaded in-place. "
-            f"Please restart your runtime/kernel after installing packages. "
-            f"Original error: {e_str} *****"
-        )
-    raise
-pass
+    except Exception as e:
+        e_str = str(e)
+        if "float8_e8m0fnu" in e_str and "has no attribute" in e_str:
+            raise RuntimeError(
+                f"***** Unsloth: your transformers build needs torch.float8_e8m0fnu "
+                f"(PyTorch >= 2.7), but torch {torch.__version__} does not provide it. "
+                f"Upgrade torch to use UE8M0 FP8 checkpoints, or update unsloth_zoo if "
+                f"you are on an older torch and only training non-FP8 models. "
+                f"Original error: {e_str} *****"
+            ) from None
+        if "torchvision::nms does not exist" in e_str:
+            raise RuntimeError(_TORCHVISION_BROKE)
+        if "numpy" in e_str and ("_blas" in e_str or "_multiarray" in e_str):
+            raise RuntimeError(
+                f"***** numpy was likely upgraded mid-session without restarting the kernel. "
+                f"numpy C extensions cannot be reloaded in-place. "
+                f"Please restart your runtime/kernel after installing packages. "
+                f"Original error: {e_str} *****"
+            )
+        raise
+
+if _STUBBED_TRANSFORMERS_IMPORT:
+    _install_finegrained_fp8_ue8m0_guard()
 KWARGS_TYPE = t_Unpack[t_TypedDictMeta]
 
 

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1374,6 +1374,9 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                 kwargs["quant_type"] = quantization_config["bnb_4bit_quant_type"]
                 kwargs["quant_storage"] = _get_dtype(quantization_config["bnb_4bit_quant_storage"])
             elif quant_method == 'fp8':
+                if quantization_config.get("scale_fmt") == "ue8m0":
+                    from .temporary_patches.utils import require_native_float8_e8m0fnu
+                    require_native_float8_e8m0fnu()
                 kwargs['activation_scheme'] = quantization_config['activation_scheme']
                 kwargs['block_size'] = quantization_config['weight_block_size']
                 try:
@@ -1387,6 +1390,9 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                 except:
                     raise ImportError("Unsloth: FP8 models need importing FbgemmFP8Linear from `transformers.integrations.fbgemm_fp8` but we don't see it.")
             elif quant_method == 'compressed-tensors':
+                if quantization_config.get("scale_fmt") == "ue8m0":
+                    from .temporary_patches.utils import require_native_float8_e8m0fnu
+                    require_native_float8_e8m0fnu()
                 kwargs['activation_scheme'] = 'dynamic' # mark it dynamic for now
                 block_size = [128, 128] # The default we override if we find in config
                 config_groups = quantization_config.get('config_groups', None)


### PR DESCRIPTION
## Summary

Fixes unslothai/unsloth#8933.

On torch builds before 2.7, `import unsloth` fails during Studio training with:

```
module 'torch' has no attribute 'float8_e8m0fnu'
```

Pinned transformers releases bind `torch.float8_e8m0fnu` at import time in `integrations/finegrained_fp8.py`, even when the run will never touch UE8M0 FP8 checkpoints.

This PR stubs the missing dtype to `torch.float8_e4m3fn` before transformers is imported, so normal LoRA training can start on older torch. A clearer fallback error is added when no FP8 dtypes exist at all.

## Test plan

- [x] `pytest tests/test_torch_float8_e8m0fnu_stub.py` (6 passed)
- [x] **torch 2.6 integration** (`scripts/verify_e8m0_import.py`, 4/4 passed):
  - Studio `finegrained_fp8` bind fails without stub (reproduces #8933)
  - Same bind succeeds after stub
  - `unsloth_zoo.temporary_patches.utils` imports on real torch 2.6.0+cpu
  - UE8M0 path checked on torch 2.12 venv (no regression)
- [x] `import unsloth` reaches zoo init on torch 2.6 (blocked later only by CPU-only torch CUDA ops; Studio users have GPUs)

Fixes unslothai/unsloth#8933
