### PR TITLE
Decline MLX RNG key words that are not 32-bit instead of masking them

### DIFF
--- a/tests/test_mlx_rng_rewind.py
+++ b/tests/test_mlx_rng_rewind.py
@@ -49,8 +49,12 @@ _SPLIT_KEY_SEED = 0xFEDCBA9876543210
 class _NoItemAssignment:
     """``mx.random.state`` as mlx >= 0.32.1 exposes it: readable, not writable."""
 
-    def __init__(self, words = None):
+    def __init__(self, words = None, dtype = None):
         self._words = words
+        # uint32 is what mlx stores today. A wider dtype is the only way a word
+        # outside the 32-bit range can reach the capture at all, and is what a
+        # future upstream key layout would look like from here.
+        self._dtype = dtype
 
     def __len__(self):
         return 1
@@ -60,7 +64,7 @@ class _NoItemAssignment:
             raise IndexError("random state index out of range")
         if self._words is None:
             return mx.random.key(_SPLIT_KEY_SEED)
-        return mx.array(list(self._words), dtype = mx.uint32)
+        return mx.array(list(self._words), dtype = self._dtype or mx.uint32)
 
     def __iter__(self):
         return iter([self[0]])
@@ -170,24 +174,50 @@ def test_shadowing_the_state_does_not_outlive_the_test():
     _draw()
 
 
-@pytest.mark.parametrize("words", [
-    (-1, -2), (-2147483648, 5), (0, -1), (2**32, 0), (0, 2**32),
-])
-def test_restore_normalises_words_outside_the_unsigned_32_bit_range(words):
+@pytest.mark.parametrize("words", [(-1, -2), (-2147483648, 5), (0, -1)])
+def test_restore_reinterprets_signed_words(words):
     """`mx.random.seed` takes a uint64 and hard-raises outside [0, 2**64).
 
     The restore is unguarded on purpose, since a blanket `except` would be a
     failure indistinguishable from an intentional no-op. That holds only if the
-    words cannot put it out of range, and capture no longer type-checks the
-    state, so the masking is what makes "cannot raise" true. A raise would land
-    in `_preserved_preprocessing_rng`'s `finally`, or replace the compile error
-    a fallback is recovering from.
+    words cannot put it out of range, and capture does not type-check the state,
+    so this conversion is what makes "cannot raise" true. A raise would land in
+    `_preserved_preprocessing_rng`'s `finally`, or replace the compile error a
+    fallback is recovering from.
+
+    A negative word is the two's complement of the uint32 mlx stores, so
+    reinterpreting it is lossless and the round trip must survive it.
     """
     _restore_mlx_rng_key(words)
     assert _mlx_rng_key() == (words[0] & 0xFFFFFFFF, words[1] & 0xFFFFFFFF)
 
 
-def test_capture_masks_a_state_whose_words_are_not_unsigned():
+@pytest.mark.parametrize("words", [
+    (2**32, 0), (0, 2**32), (2**62, 1), (-(2**31) - 1, 0), (0, -(2**40)),
+])
+def test_words_that_are_not_32_bit_are_declined_not_truncated(words):
+    """Masking these would be worse than declining them.
+
+    (2**32, 0) masks to (0, 0), so a key that cannot be represented becomes a
+    plausible wrong one and a compile fallback looks like it rewound the RNG
+    while actually diverging. Declining is the outcome every caller already
+    handles, and it is the only one that says so out loud.
+    """
+    _restore_mlx_rng_key((0, 0))
+    before = _mlx_rng_key()
+
+    with _shadowing_random_state(_NoItemAssignment(words, dtype = mx.int64)):
+        with pytest.warns(RuntimeWarning, match = "not a 32-bit word"):
+            assert _mlx_rng_key() is None
+
+    # Restore is total: a caller that hands it these words directly must get a
+    # no-op and a warning, never a raise into a `finally` and never a wrong key.
+    with pytest.warns(RuntimeWarning, match = "not a 32-bit word"):
+        _restore_mlx_rng_key(words)
+    assert _mlx_rng_key() == before
+
+
+def test_capture_reinterprets_a_state_whose_words_are_not_unsigned():
     with _shadowing_random_state(_NoItemAssignment((0xFFFFFFFF, 0xFFFFFFFE))):
         words = _mlx_rng_key()
     assert words == (0xFFFFFFFF, 0xFFFFFFFE)

