### PR TITLE
Resolve the MoE weight-preprocessor registry through the package so the compiled-cache copy sees it

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -215,8 +215,8 @@ jobs:
         #
         # The two MoE registry files pin preprocess_weight's layout resolution (#849)
         # and that the weight-preprocessor registry is one dict across the package
-        # module and its unsloth_compiled_cache copy (#915). CPU-pure torch, no
-        # weights; neither was executed by any job before.
+        # module and its unsloth_compiled_cache copies. CPU-pure torch, no weights;
+        # neither was executed by any job before.
         #
         # The seven base-model-source files are here for the same reason. They pin
         # that an unreachable Hub is never reported as a missing or unquantized

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -213,6 +213,11 @@ jobs:
         # mapping (no GPU, no vLLM needed). test_sft_prepare_dataset_double_bos
         # pins add_special_tokens for text that already carries BOS.
         #
+        # The two MoE registry files pin preprocess_weight's layout resolution (#849)
+        # and that the weight-preprocessor registry is one dict across the package
+        # module and its unsloth_compiled_cache copy (#915). CPU-pure torch, no
+        # weights; neither was executed by any job before.
+        #
         # The seven base-model-source files are here for the same reason. They pin
         # that an unreachable Hub is never reported as a missing or unquantized
         # model, which is what stops save_pretrained_merged from writing nothing
@@ -269,6 +274,8 @@ jobs:
             tests/test_find_common_token_ids_no_match.py \
             tests/test_vllm_direct_lora_loading.py \
             tests/test_sft_prepare_dataset_double_bos.py \
+            tests/test_moe_preprocess_weight_transpose.py \
+            tests/test_moe_weight_preprocessor_registry_shared.py \
             tests/test_python39_compatibility.py \
             tests/test_checkpoint_modes.py \
             tests/test_wheel_top_level_packages.py \

--- a/tests/test_moe_weight_preprocessor_registry_shared.py
+++ b/tests/test_moe_weight_preprocessor_registry_shared.py
@@ -2,8 +2,8 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -16,11 +16,10 @@
 
 """The weight-preprocessor registry is one dict across every loaded copy of moe_utils.
 
-moe_utils.py copies itself into unsloth_compiled_cache at import, and
-get_forward_moe_backend() prefers the forward from that copy, a separate module object
-that used to carry its own _WEIGHT_PREPROCESSORS. So a registration through the package
-never reached the forward that ran, leaving a square expert weight to layout inference
-(#849). These tests load a real cache copy and check both copies share one registry.
+get_forward_moe_backend() prefers the forward from the unsloth_compiled_cache copy, a
+separate module object that used to carry its own _WEIGHT_PREPROCESSORS, so a
+registration through the package never reached the forward that ran and a square expert
+weight fell back to layout inference (#849). These load a real copy and check both ways.
 """
 
 import os
