### PR TITLE
Stop the Mac lane dying on an mlx teardown segfault

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -90,7 +90,13 @@ jobs:
 
       - name: tests/test_qwen35_vjp_metal.py
         # Metal VJP regressions for the qwen3_5 training patches (issue 6002).
-        run: python -m pytest tests/test_qwen35_vjp_metal.py -v -rs
+        #
+        # Run through the wrapper, not `python -m pytest`: on mlx 0.32.1 a fused
+        # Metal kernel left live at interpreter shutdown segfaults, so this file
+        # exits 139 with every test passing. The wrapper returns pytest's own exit
+        # code, so a real failure still fails the job. See its docstring for the
+        # measurements. Revert to plain pytest once mlx fixes the teardown crash.
+        run: python tests/_run_then_exit_hard.py tests/test_qwen35_vjp_metal.py -v -rs
 
       - name: tests/test_mlx_training_e2e_metal.py
         # Real LoRA training smoke: tiny 4-bit model through FastMLXModel +

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -90,12 +90,9 @@ jobs:
 
       - name: tests/test_qwen35_vjp_metal.py
         # Metal VJP regressions for the qwen3_5 training patches (issue 6002).
-        #
-        # Run through the wrapper, not `python -m pytest`: on mlx 0.32.1 a fused
-        # Metal kernel left live at interpreter shutdown segfaults, so this file
-        # exits 139 with every test passing. The wrapper returns pytest's own exit
-        # code, so a real failure still fails the job. See its docstring for the
-        # measurements. Revert to plain pytest once mlx fixes the teardown crash.
+        # Not plain pytest: on mlx 0.32.1 this file exits 139 at interpreter
+        # shutdown with every test passing. The wrapper returns pytest's own exit
+        # code, so real failures still fail. See its docstring; revert once fixed.
         run: python tests/_run_then_exit_hard.py tests/test_qwen35_vjp_metal.py -v -rs
 
       - name: tests/test_mlx_training_e2e_metal.py

--- a/tests/_run_then_exit_hard.py
+++ b/tests/_run_then_exit_hard.py
@@ -1,0 +1,57 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Run pytest, then exit without interpreter finalization.
+
+mlx 0.32.1 segfaults during interpreter shutdown when a fused Metal custom
+kernel is the last thing a process touched. Every test passes and the crash
+lands after the run, so the job dies with exit 139 on a fully green suite.
+
+Measured on an Apple Silicon runner, three samples each, using the shape from
+tests/test_qwen35_vjp_metal.py::test_disable_fused_mrope_fixes_rotary_grad:
+
+    build model + fused rotary forward                exit 139, 139, 139
+      + del refs, gc.collect(), mx.synchronize()      exit 139, 139, 139
+      + gc.collect() registered at exit               exit 139, 139, 139
+      + os._exit() after the work                     exit   0,   0,   0
+
+So it is not ours to fix from Python: releasing everything we hold and flushing
+the stream still crashes, because the fault is in mlx's own static destruction
+after our cleanup. mlx 0.32.0 does not crash on the same tree, which dates it to
+0.32.1 exactly, the release that also broke saving over a loaded file.
+
+This exits with pytest's own return code, so a failing test still fails the job.
+The only thing skipped is interpreter finalization. Drop this wrapper once mlx
+ships a fix and call pytest directly again.
+"""
+
+import os
+import sys
+
+import pytest
+
+
+def main():
+    code = pytest.main(sys.argv[1:])
+    code = int(getattr(code, "value", code))
+    sys.stdout.flush()
+    sys.stderr.flush()
+    # Not sys.exit: that unwinds and finalizes, which is the part that crashes.
+    os._exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_run_then_exit_hard.py
+++ b/tests/_run_then_exit_hard.py
@@ -16,9 +16,8 @@
 
 """Run pytest, then exit without interpreter finalization.
 
-mlx 0.32.1 segfaults during interpreter shutdown when a fused Metal custom
-kernel is the last thing a process touched. Every test passes and the crash
-lands after the run, so the job dies with exit 139 on a fully green suite.
+mlx 0.32.1 segfaults at interpreter shutdown when a fused Metal custom kernel is
+the last thing a process touched, so a fully green suite dies with exit 139.
 
 Measured on an Apple Silicon runner, three samples each, using the shape from
 tests/test_qwen35_vjp_metal.py::test_disable_fused_mrope_fixes_rotary_grad:
@@ -28,14 +27,11 @@ tests/test_qwen35_vjp_metal.py::test_disable_fused_mrope_fixes_rotary_grad:
       + gc.collect() registered at exit               exit 139, 139, 139
       + os._exit() after the work                     exit   0,   0,   0
 