--- a/tests/test_mlx_rng_rewind.py
+++ b/tests/test_mlx_rng_rewind.py
@@ -29,6 +29,8 @@ never run on a pull request. The Linux CPU lane gates these on every push.
 import contextlib
 from types import SimpleNamespace
 
+import io
+import sys
 import warnings
 
 import pytest
@@ -505,3 +507,43 @@ def test_an_unsupported_key_is_reported_once_not_once_per_step():
                 assert _mlx_rng_key() is None
     runtime = [w for w in caught if issubclass(w.category, RuntimeWarning)]
     assert len(runtime) == 1, [str(w.message) for w in runtime]
+
+
+@pytest.mark.parametrize("stderr_factory,label", [
+    (lambda: _closed_stream(), "closed stderr"),
+    (lambda: _hostile_stream(), "stderr.write raises"),
+])
+def test_an_unreportable_diagnostic_still_does_not_raise(stderr_factory, label):
+    """The helper's contract is that it never raises, and callers rely on it.
+
+    Both trainer captures and `_preserved_preprocessing_rng` read the key above
+    the `try` that would contain a raise, so if the stderr fallback itself throws
+    the unsupported key aborts the run anyway, which is the whole thing this
+    helper exists to prevent.
+    """
+    _reported_unrewindable_keys.clear()
+    original = sys.stderr
+    sys.stderr = stderr_factory()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            with _shadowing_random_state(
+                _NoItemAssignment((2**32, 0), dtype = mx.int64)
+            ):
+                assert _mlx_rng_key() is None      # must not raise, label: 
+    finally:
+        sys.stderr = original
+
+
+def _closed_stream():
+    stream = io.StringIO()
+    stream.close()
+    return stream
+
+
+def _hostile_stream():
+    class _Hostile(io.TextIOBase):
+        def write(self, _s):
+            raise OSError("stream is gone")
+
+    return _Hostile()

--- a/tests/test_mlx_rng_rewind.py
+++ b/tests/test_mlx_rng_rewind.py
@@ -41,6 +41,7 @@ from mlx.utils import tree_map                                     # noqa: E402
 from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig  # noqa: E402
 from unsloth_zoo.mlx.utils import (                                # noqa: E402
     FiniteTextBatchPlan, _FiniteTextRow, _mlx_rng_key,
+    _reported_unrewindable_keys,
     _preserved_preprocessing_rng, _restore_mlx_rng_key,
 )
 
@@ -70,6 +71,15 @@ class _NoItemAssignment:
 
     def __iter__(self):
         return iter([self[0]])
+
+
+@pytest.fixture(autouse = True)
+def _forget_reported_key_problems():
+    """The report-once set is process-global, so without this the first test to
+    trip a warning silences it for every test after it."""
+    _reported_unrewindable_keys.clear()
+    yield
+    _reported_unrewindable_keys.clear()
 
 
 @contextlib.contextmanager
@@ -214,6 +224,9 @@ def test_words_that_are_not_32_bit_are_declined_not_truncated(words):
 
     # Restore is total: a caller that hands it these words directly must get a
     # no-op and a warning, never a raise into a `finally` and never a wrong key.
+    # Cleared first so this asserts the restore path reports on its own, rather
+    # than riding on the report the capture above already made.
+    _reported_unrewindable_keys.clear()
     with pytest.warns(RuntimeWarning, match = "not a 32-bit word"):
         _restore_mlx_rng_key(words)
     assert _mlx_rng_key() == before
@@ -453,3 +466,34 @@ def test_every_compile_fallback_rewinds_the_rng_before_retrying_eagerly():
             assert restore.lineno < retry.lineno, (
                 "an eager fallback re-runs the step without rewinding the RNG"
             )
+
+
+def test_an_unsupported_key_is_reported_once_not_once_per_step():
+    """Both trainer captures run inside the per-batch loop.
+
+    The message interpolates the offending word, so a value that changes between
+    draws makes every message unique and the `warnings` registry can never
+    suppress it. The stderr fallback has no registry at all. Without dedup an
+    otherwise fine run emits one warning per batch.
+    """
+    seen = []
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        for word in range(2**32, 2**32 + 25):
+            with _shadowing_random_state(
+                _NoItemAssignment((word, 0), dtype = mx.int64)
+            ):
+                assert _mlx_rng_key() is None
+            seen.append(word)
+    assert len(seen) == 25
+    runtime = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert len(runtime) == 1, [str(w.message) for w in runtime]
+
+    # A different kind still gets its own single report.
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        for _ in range(5):
+            with _shadowing_random_state(_NoItemAssignment((1, 2, 3))):
+                assert _mlx_rng_key() is None
+    runtime = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert len(runtime) == 1, [str(w.message) for w in runtime]

