### PR TITLE
Put bitsandbytes.functional back after stubbing it

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,3 +273,76 @@ def _isolate_xet_health_state(tmp_path_factory, monkeypatch):
     except Exception:
         # Module absent (partial checkout / security-only suite): nothing to isolate.
         yield
+
+
+# A test that swaps a module into sys.modules and does not swap it back breaks whatever
+# imports that name later IN THE SAME PROCESS. Serially that is often invisible, because
+# the victim happens to sort before the polluter and never sees it; under pytest-xdist a
+# worker can take them the other way round and the victim fails for a reason that has
+# nothing to do with it.
+#
+# That is not hypothetical. test_vllm_to_hf_conversion installed a bitsandbytes.functional
+# carrying only dequantize_4bit and left it there, so every later
+# `from bitsandbytes.functional import QuantState` -- which is what
+# temporary_patches/moe_utils_bnb4bit.py does at import time -- failed with
+#
+#     cannot import name 'QuantState' from 'bitsandbytes.functional' (unknown location)
+#
+# Six tests in test_moe_bnb4bit_per_expert_conversions.py failed that way under -n 4 while
+# passing serially, because m sorts before v.
+#
+# Narrow on purpose. It watches the names that have actually been swapped here rather than
+# all of sys.modules, because reloading a module under test is a legitimate and common
+# thing to do in this suite and a blanket check would flag all of it. The remedy is always
+# the same and is already used elsewhere in these files: monkeypatch.setitem, which puts
+# the original back.
+_GUARDED_MODULES = ("bitsandbytes", "bitsandbytes.functional", "bitsandbytes.nn")
+_MODULE_SNAPSHOT_KEY = "_unsloth_guarded_module_snapshot"
+
+
+def _is_module_stub(mod):
+    """A real module has a file behind it; these substitutes are bare ModuleType.
+
+    That is also why the resulting ImportError says "(unknown location)".
+    """
+    return mod is not None and getattr(mod, "__file__", None) is None
+
+
+def pytest_runtest_setup(item):
+    import sys as _sys
+
+    setattr(item, _MODULE_SNAPSHOT_KEY, {n: _sys.modules.get(n) for n in _GUARDED_MODULES})
+
+
+@_pytest.hookimpl(trylast = True)
+def pytest_runtest_teardown(item, nextitem):
+    """Checked here rather than in an autouse fixture, and that is not a style choice.
+
+    Fixtures tear down in reverse order of setup, and _isolate_xet_health_state above
+    requests monkeypatch, which pulls monkeypatch's setup earlier than any fixture
+    defined after it. A fixture-based check therefore ran BEFORE the test's own
+    monkeypatch had put sys.modules back, and reported every correct test as a leak.
+    A trylast teardown hook runs after fixture finalisation, which is the point.
+    """
+    import sys as _sys
+
+    before = getattr(item, _MODULE_SNAPSHOT_KEY, None)
+    if before is None:
+        return
+    leaked = []
+    for name, was in before.items():
+        now = _sys.modules.get(name)
+        if now is was:
+            continue
+        if was is None and not _is_module_stub(now):
+            # Nothing was there and the test imported the real thing. That is an
+            # import, not a swap, and flagging it would fail every test that touches
+            # the package.
+            continue
+        leaked.append(name)
+    if leaked:
+        raise AssertionError(
+            f"{item.nodeid} replaced {leaked} in sys.modules and did not put it back, "
+            f"so every later test in this process imports the substitute. Use "
+            f"monkeypatch.setitem(sys.modules, ...), which restores on teardown."
+        )

--- a/tests/test_vllm_to_hf_conversion.py
+++ b/tests/test_vllm_to_hf_conversion.py
@@ -1013,7 +1013,7 @@ def test_finalize_routes_vision_tower_rotary_to_vision_config_by_module_path():
     )
 
 
-def test_extract_gdn_layers_dequantize_uses_unpacked_midpoint():
+def test_extract_gdn_layers_dequantize_uses_unpacked_midpoint(monkeypatch):
     # Regression: `mid = ba_weight.shape[0] // 2` was computed on the packed
     # uint8 buffer then reused to slice the dequantized full tensor (shape[0] =
     # out_features); when they differ, in_proj_b/a got wrong rows.
