### PR TITLE
fix(mlx): stop the bitsandbytes stub shadowing a real install

### DIFF
--- a/tests/test_upstream_pinned_symbols_accelerator.py
+++ b/tests/test_upstream_pinned_symbols_accelerator.py
@@ -27,6 +27,7 @@ APIs are not exercised directly so the suite is CPU-runnable in CI.
 
 from __future__ import annotations
 
+import contextlib
 import sys
 import types
 from unittest import mock
@@ -343,6 +344,325 @@ def test_stub_noop_call_raises_not_returns_none():
         assert sub is not noop
         with pytest.raises(NotImplementedError, match="test.symbol.some_attr"):
             sub()
+
+
+# Reads sys.modules rather than importing either package. Both stubs seed sys.modules
+# directly, so an import here would only let the regression under test surface as an
+# ImportError instead of as a wrong verdict below.
+_GATE_PROBE = """
+import json, sys
+if {hide_bitsandbytes}:
+    # Simulate a host with no bitsandbytes regardless of what is really installed,
+    # so this case cannot fail on a machine that happens to have the real one.
+    import importlib.util
+    _find_spec = importlib.util.find_spec
+    importlib.util.find_spec = (
+        lambda name, *a, **k: None if name == "bitsandbytes"
+        else _find_spec(name, *a, **k)
+    )
+import unsloth_zoo  # runs the stub-injection gate
+bnb = sys.modules.get("bitsandbytes")
+triton = sys.modules.get("triton")
+print(json.dumps({{
+    "bnb_stubbed": bool(getattr(bnb, "IS_UNSLOTH_STUB", False)),
+    "triton_stubbed": "triton_stub" in (getattr(triton, "__file__", "") or ""),
+}}))
+"""
+
+
+@pytest.mark.parametrize("bitsandbytes_installed", [True, False])
+def test_the_stub_gate_shadows_no_real_bitsandbytes_but_always_stubs_triton(
+    tmp_path, bitsandbytes_installed,
+):
+    """Run the real gate in a fresh interpreter and look at what it produced.
+
+    Shadowing a real bitsandbytes made every bnb-quantized checkpoint unloadable. Triton
+    ships no macOS wheel to prefer, so it is stubbed either way.
+    """
+    import json
+    import os
+    import pathlib
+    import subprocess
+
+    import unsloth_zoo
+
+    env = dict(os.environ)
+    # Forces the skip-GPU-init branch on a non-MLX host too, so this runs everywhere.
+    env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
+    path = [str(pathlib.Path(unsloth_zoo.__file__).parent.parent)]
+    if bitsandbytes_installed:
+        fake = tmp_path / "bitsandbytes"
+        fake.mkdir()
+        (fake / "__init__.py").write_text("__version__ = '0.0.0-fake'\n")
+        path.insert(0, str(tmp_path))
+    env["PYTHONPATH"] = os.pathsep.join(path)
+
+    run = subprocess.run(
+        [sys.executable, "-c",
+         _GATE_PROBE.format(hide_bitsandbytes = not bitsandbytes_installed)],
+        capture_output = True, text = True, env = env, timeout = 300,
+    )
+    # No skip on failure: the gate runs during `import unsloth_zoo`, so a crash in the
+    # code under test and an unusable environment produce the same traceback. Every other
+    # test here already needs unsloth_zoo importable.
+    assert run.returncode == 0, f"gate probe failed:\n{run.stderr[-2000:]}"
+    result = json.loads(run.stdout.strip().splitlines()[-1])
+
+    assert result["bnb_stubbed"] is not bitsandbytes_installed, (
+        "the stub shadowed a real bitsandbytes install"
+        if bitsandbytes_installed else
+        "bitsandbytes was left unstubbed with none installed"
+    )
+    assert result["triton_stubbed"], "triton stubbing became conditional"
+
+
+def test_real_bitsandbytes_available_distinguishes_a_stub_from_a_real_module():
+    from unsloth_zoo.stubs import bitsandbytes_stub
+
+    real = types.ModuleType("bitsandbytes")
+    stub_like = types.ModuleType("bitsandbytes")
+    stub_like.IS_UNSLOTH_STUB = True
+
+    with mock.patch.dict(sys.modules, {"bitsandbytes": real}):
+        assert bitsandbytes_stub.real_bitsandbytes_available() is True
+    with mock.patch.dict(sys.modules, {"bitsandbytes": stub_like}):
+        assert bitsandbytes_stub.real_bitsandbytes_available() is False
+
+
+@pytest.mark.parametrize("installed", [True, False])
+def test_real_bitsandbytes_available_locates_without_importing(installed):
+    """Detection must not import bitsandbytes: that pulls in torch, ~1s, on hosts whose
+    whole reason for skipping GPU init is to avoid it."""
+    import builtins
+
+    from unsloth_zoo.stubs import bitsandbytes_stub
+
+    spec = object() if installed else None
+    real_import = builtins.__import__
+
+    def guarded_import(name, *a, **kw):
+        # Catches a plain `import bitsandbytes` too, not just importlib.import_module.
+        assert not name.startswith("bitsandbytes"), f"must not import {name}"
+        return real_import(name, *a, **kw)
+
+    saved = {k: v for k, v in sys.modules.items() if k.startswith("bitsandbytes")}
+    for k in saved:
+        del sys.modules[k]
+    try:
+        with mock.patch.object(
+            bitsandbytes_stub.importlib.util, "find_spec", return_value = spec
+        ) as find_spec, mock.patch.object(builtins, "__import__", guarded_import):
+            assert bitsandbytes_stub.real_bitsandbytes_available() is installed
+        find_spec.assert_called_once_with("bitsandbytes")
+        assert not [k for k in sys.modules if k.startswith("bitsandbytes")], (
+            "detection left bitsandbytes resident, so it imported rather than located"
+        )
+    finally:
+        sys.modules.update(saved)
+
+
+def test_bitsandbytes_is_stubbed_only_reports_the_unsloth_stub():
+    from unsloth_zoo.mlx import loader
+
+    stubbed = types.ModuleType("bitsandbytes")
+    stubbed.IS_UNSLOTH_STUB = True
+
+    with mock.patch.dict(sys.modules, {"bitsandbytes": stubbed}):
+        assert loader._bitsandbytes_is_stubbed() is True
+    with mock.patch.dict(sys.modules, {"bitsandbytes": types.ModuleType("bitsandbytes")}):
+        assert loader._bitsandbytes_is_stubbed() is False
+    saved = sys.modules.pop("bitsandbytes", None)
+    try:
+        assert loader._bitsandbytes_is_stubbed() is False
+    finally:
+        if saved is not None:
+            sys.modules["bitsandbytes"] = saved
+
+
+@contextlib.contextmanager
+def _bnb_modules(entries):
+    """Run with exactly ``entries`` as the resident bitsandbytes modules."""
+    from unsloth_zoo.mlx import loader
+
+    saved = {k: v for k, v in sys.modules.items() if k.startswith("bitsandbytes")}
+    saved_real = loader._REAL_BITSANDBYTES_MODULES
+    saved_meta = list(sys.meta_path)
+    for k in saved:
+        del sys.modules[k]
+    sys.modules.update(entries)
+    try:
+        yield
+    finally:
+        for k in [k for k in sys.modules if k.startswith("bitsandbytes")]:
+            del sys.modules[k]
+        sys.modules.update(saved)
+        loader._REAL_BITSANDBYTES_MODULES = saved_real
+        sys.meta_path[:] = saved_meta
+
+
+def test_lifting_the_bnb_stub_exposes_the_real_wheel_then_puts_the_stub_back():
+    """The swap must lift the stub, cache what the block imported, and restore."""
+    from unsloth_zoo.mlx import loader
+
+    stub = types.ModuleType("bitsandbytes")
+    stub.IS_UNSLOTH_STUB = True
+    real = types.ModuleType("bitsandbytes")
+    real_ops = types.ModuleType("bitsandbytes._ops")
+
+    class _BnbFinder:  # the swap filters meta_path by this class name
+        pass
+
+    finder = _BnbFinder()
+
+    with _bnb_modules({"bitsandbytes": stub, "bitsandbytes.nn": types.ModuleType("bitsandbytes.nn")}):
+        loader._REAL_BITSANDBYTES_MODULES = {}
+        sys.meta_path.insert(0, finder)
+        with loader._lifted_bitsandbytes_stub():
+            assert "bitsandbytes" not in sys.modules, "the stub was not lifted"
+            assert "bitsandbytes.nn" not in sys.modules, "a stub submodule survived"
+            assert finder not in sys.meta_path, (
+                "the stub's finder still serves bitsandbytes submodules, so the real "
+                "wheel would come back half stubbed"
+            )
+            sys.modules["bitsandbytes"] = real          # stands in for the real import
+            sys.modules["bitsandbytes._ops"] = real_ops  # ... and its operator module
+        assert sys.modules["bitsandbytes"] is stub, "the stub was not put back"
+        assert "bitsandbytes.nn" in sys.modules, "a stub submodule was not put back"
+        assert finder in sys.meta_path, "the stub's finder was not put back"
+        # The real wheel is cached so a second call need not re-import it, which is what
+        # re-registers its torch operators and raises. Caching the package root alone
+        # would leave those operator submodules to be imported again.
+        assert loader._REAL_BITSANDBYTES_MODULES["bitsandbytes"] is real
+        assert loader._REAL_BITSANDBYTES_MODULES["bitsandbytes._ops"] is real_ops
+
+        # Second call: the cached real modules are reinstated rather than re-imported.
+        with loader._lifted_bitsandbytes_stub():
+            assert sys.modules["bitsandbytes"] is real
+            assert sys.modules["bitsandbytes._ops"] is real_ops
+        assert sys.modules["bitsandbytes"] is stub
+
+
+def test_lifting_the_bnb_stub_is_a_no_op_when_no_stub_is_resident():
+    """Evicting a resident real wheel makes the next import re-execute it and
+    re-register its torch operators, which raises."""
+    from unsloth_zoo.mlx import loader
+
+    real = types.ModuleType("bitsandbytes")
+    ops = types.ModuleType("bitsandbytes._ops")
+
+    late_finder = types.SimpleNamespace()
+    late_submodule = types.ModuleType("bitsandbytes.functional")
+
+    with _bnb_modules({"bitsandbytes": real, "bitsandbytes._ops": ops}):
+        before_meta = list(sys.meta_path)
+        with loader._lifted_bitsandbytes_stub():
+            assert sys.modules["bitsandbytes"] is real, "the real wheel was evicted"
+            assert sys.modules["bitsandbytes._ops"] is ops
+            assert sys.meta_path == before_meta, (
+                "meta_path was disturbed with no stub to lift"
+            )
+            # A dequant runs for minutes; another thread can install a finder or
+            # complete a submodule import meanwhile.
+            sys.meta_path.insert(0, late_finder)
+            sys.modules["bitsandbytes.functional"] = late_submodule
+        assert sys.modules["bitsandbytes"] is real, "the real wheel was evicted on exit"
+        assert sys.modules["bitsandbytes._ops"] is ops
+        assert late_finder in sys.meta_path, (
+            "a finder installed during the block was clobbered by a meta_path restore "
+            "that had nothing to restore"
+        )
+        assert sys.modules.get("bitsandbytes.functional") is late_submodule, (
+            "a submodule whose import completed during the block was evicted by a "
+            "snapshot restore that had nothing to restore"
+        )
+
+
+def test_lifting_the_bnb_stub_keeps_a_wheel_first_imported_inside_the_block():
+    """The cold path: detection never imports, so a dequant can be the first consumer.
+
+    A restore that runs anyway drops the wheel the block just imported.
+    """
+    from unsloth_zoo.mlx import loader
+
+    real = types.ModuleType("bitsandbytes")
+    ops = types.ModuleType("bitsandbytes._ops")
+
+    with _bnb_modules({}):
+        assert not [k for k in sys.modules if k.startswith("bitsandbytes")]
+        with loader._lifted_bitsandbytes_stub():
+            sys.modules["bitsandbytes"] = real      # stands in for the first real import
+            sys.modules["bitsandbytes._ops"] = ops
+        assert sys.modules.get("bitsandbytes") is real, (
+            "the wheel imported inside the block was evicted on exit"
+        )
+        assert sys.modules.get("bitsandbytes._ops") is ops
+
+
+def test_the_dequant_sees_the_real_wheel_not_the_stub(monkeypatch, tmp_path):
+    """The dequant must run inside the lift, not merely have one available.
+
+    Without it it imports whatever is resident, which on a stubbed host is the stub.
+    """
+    import transformers
+
+    from unsloth_zoo.mlx import loader
+
+    stub = types.ModuleType("bitsandbytes")
+    stub.IS_UNSLOTH_STUB = True
+    real = types.ModuleType("bitsandbytes")
+    seen = {}
+
+    class _FakeModel:
+        config = types.SimpleNamespace()
+
+        def dequantize(self):
+            return self
+
+        def save_pretrained(self, *a, **k):
+            pass
+
+    class _FakeModelLoader:
+        @staticmethod
+        def from_pretrained(*a, **k):
+            # Recorded under its own key: the dequantization is this call, so a later
+            # tokenizer load seeing the real module must not stand in for it.
+            seen["model_load"] = sys.modules.get("bitsandbytes")
+            return _FakeModel()
+
+    class _FakeTokenizerLoader:
+        @staticmethod
+        def from_pretrained(*a, **k):
+            seen["tokenizer_load"] = sys.modules.get("bitsandbytes")
+            return _FakeModel()
+
+    monkeypatch.setattr(transformers, "AutoModelForCausalLM", _FakeModelLoader)
+    monkeypatch.setattr(transformers, "AutoTokenizer", _FakeTokenizerLoader)
+    monkeypatch.setattr(loader.tempfile, "mkdtemp", lambda **k: str(tmp_path))
+
+    with _bnb_modules({"bitsandbytes": stub}):
+        # The lift reinstates cached real modules, standing in for the real import.
+        loader._REAL_BITSANDBYTES_MODULES = {"bitsandbytes": real}
+        loader._dequantize_bnb_to_tempdir(
+            "some/repo", token = None, trust_remote_code = False,
+        )
+        assert seen["model_load"] is real, (
+            "the dequant ran against the stub, so it never entered the lift"
+        )
+        assert sys.modules["bitsandbytes"] is stub, "the stub was not put back"
+
+
+def test_lifting_the_bnb_stub_restores_after_the_block_raises():
+    from unsloth_zoo.mlx import loader
+
+    stub = types.ModuleType("bitsandbytes")
+    stub.IS_UNSLOTH_STUB = True
+
+    with _bnb_modules({"bitsandbytes": stub}):
+        loader._REAL_BITSANDBYTES_MODULES = {}
+        with pytest.raises(ImportError):
+            with loader._lifted_bitsandbytes_stub():
+                raise ImportError("no real wheel here")
+        assert sys.modules["bitsandbytes"] is stub, "the stub was lost on the error path"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_upstream_pinned_symbols_accelerator.py
+++ b/tests/test_upstream_pinned_symbols_accelerator.py
@@ -346,9 +346,9 @@ def test_stub_noop_call_raises_not_returns_none():
             sub()
 
 
