### PR TITLE
Keep a trained classification head when merging to 16bit

### DIFF
--- a/tests/test_merge_e2e_classification_head.py
+++ b/tests/test_merge_e2e_classification_head.py
@@ -332,6 +332,48 @@ def test_the_corrected_config_is_re_uploaded_when_pushing():
     )
 
 
+def test_the_mxfp4_rewrite_counts_a_seeded_head(tmp_path):
+    """An mxfp4 base with save_method='merged_16bit' routes to _merge_and_overwrite_lora_mxfp4,
+    whose every `count += 1` was gated on lora_A. A seeded head has no lora_A, so it counted
+    zero there while the Step-7 `_count_backed_lora_modules` counted it as backed, and the
+    export aborted on the count mismatch. The dense path has always had this branch.
+    """
+    import collections
+    from safetensors.torch import save_file
+    from unsloth_zoo.saving_utils import LoraStats, _merge_and_overwrite_lora_mxfp4
+
+    head = torch.full((3, 4), 0.5)
+
+    class _Saved(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            linear = torch.nn.Linear(4, 3, bias=False)
+            with torch.no_grad():
+                linear.weight.copy_(head)
+            self.modules_to_save = torch.nn.ModuleDict({"default": linear})
+
+    stats = LoraStats(None, None, None, 0)
+    stats.module = _Saved()
+    lora_weights = collections.defaultdict(lambda: None)
+    lora_weights["score"] = stats
+
+    # A 16-bit tensor coexisting with the mxfp4 pair is exactly where a seeded head lands.
+    fname = "model.safetensors"
+    save_file({"score.weight": torch.zeros(3, 4, dtype=torch.bfloat16)},
+              str(tmp_path / fname), metadata={"format": "pt"})
+
+    count, keys = _merge_and_overwrite_lora_mxfp4(
+        save_directory=str(tmp_path), filename=fname, lora_weights=lora_weights,
+        output_dtype=torch.bfloat16, model_class_name="LlamaForSequenceClassification",
+    )
+    assert count == 1, (
+        f"the mxfp4 rewrite counted {count} saved modules for one modules_to_save head; "
+        "Step-7 would see one more backed module than saved and abort the export"
+    )
+    written = H.read_safetensors_dir(str(tmp_path))["score.weight"]
+    assert torch.equal(written.float(), head), "the trained head was not written"
+
+
 def test_appending_to_a_shard_leaves_the_existing_tensors_byte_identical(tmp_path):
     """`_stream_rewrite_resized_shard` gained an append path; the copy path must not move."""
     from safetensors.torch import save_file

--- a/tests/test_merge_e2e_classification_head.py
+++ b/tests/test_merge_e2e_classification_head.py
@@ -1,0 +1,309 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""End-to-end merge correctness for a trained head the base checkpoint does not have.
+
+`merged_16bit` takes its weights from the base checkpoint and rewrites the shards in
+place, so a `modules_to_save` head trained on a causal-LM base (sequence classification,
+token classification) had no key to be written into and was dropped. The Step-7 count
+excluded it from both sides, so nothing raised: the export simply reloaded with a fresh
+random head and the wrong label count.
+
+The load-bearing assertion is that the reloaded head is bit-identical to the trained one.
+A shape match alone passes against a randomly initialized head of the right size.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+import torch
+
+import _merge_e2e_helpers as H
+
+LABELS = {0: "neg", 1: "neu", 2: "pos", 3: "mixed", 4: "other"}
+
+
+def _labels(num_labels):
+    """id2label sized to the head; a short map would silently redefine num_labels."""
+    return {i: LABELS.get(i, f"label_{i}") for i in range(num_labels)}
+
+
+def _distinct_head(out_features, in_features):
+    """A head no random initializer would produce, so a re-init cannot pass by luck."""
+    return torch.arange(out_features * in_features, dtype=torch.float32).reshape(
+        out_features, in_features) / 97.0
+
+
+def _build_seqcls_case(tmp_path, *, num_labels=5, dtype=torch.float32, labels=True):
+    from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForSequenceClassification
+    from peft import LoraConfig, get_peft_model
+
+    H.set_offline_cpu_env()
+    if not H.family_available("llama"):
+        pytest.skip("llama unavailable")
+
+    base = str(tmp_path / "base")
+    spec = H.make_spec("llama")
+    torch.manual_seed(H.SEED)
+    AutoModelForCausalLM.from_config(spec.config).to(torch.float32).save_pretrained(
+        base, safe_serialization=True)
+
+    config = AutoConfig.from_pretrained(base)
+    config.num_labels = num_labels
+    if labels:
+        config.id2label = _labels(num_labels)
+        config.label2id = {v: k for k, v in config.id2label.items()}
+        config.problem_type = "single_label_classification"
+    torch.manual_seed(H.SEED)
+    model = AutoModelForSequenceClassification.from_config(config).to(torch.float32)
+    model.config._name_or_path = base
+
+    peft_model = get_peft_model(model, LoraConfig(
+        r=8, lora_alpha=16, lora_dropout=0.0, bias="none",
+        target_modules=["q_proj", "v_proj"], modules_to_save=["score"],
+        task_type="SEQ_CLS"))
+    H.seed_lora(peft_model)
+
+    head = _distinct_head(num_labels, spec.config.hidden_size)
+    with torch.no_grad():
+        for name, param in peft_model.named_parameters():
+            if name.endswith("score.modules_to_save.default.weight"):
+                param.copy_(head)
+
+    out = str(tmp_path / "out")
+    H.run_merge(peft_model, base, out, save_dtype=dtype)
+    return base, out, head
+
+
+def _exported_config(out):
+    with open(os.path.join(out, "config.json"), encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_trained_head_survives_the_merge(tmp_path):
+    """The regression: on the unfixed code `score.weight` is absent and the reload is random."""
+    from transformers import AutoModelForSequenceClassification
+
+    _, out, head = _build_seqcls_case(tmp_path)
+
+    written = H.read_safetensors_dir(out)
+    assert "score.weight" in written, sorted(written)
+
+    reloaded, info = AutoModelForSequenceClassification.from_pretrained(
+        out, output_loading_info=True, local_files_only=True)
+    assert [k for k in info["missing_keys"] if "score" in k] == []
+    assert torch.equal(reloaded.score.weight.detach().float(), head)
+
+
+def test_label_maps_and_architecture_follow_the_head(tmp_path):
+    _, out, _ = _build_seqcls_case(tmp_path)
+
+    data = _exported_config(out)
+    assert data["architectures"] == ["LlamaForSequenceClassification"]
+    assert data["id2label"] == {str(k): v for k, v in _labels(5).items()}
+    assert data["label2id"] == {v: k for k, v in _labels(5).items()}
+    assert data["problem_type"] == "single_label_classification"
+
+
+def test_the_head_bias_travels_with_its_weight():
+    """Unit level on purpose: Llama builds `score` with bias=False, so an end-to-end case
+    cannot show this. Heads that do carry a bias must not have it left behind."""
+    import collections
+    from unsloth_zoo.saving_utils import LoraStats, _unbacked_trained_tensors
+
+    class _BiasedHead(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.modules_to_save = torch.nn.ModuleDict(
+                {"default": torch.nn.Linear(4, 3, bias=True)})
+
+    stats = LoraStats(None, None, None, 0)
+    stats.module = _BiasedHead()
+    lora_weights = collections.defaultdict(lambda: LoraStats(None, None, None, 0))
+    lora_weights["score"] = stats
+
+    found = _unbacked_trained_tensors(lora_weights, {"model.embed_tokens.weight"},
+                                      "LlamaForCausalLM")
+    assert set(found) == {"score.weight", "score.bias"}
+    assert tuple(found["score.bias"].shape) == (3,)
+
+
+@pytest.mark.parametrize("num_labels", [2, 3, 5, 17])
+def test_any_label_count_round_trips(tmp_path, num_labels):
+    from transformers import AutoModelForSequenceClassification
+
+    _, out, head = _build_seqcls_case(tmp_path, num_labels=num_labels)
+    reloaded = AutoModelForSequenceClassification.from_pretrained(out, local_files_only=True)
+    assert reloaded.config.num_labels == num_labels
+    assert torch.equal(reloaded.score.weight.detach().float(), head)
+
+
+def test_the_backbone_merge_is_unchanged_by_the_seeding(tmp_path):
+    """Rewriting a shard to add the head must not disturb the tensors already in it."""
+    base, out, _ = _build_seqcls_case(tmp_path)
+
+    base_tensors = H.read_safetensors_dir(base)
+    written = H.read_safetensors_dir(out)
+    assert set(written) == set(base_tensors) | {"score.weight"}
+    for key, tensor in base_tensors.items():
+        if any(t in key for t in ("q_proj", "v_proj")):
+            continue                                    # LoRA targets, expected to differ
+        assert torch.equal(written[key], tensor), key
+
+
+def test_a_half_precision_export_keeps_the_head(tmp_path):
+    from transformers import AutoModelForSequenceClassification
+
+    _, out, head = _build_seqcls_case(tmp_path, dtype=torch.bfloat16)
+    written = H.read_safetensors_dir(out)
+    assert written["score.weight"].dtype == torch.bfloat16
+    reloaded = AutoModelForSequenceClassification.from_pretrained(out, local_files_only=True)
+    got = reloaded.score.weight.detach().float()
+    assert torch.allclose(got, head, atol=1e-2, rtol=1e-2)
+
+
+def test_a_plain_causal_lm_export_is_untouched(tmp_path):
+    """No `modules_to_save` head, so nothing is seeded and no head fields are written."""
+    from transformers import AutoModelForCausalLM
+    from peft import LoraConfig, get_peft_model
+
+    H.set_offline_cpu_env()
+    if not H.family_available("llama"):
+        pytest.skip("llama unavailable")
+    base, out = str(tmp_path / "base"), str(tmp_path / "out")
+    spec = H.make_spec("llama")
+    torch.manual_seed(H.SEED)
+    AutoModelForCausalLM.from_config(spec.config).to(torch.float32).save_pretrained(
+        base, safe_serialization=True)
+    model = AutoModelForCausalLM.from_pretrained(base)
+    model.config._name_or_path = base
+    peft_model = get_peft_model(model, LoraConfig(
+        r=8, lora_alpha=16, target_modules=["q_proj", "v_proj"]))
+    H.seed_lora(peft_model)
+    H.run_merge(peft_model, base, out, save_dtype=torch.float32)
+
+    assert set(H.read_safetensors_dir(out)) == set(H.read_safetensors_dir(base))
+    data = _exported_config(out)
+    assert data["architectures"] == ["LlamaForCausalLM"]
+    assert "id2label" not in data or len(data["id2label"]) == 2   # transformers' own default
+
+
+# ---- unit level -------------------------------------------------------------------
+
+def test_only_modules_to_save_is_seeded_not_an_unbacked_lora():
+    """A LoRA target missing from the base has no trained tensor of its own to lose, so it
+    must stay excluded; only `modules_to_save` carries weights that exist nowhere else."""
+    import collections
+    from unsloth_zoo.saving_utils import LoraStats, _unbacked_trained_tensors
+
+    lora_weights = collections.defaultdict(lambda: LoraStats(None, None, None, 0))
+    lora_weights["vision_tower.layers.0.q_proj"] = LoraStats(None, None, None, 0)
+    assert _unbacked_trained_tensors(lora_weights, {"model.layers.0.q_proj.weight"},
+                                     "LlamaForCausalLM") == {}
+
+
+def test_a_backed_head_is_not_seeded_twice():
+    """When the base already ships the key, the ordinary in-place merge owns it."""
+    import collections
+    from unsloth_zoo.saving_utils import LoraStats, _unbacked_trained_tensors
+
+    class _Saved(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.modules_to_save = torch.nn.ModuleDict({"default": torch.nn.Linear(4, 3)})
+
+    stats = LoraStats(None, None, None, 0)
+    stats.module = _Saved()
+    lora_weights = collections.defaultdict(lambda: LoraStats(None, None, None, 0))
+    lora_weights["score"] = stats
+    assert _unbacked_trained_tensors(lora_weights, {"score.weight"}, "LlamaForCausalLM") == {}
+    assert "score.weight" in _unbacked_trained_tensors(
+        lora_weights, {"model.embed_tokens.weight"}, "LlamaForCausalLM")
+
+
+@pytest.mark.parametrize("name", ["lm_head", "embed_tokens", "model.language_model.lm_head"])
+def test_backbone_tensors_are_never_seeded(name):
+    """gemma3 ties its text embeddings, so that architecture has no `lm_head` slot at all.
+    Seeding one put an unexpected key in the export and broke the text_only resize case on
+    transformers 4.51.3, which is why this exclusion exists rather than a general rule."""
+    import collections
+    from unsloth_zoo.saving_utils import LoraStats, _unbacked_trained_tensors
+
+    class _Saved(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.modules_to_save = torch.nn.ModuleDict({"default": torch.nn.Linear(4, 3)})
+
+    stats = LoraStats(None, None, None, 0)
+    stats.module = _Saved()
+    lora_weights = collections.defaultdict(lambda: LoraStats(None, None, None, 0))
+    lora_weights[name] = stats
+    assert _unbacked_trained_tensors(lora_weights, {"model.layers.0.q_proj.weight"},
+                                     "LlamaForCausalLM") == {}
+
+
+def test_a_sharded_export_records_the_head_in_its_index(tmp_path):
+    """transformers resolves a sharded checkpoint through the index alone, so a key absent
+    from the weight_map is invisible even though the bytes are on disk."""
+    from unsloth_zoo.saving_utils import _add_keys_to_index
+
+    index = tmp_path / "model.safetensors.index.json"
+    index.write_text(json.dumps({
+        "metadata": {"total_size": 8},
+        "weight_map": {"model.embed_tokens.weight": "model-00001-of-00002.safetensors"},
+    }), encoding="utf-8")
+
+    seeded = {"score.weight": "model-00002-of-00002.safetensors"}
+    assert _add_keys_to_index(str(tmp_path), seeded) is True
+    weight_map = json.loads(index.read_text(encoding="utf-8"))["weight_map"]
+    assert weight_map["score.weight"] == "model-00002-of-00002.safetensors"
+    assert weight_map["model.embed_tokens.weight"] == "model-00001-of-00002.safetensors"
+
+    # Idempotent: a second pass has nothing to add, so nothing is re-uploaded.
+    assert _add_keys_to_index(str(tmp_path), seeded) is False
+
+
+def test_an_unsharded_export_has_no_index_to_touch(tmp_path):
+    from unsloth_zoo.saving_utils import _add_keys_to_index
+    assert _add_keys_to_index(str(tmp_path), {"score.weight": "model.safetensors"}) is False
+
+
+def test_appending_to_a_shard_leaves_the_existing_tensors_byte_identical(tmp_path):
+    """`_stream_rewrite_resized_shard` gained an append path; the copy path must not move."""
+    from safetensors.torch import save_file
+    from unsloth_zoo.saving_utils import _stream_rewrite_resized_shard
+
+    src = str(tmp_path / "model.safetensors")
+    original = {"a": torch.randn(4, 5), "b": torch.arange(6, dtype=torch.float32)}
+    save_file(original, src, metadata={"format": "pt"})
+
+    with open(src, "rb") as f:
+        length_of_header = int.from_bytes(f.read(8), "little")
+        header_metadata = json.loads(f.read(length_of_header))
+
+    added = {"score.weight": torch.full((3, 5), 0.25)}
+    dst = str(tmp_path / "out.safetensors")
+    _stream_rewrite_resized_shard(src, dst, header_metadata, length_of_header, added)
+
+    from safetensors.torch import load_file
+    got = load_file(dst)
+    assert set(got) == {"a", "b", "score.weight"}
+    for key, tensor in original.items():
+        assert torch.equal(got[key], tensor), key
+    assert torch.equal(got["score.weight"], added["score.weight"])

--- a/tests/test_merge_e2e_classification_head.py
+++ b/tests/test_merge_e2e_classification_head.py
@@ -284,6 +284,54 @@ def test_an_unsharded_export_has_no_index_to_touch(tmp_path):
     assert _add_keys_to_index(str(tmp_path), {"score.weight": "model.safetensors"}) is False
 
 
+def test_seeding_refuses_rather_than_dropping_the_head_when_disk_is_short(tmp_path, monkeypatch):
+    """Adding a key rewrites the shard through a temp copy, and appending moves every offset
+    so there is no in-place fallback. Refusing beats silently dropping the head, which is the
+    bug this whole path exists to fix."""
+    import collections
+    import shutil as _shutil
+    from safetensors.torch import save_file
+    from unsloth_zoo.saving_utils import LoraStats, _seed_unbacked_trained_tensors
+
+    save_file({"model.embed_tokens.weight": torch.zeros(4, 4)},
+              str(tmp_path / "model.safetensors"), metadata={"format": "pt"})
+
+    class _Saved(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.modules_to_save = torch.nn.ModuleDict({"default": torch.nn.Linear(4, 3)})
+
+    stats = LoraStats(None, None, None, 0)
+    stats.module = _Saved()
+    lora_weights = collections.defaultdict(lambda: LoraStats(None, None, None, 0))
+    lora_weights["score"] = stats
+
+    monkeypatch.setattr(_shutil, "disk_usage",
+                        lambda _p: type("U", (), {"free": 1024})())
+    with pytest.raises(RuntimeError, match="not enough free disk"):
+        _seed_unbacked_trained_tensors(str(tmp_path), ["model.safetensors"],
+                                       lora_weights, "LlamaForCausalLM")
+    # The shard must be left exactly as it was, not half-rewritten.
+    assert set(H.read_safetensors_dir(str(tmp_path))) == {"model.embed_tokens.weight"}
+    assert not list(tmp_path.glob("*.unsloth_seed_tmp"))
+
+
+def test_the_corrected_config_is_re_uploaded_when_pushing():
+    """Step 2 uploads config.json before the head exists and Step 7's folder re-upload is
+    skipped in low-disk mode, so without this the remote keeps the causal-LM config beside
+    shards that hold the head."""
+    import inspect
+    from unsloth_zoo.saving_utils import merge_and_overwrite_lora
+
+    src = inspect.getsource(merge_and_overwrite_lora)
+    seeded = src.split("_seeded_head_keys", 1)[1]
+    block = seeded.split("for filename in ProgressBar", 1)[0]
+    assert 'upload_items("config.json")' in block, (
+        "the seeding block no longer re-uploads config.json; a low-disk push would leave "
+        "the remote config describing the base architecture instead of the trained head."
+    )
+
+
 def test_appending_to_a_shard_leaves_the_existing_tensors_byte_identical(tmp_path):
     """`_stream_rewrite_resized_shard` gained an append path; the copy path must not move."""
     from safetensors.torch import save_file

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -280,8 +280,7 @@ def _get_modules_to_save_weight(module, attr = "weight"):
     if modules_to_save is None:
         return None
 
-    # `attr` so a head's bias travels with its weight; defaulted, so existing callers
-    # keep asking for the weight alone.
+    # `attr` so a head's bias travels with its weight; defaulted for existing callers.
     # Prefer the default adapter, else first entry with a weight
     for key in ("default",):
         try:
@@ -655,8 +654,8 @@ except:
     }
 pass
 
-# For a tensor appended to a shard, which has no source header entry to copy a label from.
-# Reversed rather than hand-written so it cannot drift from the table above.
+# Labels a tensor appended to a shard, which has no header entry to copy from. Reversed so
+# it cannot drift from the table above.
 _SAFETENSORS_DTYPE_NAMES = {v : k for k, v in SAFETENSORS_DTYPES.items()}
 
 @torch.inference_mode
@@ -2229,9 +2228,8 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
             elif (W is not None and lora_stats is not None and not action_logged
                   and getattr(lora_stats, "lora_A", None) is None
                   and getattr(lora_stats, "module", None) is not None):
-                # modules_to_save with no LoRA delta, e.g. a seeded classification head. The
-                # dense path writes and counts these; without the same branch here the Step-7
-                # check sees one more backed module than were saved and the export aborts.
+                # modules_to_save with no LoRA delta (a seeded head). The dense path writes and
+                # counts these; without the same branch Step-7 sees one extra backed module and aborts.
                 saved_weight = _get_modules_to_save_weight(lora_stats.module)
                 if saved_weight is None and hasattr(lora_stats.module, "weight"):
                     saved_weight = lora_stats.module.weight
@@ -3571,10 +3569,9 @@ def merge_and_overwrite_lora(
     _fp8_prerewrite_keys = _collect_fp8_weight_keys(save_directory, final_safetensors_list) if _fp8_post_cleanup else set()
     _defer_low_disk = low_disk_space_usage and push_to_hub and _fp8_post_cleanup
 
-    # A trained head the base checkpoint never had (sequence classification on a causal-LM
-    # base) is invisible to the in-place shard rewrite, so put it on disk before the loop
-    # runs. Scoped to merged_16bit: the mxfp4 and native-quant paths preserve packed base
-    # tensors rather than rewriting them, so seeding a 16bit head there would not reload.
+    # A trained head the base checkpoint never had is invisible to the in-place shard rewrite,
+    # so put it on disk before the loop. Scoped to merged_16bit: the mxfp4 and native-quant
+    # paths preserve packed base tensors, so a seeded 16bit head there would not reload.
     _seeded_head_keys = _seed_unbacked_trained_tensors(
         save_directory, final_safetensors_list, lora_weights, _merge_model_class_name,
         output_dtype = output_dtype, tie_word_embeddings = _merge_tie_word_embeddings,
@@ -3583,10 +3580,9 @@ def merge_and_overwrite_lora(
         print(f"Unsloth: Writing {len(_seeded_head_keys)} trained tensor(s) absent from the "
               f"base checkpoint: {', '.join(sorted(_seeded_head_keys))}")
         _carry_over_trained_head_config(save_directory, model, _merge_model_class_name)
-        # Step 2 uploaded config.json before the head existed and Step 7's folder re-upload
-        # is skipped in low-disk mode, so push the corrected one now. Otherwise the remote
-        # keeps a causal-LM config beside shards that do hold the head, which is the same
-        # config/weights mismatch this seeding exists to remove.
+        # Step 2 uploaded config.json before the head existed and Step 7's folder re-upload is
+        # skipped in low-disk mode, so push the corrected one now. Otherwise the remote keeps a
+        # causal-LM config beside shards that do hold the head.
         if push_to_hub: upload_items("config.json")
         # The index was copied (and, when pushing, already uploaded) before the seeding, so
         # re-upload it if the new key had to be added there.
@@ -4579,10 +4575,9 @@ def _backed_lora_keys(converted, safetensor_keys_seen, tie_word_embeddings,
 pass
 
 
-# Backbone tensors, never a task head. They belong to the base architecture, so when the
-# merge decides it cannot place one (tied embeddings, or a composite-VLM prefix it will not
-# bridge) a bare top-level copy is wrong: gemma3 ties its text embeddings, and seeding
-# `lm_head.weight` there puts a key in the export that the model has no slot for.
+# Backbone tensors, never a task head. When the merge cannot place one (tied embeddings, or a
+# composite-VLM prefix it will not bridge) a bare top-level copy is wrong: gemma3 ties its text
+# embeddings, so seeding `lm_head.weight` puts a key in the export with no slot for it.
 _NEVER_SEEDED = ("lm_head", "embed_tokens")
 
 
@@ -4654,10 +4649,9 @@ def _seed_unbacked_trained_tensors(save_directory, safetensors_list, lora_weight
     target = min(sizes, key = sizes.get)
     path = os.path.join(save_directory, target)
 
-    # safetensors is a flat format, so adding a key means rewriting the shard through a temp
-    # copy, and a transient second copy of it has to fit. There is no in-place fallback the
-    # way a resize has: appending moves every offset. Refuse loudly rather than drop the head,
-    # since dropping it silently is the bug this is here to fix.
+    # safetensors is flat, so adding a key rewrites the shard through a temp copy that has to
+    # fit. Appending moves every offset, so there is no in-place fallback like a resize has.
+    # Refuse loudly rather than drop the head, since a silent drop is the bug this fixes.
     needed = sizes[target] + sum(t.numel() * t.element_size() for t in tensors.values())
     margin = 64 * 1024 * 1024
     try: free_bytes = shutil.disk_usage(save_directory).free
@@ -4714,9 +4708,8 @@ def _add_keys_to_index(save_directory, seeded_keys):
 pass
 
 
-# Fields that describe the head rather than the backbone. Written only alongside the head's
-# own tensors: advertising a classifier whose weights are not there is the same silent
-# failure in reverse, since the reload then builds a random one and reports nothing.
+# Fields describing the head, not the backbone. Written only alongside the head's own tensors:
+# advertising a classifier whose weights are absent is the same silent failure in reverse.
 _TRAINED_HEAD_CONFIG_FIELDS = ("id2label", "label2id", "problem_type")
 
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2226,6 +2226,23 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                     count += 1
                     W = _merge_lora(W, lora_stats, output_key)
                     action_logged = True
+            elif (W is not None and lora_stats is not None and not action_logged
+                  and getattr(lora_stats, "lora_A", None) is None
+                  and getattr(lora_stats, "module", None) is not None):
+                # modules_to_save with no LoRA delta, e.g. a seeded classification head. The
+                # dense path writes and counts these; without the same branch here the Step-7
+                # check sees one more backed module than were saved and the export aborts.
+                saved_weight = _get_modules_to_save_weight(lora_stats.module)
+                if saved_weight is None and hasattr(lora_stats.module, "weight"):
+                    saved_weight = lora_stats.module.weight
+                if saved_weight is not None:
+                    W = saved_weight.to(
+                        W.device,
+                        dtype = output_dtype if output_dtype is not None else W.dtype,
+                        non_blocking = True,
+                    )
+                    count += 1
+                    action_logged = True
 
             if W is None:
                 continue

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3566,6 +3566,11 @@ def merge_and_overwrite_lora(
         print(f"Unsloth: Writing {len(_seeded_head_keys)} trained tensor(s) absent from the "
               f"base checkpoint: {', '.join(sorted(_seeded_head_keys))}")
         _carry_over_trained_head_config(save_directory, model, _merge_model_class_name)
+        # Step 2 uploaded config.json before the head existed and Step 7's folder re-upload
+        # is skipped in low-disk mode, so push the corrected one now. Otherwise the remote
+        # keeps a causal-LM config beside shards that do hold the head, which is the same
+        # config/weights mismatch this seeding exists to remove.
+        if push_to_hub: upload_items("config.json")
         # The index was copied (and, when pushing, already uploaded) before the seeding, so
         # re-upload it if the new key had to be added there.
         if _add_keys_to_index(save_directory, _seeded_head_keys) and push_to_hub:
@@ -4631,6 +4636,24 @@ def _seed_unbacked_trained_tensors(save_directory, safetensors_list, lora_weight
     # cheapest place to put a head measured in kilobytes.
     target = min(sizes, key = sizes.get)
     path = os.path.join(save_directory, target)
+
+    # safetensors is a flat format, so adding a key means rewriting the shard through a temp
+    # copy, and a transient second copy of it has to fit. There is no in-place fallback the
+    # way a resize has: appending moves every offset. Refuse loudly rather than drop the head,
+    # since dropping it silently is the bug this is here to fix.
+    needed = sizes[target] + sum(t.numel() * t.element_size() for t in tensors.values())
+    margin = 64 * 1024 * 1024
+    try: free_bytes = shutil.disk_usage(save_directory).free
+    except OSError: free_bytes = None
+    if free_bytes is not None and free_bytes < needed + margin:
+        raise RuntimeError(
+            f"Unsloth: not enough free disk to write the trained tensor(s) "
+            f"{', '.join(sorted(tensors))} into {target} (free={free_bytes}, "
+            f"need~={needed + margin}). They exist only in memory, so the export would "
+            f"otherwise reload with a randomly initialized head. Free disk space, or point "
+            f"the save directory at a larger volume."
+        )
+
     with open(path, "rb") as f:
         length_of_header = int.from_bytes(f.read(8), "little")
         header_metadata = json.loads(f.read(length_of_header))

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -275,23 +275,25 @@ def _merge_lora(W, lora_stats, name, use_dequant_base = False):
 pass
 
 
-def _get_modules_to_save_weight(module):
+def _get_modules_to_save_weight(module, attr = "weight"):
     modules_to_save = getattr(module, "modules_to_save", None)
     if modules_to_save is None:
         return None
 
+    # `attr` so a head's bias travels with its weight; defaulted, so existing callers
+    # keep asking for the weight alone.
     # Prefer the default adapter, else first entry with a weight
     for key in ("default",):
         try:
             candidate = modules_to_save[key]
-            if hasattr(candidate, "weight"):
-                return candidate.weight
+            if hasattr(candidate, attr):
+                return getattr(candidate, attr)
         except Exception:
             continue
 
     for _, candidate in modules_to_save.items():
-        if hasattr(candidate, "weight"):
-            return candidate.weight
+        if hasattr(candidate, attr):
+            return getattr(candidate, attr)
 
     return None
 
@@ -652,6 +654,10 @@ except:
         'U16': torch.uint16,
     }
 pass
+
+# For a tensor appended to a shard, which has no source header entry to copy a label from.
+# Reversed rather than hand-written so it cannot drift from the table above.
+_SAFETENSORS_DTYPE_NAMES = {v : k for k, v in SAFETENSORS_DTYPES.items()}
 
 @torch.inference_mode
 def _merge_and_overwrite_lora(
@@ -3547,6 +3553,24 @@ def merge_and_overwrite_lora(
     # cleanup anchors on weights that were actually FP8 (not a `*_scale` name heuristic).
     _fp8_prerewrite_keys = _collect_fp8_weight_keys(save_directory, final_safetensors_list) if _fp8_post_cleanup else set()
     _defer_low_disk = low_disk_space_usage and push_to_hub and _fp8_post_cleanup
+
+    # A trained head the base checkpoint never had (sequence classification on a causal-LM
+    # base) is invisible to the in-place shard rewrite, so put it on disk before the loop
+    # runs. Scoped to merged_16bit: the mxfp4 and native-quant paths preserve packed base
+    # tensors rather than rewriting them, so seeding a 16bit head there would not reload.
+    _seeded_head_keys = _seed_unbacked_trained_tensors(
+        save_directory, final_safetensors_list, lora_weights, _merge_model_class_name,
+        output_dtype = output_dtype, tie_word_embeddings = _merge_tie_word_embeddings,
+    ) if save_method == "merged_16bit" else {}
+    if _seeded_head_keys:
+        print(f"Unsloth: Writing {len(_seeded_head_keys)} trained tensor(s) absent from the "
+              f"base checkpoint: {', '.join(sorted(_seeded_head_keys))}")
+        _carry_over_trained_head_config(save_directory, model, _merge_model_class_name)
+        # The index was copied (and, when pushing, already uploaded) before the seeding, so
+        # re-upload it if the new key had to be added there.
+        if _add_keys_to_index(save_directory, _seeded_head_keys) and push_to_hub:
+            upload_items("model.safetensors.index.json")
+
     for filename in ProgressBar(final_safetensors_list, desc=f'Unsloth: Merging weights into {"mxfp4" if save_method=="mxfp4" else "16bit"}'):
         merged_count, shard_keys = _merge_and_overwrite_lora(
             save_directory = save_directory,
@@ -4494,6 +4518,15 @@ def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_n
     converted = _convert_lora_keys_to_safetensor_format(
         lora_weights, safetensor_keys_seen, model_class_name = model_class_name,
     )
+    return len(_backed_lora_keys(converted, safetensor_keys_seen, tie_word_embeddings,
+                                 count_packed_mxfp4 = count_packed_mxfp4))
+pass
+
+
+def _backed_lora_keys(converted, safetensor_keys_seen, tie_word_embeddings,
+                      count_packed_mxfp4 = True):
+    """The converted keys the merge can actually write, shared with the seeding pass so
+    both agree on what "the base has no counterpart for this" means."""
     # Pre-build parent prefixes once so the MoE backing check is O(1) per key, not O(N).
     valid_prefixes = _build_valid_prefixes(safetensor_keys_seen, count_packed_mxfp4 = count_packed_mxfp4)
 
@@ -4520,7 +4553,159 @@ def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_n
                     return True
         return False
 
-    return sum(1 for key in converted if _backed(key))
+    return {key for key in converted if _backed(key)}
+pass
+
+
+# Backbone tensors, never a task head. They belong to the base architecture, so when the
+# merge decides it cannot place one (tied embeddings, or a composite-VLM prefix it will not
+# bridge) a bare top-level copy is wrong: gemma3 ties its text embeddings, and seeding
+# `lm_head.weight` there puts a key in the export that the model has no slot for.
+_NEVER_SEEDED = ("lm_head", "embed_tokens")
+
+
+def _unbacked_trained_tensors(lora_weights, shard_keys, model_class_name,
+                              tie_word_embeddings = False):
+    """Trained `modules_to_save` weights with no counterpart in the base checkpoint.
+
+    A sequence-classification head trained on a causal-LM base exists ONLY in memory. The
+    shard rewrite overwrites in place, so a key the base never had is never written, and
+    `_count_backed_lora_modules` excludes it from both sides of the Step-7 check, so the
+    head is dropped with no error and the reload silently builds a random one.
+
+    Scoped to `modules_to_save` on purpose. A LoRA adapter whose target is absent from the
+    base (a vision tower under `text_only`) has no trained tensor of its own to lose, and
+    the merge is right to skip it.
+
+    "No counterpart" has to mean what the MERGE means by it, not just a literal key miss:
+    a tied or prefix-bridged `lm_head` reaches the base through `embed_tokens`, and seeding
+    a bare `lm_head.weight` for it puts an unexpected key in the export.
+    """
+    converted = _convert_lora_keys_to_safetensor_format(
+        lora_weights, shard_keys, model_class_name = model_class_name,
+    )
+    backed = _backed_lora_keys(converted, shard_keys, tie_word_embeddings)
+    tensors = {}
+    for key, lora_stats in converted.items():
+        if not isinstance(key, str) or f"{key}.weight" in shard_keys: continue
+        if key in backed or key.rpartition(".")[2] in _NEVER_SEEDED: continue
+        module = getattr(lora_stats, "module", None)
+        if module is None: continue
+        weight = _get_modules_to_save_weight(module)
+        if weight is None: continue
+        tensors[f"{key}.weight"] = weight
+        bias = _get_modules_to_save_weight(module, "bias")
+        if bias is not None: tensors[f"{key}.bias"] = bias
+    return tensors
+pass
+
+
+def _seed_unbacked_trained_tensors(save_directory, safetensors_list, lora_weights,
+                                   model_class_name, output_dtype = None,
+                                   tie_word_embeddings = False):
+    """Append the tensors `_unbacked_trained_tensors` finds into a shard, returning their keys.
+
+    Deliberately runs BEFORE the merge loop: once the key is on disk, the in-place rewrite,
+    the index build and the Step-7 count all treat it as an ordinary shard key, so no
+    downstream stage needs to know a head was added.
+    """
+    if not safetensors_list: return {}
+    shard_keys, sizes = set(), {}
+    for filename in safetensors_list:
+        path = os.path.join(save_directory, filename)
+        if not os.path.exists(path): continue
+        with safe_open(path, framework = "pt", device = "cpu") as f:
+            shard_keys.update(f.keys())
+        sizes[filename] = os.path.getsize(path)
+    if not sizes: return {}
+
+    tensors = _unbacked_trained_tensors(lora_weights, shard_keys, model_class_name,
+                                        tie_word_embeddings = tie_word_embeddings)
+    if not tensors: return {}
+    # The seeded key carries its own dtype into the header, and the in-place merge that
+    # follows cannot change it. Cast here or the head is the one fp32 tensor in a bf16 export.
+    if output_dtype is not None:
+        tensors = {key : tensor.to(output_dtype) for key, tensor in tensors.items()}
+
+    # Smallest shard: the rewrite byte-copies everything it does not replace, so this is the
+    # cheapest place to put a head measured in kilobytes.
+    target = min(sizes, key = sizes.get)
+    path = os.path.join(save_directory, target)
+    with open(path, "rb") as f:
+        length_of_header = int.from_bytes(f.read(8), "little")
+        header_metadata = json.loads(f.read(length_of_header))
+    temp_path = path + ".unsloth_seed_tmp"
+    try:
+        _stream_rewrite_resized_shard(path, temp_path, header_metadata, length_of_header, tensors)
+        os.replace(temp_path, path)
+    except Exception:
+        if os.path.exists(temp_path): os.remove(temp_path)
+        raise
+    return {key : target for key in tensors}
+pass
+
+
+def _add_keys_to_index(save_directory, seeded_keys):
+    """Record seeded keys in an existing shard index, returning whether it changed.
+
+    A sharded base ships its own `model.safetensors.index.json`, copied verbatim before the
+    merge. transformers loads a sharded checkpoint through that map alone, so a key missing
+    from it is a key that does not exist as far as the reload is concerned.
+    """
+    index_path = Path(save_directory) / "model.safetensors.index.json"
+    if not index_path.exists(): return False
+    try:
+        data = json.loads(index_path.read_text(encoding = "utf-8"))
+    except Exception as index_error:
+        warnings.warn(f"Unsloth: could not read {index_path} to record "
+                      f"{', '.join(sorted(seeded_keys))} ({index_error}); the reload may not "
+                      f"find them.")
+        return False
+    weight_map = data.get("weight_map")
+    if not isinstance(weight_map, dict): return False
+    changed = False
+    for key, filename in seeded_keys.items():
+        if weight_map.get(key) != filename:
+            weight_map[key] = filename
+            changed = True
+    if changed:
+        index_path.write_text(json.dumps(data, indent = 4), encoding = "utf-8")
+    return changed
+pass
+
+
+# Fields that describe the head rather than the backbone. Written only alongside the head's
+# own tensors: advertising a classifier whose weights are not there is the same silent
+# failure in reverse, since the reload then builds a random one and reports nothing.
+_TRAINED_HEAD_CONFIG_FIELDS = ("id2label", "label2id", "problem_type")
+
+
+def _carry_over_trained_head_config(save_directory, model, model_class_name):
+    """Point the exported config at the head that was actually written.
+
+    #1073 made the config come from the base checkpoint so it would describe the base's
+    weights. A seeded head is the one part of the export that does NOT come from there, so
+    its architecture and label maps have to come from the trained model instead.
+    """
+    config_path = Path(save_directory) / "config.json"
+    if not config_path.exists(): return
+    trained_config = getattr(model, "config", None)
+    if trained_config is None: return
+    try:
+        data = json.loads(config_path.read_text(encoding = "utf-8"))
+    except Exception as config_error:
+        warnings.warn(f"Unsloth: could not read {config_path} to record the trained head "
+                      f"({config_error}); the exported config may not match it.")
+        return
+
+    data["architectures"] = [model_class_name]
+    for field in _TRAINED_HEAD_CONFIG_FIELDS:
+        value = getattr(trained_config, field, None)
+        if value is None: continue
+        # JSON object keys are strings, and transformers reads id2label back through int().
+        if field == "id2label": value = {str(k) : v for k, v in value.items()}
+        data[field] = value
+    config_path.write_text(json.dumps(data, indent = 2), encoding = "utf-8")
 pass
 
 def find_lora_base_model(model_to_inspect):
@@ -5842,17 +6027,23 @@ pass
 def _stream_rewrite_resized_shard(src_path, dst_path, header_metadata, length_of_header, resized):
     # Stream one tensor at a time (peak RAM ~ one tensor): resized tensors from
     # `resized`, the rest byte-copied from src. Tensor-identical to dict+save_file.
+    # A key of `resized` absent from the source header is APPENDED rather than replaced,
+    # which is how a trained head with no base counterpart reaches the shard.
     import struct
     src_data_start = 8 + length_of_header
     meta = header_metadata.get("__metadata__", None)
     tensor_keys = [k for k in header_metadata.keys() if k != "__metadata__"]
     tensor_keys.sort(key = lambda k: header_metadata[k]["data_offsets"][0])
 
-    # Cast resized tensors to the header dtype so bytes match the label.
+    # Cast resized tensors to the header dtype so bytes match the label. An appended key has
+    # no header to match, so it keeps its own dtype and labels itself.
     res_t = {}
     for k in resized:
-        dt = SAFETENSORS_DTYPES[header_metadata[k]["dtype"]]
-        res_t[k] = resized[k].detach().to(dt).contiguous().cpu()
+        entry = header_metadata.get(k)
+        tensor = resized[k].detach()
+        if entry is not None: tensor = tensor.to(SAFETENSORS_DTYPES[entry["dtype"]])
+        res_t[k] = tensor.contiguous().cpu()
+    tensor_keys += [k for k in res_t if k not in header_metadata]
 
     new_header = {}
     if meta is not None:
@@ -5860,19 +6051,21 @@ def _stream_rewrite_resized_shard(src_path, dst_path, header_metadata, length_of
     layout = []  # (key, src_off0, nbytes, is_resized)
     cursor = 0
     for k in tensor_keys:
-        entry = header_metadata[k]
+        entry = header_metadata.get(k)
         if k in res_t:
             t = res_t[k]
             shape = list(t.shape)
             nbytes = t.numel() * t.element_size()
+            # dtype is unchanged by a vocab resize; an appended key labels its own.
+            dtype = entry["dtype"] if entry is not None else _SAFETENSORS_DTYPE_NAMES[t.dtype]
         else:
             shape = list(entry["shape"])
             o0, o1 = entry["data_offsets"]
             nbytes = o1 - o0
-        # dtype is unchanged by a vocab resize
-        new_header[k] = {"dtype": entry["dtype"], "shape": shape,
+            dtype = entry["dtype"]
+        new_header[k] = {"dtype": dtype, "shape": shape,
                          "data_offsets": [cursor, cursor + nbytes]}
-        layout.append((k, entry["data_offsets"][0], nbytes, k in res_t))
+        layout.append((k, entry["data_offsets"][0] if entry is not None else 0, nbytes, k in res_t))
         cursor += nbytes
 
     header_bytes = json.dumps(new_header, separators = (",", ":")).encode("utf-8")


### PR DESCRIPTION
## Problem

`save_pretrained_merged(save_method = "merged_16bit")` silently drops a trained classification head.

`merge_and_overwrite_lora` takes its weights from the base checkpoint and rewrites the shards **in place** (`saving_utils.py` opens each shard `r+b` and mmaps it). A `modules_to_save` head trained on a causal-LM base has no key in those shards, so there is nothing to overwrite and the tensor is never written. The Step-7 accounting cannot catch it either: `_count_backed_lora_modules` deliberately excludes unbacked targets from **both** sides of the equality check, which is correct for a LoRA adapter on a vision tower absent from the base, but a `modules_to_save` head is different in kind. It is a fully trained tensor that exists nowhere else.

Nothing raises. The export prints "Merge process complete" and the damage only appears later, somewhere else.

Measured on a 5-label `LlamaForSequenceClassification` LoRA finetune, before this change:

```
trained          : num_labels=5, score.weight (5, 32), id2label={0:'neg' ... 4:'other'}
exported         : no score tensor, num_labels=None, id2label=None,
                   architectures=['LlamaForCausalLM']
reload as SeqCls : score.weight NEWLY INITIALIZED, shape (2, 32), num_labels=2
```

Every parameter trained in the head is gone, the label count is wrong, and the label names are lost.

## Fix

Write the head, and make the config describe it.

1. `_unbacked_trained_tensors` finds `modules_to_save` weights (and biases) with no counterpart in the base checkpoint.
2. `_seed_unbacked_trained_tensors` appends them to the smallest shard **before** the merge loop. Once the key is on disk, every downstream stage treats it as an ordinary shard key: the in-place rewrite writes the trained weight, the index build picks it up from the file, and the Step-7 count sees it on both sides. No later stage needs to know a head was added.
3. `_carry_over_trained_head_config` sets `architectures` and the label maps from the trained model, since a seeded head is the one part of the export that does not come from the base checkpoint.
4. `_add_keys_to_index` records the key in a sharded base's `model.safetensors.index.json`, which transformers uses as the sole resolution map, and re-uploads it when pushing.

After:

```
exported         : score.weight present, id2label preserved,
                   architectures=['LlamaForSequenceClassification']
reload as SeqCls : score.weight (5, 32), num_labels=5, missing_keys=[]
                   head bit-identical to the trained one (max abs diff 0.000e+00)
```

### Scope, deliberately narrow

- **`merged_16bit` only.** The mxfp4 and native-quant paths preserve packed base tensors rather than rewriting them, so a seeded 16bit head would not reload there.
- **`modules_to_save` only.** A LoRA adapter whose target is absent from the base has no trained tensor of its own to lose, and the merge is right to skip it.
- **Never `lm_head` or `embed_tokens`.** These belong to the base architecture. When the merge decides it cannot place one (tied embeddings, or a composite-VLM prefix it will not bridge) a bare top-level copy is wrong. gemma3 ties its text embeddings, so seeding `lm_head.weight` there puts a key in the export the model has no slot for. This was a real regression during development, caught by `test_merge_e2e_text_only_config.py` on transformers 4.51.3, and `_backed_lora_keys` is now shared between the counting and seeding passes so both agree on what "the base has no counterpart for this" means.
- **The config fields move only with the tensors.** Writing `id2label` without the weights is the same silent failure in reverse: the reload would advertise a classifier and build a random one.

`_stream_rewrite_resized_shard` gained an append path (a key absent from the source header is appended rather than replaced) and keeps its streaming, one-tensor-at-a-time memory profile. `_get_modules_to_save_weight` gained a defaulted `attr` argument so a head's bias travels with its weight; existing callers are unchanged.

## Tests

`tests/test_merge_e2e_classification_head.py`, 18 tests, offline and CPU-only on the existing `_merge_e2e_helpers` harness.

The load-bearing assertion is that the reloaded head is **bit-identical** to the trained one. A shape match alone passes against a randomly initialized head of the right size, which is exactly the bug. The head is filled with a deterministic non-random pattern so a re-init cannot coincide.

Covered: the end-to-end round trip, label maps and architecture, 2/3/5/17 labels, bf16 export, the backbone being untouched by the seeding rewrite, the sharded index, the `lm_head`/`embed_tokens` exclusion, bias handling, and byte-identity of existing tensors across an append.

**Negative control:** 12 of the 18 fail on the unfixed parent commit. The one end-to-end test that passes there is `test_a_plain_causal_lm_export_is_untouched`, which is the control that ordinary exports are unchanged.

Verified on transformers 4.51.3, 4.57.6 and 5.5.0 (61 / 70 / 75 passed, 0 failed across the merge suite), plus the full `tests/` suite.
