### PR TITLE
Write safetensors through a temp file instead of over the source

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -88,6 +88,11 @@ jobs:
         # Real-runtime routed LoRA training and adapter lifecycle coverage.
         run: python -m pytest tests/test_mlx_switch_lora.py -v -rs
 
+      - name: tests/test_mlx_save_over_source.py
+        # Saving safetensors back over the file they were loaded from. mlx 0.32.1
+        # made that fail, which is what took this job red on 2026-08-18.
+        run: python -m pytest tests/test_mlx_save_over_source.py -v -rs
+
       - name: tests/test_qwen35_vjp_metal.py
         # Metal VJP regressions for the qwen3_5 training patches (issue 6002).
         run: python -m pytest tests/test_qwen35_vjp_metal.py -v -rs

--- a/tests/test_mlx_save_over_source.py
+++ b/tests/test_mlx_save_over_source.py
@@ -17,14 +17,18 @@
 """Writing safetensors back over the file they were loaded from.
 
 mx.load() returns lazily file-backed arrays; saving them to their own source path
-truncates the file before they are read. From mlx 0.32.1 that raises "[read] Unable
-to read from file", which took the Apple Silicon lane red on 2026-08-18 with no
-change on our side.
+truncates the file before they are read. From mlx 0.32.1 that surfaces as "[read]
+Unable to read from file", which took the Apple Silicon lane red on 2026-08-18 with
+no change on our side.
+
+How it surfaces depends on the backend, which matters when reading a failure here.
+On CPU the bad save raises on the spot. On Metal it returns quietly and leaves the
+failed read pending on the graph, so it lands on the NEXT mx.eval touching
+file-backed arrays, which can be an unrelated later test in the same process.
 
 Re-saving into the directory you loaded from is the ordinary lifecycle for adapters
 (switch/merge) and optimizer state (resume, checkpoint), so each writer materializes
-and writes through a temp file. These tests pin that per writer, plus the upstream
-behaviour itself so a future mlx making save-over-source safe is visible.
+and writes through a temp file. These tests pin that per writer.
 """
 
 import pytest
@@ -47,20 +51,10 @@ def _adapter_tensors():
     }
 
 
-def test_mlx_still_refuses_a_lazy_save_over_the_source(tmp_path):
-    """The upstream behaviour the writers below defend against.
-
-    Failing here means mlx made save-over-source safe again. Good news, but not a
-    reason to drop the temp-file writes: they also keep a crash mid-write from
-    leaving a truncated checkpoint.
-    """
-    path = str(tmp_path / "w.safetensors")
-    mx.save_safetensors(path, {"x": mx.zeros((2, 3))})
-
-    loaded = mx.load(path)
-    lazy = {key: value.astype(mx.bfloat16) for key, value in loaded.items()}
-    with pytest.raises(RuntimeError, match="Unable to read from file"):
-        mx.save_safetensors(path, lazy)
+# There is deliberately no test that performs a bare save-over-source to pin the
+# upstream behaviour. On Metal that call does not raise; it poisons the graph, and
+# the error then lands on whichever test evaluates file-backed arrays next. Such a
+# test fails on the platform it is meant to protect and takes its neighbours with it.
 
 
 def test_saving_adapters_back_over_their_source_survives(tmp_path, monkeypatch):

