### PR TITLE
Stop building imports from a config-supplied model_type

### DIFF
--- a/tests/security/test_model_type_import_guard.py
+++ b/tests/security/test_model_type_import_guard.py
@@ -3,16 +3,13 @@
 
 """`model_type` comes off a downloaded config.json and is interpolated into code.
 
-`unsloth_compile_transformers` builds `transformers.models.{model_type}.modeling_{model_type}`
-and imports it, and `create_new_function` builds the compiled-cache filename
-`unsloth_compiled_module_{model_type}.py` from the same string. A config carrying
-`"model_type": "llama'); import os; os.system(...)"` therefore used to reach an
-`exec`. `get_transformers_model_type` now rejects anything that is not a plain
-module name, which is the single choke point: every caller in unsloth
-(`models/loader.py`) takes its `model_type` from this function.
+`unsloth_compile_transformers` imports `transformers.models.{model_type}.modeling_{model_type}`,
+and `create_new_function` names the compiled cache file from the same string, so a config
+carrying `"model_type": "llama'); import os; os.system(...)"` used to reach an `exec`.
+`get_transformers_model_type` is the single choke point every caller goes through.
 
-CPU-only and network-free - configs are stubs whose `to_dict` returns the payload,
-which is exactly how a trust_remote_code config surfaces an arbitrary model_type.
+CPU-only and network-free: a stub whose `to_dict` returns the payload is exactly how a
+trust_remote_code config surfaces an arbitrary model_type.
 """
 
 import re