--- a/tests/test_mlx_rng_rewind.py
+++ b/tests/test_mlx_rng_rewind.py
@@ -29,6 +29,8 @@ never run on a pull request. The Linux CPU lane gates these on every push.
 import contextlib
 from types import SimpleNamespace
 
+import warnings
+
 import pytest
 
 mx = pytest.importorskip("mlx.core")
@@ -215,6 +217,26 @@ def test_words_that_are_not_32_bit_are_declined_not_truncated(words):
     with pytest.warns(RuntimeWarning, match = "not a 32-bit word"):
         _restore_mlx_rng_key(words)
     assert _mlx_rng_key() == before
+
+
+@pytest.mark.parametrize("state,expect_words", [
+    ((2**32, 0), False),
+    ((1, 2, 3), False),
+])
+def test_warnings_as_errors_does_not_turn_declining_into_raising(state, expect_words):
+    """`PYTHONWARNINGS=error` must not promote the diagnostic into the abort.
+
+    Every caller reads the key before entering the `try` a raise would land in,
+    so a filter that turns RuntimeWarning into an exception would abort training
+    or preprocessing on exactly the path documented as declining safely.
+    """
+    dtype = mx.int64 if len(state) == 2 else mx.uint32
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        with _shadowing_random_state(_NoItemAssignment(state, dtype = dtype)):
+            assert _mlx_rng_key() is None            # must not raise
+        _restore_mlx_rng_key(state[:2])              # must not raise either
+    assert expect_words is False
 
 
 def test_capture_reinterprets_a_state_whose_words_are_not_unsigned():

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -8968,8 +8968,19 @@ def _vlm_family_divergence(expected, observed, path="batch"):
     return f"{path}: surveyed {expected!r} vs runtime {observed!r}"
 
 
-def _warn_unrewindable_key(message):
-    """Report a key we cannot rewind, without ever raising.
+# Problem kinds already reported, so an unsupported key layout costs one message
+# per process rather than one per training step. Both trainer captures sit inside
+# the per-batch loop, so without this a run that is otherwise fine emits a warning
+# per batch. Keyed on the kind and not the rendered text: the message interpolates
+# the offending word, so a value that changes between draws would defeat both the
+# `warnings` registry and the stderr fallback below, which has no registry at all.
+# A plain set is enough here; two threads racing costs a duplicate message, never
+# a lost one.
+_reported_unrewindable_keys = set()
+
+
+def _warn_unrewindable_key(kind, message):
+    """Report a key we cannot rewind, at most once per kind, without ever raising.
 
     Every caller reads the key *before* entering the `try` that a raise here
     would land in: both trainer captures sit above their compile-fallback