@@ -38,8 +37,7 @@ _CACHED_NAME = "unsloth_cached_moe_utils"
 def cache_copy(tmp_path_factory):
     """moe_utils loaded from a scratch compile location, as the cache copy is.
 
-    One copy per module, as in a real process. Any copy resolved earlier in the
-    session is set aside for the duration and put back afterwards."""
+    One copy per module, as in a real process; any earlier one is set aside."""
     patch = pytest.MonkeyPatch()
     patch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path_factory.mktemp("compile_location")))
     moe_utils.install_to_cache(moe_utils.__file__, "moe_utils.py")
@@ -59,8 +57,8 @@ def cache_copy(tmp_path_factory):
 
 
 def test_backend_resolves_to_the_cache_copy(cache_copy):
-    # The premise: the installed forward runs with the copy's globals, not the
-    # package's, so a registry local to the package would never be consulted by it.
+    # The premise: the installed forward runs with the copy's globals, so a registry
+    # local to the package would never be consulted by it.
     forward = moe_utils.get_forward_moe_backend()
     assert forward is cache_copy.forward_moe_backend
     assert forward.__globals__ is cache_copy.__dict__
@@ -79,8 +77,8 @@ def test_package_registration_is_visible_from_the_cache_copy(cache_copy, capsys)
     moe_utils.register_weight_preprocessor(key, fn)
     try:
         assert cache_copy.get_weight_preprocessor(key) is fn
-        # Square weight, no experts_module: unregistered, the copy's preprocess_weight
-        # would warn and guess (#849); registered, it dispatches before any shape logic.
+        # Square weight, no experts_module: unregistered this would warn and guess
+        # (#849); registered it dispatches before any shape logic.
         out = cache_copy.preprocess_weight(torch.randn(4, 64, 64), "gate_up", 64, model_type=key)
         assert out is sentinel
         assert "ambiguous" not in capsys.readouterr().err.lower()

--- a/tests/test_moe_weight_preprocessor_registry_shared.py
+++ b/tests/test_moe_weight_preprocessor_registry_shared.py
@@ -57,8 +57,8 @@ def cache_copy(tmp_path_factory):
 
 
 def test_backend_resolves_to_the_cache_copy(cache_copy):
-    # The premise: the installed forward runs with the copy's globals, so a registry
-    # local to the package would never be consulted by it.
+    # The premise: it runs with the copy's globals, so a package-local registry is
+    # never consulted by it.
     forward = moe_utils.get_forward_moe_backend()
     assert forward is cache_copy.forward_moe_backend
     assert forward.__globals__ is cache_copy.__dict__
@@ -77,8 +77,8 @@ def test_package_registration_is_visible_from_the_cache_copy(cache_copy, capsys)
     moe_utils.register_weight_preprocessor(key, fn)
     try:
         assert cache_copy.get_weight_preprocessor(key) is fn
-        # Square weight, no experts_module: unregistered this would warn and guess
-        # (#849); registered it dispatches before any shape logic.
+        # Square, no experts_module: unregistered this guesses (#849), registered it
+        # dispatches before any shape logic.
         out = cache_copy.preprocess_weight(torch.randn(4, 64, 64), "gate_up", 64, model_type=key)
         assert out is sentinel
         assert "ambiguous" not in capsys.readouterr().err.lower()
@@ -97,8 +97,8 @@ def test_cache_copy_registration_lands_in_the_package(cache_copy):
 
 
 def test_bare_moe_utils_copy_shares_the_registry(cache_copy, monkeypatch):
-    # A third copy: compiler.py puts the compile location on sys.path and generated
-    # modules do a bare `from moe_utils import ...`, so that name is its own module too.
+    # A third copy: compiler.py puts the compile location on sys.path, so the bare
+    # `from moe_utils import ...` generated modules do is its own module too.
     monkeypatch.syspath_prepend(os.environ["UNSLOTH_COMPILE_LOCATION"])
     monkeypatch.delitem(sys.modules, "moe_utils", raising=False)
     import moe_utils as bare

--- a/tests/test_moe_weight_preprocessor_registry_shared.py
+++ b/tests/test_moe_weight_preprocessor_registry_shared.py
@@ -16,14 +16,11 @@
 
 """The weight-preprocessor registry is one dict across every loaded copy of moe_utils.
 