-# Reads sys.modules rather than importing either package. Both stubs seed sys.modules
-# directly, so an import here would only let the regression under test surface as an
-# ImportError instead of as a wrong verdict below.
+# Reads sys.modules rather than importing either package: both stubs seed sys.modules
+# directly, so an import would surface the regression as an ImportError instead of as a
+# wrong verdict below.
 _GATE_PROBE = """
 import json, sys
 if {hide_bitsandbytes}:
@@ -403,8 +403,7 @@ def test_the_stub_gate_shadows_no_real_bitsandbytes_but_always_stubs_triton(
         capture_output = True, text = True, env = env, timeout = 300,
     )
     # No skip on failure: the gate runs during `import unsloth_zoo`, so a crash in the
-    # code under test and an unusable environment produce the same traceback. Every other
-    # test here already needs unsloth_zoo importable.
+    # code under test and an unusable environment produce the same traceback.
     assert run.returncode == 0, f"gate probe failed:\n{run.stderr[-2000:]}"
     result = json.loads(run.stdout.strip().splitlines()[-1])
 
@@ -437,8 +436,8 @@ def test_real_bitsandbytes_available_locates_without_importing(installed):
 
     from unsloth_zoo.stubs import bitsandbytes_stub
 
-    # A loader-bearing spec is what a real distribution produces; a loaderless one is a
-    # namespace package, which is not an install (see the namespace test below).
+    # A real distribution produces a loader-bearing spec; a loaderless one is a namespace
+    # package, which is not an install (see the namespace test below).
     spec = types.SimpleNamespace(loader = object()) if installed else None
     real_import = builtins.__import__
 
@@ -464,12 +463,12 @@ def test_real_bitsandbytes_available_locates_without_importing(installed):
 
 
 def test_a_namespace_bitsandbytes_directory_is_not_a_real_install(tmp_path):
-    """A bare `bitsandbytes/` directory with no __init__.py -- what a half-removed
-    install, or a source checkout sitting beside the script, leaves on sys.path.
+    """A bare `bitsandbytes/` directory with no __init__.py -- what a half-removed install
+    leaves on sys.path.
 
-    find_spec answers with a loaderless namespace spec, so treating "found" as
-    "installed" would stand aside for a package that imports to nothing: the caller then
-    has neither a working wheel nor the stub that used to cover for it.
+    find_spec answers with a loaderless namespace spec, so treating "found" as "installed"
+    stands aside for a package that imports to nothing, leaving the caller with neither a
+    wheel nor the stub.
     """
     from unsloth_zoo.stubs import bitsandbytes_stub
 