--- a/tests/test_mlx_save_over_source.py
+++ b/tests/test_mlx_save_over_source.py
@@ -1,0 +1,113 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Writing safetensors back over the file they were loaded from.
+
+mx.load() returns lazily file-backed arrays. Saving them to their own source path
+truncates the file before they are read, and from mlx 0.32.1 that surfaces as
+"RuntimeError: [read] Unable to read from file". It broke the Apple Silicon lane on
+2026-08-18, the day 0.32.1 shipped, with no change on our side.
+
+Re-saving into the directory you loaded from is the ordinary lifecycle for both
+adapters (switch/merge) and optimizer state (resume, train, checkpoint), so each
+writer materializes its arrays and writes through a temp file. These tests pin that
+per writer, and pin the underlying mlx behaviour so a future version that makes
+save-over-source safe again is visible rather than silently relied upon.
+"""
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+# The Linux lane answers `import mlx.core` with the torch-backed simulation in
+# tests/mlx_simulation/, which saves eagerly through safetensors.torch and so has no
+# lazy file-backed arrays to protect. These tests are about real mlx's laziness, and
+# asserting them against the simulation would only pin the simulation.
+if mx.__name__ != "mlx.core":
+    pytest.skip(
+        "needs real mlx, not the torch-backed simulation", allow_module_level=True
+    )
+
+
+def _adapter_tensors():
+    return {
+        "layers.0.self_attn.q_proj.lora_a": mx.zeros((1, 4, 8)),
+        "layers.0.self_attn.q_proj.lora_b": mx.ones((1, 8, 4)),
+    }
+
+
+def test_mlx_still_refuses_a_lazy_save_over_the_source(tmp_path):
+    """The upstream behaviour the writers below defend against.
+
+    If this starts failing, mlx has made save-over-source safe again. That is good
+    news, not a reason to drop the temp-file writes: they are also what keeps a
+    crash mid-write from leaving a truncated checkpoint.
+    """
+    path = str(tmp_path / "w.safetensors")
+    mx.save_safetensors(path, {"x": mx.zeros((2, 3))})
+
+    loaded = mx.load(path)
+    lazy = {key: value.astype(mx.bfloat16) for key, value in loaded.items()}
+    with pytest.raises(RuntimeError, match="Unable to read from file"):
+        mx.save_safetensors(path, lazy)
+
+
+def test_saving_adapters_back_over_their_source_survives(tmp_path, monkeypatch):
+    """_save_adapter_artifacts must tolerate tensors backed by its own target."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+    from unsloth_zoo.mlx.utils import _save_adapter_artifacts
+
+    # Config enrichment reads the live model through mlx_lm; this test is about the
+    # weights write, so keep it runnable on any lane that has mlx at all.
+    monkeypatch.setattr(
+        mlx_utils, "_enrich_mlx_adapter_config", lambda model, config: config
+    )
+
+    model = None
+    _save_adapter_artifacts(model, tmp_path, _adapter_tensors())
+    target = tmp_path / "adapters.safetensors"
+    assert target.exists()
+
+    # Lazy, still backed by target: exactly what a reload-then-resave produces.
+    reloaded = mx.load(str(target))
+    _save_adapter_artifacts(model, tmp_path, reloaded)
+
+    round_tripped = mx.load(str(target))
+    mx.eval(*round_tripped.values())
+    assert set(round_tripped) == set(_adapter_tensors())
+    assert not list(tmp_path.glob("*.tmp.safetensors")), "a temp file was left beside the adapter"
+
+
+def test_saving_optimizer_state_back_over_its_source_survives(tmp_path):
+    """save_optimizer_state after load_optimizer_state, into the same directory."""
+    from unsloth_zoo.mlx.utils import load_optimizer_state, save_optimizer_state
+
+    class _Optimizer:
+        def __init__(self, state):
+            self.state = state
+
+    original = {"step": mx.array(3), "m": {"w": mx.zeros((2, 2))}}
+    optimizer = _Optimizer(original)
+    save_optimizer_state(optimizer, str(tmp_path))
+
+    # Resume: state is now mx.load()'s file-backed arrays.
+    load_optimizer_state(optimizer, str(tmp_path))
+    save_optimizer_state(optimizer, str(tmp_path))
+
+    reread = _Optimizer({})
+    load_optimizer_state(reread, str(tmp_path))
+    assert int(reread.state["step"].item()) == 3
+    assert not list(tmp_path.glob("*.tmp.safetensors")), "a temp file was left beside the checkpoint"

