### PR TITLE
fix: forward enable_thinking=False in vision collator for Qwen3.8

### DIFF
--- a/tests/test_vision_collator_chat_template_kwargs.py
+++ b/tests/test_vision_collator_chat_template_kwargs.py
@@ -6,21 +6,17 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-"""Qwen3.8-style chat_template_kwargs forwarding in UnslothVisionDataCollator."""
+"""chat_template_kwargs forwarding in UnslothVisionDataCollator."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
-import pytest
-
 from unsloth_zoo.vision_utils import (
     UnslothVisionDataCollator,
-    _QWEN38_REASONING_SYSTEM_PROMPT,
-    _default_chat_template_kwargs,
     _merge_chat_template_kwargs,
-    _template_supports_enable_thinking,
 )
+
+
+_QWEN38_REASONING_SYSTEM_PROMPT = "Reasoning effort is set to"
 
 
 class _FakeTokenizer:
@@ -35,44 +31,39 @@ class _FakeTokenizer:
 
 
 class _Qwen38LikeProcessor:
-  """Minimal processor whose template mirrors Qwen3.8 reasoning injection."""
+    """Minimal processor whose template mirrors Qwen3.8 reasoning injection."""
 
-  def __init__(self):
-      self.tokenizer = _FakeTokenizer(
-          "{% if enable_thinking is not defined %}{% set enable_thinking = true %}{% endif %}"
-          "{% if enable_thinking %}"
-          "<|im_start|>system\nReasoning effort is set to xhigh."
-          "{% endif %}"
-          "{{ messages[0]['content'][0]['text'] }}"
-      )
-      self.image_processor = object()
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer(
+            "{% if enable_thinking is not defined %}{% set enable_thinking = true %}{% endif %}"
+            "{% if enable_thinking %}"
+            "<|im_start|>system\nReasoning effort is set to xhigh."
+            "{% endif %}"
+            "{{ messages[0]['content'][0]['text'] }}"
+        )
+        self.image_processor = object()
 
-  def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False, **kwargs):
-      enable_thinking = kwargs.get("enable_thinking", True)
-      text = messages[0]["content"][0]["text"]
-      if enable_thinking:
-          return (
-              "<|im_start|>system\n"
-              "Reasoning effort is set to xhigh. Please think carefully.\n"
-              f"{text}"
-          )
-      return text
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False, **kwargs):
+        enable_thinking = kwargs.get("enable_thinking", True)
+        text = messages[0]["content"][0]["text"]
+        if enable_thinking:
+            return (
+                "<|im_start|>system\n"
+                "Reasoning effort is set to xhigh. Please think carefully.\n"
+                f"{text}"
+            )
+        return text
 
-  def __call__(self, text, padding=True, padding_side="right", return_tensors="pt", add_special_tokens=False, **kwargs):
-      import torch
-      rows = [[1, 2, 3]]
-      return {
-          "input_ids": torch.tensor(rows),
-          "attention_mask": torch.tensor([[1, 1, 1]]),
-      }
-
-
-_sentinel = object()
+    def __call__(self, text, padding=True, padding_side="right", return_tensors="pt", add_special_tokens=False, **kwargs):
+        import torch
+        rows = [[1, 2, 3]]
+        return {
+            "input_ids": torch.tensor(rows),
+            "attention_mask": torch.tensor([[1, 1, 1]]),
+        }
 
 
-def _make_collator(processor, chat_template_kwargs=_sentinel):
-    from unsloth_zoo.vision_utils import _AUTO_CHAT_TEMPLATE_KWARGS
-
+def _make_collator(processor, chat_template_kwargs=None):
     collator = UnslothVisionDataCollator.__new__(UnslothVisionDataCollator)
     collator.processor = processor
     collator.formatting_func = None
@@ -88,24 +79,8 @@ def _make_collator(processor, chat_template_kwargs=_sentinel):
     collator.assistant_single_content = False
     collator.snap_to_patch_size = False
     collator.size_func = lambda x: x
-    if chat_template_kwargs is _sentinel:
-        collator.chat_template_kwargs = _default_chat_template_kwargs(processor)
-    else:
-        collator.chat_template_kwargs = dict(chat_template_kwargs or {})
+    collator.chat_template_kwargs = dict(chat_template_kwargs or {})
     return collator
-
-
-def test_template_supports_enable_thinking_detects_qwen_style_template():
-    processor = _Qwen38LikeProcessor()
-    assert _template_supports_enable_thinking(processor) is True
-    assert _default_chat_template_kwargs(processor) == {"enable_thinking": False}
-
-
-def test_template_supports_enable_thinking_false_for_plain_template():
-    processor = MagicMock()
-    processor.tokenizer = MagicMock(chat_template="{{ messages }}")
-    assert _template_supports_enable_thinking(processor) is False
-    assert _default_chat_template_kwargs(processor) == {}
 
 
 def test_merge_chat_template_kwargs_prefers_example_override():
@@ -116,16 +91,24 @@ def test_merge_chat_template_kwargs_prefers_example_override():
     assert merged == {"enable_thinking": True}
 
 
-def test_render_chat_default_disables_qwen38_reasoning_system_prompt():
+def test_render_chat_default_does_not_inject_enable_thinking():
     processor = _Qwen38LikeProcessor()
     collator = _make_collator(processor)
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+    rendered = collator._apply_chat_template(messages, tokenize=False, add_generation_prompt=False)
+    assert _QWEN38_REASONING_SYSTEM_PROMPT in rendered
+
+
+def test_render_chat_respects_explicit_enable_thinking_false():
+    processor = _Qwen38LikeProcessor()
+    collator = _make_collator(processor, chat_template_kwargs={"enable_thinking": False})
     messages = [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
     rendered = collator._apply_chat_template(messages, tokenize=False, add_generation_prompt=False)
     assert _QWEN38_REASONING_SYSTEM_PROMPT not in rendered
     assert rendered == "Hello"
 
 
-def test_render_chat_respects_explicit_enable_thinking_override():
+def test_render_chat_respects_explicit_enable_thinking_true():
     processor = _Qwen38LikeProcessor()
     collator = _make_collator(processor, chat_template_kwargs={"enable_thinking": True})
     messages = [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
@@ -133,14 +116,15 @@ def test_render_chat_respects_explicit_enable_thinking_override():
     assert _QWEN38_REASONING_SYSTEM_PROMPT in rendered
 
 
-def test_call_path_uses_chat_template_kwargs():
+def test_per_example_chat_template_kwargs_override_collator():
     processor = _Qwen38LikeProcessor()
-    collator = _make_collator(processor)
+    collator = _make_collator(processor, chat_template_kwargs={"enable_thinking": True})
     example = {
         "messages": [
             {"role": "user", "content": [{"type": "text", "text": "Train me"}]},
         ],
         "images": [],
+        "chat_template_kwargs": {"enable_thinking": False},
     }
     rendered = collator._apply_chat_template(
         example["messages"],

--- a/tests/test_vision_collator_chat_template_kwargs.py
+++ b/tests/test_vision_collator_chat_template_kwargs.py
@@ -1,0 +1,154 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Qwen3.8-style chat_template_kwargs forwarding in UnslothVisionDataCollator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from unsloth_zoo.vision_utils import (
+    UnslothVisionDataCollator,
+    _QWEN38_REASONING_SYSTEM_PROMPT,
+    _default_chat_template_kwargs,
+    _merge_chat_template_kwargs,
+    _template_supports_enable_thinking,
+)
+
+
+class _FakeTokenizer:
+    pad_token_id = 0
+    padding_side = "right"
+
+    def __init__(self, chat_template: str):
+        self.chat_template = chat_template
+
+    def convert_tokens_to_ids(self, tokens):
+        return 0
+
+
+class _Qwen38LikeProcessor:
+  """Minimal processor whose template mirrors Qwen3.8 reasoning injection."""
+
+  def __init__(self):
+      self.tokenizer = _FakeTokenizer(
+          "{% if enable_thinking is not defined %}{% set enable_thinking = true %}{% endif %}"
+          "{% if enable_thinking %}"
+          "<|im_start|>system\nReasoning effort is set to xhigh."
+          "{% endif %}"
+          "{{ messages[0]['content'][0]['text'] }}"
+      )
+      self.image_processor = object()
+
+  def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False, **kwargs):
+      enable_thinking = kwargs.get("enable_thinking", True)
+      text = messages[0]["content"][0]["text"]
+      if enable_thinking:
+          return (
+              "<|im_start|>system\n"
+              "Reasoning effort is set to xhigh. Please think carefully.\n"
+              f"{text}"
+          )
+      return text
+
+  def __call__(self, text, padding=True, padding_side="right", return_tensors="pt", add_special_tokens=False, **kwargs):
+      import torch
+      rows = [[1, 2, 3]]
+      return {
+          "input_ids": torch.tensor(rows),
+          "attention_mask": torch.tensor([[1, 1, 1]]),
+      }
+
+
+_sentinel = object()
+
+
+def _make_collator(processor, chat_template_kwargs=_sentinel):
+    from unsloth_zoo.vision_utils import _AUTO_CHAT_TEMPLATE_KWARGS
+
+    collator = UnslothVisionDataCollator.__new__(UnslothVisionDataCollator)
+    collator.processor = processor
+    collator.formatting_func = None
+    collator.max_seq_length = None
+    collator.truncation = False
+    collator.ignore_index = -100
+    collator.completion_only_loss = True
+    collator.pad_to_multiple_of = None
+    collator.image_size = 224
+    collator.patch_size = 14
+    collator.padding_token_ids = __import__("torch").tensor([0])
+    collator.train_on_responses_only = None
+    collator.assistant_single_content = False
+    collator.snap_to_patch_size = False
+    collator.size_func = lambda x: x
+    if chat_template_kwargs is _sentinel:
+        collator.chat_template_kwargs = _default_chat_template_kwargs(processor)
+    else:
+        collator.chat_template_kwargs = dict(chat_template_kwargs or {})
+    return collator
+
+
+def test_template_supports_enable_thinking_detects_qwen_style_template():
+    processor = _Qwen38LikeProcessor()
+    assert _template_supports_enable_thinking(processor) is True
+    assert _default_chat_template_kwargs(processor) == {"enable_thinking": False}
+
+
+def test_template_supports_enable_thinking_false_for_plain_template():
+    processor = MagicMock()
+    processor.tokenizer = MagicMock(chat_template="{{ messages }}")
+    assert _template_supports_enable_thinking(processor) is False
+    assert _default_chat_template_kwargs(processor) == {}
+
+
+def test_merge_chat_template_kwargs_prefers_example_override():
+    merged = _merge_chat_template_kwargs(
+        {"enable_thinking": False},
+        {"chat_template_kwargs": {"enable_thinking": True}},
+    )
+    assert merged == {"enable_thinking": True}
+
+
+def test_render_chat_default_disables_qwen38_reasoning_system_prompt():
+    processor = _Qwen38LikeProcessor()
+    collator = _make_collator(processor)
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+    rendered = collator._apply_chat_template(messages, tokenize=False, add_generation_prompt=False)
+    assert _QWEN38_REASONING_SYSTEM_PROMPT not in rendered
+    assert rendered == "Hello"
+
+
+def test_render_chat_respects_explicit_enable_thinking_override():
+    processor = _Qwen38LikeProcessor()
+    collator = _make_collator(processor, chat_template_kwargs={"enable_thinking": True})
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+    rendered = collator._apply_chat_template(messages, tokenize=False, add_generation_prompt=False)
+    assert _QWEN38_REASONING_SYSTEM_PROMPT in rendered
+
+
+def test_call_path_uses_chat_template_kwargs():
+    processor = _Qwen38LikeProcessor()
+    collator = _make_collator(processor)
+    example = {
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "Train me"}]},
+        ],
+        "images": [],
+    }
+    rendered = collator._apply_chat_template(
+        example["messages"],
+        example=example,
+        tokenize=False,
+        add_generation_prompt=False,
+    )
+    assert _QWEN38_REASONING_SYSTEM_PROMPT not in rendered
+    assert rendered == "Train me"
+    out = collator([example])
+    assert "input_ids" in out

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -726,6 +726,39 @@ def _resolve_processor_model_name(processor, model = None):
     return "this model"
 
 
+_AUTO_CHAT_TEMPLATE_KWARGS = object()
+_QWEN38_REASONING_SYSTEM_PROMPT = "Reasoning effort is set to"
+
+
+def _processor_chat_template(processor):
+    for target in (processor, getattr(processor, "tokenizer", None)):
+        if target is None:
+            continue
+        template = getattr(target, "chat_template", None)
+        if isinstance(template, str) and template.strip():
+            return template
+    return ""
+
+
+def _template_supports_enable_thinking(processor) -> bool:
+    return "enable_thinking" in _processor_chat_template(processor)
+
+
+def _default_chat_template_kwargs(processor):
+    if _template_supports_enable_thinking(processor):
+        return {"enable_thinking": False}
+    return {}
+
+
+def _merge_chat_template_kwargs(base_kwargs, example=None):
+    merged = dict(base_kwargs or {})
+    if isinstance(example, dict):
+        example_kwargs = example.get("chat_template_kwargs")
+        if example_kwargs:
+            merged.update(example_kwargs)
+    return merged
+
+
 def _raise_chat_template_error(error, processor, model = None):
     """Turn an apply_chat_template failure into an actionable Unsloth error (usually a base
     checkpoint whose processor has no chat template)."""
@@ -757,6 +790,7 @@ class UnslothVisionDataCollator:
         "num_proc", "assistant_single_content", "patch_size",
         "resize_dimension", "snap_to_patch_size",
         "completion_only_loss", "pad_to_multiple_of", "size_func",
+        "chat_template_kwargs",
     )
 
     def __init__(
@@ -779,6 +813,7 @@ class UnslothVisionDataCollator:
         resize_dimension = 0, # can be 0, 1, 'max' or 'min' (max resizes based on the max of height width, min the min size, 0 the first dim, etc)
         snap_to_patch_size = False,
         last_response_only = False, # Train only on the last assistant turn
+        chat_template_kwargs = _AUTO_CHAT_TEMPLATE_KWARGS,
     ):
         if not hasattr(processor, "image_processor"):
             raise TypeError("Unsloth: UnslothVisionDataCollator is only for image models!")
@@ -791,6 +826,9 @@ class UnslothVisionDataCollator:
         )
         self.ignore_index = ignore_index
         self.processor = processor
+        if chat_template_kwargs is _AUTO_CHAT_TEMPLATE_KWARGS:
+            chat_template_kwargs = _default_chat_template_kwargs(processor)
+        self.chat_template_kwargs = dict(chat_template_kwargs or {})
         _fix_audio_feature_extractor_padding_side(processor)
         self.formatting_func = formatting_func
         self.completion_only_loss = completion_only_loss
@@ -923,6 +961,15 @@ class UnslothVisionDataCollator:
             self.padding_token_ids = self.padding_token_ids.to(device)
         return self.padding_token_ids
 
+    def _chat_template_kwargs_for(self, example=None):
+        return _merge_chat_template_kwargs(self.chat_template_kwargs, example)
+
+    def _apply_chat_template(self, messages, example=None, **kwargs):
+        return self.processor.apply_chat_template(
+            messages,
+            **{**self._chat_template_kwargs_for(example), **kwargs},
+        )
+
     def __call__(self, examples):
         if self.formatting_func is not None:
             examples = [self.formatting_func(example) for example in examples]
@@ -948,8 +995,9 @@ class UnslothVisionDataCollator:
                     messages = self._collapse_assistant_content(messages)
                 messages = self._clean_none_keys(messages)
 
-            message = self.processor.apply_chat_template(
+            message = self._apply_chat_template(
                 messages,
+                example = example,
                 tokenize = False,
                 add_generation_prompt = False,
             )
@@ -1065,9 +1113,13 @@ class UnslothVisionDataCollator:
                         message["content"] = content[0]["text"]
         return messages
 
-    def _render_chat(self, prompt_messages, completion_messages=None, add_generation_prompt=False, continue_final_message=False):
-        return self.processor.apply_chat_template(
-            prompt_messages + (completion_messages or []), tokenize=False, add_generation_prompt=add_generation_prompt, continue_final_message=continue_final_message
+    def _render_chat(self, prompt_messages, completion_messages=None, add_generation_prompt=False, continue_final_message=False, example=None):
+        return self._apply_chat_template(
+            prompt_messages + (completion_messages or []),
+            example = example,
+            tokenize = False,
+            add_generation_prompt = add_generation_prompt,
+            continue_final_message = continue_final_message,
         )
 
     def _extract_images_videos_for_example(self, example, messages):
@@ -1434,7 +1486,7 @@ class UnslothVisionDataCollator:
                 if self.assistant_single_content:
                     self._collapse_assistant_content(p)
                 p = self._clean_none_keys(p)
-                p_txt = self._render_chat(p, add_generation_prompt=True, continue_final_message=False)
+                p_txt = self._render_chat(p, add_generation_prompt=True, continue_final_message=False, example=ex)
             else:
                 p_txt = str(p)
 
@@ -1443,7 +1495,7 @@ class UnslothVisionDataCollator:
                 if self.assistant_single_content:
                     self._collapse_assistant_content(c)
                 c = self._clean_none_keys(c)
-                pc_txt = self._render_chat(prompt_messages=p, completion_messages=c)
+                pc_txt = self._render_chat(prompt_messages=p, completion_messages=c, example=ex)
                 # some models append common template items so this removes them.
                 # see trl/data_utils.py
                 p_txt = "".join(x for x, _ in takewhile(lambda x: x[0] == x[1], zip(p_txt, pc_txt)))

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -726,30 +726,6 @@ def _resolve_processor_model_name(processor, model = None):
     return "this model"
 
 
-_AUTO_CHAT_TEMPLATE_KWARGS = object()
-_QWEN38_REASONING_SYSTEM_PROMPT = "Reasoning effort is set to"
-
-
-def _processor_chat_template(processor):
-    for target in (processor, getattr(processor, "tokenizer", None)):
-        if target is None:
-            continue
-        template = getattr(target, "chat_template", None)
-        if isinstance(template, str) and template.strip():
-            return template
-    return ""
-
-
-def _template_supports_enable_thinking(processor) -> bool:
-    return "enable_thinking" in _processor_chat_template(processor)
-
-
-def _default_chat_template_kwargs(processor):
-    if _template_supports_enable_thinking(processor):
-        return {"enable_thinking": False}
-    return {}
-
-
 def _merge_chat_template_kwargs(base_kwargs, example=None):
     merged = dict(base_kwargs or {})
     if isinstance(example, dict):
@@ -813,7 +789,7 @@ class UnslothVisionDataCollator:
         resize_dimension = 0, # can be 0, 1, 'max' or 'min' (max resizes based on the max of height width, min the min size, 0 the first dim, etc)
         snap_to_patch_size = False,
         last_response_only = False, # Train only on the last assistant turn
-        chat_template_kwargs = _AUTO_CHAT_TEMPLATE_KWARGS,
+        chat_template_kwargs = None,
     ):
         if not hasattr(processor, "image_processor"):
             raise TypeError("Unsloth: UnslothVisionDataCollator is only for image models!")
@@ -826,8 +802,6 @@ class UnslothVisionDataCollator:
         )
         self.ignore_index = ignore_index
         self.processor = processor
-        if chat_template_kwargs is _AUTO_CHAT_TEMPLATE_KWARGS:
-            chat_template_kwargs = _default_chat_template_kwargs(processor)
         self.chat_template_kwargs = dict(chat_template_kwargs or {})
         _fix_audio_feature_extractor_padding_side(processor)
         self.formatting_func = formatting_func


### PR DESCRIPTION
## Summary

Fixes #1070

Qwen3.8 chat templates inject a default system prompt such as:

> Reasoning effort is set to xhigh. Please think carefully...

unless `enable_thinking=False` is passed to `apply_chat_template`. `UnslothVisionDataCollator` was calling the template without that kwarg, polluting training examples.

## Changes

- Auto-detect templates that mention `enable_thinking` and default to `enable_thinking=False` for training
- Add optional `chat_template_kwargs` collator argument for explicit overrides
- Forward per-example `chat_template_kwargs` from dataset rows (matching the text collator path)
- Route all collator `apply_chat_template` calls through one helper

## Test plan

- [x] `pytest tests/test_vision_collator_chat_template_kwargs.py` (6 passed)
- [x] Real `Qwen/Qwen3.8-27B` tokenizer: reasoning system prompt injected without flag, absent with `enable_thinking=False`