@@ -8983,6 +8994,9 @@ def _warn_unrewindable_key(message):
     would briefly disarm another thread's warnings-as-errors. Falling back to
     stderr keeps the message instead of swallowing it.
     """
+    if kind in _reported_unrewindable_keys:
+        return
+    _reported_unrewindable_keys.add(kind)
     try:
         warnings.warn(message, RuntimeWarning, stacklevel = 3)
     except Exception:
@@ -9004,6 +9018,7 @@ def _mlx_rng_key():
         return None
     if len(words) != 2:
         _warn_unrewindable_key(
+            "word-count",
             f"Unsloth: MLX now exposes a {len(words)}-word random key. Unsloth "
             "can only rewind the two-word form, so a run that falls back from "
             "mx.compile to eager will not have its RNG restored and may diverge "
@@ -9032,6 +9047,7 @@ def _as_uint32_pair(high, low):
     for word in (high, low):
         if not -(2**31) <= word < 2**32:
             _warn_unrewindable_key(
+                "word-range",
                 f"Unsloth: MLX exposed a random key word of {word}, which is not "
                 "a 32-bit word. Unsloth cannot rewind this key, so a run that "
                 "falls back from mx.compile to eager will not have its RNG "

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -8991,10 +8991,38 @@ def _mlx_rng_key():
             stacklevel = 2,
         )
         return None
-    # Masked, not just converted: mx.random.seed takes a uint64 and raises
-    # outside [0, 2**64), and that raise would land in a `finally` or a
-    # compile-failure handler. A no-op for real uint32 keys.
-    return (int(words[0]) & 0xFFFFFFFF, int(words[1]) & 0xFFFFFFFF)
+    return _as_uint32_pair(int(words[0]), int(words[1]))
+
+
+def _as_uint32_pair(high, low):
+    """Both words as uint32, or None if either is not a 32-bit word at all.
+
+    mx.random.seed takes a uint64 and raises outside [0, 2**64), and that raise
+    would land in a `finally` or a compile-failure handler. Range-checking here
+    is what lets the restore below stay unguarded.
+
+    Range-checked rather than masked, though. A negative reads as the two's
+    complement of the uint32 mlx stores, so reinterpreting it loses nothing. A
+    value at or above 2**32 is not a 32-bit word under any reading, and masking
+    it would turn a key we cannot represent into a plausible wrong one:
+    (2**32, 0) would restore as (0, 0), so the fallback would look like it had
+    rewound the RNG while actually diverging. Declining says so instead, and is
+    the outcome every caller already handles.
+    """
+    converted = []
+    for word in (high, low):
+        if not -(2**31) <= word < 2**32:
+            warnings.warn(
+                f"Unsloth: MLX exposed a random key word of {word}, which is not "
+                "a 32-bit word. Unsloth cannot rewind this key, so a run that "
+                "falls back from mx.compile to eager will not have its RNG "
+                "restored and may diverge from an eager run of the same seed.",
+                RuntimeWarning,
+                stacklevel = 3,
+            )
+            return None
+        converted.append(word & 0xFFFFFFFF)
+    return (converted[0], converted[1])
 
 
 def _restore_mlx_rng_key(words):
@@ -9003,15 +9031,16 @@ def _restore_mlx_rng_key(words):
     mlx 0.32.1 made ``mx.random.state`` a sentinel that refuses item assignment.
     Upstream builds a key as ``{seed >> 32, (uint32) seed}``, so reseeding with a
     key's own words restores it exactly over the whole unsigned 64-bit range.
-    Unguarded on purpose: the masking above removes the only way this can raise,
-    and a blanket ``except`` would be a failure indistinguishable from an
-    intentional no-op, which is the defect this fixes.
+    Unguarded on purpose: the range check in ``_as_uint32_pair`` removes the only
+    way this can raise, and a blanket ``except`` would be a failure
+    indistinguishable from an intentional no-op, which is the defect this fixes.
     """
     if words is None:
         return
-    high = int(words[0]) & 0xFFFFFFFF
-    low = int(words[1]) & 0xFFFFFFFF
-    mx.random.seed((high << 32) | low)
+    pair = _as_uint32_pair(int(words[0]), int(words[1]))
+    if pair is None:
+        return
+    mx.random.seed((pair[0] << 32) | pair[1])
 
 
 @contextlib.contextmanager

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -9000,7 +9000,15 @@ def _warn_unrewindable_key(kind, message):
     try:
         warnings.warn(message, RuntimeWarning, stacklevel = 3)
     except Exception:
-        print(message, file = sys.stderr)
+        # A filter promoted the warning, so say it on stderr rather than lose it.
+        # Guarded too, though: stderr can be closed (a daemonised Studio backend,
+        # or a test runner tearing down its capture) or a stream whose write
+        # raises, and this helper is called ABOVE the `try` that would contain
+        # such a raise. An unreportable diagnostic must not become the abort.
+        try:
+            print(message, file = sys.stderr)
+        except Exception:
+            pass
 
 
 def _mlx_rng_key():

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -8968,6 +8968,27 @@ def _vlm_family_divergence(expected, observed, path="batch"):
     return f"{path}: surveyed {expected!r} vs runtime {observed!r}"
 
 