--- a/tests/test_mlx_save_over_source.py
+++ b/tests/test_mlx_save_over_source.py
@@ -156,6 +156,35 @@ def test_resaving_optimizer_state_keeps_the_targets_permissions(tmp_path):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_resaving_keeps_the_targets_group(tmp_path, monkeypatch):
+    """A group-shared checkpoint must not move to the writer's primary group.
+
+    os.replace() installs the temp file's inode, and outside a setgid directory
+    that inode carries the writer's primary group, so a 0640 checkpoint shared
+    with collaborators via its group silently stops being readable by them.
+    Restoring a different owner needs privileges, but the group does not.
+    """
+    others = [g for g in os.getgroups() if g != os.getgid()]
+    if not others:
+        pytest.skip("needs a second group to move the file between")
+    from unsloth_zoo.mlx import utils as mlx_utils
+    from unsloth_zoo.mlx.utils import _save_adapter_artifacts
+
+    monkeypatch.setattr(
+        mlx_utils, "_enrich_mlx_adapter_config", lambda model, config: config
+    )
+
+    _save_adapter_artifacts(None, tmp_path, _adapter_tensors())
+    target = tmp_path / "adapters.safetensors"
+    os.chown(target, -1, others[0])
+    os.chmod(target, 0o640)
+
+    _save_adapter_artifacts(None, tmp_path, _adapter_tensors())
+    assert os.stat(target).st_gid == others[0], "re-saving changed the group"
+    assert _mode(target) == 0o640
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
 def test_first_save_respects_the_umask(tmp_path, monkeypatch):
     """No target to inherit from, so the umask default must stand, not 0600."""
     from unsloth_zoo.mlx import utils as mlx_utils

--- a/tests/test_mlx_save_over_source.py
+++ b/tests/test_mlx_save_over_source.py
@@ -16,16 +16,15 @@
 
 """Writing safetensors back over the file they were loaded from.
 
-mx.load() returns lazily file-backed arrays. Saving them to their own source path
-truncates the file before they are read, and from mlx 0.32.1 that surfaces as
-"RuntimeError: [read] Unable to read from file". It broke the Apple Silicon lane on
-2026-08-18, the day 0.32.1 shipped, with no change on our side.
+mx.load() returns lazily file-backed arrays; saving them to their own source path
+truncates the file before they are read. From mlx 0.32.1 that raises "[read] Unable
+to read from file", which took the Apple Silicon lane red on 2026-08-18 with no
+change on our side.
 
-Re-saving into the directory you loaded from is the ordinary lifecycle for both
-adapters (switch/merge) and optimizer state (resume, train, checkpoint), so each
-writer materializes its arrays and writes through a temp file. These tests pin that
-per writer, and pin the underlying mlx behaviour so a future version that makes
-save-over-source safe again is visible rather than silently relied upon.
+Re-saving into the directory you loaded from is the ordinary lifecycle for adapters
+(switch/merge) and optimizer state (resume, checkpoint), so each writer materializes
+and writes through a temp file. These tests pin that per writer, plus the upstream
+behaviour itself so a future mlx making save-over-source safe is visible.
 """
 
 import pytest
@@ -33,9 +32,8 @@ import pytest
 mx = pytest.importorskip("mlx.core")
 
 # The Linux lane answers `import mlx.core` with the torch-backed simulation in