@@ -477,8 +476,8 @@ def test_a_namespace_bitsandbytes_directory_is_not_a_real_install(tmp_path):
     saved = {k: v for k, v in sys.modules.items() if k.startswith("bitsandbytes")}
     for k in saved:
         del sys.modules[k]
-    # A regular package anywhere later on the path beats a namespace portion, so an
-    # installed wheel on this runner would mask the case under test.
+    # A regular package later on the path beats a namespace portion, so an installed
+    # wheel on this runner would mask the case under test.
     saved_path = list(sys.path)
     sys.path[:] = [str(tmp_path)] + [p for p in sys.path if "site-packages" not in p]
     try:
@@ -493,8 +492,8 @@ def test_a_namespace_bitsandbytes_directory_is_not_a_real_install(tmp_path):
 
 
 def _mlx_loader():
-    """The MLX loader, or skip. Importing it pulls in mlx.core, and this file also runs
-    in the Linux upstream-regression lane, which installs no mlx."""
+    """The MLX loader, or skip: importing it pulls in mlx.core, and this file also runs in
+    the Linux upstream-regression lane, which installs no mlx."""
     pytest.importorskip("mlx")
     from unsloth_zoo.mlx import loader
 
@@ -569,9 +568,9 @@ def test_lifting_the_bnb_stub_exposes_the_real_wheel_then_puts_the_stub_back():
         assert sys.modules["bitsandbytes"] is stub, "the stub was not put back"
         assert "bitsandbytes.nn" in sys.modules, "a stub submodule was not put back"
         assert finder in sys.meta_path, "the stub's finder was not put back"
-        # The real wheel is cached so a second call need not re-import it, which is what
-        # re-registers its torch operators and raises. Caching the package root alone
-        # would leave those operator submodules to be imported again.
+        # Cached so a second call need not re-import it, which re-registers its torch
+        # operators and raises. Caching the package root alone would leave the operator
+        # submodules to be imported again.
         assert loader._REAL_BITSANDBYTES_MODULES["bitsandbytes"] is real
         assert loader._REAL_BITSANDBYTES_MODULES["bitsandbytes._ops"] is real_ops
 
@@ -583,8 +582,8 @@ def test_lifting_the_bnb_stub_exposes_the_real_wheel_then_puts_the_stub_back():
 
 
 def test_lifting_the_bnb_stub_is_a_no_op_when_no_stub_is_resident():
-    """Evicting a resident real wheel makes the next import re-execute it and
-    re-register its torch operators, which raises."""
+    """Evicting a resident real wheel makes the next import re-register its torch
+    operators, which raises."""
     loader = _mlx_loader()
 
     real = types.ModuleType("bitsandbytes")
@@ -601,8 +600,8 @@ def test_lifting_the_bnb_stub_is_a_no_op_when_no_stub_is_resident():
             assert sys.meta_path == before_meta, (
                 "meta_path was disturbed with no stub to lift"
             )
-            # A dequant runs for minutes; another thread can install a finder or
-            # complete a submodule import meanwhile.
+            # A dequant runs for minutes; another thread can install a finder or finish a
+            # submodule import meanwhile.
             sys.meta_path.insert(0, late_finder)
             sys.modules["bitsandbytes.functional"] = late_submodule
         assert sys.modules["bitsandbytes"] is real, "the real wheel was evicted on exit"
@@ -618,10 +617,8 @@ def test_lifting_the_bnb_stub_is_a_no_op_when_no_stub_is_resident():
 
 
 def test_lifting_the_bnb_stub_keeps_a_wheel_first_imported_inside_the_block():
-    """The cold path: detection never imports, so a dequant can be the first consumer.
-
-    A restore that runs anyway drops the wheel the block just imported.
-    """
+    """The cold path: detection never imports, so a dequant can be the first consumer and
+    a restore that runs anyway drops the wheel the block just imported."""
     loader = _mlx_loader()
 
     real = types.ModuleType("bitsandbytes")
@@ -639,10 +636,8 @@ def test_lifting_the_bnb_stub_keeps_a_wheel_first_imported_inside_the_block():
 
 
 def test_the_dequant_sees_the_real_wheel_not_the_stub(monkeypatch, tmp_path):
-    """The dequant must run inside the lift, not merely have one available.
-
-    Without it it imports whatever is resident, which on a stubbed host is the stub.
-    """
+    """The dequant must run inside the lift, not merely have one available: otherwise it
+    imports whatever is resident, which on a stubbed host is the stub."""
     import transformers
 
     loader = _mlx_loader()
@@ -664,8 +659,8 @@ def test_the_dequant_sees_the_real_wheel_not_the_stub(monkeypatch, tmp_path):
     class _FakeModelLoader:
         @staticmethod
         def from_pretrained(*a, **k):
-            # Recorded under its own key: the dequantization is this call, so a later
-            # tokenizer load seeing the real module must not stand in for it.
+            # Its own key: the dequantization is this call, so a later tokenizer load
+            # seeing the real module must not stand in for it.
             seen["model_load"] = sys.modules.get("bitsandbytes")
             return _FakeModel()
 
