### PR TITLE
Pin the MLX dependencies instead of only flooring them

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -71,6 +71,27 @@ jobs:
           # remote processor code that imports timm, which .[mlx] does not pull.
           pip install timm
 
+      - name: Adopt the newest MLX (unattended runs only)
+        # pyproject pins mlx and mlx-lm exactly so that nobody installing
+        # unsloth_zoo is upgraded into a broken release unattended. That pin also
+        # holds `.[mlx]` above at the pinned versions forever, and this job is the
+        # only lane that runs real MLX on Apple Silicon, so without this step the
+        # pin would silently remove the very check that is supposed to tell us
+        # whether the next release is safe to adopt. On the nightly and on manual
+        # dispatch we therefore deliberately install past the pin; PR runs keep the
+        # pinned set, which is what users actually get.
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          pip install --upgrade mlx mlx-lm
+          python - <<'PY'
+          from importlib.metadata import version
+          for name in ("mlx", "mlx-lm", "mlx-vlm"):
+              try:
+                  print(f"{name}=={version(name)}")
+              except Exception as error:
+                  print(f"{name}: {error}")
+          PY
+
       - name: MLX module import smoke
         run: |
           python -c "import unsloth_zoo.mlx_loader; print('mlx_loader OK')"

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   mlx-smoke:
-    name: MLX install + import smoke (Apple Silicon)
+    name: MLX install + import smoke (Apple Silicon, ${{ matrix.mlx }})
     # Opt-in: schedule / workflow_dispatch always run; PR runs only with `mlx` label.
     if: >-
       github.event_name == 'schedule' ||