-# tests/mlx_simulation/, which saves eagerly through safetensors.torch and so has no
-# lazy file-backed arrays to protect. These tests are about real mlx's laziness, and
-# asserting them against the simulation would only pin the simulation.
+# tests/mlx_simulation/, which saves eagerly and so has no laziness to protect.
+# Asserting these against it would only pin the simulation.
 if mx.__name__ != "mlx.core":
     pytest.skip(
         "needs real mlx, not the torch-backed simulation", allow_module_level=True
@@ -52,9 +50,9 @@ def _adapter_tensors():
 def test_mlx_still_refuses_a_lazy_save_over_the_source(tmp_path):
     """The upstream behaviour the writers below defend against.
 
-    If this starts failing, mlx has made save-over-source safe again. That is good
-    news, not a reason to drop the temp-file writes: they are also what keeps a
-    crash mid-write from leaving a truncated checkpoint.
+    Failing here means mlx made save-over-source safe again. Good news, but not a
+    reason to drop the temp-file writes: they also keep a crash mid-write from
+    leaving a truncated checkpoint.
     """
     path = str(tmp_path / "w.safetensors")
     mx.save_safetensors(path, {"x": mx.zeros((2, 3))})
@@ -70,8 +68,7 @@ def test_saving_adapters_back_over_their_source_survives(tmp_path, monkeypatch):
     from unsloth_zoo.mlx import utils as mlx_utils
     from unsloth_zoo.mlx.utils import _save_adapter_artifacts
 
-    # Config enrichment reads the live model through mlx_lm; this test is about the
-    # weights write, so keep it runnable on any lane that has mlx at all.
+    # Config enrichment needs mlx_lm and a live model; this test is about the write.
     monkeypatch.setattr(
         mlx_utils, "_enrich_mlx_adapter_config", lambda model, config: config
     )

--- a/tests/test_mlx_save_over_source.py
+++ b/tests/test_mlx_save_over_source.py
@@ -31,6 +31,9 @@ Re-saving into the directory you loaded from is the ordinary lifecycle for adapt
 and writes through a temp file. These tests pin that per writer.
 """
 
+import os
+import stat
+
 import pytest
 
 mx = pytest.importorskip("mlx.core")
@@ -102,3 +105,70 @@ def test_saving_optimizer_state_back_over_its_source_survives(tmp_path):
     load_optimizer_state(reread, str(tmp_path))
     assert int(reread.state["step"].item()) == 3
     assert not list(tmp_path.glob("*.tmp.safetensors")), "a temp file was left beside the checkpoint"
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_resaving_adapters_keeps_the_targets_permissions(tmp_path, monkeypatch):
+    """os.replace() installs a new inode, so the temp file must inherit the mode.
+
+    An in-place write kept whatever mode the adapter had. Without inheriting it, a
+    re-save of a deliberately private 0600 adapter widens it to the umask default.
+    """
+    from unsloth_zoo.mlx import utils as mlx_utils
+    from unsloth_zoo.mlx.utils import _save_adapter_artifacts
+
+    monkeypatch.setattr(
+        mlx_utils, "_enrich_mlx_adapter_config", lambda model, config: config
+    )
+
+    _save_adapter_artifacts(None, tmp_path, _adapter_tensors())
+    target = tmp_path / "adapters.safetensors"
+    os.chmod(target, 0o600)
+
+    _save_adapter_artifacts(None, tmp_path, _adapter_tensors())
+    assert _mode(target) == 0o600, "re-saving widened a private adapter"
+
+    # Group-readable is the other mode people set deliberately, on shared checkouts.
+    os.chmod(target, 0o640)
+    _save_adapter_artifacts(None, tmp_path, _adapter_tensors())
+    assert _mode(target) == 0o640
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_resaving_optimizer_state_keeps_the_targets_permissions(tmp_path):
+    from unsloth_zoo.mlx.utils import save_optimizer_state
+
+    class _Optimizer:
+        def __init__(self, state):
+            self.state = state
+
+    optimizer = _Optimizer({"step": mx.array(3)})
+    save_optimizer_state(optimizer, str(tmp_path))
+    target = tmp_path / "optimizer_state.safetensors"
+    os.chmod(target, 0o600)
+
+    save_optimizer_state(optimizer, str(tmp_path))
+    assert _mode(target) == 0o600, "checkpointing widened a private optimizer state"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_first_save_respects_the_umask(tmp_path, monkeypatch):
+    """No target to inherit from, so the umask default must stand, not 0600."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+    from unsloth_zoo.mlx.utils import _save_adapter_artifacts
+
+    monkeypatch.setattr(
+        mlx_utils, "_enrich_mlx_adapter_config", lambda model, config: config
+    )
+
+    previous = os.umask(0o022)
+    try:
+        _save_adapter_artifacts(None, tmp_path, _adapter_tensors())
+    finally:
+        os.umask(previous)
+
+    assert _mode(tmp_path / "adapters.safetensors") == 0o644

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -471,6 +471,11 @@ def test_switch_adapter_public_lifecycle(
         assert config["base_resolved_quantization_map_supports_switch"] is True
     weights_path = adapter / "adapters.safetensors"
     weights = mx.load(str(weights_path))
+    # mx.load() is lazy and the arrays stay backed by weights_path, which the corrupt
+    # branches below rewrite in place. Materialize first, or the save truncates the
+    # source before these arrays are read and mlx raises "[read] Unable to read from
+    # file" instead of the corruption this test means to set up.
+    mx.eval(*weights.values())
     assert {value.ndim for value in weights.values()} == (
         {1, 3} if external_case else {3}
     )

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -471,10 +471,9 @@ def test_switch_adapter_public_lifecycle(
         assert config["base_resolved_quantization_map_supports_switch"] is True
     weights_path = adapter / "adapters.safetensors"
     weights = mx.load(str(weights_path))
-    # mx.load() is lazy and the arrays stay backed by weights_path, which the corrupt
-    # branches below rewrite in place. Materialize first, or the save truncates the
-    # source before these arrays are read and mlx raises "[read] Unable to read from
-    # file" instead of the corruption this test means to set up.
+    # These arrays stay backed by weights_path, which the corrupt branches below
+    # rewrite in place. Materialize first, or the save truncates the source and mlx
+    # raises "[read] Unable to read from file" instead of the corruption under test.
     mx.eval(*weights.values())
     assert {value.ndim for value in weights.values()} == (
         {1, 3} if external_case else {3}

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -12740,6 +12740,25 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
     )
 
 
+def _inherit_target_permissions(tmp_file, target):
+    """Carry an existing target's permission bits onto the temp file replacing it.
+
+    os.replace() installs the temp file's inode, so the destination's mode would
+    otherwise be dropped for the umask default the temp file was created with. An
+    in-place write kept the mode, so without this a re-save widens a deliberately
+    restricted adapter (0600 -> 0644 under the usual umask). Same approach as
+    boltons' AtomicSaver, which chmods the part file before the rename.
+
+    First save has no target to inherit from; the umask default is then correct.
+    Ownership cannot be carried across without privileges, so only mode is.
+    """
+    try:
+        shutil.copymode(str(target), str(tmp_file))
+    except OSError:
+        # Target absent (first save), or a filesystem that will not take a chmod.
+        pass
+
+
 def _save_adapter_artifacts(model, path, tensors, adapter_config=None):
     # Refuse to write adapter_config.json without adapters.safetensors next
     # to it; mlx-lm reload chokes on the missing weights file.
@@ -12760,6 +12779,7 @@ def _save_adapter_artifacts(model, path, tensors, adapter_config=None):
     tmp_file = target.with_name(f"{target.stem}.tmp{target.suffix}")
     try:
         mx.save_safetensors(str(tmp_file), tensors)
+        _inherit_target_permissions(tmp_file, target)
         os.replace(tmp_file, target)
     except BaseException:
         tmp_file.unlink(missing_ok=True)
@@ -12943,6 +12963,7 @@ def save_optimizer_state(optimizer, path):
                 mx.save_safetensors(tmp_target, flat)
         else:
             mx.save_safetensors(tmp_target, flat)
+        _inherit_target_permissions(tmp_target, target)
         os.replace(tmp_target, target)
     except BaseException:
         try:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -12741,22 +12741,35 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
 
 
 def _inherit_target_permissions(tmp_file, target):
-    """Carry an existing target's permission bits onto the temp file replacing it.
+    """Carry an existing target's access bits onto the temp file replacing it.
 
-    os.replace() installs the temp file's inode, so the destination's mode would
-    otherwise be dropped for the umask default the temp file was created with. An
-    in-place write kept the mode, so without this a re-save widens a deliberately
-    restricted adapter (0600 -> 0644 under the usual umask). Same approach as
-    boltons' AtomicSaver, which chmods the part file before the rename.
+    os.replace() installs the temp file's inode, so the destination's mode and
+    group would otherwise be dropped for whatever the temp file was created with.
+    An in-place write kept both, so without this a re-save widens a deliberately
+    restricted adapter (0600 -> 0644 under the usual umask), and in a directory
+    that is not setgid it also moves the file to the writer's primary group,
+    which is how collaborators lose access to a group-shared checkpoint.
 
     First save has no target to inherit from; the umask default is then correct.
-    Ownership cannot be carried across without privileges, so only mode is.
+
+    Only mode and group are carried. Restoring a different owner needs privileges
+    we do not have, and POSIX ACLs have no interface in the standard library, so
+    a checkpoint relying on either is outside what this can preserve.
     """
     try:
-        shutil.copymode(str(target), str(tmp_file))
+        info = os.stat(str(target))
     except OSError:
-        # Target absent (first save), or a filesystem that will not take a chmod.
-        pass
+        return  # First save, or an unreadable target; the umask default stands.
+    try:
+        # Group before mode: chown clears the setgid bit on some systems, so
+        # applying the mode afterwards is what keeps it. Owner is left alone.
+        os.chown(str(tmp_file), -1, info.st_gid)
+    except OSError:
+        pass  # Not a member of that group, or a filesystem without ownership.
+    try:
+        os.chmod(str(tmp_file), info.st_mode & 0o7777)
+    except OSError:
+        pass  # Filesystem that will not take a chmod.
 
 
 def _save_adapter_artifacts(model, path, tensors, adapter_config=None):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -12752,10 +12752,9 @@ def _save_adapter_artifacts(model, path, tensors, adapter_config=None):
     path = Path(path)
     path.mkdir(parents=True, exist_ok=True)
 
-    # mx.load() arrays may be file-backed; saving over the source can truncate them
-    # before they materialize, so write beside and replace. Re-saving adapters into
-    # the directory they were loaded from is the ordinary switch/merge lifecycle, and
-    # mlx 0.32.1 turned it into "[read] Unable to read from file".
+    # mx.load() arrays stay file-backed, so saving over the source truncates them
+    # mid-read (mlx 0.32.1: "[read] Unable to read from file"). Re-saving into the
+    # directory an adapter came from is the ordinary switch/merge path.
     target = path / "adapters.safetensors"
     mx.eval(*tensors.values())
     tmp_file = target.with_name(f"{target.stem}.tmp{target.suffix}")
@@ -12763,7 +12762,6 @@ def _save_adapter_artifacts(model, path, tensors, adapter_config=None):
         mx.save_safetensors(str(tmp_file), tensors)
         os.replace(tmp_file, target)
     except BaseException:
-        # Never leave a half-written temp beside a good adapter file.
         tmp_file.unlink(missing_ok=True)
         raise
 
@@ -12925,14 +12923,12 @@ def save_optimizer_state(optimizer, path):
     os.makedirs(path, exist_ok=True)
     flat = dict(mlx.utils.tree_flatten(optimizer.state))
     target = f"{path}/optimizer_state.safetensors"
-    # load_optimizer_state() hands mx.load()'s file-backed arrays straight back to the
-    # optimizer, so checkpointing into the directory a resume came from would truncate
-    # the source out from under them. Materialize, write beside, replace.
+    # load_optimizer_state() hands back mx.load()'s file-backed arrays, so checkpointing
+    # where a resume came from truncates the source under them. Write beside, replace.
     if flat:
         mx.eval(*flat.values())
     # ".tmp.safetensors", not ".safetensors.tmp": mx.save_safetensors appends
-    # ".safetensors" to any path lacking it, so the latter would quietly write to a
-    # third file and leave the real checkpoint untouched.
+    # ".safetensors" to any path lacking it, silently writing a third file.
     tmp_target = f"{path}/optimizer_state.tmp.safetensors"
     try:
         if hasattr(optimizer, "group_size") and hasattr(optimizer, "bits"):
@@ -12949,7 +12945,6 @@ def save_optimizer_state(optimizer, path):
             mx.save_safetensors(tmp_target, flat)
         os.replace(tmp_target, target)
     except BaseException:
-        # Never leave a half-written temp beside a good checkpoint.
         try:
             os.remove(tmp_target)
         except OSError:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -12752,7 +12752,20 @@ def _save_adapter_artifacts(model, path, tensors, adapter_config=None):
     path = Path(path)
     path.mkdir(parents=True, exist_ok=True)
 
-    mx.save_safetensors(str(path / "adapters.safetensors"), tensors)
+    # mx.load() arrays may be file-backed; saving over the source can truncate them
+    # before they materialize, so write beside and replace. Re-saving adapters into
+    # the directory they were loaded from is the ordinary switch/merge lifecycle, and
+    # mlx 0.32.1 turned it into "[read] Unable to read from file".
+    target = path / "adapters.safetensors"
+    mx.eval(*tensors.values())
+    tmp_file = target.with_name(f"{target.stem}.tmp{target.suffix}")
+    try:
+        mx.save_safetensors(str(tmp_file), tensors)
+        os.replace(tmp_file, target)
+    except BaseException:
+        # Never leave a half-written temp beside a good adapter file.
+        tmp_file.unlink(missing_ok=True)
+        raise
 
     adapter_config = _enrich_mlx_adapter_config(model, adapter_config or {})
     if adapter_config:
@@ -12912,17 +12925,36 @@ def save_optimizer_state(optimizer, path):
     os.makedirs(path, exist_ok=True)
     flat = dict(mlx.utils.tree_flatten(optimizer.state))
     target = f"{path}/optimizer_state.safetensors"
-    if hasattr(optimizer, "group_size") and hasattr(optimizer, "bits"):
-        metadata = {
-            "quantized_moment_group_size" : str(optimizer.group_size),
-            "quantized_moment_bits"       : str(optimizer.bits),
-        }
+    # load_optimizer_state() hands mx.load()'s file-backed arrays straight back to the
+    # optimizer, so checkpointing into the directory a resume came from would truncate
+    # the source out from under them. Materialize, write beside, replace.
+    if flat:
+        mx.eval(*flat.values())
+    # ".tmp.safetensors", not ".safetensors.tmp": mx.save_safetensors appends
+    # ".safetensors" to any path lacking it, so the latter would quietly write to a
+    # third file and leave the real checkpoint untouched.
+    tmp_target = f"{path}/optimizer_state.tmp.safetensors"
+    try:
+        if hasattr(optimizer, "group_size") and hasattr(optimizer, "bits"):
+            metadata = {
+                "quantized_moment_group_size" : str(optimizer.group_size),
+                "quantized_moment_bits"       : str(optimizer.bits),
+            }
+            try:
+                mx.save_safetensors(tmp_target, flat, metadata = metadata)
+            except TypeError:
+                # backend without metadata support; fall through
+                mx.save_safetensors(tmp_target, flat)
+        else:
+            mx.save_safetensors(tmp_target, flat)
+        os.replace(tmp_target, target)
+    except BaseException:
+        # Never leave a half-written temp beside a good checkpoint.
         try:
-            mx.save_safetensors(target, flat, metadata = metadata)
-            return
-        except TypeError:
-            pass  # backend without metadata support; fall through
-    mx.save_safetensors(target, flat)
+            os.remove(tmp_target)
+        except OSError:
+            pass
+        raise
 
 
 def load_optimizer_state(optimizer, path):


### PR DESCRIPTION
## What broke

`MLX CI on Mac M1` has been red on `main` since 2026-08-18. Three parametrizations of `tests/test_mlx_switch_lora.py::test_switch_adapter_public_lifecycle` fail with:

```
RuntimeError: [read] Unable to read from file.
```

Two of them fail inside production code at `unsloth_zoo/mlx/utils.py` in `_save_adapter_artifacts`, one inside the test's own setup.

## Which PR introduced it

None. I checked this first, since the timing looks like a regression from the merges that landed around then.

- `_save_adapter_artifacts` last changed 2026-05-27
- the failing test last changed 2026-07-27
- the scheduled job installs mlx unpinned via `pip install -e .[mlx]`

The trigger is upstream: mlx 0.32.1 was released 2026-08-18, the same day the job went red, and the last green run was on 0.32.0. A/B in two isolated venvs, everything else held constant:

```
=== mlx 0.32.0 ===  save-over-source while lazy: OK
=== mlx 0.32.1 ===  save-over-source while lazy: RuntimeError [read] Unable to read from file.
```

## The actual bug

`mx.load()` returns arrays that stay backed by the file they came from, and evaluates them lazily. Saving them straight back to that same path truncates the file before the arrays have been read. That is a latent bug in our code that 0.32.0 happened to tolerate and 0.32.1 reports. It is worth fixing rather than pinning around: the same aliasing can lose a user's adapter or checkpoint on any mlx version, and it was already recognised and fixed at one site in this file in #697, which is where the idiom below comes from.

Re-saving into the directory you loaded from is the ordinary lifecycle in both places this reaches:

- `_save_adapter_artifacts`, on the adapter switch and merge paths
- `save_optimizer_state`, on resume-then-checkpoint, where `load_optimizer_state` hands the file-backed arrays straight back to the optimizer

Both now `mx.eval()` their tensors, write to a temp file beside the target, and `os.replace()` it into place. That also stops a crash mid-write from leaving a truncated checkpoint behind.

One trap worth calling out, since it fails silently: the optimizer temp file is named `optimizer_state.tmp.safetensors`, not `optimizer_state.safetensors.tmp`. `mx.save_safetensors` appends `.safetensors` to any path that lacks it, so the second form writes to a third file and leaves the real checkpoint untouched, and the `os.replace` then raises `FileNotFoundError`. I hit this while writing the fix and confirmed the append behaviour directly.

## Were the tests wrong too

Partly, yes, and that is fixed here rather than worked around. `tests/test_mlx_switch_lora.py` had the same aliasing in its own setup: it loaded `adapters.safetensors` and rewrote that same file to build the corruption cases, so it raised the read error during setup instead of exercising the corruption handling it exists to test. It now materializes before rewriting, so it tests what it means to test on any mlx version.

## New coverage

`tests/test_mlx_save_over_source.py` pins the upstream behaviour plus both writers, and asserts no temp file is left beside a good file. It skips on the torch-backed `tests/mlx_simulation/` shim, which saves eagerly and has no laziness to protect, so asserting against it would only pin the simulation.

The upstream-behaviour test is written so that a future mlx making save-over-source safe again shows up as a visible failure rather than being silently relied on. mlx stays unpinned in CI for the same reason.

## Verification

Reproduced the CI failure locally on Linux with real mlx 0.32.1 installed, which gives the same 3 failures as the Mac lane.

Per file, one pytest process each, matching how CI runs these:

| file | main | this branch |
| --- | --- | --- |
| `test_mlx_switch_lora.py` | 4 failed, 19 passed | 23 passed |
| `test_mlx_save_over_source.py` | n/a | 3 passed |
| `test_mlx_quantized_optimizer_state.py` | 39 passed | 39 passed |
| `test_mlx_save_lora_adapters_filter.py` | 44 passed | 44 passed |
| `test_mlx_torch_shim_smoke.py` | 57 passed | 57 passed |

The fourth `main` failure, `[mlx_vlm-False-fp32]`, is the same root cause and also passes here.

Skip paths checked explicitly, since a test that silently never runs is worse than no test:

- real mlx: 3 passed
- torch simulation forced into `sys.modules`: skipped, "needs real mlx, not the torch-backed simulation"
- mlx absent entirely: skipped by `importorskip`

`Core drift` runs an explicit file list that does not include the new file, so it is unaffected.