@@ -708,9 +703,8 @@ def test_lifting_the_bnb_stub_restores_after_the_block_raises():
 def test_lifting_the_bnb_stub_keeps_a_finder_installed_while_the_block_ran():
     """The stubbed path must leave sys.meta_path alone apart from the stub's own finder.
 
-    The no-stub path above already declines to touch it for exactly this reason, and the
-    block is a multi-GB dequant that runs for minutes: restoring a whole snapshot taken
-    at entry silently drops whatever another thread installed in between.
+    The block is a multi-GB dequant running for minutes, so restoring a whole snapshot
+    taken at entry silently drops whatever another thread installed in between.
     """
     loader = _mlx_loader()
 

--- a/tests/test_upstream_pinned_symbols_accelerator.py
+++ b/tests/test_upstream_pinned_symbols_accelerator.py
@@ -437,7 +437,9 @@ def test_real_bitsandbytes_available_locates_without_importing(installed):
 
     from unsloth_zoo.stubs import bitsandbytes_stub
 
-    spec = object() if installed else None
+    # A loader-bearing spec is what a real distribution produces; a loaderless one is a
+    # namespace package, which is not an install (see the namespace test below).
+    spec = types.SimpleNamespace(loader = object()) if installed else None
     real_import = builtins.__import__
 
     def guarded_import(name, *a, **kw):
@@ -461,8 +463,46 @@ def test_real_bitsandbytes_available_locates_without_importing(installed):
         sys.modules.update(saved)
 
 
-def test_bitsandbytes_is_stubbed_only_reports_the_unsloth_stub():
+def test_a_namespace_bitsandbytes_directory_is_not_a_real_install(tmp_path):
+    """A bare `bitsandbytes/` directory with no __init__.py -- what a half-removed
+    install, or a source checkout sitting beside the script, leaves on sys.path.
+
+    find_spec answers with a loaderless namespace spec, so treating "found" as
+    "installed" would stand aside for a package that imports to nothing: the caller then
+    has neither a working wheel nor the stub that used to cover for it.
+    """
+    from unsloth_zoo.stubs import bitsandbytes_stub
+
+    (tmp_path / "bitsandbytes").mkdir()
+    saved = {k: v for k, v in sys.modules.items() if k.startswith("bitsandbytes")}
+    for k in saved:
+        del sys.modules[k]
+    # A regular package anywhere later on the path beats a namespace portion, so an
+    # installed wheel on this runner would mask the case under test.
+    saved_path = list(sys.path)
+    sys.path[:] = [str(tmp_path)] + [p for p in sys.path if "site-packages" not in p]
+    try:
+        spec = bitsandbytes_stub.importlib.util.find_spec("bitsandbytes")
+        assert spec is not None and spec.loader is None, "not a namespace package"
+        assert bitsandbytes_stub.real_bitsandbytes_available() is False
+    finally:
+        sys.path[:] = saved_path
+        for k in [k for k in sys.modules if k.startswith("bitsandbytes")]:
+            del sys.modules[k]
+        sys.modules.update(saved)
+
+
+def _mlx_loader():
+    """The MLX loader, or skip. Importing it pulls in mlx.core, and this file also runs
+    in the Linux upstream-regression lane, which installs no mlx."""
+    pytest.importorskip("mlx")
     from unsloth_zoo.mlx import loader
+
+    return loader
+
+
+def test_bitsandbytes_is_stubbed_only_reports_the_unsloth_stub():
+    loader = _mlx_loader()
 
     stubbed = types.ModuleType("bitsandbytes")
     stubbed.IS_UNSLOTH_STUB = True
@@ -482,7 +522,7 @@ def test_bitsandbytes_is_stubbed_only_reports_the_unsloth_stub():
 @contextlib.contextmanager
 def _bnb_modules(entries):
     """Run with exactly ``entries`` as the resident bitsandbytes modules."""
-    from unsloth_zoo.mlx import loader
+    loader = _mlx_loader()
 
     saved = {k: v for k, v in sys.modules.items() if k.startswith("bitsandbytes")}
     saved_real = loader._REAL_BITSANDBYTES_MODULES
@@ -502,7 +542,7 @@ def _bnb_modules(entries):
 
 def test_lifting_the_bnb_stub_exposes_the_real_wheel_then_puts_the_stub_back():
     """The swap must lift the stub, cache what the block imported, and restore."""
-    from unsloth_zoo.mlx import loader
+    loader = _mlx_loader()
 
     stub = types.ModuleType("bitsandbytes")
     stub.IS_UNSLOTH_STUB = True
@@ -545,7 +585,7 @@ def test_lifting_the_bnb_stub_exposes_the_real_wheel_then_puts_the_stub_back():
 def test_lifting_the_bnb_stub_is_a_no_op_when_no_stub_is_resident():
     """Evicting a resident real wheel makes the next import re-execute it and
     re-register its torch operators, which raises."""
-    from unsloth_zoo.mlx import loader
+    loader = _mlx_loader()
 
     real = types.ModuleType("bitsandbytes")
     ops = types.ModuleType("bitsandbytes._ops")
@@ -582,7 +622,7 @@ def test_lifting_the_bnb_stub_keeps_a_wheel_first_imported_inside_the_block():
 
     A restore that runs anyway drops the wheel the block just imported.
     """
-    from unsloth_zoo.mlx import loader
+    loader = _mlx_loader()
 
     real = types.ModuleType("bitsandbytes")
     ops = types.ModuleType("bitsandbytes._ops")
@@ -605,7 +645,7 @@ def test_the_dequant_sees_the_real_wheel_not_the_stub(monkeypatch, tmp_path):
     """
     import transformers
 
-    from unsloth_zoo.mlx import loader
+    loader = _mlx_loader()
 
     stub = types.ModuleType("bitsandbytes")
     stub.IS_UNSLOTH_STUB = True
@@ -652,7 +692,7 @@ def test_the_dequant_sees_the_real_wheel_not_the_stub(monkeypatch, tmp_path):
 
 
 def test_lifting_the_bnb_stub_restores_after_the_block_raises():
-    from unsloth_zoo.mlx import loader
+    loader = _mlx_loader()
 
     stub = types.ModuleType("bitsandbytes")
     stub.IS_UNSLOTH_STUB = True
@@ -663,6 +703,34 @@ def test_lifting_the_bnb_stub_restores_after_the_block_raises():
             with loader._lifted_bitsandbytes_stub():
                 raise ImportError("no real wheel here")
         assert sys.modules["bitsandbytes"] is stub, "the stub was lost on the error path"
+
+
+def test_lifting_the_bnb_stub_keeps_a_finder_installed_while_the_block_ran():
+    """The stubbed path must leave sys.meta_path alone apart from the stub's own finder.
+
+    The no-stub path above already declines to touch it for exactly this reason, and the
+    block is a multi-GB dequant that runs for minutes: restoring a whole snapshot taken
+    at entry silently drops whatever another thread installed in between.
+    """
+    loader = _mlx_loader()
+
+    stub = types.ModuleType("bitsandbytes")
+    stub.IS_UNSLOTH_STUB = True
+
+    class _BnbFinder:  # the swap filters meta_path by this class name
+        pass
+
+    stub_finder = _BnbFinder()
+    late_finder = types.SimpleNamespace()
+
+    with _bnb_modules({"bitsandbytes": stub}):
+        loader._REAL_BITSANDBYTES_MODULES = {}
+        sys.meta_path.insert(0, stub_finder)
+        with loader._lifted_bitsandbytes_stub():
+            assert stub_finder not in sys.meta_path, "the stub finder was not lifted"
+            sys.meta_path.insert(0, late_finder)   # another thread, mid-dequant
+        assert late_finder in sys.meta_path, "a concurrently installed finder was dropped"
+        assert stub_finder in sys.meta_path, "the stub finder was not put back"
 
 
 # ---------------------------------------------------------------------------

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -179,16 +179,23 @@ else:
     _SKIP_GPU_INIT = os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT", "0") == "1"
     del _is_mlx_only, is_mlx_available
 