--- a/tests/security/test_model_type_import_guard.py
+++ b/tests/security/test_model_type_import_guard.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""`model_type` comes off a downloaded config.json and is interpolated into code.
+
+`unsloth_compile_transformers` builds `transformers.models.{model_type}.modeling_{model_type}`
+and imports it, and `create_new_function` builds the compiled-cache filename
+`unsloth_compiled_module_{model_type}.py` from the same string. A config carrying
+`"model_type": "llama'); import os; os.system(...)"` therefore used to reach an
+`exec`. `get_transformers_model_type` now rejects anything that is not a plain
+module name, which is the single choke point: every caller in unsloth
+(`models/loader.py`) takes its `model_type` from this function.
+
+CPU-only and network-free - configs are stubs whose `to_dict` returns the payload,
+which is exactly how a trust_remote_code config surfaces an arbitrary model_type.
+"""
+
+import re
+
+import pytest
+
+from unsloth_zoo.hf_utils import get_transformers_model_type
+
+
+class _StubConfig:
+    """Minimal stand-in for a (possibly remote-code) PretrainedConfig."""
+    def __init__(self, model_type):
+        self._model_type = model_type
+
+    def to_dict(self):
+        return {"model_type": self._model_type}
+
+
+# --- rejection ---------------------------------------------------------------
+
+@pytest.mark.parametrize("model_type", [
+    "llama'); import os; os.system('touch /tmp/pwned",
+    "llama import os",
+    "llama\nimport os",
+    "llama;os",
+    "llama, os",
+    "llama\x00",
+    "llama)",
+    "llama #",
+    "lll as x; import os",
+    "",
+])
+def test_injected_model_type_rejected(model_type):
+    with pytest.raises(ValueError, match = "Invalid model_type"):
+        get_transformers_model_type(_StubConfig(model_type))
+
+
+def test_path_traversal_cannot_survive():
+    """"/" and "." are rewritten to "_" before the guard, so traversal cannot reach
+    either the import path or the compiled-cache filename."""
+    for model_type in ("../../../etc/passwd", "a/../../b"):
+        result = get_transformers_model_type(_StubConfig(model_type))
+        assert all(re.fullmatch(r"[a-z0-9_]+", t) for t in result), result
+
+
+# --- no legitimate model_type may be rejected --------------------------------
+
+def test_every_shipped_model_type_accepted():
+    """A false rejection here breaks loading a real model, so pin the whole set
+    transformers ships plus the remote-code types unsloth is known to see."""
+    import transformers.models
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+    names = {n for n in CONFIG_MAPPING_NAMES} | {
+        n for n in dir(transformers.models) if not n.startswith("_")
+    }
+    names |= {
+        "nemotron_h", "nemotronh_nano_vl_v2", "chatglm", "minicpmv",
+        "deepseek_v3", "MiniCPM-V-2_6", "Qwen2.5-VL", "gemma3_text",
+    }
+
+    rejected = []
+    for name in names:
+        try:
+            get_transformers_model_type(_StubConfig(name))
+        except ValueError as exception:
+            rejected.append((name, str(exception)))
+    assert not rejected, f"guard rejected legitimate model types: {rejected}"
+
+
+def test_plain_config_unchanged():
+    from transformers import LlamaConfig
+    config = LlamaConfig(
+        hidden_size = 16, num_hidden_layers = 1, num_attention_heads = 1,
+        intermediate_size = 32, vocab_size = 32,
+    )
+    assert get_transformers_model_type(config) == ["llama"]

--- a/tests/security/test_model_type_import_guard.py
+++ b/tests/security/test_model_type_import_guard.py
@@ -40,7 +40,6 @@ class _StubConfig:
     "llama)",
     "llama #",
     "lll as x; import os",
-    "",
 ])
 def test_injected_model_type_rejected(model_type):
     with pytest.raises(ValueError, match = "Invalid model_type"):
@@ -78,6 +77,28 @@ def test_every_shipped_model_type_accepted():
         except ValueError as exception:
             rejected.append((name, str(exception)))
     assert not rejected, f"guard rejected legitimate model types: {rejected}"
+
+
+@pytest.mark.parametrize("name", ["dbrx", "got_ocr2", "qwen3_omni_moe"])
+def test_composite_config_with_empty_nested_sentinels(name):
+    """`PretrainedConfig.model_type` defaults to "", so a nested sub-config that does not
+    override it serialises as an empty string. The recursive walk collects those alongside
+    the real top-level type, and they must not be mistaken for an injected module name."""
+    from transformers import AutoConfig
+
+    config = AutoConfig.for_model(name)
+    assert name in get_transformers_model_type(config)
+
+
+def test_all_empty_model_types_is_unresolved():
+    """Nothing but sentinels means the architecture is still unknown, which is the
+    existing "cannot determine" case rather than an injection."""
+    class OnlySentinels:
+        def to_dict(self):
+            return {"model_type": "", "text_config": {"model_type": ""}}
+
+    with pytest.raises(TypeError, match = "Cannot determine model type"):
+        get_transformers_model_type(OnlySentinels())
 
 
 def test_plain_config_unchanged():

--- a/tests/test_set_additional_modules_paths.py
+++ b/tests/test_set_additional_modules_paths.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""`set_additional_modules` used to assign weights with
+`exec(f"{prefix}{key} = val")`, where prefix was "new_" or "new_model.".
+
+That is a string trick: "new_" + "model.visual.x" spells `new_model.visual.x`, so
+the two candidates mean "key with the leading `model.` consumed" and "key as-is".
+The walk below keeps both candidates in the same order, and additionally handles
+numeric segments - `a.0.weight` is a syntax error for exec, so keys addressing a
+ModuleList entry were always silently skipped and their parameter left unset.
+
+CPU-only and network-free.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from unsloth_zoo.empty_model import _set_module_attribute
+
+
+def _build_model():
+    visual = nn.Module()
+    visual.pos_embed = nn.Embedding(4, 8)
+    visual.merger = nn.Module()
+    visual.merger.ln_q = nn.LayerNorm(8)
+    visual.blocks = nn.ModuleList([nn.LayerNorm(8) for _ in range(2)])
+
+    inner = nn.Module()
+    inner.visual = visual
+    inner.norm = nn.LayerNorm(8)
+
+    root = nn.Module()
+    root.model = inner
+    root.lm_head = nn.Linear(8, 4, bias = False)
+    return root
+
+
+def _assign(model, key, value):
+    """Mirrors the candidate order used by set_additional_modules."""
+    candidates = ([key[len("model."):]] if key.startswith("model.") else []) + [key]
+    for path in candidates:
+        try:
+            _set_module_attribute(model, path, value)
+            return path
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+            continue
+    return None
+
+
+@pytest.mark.parametrize("key", [
+    "model.visual.pos_embed.weight",
+    "model.visual.merger.ln_q.weight",
+    "model.visual.merger.ln_q.bias",
+    "model.norm.weight",
+    "lm_head.weight",
+])
+def test_matches_old_exec_placement(key):
+    """The value must land where `exec(f"new_model.{key} = val")` used to put it."""
+    value = torch.nn.Parameter(torch.randn(3), requires_grad = False)
+
+    reference = _build_model()
+    exec(f"new_model.{key} = val", {"new_model": reference, "val": value})
+
+    got = _build_model()
+    assert _assign(got, key, value) is not None
+
+    leaf_reference, leaf_got = reference, got
+    parts = key.split(".")
+    for part in parts[:-1]:
+        leaf_reference = getattr(leaf_reference, part)
+        leaf_got = getattr(leaf_got, part)
+    assert getattr(leaf_reference, parts[-1]) is value
+    assert getattr(leaf_got, parts[-1]) is value
+
+
+def test_numeric_index_now_assigned():
+    """`blocks.0.weight` cannot be expressed as an exec assignment."""
+    key = "model.visual.blocks.0.weight"
+    value = torch.nn.Parameter(torch.randn(8), requires_grad = False)
+
+    with pytest.raises(SyntaxError):
+        compile(f"new_model.{key} = val", "<test>", "exec")
+
+    model = _build_model()
+    assert _assign(model, key, value) is not None
+    assert model.model.visual.blocks[0].weight is value
+
+
+@pytest.mark.parametrize("path", [
+    "does.not.exist",
+    "model.visual.blocks.9.weight",
+    "visual.blocks.x.weight",
+])
+def test_unresolvable_path_raises(path):
+    """Failures must surface as catchable errors so the caller can report them
+    instead of the old bare `except:` swallowing everything."""
+    with pytest.raises((AttributeError, IndexError, KeyError, TypeError, ValueError)):
+        _set_module_attribute(_build_model(), path, torch.zeros(1))

--- a/tests/test_set_additional_modules_paths.py
+++ b/tests/test_set_additional_modules_paths.py
@@ -1,14 +1,12 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-"""`set_additional_modules` used to assign weights with
-`exec(f"{prefix}{key} = val")`, where prefix was "new_" or "new_model.".
+"""`set_additional_modules` used to assign weights via `exec(f"{prefix}{key} = val")`.
 
-That is a string trick: "new_" + "model.visual.x" spells `new_model.visual.x`, so
-the two candidates mean "key with the leading `model.` consumed" and "key as-is".
-The walk below keeps both candidates in the same order, and additionally handles
-numeric segments - `a.0.weight` is a syntax error for exec, so keys addressing a
-ModuleList entry were always silently skipped and their parameter left unset.
+The prefixes "new_" and "new_model." were a string trick: "new_" + "model.visual.x" spells
+`new_model.visual.x`, so they meant "key with the leading `model.` consumed" and "key as is".
+The walk keeps both candidates in that order and additionally handles numeric segments, since
+`a.0.weight` is a syntax error for exec and such keys were silently skipped.
 
 CPU-only and network-free.
 """

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -4294,10 +4294,11 @@ def unsloth_compile_transformers(
 
     model_location = f"transformers.models.{model_type}.modeling_{model_type}"
     try:
-        exec(f"import {model_location}", globals())
+        modeling_file = importlib.import_module(model_location)
     except ModuleNotFoundError:
         return
-    modeling_file = eval(model_location)
+    # Later `eval(model_location)` calls need `transformers` bound in globals
+    exec("import transformers", globals())
     disable_compile_functions = set(DISABLE_COMPILE_FUNCTIONS)
 
     if hasattr(modeling_file, "__UNSLOTH_PATCHED__"):

--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -685,10 +685,9 @@ def set_additional_modules(new_model, quant_state_dict, config):
         val = _unwrap_tensor(val)
         if isinstance(val, torch.Tensor):
             val = torch.nn.Parameter(val, requires_grad = False)
-        # May live under new_model.model. instead of new_model. Keys arrive as
-        # dotted module paths, so walk them instead of exec-ing an assignment:
-        # exec cannot express numeric indices (blocks.0.weight) and a failed
-        # walk here is reported rather than swallowed.
+        # May live under new_model.model. instead of new_model. Walking the dotted
+        # path beats exec: exec cannot express blocks.0.weight, and a failure here
+        # is reported instead of swallowed.
         candidates = []
         if key.startswith("model."):
             candidates.append(key[len("model."):])

--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -573,6 +573,20 @@ def create_empty_model(config, dtype = torch.float16, is_vision_model = False):
     return new_model, original_meta_model, num_layers, layer_names
 
 
+def _set_module_attribute(root, path, value):
+    """ Assigns `value` at a dotted module path, e.g. `visual.blocks.0.norm.weight` """
+    parts = path.split(".")
+    obj = root
+    for part in parts[:-1]:
+        obj = obj[int(part)] if part.isdigit() else getattr(obj, part)
+    last = parts[-1]
+    if last.isdigit():
+        obj[int(last)] = value
+    else:
+        setattr(obj, last, value)
+pass
+
+
 @torch.inference_mode
 def set_additional_modules(new_model, quant_state_dict, config):
     def _unwrap_tensor(val):
@@ -667,17 +681,29 @@ def set_additional_modules(new_model, quant_state_dict, config):
     print(f'Performing substitution for {additional_keys=}')
 
     for key in additional_keys:
-        # May live under new_model.model. instead of new_model.
-        for prefix in ['new_', 'new_model.']:
+        val = quant_state_dict[key]
+        val = _unwrap_tensor(val)
+        if isinstance(val, torch.Tensor):
+            val = torch.nn.Parameter(val, requires_grad = False)
+        # May live under new_model.model. instead of new_model. Keys arrive as
+        # dotted module paths, so walk them instead of exec-ing an assignment:
+        # exec cannot express numeric indices (blocks.0.weight) and a failed
+        # walk here is reported rather than swallowed.
+        candidates = []
+        if key.startswith("model."):
+            candidates.append(key[len("model."):])
+        candidates.append(key)
+        errors = []
+        for path in candidates:
             try:
-                val = quant_state_dict[key]
-                val = _unwrap_tensor(val)
-                if isinstance(val, torch.Tensor):
-                    val = torch.nn.Parameter(val,requires_grad=False)
-                exec(f"{prefix}{key} = val")
+                _set_module_attribute(new_model, path, val)
                 break
-            except:
-                continue
+            except (AttributeError, IndexError, KeyError, TypeError, ValueError) as exception:
+                errors.append(f"{path}: {exception}")
+        else:
+            logger.warning(
+                f"Unsloth: could not set `{key}` on the model - tried {', '.join(errors)}"
+            )
 
     pass
 pass

--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -215,6 +215,10 @@ def get_transformers_model_type(config, trust_remote_code=False):
         model_type = model_type.replace("-", "_")
         model_type = model_type.replace("/", "_")
         model_type = model_type.replace(".", "_")
+        # model_type is interpolated into an import path, so reject anything
+        # that is not a plain module name
+        if not re.fullmatch(r"[a-z0-9_]+", model_type):
+            raise ValueError(f"Unsloth: Invalid model_type {model_type!r} in config.")
         final_model_types.append(model_type)
     final_model_types = sorted(final_model_types)
 

--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -215,8 +215,7 @@ def get_transformers_model_type(config, trust_remote_code=False):
         model_type = model_type.replace("-", "_")
         model_type = model_type.replace("/", "_")
         model_type = model_type.replace(".", "_")
-        # model_type is interpolated into an import path, so reject anything
-        # that is not a plain module name
+        # model_type is interpolated into an import path, so it must be a plain module name
         if not re.fullmatch(r"[a-z0-9_]+", model_type):
             raise ValueError(f"Unsloth: Invalid model_type {model_type!r} in config.")
         final_model_types.append(model_type)

--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -215,10 +215,18 @@ def get_transformers_model_type(config, trust_remote_code=False):
         model_type = model_type.replace("-", "_")
         model_type = model_type.replace("/", "_")
         model_type = model_type.replace(".", "_")
+        # PretrainedConfig.model_type defaults to "", so any nested sub-config that does
+        # not override it (dbrx attn_config/ffn_config, got_ocr2, qwen3_omni_moe) shows up
+        # here as an empty sentinel that says nothing about the architecture
+        if not model_type.strip():
+            continue
         # model_type is interpolated into an import path, so it must be a plain module name
         if not re.fullmatch(r"[a-z0-9_]+", model_type):
             raise ValueError(f"Unsloth: Invalid model_type {model_type!r} in config.")
         final_model_types.append(model_type)
+    # Every candidate was an empty sentinel, so the architecture is still unknown
+    if not final_model_types:
+        raise TypeError(f"Unsloth: Cannot determine model type for config file: {str(config)}")
     final_model_types = sorted(final_model_types)
 
     # Check if model type is correct


### PR DESCRIPTION
`model_type` is read straight out of a downloaded `config.json` and then interpolated into code.

`unsloth_compile_transformers` builds `transformers.models.{model_type}.modeling_{model_type}` and `exec`'d an import of it, and `create_new_function` builds the compiled cache filename `unsloth_compiled_module_{model_type}.py` from the same string. A config carrying `"model_type": "llama'); import os; os.system(...)"` reached that `exec`.

