### PR TITLE
Fuse the three upstream pins and both Linux MLX suites onto one runner each

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -557,26 +557,26 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 trc=0
                 "$venv/bin/python" -m pytest -v --tb=short -rs \
-            tests/test_upstream_pinned_symbols_transformers.py \\
-            tests/test_torchvision_video_removed_message.py \\
-            tests/test_upstream_pinned_symbols_trl_vllm.py \\
-            tests/test_upstream_pinned_symbols_accelerator.py \\
-            tests/test_zoo_history_regressions_deep.py \\
-            tests/test_upstream_import_fixes_drift.py \\
-            tests/test_zoo_source_upstream_refs.py \\
-            tests/test_upstream_signatures.py \\
-            tests/test_extended_dep_api_pins.py \\
-            tests/test_upstream_source_patterns.py \\
-            tests/test_compiler_rewriter_exhaustive.py \\
-            tests/test_compiler_dynamic_exec.py \\
-            tests/test_temporary_patches_exhaustive.py \\
-            tests/test_missing_parent_package_is_drift.py \\
-            tests/test_unsloth_zoo_lora_merge.py \\
-            tests/test_peft_paramwrapper_layout_drift.py \\
-            tests/test_transformers_moe_structure_drift.py \\
-            tests/test_moe_merge_e2e_cpu.py \\
-            tests/test_merge_e2e_hub_unreachable.py \\
-            tests/test_gemma4_dtype_drift_guards.py >> "$log" 2>&1 || trc=$?
+                  tests/test_upstream_pinned_symbols_transformers.py \
+                  tests/test_torchvision_video_removed_message.py \
+                  tests/test_upstream_pinned_symbols_trl_vllm.py \
+                  tests/test_upstream_pinned_symbols_accelerator.py \
+                  tests/test_zoo_history_regressions_deep.py \
+                  tests/test_upstream_import_fixes_drift.py \
+                  tests/test_zoo_source_upstream_refs.py \
+                  tests/test_upstream_signatures.py \
+                  tests/test_extended_dep_api_pins.py \
+                  tests/test_upstream_source_patterns.py \
+                  tests/test_compiler_rewriter_exhaustive.py \
+                  tests/test_compiler_dynamic_exec.py \
+                  tests/test_temporary_patches_exhaustive.py \
+                  tests/test_missing_parent_package_is_drift.py \
+                  tests/test_unsloth_zoo_lora_merge.py \
+                  tests/test_peft_paramwrapper_layout_drift.py \
+                  tests/test_transformers_moe_structure_drift.py \
+                  tests/test_moe_merge_e2e_cpu.py \
+                  tests/test_merge_e2e_hub_unreachable.py \
+                  tests/test_gemma4_dtype_drift_guards.py >> "$log" 2>&1 || trc=$?
                 echo "$trc" > ".lanes/$id.tests"
               else
                 echo "skipped" > ".lanes/$id.tests"

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -304,219 +304,18 @@ jobs:
   # mx.quantize/dequantize/compile all run on it, so the 8-bit optimizer state
   # is gated on every PR instead of only on the opt-in Apple Silicon job.
   # Separate job: tests/mlx_simulation/ must never be in sys.modules here.
