### PR TITLE
Read merged_16bit config from the base checkpoint, not the in-memory model

### DIFF
--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -110,8 +110,7 @@ def test_text_only_export_config_matches_written_weights(tmp_path):
     pm = _attach_lora(_text_only_model(cfg, base_dir))
     H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
 
-    # transformers 5 flattens the VLM prefixes, so match on substrings rather than the
-    # top-level key name.
+    # transformers 5 flattens the VLM prefixes, so match on a substring, not the key name.
     written = list(H.read_safetensors_dir(out_dir))
     assert any("vision" in k for k in written), f"fixture wrote no vision weights: {written[:4]}"
 
@@ -190,9 +189,7 @@ def test_base_config_read_failure_falls_back_with_a_warning(tmp_path, monkeypatc
         "the fallback must not lose the export it is protecting"
 
 
-# --------------------------------------------------------------------------------
 # vocab-size helpers, config-level only
-# --------------------------------------------------------------------------------
 
 _MISSING = object()
 

--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -16,16 +16,14 @@
 
 """The merged_16bit config must describe the weights the merge actually writes (#969).
 
-`merge_and_overwrite_lora` downloads its weights from the resolved base checkpoint but
-used to save `model.config`, which `text_only = True` has already replaced with the
-nested text config. That wrote a `gemma3_text` config with no `architectures` next to
-full VLM weights. Nothing raised: every tensor was silently re-initialized on reload,
-so a finetune could be saved, reloaded and served untrained.
+`merge_and_overwrite_lora` takes its weights from the resolved base checkpoint but used to
+save `model.config`, which `text_only = True` has already replaced with the nested text
+config, so a `gemma3_text` config landed next to full VLM weights. Nothing raised: every
+tensor was silently re-initialized on reload, so a finetune could be served untrained.
 
-The shape reproduced here is the real one: a text-only decoder in memory whose
-`_name_or_path` points at a full VLM checkpoint on disk. Passing is not "no exception"
--- the original bug threw none -- it is the saved architecture matching the written
-tensors and a reload reporting no missing / unexpected / mismatched keys.
+The fixture is the real shape -- a text-only decoder whose `_name_or_path` points at a VLM
+checkpoint. Passing is not "no exception" (the bug threw none) but the saved architecture
+matching the written tensors and a reload reporting no missing/unexpected/mismatched keys.
 """
 
 from __future__ import annotations

--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -1,0 +1,312 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The merged_16bit config must describe the weights the merge actually writes (#969).
+
+`merge_and_overwrite_lora` downloads its weights from the resolved base checkpoint but
+used to save `model.config`, which `text_only = True` has already replaced with the
+nested text config. That wrote a `gemma3_text` config with no `architectures` next to
+full VLM weights. Nothing raised: every tensor was silently re-initialized on reload,
+so a finetune could be saved, reloaded and served untrained.
+
+The shape reproduced here is the real one: a text-only decoder in memory whose
+`_name_or_path` points at a full VLM checkpoint on disk. Passing is not "no exception"
+-- the original bug threw none -- it is the saved architecture matching the written
+tensors and a reload reporting no missing / unexpected / mismatched keys.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import warnings
+
+import pytest
+import torch
+
+import _merge_e2e_helpers as H
+
+_LANG_QV = ["q_proj", "v_proj"]
+
+
+def _gemma3_config():
+    """Tiny but architecturally real Gemma3 VLM (same shape as the passthrough suite)."""
+    import transformers as T
+    text = dict(hidden_size=32, intermediate_size=64, num_hidden_layers=2,
+                num_attention_heads=4, num_key_value_heads=2, vocab_size=64,
+                max_position_embeddings=64, head_dim=8)
+    vision = dict(hidden_size=32, intermediate_size=64, num_hidden_layers=2,
+                  num_attention_heads=4, image_size=16, patch_size=8, num_channels=3)
+    return T.Gemma3Config(text_config=text, vision_config=vision)
+
+
+def _write_vlm_base(tmp_path):
+    """Save a full VLM checkpoint and return (base_dir, parent_config)."""
+    import transformers as T
+    if not H.family_available("gemma3"):
+        pytest.skip("gemma3 unavailable in this transformers")
+    cfg = _gemma3_config()
+    base_dir = os.path.join(str(tmp_path), "base")
+    torch.manual_seed(H.SEED)
+    try:
+        vlm = T.AutoModelForImageTextToText.from_config(cfg).to(torch.float32)
+    except Exception as e:  # tiny VLM config quirks vary by version
+        pytest.skip(f"could not instantiate tiny gemma3: {type(e).__name__}: {e}")
+    vlm.save_pretrained(base_dir, safe_serialization=True)
+    return base_dir, cfg
+
+
+def _text_only_model(cfg, base_dir):
+    """What `text_only = True` leaves in memory: the nested text decoder, pointed at
+    the VLM checkpoint. Mirrors `_get_text_only_config` in unsloth/models/_utils.py."""
+    import transformers as T
+    text_config = cfg.get_text_config()
+    torch.manual_seed(H.SEED)
+    model = T.AutoModelForCausalLM.from_config(text_config).to(torch.float32)
+    model.config._name_or_path = base_dir
+    assert model.config.model_type == "gemma3_text", "fixture is not the text-only shape"
+    return model
+
+
+def _attach_lora(model, modules_to_save=None):
+    from peft import LoraConfig, get_peft_model
+    pm = get_peft_model(model, LoraConfig(
+        r=8, lora_alpha=16, lora_dropout=0.0, bias="none",
+        target_modules=_LANG_QV, modules_to_save=modules_to_save))
+    H.seed_lora(pm)
+    return pm
+
+
+def _saved_config(out_dir):
+    with open(os.path.join(out_dir, "config.json")) as f:
+        return json.load(f)
+
+
+def _reload_info(out_dir):
+    """Reload as the architecture the saved config declares and return loading info."""
+    import transformers as T
+    _, info = T.AutoModelForImageTextToText.from_pretrained(
+        out_dir, output_loading_info=True, local_files_only=True)
+    return info
+
+
+def test_text_only_export_config_matches_written_weights(tmp_path):
+    """#969: a text_only export must declare the VLM it actually wrote."""
+    H.set_offline_cpu_env()
+    base_dir, cfg = _write_vlm_base(tmp_path)
+    out_dir = os.path.join(str(tmp_path), "merged")
+
+    pm = _attach_lora(_text_only_model(cfg, base_dir))
+    H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
+
+    # transformers 5 flattens the VLM prefixes, so match on substrings rather than the
+    # top-level key name.
+    written = list(H.read_safetensors_dir(out_dir))
+    assert any("vision" in k for k in written), f"fixture wrote no vision weights: {written[:4]}"
+
+    base, saved = _saved_config(base_dir), _saved_config(out_dir)
+    assert saved.get("model_type") == base.get("model_type") != "gemma3_text", (
+        f"saved config describes {saved.get('model_type')!r}, not the written weights")
+    assert saved.get("architectures") == base.get("architectures") and saved.get("architectures"), (
+        f"saved architectures {saved.get('architectures')!r} do not match the weights")
+
+    info = _reload_info(out_dir)
+    for field in ("missing_keys", "unexpected_keys", "mismatched_keys", "error_msgs"):
+        assert not info.get(field), f"{field}: {info.get(field)[:6]}"
+
+
+def test_text_only_export_preserves_resized_vocab(tmp_path):
+    """Reading the base config must not drop vocab growth from training.
+
+    Without the carry-over the export declares the base vocab beside larger embedding
+    tensors, and the reload fails on a size mismatch instead of silently succeeding.
+    """
+    H.set_offline_cpu_env()
+    base_dir, cfg = _write_vlm_base(tmp_path)
+    out_dir = os.path.join(str(tmp_path), "merged")
+
+    model = _text_only_model(cfg, base_dir)
+    base_vocab = model.get_input_embeddings().weight.shape[0]
+    new_vocab = base_vocab + 16
+    model.resize_token_embeddings(new_vocab)
+    pm = _attach_lora(model, modules_to_save=["embed_tokens", "lm_head"])
+
+    H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
+
+    merged = H.read_safetensors_dir(out_dir)
+    embed = next(v for k, v in merged.items() if k.endswith("embed_tokens.weight"))
+    assert embed.shape[0] == new_vocab, "the merge did not write the resized embedding"
+
+    saved = _saved_config(out_dir)
+    declared = saved.get("text_config", {}).get("vocab_size", saved.get("vocab_size"))
+    assert declared == new_vocab, (
+        f"config declares vocab {declared} beside {embed.shape[0]} embedding rows")
+
+    info = _reload_info(out_dir)
+    for field in ("missing_keys", "unexpected_keys", "mismatched_keys", "error_msgs"):
+        assert not info.get(field), f"{field}: {info.get(field)[:6]}"
+
+
+def test_base_config_read_failure_falls_back_with_a_warning(tmp_path, monkeypatch):
+    """The fallback keeps a previously-working export working, and says so.
+
+    It deliberately restores the #969 output, so it is an availability fallback and not
+    a correct one: the warning is the only signal the user gets.
+    """
+    import transformers
+    import unsloth_zoo.saving_utils as SU
+
+    H.set_offline_cpu_env()
+    base_dir, cfg = _write_vlm_base(tmp_path)
+    out_dir = os.path.join(str(tmp_path), "merged")
+    pm = _attach_lora(_text_only_model(cfg, base_dir))
+
+    def _boom(*a, **k):
+        raise OSError("forced base config read failure")
+
+    monkeypatch.setattr(transformers.AutoConfig, "from_pretrained", _boom)
+    if getattr(SU, "AutoConfig", None) is not None:
+        monkeypatch.setattr(SU.AutoConfig, "from_pretrained", _boom, raising=False)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
+
+    assert any("Could not read the base config" in str(w.message) for w in caught), \
+        "the fallback took effect without warning the user"
+    assert _saved_config(out_dir).get("model_type") == "gemma3_text"
+    assert any(f.endswith(".safetensors") for f in os.listdir(out_dir)), \
+        "the fallback must not lose the export it is protecting"
+
+
+# --------------------------------------------------------------------------------
+# vocab-size helpers, config-level only
+# --------------------------------------------------------------------------------
+
+_MISSING = object()
+
+
+def _shape(top=_MISSING, nested=_MISSING):
+    from types import SimpleNamespace as NS
+    cfg = NS()
+    if top is not _MISSING:
+        cfg.vocab_size = top
+    if nested is not _MISSING:
+        cfg.text_config = NS(vocab_size=nested)
+    return cfg
+
+
+@pytest.mark.parametrize("top,nested,expected", [
+    (64,       72,       72),    # PaliGemma: nested wins over a stale compat value
+    (_MISSING, 72,       72),    # Gemma3 / Qwen-VL: nested only
+    (72,       _MISSING, 72),    # plain LM: top level only
+    (72,       None,     72),    # nested present but unset -> fall back
+    (_MISSING, _MISSING, None),  # nothing to read
+])
+def test_config_vocab_size_precedence(top, nested, expected):
+    from unsloth_zoo.saving_utils import _config_vocab_size
+    assert _config_vocab_size(_shape(top, nested)) == expected
+
+
+def test_carry_over_updates_both_levels_for_stale_top_level():
+    """PaliGemma is the shape that makes precedence load-bearing: resize updates the
+    nested vocab and leaves the top-level compat value behind."""
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size
+    base = _shape(top=64, nested=64)
+    _carry_over_vocab_size(base, _shape(top=64, nested=72))
+    assert (base.vocab_size, base.text_config.vocab_size) == (72, 72)
+
+
+def test_carry_over_nested_only_and_top_only():
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size
+    nested_base = _shape(nested=64)
+    _carry_over_vocab_size(nested_base, _shape(nested=72))
+    assert nested_base.text_config.vocab_size == 72
+
+    top_base = _shape(top=64)
+    _carry_over_vocab_size(top_base, _shape(top=72))
+    assert top_base.vocab_size == 72
+
+
+def test_carry_over_syncs_a_stale_base_level_that_already_agrees():
+    """Base ships inconsistent levels and the nested one already matches: the top level
+    must still be synced rather than left behind."""
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size
+    base = _shape(top=64, nested=72)
+    _carry_over_vocab_size(base, _shape(nested=72))
+    assert (base.vocab_size, base.text_config.vocab_size) == (72, 72)
+
+
+def test_carry_over_warns_instead_of_raising_when_vocab_is_read_only():
+    """A config exposing vocab_size without a setter must not crash a working export."""
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size
+
+    class ReadOnly:
+        vocab_size = property(lambda self: 64)
+
+    base = ReadOnly()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _carry_over_vocab_size(base, _shape(top=72))
+    assert any("could not set vocab_size" in str(w.message) for w in caught)
+
+
+def test_carry_over_shrink_is_carried_too():
+    """Gemma3's tokenizer is shorter than its padded matrix, so shrink is a real case."""
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size
+    base = _shape(top=262208, nested=262208)
+    _carry_over_vocab_size(base, _shape(nested=262149))
+    assert base.text_config.vocab_size == 262149
+
+
+def test_carry_over_no_resize_and_no_trained_value_are_no_ops():
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size
+    same = _shape(top=64, nested=64)
+    _carry_over_vocab_size(same, _shape(top=64, nested=64))
+    assert (same.vocab_size, same.text_config.vocab_size) == (64, 64)
+
+    untouched = _shape(top=64, nested=64)
+    _carry_over_vocab_size(untouched, _shape())
+    assert (untouched.vocab_size, untouched.text_config.vocab_size) == (64, 64)
+
+
+def test_carry_over_does_not_invent_fields():
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size
+    bare = _shape()
+    _carry_over_vocab_size(bare, _shape(top=72))
+    assert not hasattr(bare, "vocab_size")
+    assert not hasattr(bare, "text_config")
+
+
+def test_carry_over_on_real_transformers_configs():
+    """Guard the precedence against config classes rather than stand-ins."""
+    import transformers as T
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size, _config_vocab_size
+
+    if not H.family_available("paligemma"):
+        pytest.skip("paligemma unavailable in this transformers")
+    base = T.PaliGemmaConfig(text_config={"model_type": "gemma", "vocab_size": 64})
+    trained = T.PaliGemmaConfig(text_config={"model_type": "gemma", "vocab_size": 64})
+    base.vocab_size = 64
+    trained.vocab_size = 64
+    trained.text_config.vocab_size = 72
+
+    assert _config_vocab_size(trained) == 72, "stale top-level compat value won"
+    _carry_over_vocab_size(base, trained)
+    assert base.text_config.vocab_size == 72
+    assert base.vocab_size == 72
+
+    assert _config_vocab_size(T.LlamaConfig(vocab_size=72)) == 72

--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -241,13 +241,35 @@ def test_carry_over_nested_only_and_top_only():
     assert top_base.vocab_size == 72
 
 
-def test_carry_over_syncs_a_stale_base_level_that_already_agrees():
-    """Base ships inconsistent levels and the nested one already matches: the top level
-    must still be synced rather than left behind."""
+def test_carry_over_leaves_a_distinct_top_level_vocabulary_alone():
+    """A top level that already differs from the text vocab is a DIFFERENT vocabulary, not a
+    stale copy, so it must not be overwritten."""
     from unsloth_zoo.saving_utils import _carry_over_vocab_size
     base = _shape(top=64, nested=72)
-    _carry_over_vocab_size(base, _shape(nested=72))
-    assert (base.vocab_size, base.text_config.vocab_size) == (72, 72)
+    _carry_over_vocab_size(base, _shape(nested=80))
+    assert base.text_config.vocab_size == 80, "text vocab was not carried over"
+    assert base.vocab_size == 64, "a distinct top-level vocabulary was clobbered"
+
+
+def test_carry_over_preserves_ovis2_top_level_vocabulary():
+    """Ovis2 sizes its lm_head from the top-level vocab_size and ships it deliberately
+    different from text_config.vocab_size, so writing one value to both breaks the reload."""
+    import transformers as T
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size
+
+    if not H.family_available("ovis2"):
+        pytest.skip("ovis2 unavailable in this transformers")
+    base, trained = T.CONFIG_MAPPING["ovis2"](), T.CONFIG_MAPPING["ovis2"]()
+    top_before = base.vocab_size
+    assert top_before != base.text_config.vocab_size, "fixture no longer has distinct levels"
+
+    _carry_over_vocab_size(base, trained)          # no resize at all
+    assert base.vocab_size == top_before, "no-resize carry-over moved the top-level vocab"
+
+    trained.text_config.vocab_size += 8
+    _carry_over_vocab_size(base, trained)
+    assert base.text_config.vocab_size == trained.text_config.vocab_size
+    assert base.vocab_size == top_before, "resize moved the lm_head vocabulary too"
 
 
 def test_carry_over_warns_instead_of_raising_when_vocab_is_read_only():

--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -291,6 +291,33 @@ def test_carry_over_does_not_invent_fields():
     assert not hasattr(bare, "text_config")
 
 
+@pytest.mark.parametrize("family", ["qwen2_5_omni", "qwen3_omni_moe", "colqwen2", "t5gemma"])
+def test_carry_over_reaches_text_configs_not_named_text_config(family):
+    """Some composite configs nest the text section under another name, so `.text_config`
+    misses it entirely. `get_text_config()` is the documented accessor."""
+    import transformers as T
+    from unsloth_zoo.saving_utils import _carry_over_vocab_size, _config_vocab_size
+
+    if not H.family_available(family):
+        pytest.skip(f"{family} unavailable in this transformers")
+    try:
+        base, trained = T.CONFIG_MAPPING[family](), T.CONFIG_MAPPING[family]()
+    except Exception as e:
+        pytest.skip(f"{family} will not instantiate bare: {type(e).__name__}")
+    if getattr(base, "text_config", None) is not None:
+        pytest.skip(f"{family} exposes .text_config on this version")
+
+    target = _config_vocab_size(trained)
+    if target is None:
+        pytest.skip(f"{family} has no vocab_size to carry")
+    target += 8
+    trained.get_text_config().vocab_size = target
+
+    assert _config_vocab_size(trained) == target, "nested vocab not read via get_text_config()"
+    _carry_over_vocab_size(base, trained)
+    assert base.get_text_config().vocab_size == target, "nested vocab not written"
+
+
 def test_carry_over_on_real_transformers_configs():
     """Guard the precedence against config classes rather than stand-ins."""
     import transformers as T

--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -2,8 +2,8 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3214,7 +3214,27 @@ def merge_and_overwrite_lora(
     # Default handle 16 bit merge and save/push
     # Step 1: Save base model config/architecture (no weights needed here)
     if save_method == "merged_16bit":
-        config.save_pretrained(save_directory)
+        # `config` is `model.config`, which is already the nested text config when the model was
+        # loaded with `text_only = True`. The weights below come from `model_name` (the resolved
+        # base checkpoint) and still carry the full VLM prefixes, so saving `config` here writes a
+        # text-only config beside VLM weights and every tensor is silently re-initialized on
+        # reload. Take the config from the same checkpoint the weights come from, matching what the
+        # `mxfp4` branch below already does.
+        from transformers import AutoConfig
+        try:
+            base_config = AutoConfig.from_pretrained(
+                model_name,
+                token = token,
+                trust_remote_code = False,
+            )
+        except Exception as base_config_error:
+            warnings.warn(
+                f"Unsloth: Could not read the base config from `{model_name}` "
+                f"({base_config_error}). Falling back to the in-memory config, which might not "
+                f"describe the exported weights."
+            )
+            base_config = config
+        base_config.save_pretrained(save_directory)
         _remove_quantization_config(config_path = Path(save_directory) / "config.json")
         _remove_transformers_version(config_path = Path(save_directory) / "config.json")
         # #5410: keep trained eos / sampling defaults on reload.

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2877,6 +2877,31 @@ def is_hf_sharded_safetensors(filenames: list[str]) -> bool:
     prefixes, _, totals = zip(*parsed)
     return len(set(prefixes)) == 1 and len(set(totals)) == 1
 
+def _config_vocab_size(config):
+    # VLM configs keep the text vocab on the nested text config, plain LM configs at the top level.
+    vocab_size = getattr(config, "vocab_size", None)
+    if vocab_size is None:
+        vocab_size = getattr(getattr(config, "text_config", None), "vocab_size", None)
+    return vocab_size
+pass
+
+
+def _carry_over_vocab_size(base_config, trained_config):
+    # `resize_token_embeddings`, or a `modules_to_save` embed_tokens / lm_head, grows the vocab and
+    # updates the in-memory config. The merge writes those expanded tensors, but a config read from
+    # the base checkpoint still carries the original `vocab_size`, which would rebuild smaller
+    # layers and fail the reload on a size mismatch. Carry the trained size across.
+    trained_vocab_size = _config_vocab_size(trained_config)
+    if trained_vocab_size is None: return
+    if _config_vocab_size(base_config) == trained_vocab_size: return
+    if getattr(base_config, "vocab_size", None) is not None:
+        base_config.vocab_size = trained_vocab_size
+    text_config = getattr(base_config, "text_config", None)
+    if getattr(text_config, "vocab_size", None) is not None:
+        text_config.vocab_size = trained_vocab_size
+pass
+
+
 @torch.inference_mode
 def merge_and_overwrite_lora(
     get_model_name,
@@ -3234,6 +3259,8 @@ def merge_and_overwrite_lora(
                 f"describe the exported weights."
             )
             base_config = config
+        else:
+            _carry_over_vocab_size(base_config, config)
         base_config.save_pretrained(save_directory)
         _remove_quantization_config(config_path = Path(save_directory) / "config.json")
         _remove_transformers_version(config_path = Path(save_directory) / "config.json")

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2878,9 +2878,8 @@ def is_hf_sharded_safetensors(filenames: list[str]) -> bool:
     return len(set(prefixes)) == 1 and len(set(totals)) == 1
 
 def _text_configs(config):
-    # Where a composite config keeps its text vocab. `get_text_config()` is the documented
-    # accessor and finds sections not named `text_config` (qwen2_5_omni, qwen3_omni_moe,
-    # colqwen2, t5gemma); it returns `config` itself for a plain LM.
+    # Where a composite config keeps its text vocab. `get_text_config()` also finds sections
+    # not named `text_config` (qwen2_5_omni, t5gemma); it returns `config` itself for a plain LM.
     holders = []
     try: holders.append(config.get_text_config())
     except Exception: pass
@@ -2893,9 +2892,8 @@ pass
 
 
 def _config_vocab_size(config):
-    # Nested first: composite configs can carry both, and `resize_token_embeddings` updates
-    # only the nested one (PaliGemma leaves its top-level copy behind), so reading a stale
-    # top level would look like "no resize happened".
+    # Nested first: a composite can carry both, and `resize_token_embeddings` updates only the
+    # nested one (PaliGemma leaves a stale top-level copy that would read as "no resize").
     for holder in _text_configs(config):
         if holder is config: continue
         vocab_size = getattr(holder, "vocab_size", None)
@@ -2912,10 +2910,9 @@ def _carry_over_vocab_size(base_config, trained_config):
     if trained_vocab_size is None: return
     holders = [h for h in _text_configs(base_config) if h is not base_config]
     base_vocab_size = getattr(base_config, "vocab_size", None)
-    # A top level that already mirrors the text vocab is a compatibility copy and moves with it
-    # (PaliGemma). One that differs is a DIFFERENT vocabulary, not a stale copy: Ovis2 ships
-    # vocab_size=151643 against text_config.vocab_size=151936 and sizes its lm_head from the
-    # top level, so overwriting it there would break the very reload this protects.
+    # A top level mirroring the text vocab is a compatibility copy and moves with it (PaliGemma).
+    # One that differs is a DIFFERENT vocabulary: Ovis2 ships 151643 against a text 151936 and
+    # sizes its lm_head from the top level, so writing there breaks the reload this protects.
     if base_vocab_size is not None and all(
         getattr(holder, "vocab_size", base_vocab_size) == base_vocab_size for holder in holders
     ):
@@ -3274,10 +3271,9 @@ def merge_and_overwrite_lora(
     # Step 1: Save base model config/architecture (no weights needed here)
     if save_method == "merged_16bit":
         # `config` is `model.config`, already the nested text config under `text_only = True`,
-        # while the weights come from `model_name` and keep their full VLM prefixes. Saving it
-        # wrote a text-only config beside VLM weights, and every tensor was then silently
-        # re-initialized on reload (#969). Read the config from the checkpoint the weights come
-        # from, as the `mxfp4` branch below already does.
+        # while the weights come from `model_name` and keep their VLM prefixes. Saving it wrote
+        # a text-only config beside VLM weights and every tensor was silently re-initialized on
+        # reload (#969). Take the config from the checkpoint the weights come from, as `mxfp4` does.
         from transformers import AutoConfig
         try:
             base_config = AutoConfig.from_pretrained(

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2878,10 +2878,9 @@ def is_hf_sharded_safetensors(filenames: list[str]) -> bool:
     return len(set(prefixes)) == 1 and len(set(totals)) == 1
 
 def _config_vocab_size(config):
-    # VLM configs keep the text vocab on the nested text config, plain LM configs at the top level.
-    # Some composite configs carry both, and `resize_token_embeddings` only updates the nested one
-    # (PaliGemma leaves its top-level compatibility `vocab_size` behind), so the nested value wins:
-    # reading a stale top-level size would look like "no resize happened".
+    # Nested first: composite configs can carry both, and `resize_token_embeddings` updates
+    # only the nested one (PaliGemma leaves its top-level copy behind), so reading a stale
+    # top level would look like "no resize happened".
     vocab_size = getattr(getattr(config, "text_config", None), "vocab_size", None)
     if vocab_size is None:
         vocab_size = getattr(config, "vocab_size", None)
@@ -2890,18 +2889,24 @@ pass
 
 
 def _carry_over_vocab_size(base_config, trained_config):
-    # `resize_token_embeddings`, or a `modules_to_save` embed_tokens / lm_head, grows the vocab and
-    # updates the in-memory config. The merge writes those expanded tensors, but a config read from
-    # the base checkpoint still carries the original `vocab_size`, which would rebuild smaller
-    # layers and fail the reload on a size mismatch. Carry the trained size across.
+    # The merge writes the trained (possibly resized) embeddings, so the base checkpoint's own
+    # `vocab_size` would rebuild smaller layers and fail the reload. Set every level the base
+    # already exposes, so a stale top-level copy cannot survive a nested-only resize.
     trained_vocab_size = _config_vocab_size(trained_config)
     if trained_vocab_size is None: return
-    if _config_vocab_size(base_config) == trained_vocab_size: return
-    if getattr(base_config, "vocab_size", None) is not None:
-        base_config.vocab_size = trained_vocab_size
-    text_config = getattr(base_config, "text_config", None)
-    if getattr(text_config, "vocab_size", None) is not None:
-        text_config.vocab_size = trained_vocab_size
+    for holder in (base_config, getattr(base_config, "text_config", None)):
+        if getattr(holder, "vocab_size", None) is None: continue
+        try: holder.vocab_size = trained_vocab_size
+        except Exception: pass  # read-only on some composite configs
+    pass
+    # Never silently ship a config that disagrees with the rows we are about to write.
+    if _config_vocab_size(base_config) != trained_vocab_size:
+        warnings.warn(
+            f"Unsloth: could not set vocab_size={trained_vocab_size} on the base config of "
+            f"`{getattr(base_config, 'model_type', '?')}`; the exported config may not match "
+            f"the embedding rows written."
+        )
+    pass
 pass
 
 
@@ -3242,12 +3247,11 @@ def merge_and_overwrite_lora(
     # Default handle 16 bit merge and save/push
     # Step 1: Save base model config/architecture (no weights needed here)
     if save_method == "merged_16bit":
-        # `config` is `model.config`, which is already the nested text config when the model was
-        # loaded with `text_only = True`. The weights below come from `model_name` (the resolved
-        # base checkpoint) and still carry the full VLM prefixes, so saving `config` here writes a
-        # text-only config beside VLM weights and every tensor is silently re-initialized on
-        # reload. Take the config from the same checkpoint the weights come from, matching what the
-        # `mxfp4` branch below already does.
+        # `config` is `model.config`, already the nested text config under `text_only = True`,
+        # while the weights come from `model_name` and keep their full VLM prefixes. Saving it
+        # wrote a text-only config beside VLM weights, and every tensor was then silently
+        # re-initialized on reload (#969). Read the config from the checkpoint the weights come
+        # from, as the `mxfp4` branch below already does.
         from transformers import AutoConfig
         try:
             base_config = AutoConfig.from_pretrained(
@@ -3259,7 +3263,7 @@ def merge_and_overwrite_lora(
             warnings.warn(
                 f"Unsloth: Could not read the base config from `{model_name}` "
                 f"({base_config_error}). Falling back to the in-memory config, which might not "
-                f"describe the exported weights."
+                f"describe the exported weights (see #969)."
             )
             base_config = config
         else:
@@ -3280,7 +3284,7 @@ def merge_and_overwrite_lora(
         from transformers import AutoConfig
         model_config = AutoConfig.from_pretrained(
             model_name,
-            token = None,
+            token = token,  # was None, which cannot read a gated or private base
             trust_remote_code = False,
         )
         model_config.save_pretrained(save_directory)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2879,9 +2879,12 @@ def is_hf_sharded_safetensors(filenames: list[str]) -> bool:
 
 def _config_vocab_size(config):
     # VLM configs keep the text vocab on the nested text config, plain LM configs at the top level.
-    vocab_size = getattr(config, "vocab_size", None)
+    # Some composite configs carry both, and `resize_token_embeddings` only updates the nested one
+    # (PaliGemma leaves its top-level compatibility `vocab_size` behind), so the nested value wins:
+    # reading a stale top-level size would look like "no resize happened".
+    vocab_size = getattr(getattr(config, "text_config", None), "vocab_size", None)
     if vocab_size is None:
-        vocab_size = getattr(getattr(config, "text_config", None), "vocab_size", None)
+        vocab_size = getattr(config, "vocab_size", None)
     return vocab_size
 pass
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2877,14 +2877,31 @@ def is_hf_sharded_safetensors(filenames: list[str]) -> bool:
     prefixes, _, totals = zip(*parsed)
     return len(set(prefixes)) == 1 and len(set(totals)) == 1
 
+def _text_configs(config):
+    # Where a composite config keeps its text vocab. `get_text_config()` is the documented
+    # accessor and finds sections not named `text_config` (qwen2_5_omni, qwen3_omni_moe,
+    # colqwen2, t5gemma); it returns `config` itself for a plain LM.
+    holders = []
+    try: holders.append(config.get_text_config())
+    except Exception: pass
+    holders.append(getattr(config, "text_config", None))
+    seen = []
+    for holder in holders:
+        if holder is not None and not any(holder is s for s in seen): seen.append(holder)
+    return seen
+pass
+
+
 def _config_vocab_size(config):
     # Nested first: composite configs can carry both, and `resize_token_embeddings` updates
     # only the nested one (PaliGemma leaves its top-level copy behind), so reading a stale
     # top level would look like "no resize happened".
-    vocab_size = getattr(getattr(config, "text_config", None), "vocab_size", None)
-    if vocab_size is None:
-        vocab_size = getattr(config, "vocab_size", None)
-    return vocab_size
+    for holder in _text_configs(config):
+        if holder is config: continue
+        vocab_size = getattr(holder, "vocab_size", None)
+        if vocab_size is not None: return vocab_size
+    pass
+    return getattr(config, "vocab_size", None)
 pass
 
 
@@ -2894,7 +2911,7 @@ def _carry_over_vocab_size(base_config, trained_config):
     # already exposes, so a stale top-level copy cannot survive a nested-only resize.
     trained_vocab_size = _config_vocab_size(trained_config)
     if trained_vocab_size is None: return
-    for holder in (base_config, getattr(base_config, "text_config", None)):
+    for holder in [base_config] + _text_configs(base_config):
         if getattr(holder, "vocab_size", None) is None: continue
         try: holder.vocab_size = trained_vocab_size
         except Exception: pass  # read-only on some composite configs

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2907,11 +2907,20 @@ pass
 
 def _carry_over_vocab_size(base_config, trained_config):
     # The merge writes the trained (possibly resized) embeddings, so the base checkpoint's own
-    # `vocab_size` would rebuild smaller layers and fail the reload. Set every level the base
-    # already exposes, so a stale top-level copy cannot survive a nested-only resize.
+    # `vocab_size` would rebuild smaller layers and fail the reload. Only the text vocab moves.
     trained_vocab_size = _config_vocab_size(trained_config)
     if trained_vocab_size is None: return
-    for holder in [base_config] + _text_configs(base_config):
+    holders = [h for h in _text_configs(base_config) if h is not base_config]
+    base_vocab_size = getattr(base_config, "vocab_size", None)
+    # A top level that already mirrors the text vocab is a compatibility copy and moves with it
+    # (PaliGemma). One that differs is a DIFFERENT vocabulary, not a stale copy: Ovis2 ships
+    # vocab_size=151643 against text_config.vocab_size=151936 and sizes its lm_head from the
+    # top level, so overwriting it there would break the very reload this protects.
+    if base_vocab_size is not None and all(
+        getattr(holder, "vocab_size", base_vocab_size) == base_vocab_size for holder in holders
+    ):
+        holders.append(base_config)
+    for holder in holders:
         if getattr(holder, "vocab_size", None) is None: continue
         try: holder.vocab_size = trained_vocab_size
         except Exception: pass  # read-only on some composite configs


### PR DESCRIPTION
Fixes #969.

### Problem

`merge_and_overwrite_lora` takes its config and its weights from two different places:

- the weights are downloaded from the resolved base checkpoint, `model_name` (line 2960), and still carry the full VLM prefixes (`language_model.*`, `vision_tower.*`, `multi_modal_projector.*`);
- the config it saves is `model.config` (line 2902), which under `text_only = True` has already been replaced by the nested text config.

`config.save_pretrained(save_directory)` then wrote the first against the second, so a `text_only = True` export produced a `gemma3_text` config with no `architectures` key sitting next to full VLM weights.

Nothing reconciles the two, and nothing raises. On reload none of the weight names match, so every parameter is reported missing and newly initialized - a finetune can be saved, reloaded and served as an untrained model with no signal that anything is wrong. Credit to @Zelys-DFKH for the diagnosis in #969, which this follows.

### Change

Read the config from `model_name` in the `merged_16bit` branch, so it describes the weights that are actually written.

This is not a new pattern for this function - the `mxfp4` branch immediately below already resolves its config the same way:

```python
elif save_method == "mxfp4":
    from transformers import AutoConfig
    model_config = AutoConfig.from_pretrained(model_name, token = None, trust_remote_code = False)
    model_config.save_pretrained(save_directory)
```

Two details:

- the result goes into `base_config` rather than reassigning `config`, because `config` is still used further down by `should_split_shards(is_t4, config, ...)`;
- if the base config cannot be read, it warns and falls back to the previous behaviour instead of failing an export that used to work.

Issue #969 lists two possible directions. This is the first (least invasive) one: it fixes the silent-reinitialisation bug but still hands a `text_only` user a VLM checkpoint back. The second direction - remapping keys and dropping the vision/audio tensors so the export honours `text_only = True` and halves in size - is a larger change and seems better as a follow-up, but happy to take that on instead if you would prefer it.

### Verification

Traced against `main` at 117e6ce and syntax-checked. I have not been able to run the end-to-end reload check from the issue in this environment (it needs a GPU and the ~8.6GB base download), so that still wants confirming - the check is to run the reproduction in #969 and assert that `AutoModelForCausalLM.from_pretrained("out")` reports no newly initialised weights.