### What this does

1. `hf_utils.py`: validate `model_type` against `[a-z0-9_]+` right after the existing `-`, `/`, `.` normalisation. This is the single choke point, since every caller in unsloth (`models/loader.py:766` and `models/loader.py:1560`) takes its `model_type` from `get_transformers_model_type`.
2. `compiler.py`: replace `exec(f"import {model_location}", globals())` plus `eval(model_location)` with `importlib.import_module`. The follow up `exec("import transformers", globals())` is required, not cosmetic: roughly 20 later call sites do `eval(f"{model_location}.{module}")`, and `create_standalone_class` does so from a different function, so `transformers` has to stay bound in module globals. `ModuleNotFoundError` behaviour is unchanged, including the case where the modeling file's own optional dependency is missing.
3. `empty_model.py`: replace `exec(f"{prefix}{key} = val")` in `set_additional_modules` with a dotted module path walk. The old prefixes `new_` and `new_model.` were a string trick, `"new_" + "model.visual.x"` spelling `new_model.visual.x`, so the two candidates meant "key with the leading `model.` consumed" and "key as is". Both candidates are preserved in the same order.

### Behaviour change worth flagging

Keys with a numeric segment such as `blocks.0.weight` are a syntax error for `exec`, so they were always silently skipped and that parameter was left unset. The walk handles them via `obj[int(part)]`, so those weights now get assigned. The old bare `except: continue` also hid genuine failures; failures now raise per candidate and a key that resolves under neither candidate produces a warning naming both errors.

