### PR TITLE
Skip the all-linear guard on a partial MLX stack instead of failing it

### DIFF
--- a/tests/test_upstream_pinned_symbols_accelerator.py
+++ b/tests/test_upstream_pinned_symbols_accelerator.py
@@ -795,9 +795,37 @@ def test_collect_all_linear_target_names_finds_qkv_and_moe():
     experts — not just the canonical 7. Walks a fake model whose
     named_modules emits the names we care about so we don't need real MLX.
     """
-    pytest.importorskip("mlx")  # the helper imports mlx.nn for isinstance
-    from unsloth_zoo.mlx_loader import _collect_all_linear_target_names
+    # Both packages, not just mlx. The helper reaches _mlx_lora_type_specs(), which does
+    # `from mlx_lm.models.switch_layers import ...` and `from mlx_lm.tuner.lora import ...`,
+    # and _collect_all_linear_target_names wraps the whole walk in a blanket
+    # `except Exception: return []` so that LoRA setup never raises. Guarding on mlx alone
+    # therefore let this test RUN against an mlx with no usable mlx_lm beside it, where the
+    # helper returns [] for a missing-dependency reason and the assertion below reports it
+    # as `assert {...} <= set()` -- indistinguishable from the coverage regression this test
+    # exists to catch, and pointing at the wrong file.
+    pytest.importorskip("mlx")
+    pytest.importorskip("mlx_lm")
+    from unsloth_zoo.mlx_loader import _collect_all_linear_target_names, _mlx_lora_base_types
     import mlx.nn as nn
+
+    # Prove the prerequisite BEFORE asserting on the output. An empty type tuple makes every
+    # isinstance() below false, so the helper returns nothing no matter how correct it is;
+    # that is a broken environment, not dropped targeting, and it must not be reported as one.
+    try:
+        base_types = _mlx_lora_base_types()
+    except Exception as exc:  # noqa: BLE001 - mirrors the helper's own blanket catch
+        pytest.skip(f"MLX LoRA base types unavailable ({exc!r}); the helper would return [] "
+                    f"for a reason unrelated to all-linear targeting")
+    # Both of these are degraded-environment conditions, not regressions, so they SKIP.
+    # Failing here would redden CI for a partial or stubbed MLX that says nothing about
+    # whether all-linear targeting is correct -- which is the bug this whole guard had.
+    if not base_types:
+        pytest.skip("_mlx_lora_base_types() resolved to an empty tuple, so nothing can match "
+                    "the isinstance walk and the helper returns [] regardless of its logic")
+    if not (isinstance(nn.Linear, type) and issubclass(nn.Linear, tuple(base_types))):
+        pytest.skip(f"mlx.nn.Linear is not among the types the helper matches on "
+                    f"({base_types}); a stand-in MLX left in sys.modules by another test "
+                    f"cannot exercise the walk")
 
     class FakeQwen3p5:
         """Minimal model whose named_modules() exposes the leaves that
@@ -825,8 +853,13 @@ def test_collect_all_linear_target_names_finds_qkv_and_moe():
     names = set(_collect_all_linear_target_names(FakeQwen3p5()))
     canonical = {"q_proj", "k_proj", "v_proj", "o_proj",
                  "gate_proj", "up_proj", "down_proj"}
-    # Canonical 7 still resolve.
-    assert canonical <= names
+    # Canonical 7 still resolve. Spelled with a message because the bare form renders as
+    # `assert {...} <= set()`, which says nothing about which of the two failure modes it is.
+    assert canonical <= names, (
+        f"all-linear lost canonical names {sorted(canonical - names)}; got {sorted(names)}. "
+        f"An EMPTY result here means the walk matched nothing at all -- check the MLX stack "
+        f"before suspecting the targeting logic."
+    )
     # Plus the extras the pre-fix collapse dropped.
     extras = {"in_proj_qkv", "in_proj_z", "out_proj",
               "router", "w1", "qkv"}


### PR DESCRIPTION
`test_collect_all_linear_target_names_finds_qkv_and_moe` is currently red on every unsloth pull request that runs the Core job, which runs this suite against zoo main. Seen on unslothai/unsloth#9386, #9387 and #9390, on more than one Core leg:

```
tests/test_upstream_pinned_symbols_accelerator.py:829: in test_collect_all_linear_target_names_finds_qkv_and_moe
    assert canonical <= names
E   AssertionError: assert {'down_proj', ... 'up_proj', ...} <= set()
```

The helper returned an empty set, so the message reads as though all-linear targeting had collapsed back to the canonical 7 and regressed 7f8b0ca. It had not. The test was asserting against a dependency it never required.

## Why an empty set does not mean what the assertion says

`_collect_all_linear_target_names` wraps its whole walk so that LoRA setup can never raise:

```python
try:
    linear_types = _mlx_lora_base_types()
    ...
except Exception:
    return []
```

and `_mlx_lora_base_types` reaches `_mlx_lora_type_specs`, which imports **mlx_lm**, not just mlx:

```python
from mlx_lm.models.switch_layers import QuantizedSwitchLinear, SwitchLinear
from mlx_lm.tuner.lora import LoRALinear, LoRASwitchLinear
```

The test guarded only `pytest.importorskip("mlx")`. So on any host where `mlx` resolves but `mlx_lm` does not resolve usably, the import raises inside the helper, the blanket catch turns that into `[]`, and the assertion reports a missing dependency as dropped coverage while pointing at the wrong file. An empty result is the one value that cannot distinguish "the environment is incomplete" from "targeting is broken", and the bare `assert canonical <= names` renders it as `assert {...} <= set()`, which says neither.

Note that a stand-in MLX left in `sys.modules` by an earlier test in the same worker satisfies `importorskip("mlx")` just as well as a real one, so this does not require mlx to be installed at all.

## The change

Test-only. The guard now describes what the helper actually needs, and the three degraded-environment cases skip with a reason rather than failing:

- `importorskip("mlx_lm")` beside the existing `importorskip("mlx")`.
- `_mlx_lora_base_types()` is resolved up front; if it raises, or yields an empty tuple, the test skips. An empty tuple makes every `isinstance` false, so the helper returns nothing no matter how correct it is.
- If `mlx.nn.Linear` is not among the types the helper matches on, the fake model cannot exercise the walk, so that skips too. That is the stand-in-MLX case.

A genuine regression still fails, and now says so: the canonical assertion carries a message naming the missing names and stating that an empty result points at the MLX stack rather than at the targeting logic.

## Verification

Reproduced by injecting a bare `mlx` with a real `nn.Linear` and no `mlx_lm`, which is the failing shape:

```
before (main):  1 failed
after:          1 skipped   (could not import 'mlx_lm')
```

The other two states are unchanged:

```
no mlx at all                -> 1 skipped
complete simulated MLX stack -> runs and passes (14 passed alongside test_mlx_batch_padding.py)
```

so the test still executes and still proves what it was written to prove wherever the stack is real.

One caveat stated plainly: the local reproduction above fails with an `ImportError` rather than with CI's `assert ... <= set()`. Both are the same class of fault, a degraded MLX environment failing the test instead of skipping it, and the change covers both, but the specific empty-set path on CI is derived from reading the two functions above rather than from a runtime reproduction.

## Not changed, but worth a look separately

The blanket `except Exception: return []` in `_collect_all_linear_target_names` is deliberate, and the comment says so. It does mean a user on a partial MLX install silently gets canonical-7 targeting instead of all-linear, which is the same user-visible outcome as the bug 7f8b0ca fixed, with nothing logged. Making that path observable is a production change and does not belong in a test fix.