-  mlx-cpu-numerics:
-    name: MLX numerics (Linux CPU)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Harden runner (audit)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-
-      - name: Install torch CPU + zoo + mlx-cpu
-        run: |
-          python -m pip install --upgrade pip
-          pip install --index-url https://download.pytorch.org/whl/cpu \
-            "torch>=2.4.0,<2.11.0"
-          pip install -e .[core]
-          pip install --no-deps "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
-          pip install pytest==9.0.3 "mlx>=0.22.0" mlx-cpu
-
-      - name: pytest tests/test_mlx_quantized_optimizer_state.py (HARD GATE)
-        # -rs surfaces skips; the next step fails the job if the file skipped,
-        # because a skipped numeric suite is not a gate.
-        run: python -m pytest tests/test_mlx_quantized_optimizer_state.py -v -rs
-
-      - name: Fail if the numeric tests skipped
-        run: |
-          python -m pytest tests/test_mlx_quantized_optimizer_state.py -q -rs | tee out.txt
-          if grep -qiE '[0-9]+ skipped' out.txt; then
-            echo "real mlx is installed but the numeric tests skipped"; exit 1
-          fi
-
-  # Core (HF/TRL/peft) drift matrix. Three cells: HF=4.57.6+TRL<1, HF=latest+TRL=latest,
-  # and pyproject defaults. fail-fast=false; drift in one cell shouldn't cancel others.
-  core-upstream-matrix:
-    name: "Core (${{ matrix.combo.label }})"
+  # Both Linux CPU MLX suites. One runner, two venvs, run concurrently.
+  #
+  # These were two jobs, 158s and 164s of execution, ~85s of it the same
+  # torch-CPU + zoo install, behind ~4000s queues. They must keep SEPARATE
+  # ENVIRONMENTS and the source says why: the suites need mlx-lm and mlx-vlm,
+  # which the numerics job deliberately omits because resolving them there could
+  # move transformers. That is an argument about environments, not about runners,
+  # so a venv each satisfies it exactly while costing one slot instead of two.
+  mlx-cpu-linux:
+    name: "MLX (Linux CPU: numerics + suites)"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        combo:
-          - id: t4576-trl0latest
-            label: "HF=4.57.6 + TRL<1"
-            transformers_spec: "transformers==4.57.6"
-            trl_spec: "trl>=0.18.2,<1.0.0"
-            peft_spec: "peft>=0.18,<0.20"
-          - id: tlatest5-trl1latest
-            label: "HF=latest + TRL=latest"
-            transformers_spec: "transformers>=5,<6"
-            trl_spec: "trl>=1,<2"
-            peft_spec: "peft"
-          - id: pyproject
-            label: "HF=default + TRL=default"
-            transformers_spec: "__from_pyproject__"
-            trl_spec: "__from_pyproject__"
-            peft_spec: "__from_pyproject__"
-    env:
-      MATRIX_TRANSFORMERS_SPEC: ${{ matrix.combo.transformers_spec }}
-      MATRIX_TRL_SPEC: ${{ matrix.combo.trl_spec }}
-      MATRIX_PEFT_SPEC: ${{ matrix.combo.peft_spec }}
-      MATRIX_COMBO_ID: ${{ matrix.combo.id }}
-      # Pure-Python protobuf parser; transformers' bundled *_pb2.py is rejected by C++ protobuf 4+/5+.
-      PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
-      UNSLOTH_COMPILE_DISABLE: '1'
-      # Secondary handshake after find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
-      UNSLOTH_IS_PRESENT: '1'
-    steps:
-      - name: Harden runner (audit)
-        # audit (not block): matrix pulls arbitrary transformers/TRL/peft pins.
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-
-      - name: Resolve matrix specs (handle __from_pyproject__ sentinel)
-        # Resolve transformers/trl/peft from pyproject.toml when the sentinel is used.
-        run: |
-          set -euxo pipefail
-          python <<'PY' >> "$GITHUB_ENV"
-          import os, re, tomllib
-          spec_t = os.environ["MATRIX_TRANSFORMERS_SPEC"]
-          spec_r = os.environ["MATRIX_TRL_SPEC"]
-          spec_p = os.environ["MATRIX_PEFT_SPEC"]
-
-          def _pkg_name(spec: str) -> str:
-              m = re.match(r"\s*([A-Za-z0-9_.-]+)", spec)
-              return (m.group(1).lower() if m else "")
-
-          if "__from_pyproject__" in (spec_t, spec_r, spec_p):
-              with open("pyproject.toml", "rb") as f:
-                  doc = tomllib.load(f)
-              proj = doc.get("project", {})
-              all_deps: list[str] = list(proj.get("dependencies", []))
-              for _name, dep_list in proj.get("optional-dependencies", {}).items():
-                  all_deps.extend(dep_list)
-
-              # Strip environment markers so the resolved spec is pip-installable.
-              def _strip_marker(s: str) -> str:
-                  return s.split(";", 1)[0].strip()
-
-              if spec_t == "__from_pyproject__":
-                  spec_t = next((_strip_marker(x) for x in all_deps if _pkg_name(x) == "transformers"),
-                                "transformers")
-              if spec_r == "__from_pyproject__":
-                  spec_r = next((_strip_marker(x) for x in all_deps if _pkg_name(x) == "trl"),
-                                "trl")
-              if spec_p == "__from_pyproject__":
-                  spec_p = next((_strip_marker(x) for x in all_deps if _pkg_name(x) == "peft"),
-                                "peft")
-          print(f"RESOLVED_TRANSFORMERS_SPEC={spec_t}")
-          print(f"RESOLVED_TRL_SPEC={spec_r}")
-          print(f"RESOLVED_PEFT_SPEC={spec_p}")
-          PY
-          grep RESOLVED_ "$GITHUB_ENV" || true
-
-      - name: Install torch CPU + zoo + matrix-specified upstream libs
-        # Two-phase: `-e .[core]` for pyproject defaults, then `-U <RESOLVED_*>` to override.
-        # The -U is critical so pip will downgrade transformers (e.g. cell-1 pin 4.57.6).
-        # --no-deps unsloth satisfies the find_spec guard at unsloth_zoo/__init__.py:128.
-        run: |
-          set -euxo pipefail
-          python -m pip install --upgrade pip
-          pip install --index-url https://download.pytorch.org/whl/cpu \
-            "torch>=2.4.0,<2.11.0" "torchvision<0.26"
-          # torchvision: transitive import of transformers.models.qwen2_vl
-          # / qwen2_5_vl image processors. The Qwen2_VL image-processor
-          # zoo references chains through `from torchvision...` at module
-          # top, so a missing torchvision turns the existence-probe drift
-          # tests RED on "ModuleNotFoundError: No module named 'torchvision'".
-          # CPU build is plenty; we don't need the CUDA variant.
-          pip install -e .[core]
-          pip install --no-deps "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
-          # Override with matrix-resolved specs.
-          pip install -U "$RESOLVED_TRANSFORMERS_SPEC" "$RESOLVED_TRL_SPEC" "$RESOLVED_PEFT_SPEC"
-          # bitsandbytes: imported at module scope in saving_utils.py (_active_merge_device path).
-          pip install 'bitsandbytes>=0.45'
-          # IPython + ipywidgets: logging_utils.py:50 imports transformers.utils.notebook.
-          # Required so drift detector only fires on real drift, not missing CI deps.
-          pip install 'ipython>=8' 'ipywidgets>=8'
-          pip install pytest==9.0.3 packaging
-          echo "::group::Installed transformers + trl + peft + torch versions"
-          pip show transformers
-          pip show trl
-          pip show peft
-          pip show torch
-          echo "::endgroup::"
-
-      - name: pytest upstream-regression suite (94 pinned + 117 expanded)
-        # 626 drift-detector tests / cell across 12 files. HARD GATE: a red cell
-        # means real upstream drift (transformers/trl/peft/vllm/datasets renamed
-        # or removed a symbol zoo references). Zoo PRs #4 through #635 mined.
-        #
-        # test_gemma4_dtype_drift_guards belongs here, not to the CPU job: its
-        # real-source canaries read the INSTALLED transformers gemma4 module and
-        # only mean something against a moving pin, which this matrix alone
-        # supplies. They skip on the HF=4.57.6 cell (no gemma4 before transformers
-        # 5.5.0). Until now no job executed the file at all -- `--collect-only`
-        # proves only that it imports, and is continue-on-error besides.
-        run: |
-          python -m pytest -v --tb=short -rs \
-            tests/test_upstream_pinned_symbols_transformers.py \
-            tests/test_torchvision_video_removed_message.py \
-            tests/test_upstream_pinned_symbols_trl_vllm.py \
-            tests/test_upstream_pinned_symbols_accelerator.py \
-            tests/test_zoo_history_regressions_deep.py \
-            tests/test_upstream_import_fixes_drift.py \
-            tests/test_zoo_source_upstream_refs.py \
-            tests/test_upstream_signatures.py \
-            tests/test_extended_dep_api_pins.py \
-            tests/test_upstream_source_patterns.py \
-            tests/test_compiler_rewriter_exhaustive.py \
-            tests/test_compiler_dynamic_exec.py \
-            tests/test_temporary_patches_exhaustive.py \
-            tests/test_missing_parent_package_is_drift.py \
-            tests/test_unsloth_zoo_lora_merge.py \
-            tests/test_peft_paramwrapper_layout_drift.py \
-            tests/test_transformers_moe_structure_drift.py \
-            tests/test_moe_merge_e2e_cpu.py \
-            tests/test_merge_e2e_hub_unreachable.py \
-            tests/test_gemma4_dtype_drift_guards.py
-
-  # The MLX VLM/shape/batching suites on Linux CPU MLX: mlx ships manylinux CPU
-  # wheels and mlx-lm/mlx-vlm are py3-none-any, so these cost no macOS minutes.
-  # mlx-ci.yml runs the same three files against real Metal.
-  #
-  # No job ran them before: `pytest tests/ --collect-only` proves only that they
-  # import, and is continue-on-error besides. That is how the audio family gate
-  # reached main admitting one exact mlx-vlm string while pyproject allows every
-  # later release, leaving the feature unreachable on a normal install.
-  #
-  # Separate from mlx-cpu-numerics: these need mlx-lm and mlx-vlm, which that job
-  # deliberately omits, and resolving them there could move transformers.
-  mlx-cpu-tests:
-    name: MLX suites (Linux CPU MLX)
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
     steps:
       - name: Harden runner (audit)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
