### PR TITLE
deps: allow torch 2.13.x for CVE-2025-3000 remediation

### DIFF
--- a/.github/workflows/gemma4-audio-probe.yml
+++ b/.github/workflows/gemma4-audio-probe.yml
@@ -74,7 +74,7 @@ jobs:
         # the zoo import path still wants it.
         run: |
           python -m pip install --upgrade pip
-          pip install "torch>=2.4.0,<2.13.0"
+          pip install "torch>=2.4.0,<2.14.0"
           pip install -e .[mlx] "mlx-vlm==${{ matrix.mlx_vlm }}"
           python -c "
           import mlx_vlm, transformers

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -64,7 +64,7 @@ jobs:
         # ModuleNotFoundError: No module named 'torch'.
         run: |
           python -m pip install --upgrade pip
-          pip install "torch>=2.4.0,<2.13.0"
+          pip install "torch>=2.4.0,<2.14.0"
           pip install -e .[mlx]
           pip install pytest==9.0.3
           # The vision model used by tests/test_mlx_generate_metal.py loads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     # --- GPU-only deps (skipped on macOS arm64) ---
-    "torch>=2.4.0,<2.13.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
+    "torch>=2.4.0,<2.14.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "torchao>=0.13.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "triton>=3.0.0 ; ('linux' in sys_platform)",
     "tyro ; (sys_platform != 'darwin' or platform_machine != 'arm64')",


### PR DESCRIPTION
## Summary

Raises the published `torch` upper bound from `<2.13.0` to `<2.14.0` so `pip` can resolve `torch==2.13.0` alongside `unsloth_zoo`.

This unblocks the security remediation for [GHSA-rrmf-rvhw-rf47](https://github.com/advisories/GHSA-rrmf-rvhw-rf47) (CVE-2025-3000), where torch `<=2.12.1` is affected and `2.13.0` is the first patched release.

Fixes unslothai/unsloth#8926

## Changes

- `pyproject.toml`: `torch>=2.4.0,<2.13.0` → `torch>=2.4.0,<2.14.0` (Linux/non-Apple-Silicon)
- CI workflows updated to match (`mlx-ci.yml`, `gemma4-audio-probe.yml`)

## Test plan

- [x] `pip install --dry-run -e . 'torch==2.13.0'` resolves successfully on Python 3.13
- [ ] CUDA training smoke on RTX 4090 (not run on contributor VM — no GPU)

## Notes

This is the zoo half of the coordinated release requested in #8926. A matching `unsloth` PR widens the CUDA/CPU install constraints; both should ship together.