@@ -35,6 +35,21 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'mlx')
     runs-on: macos-15   # Apple Silicon (M1) hosted runner
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # `pinned` is the gate: the exact MLX set pyproject ships, which is what
+        # users actually install, so it runs on every execution of this job.
+        # `latest` is the detection leg answering "is the next release safe to
+        # adopt", added only where nothing is waiting on the answer. Both are
+        # needed: with only `pinned` the pin goes stale unnoticed, and with only
+        # `latest` the supported combination is never exercised on Apple hardware
+        # at all, since PR runs are opt-in behind the `mlx` label.
+        mlx: ${{ fromJSON((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '["pinned", "latest"]' || '["pinned"]') }}
+    # The detection leg reports, it does not gate. It deliberately installs
+    # combinations nobody supports yet, so letting it fail the workflow would
+    # turn every upstream release into a red main until someone bumps the pin.
+    continue-on-error: ${{ matrix.mlx == 'latest' }}
     steps:
       # harden-runner block-mode is Linux-only; stay in audit on macOS for parity.
       - name: Harden runner (audit)
@@ -71,18 +86,23 @@ jobs:
           # remote processor code that imports timm, which .[mlx] does not pull.
           pip install timm
 
-      - name: Adopt the newest MLX (unattended runs only)
-        # pyproject pins mlx and mlx-lm exactly so that nobody installing
-        # unsloth_zoo is upgraded into a broken release unattended. That pin also
-        # holds `.[mlx]` above at the pinned versions forever, and this job is the
-        # only lane that runs real MLX on Apple Silicon, so without this step the
-        # pin would silently remove the very check that is supposed to tell us
-        # whether the next release is safe to adopt. On the nightly and on manual
-        # dispatch we therefore deliberately install past the pin; PR runs keep the
-        # pinned set, which is what users actually get.
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      - name: Adopt the newest MLX (detection leg only)
+        # pyproject pins mlx and mlx-lm exactly so nobody installing unsloth_zoo is
+        # upgraded into a broken release unattended. That pin also holds `.[mlx]`
+        # above at the pinned versions forever, and this job is the only lane that
+        # runs real MLX on Apple Silicon, so without this leg the pin would
+        # silently remove the very check that is supposed to tell us whether the
+        # next release is safe to adopt.
+        #
+        # mlx-vlm is upgraded past its `<0.7.0` ceiling too. The ceiling exists
+        # because the current mlx-vlm wants transformers>=5.14.0 against this
+        # repo's `transformers<=5.5.0` cap, and leaving it out would mean the one
+        # lane that could ever justify lifting that ceiling never tests the
+        # version it would be lifted to. Letting transformers move with it is the
+        # point of this leg, and is why it does not gate.
+        if: matrix.mlx == 'latest'
         run: |
-          pip install --upgrade mlx mlx-lm
+          pip install --upgrade mlx mlx-lm mlx-vlm
           python - <<'PY'
           from importlib.metadata import version
           for name in ("mlx", "mlx-lm", "mlx-vlm"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,24 @@ dependencies = [
     "peft>=0.18.0,!=0.11.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "cut_cross_entropy ; python_version >= '3.10' and (sys_platform != 'darwin' or platform_machine != 'arm64')",
     # --- MLX-only deps (macOS arm64) ---
-    "mlx>=0.22.0 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
+    # Pinned, not floored. mlx ships breaking changes in PATCH releases: 0.32.1
+    # replaced mx.random.state with a sentinel that refuses item assignment and
+    # broke three separate call sites here and in Studio (unsloth-zoo #1078,
+    # #1081, unsloth #9478), and it reached users through an unattended upgrade
+    # because nothing bounded it. Bump these deliberately, after the Apple
+    # Silicon lane is green on the new release.
+    "mlx==0.32.1 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
     # GenerationBatch.Response and BatchGenerator.next_generated, which batched
     # generation drives, first ship in mlx-lm 0.31.2.
-    "mlx-lm>=0.31.2 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
-    "mlx-vlm>=0.4.4 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
+    "mlx-lm==0.31.3 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
+    # A ceiling rather than an exact pin, because the two consumers resolve
+    # different patches and both are correct. Under the transformers<=5.5.0 cap
+    # below, the newest mlx-vlm that fits is 0.6.4 (0.6.9+ requires
+    # transformers>=5.14). Studio's installer overrides that requirement, so it
+    # gets 0.6.15 -- which matters: the UnicodeDecodeError during generation in
+    # unsloth #9466 is fixed in 0.6.9. Pinning either patch exactly would make
+    # one of those two environments unresolvable or reintroduce a fixed bug.
+    "mlx-vlm>=0.4.4,<0.7.0 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
     # --- Shared deps (all platforms) ---
     "packaging>=24.1",
     "transformers>=4.51.3,!=4.52.0,!=4.52.1,!=4.52.2,!=4.52.3,!=4.53.0,!=4.54.0,!=4.55.0,!=4.55.1,!=4.57.4,!=4.57.5,!=5.0.0,!=5.1.0,<=5.5.0",
@@ -75,10 +88,11 @@ exclude = ["images*", "tests*", "scripts*"]
 
 [project.optional-dependencies]
 mlx = [
-    "mlx>=0.22.0",
-    # Keep in sync with the MLX-only dependency pin above.
-    "mlx-lm>=0.31.2",
-    "mlx-vlm>=0.4.4",
+    # Keep in sync with the MLX-only dependency pins above, including the reason
+    # they are pins.
+    "mlx==0.32.1",
+    "mlx-lm==0.31.3",
+    "mlx-vlm>=0.4.4,<0.7.0",
 ]
 core = [
     "packaging>=24.1",


### PR DESCRIPTION
## What this changes

Pins the MLX dependencies instead of only setting a floor on them.

```
mlx>=0.22.0    ->  mlx==0.32.1
mlx-lm>=0.31.2 ->  mlx-lm==0.31.3
mlx-vlm>=0.4.4 ->  mlx-vlm>=0.4.4,<0.7.0
```

Both the main `[project.dependencies]` block and the `[mlx]` extra.

## Why

mlx ships breaking changes in patch releases. 0.32.1 replaced `mx.random.state`, previously a plain list, with a sentinel exposing `__len__`, `__getitem__` and `__iter__` but no `__setitem__`. Nothing bounded mlx anywhere in the install path, so that release reached users the day it was published and broke three separate things:

- saving safetensors back over the source file, fixed in #1078
- the Studio KV quantization probe, fixed in unslothai/unsloth#9478
- the DDP and single-process `mx.compile` fallbacks plus `_preserved_preprocessing_rng`, fixed in #1081

The reporter of unslothai/unsloth#9466 did not choose that upgrade. In their own words, "an MLX update was automatically installed by Unsloth shortly before updating Unsloth Desktop". Studio's unattended self-heal fetched it on startup, because every path that installs mlx declares a floor and no ceiling.

Three fixes in five days, none of which the release notes would have warned us about, is enough evidence that the floor-only policy is not working for this dependency.

## Why mlx-vlm gets a ceiling and not an exact pin

The two environments that install mlx-vlm resolve different patches, and both are correct.

Under the `transformers<=5.5.0` cap in this same file, the newest mlx-vlm that fits is **0.6.4**, because 0.6.9 and later require `transformers>=5.14.0`. Studio's installer overrides that requirement through `overrides-darwin-arm64.txt`, so it resolves **0.6.15**.

That difference is not cosmetic. The `UnicodeDecodeError` during generation in the second half of #9466 is an upstream mlx-vlm bug fixed in 0.6.9, and the reporter only got working generation after the installer moved them to 0.6.15. Pinning 0.6.4 exactly would downgrade every Studio user back onto that bug; pinning 0.6.15 exactly would make this repo's own CI unresolvable. A ceiling bounds the surprise without forcing either environment onto the wrong patch.

## Verification

Resolved both contexts with `uv pip install --dry-run`:

| transformers constraint | mlx | mlx-lm | mlx-vlm |
|---|---|---|---|
| `>=4.51.3,<=5.5.0` (this repo) | 0.32.1 | 0.31.3 | 0.6.4 |
| `>=5.5.0` (Studio override) | 0.32.1 | 0.31.3 | 0.6.15 |

The first row matches what the Apple Silicon lane resolved on its most recent green run. The second matches what the installer produces on a user machine.

## Bumping these later

Bump deliberately, after the Apple Silicon lane passes on the new release. That lane runs daily against main at 04:23 UTC and it is what caught 0.32.1 originally.

An earlier revision of this description claimed the detection path stayed intact for free. It did not. `mlx-ci.yml` installs with `pip install -e .[mlx]`, so an exact pin in that extra would have held the scheduled lane at 0.32.1 forever and removed the only place real MLX runs on Apple hardware. `cb72d779` and `cb328ff7` fix that. The job is now a matrix rather than an in-place upgrade:

- `pinned` runs on every execution and gates. It is the exact set `pyproject` ships, which matters because PR runs of this job are opt-in behind the `mlx` label, so without this leg the supported combination would never be exercised on Apple hardware at all.
- `latest` is added only on `schedule` and `workflow_dispatch`, upgrades `mlx`, `mlx-lm` and `mlx-vlm`, prints the resolved versions, and is `continue-on-error`. It deliberately installs combinations nobody supports yet, so letting it fail the workflow would turn every upstream release into a red main until someone bumps the pin.

`mlx-vlm` is upgraded past its `<0.7.0` ceiling in that leg too, since otherwise the only lane that could justify lifting the ceiling never tests the version it would be lifted to.

The Linux CPU lanes in `consolidated-tests-ci.yml` were never affected, since they install `mlx>=0.22.0` explicitly rather than through `.[mlx]`.

So this change stops an unreviewed release reaching users before the nightly has had a chance to report, without blinding the nightly.

## Tradeoff worth stating

An exact pin in a library propagates to every consumer, and Apple Silicon users generally want current mlx for new model support. The counter-argument is the record above: mlx patch releases have broken this repo three times in a week. If the pin turns out to lag too far behind in practice, the fallback is a ceiling only (`mlx>=0.22.0,<0.33`) rather than a return to no bound at all.