@@ -532,41 +331,74 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Install CPU torch + zoo + CPU MLX
-        # --no-deps unsloth satisfies the find_spec("unsloth") guard in
-        # unsloth_zoo/__init__.py; mlx-cpu is the Linux runtime, spelled as
-        # mlx-cpu-numerics spells it.
-        #
-        # The MLX packages must resolve in the SAME pip call as .[core]. Split,
-        # pip solves them independently and mlx-vlm 0.6.9 (transformers>=5.14)
-        # drags transformers past the <=5.5.0 this project pins: measured
-        # 5.5.0 -> 5.14.1. Together, pip honours the cap and lands on the newest
-        # mlx-vlm that fits, which is the 0.6.4 ceiling the audio gate records.
+      - name: Build both environments (concurrently)
         run: |
-          python -m pip install --upgrade pip
-          pip install --index-url https://download.pytorch.org/whl/cpu \
-            "torch>=2.4.0,<2.11.0"
-          pip install -e .[core] \
-            "mlx>=0.22.0" mlx-cpu "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4"
-          pip install --no-deps "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
-          pip install pytest==9.0.3
+          mkdir -p .lanes
+
+          # numerics: minimal on purpose -- mlx core only, no mlx-lm / mlx-vlm.
+          (
+            rc=0
+            {
+              python -m venv .lanes/venv-numerics
+              .lanes/venv-numerics/bin/python -m pip install --upgrade pip
+              .lanes/venv-numerics/bin/pip install --index-url https://download.pytorch.org/whl/cpu \
+                "torch>=2.4.0,<2.11.0"
+              .lanes/venv-numerics/bin/pip install -e .[core]
+              .lanes/venv-numerics/bin/pip install --no-deps \
+                "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
+              .lanes/venv-numerics/bin/pip install pytest==9.0.3 "mlx>=0.22.0" mlx-cpu
+            } > .lanes/numerics-install.log 2>&1 || rc=$?
+            echo "$rc" > .lanes/numerics.install
+          ) < /dev/null > /dev/null 2>&1 &
+
+          # suites: the MLX packages MUST resolve in the SAME pip call as .[core].
+          # Split, pip solves them independently and mlx-vlm 0.6.9
+          # (transformers>=5.14) drags transformers past the <=5.5.0 this project
+          # pins: measured 5.5.0 -> 5.14.1. Together, pip honours the cap and lands
+          # on the newest mlx-vlm that fits, which is the 0.6.4 ceiling the audio
+          # gate records.
+          (
+            rc=0
+            {
+              python -m venv .lanes/venv-suites
+              .lanes/venv-suites/bin/python -m pip install --upgrade pip
+              .lanes/venv-suites/bin/pip install --index-url https://download.pytorch.org/whl/cpu \
+                "torch>=2.4.0,<2.11.0"
+              .lanes/venv-suites/bin/pip install -e .[core] \
+                "mlx>=0.22.0" mlx-cpu "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4"
+              .lanes/venv-suites/bin/pip install --no-deps \
+                "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
+              .lanes/venv-suites/bin/pip install pytest==9.0.3
+            } > .lanes/suites-install.log 2>&1 || rc=$?
+            echo "$rc" > .lanes/suites.install
+          ) < /dev/null > /dev/null 2>&1 &
+
+          wait
+          for id in numerics suites; do
+            echo "::group::$id install"; cat ".lanes/$id-install.log" 2>/dev/null || true; echo "::endgroup::"
+            rc="$(cat ".lanes/$id.install" 2>/dev/null || echo missing)"
+            [ "$rc" = "0" ] || { echo "::error::$id environment could not be built (status $rc)"; exit 1; }
+          done
 
       - name: Assert the real MLX runtime is what got installed
