### PR TITLE
Skip the MLX RNG rewind tests when mlx.core is the torch simulation

### DIFF
--- a/tests/test_mlx_rng_rewind.py
+++ b/tests/test_mlx_rng_rewind.py
@@ -34,6 +34,16 @@ import pytest
 mx = pytest.importorskip("mlx.core")
 nn = pytest.importorskip("mlx.nn")
 
+# `importorskip` is not enough here. Most of the tests/test_mlx_*.py files install the
+# torch-backed simulation from tests/mlx_simulation into sys.modules and never take it out,
+# so by the time this module is collected in a full-suite run `mlx.core` can be that stub
+# rather than the real package, and `importorskip` happily returns it. Everything below pins
+# real mlx >= 0.32.1 semantics (a `mx.random.state` sentinel that refuses item assignment),
+# which the simulation does not model, so running against the stub asserts nothing and fails.
+if "mlx_simulation" in (getattr(mx, "__file__", "") or ""):
+    pytest.skip("mlx.core is the tests/mlx_simulation stub, not real MLX",
+                allow_module_level = True)
+
 from mlx.utils import tree_map                                     # noqa: E402
 
 from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig  # noqa: E402

--- a/tests/test_mlx_rng_rewind.py
+++ b/tests/test_mlx_rng_rewind.py
@@ -34,12 +34,10 @@ import pytest
 mx = pytest.importorskip("mlx.core")
 nn = pytest.importorskip("mlx.nn")
 
-# `importorskip` is not enough here. Most of the tests/test_mlx_*.py files install the
-# torch-backed simulation from tests/mlx_simulation into sys.modules and never take it out,
-# so by the time this module is collected in a full-suite run `mlx.core` can be that stub
-# rather than the real package, and `importorskip` happily returns it. Everything below pins
-# real mlx >= 0.32.1 semantics (a `mx.random.state` sentinel that refuses item assignment),
-# which the simulation does not model, so running against the stub asserts nothing and fails.
+# `importorskip` is not enough: most tests/test_mlx_*.py files install the torch-backed
+# tests/mlx_simulation stub into sys.modules and never remove it, so in a full-suite run
+# `mlx.core` can be that stub. Everything below pins real mlx >= 0.32.1 semantics (a
+# `mx.random.state` sentinel refusing item assignment), which the stub does not model.
 if "mlx_simulation" in (getattr(mx, "__file__", "") or ""):
     pytest.skip("mlx.core is the tests/mlx_simulation stub, not real MLX",
                 allow_module_level = True)


### PR DESCRIPTION
## Problem

`tests/test_mlx_rng_rewind.py` fails 19 times in a full-suite run and passes when run on its own.

The file guards itself with `pytest.importorskip("mlx.core")`, which is not enough here. Roughly thirty `tests/test_mlx_*.py` files install the torch-backed stub from `tests/mlx_simulation` into `sys.modules`, and most of them never take it out. `tests/test_mlx_trainer_internals.py` is the exception: it captures the real modules, and on teardown pops the shim entries and strips `_MLXFinder` from `sys.meta_path`. The rest just call `simulate_mlx_on_torch()` in a module-scoped autouse fixture with no teardown.

So by the time this module is collected, `mlx.core` is frequently the stub, `importorskip` returns it rather than skipping, and the tests run against a fake:

```
mlx.core.__file__ : tests/mlx_simulation/mlx_stub.py
```

Every case in the file pins real mlx >= 0.32.1 semantics, where `mx.random.state` is a sentinel that refuses item assignment. The simulation does not model that, so the assertions are meaningless against it and fail.

This is a test isolation problem, not a product bug. The fix in #1081 is correct; only its test was under-guarded.

## Fix

Detect the stub by its `__file__` and skip at module level. Real MLX still runs the tests, which is what matters for the Mac lane.

## Verification

On `main`, `tests/test_mlx_*.py` plus the two files that also trip over the leaked shim:

| | before | after |
|---|---|---|
| failed | 19 | **0** |
| passed | 864 | 853 |
| skipped | 93 | 94 |

Run on its own with no MLX installed, the file skips cleanly as before.

## Note on the wider issue

The narrow fix is deliberate. Making every `test_mlx_*.py` file restore `sys.modules` would touch about thirty files and risks breaking cases that currently rely on the leak, which is a much larger change than a CI-noise fix warrants. If you would rather have the shim cleaned up centrally, the teardown in `tests/test_mlx_trainer_internals.py:34` is the pattern to lift into a shared fixture, and I can do that as a follow-up.
