### PR TITLE
Run the RNG rewind tests on the Apple Silicon lane

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -84,6 +84,12 @@ jobs:
         # on Apple Silicon; on Linux runners it would run against tests/mlx_simulation/ stubs.
         run: python -m pytest tests/test_mlx_torch_shim_smoke.py -v
 
+      - name: tests/test_mlx_rng_rewind.py
+        # PRNG capture and rewind across the mx.compile fallbacks. The Linux CPU
+        # lane gates this too, but the mlx 0.32.1 sentinel that broke it shipped
+        # in the Metal wheel first, so this is where a repeat surfaces earliest.
+        run: python -m pytest tests/test_mlx_rng_rewind.py -v -rs
+
       - name: tests/test_mlx_switch_lora.py
         # Real-runtime routed LoRA training and adapter lifecycle coverage.
         run: python -m pytest tests/test_mlx_switch_lora.py -v -rs


### PR DESCRIPTION
## What this changes

Adds one step to the Apple Silicon lane in `.github/workflows/mlx-ci.yml`:

```yaml
- name: tests/test_mlx_rng_rewind.py
  run: python -m pytest tests/test_mlx_rng_rewind.py -v -rs
```

## Why

`tests/test_mlx_rng_rewind.py` came in with #1081 and is currently gated only on the Linux CPU lane in `consolidated-tests-ci.yml`. Its subject is the mlx 0.32.1 change that turned `mx.random.state` into a sentinel refusing item assignment, and that change arrived in the Metal wheel. The Apple Silicon lane is therefore where a repeat of that class of break shows up first.

Nothing in the file needs Metal, which is why it is not named `*_metal.py`. It is key arithmetic, a context manager, and a trainer driven with `mx.compile` rigged to fail. But running it here costs a few seconds and closes the gap between the backend the tests exercise and the backend the bug actually arrived on.

The same lane already carries `tests/test_mlx_save_over_source.py` for exactly this reason, and its comment records the precedent: "mlx 0.32.1 made that fail, which is what took this job red on 2026-08-18".

## Verification

Ran the whole lane on a staging replica of this branch, macOS arm64 hosted runner, opted in with the `mlx` label:

```
mlx 0.32.1 + mlx-metal 0.32.1 + mlx-lm 0.31.3 + mlx-vlm 0.6.4
tests/test_mlx_rng_rewind.py .......... 30 passed
```

All 21 steps in the job green, including every pre-existing one. This is the first time that file has run against real Metal rather than the Linux CPU backend.