-        # All three files importorskip mlx.core, and a module that skips
+        # All the MLX files importorskip mlx.core, and a module that skips
         # wholesale still exits 0, so without this the job could go green having
         # run nothing. tests/mlx_simulation/ is the torch-backed shim.
         run: |
-          python - <<'PY'
+          for venv in .lanes/venv-numerics .lanes/venv-suites; do
+            echo "== $venv"
+            "$venv/bin/python" - <<'PY'
           import mlx.core as mx
           origin = str(getattr(mx, "__file__", "") or "")
           assert "mlx_simulation" not in origin, f"shim, not real mlx: {origin}"
           assert int(mx.array([1, 2, 3]).sum()) == 6, "mlx cannot add"
           print("real mlx at", origin)
           PY
-          python -c "import mlx_vlm, mlx_lm; print('mlx-vlm', mlx_vlm.__version__)"
+          done
+          .lanes/venv-suites/bin/python -c "import mlx_vlm, mlx_lm; print('mlx-vlm', mlx_vlm.__version__)"
           # If the joint resolution missed the transformers cap, this job is
           # gating an environment the package forbids.
-          python - <<'PY'
+          .lanes/venv-suites/bin/python - <<'PY'
           from importlib.metadata import version
           from packaging.version import Version
           transformers = Version(version("transformers"))