-# Inject triton & bitsandbytes stubs whenever GPU init is skipped (MLX host or the
-# opt-in download child), so unsloth's CUDA-only imports resolve to a loud no-op stub
-# instead of a hard ImportError. Inert in the download child, which never touches them.
-# On a normal CUDA/CPU run _SKIP_GPU_INIT is False and the real modules are untouched.
+# Stub the CUDA-only imports whenever GPU init is skipped (MLX host or the opt-in
+# download child), so they resolve to a loud no-op instead of a hard ImportError. Inert
+# in the download child, which never touches them. On a normal CUDA/CPU run
+# _SKIP_GPU_INIT is False and the real modules are untouched.
 if _SKIP_GPU_INIT:
     from unsloth_zoo.stubs.triton_stub import inject_into_sys_modules as _inject_triton
     _inject_triton()
-    from unsloth_zoo.stubs.bitsandbytes_stub import inject_into_sys_modules as _inject_bnb
-    _inject_bnb()
-    del _inject_triton, _inject_bnb
+    # bitsandbytes, unlike triton, ships a working arm64 macOS wheel, and shadowing a
+    # real install makes bnb-quantized checkpoints unloadable. Locating it imports
+    # nothing, so the download-only child can take this path too.
+    from unsloth_zoo.stubs.bitsandbytes_stub import (
+        inject_into_sys_modules as _inject_bnb,
+        real_bitsandbytes_available as _real_bnb,
+    )
+    if not _real_bnb():
+        _inject_bnb()
+    del _inject_triton, _inject_bnb, _real_bnb
 
 # Lazy bridge for downstream code that still imports the old flat MLX module
 # names. Installed on every host so external scripts don't hit a hard

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -180,9 +180,8 @@ else:
     del _is_mlx_only, is_mlx_available
 
 # Stub the CUDA-only imports whenever GPU init is skipped (MLX host or the opt-in
-# download child), so they resolve to a loud no-op instead of a hard ImportError. Inert
-# in the download child, which never touches them. On a normal CUDA/CPU run
-# _SKIP_GPU_INIT is False and the real modules are untouched.
+# download child), so they resolve to a loud no-op instead of a hard ImportError. On a
+# normal CUDA/CPU run _SKIP_GPU_INIT is False and the real modules are untouched.
 if _SKIP_GPU_INIT:
     from unsloth_zoo.stubs.triton_stub import inject_into_sys_modules as _inject_triton
     _inject_triton()

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4827,105 +4827,121 @@ def _bnb_module_names():
     ]
 
 
+def _bitsandbytes_is_stubbed():
+    return getattr(sys.modules.get("bitsandbytes"), "IS_UNSLOTH_STUB", False)
+
+
+@contextmanager
+def _lifted_bitsandbytes_stub():
+    """Make the real bitsandbytes importable for the duration of the block.
+
+    A no-op when no stub is in the way: the resident modules are then the real wheel, and
+    evicting them makes the next import re-execute it and re-register its torch
+    operators, which raises.
+    """
+    global _REAL_BITSANDBYTES_MODULES
+    if not _bitsandbytes_is_stubbed():
+        yield
+        return
+    saved_meta = list(sys.meta_path)
+    stub_modules = {name: sys.modules[name] for name in _bnb_module_names()}
+    sys.meta_path[:] = [
+        finder for finder in sys.meta_path if type(finder).__name__ != "_BnbFinder"
+    ]
+    for name in _bnb_module_names():
+        del sys.modules[name]
+    # Reuse the already-initialized real bnb if we imported it earlier; only a cold
+    # process re-imports (and re-registers torch ops) for the first time.
+    sys.modules.update(_REAL_BITSANDBYTES_MODULES)
+    try:
+        yield
+    finally:
+        _REAL_BITSANDBYTES_MODULES = {
+            name: sys.modules[name] for name in _bnb_module_names()
+        }
+        for name in _bnb_module_names():
+            del sys.modules[name]
+        sys.modules.update(stub_modules)
+        sys.meta_path[:] = saved_meta
+
+
 def _dequantize_bnb_to_tempdir(source, *, token, trust_remote_code):
     """Dequantize a bitsandbytes (NF4) repo to fp16 and write a clean,
     non-quantized copy to a temp dir, returning its path.
 
-    unsloth_zoo stubs out bitsandbytes on Apple Silicon (stubs/bitsandbytes_stub),
-    so the real wheel is imported here with the stub temporarily lifted and
-    restored afterwards. bnb itself dequantizes the NF4 weights; the caller then
-    re-quantizes via MLX's affine path. Raises if bitsandbytes (or its dequant)
-    is unavailable so the caller can fall back to the clear bnb-unsupported error.
+    bnb itself dequantizes the NF4 weights; the caller then re-quantizes via MLX's affine
+    path. Raises if bitsandbytes (or its dequant) is unavailable so the caller can fall
+    back to the clear bnb-unsupported error.
     """
-    global _REAL_BITSANDBYTES_MODULES
-    with _BNB_IMPORT_LOCK:
-        saved_meta = list(sys.meta_path)
-        stub_modules = {name: sys.modules[name] for name in _bnb_module_names()}
-        sys.meta_path[:] = [
-            finder for finder in sys.meta_path if type(finder).__name__ != "_BnbFinder"
-        ]
-        for name in _bnb_module_names():
-            del sys.modules[name]
-        # Reuse the already-initialized real bnb if we imported it earlier; only a
-        # cold process re-imports (and re-registers torch ops) for the first time.
-        sys.modules.update(_REAL_BITSANDBYTES_MODULES)
+    with _BNB_IMPORT_LOCK, _lifted_bitsandbytes_stub():
+        import bitsandbytes  # noqa: F401 — real wheel; ImportError => fall back
+        import torch
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        device = "mps" if torch.backends.mps.is_available() else "cpu"
+
+        # Only text bnb repos reach here; VLM bnb repos are rejected by the
+        # caller (mlx-vlm dequant is not wired up yet). AutoModelForCausalLM
+        # dequantizes the NF4 weights to fp16. Pass torch_dtype, not dtype:
+        # the supported transformers 4.x range only accepts torch_dtype (a
+        # `dtype` kwarg raises TypeError there), and 5.x still accepts it.
+        model = AutoModelForCausalLM.from_pretrained(
+            source,
+            torch_dtype=torch.float16,
+            device_map={"": device},
+            token=token,
+            trust_remote_code=trust_remote_code,
+        ).dequantize()
+        # After dequantize, the model config still carries bnb's
+        # quantization_config plus _pre_quantization_dtype (a torch.dtype).
+        # The dtype is not JSON-serializable and breaks save_pretrained; the
+        # dequantized weights no longer need any of this metadata.
+        def _strip_quant_meta(cfg):
+            if cfg is None:
+                return
+            for _attr in ("quantization_config", "_pre_quantization_dtype"):
+                if hasattr(cfg, _attr):
+                    try:
+                        delattr(cfg, _attr)
+                    except Exception:
+                        pass
+            # Walk known sub-config attrs that models use to nest configs.
+            for _sub in (
+                "vision_config", "text_config", "audio_config",
+                "speech_config", "image_config", "encoder_config",
+                "decoder_config",
+            ):
+                _strip_quant_meta(getattr(cfg, _sub, None))
+        _strip_quant_meta(model.config)
+        tmpdir = tempfile.mkdtemp(prefix="unsloth_bnb_dequant_")
         try:
-            import bitsandbytes  # noqa: F401 — real wheel; ImportError => fall back
-            import torch
-            from transformers import AutoModelForCausalLM, AutoTokenizer
-
-            device = "mps" if torch.backends.mps.is_available() else "cpu"
-
-            # Only text bnb repos reach here; VLM bnb repos are rejected by the
-            # caller (mlx-vlm dequant is not wired up yet). AutoModelForCausalLM
-            # dequantizes the NF4 weights to fp16. Pass torch_dtype, not dtype:
-            # the supported transformers 4.x range only accepts torch_dtype (a
-            # `dtype` kwarg raises TypeError there), and 5.x still accepts it.
-            model = AutoModelForCausalLM.from_pretrained(
-                source,
-                torch_dtype=torch.float16,
-                device_map={"": device},
-                token=token,
-                trust_remote_code=trust_remote_code,
-            ).dequantize()
-            # After dequantize, the model config still carries bnb's
-            # quantization_config plus _pre_quantization_dtype (a torch.dtype).
-            # The dtype is not JSON-serializable and breaks save_pretrained; the
-            # dequantized weights no longer need any of this metadata.
-            def _strip_quant_meta(cfg):
-                if cfg is None:
-                    return
-                for _attr in ("quantization_config", "_pre_quantization_dtype"):
-                    if hasattr(cfg, _attr):
-                        try:
-                            delattr(cfg, _attr)
-                        except Exception:
-                            pass
-                # Walk known sub-config attrs that models use to nest configs.
-                for _sub in (
-                    "vision_config", "text_config", "audio_config",
-                    "speech_config", "image_config", "encoder_config",
-                    "decoder_config",
-                ):
-                    _strip_quant_meta(getattr(cfg, _sub, None))
-            _strip_quant_meta(model.config)
-            tmpdir = tempfile.mkdtemp(prefix="unsloth_bnb_dequant_")
+            # transformers 5.x: the dequantized model still carries
+            # weight-name conversions that can't be reversed for quantized
+            # weights, so save_pretrained's revert_weight_conversion raises.
+            # The dequantized weights need no conversion; clear it. No-op on
+            # 4.x, where the attribute doesn't exist.
             try:
-                # transformers 5.x: the dequantized model still carries
-                # weight-name conversions that can't be reversed for quantized
-                # weights, so save_pretrained's revert_weight_conversion raises.
-                # The dequantized weights need no conversion; clear it. No-op on
-                # 4.x, where the attribute doesn't exist.
-                try:
-                    model._weight_conversions = []
-                except Exception:
-                    pass
-                model.save_pretrained(tmpdir, safe_serialization=True)
-                # Save the tokenizer so the downstream mlx-lm load can read it.
-                AutoTokenizer.from_pretrained(
-                    source, token=token, trust_remote_code=trust_remote_code,
-                ).save_pretrained(tmpdir)
-            except BaseException:
-                # Don't leak the multi-GB fp16 scratch copy: BaseException,
-                # because a Ctrl-C during the long safetensors write is the
-                # likeliest abort and must clean up too.
-                shutil.rmtree(tmpdir, ignore_errors=True)
-                raise
-            # Release the fp16 model and bnb's MPS allocator cache so the caller's
-            # MLX re-quantization (and any later loads) aren't starved of memory.
-            del model
-            gc.collect()
-            if device == "mps":
-                torch.mps.empty_cache()
-            return tmpdir
-        finally:
-            _REAL_BITSANDBYTES_MODULES = {
-                name: sys.modules[name] for name in _bnb_module_names()
-            }
-            for name in _bnb_module_names():
-                del sys.modules[name]
-            sys.modules.update(stub_modules)
-            sys.meta_path[:] = saved_meta
+                model._weight_conversions = []
+            except Exception:
+                pass
+            model.save_pretrained(tmpdir, safe_serialization=True)
+            # Save the tokenizer so the downstream mlx-lm load can read it.
+            AutoTokenizer.from_pretrained(
+                source, token=token, trust_remote_code=trust_remote_code,
+            ).save_pretrained(tmpdir)
+        except BaseException:
+            # Don't leak the multi-GB fp16 scratch copy: BaseException,
+            # because a Ctrl-C during the long safetensors write is the
+            # likeliest abort and must clean up too.
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            raise
+        # Release the fp16 model and bnb's MPS allocator cache so the caller's
+        # MLX re-quantization (and any later loads) aren't starved of memory.
+        del model
+        gc.collect()
+        if device == "mps":
+            torch.mps.empty_cache()
+        return tmpdir
 
 
 def _apply_mlx_quantization(model, config, spec: _MLXQuantizationSpec, *, is_vlm, user_predicate=None):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4843,11 +4843,17 @@ def _lifted_bitsandbytes_stub():
     if not _bitsandbytes_is_stubbed():
         yield
         return
-    saved_meta = list(sys.meta_path)
     stub_modules = {name: sys.modules[name] for name in _bnb_module_names()}
