### PR TITLE
Restore bitsandbytes too when the offline test reloads unsloth_zoo

### DIFF
--- a/tests/test_offline_env_cross_sync.py
+++ b/tests/test_offline_env_cross_sync.py
@@ -21,6 +21,19 @@ import sys
 import pytest
 
 
+# The package the fixture reloads, plus what that reload drags in with it. A
+# prefix match, so submodules (`unsloth_zoo.vision_utils`,
+# `bitsandbytes.functional`) travel with their parent.
+_RELOAD_DISTURBS = ("unsloth_zoo", "bitsandbytes")
+
+
+def _is_guarded(name: str) -> bool:
+    return any(
+        name == root or name.startswith(root + ".")
+        for root in _RELOAD_DISTURBS
+    )
+
+
 @pytest.fixture
 def reload_zoo(monkeypatch):
     """Strip the three offline env vars, then reload ``unsloth_zoo`` so its
@@ -33,6 +46,19 @@ def reload_zoo(monkeypatch):
     teardown so the reload does not leak that shell into the rest of the
     session and break later tests that resolve submodules via string paths
     (e.g. ``monkeypatch.setattr("unsloth_zoo.vision_utils.<attr>", ...)``).
+
+    ``bitsandbytes*`` is snapshotted for the same reason and was missed the
+    first time: importing ``unsloth_zoo`` pulls bitsandbytes in, so a reload
+    can swap whatever was already in ``sys.modules`` under that name -- a stub
+    an earlier test installed, or the real package -- for the other one. The
+    conftest teardown guard catches exactly this and named this fixture:
+
+        test_unset_stays_unset replaced ['bitsandbytes'] in sys.modules and
+        did not put it back, so every later test in this process imports the
+        substitute
+
+    Restoring means "leave sys.modules as this fixture found it", which is the
+    fixture's contract for unsloth_zoo already; bitsandbytes is not special.
     """
     for v in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE"):
         monkeypatch.delenv(v, raising = False)
@@ -40,7 +66,7 @@ def reload_zoo(monkeypatch):
     saved = {
         name: module
         for name, module in sys.modules.items()
-        if name == "unsloth_zoo" or name.startswith("unsloth_zoo.")
+        if _is_guarded(name)
     }
 
     def _reload():
@@ -49,10 +75,7 @@ def reload_zoo(monkeypatch):
 
     yield _reload
 
-    for name in [
-        name for name in sys.modules
-        if name == "unsloth_zoo" or name.startswith("unsloth_zoo.")
-    ]:
+    for name in [name for name in sys.modules if _is_guarded(name)]:
         if name not in saved:
             del sys.modules[name]
     sys.modules.update(saved)


### PR DESCRIPTION
`reload_zoo` snapshots and restores `unsloth_zoo*` in `sys.modules`, and its docstring explains why: the reload swaps in a half-initialized package object that later tests would otherwise resolve submodules against.

Importing `unsloth_zoo` also pulls `bitsandbytes` in, and that was not snapshotted. So the reload could swap whatever `sys.modules` already held under that name - a stub an earlier test installed, or the real package - for the other one, and leave it swapped.

The teardown guard from #1076 caught it and named the fixture:

```
test_unset_stays_unset replaced ['bitsandbytes'] in sys.modules and did not put it
back, so every later test in this process imports the substitute
```

That failed unsloth's `Core` job (`unsloth_zoo @ main - full pytest (CPU)`) at `4660 passed, 302 skipped, 1 error`, on all three HF/TRL cells.

### The change

The snapshot is a prefix match over both roots, so submodules (`unsloth_zoo.vision_utils`, `bitsandbytes.functional`) travel with their parent. This is the fixture's existing contract - leave `sys.modules` as you found it - applied to the other package the reload disturbs. Restoring is the right direction regardless of which object was there first: the rest of the session already agreed on whatever that was.

### Verification, stated honestly

**Not reproducible on my dev box, so CI is the check.** `bitsandbytes` there is 0.41.3.post2 and raises on import, and the zoo import dies even earlier on a torchao/torch mismatch, so the reload never reaches bitsandbytes and the guard cannot fire locally. `tests/test_offline_env_cross_sync.py` passes there both with and without this change, which is exactly why a local pass proves nothing.

What makes this different from a guess is that the guard's message names the defect: it says which module was replaced and not put back, and this puts that module back.

### Watch items, deliberately not changed

Three other tests pop or re-import `unsloth_zoo` and never mention bitsandbytes: `test_encode_conversations_with_harmony.py`, `test_encode_conversations_with_harmony_render.py`, `test_zoo_history_regressions_deep.py`. The guard ran over the whole suite and named only `test_offline_env_cross_sync.py`, so changing the other three would be speculative. If any of them leaks, the guard will name it too.