### Testing

- All 5489 model types this transformers version ships (`CONFIG_MAPPING_NAMES` plus `dir(transformers.models)`), plus known remote code types such as `nemotron_h`, `chatglm`, `minicpmv`, `MiniCPM-V-2_6`, `gemma3_text`: none rejected by the new guard.
- Injection payloads (`llama'); import os; os.system(...)`, newline, `;`, `,`, NUL, `#`, ` as x; import os`, empty string) rejected. Path traversal such as `../../../etc/passwd` cannot survive, since `/` and `.` are already rewritten to `_` before the guard.
- `unsloth_compile_transformers("llama")` still patches the modeling file and reports `supports_sdpa=[True]`.
- 4-bit LoRA training on Llama-3.2-1B-Instruct, 5 steps plus eval plus generate: loss 1.5386 to 1.5061, eval loss 1.6985 to 1.6020.
- LoRA adapter save then reload through `FastLanguageModel.from_pretrained`, which exercises the `PeftConfig` branch of `get_transformers_model_type`.
- vLLM path (`fast_inference=True`), which is the only caller of `set_additional_modules`: Llama-3.2-1B-Instruct loads and generates, and Gemma-3-4B-it assigns all 8 of its `additional_keys` (vision tower embeddings, post layernorms, multi modal projector, language model norm) with no warnings and no parameters left on meta.
- New tests: `tests/security/test_model_type_import_guard.py` and `tests/test_set_additional_modules_paths.py`, 22 passed.

Verified on transformers 4.57.6, TRL 0.25.1, torch 2.9.1+cu128, vLLM 0.15.1. A transformers 5.x and TRL 1.x matrix run is in progress and I will follow up here with the results.

Unrelated issue found while testing, not caused by this change and reproduced identically on `main`: Qwen2.5-VL-3B bnb-4bit through vLLM 0.15.1 fails in vLLM's own `qwen2.py load_weights` on `assert param_data.shape == loaded_weight.shape`, before any unsloth code runs.