-moe_utils.py installs a copy of itself into unsloth_compiled_cache at import, and
-get_forward_moe_backend() prefers the forward_moe_backend loaded from that copy, a
-separate module object. Each copy used to carry its own module-level
-_WEIGHT_PREPROCESSORS, so a preprocessor registered through the package
-(register_weight_preprocessor) was invisible to the forward that actually ran, and a
-square expert weight there fell back to layout inference (#849; found on #915). These
-tests load a real cache copy the way get_forward_moe_backend() does and check that
-both copies read and write the same registry.
+moe_utils.py copies itself into unsloth_compiled_cache at import, and
+get_forward_moe_backend() prefers the forward from that copy, a separate module object
+that used to carry its own _WEIGHT_PREPROCESSORS. So a registration through the package
+never reached the forward that ran, leaving a square expert weight to layout inference
+(#849). These tests load a real cache copy and check both copies share one registry.
 """
 
 import sys

--- a/tests/test_moe_weight_preprocessor_registry_shared.py
+++ b/tests/test_moe_weight_preprocessor_registry_shared.py
@@ -1,0 +1,100 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The weight-preprocessor registry is one dict across every loaded copy of moe_utils.
+
+moe_utils.py installs a copy of itself into unsloth_compiled_cache at import, and
+get_forward_moe_backend() prefers the forward_moe_backend loaded from that copy, a
+separate module object. Each copy used to carry its own module-level
+_WEIGHT_PREPROCESSORS, so a preprocessor registered through the package
+(register_weight_preprocessor) was invisible to the forward that actually ran, and a
+square expert weight there fell back to layout inference (#849; found on #915). These
+tests load a real cache copy the way get_forward_moe_backend() does and check that
+both copies read and write the same registry.
+"""
+
+import sys
+
+import pytest
+import torch
+
+from unsloth_zoo.temporary_patches import moe_utils
+
+_CACHED_NAME = "unsloth_cached_moe_utils"
+
+
+@pytest.fixture(scope="module")
+def cache_copy(tmp_path_factory):
+    """moe_utils loaded from a scratch compile location, as the cache copy is.
+
+    One copy per module, as in a real process. Any copy resolved earlier in the
+    session is set aside for the duration and put back afterwards."""
+    patch = pytest.MonkeyPatch()
+    patch.setenv("UNSLOTH_COMPILE_LOCATION", str(tmp_path_factory.mktemp("compile_location")))
+    moe_utils.install_to_cache(moe_utils.__file__, "moe_utils.py")
+    patch.setattr(moe_utils, "_CACHED_MOE_UTILS_MODULE", None)
+    patch.setattr(moe_utils, "_CACHED_FORWARD_MOE_BACKEND", None)
+    previous = sys.modules.pop(_CACHED_NAME, None)
+    try:
+        copy = moe_utils._load_cached_moe_utils_module()
+        assert copy is not None, "the scratch cache copy did not load"
+        assert copy is not moe_utils
+        yield copy
+    finally:
+        sys.modules.pop(_CACHED_NAME, None)
+        if previous is not None:
+            sys.modules[_CACHED_NAME] = previous
+        patch.undo()
+
+
+def test_backend_resolves_to_the_cache_copy(cache_copy):
+    # The premise: the installed forward runs with the copy's globals, not the
+    # package's, so a registry local to the package would never be consulted by it.
+    forward = moe_utils.get_forward_moe_backend()
+    assert forward is cache_copy.forward_moe_backend
+    assert forward.__globals__ is cache_copy.__dict__
+    assert cache_copy.preprocess_weight is not moe_utils.preprocess_weight
+
+
+def test_both_copies_resolve_one_registry(cache_copy):
+    assert cache_copy._weight_preprocessor_registry() is moe_utils._WEIGHT_PREPROCESSORS
+    assert moe_utils._weight_preprocessor_registry() is moe_utils._WEIGHT_PREPROCESSORS
+
+
+def test_package_registration_is_visible_from_the_cache_copy(cache_copy, capsys):
+    key = "unit_test_registry_shared_arch"
+    sentinel = torch.zeros(1)
+    fn = lambda weight, proj_type, hidden_dim: sentinel
+    moe_utils.register_weight_preprocessor(key, fn)
+    try:
+        assert cache_copy.get_weight_preprocessor(key) is fn
+        # Square weight, no experts_module: unregistered, the copy's preprocess_weight
+        # would warn and guess (#849); registered, it dispatches before any shape logic.
+        out = cache_copy.preprocess_weight(torch.randn(4, 64, 64), "gate_up", 64, model_type=key)
+        assert out is sentinel
+        assert "ambiguous" not in capsys.readouterr().err.lower()
+    finally:
+        moe_utils._WEIGHT_PREPROCESSORS.pop(key, None)
+
+
+def test_cache_copy_registration_lands_in_the_package(cache_copy):
+    key = "unit_test_registry_shared_arch_reverse"
+    fn = lambda weight, proj_type, hidden_dim: weight
+    cache_copy.register_weight_preprocessor(key, fn)
+    try:
+        assert moe_utils.get_weight_preprocessor(key) is fn
+    finally:
+        moe_utils._WEIGHT_PREPROCESSORS.pop(key, None)

--- a/tests/test_moe_weight_preprocessor_registry_shared.py
+++ b/tests/test_moe_weight_preprocessor_registry_shared.py
@@ -23,6 +23,7 @@ never reached the forward that ran, leaving a square expert weight to layout inf
 (#849). These tests load a real cache copy and check both copies share one registry.
 """
 
+import os
 import sys
 
 import pytest
@@ -93,5 +94,22 @@ def test_cache_copy_registration_lands_in_the_package(cache_copy):
     cache_copy.register_weight_preprocessor(key, fn)
     try:
         assert moe_utils.get_weight_preprocessor(key) is fn
+    finally:
+        moe_utils._WEIGHT_PREPROCESSORS.pop(key, None)
+
+
+def test_bare_moe_utils_copy_shares_the_registry(cache_copy, monkeypatch):
+    # A third copy: compiler.py puts the compile location on sys.path and generated
+    # modules do a bare `from moe_utils import ...`, so that name is its own module too.
+    monkeypatch.syspath_prepend(os.environ["UNSLOTH_COMPILE_LOCATION"])
+    monkeypatch.delitem(sys.modules, "moe_utils", raising=False)
+    import moe_utils as bare
+    monkeypatch.setitem(sys.modules, "moe_utils", bare)
+    assert bare is not moe_utils and bare is not cache_copy
+    key = "unit_test_registry_shared_arch_bare"
+    fn = lambda weight, proj_type, hidden_dim: weight
+    moe_utils.register_weight_preprocessor(key, fn)
+    try:
+        assert bare.get_weight_preprocessor(key) is fn
     finally:
         moe_utils._WEIGHT_PREPROCESSORS.pop(key, None)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1100,12 +1100,11 @@ def _should_use_separated_lora() -> bool:
 # Model-specific weight preprocessing hooks: each model registers a transposition
 # function so the generic backend works across weight layouts.
 #
-# This file is also copied into unsloth_compiled_cache and loaded from there as
-# separate module objects (unsloth_cached_moe_utils, whose forward
-# get_forward_moe_backend() prefers, and the bare `moe_utils` compiled modules
-# import), each with its own empty dict. Resolving through the package module keeps
-# registration and lookup on one dict whichever copy runs, so a registration is not
-# silently ignored and left to layout inference (#849).
+# unsloth_compiled_cache holds copies of this file, loaded as their own module objects
+# (unsloth_cached_moe_utils, whose forward get_forward_moe_backend() prefers, and the
+# bare `moe_utils` compiled modules import), each with its own empty dict. Resolving
+# through the package keeps registration and lookup on one dict whichever copy runs,
+# so a registration is not dropped and left to layout inference (#849).
 
 _WEIGHT_PREPROCESSORS = {}
 
@@ -1114,8 +1113,7 @@ def _weight_preprocessor_registry():
     """The registry shared by every loaded copy of this module (see above)."""
     package_module = sys.modules.get("unsloth_zoo.temporary_patches.moe_utils")
     if package_module is None:
-        # Package copy not loaded, so nothing was registered through it.
-        return _WEIGHT_PREPROCESSORS
+        return _WEIGHT_PREPROCESSORS  # package copy not loaded, so nothing registered
     return getattr(package_module, "_WEIGHT_PREPROCESSORS", _WEIGHT_PREPROCESSORS)
 
 
@@ -1230,8 +1228,8 @@ def preprocess_weight(
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    # Guarded so the shipped models, which pass model_type=None, keep the old cost:
-    # this runs per projection per MoE forward, and again in recompute backward.
+    # Guarded: this runs per projection per MoE forward and again in recompute
+    # backward, and the shipped models pass model_type=None.
     if model_type:
         registry = _weight_preprocessor_registry()
         if model_type in registry:

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1100,15 +1100,12 @@ def _should_use_separated_lora() -> bool:
 # Model-specific weight preprocessing hooks: each model registers a transposition
 # function so the generic backend works across weight layouts.
 #
-# Every loaded copy of this module reads ONE registry: the package module's. This
-# file is also installed into unsloth_compiled_cache (install_to_cache above) and
-# loaded from there as a separate module object -- unsloth_cached_moe_utils, whose
-# forward get_forward_moe_backend() prefers, and the bare `moe_utils` the compiled
-# model modules import. A module-level dict starts empty in each of those copies, so
-# a register_weight_preprocessor() call made through the package was invisible to the
-# forward that actually ran, and a square expert weight there fell back to layout
-# inference (#849). Resolving through the package keeps registration and lookup on
-# the same dict whichever copy executes.
+# This file is also copied into unsloth_compiled_cache and loaded from there as
+# separate module objects (unsloth_cached_moe_utils, whose forward
+# get_forward_moe_backend() prefers, and the bare `moe_utils` compiled modules
+# import), each with its own empty dict. Resolving through the package module keeps
+# registration and lookup on one dict whichever copy runs, so a registration is not
+# silently ignored and left to layout inference (#849).
 
 _WEIGHT_PREPROCESSORS = {}
 
@@ -1117,7 +1114,7 @@ def _weight_preprocessor_registry():
     """The registry shared by every loaded copy of this module (see above)."""
     package_module = sys.modules.get("unsloth_zoo.temporary_patches.moe_utils")
     if package_module is None:
-        # The package copy is not loaded, so nothing was registered through it.
+        # Package copy not loaded, so nothing was registered through it.
         return _WEIGHT_PREPROCESSORS
     return getattr(package_module, "_WEIGHT_PREPROCESSORS", _WEIGHT_PREPROCESSORS)
 
@@ -1233,9 +1230,12 @@ def preprocess_weight(
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    registry = _weight_preprocessor_registry()
-    if model_type and model_type in registry:
-        return registry[model_type](weight, proj_type, hidden_dim)
+    # Guarded so the shipped models, which pass model_type=None, keep the old cost:
+    # this runs per projection per MoE forward, and again in recompute backward.
+    if model_type:
+        registry = _weight_preprocessor_registry()
+        if model_type in registry:
+            return registry[model_type](weight, proj_type, hidden_dim)
 
     # Non-square shapes reveal layout directly.
     needs_transpose = _orientation_needs_transpose(tuple(weight.shape), proj_type, hidden_dim)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1099,18 +1099,37 @@ def _should_use_separated_lora() -> bool:
 
 # Model-specific weight preprocessing hooks: each model registers a transposition
 # function so the generic backend works across weight layouts.
+#
+# Every loaded copy of this module reads ONE registry: the package module's. This
+# file is also installed into unsloth_compiled_cache (install_to_cache above) and
+# loaded from there as a separate module object -- unsloth_cached_moe_utils, whose
+# forward get_forward_moe_backend() prefers, and the bare `moe_utils` the compiled
+# model modules import. A module-level dict starts empty in each of those copies, so
+# a register_weight_preprocessor() call made through the package was invisible to the
+# forward that actually ran, and a square expert weight there fell back to layout
+# inference (#849). Resolving through the package keeps registration and lookup on
+# the same dict whichever copy executes.
 
 _WEIGHT_PREPROCESSORS = {}
 
 
+def _weight_preprocessor_registry():
+    """The registry shared by every loaded copy of this module (see above)."""
+    package_module = sys.modules.get("unsloth_zoo.temporary_patches.moe_utils")
+    if package_module is None:
+        # The package copy is not loaded, so nothing was registered through it.
+        return _WEIGHT_PREPROCESSORS
+    return getattr(package_module, "_WEIGHT_PREPROCESSORS", _WEIGHT_PREPROCESSORS)
+
+
 def register_weight_preprocessor(model_type: str, preprocessor_fn):
     """Register a weight preprocessor (weight, proj_type, hidden_dim) -> weight for a model type."""
-    _WEIGHT_PREPROCESSORS[model_type] = preprocessor_fn
+    _weight_preprocessor_registry()[model_type] = preprocessor_fn
 
 
 def get_weight_preprocessor(model_type: str):
     """Get registered weight preprocessor for model type."""
-    return _WEIGHT_PREPROCESSORS.get(model_type)
+    return _weight_preprocessor_registry().get(model_type)
 
 
 def _logical_expert_shape(param):
@@ -1214,8 +1233,9 @@ def preprocess_weight(
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    if model_type and model_type in _WEIGHT_PREPROCESSORS:
-        return _WEIGHT_PREPROCESSORS[model_type](weight, proj_type, hidden_dim)
+    registry = _weight_preprocessor_registry()
+    if model_type and model_type in registry:
+        return registry[model_type](weight, proj_type, hidden_dim)
 
     # Non-square shapes reveal layout directly.
     needs_transpose = _orientation_needs_transpose(tuple(weight.shape), proj_type, hidden_dim)


### PR DESCRIPTION
The piece @danielhanchen asked me to split out of #915.

`moe_utils.py` copies itself into `unsloth_compiled_cache`, and `get_forward_moe_backend()` hands back the forward from that copy, which is its own module object (`unsloth_cached_moe_utils`, plus the bare `moe_utils` the compiled modules import). Each copy had its own `_WEIGHT_PREPROCESSORS`, so registering through the package never reached the forward that actually runs. `preprocess_weight` over there just fell back to shape inference, which for a square weight with no readable sibling is the #849 guess. Nothing in-tree registers one yet btw, OLMoE in #915 would be the first.

Fix is small: the registry functions go through `_weight_preprocessor_registry()`, which hands back the package module's dict if it's loaded (a `sys.modules` lookup, no import) and the local one if not. Package path doesn't change.

Test loads a real cache copy via `_load_cached_moe_utils_module()` from a scratch `UNSLOTH_COMPILE_LOCATION`, checks the resolved backend really is the copy's forward, and registers both ways. 3 of 4 fail on main. Also put it and `tests/test_moe_preprocess_weight_transpose.py` in the hard gate, since it turns out nothing was running the #849 test. CPU-only, no weights.

Either order with #915 is fine. That one works on its own since #913, this just makes its registration stick on the cache path.