-So it is not ours to fix from Python: releasing everything we hold and flushing
-the stream still crashes, because the fault is in mlx's own static destruction
-after our cleanup. mlx 0.32.0 does not crash on the same tree, which dates it to
-0.32.1 exactly, the release that also broke saving over a loaded file.
+Not fixable from Python: the fault is in mlx's own static destruction, after any
+cleanup we can do. mlx 0.32.0 is clean on the same tree, dating it to 0.32.1.
 
-This exits with pytest's own return code, so a failing test still fails the job.
-The only thing skipped is interpreter finalization. Drop this wrapper once mlx
-ships a fix and call pytest directly again.
+Exits with pytest's own return code, so a failing test still fails the job; only
+finalization is skipped. Drop this wrapper once mlx ships a fix.
 """
 
 import os


### PR DESCRIPTION
## What breaks

`tests/test_qwen35_vjp_metal.py` passes all 4 tests, then the process segfaults during interpreter shutdown:

```
4 passed, 1 warning in 6.61s
Segmentation fault: 11   python -m pytest tests/test_qwen35_vjp_metal.py
##[error]Process completed with exit code 139
```

Nothing is failing. The job dies on a green suite.

This has been invisible until now because it is the step immediately after `tests/test_mlx_switch_lora.py`, which has been red since 2026-08-18. The job stopped there and skipped everything below, this step included. Fixing that earlier failure in #1078 is what exposed this one.

## It is mlx 0.32.1

Measured on an Apple Silicon runner, same tree, flipped both directions inside one job:

| mlx | result |
| --- | --- |
| 0.32.1 | 4 passed, Segfault 11, exit 139 |
| 0.32.0 | 4 passed, **exit 0** |
| back to 0.32.1 | 4 passed, Segfault 11, exit 139 |

The last green scheduled run of this workflow was 2026-08-17 on 0.32.0; 0.32.1 shipped on the 18th. The same before-and-after shows up independently in the scheduled runs on the staging mirrors. This is the second thing 0.32.1 broke here, the other being saving over a loaded file, which #1078 fixes in our own code.

## It is not ours to fix from Python

The crash needs a fused Metal custom-kernel forward to be the last operation the process touched. Only `test_disable_fused_mrope_fixes_rotary_grad` arms it; the other three tests in the file are clean when run alone. Doing a `value_and_grad` after that forward is also clean, which is why the file only fails as a whole.

Using the arming shape directly, three samples each:

```
build model + fused rotary forward            139 139 139
  + del refs, gc.collect(), mx.synchronize()  139 139 139
  + gc.collect() registered at exit           139 139 139
  + os._exit() after the work                   0   0   0
```

Dropping every reference we hold, collecting, and flushing the stream still crashes, so there is nothing left for us to release. The fault is in mlx's own static destruction, after our cleanup has run. Clearing the cache at exit does not help either. Only skipping interpreter finalization avoids it.

## The change

That one file now runs through a small wrapper that calls `pytest.main` and then `os._exit` with pytest's own return code.

This hides nothing. The exit code is pytest's, verified locally:

| case | exit |
| --- | --- |
| passing file | 0 |
| failing test | 1 |
| collection error | 4 |

No test is skipped, relaxed or marked xfail, and mlx stays unpinned so the next release is still exercised on this lane. The wrapper is removed once mlx fixes the teardown crash.

## Verification

This alone does not turn the lane green, because on `main` the job still dies earlier at `test_mlx_switch_lora.py`. Both this and #1078 are needed. Validated on a real Apple Silicon runner with both applied, all 14 test steps green including the seven that have been skipped since 2026-08-18:

```
success  tests/test_mlx_torch_shim_smoke.py
success  tests/test_mlx_switch_lora.py
success  tests/test_mlx_save_over_source.py
success  tests/test_qwen35_vjp_metal.py
success  tests/test_mlx_training_e2e_metal.py
success  tests/test_mlx_generate.py
success  tests/test_mlx_generate_metal.py
success  tests/test_mlx_cpt_partition_metal.py
success  tests/test_mlx_pr684_full_validation_metal.py
success  tests/test_mlx_quantized_optimizer_state.py
success  tests/test_mlx_shape_guard.py
success  tests/test_mlx_vlm_label_masks.py
success  tests/test_mlx_batching_and_decay.py
```

Worth flagging that those seven steps had not run for three days, so this is also the first confirmation that nothing else regressed behind them.

This is worth reporting upstream to ml-explore/mlx with the reproducer above.