@@ -1070,14 +1070,38 @@ def test_extract_gdn_layers_dequantize_uses_unpacked_midpoint():
             )
             self.out_proj = _PlainProj(self.hidden_size, self.value_dim)
 
-    bnb = sys.modules.setdefault("bitsandbytes", types.ModuleType("bitsandbytes"))
+    # monkeypatch.setitem, not a bare assignment: these entries have to come back
+    # out of sys.modules when the test ends.
+    #
+    # The stub carries dequantize_4bit and nothing else, so while it is installed
+    # `from bitsandbytes.functional import QuantState` fails with "cannot import
+    # name 'QuantState' from 'bitsandbytes.functional' (unknown location)" -- the
+    # "unknown location" being this module having no file behind it. That is
+    # precisely what unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py:735 does at
+    # import time, so leaving the stub in place breaks every later test that
+    # reaches it, in a process that has already left this file.
+    #
+    # Serially that never showed: this file sorts after
+    # test_moe_bnb4bit_per_expert_conversions.py, so the victim always ran first.
+    # Under pytest-xdist a worker can take them in the other order, and six tests
+    # there failed with that ImportError while the same run passed serially. The
+    # order was the trigger; the missing cleanup was the bug.
+    #
+    # The vllm stubs further down this file already save and restore. This one was
+    # the exception, not the convention.
+    # setdefault leaked too, in the case where it does anything: on a runner without
+    # bitsandbytes it inserted a bare parent module and left it there, which shadows
+    # the real package for anything that installs later in the same process.
+    if "bitsandbytes" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "bitsandbytes", types.ModuleType("bitsandbytes"))
+    bnb = sys.modules["bitsandbytes"]
     bnb_fn = types.ModuleType("bitsandbytes.functional")
 
     def fake_dequantize_4bit(data, quant_state=None):
         return torch.arange(24, dtype=torch.float32).reshape(24, 1)
 
     bnb_fn.dequantize_4bit = fake_dequantize_4bit
-    sys.modules["bitsandbytes.functional"] = bnb_fn
+    monkeypatch.setitem(sys.modules, "bitsandbytes.functional", bnb_fn)
 
     def _fake_get_state_dict(prefix, kk, sd, module, slice_weights=True):
         sd[f"{prefix}.weight"] = module.weight.data


### PR DESCRIPTION
unsloth's CI runs this suite three times per commit, and running it under
pytest-xdist cut it from ~570s to ~250s -- except that one cell in three came
back with 14 failures serial did not produce. Six of them were always these:

    tests/test_moe_bnb4bit_per_expert_conversions.py ...
    ImportError: cannot import name 'QuantState' from 'bitsandbytes.functional'
    (unknown location)

test_extract_gdn_layers_dequantize_uses_unpacked_midpoint installs a
bitsandbytes.functional carrying only dequantize_4bit, and never takes it out
again. From that point on, in that process, every
`from bitsandbytes.functional import QuantState` fails -- which is exactly what
temporary_patches/moe_utils_bnb4bit.py:735 does at import time. "unknown
location" is the stub having no file behind it.

Reproduced directly, with a real bitsandbytes installed: swap the module, import
QuantState, get that error string verbatim.

Serially this never showed, and that is the whole reason it went unnoticed:
pytest walks files alphabetically, test_moe_bnb4bit... sorts before
test_vllm_to_hf_conversion..., so the victim always ran first. xdist assigns
files to workers, a worker can take them the other way round, and then six tests
fail for a reason that has nothing to do with them.

The vllm stubs further down this same file already save and restore. This one was
the exception, so it now uses monkeypatch.setitem, which restores on teardown.
The setdefault above it leaked too in the case where it does anything -- on a
runner without bitsandbytes it inserted a bare parent module and left it there,
shadowing the real package for anything installed later in the process.

The guard is a teardown hook rather than an autouse fixture, and that is not a
style preference. Fixtures tear down in reverse order of setup, and
_isolate_xet_health_state requests monkeypatch, which pulls monkeypatch's setup
earlier than any fixture defined after it -- so a fixture-based check ran before
the test's own monkeypatch had restored sys.modules and reported every correct
test as a leak. I wrote it that way first and it failed the fixed test. A
trylast teardown hook runs after fixture finalisation.

It also has to tell a swap from an import: a test that merely imports
bitsandbytes for the first time changes the sys.modules entry legitimately, so
only a replacement, or a bare stub left where nothing was, counts.