-    sys.meta_path[:] = [
-        finder for finder in sys.meta_path if type(finder).__name__ != "_BnbFinder"
+    # Pull out only the stub's own finders and put those back afterwards. Restoring a
+    # whole snapshot of sys.meta_path instead would drop any finder another thread
+    # installed while the block ran, and the block is a multi-GB dequant that runs for
+    # minutes -- the same window the no-stub path above already declines to disturb.
+    lifted_finders = [
+        (index, finder) for index, finder in enumerate(sys.meta_path)
+        if type(finder).__name__ == "_BnbFinder"
     ]
+    for _, finder in lifted_finders:
+        sys.meta_path.remove(finder)
     for name in _bnb_module_names():
         del sys.modules[name]
     # Reuse the already-initialized real bnb if we imported it earlier; only a cold
@@ -4862,7 +4868,8 @@ def _lifted_bitsandbytes_stub():
         for name in _bnb_module_names():
             del sys.modules[name]
         sys.modules.update(stub_modules)
-        sys.meta_path[:] = saved_meta
+        for index, finder in lifted_finders:
+            sys.meta_path.insert(min(index, len(sys.meta_path)), finder)
 
 
 def _dequantize_bnb_to_tempdir(source, *, token, trust_remote_code):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4835,9 +4835,8 @@ def _bitsandbytes_is_stubbed():
 def _lifted_bitsandbytes_stub():
     """Make the real bitsandbytes importable for the duration of the block.
 
-    A no-op when no stub is in the way: the resident modules are then the real wheel, and
-    evicting them makes the next import re-execute it and re-register its torch
-    operators, which raises.
+    A no-op when no stub is in the way: evicting the resident real wheel would make the
+    next import re-register its torch operators, which raises.
     """
     global _REAL_BITSANDBYTES_MODULES
     if not _bitsandbytes_is_stubbed():
@@ -4845,9 +4844,8 @@ def _lifted_bitsandbytes_stub():
         return
     stub_modules = {name: sys.modules[name] for name in _bnb_module_names()}
     # Pull out only the stub's own finders and put those back afterwards. Restoring a
-    # whole snapshot of sys.meta_path instead would drop any finder another thread
-    # installed while the block ran, and the block is a multi-GB dequant that runs for
-    # minutes -- the same window the no-stub path above already declines to disturb.
+    # whole sys.meta_path snapshot would drop any finder another thread installed during
+    # the block, which is a multi-GB dequant running for minutes.
     lifted_finders = [
         (index, finder) for index, finder in enumerate(sys.meta_path)
         if type(finder).__name__ == "_BnbFinder"
@@ -4857,7 +4855,7 @@ def _lifted_bitsandbytes_stub():
     for name in _bnb_module_names():
         del sys.modules[name]
     # Reuse the already-initialized real bnb if we imported it earlier; only a cold
-    # process re-imports (and re-registers torch ops) for the first time.
+    # process re-imports (and re-registers torch ops).
     sys.modules.update(_REAL_BITSANDBYTES_MODULES)
     try:
         yield
@@ -4873,12 +4871,11 @@ def _lifted_bitsandbytes_stub():
 
 
 def _dequantize_bnb_to_tempdir(source, *, token, trust_remote_code):
-    """Dequantize a bitsandbytes (NF4) repo to fp16 and write a clean,
-    non-quantized copy to a temp dir, returning its path.
+    """Dequantize a bitsandbytes (NF4) repo to fp16 into a temp dir, returning its path.
 
-    bnb itself dequantizes the NF4 weights; the caller then re-quantizes via MLX's affine
-    path. Raises if bitsandbytes (or its dequant) is unavailable so the caller can fall
-    back to the clear bnb-unsupported error.
+    bnb itself dequantizes; the caller then re-quantizes via MLX's affine path. Raises if
+    bitsandbytes (or its dequant) is unavailable so the caller can fall back to the clear
+    bnb-unsupported error.
     """
     with _BNB_IMPORT_LOCK, _lifted_bitsandbytes_stub():
         import bitsandbytes  # noqa: F401 — real wheel; ImportError => fall back
@@ -4887,11 +4884,9 @@ def _dequantize_bnb_to_tempdir(source, *, token, trust_remote_code):
 
         device = "mps" if torch.backends.mps.is_available() else "cpu"
 
-        # Only text bnb repos reach here; VLM bnb repos are rejected by the
-        # caller (mlx-vlm dequant is not wired up yet). AutoModelForCausalLM
-        # dequantizes the NF4 weights to fp16. Pass torch_dtype, not dtype:
-        # the supported transformers 4.x range only accepts torch_dtype (a
-        # `dtype` kwarg raises TypeError there), and 5.x still accepts it.
+        # Only text bnb repos reach here; the caller rejects VLM ones (mlx-vlm dequant is
+        # not wired up yet). Pass torch_dtype, not dtype: transformers 4.x raises
+        # TypeError on `dtype`, and 5.x still accepts torch_dtype.
         model = AutoModelForCausalLM.from_pretrained(
             source,
             torch_dtype=torch.float16,
@@ -4899,10 +4894,9 @@ def _dequantize_bnb_to_tempdir(source, *, token, trust_remote_code):
             token=token,
             trust_remote_code=trust_remote_code,
         ).dequantize()
-        # After dequantize, the model config still carries bnb's
-        # quantization_config plus _pre_quantization_dtype (a torch.dtype).
-        # The dtype is not JSON-serializable and breaks save_pretrained; the
-        # dequantized weights no longer need any of this metadata.
+        # The config still carries bnb's quantization_config and _pre_quantization_dtype,
+        # whose torch.dtype is not JSON-serializable and breaks save_pretrained. The
+        # dequantized weights need none of it.
         def _strip_quant_meta(cfg):
             if cfg is None:
                 return
@@ -4912,7 +4906,6 @@ def _dequantize_bnb_to_tempdir(source, *, token, trust_remote_code):
                         delattr(cfg, _attr)
                     except Exception:
                         pass
-            # Walk known sub-config attrs that models use to nest configs.
             for _sub in (
                 "vision_config", "text_config", "audio_config",
                 "speech_config", "image_config", "encoder_config",
@@ -4922,28 +4915,25 @@ def _dequantize_bnb_to_tempdir(source, *, token, trust_remote_code):
         _strip_quant_meta(model.config)
         tmpdir = tempfile.mkdtemp(prefix="unsloth_bnb_dequant_")
         try:
-            # transformers 5.x: the dequantized model still carries
-            # weight-name conversions that can't be reversed for quantized
-            # weights, so save_pretrained's revert_weight_conversion raises.
-            # The dequantized weights need no conversion; clear it. No-op on
-            # 4.x, where the attribute doesn't exist.
+            # transformers 5.x: leftover weight-name conversions can't be reversed for
+            # quantized weights, so save_pretrained's revert_weight_conversion raises.
+            # Dequantized weights need none. No-op on 4.x, which lacks the attribute.
             try:
                 model._weight_conversions = []
             except Exception:
                 pass
             model.save_pretrained(tmpdir, safe_serialization=True)
-            # Save the tokenizer so the downstream mlx-lm load can read it.
+            # Needed by the downstream mlx-lm load.
             AutoTokenizer.from_pretrained(
                 source, token=token, trust_remote_code=trust_remote_code,
             ).save_pretrained(tmpdir)
         except BaseException:
-            # Don't leak the multi-GB fp16 scratch copy: BaseException,
-            # because a Ctrl-C during the long safetensors write is the
-            # likeliest abort and must clean up too.
+            # Don't leak the multi-GB fp16 scratch copy. BaseException, because a Ctrl-C
+            # during the long safetensors write is the likeliest abort.
             shutil.rmtree(tmpdir, ignore_errors=True)
             raise
-        # Release the fp16 model and bnb's MPS allocator cache so the caller's
-        # MLX re-quantization (and any later loads) aren't starved of memory.
+        # Release the fp16 model and bnb's MPS allocator cache so the caller's MLX
+        # re-quantization isn't starved of memory.
         del model
         gc.collect()
         if device == "mps":

--- a/unsloth_zoo/stubs/bitsandbytes_stub.py
+++ b/unsloth_zoo/stubs/bitsandbytes_stub.py
@@ -15,12 +15,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
-Bitsandbytes stub for Apple Silicon / MLX.
+Bitsandbytes stub for hosts that skip GPU init (gated in unsloth_zoo/__init__.py).
 
-Any `import bitsandbytes.X.Y` auto-resolves to a permissive stub module.
-Only injected on macOS ARM64 with MLX (gated in unsloth_zoo/__init__.py).
+Any `import bitsandbytes.X.Y` auto-resolves to a permissive stub module. Injected only
+when no real bitsandbytes is installed: shadowing a working one makes bnb-quantized
+checkpoints unloadable.
 """
 
+import importlib.util
 import types
 import sys
 from importlib.abc import MetaPathFinder
@@ -99,6 +101,21 @@ def __getattr__(name):
     if name.startswith("__") and name.endswith("__"):
         raise AttributeError(name)
     return _Noop(f"bitsandbytes.{name}")
+
+
+def real_bitsandbytes_available():
+    """Whether a real (non-stub) bitsandbytes is installed.
+
+    Locates the distribution rather than importing it: importing pulls in torch, which
+    costs about a second on the hosts that skip GPU init to avoid exactly that.
+    """
+    existing = sys.modules.get("bitsandbytes")
+    if existing is not None:
+        return not getattr(existing, "IS_UNSLOTH_STUB", False)
+    try:
+        return importlib.util.find_spec("bitsandbytes") is not None
+    except Exception:  # noqa: BLE001 -- an unlocatable install is not usable either
+        return False
 
 
 def inject_into_sys_modules():

--- a/unsloth_zoo/stubs/bitsandbytes_stub.py
+++ b/unsloth_zoo/stubs/bitsandbytes_stub.py
@@ -64,6 +64,12 @@ def _make_module(name, attrs=None):
     mod = _PermissiveModule(name)
     mod.__path__ = []
     mod.__package__ = name
+    # Carried by every stub module, not just the one aliased in by injection: a caller
+    # that evicts sys.modules["bitsandbytes"] and re-imports gets a finder-minted module,
+    # and without the flag `getattr(mod, "IS_UNSLOTH_STUB", False)` falls through to the
+    # permissive __getattr__ and answers with a _Noop, which is falsy. Every stub check
+    # would then read "this is a real wheel".
+    mod.IS_UNSLOTH_STUB = True
     if attrs:
         for k, v in attrs.items():
             setattr(mod, k, v)
@@ -113,9 +119,14 @@ def real_bitsandbytes_available():
     if existing is not None:
         return not getattr(existing, "IS_UNSLOTH_STUB", False)
     try:
-        return importlib.util.find_spec("bitsandbytes") is not None
+        spec = importlib.util.find_spec("bitsandbytes")
     except Exception:  # noqa: BLE001 -- an unlocatable install is not usable either
         return False
+    # A namespace package -- a bare `bitsandbytes/` directory with no __init__.py, which
+    # is what a half-removed install or a source checkout beside the script leaves on the
+    # path -- has no loader and imports to an empty module. It is not an install, and
+    # standing aside for it would leave the caller with neither a wheel nor the stub.
+    return spec is not None and spec.loader is not None
 
 
 def inject_into_sys_modules():

--- a/unsloth_zoo/stubs/bitsandbytes_stub.py
+++ b/unsloth_zoo/stubs/bitsandbytes_stub.py
@@ -64,11 +64,9 @@ def _make_module(name, attrs=None):
     mod = _PermissiveModule(name)
     mod.__path__ = []
     mod.__package__ = name
-    # Carried by every stub module, not just the one aliased in by injection: a caller
-    # that evicts sys.modules["bitsandbytes"] and re-imports gets a finder-minted module,
-    # and without the flag `getattr(mod, "IS_UNSLOTH_STUB", False)` falls through to the
-    # permissive __getattr__ and answers with a _Noop, which is falsy. Every stub check
-    # would then read "this is a real wheel".
+    # Set on every stub module, including finder-minted ones: without a real attribute,
+    # the permissive __getattr__ answers the stub check with a falsy _Noop and every
+    # caller reads "this is a real wheel".
     mod.IS_UNSLOTH_STUB = True
     if attrs:
         for k, v in attrs.items():
@@ -112,8 +110,8 @@ def __getattr__(name):
 def real_bitsandbytes_available():
     """Whether a real (non-stub) bitsandbytes is installed.
 
-    Locates the distribution rather than importing it: importing pulls in torch, which
-    costs about a second on the hosts that skip GPU init to avoid exactly that.
+    Locates it rather than importing it: importing pulls in torch, which costs about a
+    second on the hosts that skip GPU init to avoid exactly that.
     """
     existing = sys.modules.get("bitsandbytes")
     if existing is not None:
@@ -122,10 +120,8 @@ def real_bitsandbytes_available():
         spec = importlib.util.find_spec("bitsandbytes")
     except Exception:  # noqa: BLE001 -- an unlocatable install is not usable either
         return False
-    # A namespace package -- a bare `bitsandbytes/` directory with no __init__.py, which
-    # is what a half-removed install or a source checkout beside the script leaves on the
-    # path -- has no loader and imports to an empty module. It is not an install, and
-    # standing aside for it would leave the caller with neither a wheel nor the stub.
+    # A namespace package (loaderless, e.g. a half-removed install) imports to an empty
+    # module; standing aside for it leaves the caller with neither a wheel nor the stub.
     return spec is not None and spec.loader is not None
 
 


### PR DESCRIPTION
Fixes unslothai/unsloth#8940

## Impact

On every host where `unsloth_zoo` skips GPU init — Apple Silicon / MLX, and the opt-in download child — loading **any** bitsandbytes-quantized checkpoint failed:

```
'_Noop' object is not iterable
```

This is not specific to one model family. The failure is raised out of transformers' `validate_bnb_backend_availability`, which takes no model argument, so every nf4/int8 checkpoint was unloadable on those hosts regardless of architecture.

## Root cause

`unsloth_zoo/__init__.py` injected the permissive bitsandbytes stub unconditionally whenever GPU init was skipped. That was correct when bitsandbytes had no macOS wheel; it now ships a working arm64 macOS wheel whose cpu/mps 4-bit kernels are usable, so the stub was shadowing a real, functional install.

The stub's `_Noop` answers *any* attribute, which defeats callers' `getattr` defaults. transformers does:

```python
bnb_supported_devices = getattr(bnb, "supported_torch_devices", set())
...
if device_name not in bnb_supported_devices:   # set().intersection(_Noop) in the real code path
```

`getattr` finds a `_Noop` instead of falling back to the default, and iterating it raises. The version guard in `BitsAndBytesConfig.post_init` did not catch this because `importlib.metadata.version("bitsandbytes")` reads the installed distribution's `dist-info` and never consults `sys.modules` — it reported the real wheel's version while the imported module was the stub.

## Changes

**Gate the injection.** Stub bitsandbytes only when no real one is installed. Detection uses `importlib.util.find_spec`, not an import: importing bitsandbytes pulls in torch, which costs roughly a second on precisely the hosts that skip GPU init in order to avoid that cost. `find_spec` imports nothing and takes ~0.06 ms, so `import unsloth_zoo` is unchanged. Triton has no macOS wheel to prefer and stays unconditional.

**Fix the MLX dequant swap.** `_dequantize_bnb_to_tempdir` needs the real wheel in order to dequantize bnb weights to a temp dir, and it assumed the resident `bitsandbytes` modules were always stubs: it dropped them, imported the real wheel over the top, then restored the snapshot. Against a real wheel both halves are wrong — the eviction drops live modules, and the next import re-executes the wheel and re-registers its torch operators:

```
RuntimeError: Tried to register an operator (bitsandbytes::int8_mixed_scaled_mm(...)) with the same name and overload name multiple times.
```

The lift-and-restore is now a `_lifted_bitsandbytes_stub()` context manager that no-ops when nothing was stubbed, and caches the initialized real modules so a repeat dequant in the same process reuses them rather than re-importing.

## Risks and tradeoffs

- On a host that *does* have bitsandbytes installed, `import bitsandbytes` now resolves to the real module rather than the stub. Any caller that previously relied on the stub silently absorbing a CUDA-only call will now reach the real code path. This is the intended behavior change; the stub's `_Noop.__call__` already raised loudly rather than returning `None`, so such a caller was already failing, just with a different message.
- Real bitsandbytes costs about 25 MB RSS on top of torch at import, and allocates nothing on MPS. `find_spec` gating keeps that cost off hosts with no install.
- The gate reads `sys.modules["bitsandbytes"]` first and only falls back to `find_spec`, so a stub already injected by an earlier import is still recognized as a stub.

## Validation

Focused suite on the touched area:

```
pytest tests/test_upstream_pinned_symbols_accelerator.py tests/test_triton_stub_class_symbols.py \
       tests/test_mlx_dequantize_modules.py tests/test_mlx_double_quant_reject.py -q
1 failed, 59 passed, 1 skipped
```

The one failure, `test_xpu_partial_build_all_three_helpers_silent_no_op`, is pre-existing and unrelated — it fails identically on `main` (`unsloth_zoo/device_type.py:424: NameError`) and nothing here touches that path.

The gate itself is covered by a subprocess probe that runs the import both with bitsandbytes visible and with it hidden, and asserts the resident module is the real one in the first case and the stub in the second — while triton is stubbed in both. The context manager is covered for the stubbed path, the no-stub path, the cold path where the wheel is first imported inside the block, and the raising path.

End to end on Apple Silicon, a real nf4 checkpoint (`ideogram-ai/ideogram-4-nf4-diffusers`) that previously failed now assembles:

```
pipeline assembled in 27.4s: Ideogram4Pipeline
279 Linear4bit modules, 14.3 GB resident
```