@@ -577,14 +409,211 @@ jobs:
           print("transformers", transformers, "within the pinned cap")
           PY
 
+      - name: pytest tests/test_mlx_quantized_optimizer_state.py (HARD GATE)
+        # -rs surfaces skips; the next step fails the job if the file skipped,
+        # because a skipped numeric suite is not a gate.
+        run: .lanes/venv-numerics/bin/python -m pytest tests/test_mlx_quantized_optimizer_state.py -v -rs
+
+      - name: Fail if the numeric tests skipped
+        run: |
+          .lanes/venv-numerics/bin/python -m pytest tests/test_mlx_quantized_optimizer_state.py -q -rs | tee out.txt
+          if grep -qiE '[0-9]+ skipped' out.txt; then
+            echo "real mlx is installed but the numeric tests skipped"; exit 1
+          fi
+
       # One pytest process per file: tests/mlx_simulation/ replaces
       # sys.modules["mlx.core"] process-wide, disarming whatever runs after it.
       - name: tests/test_mlx_shape_guard.py
-        run: python -m pytest tests/test_mlx_shape_guard.py -v -rs
+        run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_shape_guard.py -v -rs
 
       - name: tests/test_mlx_vlm_label_masks.py
         # Audio collation, label masking and the family/version gate.
-        run: python -m pytest tests/test_mlx_vlm_label_masks.py -v -rs
+        run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_vlm_label_masks.py -v -rs
 
       - name: tests/test_mlx_batching_and_decay.py