+def _warn_unrewindable_key(message):
+    """Report a key we cannot rewind, without ever raising.
+
+    Every caller reads the key *before* entering the `try` that a raise here
+    would land in: both trainer captures sit above their compile-fallback
+    `try`, and `_preserved_preprocessing_rng` captures before it yields. This
+    path is documented as declining rather than failing, so under
+    `PYTHONWARNINGS=error` (or any filter promoting RuntimeWarning) the
+    diagnostic must not become the abort it is warning about.
+
+    Not `catch_warnings` + `simplefilter`: that mutates a process-global filter
+    list, and MLX training runs these paths from more than one thread, where it
+    would briefly disarm another thread's warnings-as-errors. Falling back to
+    stderr keeps the message instead of swallowing it.
+    """
+    try:
+        warnings.warn(message, RuntimeWarning, stacklevel = 3)
+    except Exception:
+        print(message, file = sys.stderr)
+
+
 def _mlx_rng_key():
     """The current MLX PRNG key as its two 32-bit words, or None if unreadable.
 
@@ -8982,13 +9003,11 @@ def _mlx_rng_key():
     except Exception:
         return None
     if len(words) != 2:
-        warnings.warn(
+        _warn_unrewindable_key(
             f"Unsloth: MLX now exposes a {len(words)}-word random key. Unsloth "
             "can only rewind the two-word form, so a run that falls back from "
             "mx.compile to eager will not have its RNG restored and may diverge "
-            "from an eager run of the same seed.",
-            RuntimeWarning,
-            stacklevel = 2,
+            "from an eager run of the same seed."
         )
         return None
     return _as_uint32_pair(int(words[0]), int(words[1]))
@@ -9012,13 +9031,11 @@ def _as_uint32_pair(high, low):
     converted = []
     for word in (high, low):
         if not -(2**31) <= word < 2**32:
-            warnings.warn(
+            _warn_unrewindable_key(
                 f"Unsloth: MLX exposed a random key word of {word}, which is not "
                 "a 32-bit word. Unsloth cannot rewind this key, so a run that "
                 "falls back from mx.compile to eager will not have its RNG "
-                "restored and may diverge from an eager run of the same seed.",
-                RuntimeWarning,
-                stacklevel = 3,
+                "restored and may diverge from an eager run of the same seed."
             )
             return None
         converted.append(word & 0xFFFFFFFF)


### PR DESCRIPTION
`#1081` replaced the `mx.random.state[0] = key` assignment that mlx 0.32.1 broke with a capture/reseed pair, and normalised the captured words with `& 0xFFFFFFFF` so the packed seed could never fall outside the uint64 domain `mx.random.seed` accepts. Keeping the restore unable to raise matters, because it runs in a `finally` and in the handler recovering from an `mx.compile` failure, where a raise would replace the error the operator actually needs.

Masking achieves that, but it achieves it by destroying information. A word at or above `2**32` is not a 32-bit word under any reading, and masking turns a key we cannot represent into a plausible wrong one:

- `(2**32, 0)` masks to `(0, 0)`
- the fallback then looks like it rewound the RNG
- and the eager retry silently diverges from the compiled run it is standing in for

That is the same class of silent divergence `#1081` set out to remove, moved from the write to the conversion.

## Change

`_as_uint32_pair` replaces the inline mask and range-checks instead:

- a word in `[-2**31, 0)` is still reinterpreted. It is the two's complement of the uint32 mlx stores, so nothing is lost, and this is the case the mask was really there for.
- a word at or above `2**32`, or below `-2**31`, is declined with a `RuntimeWarning` naming the value. `None` is the outcome every caller already handles, and it is the only one that says out loud that the RNG will not be restored.

`_restore_mlx_rng_key` now routes its own input through the same check rather than masking. It is documented as taking a key from `_mlx_rng_key` and every call site does, but "unguarded because it cannot raise" is only worth writing down if it holds for any input. It stays a no-op, never a raise, and never seeds a key it was not given.

## Tests

`tests/test_mlx_rng_rewind.py`:

- `test_restore_reinterprets_signed_words` keeps the negative round trip, which is the behaviour worth preserving.
- `test_words_that_are_not_32_bit_are_declined_not_truncated` is new: capture declines and warns, and restore handed the same words directly is a warned no-op that leaves the key where it was.
- `_NoItemAssignment` grew a `dtype`. It built a real `mx.array(..., dtype = mx.uint32)`, so an oversized word could never reach the check at all; the array construction raised first and the capture's `except` swallowed it. A wider dtype is the only way such a word can arrive, and is what a future upstream key layout would look like from here.

Full file: 33 passed on mlx 0.32.1 and on mlx 0.29.4. Mutation check: forcing the range test false, that is, reverting to the mask, fails 5 of the 33.