-        run: python -m pytest tests/test_mlx_batching_and_decay.py -v -rs
+        run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_batching_and_decay.py -v -rs
+  # Core (HF/TRL/peft) drift matrix. Three cells: HF=4.57.6+TRL<1, HF=latest+TRL=latest,
+  # and pyproject defaults.
+  #
+  # Was a three-cell matrix: three runners, 171-176s of execution each, of which
+  # 90-94s is an install that differs only in three version specs, behind a queue
+  # whose median is 4577-5115s. The cells cannot share an ENVIRONMENT -- the whole
+  # point is that they pin conflicting upstream versions -- but nothing required
+  # them to occupy three runners. One runner, three venvs, run concurrently.
+  #
+  # fail-fast is gone with the matrix and its intent is kept explicitly: drift in
+  # one cell must not stop the others being reported, so every lane runs to
+  # completion and the collect step names each one.
+  core-upstream-matrix:
+    name: "Core drift (3 upstream pins)"
+    runs-on: ubuntu-latest
+    # Three concurrent installs, budgeted for the serial worst case so a slow
+    # index degrades to slow rather than to red.
+    timeout-minutes: 45
+    env:
+      # Pure-Python protobuf parser; transformers' bundled *_pb2.py is rejected by C++ protobuf 4+/5+.
+      PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
+      UNSLOTH_COMPILE_DISABLE: '1'
+      # Secondary handshake after find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
+      UNSLOTH_IS_PRESENT: '1'
+    steps:
+      - name: Harden runner (audit)
+        # audit (not block): the cells pull arbitrary transformers/TRL/peft pins.
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Run all three upstream pins (concurrently)
+        run: |
+          mkdir -p .lanes
+
+          # Resolve the __from_pyproject__ sentinel. Was a separate step writing
+          # $GITHUB_ENV, which is per-job and so cannot carry three different
+          # answers; it takes the specs as arguments and prints them instead.
+          resolve() {
+            python - "$@" <<'PY'
+          import re, sys, tomllib
+
+          spec_t, spec_r, spec_p = sys.argv[1:4]
+
+          def _pkg_name(spec):
+              m = re.match(r"\s*([A-Za-z0-9_.-]+)", spec)
+              return (m.group(1).lower() if m else "")
+
+          if "__from_pyproject__" in (spec_t, spec_r, spec_p):
+              with open("pyproject.toml", "rb") as f:
+                  doc = tomllib.load(f)
+              proj = doc.get("project", {})
+              all_deps = list(proj.get("dependencies", []))
+              for _name, dep_list in proj.get("optional-dependencies", {}).items():
+                  all_deps.extend(dep_list)
+
+              # Strip environment markers so the resolved spec is pip-installable.
+              def _strip_marker(s):
+                  return s.split(";", 1)[0].strip()
+
+              def _pick(spec, name):
+                  if spec != "__from_pyproject__":
+                      return spec
+                  return next((_strip_marker(x) for x in all_deps if _pkg_name(x) == name), name)
+
+              spec_t = _pick(spec_t, "transformers")
+              spec_r = _pick(spec_r, "trl")
+              spec_p = _pick(spec_p, "peft")
+
+          print(spec_t)
+          print(spec_r)
+          print(spec_p)
+          PY
+          }
+
+          # Two-phase install, exactly as the matrix job did it: `-e .[core]` for the
+          # pyproject defaults, then `-U <resolved>` to override. The -U is what lets
+          # pip DOWNGRADE transformers for the 4.57.6 cell.
+          lane() {
+            id="$1"; shift
+            venv=".lanes/venv-$id"; log=".lanes/$id.log"
+            (
+              rc=0
+              {
+                set -x
+                specs="$(resolve "$@")"
+                spec_t="$(echo "$specs" | sed -n 1p)"
+                spec_r="$(echo "$specs" | sed -n 2p)"
+                spec_p="$(echo "$specs" | sed -n 3p)"
+                echo "resolved: $spec_t | $spec_r | $spec_p"
+
+                python -m venv "$venv"
+                "$venv/bin/python" -m pip install --upgrade pip
+                # torchvision: transformers' qwen2_vl / qwen2_5_vl image processors
+                # import it at module top, so without it the existence probes go red
+                # on ModuleNotFoundError rather than on drift. CPU build is plenty.
+                "$venv/bin/pip" install --index-url https://download.pytorch.org/whl/cpu \
+                  "torch>=2.4.0,<2.11.0" "torchvision<0.26"
+                "$venv/bin/pip" install -e .[core]
+                "$venv/bin/pip" install --no-deps \
+                  "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
+                "$venv/bin/pip" install -U "$spec_t" "$spec_r" "$spec_p"
+                # bitsandbytes: imported at module scope in saving_utils.py.
+                # IPython + ipywidgets: logging_utils.py:50 imports
+                # transformers.utils.notebook. Both so the drift detector fires on
+                # real drift and not on a missing CI dep.
+                "$venv/bin/pip" install 'bitsandbytes>=0.45' 'ipython>=8' 'ipywidgets>=8'
+                "$venv/bin/pip" install pytest==9.0.3 packaging
+                set +x
+                "$venv/bin/pip" show transformers trl peft torch
+              } > "$log" 2>&1 || rc=$?
+              echo "$rc" > ".lanes/$id.install"
+
+              if [ "$rc" -eq 0 ]; then
+                trc=0
+                "$venv/bin/python" -m pytest -v --tb=short -rs \
+            tests/test_upstream_pinned_symbols_transformers.py \\
+            tests/test_torchvision_video_removed_message.py \\
+            tests/test_upstream_pinned_symbols_trl_vllm.py \\
+            tests/test_upstream_pinned_symbols_accelerator.py \\
+            tests/test_zoo_history_regressions_deep.py \\
+            tests/test_upstream_import_fixes_drift.py \\
+            tests/test_zoo_source_upstream_refs.py \\
+            tests/test_upstream_signatures.py \\
+            tests/test_extended_dep_api_pins.py \\
+            tests/test_upstream_source_patterns.py \\
+            tests/test_compiler_rewriter_exhaustive.py \\
+            tests/test_compiler_dynamic_exec.py \\
+            tests/test_temporary_patches_exhaustive.py \\
+            tests/test_missing_parent_package_is_drift.py \\
+            tests/test_unsloth_zoo_lora_merge.py \\
+            tests/test_peft_paramwrapper_layout_drift.py \\
+            tests/test_transformers_moe_structure_drift.py \\
+            tests/test_moe_merge_e2e_cpu.py \\
+            tests/test_merge_e2e_hub_unreachable.py \\
+            tests/test_gemma4_dtype_drift_guards.py >> "$log" 2>&1 || trc=$?
+                echo "$trc" > ".lanes/$id.tests"
+              else
+                echo "skipped" > ".lanes/$id.tests"
+              fi
+            ) < /dev/null > /dev/null 2>&1 &
+          }
+
+          lane t4576-trl0latest "transformers==4.57.6" "trl>=0.18.2,<1.0.0" "peft>=0.18,<0.20"
+          lane tlatest5-trl1latest "transformers>=5,<6" "trl>=1,<2" "peft"
+          lane pyproject __from_pyproject__ __from_pyproject__ __from_pyproject__
+          wait
+          echo "all three lanes finished"
+          df -h / | tail -1
+
+      - name: What each pin said
+        if: always()
+        run: |
+          failed=0
+          for id in t4576-trl0latest tlatest5-trl1latest pyproject; do
+            echo "::group::$id"
+            cat ".lanes/$id.log" 2>/dev/null || echo "no log: the lane never started"
+            echo "::endgroup::"
+
+            # A lane that dies without recording a status is a failure, not a pass:
+            # that is the whole risk of backgrounding, so it is made loud.
+            install="$(cat ".lanes/$id.install" 2>/dev/null || echo missing)"
+            tests="$(cat ".lanes/$id.tests" 2>/dev/null || echo missing)"
+            echo "$id: install=$install tests=$tests"
+
+            if [ "$install" != "0" ]; then
+              echo "::error::$id: the environment could not be built (status $install)"
+              failed=1
+            elif [ "$tests" != "0" ]; then
+              # HARD GATE, as it was per-cell: a red lane means real upstream drift.
+              echo "::error::$id: the upstream-regression suite failed (status $tests)"
+              failed=1
+            fi
+          done
+          [ "$failed" -eq 0 ] || exit 1
+

--- a/tests/test_ci_lane_scripts_parse.py
+++ b/tests/test_ci_lane_scripts_parse.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""
+The concurrent CI lanes must be syntactically whole shell, and their pytest
+invocations must still carry every file.
+
+Fusing matrix cells onto one runner turns YAML into shell, and shell that is
+assembled rather than written has a failure mode YAML validation cannot see. The
+fused Core job shipped with
+
+    "$venv/bin/python" -m pytest -v --tb=short -rs \\
+                tests/test_upstream_pinned_symbols_transformers.py \\\\
+                tests/test_torchvision_video_removed_message.py \\\\
+
+-- double backslashes, from a generator whose f-string escaped one too many. The
+YAML parsed, actionlint passed, and every lane reported `install=0 tests=missing`
+because the continuation ended the command and the remaining files ran as their
+own (nonexistent) commands. Twenty test files silently stopped being a test run.
+
+`bash -n` catches the class in a second, which is the whole point: it is cheaper
+than a CI round trip and it is what was missing.
+
+The file-count assertion is the other half. A command that parses is not the same
+as a command that still runs everything; a dropped continuation can leave a
+perfectly valid pytest call that collects three files instead of twenty.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# Steps that build shell by hand for concurrent lanes. Matched on content rather
+# than a hardcoded list, so a new fused job is covered the day it lands.
+_LANE_MARKERS = ("lane()", ".lanes/", "venv-")
+
+
+def _lane_steps() -> list[tuple[str, str, str, str]]:
+    """(workflow, job, step name, run body) for every step that drives lanes."""
+    out = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        doc = yaml.safe_load(path.read_text(encoding = "utf-8"))
+        for job_id, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                run = step.get("run")
+                if isinstance(run, str) and any(m in run for m in _LANE_MARKERS):
+                    out.append((path.name, job_id, step.get("name", "<unnamed>"), run))
+    return out
+
+
+def test_there_are_lane_steps_to_check() -> None:
+    """Otherwise every test below passes by finding nothing."""
+    steps = _lane_steps()
+    assert len(steps) >= 2, f"only {len(steps)} lane steps found; the detector looks broken"
+
+
+@pytest.mark.parametrize(
+    "workflow,job,name,run",
+    _lane_steps(),
+    ids = lambda v: v if isinstance(v, str) and len(v) < 40 else "",
+)
+def test_every_lane_step_is_valid_shell(workflow: str, job: str, name: str, run: str) -> None:
+    with tempfile.NamedTemporaryFile("w", suffix = ".sh", delete = False) as handle:
+        handle.write(run)
+        path = handle.name
+    try:
+        result = subprocess.run([ "bash", "-n", path ], capture_output = True, text = True)
+    finally:
+        Path(path).unlink(missing_ok = True)
+    assert result.returncode == 0, (
+        f"{workflow}: job '{job}' step '{name}' is not valid shell:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize(
+    "workflow,job,name,run",
+    _lane_steps(),
+    ids = lambda v: v if isinstance(v, str) and len(v) < 40 else "",
+)
+def test_no_double_backslash_continuations(workflow: str, job: str, name: str, run: str) -> None:
+    """
+    `\\\\` at end of line is an escaped backslash, not a continuation. It ends the
+    command and hands the next line to the shell as its own -- which is how twenty
+    pytest files became twenty "command not found" lines that nothing checked.
+    Valid shell, wrong program, and `bash -n` alone would not object.
+    """
+    bad = [
+        i + 1
+        for i, line in enumerate(run.splitlines())
+        if re.search(r"[^\\]\\\\$", line)
+    ]
+    assert not bad, (
+        f"{workflow}: job '{job}' step '{name}' has escaped backslashes where line "
+        f"continuations were meant, at line(s) {bad}"
+    )
+
+
+def test_the_fused_core_job_still_runs_every_drift_file() -> None:
+    """
+    A command can parse and still have lost most of its arguments. This pins the
+    count against the workflow the cells were fused from, so a continuation that
+    silently drops files fails here rather than going green having run three.
+    """
+    doc = yaml.safe_load((WORKFLOWS / "consolidated-tests-ci.yml").read_text(encoding = "utf-8"))
+    steps = doc["jobs"]["core-upstream-matrix"]["steps"]
+    run = next(s["run"] for s in steps if "concurrently" in (s.get("name") or ""))
+
+    body = run[run.index("-m pytest"):]
+    body = body[: body.index("|| trc=$?")]
+    # Join the continuations the way the shell does, then count what is left.
+    joined = body.replace("\\\n", " ")
+    files = re.findall(r"tests/\S+\.py", joined)
+
+    assert len(files) == 20, (
+        f"the fused Core lane invokes pytest on {len(files)} files; the three matrix "
+        f"cells it replaced each ran 20. Found: {files}"
+    )
+    assert '>> "$log" 2>&1' in joined, (
+        "the pytest output is no longer redirected into the lane log, so a failing "
+        "lane would report a status with nothing to read"
+    )


### PR DESCRIPTION
Fuse the three upstream pins and both Linux MLX suites onto one runner each

Second half of the measured plan from #1074. Tests CI goes 10 runner
slots to 4, and this half is the 6 that were left.

Core drift was three runners: 171-176s of execution each, of which 90-94s
is an install differing only in three version specs, behind 4577-5115s
queues. The cells cannot share an ENVIRONMENT -- pinning conflicting
upstream versions is the entire point -- but nothing required them to
occupy three runners. One runner, three venvs, concurrent. fail-fast is
gone with the matrix and its intent is kept explicitly: every lane runs to
completion and the collect step names each one, so drift in one cell still
cannot hide drift in another.

The two Linux MLX jobs were 158s and 164s, ~85s of it the same install.
The source already says why they must stay apart, and it is an argument
about environments rather than runners: the suites need mlx-lm and mlx-vlm,
which the numerics job deliberately omits because resolving them there
could move transformers. A venv each satisfies that exactly, and the joint
resolution the suites depend on is preserved verbatim -- .[core] and the
MLX packages still go in ONE pip call, so pip honours the <=5.5.0
transformers cap instead of landing on mlx-vlm 0.6.9 and dragging it to
5.14.1. The assertion that checks that cap still runs.

The __from_pyproject__ resolution moved out of a $GITHUB_ENV step, which
is per-job and so cannot carry three different answers, into a function
taking the specs as arguments.

Severity is unchanged: the upstream-regression suite stays a hard gate per
pin, the numerics file stays a hard gate, and a skipped numerics run still
fails.

Verified nothing was dropped rather than assumed: 60 test-file references
before and 60 after, and no package spec lost, both checked against
origin/main by diffing the extracted sets.
