### PR TITLE
feat(mlx): evaluate ORPO and DPO runs, not just sample from them

### DIFF
--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -1323,3 +1323,29 @@ def test_generation_prompt_rejects_a_budget_with_no_room():
             {"prompt": "p", "chosen": "", "rejected": ""},
             max_seq_length=8, max_new_tokens=8,
         )
+
+
+def test_eval_loss_weights_every_pair_once_across_a_ragged_tail():
+    """Three rows at batch_size 2 leave a one-pair tail. Weighting each batch
+    equally would give that tail the same say as the two pairs before it."""
+    from unsloth_zoo.mlx.preference import (
+        create_preference_batch_plan, make_preference_eval_fn,
+    )
+
+    options = dict(max_seq_length=64, num_epochs=1, grad_accum=1,
+                   preserve_dataset_order=True)
+    split = create_preference_batch_plan(
+        rows(3), Tokenizer(), batch_size=2, **options)
+    whole = create_preference_batch_plan(
+        rows(3), Tokenizer(), batch_size=3, **options)
+    assert len(split) == 2 and len(whole) == 1
+    model = TinyModel()
+    eval_fn = make_preference_eval_fn("dpo", beta=0.1, reference_free=True)
+    total, weight = 0.0, 0
+    for index in range(len(split)):
+        loss, pairs, _stats = eval_fn(model, *split[index])
+        total += float(loss) * int(pairs)
+        weight += int(pairs)
+    assert weight == 3, "every pair is weighted once"
+    assert math.isclose(total / weight, float(eval_fn(model, *whole[0])[0]),
+                        rel_tol=2e-5, abs_tol=2e-5)

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -820,26 +820,6 @@ def test_final_loss_averages_logical_updates_with_ragged_epoch_tail(
     assert result["train_loss"] == pytest.approx(expected, rel=1e-6)
 
 
-@pytest.mark.parametrize("eval_dataset,eval_steps", [
-    (rows(1), 1), (rows(1), 0), (None, 1),
-])
-def test_preference_capabilities_fail_before_model_setup(eval_dataset, eval_steps):
-    import mlx.nn as nn
-    from unsloth_zoo.mlx.trainer import MLXORPOConfig, MLXORPOTrainer
-
-    class CapabilityModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self._config = {"model_type": "tiny"}
-
-    trainer = MLXORPOTrainer(
-        CapabilityModel(), Tokenizer(), rows(1), eval_dataset=eval_dataset,
-        args=MLXORPOConfig(eval_steps=eval_steps),
-    )
-    with pytest.raises(ValueError, match="evaluation, best-model loading"):
-        trainer._prepare_data(False)
-
-
 def test_trainer_applies_preference_formatter_once_per_row():
     import mlx.nn as nn
     from unsloth_zoo.mlx.trainer import MLXORPOConfig, MLXORPOTrainer
@@ -1081,14 +1061,6 @@ def test_callback_requested_eval_samples_without_a_step_cadence(
 
 
 @pytest.mark.parametrize("overrides,with_eval,error,message", [
-    ({"load_best_model_at_end": True}, True, ValueError, "not supported yet"),
-    ({"early_stopping_patience": 1}, True, ValueError, "not supported yet"),
-    # Both size eval-loss batching a sampling pass never runs, and both default
-    # to None, so only an explicit set reaches this.
-    ({"per_device_eval_batch_size": 4}, True, ValueError,
-     "does not apply to generate_during_eval"),
-    ({"max_eval_batches": 2}, True, ValueError,
-     "does not apply to generate_during_eval"),
     ({}, False, ValueError, "needs an eval_dataset"),
     ({"generation_max_tokens": 64}, True, ValueError,
      "smaller than max_seq_length"),
@@ -1285,32 +1257,34 @@ def test_a_reused_trainer_does_not_report_the_previous_run_samples(
 
 
 def test_prompt_preparation_runs_inside_the_rng_guard(tmp_path, monkeypatch):
-    """An augmenting formatting_func draws from the shared RNG while rendering.
-
-    Two evaluations redraw the same values only if the guard covers prompt
-    building, not just the sampling burst.
-    """
+    """Building the eval batches draws from the shared RNG, so it has to run
+    inside the preservation. Falsified against a run that builds none."""
     import random
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
 
-    draws = []
-
-    def formatter(row):
-        if str(row["prompt"]).startswith("eval"):
-            draws.append(random.random())
-        return row
-
     held_out = [{"prompt": f"eval {index}: ", "chosen": "yes", "rejected": "no"}
-                for index in range(2)]
-    trainer = MLXDPOTrainer(
-        _tiny_model(), Tokenizer(), rows(4), eval_dataset=held_out,
-        formatting_func=formatter,
-        args=MLXDPOConfig(**_generation_common(
-            tmp_path, reference_free=True, max_steps=2, eval_steps=1)),
-    )
-    _run_generation_trainer(trainer, monkeypatch, [])
-    assert len(draws) == 4, "two prompts rendered at each of two evaluations"
-    assert draws[:2] == draws[2:], "the second evaluation redrew the same values"
+                for index in range(4)]
+
+    def training_draws(evaluating):
+        drawn, calls = [], []
+        random.seed(11)
+        trainer = MLXDPOTrainer(
+            _tiny_model(), Tokenizer(), rows(4),
+            eval_dataset=held_out if evaluating else None,
+            formatting_func=lambda row: (random.random(), row)[1],
+            args=MLXDPOConfig(**_generation_common(
+                tmp_path, reference_free=True, max_steps=2, eval_steps=1,
+                generate_during_eval=evaluating)))
+        # After each step, so the second lands past the first evaluation.
+        trainer.add_step_callback(lambda *_a, **_k: drawn.append(random.random()))
+        _run_generation_trainer(trainer, monkeypatch, calls)
+        return drawn, calls
+
+    evaluated, calls = training_draws(True)
+    control, no_calls = training_draws(False)
+    assert calls and not no_calls, "one run evaluated and the other did not"
+    assert len(evaluated) == len(control) == 2
+    assert evaluated == control, "building eval batches moved the training draws"
 
 
 def test_generation_prompt_rejects_a_budget_with_no_room():
@@ -1323,6 +1297,30 @@ def test_generation_prompt_rejects_a_budget_with_no_room():
             {"prompt": "p", "chosen": "", "rejected": ""},
             max_seq_length=8, max_new_tokens=8,
         )
+
+
+@pytest.mark.parametrize("objective", ["orpo", "dpo"])
+def test_evaluation_reports_the_trl_metric_set(objective, tmp_path, monkeypatch):
+    """No perplexity: a preference loss is not a per-token likelihood."""
+    from unsloth_zoo.mlx.preference import PREFERENCE_EVAL_METRICS
+    from unsloth_zoo.mlx.trainer import (
+        MLXDPOConfig, MLXDPOTrainer, MLXORPOConfig, MLXORPOTrainer,
+    )
+
+    cls, config = ((MLXORPOTrainer, MLXORPOConfig) if objective == "orpo"
+                   else (MLXDPOTrainer, MLXDPOConfig))
+    common = _generation_common(
+        tmp_path, max_steps=1, eval_steps=1, generate_during_eval=False)
+    if objective == "dpo":
+        common["reference_free"] = True
+    trainer = cls(_tiny_model(), Tokenizer(), rows(4), eval_dataset=rows(3),
+                  args=config(**common))
+    _run_generation_trainer(trainer, monkeypatch, [])
+    metrics = trainer._last_eval_metrics
+    assert not [name for name in PREFERENCE_EVAL_METRICS[objective]
+                if f"eval_{name}" not in metrics]
+    assert "eval_loss" in metrics and "eval_perplexity" not in metrics
+    assert any("eval_loss" in entry for entry in trainer.state.log_history)
 
 
 def test_eval_loss_weights_every_pair_once_across_a_ragged_tail():
@@ -1349,3 +1347,59 @@ def test_eval_loss_weights_every_pair_once_across_a_ragged_tail():
     assert weight == 3, "every pair is weighted once"
     assert math.isclose(total / weight, float(eval_fn(model, *whole[0])[0]),
                         rel_tol=2e-5, abs_tol=2e-5)
+
+
+def test_a_token_mean_is_taken_over_every_token_not_every_batch():
+    """Two pairs averaging 1 over two tokens then a one-pair tail averaging 10
+    over four is a mean of 7; by-pair weighting gives 4, equal weighting 5.5."""
+    import mlx.core as mx
+    from unsloth_zoo.mlx import preference as pref
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    names = pref.PREFERENCE_EVAL_METRICS["dpo"]
+    at = names.index("logits/chosen")
+    over = pref.PREFERENCE_EVAL_DENOMINATORS["dpo"][at]
+
+    def scored(logit_sum, tokens, pairs):
+        values = [0.0] * pref.PREFERENCE_EVAL_STATS_WIDTH["dpo"]
+        values[at], values[over] = logit_sum, tokens
+        return mx.array(0.0), mx.array(pairs), mx.array(values)
+
+    batches = {"full": scored(2.0, 2.0, 2), "tail": scored(40.0, 4.0, 1)}
+    loss_fn = lambda _m, name, _l, _labels=None: batches[name]
+    loss_fn._unsloth_preference_metrics = names
+    loss_fn._unsloth_preference_denominators = pref.PREFERENCE_EVAL_DENOMINATORS["dpo"]
+    loss_fn._unsloth_preference_stats_width = pref.PREFERENCE_EVAL_STATS_WIDTH["dpo"]
+
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.model, trainer.stop_requested = _tiny_model(), False
+    trainer._evaluate(
+        [("full", None, None), ("tail", None, None)], loss_fn, is_vlm=False)
+    assert trainer._last_eval_metrics["eval_logits/chosen"] == pytest.approx(7.0)
+
+
+@pytest.mark.parametrize("eval_dataset,overrides,message", [
+    pytest.param(None, {"load_best_model_at_end": True},
+                 "need an eval_dataset", id="nothing-to-select-on"),
+    pytest.param({}, {"load_best_model_at_end": True},
+                 "at least one eval split", id="empty-mapping"),
+    pytest.param([], {}, "eval dataset is empty", id="empty-split"),
+    pytest.param({"a": rows(1), "b": []}, {}, "eval dataset is empty",
+                 id="one-empty-split"),
+    pytest.param(iter(rows(2)), {}, "requires a finite", id="unsized"),
+    pytest.param(rows(2), {"max_eval_batches": 1}, "max_eval_batches",
+                 id="capped-by-batch-count"),
+])
+def test_an_evaluation_that_cannot_be_trusted_is_rejected_before_the_run(
+    eval_dataset, overrides, message, tmp_path,
+):
+    """Each would otherwise report a number that reads like a real evaluation."""
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(4), eval_dataset=eval_dataset,
+        args=MLXDPOConfig(**_generation_common(
+            tmp_path, reference_free=True, generate_during_eval=False,
+            **overrides)))
+    with pytest.raises(ValueError, match=message):
+        trainer._prepare_data(False)

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -649,23 +649,6 @@ def test_preference_trainer_runs_through_shared_training_loop(
         MLXDPOConfig, MLXDPOTrainer, MLXORPOConfig, MLXORPOTrainer,
     )
 
-    class Model(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.embed = nn.Embedding(64, 4)
-            self.proj = nn.Linear(4, 64, bias=False)
-            self._config = {"model_type": "tiny"}
-
-        def __call__(self, tokens):
-            return self.proj(self.embed(tokens))
-
-        def train(self, mode=True):
-            return self
-
-        @property
-        def state(self):
-            return []
-
     def value_and_grad_with_aux(model, fn):
         def wrapped(*args):
             return fn(*args), tree_map(mx.zeros_like, model.trainable_parameters())
@@ -687,11 +670,11 @@ def test_preference_trainer_runs_through_shared_training_loop(
     )
     if objective == "orpo":
         trainer = MLXORPOTrainer(
-            Model(), Tokenizer(), rows(3), args=MLXORPOConfig(**common),
+            _tiny_model(), Tokenizer(), rows(3), args=MLXORPOConfig(**common),
         )
     else:
         trainer = MLXDPOTrainer(
-            Model(), Tokenizer(), rows(3),
+            _tiny_model(), Tokenizer(), rows(3),
             args=MLXDPOConfig(reference_free=True, **common),
         )
     trainer._build_optimizer = lambda _steps: types.SimpleNamespace(
@@ -808,23 +791,6 @@ def test_final_loss_averages_logical_updates_with_ragged_epoch_tail(
     from unsloth_zoo.mlx.preference import make_orpo_loss_fn
     from unsloth_zoo.mlx.trainer import MLXORPOConfig, MLXORPOTrainer
 
-    class Model(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.embed = nn.Embedding(64, 4)
-            self.proj = nn.Linear(4, 64, bias=False)
-            self._config = {"model_type": "tiny"}
-
-        def __call__(self, tokens):
-            return self.proj(self.embed(tokens))
-
-        def train(self, mode=True):
-            return self
-
-        @property
-        def state(self):
-            return []
-
     def value_and_grad_with_aux(model, fn):
         def wrapped(*args):
             return fn(*args), tree_map(mx.zeros_like, model.trainable_parameters())
@@ -839,7 +805,7 @@ def test_final_loss_averages_logical_updates_with_ragged_epoch_tail(
         max_grad_norm=0.0, max_grad_leaf_norm=0.0, logging_steps=10,
         output_dir=str(tmp_path),
     )
-    model = Model()
+    model = _tiny_model()
     trainer = MLXORPOTrainer(model, Tokenizer(), rows(5), args=config)
     plan, _ = trainer._prepare_data(False)
     objective = make_orpo_loss_fn(config.beta)
@@ -854,7 +820,10 @@ def test_final_loss_averages_logical_updates_with_ragged_epoch_tail(
     assert result["train_loss"] == pytest.approx(expected, rel=1e-6)
 
 
-def test_preference_capabilities_fail_before_model_setup():
+@pytest.mark.parametrize("eval_dataset,eval_steps", [
+    (rows(1), 1), (rows(1), 0), (None, 1),
+])
+def test_preference_capabilities_fail_before_model_setup(eval_dataset, eval_steps):
     import mlx.nn as nn
     from unsloth_zoo.mlx.trainer import MLXORPOConfig, MLXORPOTrainer
 
@@ -864,8 +833,8 @@ def test_preference_capabilities_fail_before_model_setup():
             self._config = {"model_type": "tiny"}
 
     trainer = MLXORPOTrainer(
-        CapabilityModel(), Tokenizer(), rows(1), eval_dataset=rows(1),
-        args=MLXORPOConfig(eval_steps=1),
+        CapabilityModel(), Tokenizer(), rows(1), eval_dataset=eval_dataset,
+        args=MLXORPOConfig(eval_steps=eval_steps),
     )
     with pytest.raises(ValueError, match="evaluation, best-model loading"):
         trainer._prepare_data(False)
@@ -892,7 +861,7 @@ def test_trainer_applies_preference_formatter_once_per_row():
 
     dataset = [dict(row, id=index) for index, row in enumerate(rows(3))]
     trainer = MLXORPOTrainer(
-        Model(), Tokenizer(), dataset, formatting_func=formatter,
+        _tiny_model(), Tokenizer(), dataset, formatting_func=formatter,
         args=MLXORPOConfig(max_steps=1, gradient_accumulation_steps=1),
     )
     trainer._prepare_data(False)
@@ -963,3 +932,394 @@ def test_mismatched_referenced_resume_rejects_before_adapter_hydration(tmp_path)
         trainer.train(resume_from_checkpoint=str(checkpoint))
     assert model.loaded is False
     assert model.adapter.lora_b.tolist() == [[0.0]]
+
+
+def _tiny_model(lora=False):
+    """lora=True adds one adapter at zero delta, as referenced DPO requires."""
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    class Adapter:
+        def __init__(self):
+            self.lora_a = mx.array([[1.0]])
+            self.lora_b = mx.array([[0.0]])
+            self.scale = 1.0
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed = nn.Embedding(64, 4)
+            self.proj = nn.Linear(4, 64, bias=False)
+            self._config = {"model_type": "tiny"}
+            if lora:
+                self.q_proj = Adapter()
+
+        def __call__(self, tokens):
+            return self.proj(self.embed(tokens))
+
+        def train(self, mode=True):
+            return self
+
+        @property
+        def state(self):
+            return []
+
+        if lora:
+            def named_modules(self):
+                return [("", self), ("q_proj", self.q_proj)]
+
+            def parameters(self):
+                return {"q_proj": {
+                    "lora_a": self.q_proj.lora_a, "lora_b": self.q_proj.lora_b,
+                }}
+
+            def trainable_parameters(self):
+                return self.parameters()
+
+    return Model()
+
+
+def _generation_common(tmp_path, **overrides):
+    common = dict(
+        max_steps=1, gradient_accumulation_steps=2, per_device_train_batch_size=2,
+        compile=True, gradient_checkpointing=False, disable_memory_limits=True,
+        cast_norm_output_to_input_dtype=False,
+        max_grad_norm=0.0, max_grad_leaf_norm=0.0, logging_steps=1,
+        output_dir=str(tmp_path), max_seq_length=64, generate_during_eval=True,
+        num_generation_prompts=2, generation_max_tokens=8, eval_steps=1,
+        generation_temperature=0.25,
+    )
+    common.update(overrides)
+    return common
+
+
+def _run_generation_trainer(trainer, monkeypatch, calls):
+    """Drive one training step whose evaluation samples, recording engine calls."""
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx.utils import tree_map
+    from unsloth_zoo.mlx import generate as generate_module
+    from unsloth_zoo.mlx.utils import iter_mlx_lora_modules
+
+    def fake_generate_batch(model, tokenizer, requests, *, defaults=None):
+        call = len(calls) + 1
+        calls.append({
+            "requests": list(requests),
+            "defaults": defaults,
+            "scales": [module.scale for _, module in iter_mlx_lora_modules(model)],
+        })
+        # Distinct per call and per row, so a mis-mapped sample reads wrong.
+        return [
+            types.SimpleNamespace(
+                token_ids=[1, 2], text=f"c{call}r{index}", logprobs=[0.0, 0.0],
+                finish_reason="length", stop_match=None,
+            )
+            for index, _ in enumerate(requests)
+        ]
+
+    monkeypatch.setattr(generate_module, "generate_batch", fake_generate_batch)
+
+    def value_and_grad_with_aux(model, fn):
+        def wrapped(*args):
+            return fn(*args), tree_map(mx.zeros_like, model.trainable_parameters())
+        return wrapped
+
+    monkeypatch.setattr(nn, "value_and_grad", value_and_grad_with_aux)
+    trainer._build_optimizer = lambda _steps: types.SimpleNamespace(
+        learning_rate=mx.array(1e-5), state={}, update=lambda _model, _grad: None,
+    )
+    trainer.save_model = lambda *_args, **_kwargs: None
+    return trainer.train()
+
+
+def test_generation_fields_stay_appended_for_a_wholesale_config_copy():
+    """A config round-tripped without the generation fields is still a copy.
+
+    An unregistered field flips the copy detection, letting a copied default
+    warmup_steps override an explicit warmup_ratio.
+    """
+    import dataclasses
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig
+
+    generation_fields = {
+        "generate_during_eval", "num_generation_prompts",
+        "generation_max_tokens", "generation_temperature",
+    }
+    baseline = MLXDPOConfig()
+    provided = {
+        field.name: getattr(baseline, field.name)
+        for field in dataclasses.fields(MLXDPOConfig)
+        if field.name not in generation_fields
+    }
+    provided["warmup_ratio"] = 0.25
+    config = MLXDPOConfig(**provided)
+    assert config._unsloth_mlx_warmup_steps_explicit is False
+
+
+def test_callback_requested_eval_samples_without_a_step_cadence(
+    tmp_path, monkeypatch,
+):
+    """A callback raising should_evaluate reaches the sampling pass."""
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3), eval_dataset=rows(2),
+        args=MLXDPOConfig(
+            **_generation_common(tmp_path, reference_free=True, eval_steps=0)
+        ),
+    )
+
+    class RequestEval:
+        def on_step_end(self, args, state, control, **kwargs):
+            control.should_evaluate = True
+
+    assert trainer.last_generation_samples == [], "readable before the first eval"
+    trainer.add_callback(RequestEval())
+    calls = []
+    _run_generation_trainer(trainer, monkeypatch, calls)
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("overrides,with_eval,error,message", [
+    ({"load_best_model_at_end": True}, True, ValueError, "not supported yet"),
+    ({"early_stopping_patience": 1}, True, ValueError, "not supported yet"),
+    # Both size eval-loss batching a sampling pass never runs, and both default
+    # to None, so only an explicit set reaches this.
+    ({"per_device_eval_batch_size": 4}, True, ValueError,
+     "does not apply to generate_during_eval"),
+    ({"max_eval_batches": 2}, True, ValueError,
+     "does not apply to generate_during_eval"),
+    ({}, False, ValueError, "needs an eval_dataset"),
+    ({"generation_max_tokens": 64}, True, ValueError,
+     "smaller than max_seq_length"),
+    ({"num_generation_prompts": 0}, True, ValueError,
+     "num_generation_prompts must be at least 1"),
+    # The engine validates these itself, and both of its rejections must land at
+    # configuration time rather than at the first evaluation.
+    ({"generation_max_tokens": 0}, True, ValueError,
+     "generation_max_tokens is invalid"),
+    ({"generation_max_tokens": 8.5}, True, TypeError,
+     "generation_max_tokens is invalid"),
+    ({"generation_temperature": -1.0}, True, ValueError,
+     "generation_temperature is invalid"),
+])
+def test_generate_during_eval_rejects_a_configuration_it_cannot_honour(
+    tmp_path, overrides, with_eval, error, message,
+):
+    """What a sampling pass cannot honour fails while the config is checked."""
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3),
+        eval_dataset=rows(2) if with_eval else None,
+        args=MLXDPOConfig(**_generation_common(
+            tmp_path, reference_free=True, **overrides)),
+    )
+    with pytest.raises(error, match=message):
+        trainer._prepare_data(False)
+
+
+def test_generation_prompt_is_the_standalone_encoding_not_the_training_boundary():
+    """A merged seam is prompt when there is no completion to merge with.
+
+    tokenize_preference_row gives that token to the response span so supervision
+    starts after the merge; generation must not inherit that boundary.
+    """
+    from unsloth_zoo.mlx.preference import (
+        encode_generation_prompt, tokenize_preference_row,
+    )
+
+    tokenizer = MappingTokenizer({"ab": [1, 2], "abc": [1, 3, 4], "abd": [1, 5, 6]})
+    row = {"prompt": "ab", "chosen": "c", "rejected": "d"}
+    trained = tokenize_preference_row(tokenizer, row, max_seq_length=16)
+    assert trained.chosen_prompt_ids == (1,)
+
+    _text, prompt_ids = encode_generation_prompt(
+        tokenizer, row, max_seq_length=16, max_new_tokens=4,
+    )
+    assert prompt_ids == (1, 2)
+
+
+def test_generation_prompt_reserves_room_for_the_sample():
+    """The prompt keeps its end and leaves max_new_tokens of context free."""
+    from unsloth_zoo.mlx.preference import encode_generation_prompt
+
+    tokenizer = MappingTokenizer({"p": [1, 2, 3, 4, 5, 6, 7, 8]})
+    row = {"prompt": "p", "chosen": "", "rejected": ""}
+    _text, prompt_ids = encode_generation_prompt(
+        tokenizer, row, max_seq_length=10, max_new_tokens=6,
+    )
+    assert prompt_ids == (5, 6, 7, 8)
+
+
+def test_referenced_dpo_samples_the_reference_with_scales_zeroed(
+    tmp_path, monkeypatch,
+):
+    """The reference sample is the base policy, and the scales come back."""
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+    from unsloth_zoo.mlx.utils import iter_mlx_lora_modules
+
+    model = _tiny_model(lora=True)
+    trainer = MLXDPOTrainer(
+        model, Tokenizer(), rows(3), eval_dataset=rows(2),
+        args=MLXDPOConfig(**_generation_common(tmp_path)),
+    )
+    calls = []
+    _run_generation_trainer(trainer, monkeypatch, calls)
+
+    assert len(calls) == 2, "policy and reference"
+    assert all(scale != 0.0 for scale in calls[0]["scales"])
+    assert all(scale == 0.0 for scale in calls[1]["scales"])
+    assert all(
+        module.scale != 0.0 for _, module in iter_mlx_lora_modules(model)
+    ), "scales restored after sampling"
+    samples = trainer.last_generation_samples
+    assert [row["policy"] for row in samples] == ["c1r0", "c1r1"]
+    assert [row["reference"] for row in samples] == ["c2r0", "c2r1"], (
+        "each row reports its own reference, from the reference call"
+    )
+    # The reference must decode under the budget the prompt was truncated for.
+    for call in calls:
+        assert call["defaults"].max_tokens == 8
+        assert call["defaults"].sampling.temperature == 0.25
+
+
+@pytest.mark.parametrize("objective", ["orpo", "dpo"])
+def test_unreferenced_objectives_sample_the_policy_only(
+    tmp_path, monkeypatch, objective,
+):
+    """ORPO has no reference and reference-free DPO has none either."""
+    from unsloth_zoo.mlx.trainer import (
+        MLXDPOConfig, MLXDPOTrainer, MLXORPOConfig, MLXORPOTrainer,
+    )
+
+    common = _generation_common(tmp_path, generation_max_tokens=56)
+    if objective == "orpo":
+        cls, args = MLXORPOTrainer, MLXORPOConfig(**common)
+    else:
+        cls, args = MLXDPOTrainer, MLXDPOConfig(reference_free=True, **common)
+    trainer = cls(
+        _tiny_model(lora=True), Tokenizer(), rows(3), eval_dataset=rows(2),
+        args=args,
+    )
+    calls = []
+    _run_generation_trainer(trainer, monkeypatch, calls)
+    assert len(calls) == 1
+    assert trainer.last_generation_samples[0]["reference"] is None
+
+    from unsloth_zoo.mlx.preference import encode_generation_prompt
+    samples = trainer.last_generation_samples
+    for index, row in enumerate(rows(2)):
+        request = calls[0]["requests"][index]
+        text, expected = encode_generation_prompt(
+            Tokenizer(), row, max_seq_length=64, max_new_tokens=56,
+        )
+        # Token ids, not text: the engine encodes without special tokens, so
+        # text would drop what training adds. The budget bites at this length.
+        assert request.prompt is None
+        assert tuple(request.prompt_token_ids) == expected
+        assert len(request.prompt_token_ids) == 64 - 56
+        assert samples[index]["prompt"] == text
+    assert calls[0]["defaults"].max_tokens == 56
+    assert calls[0]["defaults"].sampling.temperature == 0.25
+
+
+def test_generation_samples_every_split_of_a_dict_eval_dataset(
+    tmp_path, monkeypatch,
+):
+    """A dict of splits is resolved, not iterated as prompts named by key.
+
+    Each split holds more rows than num_generation_prompts, so the per-split cap
+    has to bite for the count to come out right.
+    """
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3),
+        eval_dataset={"a": rows(3), "b": rows(3)},
+        args=MLXDPOConfig(**_generation_common(tmp_path, reference_free=True)),
+    )
+    calls = []
+    _run_generation_trainer(trainer, monkeypatch, calls)
+    assert len(calls) == 1
+    assert len(calls[0]["requests"]) == 4, "two prompts from each split"
+    assert [row["split"] for row in trainer.last_generation_samples] == [
+        "a", "a", "b", "b",
+    ]
+
+
+@pytest.mark.parametrize("eval_steps,expected", [(0, True), (0.5, False), (2, False)])
+def test_sampling_without_a_cadence_says_so(tmp_path, capsys, eval_steps, expected):
+    """No cadence samples nothing, which is worth a word rather than silence.
+
+    eval_steps is an HF interval, so a ratio in (0, 1) is a real cadence.
+    """
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3), eval_dataset=rows(2),
+        args=MLXDPOConfig(**_generation_common(
+            tmp_path, reference_free=True, eval_steps=eval_steps)),
+    )
+    trainer._prepare_data(False)
+    said = "no evaluation cadence" in capsys.readouterr().out
+    assert said is expected
+
+
+def test_a_reused_trainer_does_not_report_the_previous_run_samples(
+    tmp_path, monkeypatch,
+):
+    """Same contract the eval metrics get: a run reports only its own."""
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3), eval_dataset=rows(2),
+        args=MLXDPOConfig(**_generation_common(tmp_path, reference_free=True)),
+    )
+    _run_generation_trainer(trainer, monkeypatch, [])
+    assert trainer.last_generation_samples
+
+    trainer.args.eval_steps = 0
+    _run_generation_trainer(trainer, monkeypatch, [])
+    assert trainer.last_generation_samples == []
+
+
+def test_prompt_preparation_runs_inside_the_rng_guard(tmp_path, monkeypatch):
+    """An augmenting formatting_func draws from the shared RNG while rendering.
+
+    Two evaluations redraw the same values only if the guard covers prompt
+    building, not just the sampling burst.
+    """
+    import random
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    draws = []
+
+    def formatter(row):
+        if str(row["prompt"]).startswith("eval"):
+            draws.append(random.random())
+        return row
+
+    held_out = [{"prompt": f"eval {index}: ", "chosen": "yes", "rejected": "no"}
+                for index in range(2)]
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(4), eval_dataset=held_out,
+        formatting_func=formatter,
+        args=MLXDPOConfig(**_generation_common(
+            tmp_path, reference_free=True, max_steps=2, eval_steps=1)),
+    )
+    _run_generation_trainer(trainer, monkeypatch, [])
+    assert len(draws) == 4, "two prompts rendered at each of two evaluations"
+    assert draws[:2] == draws[2:], "the second evaluation redrew the same values"
+
+
+def test_generation_prompt_rejects_a_budget_with_no_room():
+    """A non-positive budget would slice the wrong end, or the whole prompt."""
+    from unsloth_zoo.mlx.preference import encode_generation_prompt
+
+    with pytest.raises(ValueError, match="at least one"):
+        encode_generation_prompt(
+            MappingTokenizer({"p": [1, 2]}),
+            {"prompt": "p", "chosen": "", "rejected": ""},
+            max_seq_length=8, max_new_tokens=8,
+        )

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -589,7 +589,6 @@ def test_compiled_clip_accum_matches_eager_bitwise(tmp_path, capsys):
         assert np.array_equal(eager_snap[key][1], comp_snap[key][1]), key
 
 
-
 @metal_only
 def test_evaluation_failure_propagates_without_eager_retry(tmp_path, monkeypatch, capsys):
     import functools
@@ -625,7 +624,6 @@ def test_evaluation_failure_propagates_without_eager_retry(tmp_path, monkeypatch
                     overrides={"compile_mode": "best_effort"})
     assert state["step_ran"] and state["raised"]
     assert "falling back to eager" not in capsys.readouterr().out
-
 
 
 @metal_only
@@ -1140,3 +1138,80 @@ def test_preference_generate_during_eval_samples_through_the_real_engine(tmp_pat
     assert all(
         module.scale != 0.0 for _, module in iter_mlx_lora_modules(model)
     ), "the reference sample restored every adapter scale"
+
+
+@metal_only
+def test_neftune_noise_is_gated_out_of_the_preference_eval_forward(tmp_path):
+    """Evaluation must score the model, not a noised copy of it.
+
+    The gate is the embedding's own training flag, which only a real
+    mlx.nn.Module tree propagates, so nothing short of a real run tells a
+    working gate from an absent one -- and a broken one moves an eval number
+    without failing anything.
+    """
+    import mlx.core as mx
+    from unsloth_zoo.mlx.trainer import MLXORPOConfig, MLXORPOTrainer
+
+    def pairs(start, stop):
+        return [{"prompt": f"### Question: {i} plus {i}?\n### Answer:",
+                 "chosen": f" {2 * i}.", "rejected": f" {2 * i + 3}."}
+                for i in range(start, stop)]
+
+    model, tokenizer = FastMLXModel.from_pretrained(MODEL, max_seq_length=256)
+    model = FastMLXModel.get_peft_model(model, r=8, lora_alpha=16, lora_dropout=0)
+    trainer = MLXORPOTrainer(
+        model=model, tokenizer=tokenizer,
+        train_dataset=pairs(0, 4), eval_dataset=pairs(4, 6),
+        args=MLXORPOConfig(
+            per_device_train_batch_size=2, gradient_accumulation_steps=1,
+            max_steps=1, learning_rate=1e-5, logging_steps=1,
+            output_dir=str(tmp_path), report_to="none", max_seq_length=256,
+            seed=3407, eval_steps=1, neftune_noise_alpha=5.0,
+        ),
+    )
+
+    observed, restored, noised = [], [], []
+    evaluating = {"now": False}
+    install = trainer._install_neftune
+
+    def install_and_watch():
+        install()
+        embed = trainer._neftune_emb
+        assert embed is not None, "NEFTune never attached to the embedding"
+        noisy, base = type(embed), trainer._neftune_base_cls
+        # Eager, before any transform traces the forward: without this the run
+        # below cannot tell a working gate from an embedding that never noises.
+        probe, was_training = mx.array([[1, 2, 3]]), embed.training
+        embed.train(True)
+        noised.append(
+            not mx.allclose(embed(probe), base.__call__(embed, probe)).item())
+        embed.train(was_training)
+
+        class _Recorder(noisy):
+            def __call__(self, x):
+                observed.append((bool(self.training), evaluating["now"]))
+                return noisy.__call__(self, x)
+
+        _Recorder.__name__ = noisy.__name__
+        embed.__class__ = _Recorder
+
+    trainer._install_neftune = install_and_watch
+    evaluate = trainer._evaluate
+
+    def evaluate_and_watch(*args, **kwargs):
+        evaluating["now"] = True
+        try:
+            return evaluate(*args, **kwargs)
+        finally:
+            evaluating["now"] = False
+            restored.append(bool(trainer.model.training))
+
+    trainer._evaluate = evaluate_and_watch
+    trainer.train()
+
+    assert noised == [True], "the embedding never noised, so the run proves nothing"
+    in_eval = [training for training, evaluated in observed if evaluated]
+    assert any(t for t, evaluated in observed if not evaluated), "never trained"
+    assert in_eval, "evaluation never reached the embedding"
+    assert not any(in_eval), "NEFTune noise leaked into the eval forward"
+    assert restored == [True], "_evaluate left the model in eval mode"

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -1081,3 +1081,62 @@ def test_vlm_planned_vs_unplanned_training_parity(monkeypatch, tmp_path):
         )
     )
     assert len(set(planned_widths)) <= len(set(unplanned_widths)) + 1
+
+
+@metal_only
+def test_preference_generate_during_eval_samples_through_the_real_engine(tmp_path):
+    """A referenced DPO run samples held-out prompts and keeps training.
+
+    Only a real model reaches the backend's capability probe and streaming
+    detokenizer, so this is the one place the wiring runs unmocked.
+    """
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+    from unsloth_zoo.mlx.utils import iter_mlx_lora_modules
+
+    def pairs(count):
+        return [
+            {
+                "prompt": f"### Question: what is {i} plus {i}?\n### Answer:",
+                "chosen": f" {2 * i}.",
+                "rejected": f" {2 * i + 3}.",
+            }
+            for i in range(count)
+        ]
+
+    model, tokenizer = FastMLXModel.from_pretrained(MODEL, max_seq_length=256)
+    model = FastMLXModel.get_peft_model(model, r=8, lora_alpha=16, lora_dropout=0)
+    trainer = MLXDPOTrainer(
+        model=model, tokenizer=tokenizer,
+        train_dataset=pairs(8), eval_dataset=pairs(3),
+        args=MLXDPOConfig(
+            per_device_train_batch_size=1,
+            gradient_accumulation_steps=1,
+            max_steps=2,
+            warmup_steps=0,
+            learning_rate=5e-6,
+            logging_steps=1,
+            output_dir=str(tmp_path),
+            report_to="none",
+            max_seq_length=256,
+            seed=3407,
+            beta=0.1,
+            eval_steps=1,
+            generate_during_eval=True,
+            num_generation_prompts=2,
+            generation_max_tokens=8,
+        ),
+    )
+    result = trainer.train()
+
+    samples = trainer.last_generation_samples
+    assert len(samples) == 2
+    for sample in samples:
+        assert sample["prompt"].startswith("### Question:")
+        # Batched decoding is not batch-invariant, so only presence is asserted.
+        assert isinstance(sample["policy"], str) and sample["policy"]
+        assert isinstance(sample["reference"], str) and sample["reference"]
+
+    assert result["train_steps"] == 2, "training continues past the sampling pass"
+    assert all(
+        module.scale != 0.0 for _, module in iter_mlx_lora_modules(model)
+    ), "the reference sample restored every adapter scale"

--- a/unsloth_zoo/mlx/preference.py
+++ b/unsloth_zoo/mlx/preference.py
@@ -1,5 +1,6 @@
 """MLX text preference tokenization, finite batching, and objectives."""
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -146,11 +147,18 @@ def _require_preference_fields(row):
 
 
 def tokenize_preference_row(
-    tokenizer, row, *, max_seq_length, append_eos=True,
+    tokenizer, row, *, max_seq_length, append_eos=True, rendered=None,
 ):
-    """Tokenize one row and preserve a shared prompt boundary."""
+    """Tokenize one row and preserve a shared prompt boundary.
+
+    ``rendered`` passes back a ``_render_preference_row`` result the caller
+    already has: a chat template may carry state, so rendering twice is not
+    guaranteed to give the same text.
+    """
     _require_preference_fields(row)
-    prompt_text, chosen_text, rejected_text = _render_preference_row(tokenizer, row)
+    prompt_text, chosen_text, rejected_text = (
+        _render_preference_row(tokenizer, row) if rendered is None else rendered
+    )
     chosen = _encode_mlx_prompt_completion(
         tokenizer, prompt_text, chosen_text, append_eos=append_eos,
     )
@@ -203,6 +211,16 @@ def encode_generation_prompt(tokenizer, row, *, max_seq_length, max_new_tokens):
     """
     _require_preference_fields(row)
     prompt_text, _, _ = _render_preference_row(tokenizer, row)
+    return encode_generation_prompt_text(
+        tokenizer, prompt_text,
+        max_seq_length=max_seq_length, max_new_tokens=max_new_tokens,
+    )
+
+
+def encode_generation_prompt_text(
+    tokenizer, prompt_text, *, max_seq_length, max_new_tokens,
+):
+    """Encode an already-rendered prompt, reserving room for the sample."""
     budget = int(max_seq_length) - int(max_new_tokens)
     if budget < 1:
         raise ValueError(
@@ -350,8 +368,13 @@ def create_preference_batch_plan(
     seed=None,
     append_eos=True,
     formatting_func=None,
+    prompt_sink=None,
 ):
-    """Build the finite preference plan consumed by both objectives."""
+    """Build the finite preference plan consumed by both objectives.
+
+    ``prompt_sink`` receives each row's rendered prompt text as the plan is
+    built, so a caller wanting it does not render the row a second time.
+    """
     rows = []
     for raw in dataset:
         row = formatting_func(raw) if formatting_func is not None else raw
@@ -359,8 +382,14 @@ def create_preference_batch_plan(
             raise ValueError(
                 "Unsloth MLX preference: formatting_func must return a mapping."
             )
+        rendered = None
+        if prompt_sink is not None:
+            _require_preference_fields(row)
+            rendered = _render_preference_row(tokenizer, row)
+            prompt_sink(rendered[0])
         rows.append(tokenize_preference_row(
             tokenizer, row, max_seq_length=max_seq_length, append_eos=append_eos,
+            rendered=rendered,
         ))
     if not rows:
         raise ValueError("Unsloth MLX preference: the training dataset is empty.")
@@ -435,13 +464,17 @@ def _log_sigmoid(value):
     return -mx.logaddexp(mx.array(0.0, dtype=value.dtype), -value)
 
 
-def _orpo_terms(chosen, rejected):
+def _orpo_log_odds(chosen, rejected):
     chosen = chosen.astype(mx.float32)
     rejected = rejected.astype(mx.float32)
     floor = mx.array(1e-12, dtype=mx.float32)
     chosen_odds = chosen - mx.log(mx.maximum(-mx.expm1(chosen), floor))
     rejected_odds = rejected - mx.log(mx.maximum(-mx.expm1(rejected), floor))
-    return -_log_sigmoid(chosen_odds - rejected_odds)
+    return chosen_odds - rejected_odds
+
+
+def _orpo_terms(chosen, rejected):
+    return -_log_sigmoid(_orpo_log_odds(chosen, rejected))
 
 
 def make_orpo_loss_fn(beta=0.1):
@@ -601,6 +634,150 @@ def make_dpo_loss_fn(
 
     loss_fn._unsloth_supervised_tokens = _supervised_tokens
     return loss_fn
+
+
+_SHARED_EVAL_METRICS = (
+    "rewards/chosen",
+    "rewards/rejected",
+    "rewards/accuracies",
+    "rewards/margins",
+    "logps/chosen",
+    "logps/rejected",
+    "logits/chosen",
+    "logits/rejected",
+)
+
+# The names TRL logs for these objectives, so a run reads the same on
+# either backend. ORPO adds the three terms its loss decomposes into.
+PREFERENCE_EVAL_METRICS = {
+    "dpo": _SHARED_EVAL_METRICS,
+    "orpo": _SHARED_EVAL_METRICS + (
+        "nll_loss", "log_odds_ratio", "log_odds_chosen",
+    ),
+}
+
+
+def _masked_logit_sum(logits, mask):
+    """Logit sum over the response positions, and the count it divides by.
+
+    Separate so the eval set's mean is taken over all of its positions at once.
+    """
+    kept = mask.sum() * logits.shape[-1]
+    return (logits * mask[..., None]).sum(), kept
+
+
+# Metric index -> index of the stats entry it is divided by. Anything absent is
+# a per-pair sum over the pair count. These are means over tokens, which no pair
+# count recovers once batches hold different numbers of them.
+PREFERENCE_EVAL_DENOMINATORS = {
+    "dpo": {6: 8, 7: 9},
+    "orpo": {6: 11, 7: 12, 8: 13},
+}
+
+# Reported metrics, then the denominators the trainer sums alongside them.
+PREFERENCE_EVAL_STATS_WIDTH = {
+    kind: len(names) + len(PREFERENCE_EVAL_DENOMINATORS[kind])
+    for kind, names in PREFERENCE_EVAL_METRICS.items()
+}
+
+
+def _preference_forward(model, batch, lengths):
+    """Logits, per-token cross entropy, and the response mask for one batch."""
+    targets = batch[:, 1:]
+    logits = model(batch[:, :-1])
+    ce = nn.losses.cross_entropy(
+        logits, targets, reduction="none",
+    ).reshape(targets.shape)
+    return logits, ce, _response_mask(targets, lengths)
+
+
+def make_preference_eval_fn(
+    kind, *, beta=0.1, label_smoothing=0.0,
+    reference_policy=None, reference_free=False,
+):
+    """Score one preference batch as ``(loss, pairs, stats)``.
+
+    ``stats`` holds a numerator per metric in ``PREFERENCE_EVAL_METRICS[kind]``
+    order, then the denominators ``PREFERENCE_EVAL_DENOMINATORS[kind]`` names.
+    Nothing is a per-batch mean: summing the vector across batches and dividing
+    each numerator by its own total averages the eval set exactly, however
+    unlike the batches are.
+    """
+    beta = float(beta)
+    epsilon = float(label_smoothing)
+
+    def eval_fn(model, batch, lengths, _normalizers=None):
+        logits, ce, mask = _preference_forward(model, batch, lengths)
+        pairs = batch.shape[0] // 2
+        logps = -(ce * mask).sum(axis=1)
+        # TRL is not consistent between its trainers: DPOTrainer averages its
+        # logit metric over the completion positions only, ORPOTrainer over the
+        # whole sequence. Follow each, so either compares against its own run.
+        if kind == "orpo":
+            chosen_logits = logits[:pairs].sum()
+            rejected_logits = logits[pairs:].sum()
+            chosen_logit_count = mx.array(float(math.prod(logits[:pairs].shape)))
+            rejected_logit_count = mx.array(float(math.prod(logits[pairs:].shape)))
+        else:
+            chosen_logits, chosen_logit_count = _masked_logit_sum(
+                logits[:pairs], mask[:pairs])
+            rejected_logits, rejected_logit_count = _masked_logit_sum(
+                logits[pairs:], mask[pairs:])
+        if kind == "orpo":
+            logps = logps / mx.maximum(mask.sum(axis=1), mx.array(1.0))
+        chosen, rejected = logps[:pairs], logps[pairs:]
+        if kind == "orpo":
+            nll_mask = (
+                mx.arange(1, batch.shape[1]) < lengths[:pairs, 1:]
+            ).astype(mx.float32)
+            nll_tokens = nll_mask.sum()
+            nll_sum = (ce[:pairs] * nll_mask).sum()
+            nll = nll_sum / mx.maximum(nll_tokens, mx.array(1.0))
+            log_odds = _orpo_log_odds(chosen, rejected)
+            ratio = _log_sigmoid(log_odds)
+            loss = nll - beta * ratio.mean()
+            chosen_rewards = beta * chosen
+            rejected_rewards = beta * rejected
+            extra = [nll_sum, ratio.sum(), log_odds.sum()]
+            denominators = [
+                chosen_logit_count, rejected_logit_count, nll_tokens,
+            ]
+        else:
+            if reference_free:
+                reference = mx.zeros(logps.shape, dtype=logps.dtype)
+            else:
+                reference = reference_policy.forward(model, batch, lengths)
+            margin = beta * (
+                (chosen - rejected) - (reference[:pairs] - reference[pairs:])
+            )
+            loss = -(
+                (1.0 - epsilon) * _log_sigmoid(margin)
+                + epsilon * _log_sigmoid(-margin)
+            ).mean()
+            chosen_rewards = beta * (chosen - reference[:pairs])
+            rejected_rewards = beta * (rejected - reference[pairs:])
+            extra = []
+            denominators = [chosen_logit_count, rejected_logit_count]
+        stats = [
+            chosen_rewards.sum(),
+            rejected_rewards.sum(),
+            (chosen_rewards > rejected_rewards).astype(mx.float32).sum(),
+            (chosen_rewards - rejected_rewards).sum(),
+            chosen.sum(),
+            rejected.sum(),
+            chosen_logits,
+            rejected_logits,
+        ] + extra + denominators
+        return (
+            loss,
+            mx.array(pairs, dtype=mx.int32),
+            mx.stack([value.astype(mx.float32) for value in stats]),
+        )
+
+    eval_fn._unsloth_preference_metrics = PREFERENCE_EVAL_METRICS[kind]
+    eval_fn._unsloth_preference_denominators = PREFERENCE_EVAL_DENOMINATORS[kind]
+    eval_fn._unsloth_preference_stats_width = PREFERENCE_EVAL_STATS_WIDTH[kind]
+    return eval_fn
 
 
 def lora_modules_have_nonzero_delta(modules):

--- a/unsloth_zoo/mlx/preference.py
+++ b/unsloth_zoo/mlx/preference.py
@@ -19,6 +19,7 @@ from .utils import (
     _normalize_seed,
     _torch_randperm_order,
     collect_mlx_lora_adapter_tensors,
+    encode_mlx_text,
     iter_mlx_lora_modules,
 )
 
@@ -133,10 +134,7 @@ def _render_preference_row(tokenizer, row):
     )
 
 
-def tokenize_preference_row(
-    tokenizer, row, *, max_seq_length, append_eos=True,
-):
-    """Tokenize one row and preserve a shared prompt boundary."""
+def _require_preference_fields(row):
     if not isinstance(row, Mapping):
         raise ValueError("Unsloth MLX preference: each dataset row must be a mapping.")
     missing = {"prompt", "chosen", "rejected"} - set(row)
@@ -145,6 +143,13 @@ def tokenize_preference_row(
             "Unsloth MLX preference: every row requires explicit prompt, chosen, "
             f"and rejected fields; missing {sorted(missing)!r}."
         )
+
+
+def tokenize_preference_row(
+    tokenizer, row, *, max_seq_length, append_eos=True,
+):
+    """Tokenize one row and preserve a shared prompt boundary."""
+    _require_preference_fields(row)
     prompt_text, chosen_text, rejected_text = _render_preference_row(tokenizer, row)
     chosen = _encode_mlx_prompt_completion(
         tokenizer, prompt_text, chosen_text, append_eos=append_eos,
@@ -185,6 +190,31 @@ def tokenize_preference_row(
         tuple(chosen_prompt), tuple(chosen_response),
         tuple(rejected_prompt), tuple(rejected_response),
     )
+
+
+def encode_generation_prompt(tokenizer, row, *, max_seq_length, max_new_tokens):
+    """Encode one row's prompt for generation, reserving room for the sample.
+
+    ``max_new_tokens`` comes out of ``max_seq_length`` and the prompt keeps its
+    end. Not ``tokenize_preference_row``'s prompt: that boundary hands a merged
+    prompt/completion token to the response span, and generation has no
+    completion to merge with. Not the generation engine's own encoder either,
+    which omits the special tokens training adds.
+    """
+    _require_preference_fields(row)
+    prompt_text, _, _ = _render_preference_row(tokenizer, row)
+    budget = int(max_seq_length) - int(max_new_tokens)
+    if budget < 1:
+        raise ValueError(
+            "Unsloth MLX preference: max_new_tokens must leave at least one "
+            "prompt token within max_seq_length."
+        )
+    prompt_ids = [int(token) for token in encode_mlx_text(tokenizer, prompt_text)]
+    if not prompt_ids:
+        raise ValueError(
+            "Unsloth MLX preference: a row rendered an empty prompt."
+        )
+    return prompt_text, tuple(prompt_ids[-budget:])
 
 
 class FinitePreferenceBatchPlan(_FiniteVisitMixin):

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -584,9 +584,10 @@ from .preference import (
     PreferenceRunContext,
     build_reference_policy,
     create_preference_batch_plan,
-    encode_generation_prompt,
+    encode_generation_prompt_text,
     make_dpo_loss_fn,
     make_orpo_loss_fn,
+    make_preference_eval_fn,
 )
 from .compile import (
     build_compile_policy,
@@ -1341,8 +1342,7 @@ class MLXORPOConfig(MLXTrainingConfig):
 
     beta: float = field(default=0.1, kw_only=True)
     disable_dropout: bool = field(default=True, kw_only=True)
-    # An eval dataset feeds sampling, not scoring: these objectives report no
-    # eval loss. Batched decoding is not batch-invariant, so a prompt can decode
+    # Batched decoding is not batch-invariant, so a prompt can decode
     # differently depending on what shares its batch.
     generate_during_eval: bool = field(default=False, kw_only=True)
     num_generation_prompts: int = field(default=8, kw_only=True)
@@ -2686,7 +2686,8 @@ class MLXTrainer:
     def add_eval_callback(self, fn):
         """Register a callback called after each evaluation.
 
-        fn(step, eval_loss, perplexity)
+        fn(step, eval_loss, perplexity); perplexity is None for a preference
+        objective, which reports no token-level likelihood to exponentiate.
         """
         self._eval_callbacks.append(fn)
 
@@ -3754,16 +3755,24 @@ class MLXTrainer:
                 pass  # read-only attribute; the close above already ended it
 
     def _evaluate_batch_totals(self, eval_batches, loss_fn, is_vlm=False):
-        """Accumulate weighted loss totals for one flat eval batch stream."""
+        """Accumulate weighted loss totals for one flat eval batch stream.
+
+        Returns ``(all_losses, ntokens, stats)``; ``stats`` is None unless the
+        loss function also reports per-batch metric sums.
+        """
         all_losses = mx.array(0.0)
         ntokens = mx.array(0)
+        metric_names = getattr(loss_fn, "_unsloth_preference_metrics", None)
+        stats = None if not metric_names else mx.zeros((getattr(
+            loss_fn, "_unsloth_preference_stats_width", len(metric_names),
+        ),))
         # A stop requested before evaluation must abort before the first pull:
         # an unsized source's next row can block, so cancellation could
         # otherwise never take effect. Rank-synchronized so peers return
         # together instead of diverging at the in-loop status collective.
         should_stop, _ = self._distributed_eval_status()
         if should_stop:
-            return all_losses, ntokens
+            return all_losses, ntokens, stats
         iterator = iter(eval_batches)
 
         while True:
@@ -3782,16 +3791,21 @@ class MLXTrainer:
             if not failed and not self.stop_requested:
                 try:
                     if is_vlm:
-                        loss, ntoks = loss_fn(self.model, batch_data)
+                        scored = loss_fn(self.model, batch_data)
                     else:
                         batch, lengths, labels = batch_data
-                        loss, ntoks = loss_fn(self.model, batch, lengths, labels)
+                        scored = loss_fn(self.model, batch, lengths, labels)
+                    loss, ntoks = scored[0], scored[1]
                     # Zero-token eval batches (distributed_pad_mode="empty" padding
                     # rows) make loss NaN; mask them so NaN * 0 does not poison the
                     # distributed all-sum. mx.where never selects the NaN branch.
                     all_losses += mx.where(ntoks > 0, loss * ntoks, 0.0)
                     ntokens += ntoks
-                    mx.eval(all_losses, ntokens)
+                    if stats is None:
+                        mx.eval(all_losses, ntokens)
+                    else:
+                        stats = stats + scored[2]
+                        mx.eval(all_losses, ntokens, stats)
                     # HF dispatches on_prediction_step after each evaluation
                     # batch is folded into the running totals. Raised inside
                     # this try on purpose: a callback that fails on one rank
@@ -3812,7 +3826,7 @@ class MLXTrainer:
             if should_stop:
                 break
 
-        return all_losses, ntokens
+        return all_losses, ntokens, stats
 
     def _create_text_eval_batches(
         self,
@@ -3888,62 +3902,101 @@ class MLXTrainer:
         """Run evaluation loop.
 
         Returns:
-            (avg_loss, perplexity) tuple.
+            ``(avg_loss, perplexity)``. Perplexity is None for a preference
+            objective, whose loss is not a per-token likelihood.
+
+        The weight each batch contributes is whatever its loss function returns
+        second: supervised tokens for a token objective, scored pairs for a
+        preference one.
         """
         self.model.eval()
-        metrics = {}
-        if isinstance(eval_batches, dict):
-            all_losses = mx.array(0.0)
-            ntokens = mx.array(0)
-            # HF evaluates one split at a time and rebuilds its eval_dataloader
-            # per split, so on_prediction_step reports the split being consumed
-            # rather than the dict of splits (whose len is the split count, and
-            # would give ProgressCallback a nonsense bar total).
-            handler = getattr(self, "callback_handler", None)
-            outer_dataloader = getattr(handler, "eval_dataloader", None)
-            try:
-                for split_index, (split_name, split_batches) in enumerate(
-                    eval_batches.items()
-                ):
-                    if handler is not None:
-                        if split_index:
-                            self._close_split_prediction_bars()
-                        handler.eval_dataloader = split_batches
-                    split_losses, split_tokens = self._evaluate_batch_totals(
-                        split_batches, loss_fn, is_vlm=is_vlm,
-                    )
-                    split_losses = self._distributed_all_sum(split_losses, stream=mx.cpu)
-                    split_tokens = self._distributed_all_sum(split_tokens, stream=mx.cpu)
-                    all_losses += split_losses
-                    ntokens += split_tokens
-                    mx.eval(all_losses, ntokens)
-                    split_loss = (
-                        (split_losses / split_tokens).item()
-                        if split_tokens.item() > 0 else 0.0
-                    )
-                    split_ppl = math.exp(min(split_loss, 100))
-                    split_prefix = f"eval_{split_name}"
-                    metrics[f"{split_prefix}_loss"] = split_loss
-                    metrics[f"{split_prefix}_perplexity"] = split_ppl
-                    if self._distributed_should_stop():
-                        break
-            finally:
-                if handler is not None:
-                    handler.eval_dataloader = outer_dataloader
-        else:
-            all_losses, ntokens = self._evaluate_batch_totals(
-                eval_batches, loss_fn, is_vlm=is_vlm,
-            )
-            all_losses = self._distributed_all_sum(all_losses, stream=mx.cpu)
-            ntokens = self._distributed_all_sum(ntokens, stream=mx.cpu)
+        # Restored on every path: a raise here would otherwise leave the model
+        # in eval mode for the rest of training, silently disabling dropout and
+        # NEFTune noise.
+        try:
+            metrics = {}
+            # Set by the preference scorer, which has no perplexity to report.
+            metric_names = getattr(loss_fn, "_unsloth_preference_metrics", None)
+            # Means over tokens carry their own denominator in the same vector.
+            metric_denominators = getattr(
+                loss_fn, "_unsloth_preference_denominators", None,
+            ) or {}
 
-        self.model.train()
-        avg_loss = (all_losses / ntokens).item() if ntokens.item() > 0 else 0.0
-        perplexity = math.exp(min(avg_loss, 100))
-        metrics["eval_loss"] = avg_loss
-        metrics["eval_perplexity"] = perplexity
+            def _record(prefix, losses, weights, stats):
+                """Write one scope's metrics and return its mean loss."""
+                total = weights.item()
+                value = (losses / weights).item() if total > 0 else 0.0
+                metrics[f"{prefix}loss"] = value
+                if metric_names is None:
+                    metrics[f"{prefix}perplexity"] = math.exp(min(value, 100))
+                elif total > 0:
+                    summed = stats.tolist()
+                    for index, name in enumerate(metric_names):
+                        over = metric_denominators.get(index)
+                        divisor = total if over is None else summed[over]
+                        metrics[f"{prefix}{name}"] = (
+                            summed[index] / divisor if divisor > 0 else 0.0
+                        )
+                return value
+
+            if isinstance(eval_batches, dict):
+                all_losses = mx.array(0.0)
+                ntokens = mx.array(0)
+                all_stats = None
+                # HF evaluates one split at a time and rebuilds its eval_dataloader
+                # per split, so on_prediction_step reports the split being consumed
+                # rather than the dict of splits (whose len is the split count, and
+                # would give ProgressCallback a nonsense bar total).
+                handler = getattr(self, "callback_handler", None)
+                outer_dataloader = getattr(handler, "eval_dataloader", None)
+                try:
+                    for split_index, (split_name, split_batches) in enumerate(
+                        eval_batches.items()
+                    ):
+                        if handler is not None:
+                            if split_index:
+                                self._close_split_prediction_bars()
+                            handler.eval_dataloader = split_batches
+                        split_losses, split_tokens, split_stats = (
+                            self._evaluate_batch_totals(
+                                split_batches, loss_fn, is_vlm=is_vlm,
+                            )
+                        )
+                        split_losses = self._distributed_all_sum(split_losses, stream=mx.cpu)
+                        split_tokens = self._distributed_all_sum(split_tokens, stream=mx.cpu)
+                        all_losses += split_losses
+                        ntokens += split_tokens
+                        if split_stats is not None:
+                            split_stats = self._distributed_all_sum(
+                                split_stats, stream=mx.cpu,
+                            )
+                            all_stats = (
+                                split_stats if all_stats is None
+                                else all_stats + split_stats
+                            )
+                            mx.eval(all_stats)
+                        mx.eval(all_losses, ntokens)
+                        _record(f"eval_{split_name}_", split_losses, split_tokens,
+                                split_stats)
+                        if self._distributed_should_stop():
+                            break
+                finally:
+                    if handler is not None:
+                        handler.eval_dataloader = outer_dataloader
+            else:
+                all_losses, ntokens, all_stats = self._evaluate_batch_totals(
+                    eval_batches, loss_fn, is_vlm=is_vlm,
+                )
+                all_losses = self._distributed_all_sum(all_losses, stream=mx.cpu)
+                ntokens = self._distributed_all_sum(ntokens, stream=mx.cpu)
+                if all_stats is not None:
+                    all_stats = self._distributed_all_sum(all_stats, stream=mx.cpu)
+
+        finally:
+            self.model.train()
+        avg_loss = _record("eval_", all_losses, ntokens, all_stats)
         self._last_eval_metrics = metrics
-        return avg_loss, perplexity
+        return avg_loss, metrics.get("eval_perplexity")
 
     @staticmethod
     def _bytes_to_gb(value):
@@ -4111,16 +4164,28 @@ class MLXTrainer:
                     pass
 
         def _on_eval(step, eval_loss, perplexity):
+            # Everything the evaluation reported, not just the two values this
+            # callback is handed: "eval_rewards/chosen" charts as
+            # "eval/rewards/chosen", matching the existing "eval/loss".
+            reported = {
+                f"eval/{name[len('eval_'):]}": value
+                for name, value in (self._last_eval_metrics or {}).items()
+                # These two come from the arguments, so each value has one source.
+                if name not in ("eval_loss", "eval_perplexity")
+                and name.startswith("eval_") and isinstance(value, (int, float))
+            }
+            reported["eval/loss"] = eval_loss
+            if perplexity is not None:
+                reported["eval/perplexity"] = perplexity
             if wandb_run is not None:
                 try:
-                    wandb_run.log({"eval/loss": eval_loss,
-                                   "eval/perplexity": perplexity}, step=step)
+                    wandb_run.log(reported, step=step)
                 except Exception:
                     pass
             if tb_writer is not None:
                 try:
-                    tb_writer.add_scalar("eval/loss", eval_loss, step)
-                    tb_writer.add_scalar("eval/perplexity", perplexity, step)
+                    for name, value in reported.items():
+                        tb_writer.add_scalar(name, value, step)
                 except Exception:
                     pass
 
@@ -5176,6 +5241,7 @@ class MLXTrainer:
                 ) from e
 
         _sampling_reference = None
+        preference_eval_fn = None
         if preference_kind:
             if preference_kind == "orpo":
                 loss_fn = make_orpo_loss_fn(beta=args.beta)
@@ -5206,6 +5272,15 @@ class MLXTrainer:
                 _main_print(f"Unsloth: Using DPO loss (beta={args.beta}).")
             self._preference_run_context = PreferenceRunContext(
                 model, enabled=bool(getattr(args, "disable_dropout", True)),
+            )
+            # Not the training loss: that one normalizes across an accumulation
+            # window, and reports none of these metrics.
+            preference_eval_fn = make_preference_eval_fn(
+                preference_kind,
+                beta=args.beta,
+                label_smoothing=getattr(args, "label_smoothing", 0.0),
+                reference_policy=_sampling_reference,
+                reference_free=bool(getattr(args, "reference_free", False)),
             )
 
         self.callback_handler.optimizer = optimizer
@@ -5715,6 +5790,53 @@ class MLXTrainer:
 
         # Prepare eval batches
         eval_batches = None
+        # (split_name, prompt_text, prompt_token_ids), filled by the plan
+        # builder's own pass so the eval dataset is never read twice.
+        _generation_source = []
+
+        _samples_prompts = bool(getattr(args, "generate_during_eval", False))
+        _generation_budget = {}
+
+        def _format_preference_split(split_name, split):
+            """Format a preference split's rows here, so the plan is told not to.
+
+            One call per row, whatever else reads the split: a formatting_func
+            that varies between calls, or consumes what it is given, would
+            otherwise have one example sampled and a different one scored. Only
+            the preference plan hands its formatting over; every other eval path
+            formats inside its own builder, so this wraps nothing they see --
+            it would format their rows a second time and hide a sized dataset
+            behind a generator.
+            """
+            if _samples_prompts:
+                _generation_budget[split_name] = [
+                    0, int(args.num_generation_prompts),
+                ]
+            for raw in split:
+                yield (
+                    self.formatting_func(raw)
+                    if self.formatting_func is not None else raw
+                )
+
+        def _capture_generation_prompt(split_name, prompt_text):
+            """Keep a sampler prompt from the rendering the scorer already did.
+
+            Rendering is not required to be a pure function of the row -- a chat
+            template may carry state -- so the prompt that is sampled is the one
+            the scorer rendered, not a second rendering of the same row. Keeping
+            text and token ids rather than the row is what makes that safe: an
+            iterable is free to yield one row object it rewrites every time, and
+            sampling reads these only once the pass has finished.
+            """
+            budget = _generation_budget.get(split_name)
+            if budget is None or budget[0] >= budget[1]:
+                return
+            budget[0] += 1
+            _generation_source.append((split_name,) + encode_generation_prompt_text(
+                self.tokenizer, prompt_text,
+                max_seq_length=args.max_seq_length,
+                max_new_tokens=args.generation_max_tokens,
+            ))
         text_completion_only_loss = _text_completion_only_loss_arg(args)
         text_assistant_only_loss = _text_assistant_only_loss_arg(args)
 
@@ -5738,8 +5860,29 @@ class MLXTrainer:
             if _labeled_eval is not None:
                 eval_batches = _labeled_eval
             else:
-                def _create_eval_batches(eval_dataset):
+                def _create_eval_batches(eval_dataset, _split_name=None):
                     """Build evaluation batches for one dataset split."""
+                    if self.preference_kind:
+                        # Sequential, so every evaluation scores the same
+                        # batches in the declared order. grad_accum=1 leaves each
+                        # batch's normalizers describing only itself.
+                        return create_preference_batch_plan(
+                            _format_preference_split(_split_name, eval_dataset),
+                            self.tokenizer,
+                            batch_size=eval_batch_size,
+                            max_seq_length=args.max_seq_length,
+                            num_epochs=1,
+                            grad_accum=1,
+                            preserve_dataset_order=True,
+                            seed=args.seed,
+                            append_eos=bool(args.append_eos),
+                            formatting_func=None,
+                            prompt_sink=(
+                                (lambda text, _n=_split_name:
+                                 _capture_generation_prompt(_n, text))
+                                if _samples_prompts else None
+                            ),
+                        )
                     if is_vlm:
                         if not _vlm_has_sized_index_space(eval_dataset):
                             raise ValueError(
@@ -5776,26 +5919,20 @@ class MLXTrainer:
                     """Build every eval split, in the order the user declared."""
                     if isinstance(self.eval_dataset, dict):
                         return {
-                            key: _create_eval_batches(value)
-                            for key, value in self.eval_dataset.items()
+                            key: _create_eval_batches(self.eval_dataset[key], key)
+                            for key in self.eval_dataset
                         }
-                    return _create_eval_batches(self.eval_dataset)
+                    return _create_eval_batches(self.eval_dataset, None)
 
-                if is_vlm:
-                    # Eager VLM training batches used to be built before this
-                    # point, so eval preprocessing could never reach the
-                    # training augmentation stream. A lazy training plan builds
-                    # nothing yet, so these eval builds would otherwise consume
-                    # the draws the first training batch is owed; keep them out
-                    # of that stream. ONE preservation spans every split: one
-                    # per split would restore the same snapshot before each of
-                    # them and replay a single draw sequence for all, where
-                    # sequential construction advanced from split to split.
-                    # It spans the process-global RNGs only, so state owned
-                    # privately -- by the processor, or by a user's
-                    # response_mask_fn, which the plan also calls per batch at
-                    # materialize -- does still advance here. No snapshot of an
-                    # arbitrary object's own counter exists to take.
+                if is_vlm or self.preference_kind:
+                    # A preference plan is built at the first evaluation, with
+                    # training already running, so these builds would otherwise
+                    # consume draws a training batch is owed. One preservation
+                    # spans every split: one per split would restore the same
+                    # snapshot before each and replay one draw sequence for all.
+                    # Only the process-global RNGs are spanned, so state held
+                    # privately -- by the processor, or a user's
+                    # response_mask_fn -- still advances here.
                     with _preserved_preprocessing_rng():
                         eval_batches = _create_every_eval_split()
                 else:
@@ -6169,46 +6306,20 @@ class MLXTrainer:
             steps = 0
             train_time = 0
 
-        def _generation_rows():
-            """Yield (split_name, row) — a dict of splits is resolved, not
-            iterated with its keys read as prompts. Positional, so successive
-            evaluations sample the same prompts and drift is readable."""
-            limit = int(args.num_generation_prompts)
-            splits = (
-                self.eval_dataset if isinstance(self.eval_dataset, dict)
-                else {None: self.eval_dataset}
-            )
-            for name, split in splits.items():
-                taken = 0
-                for raw in split:
-                    row = (
-                        self.formatting_func(raw)
-                        if self.formatting_func is not None else raw
-                    )
-                    yield name, row
-                    taken += 1
-                    if taken >= limit:
-                        break
-
         def _sample_generations(current_step):
             from .generate import GenerationRequest, generate_batch
 
-            # Prompt building is inside the guard as well as the burst itself: a
-            # temperature > 0 burst advances the global stream by a
-            # token-count-dependent amount, and an augmenting formatting_func or
-            # tokenizer draws from it while rendering. Either would move the
-            # NEFTune noise the next steps draw.
+            # A temperature > 0 burst advances the global stream by a
+            # token-count-dependent amount, which would move the NEFTune noise
+            # the next steps draw. Rendering is not in here: the prompts were
+            # built during the plan's pass, under the preservation that takes.
             with _preserved_preprocessing_rng():
-                labels, prompts, requests = [], [], []
-                for name, row in _generation_rows():
-                    text, prompt_ids = encode_generation_prompt(
-                        self.tokenizer, row,
-                        max_seq_length=args.max_seq_length,
-                        max_new_tokens=args.generation_max_tokens,
-                    )
-                    labels.append(name)
-                    prompts.append(text)
-                    requests.append(GenerationRequest(prompt_token_ids=prompt_ids))
+                labels = [name for name, _text, _ids in _generation_source]
+                prompts = [text for _name, text, _ids in _generation_source]
+                requests = [
+                    GenerationRequest(prompt_token_ids=ids)
+                    for _name, _text, ids in _generation_source
+                ]
                 if not requests:
                     _main_print(
                         "  Gen   eval dataset has no rows to sample; skipping."
@@ -6264,12 +6375,6 @@ class MLXTrainer:
 
         def _run_eval(current_step):
             """Run eval and dispatch MLX/HF eval callbacks in DDP lockstep."""
-            if preference_kind and bool(getattr(args, "generate_during_eval", False)):
-                # No eval loss, so this stops before the metric machinery below.
-                if not self._distributed_should_stop():
-                    _sample_generations(current_step)
-                self.control.should_evaluate = False
-                return False
             current_eval_batches = _prepare_eval_batches()
             if not current_eval_batches:
                 self.control.should_evaluate = False
@@ -6285,7 +6390,9 @@ class MLXTrainer:
             _metrics_before_eval = self._last_eval_metrics
             try:
                 val_loss, ppl = self._evaluate(
-                    current_eval_batches, loss_fn, is_vlm=is_vlm)
+                    current_eval_batches, preference_eval_fn or loss_fn,
+                    is_vlm=is_vlm,
+                )
             finally:
                 if _pf is not None:
                     _pf.resume()
@@ -6303,11 +6410,25 @@ class MLXTrainer:
                 self._last_eval_metrics = _metrics_before_eval
                 self.control.should_evaluate = False
                 return False
-            _main_print(
-                f"  Eval  {current_step}/{total_steps} | "
-                f"Val Loss: {val_loss:.4f} | "
-                f"Perplexity: {ppl:.2f}"
-            )
+            if ppl is None:
+                # No per-token likelihood to exponentiate.
+                _scores = self._last_eval_metrics or {}
+                _accuracy = _scores.get("eval_rewards/accuracies", float("nan"))
+                _margin = _scores.get("eval_rewards/margins", float("nan"))
+                _main_print(
+                    f"  Eval  {current_step}/{total_steps} | "
+                    f"Val Loss: {val_loss:.4f} | "
+                    f"Rewards Acc: {_accuracy:.4f} | "
+                    f"Margin: {_margin:.4f}"
+                )
+            else:
+                _main_print(
+                    f"  Eval  {current_step}/{total_steps} | "
+                    f"Val Loss: {val_loss:.4f} | "
+                    f"Perplexity: {ppl:.2f}"
+                )
+            if preference_kind and bool(getattr(args, "generate_during_eval", False)):
+                _sample_generations(current_step)
             if is_main_process:
                 for cb in self._eval_callbacks:
                     try:
@@ -7610,23 +7731,55 @@ class MLXTrainer:
                 raise ValueError(
                     "Unsloth MLX preference: streaming datasets are not supported."
                 )
-            # Best-model loading and early stopping need an eval loss this
-            # objective never produces. A cadence is optional: a callback can
-            # raise should_evaluate on its own.
+            # A cadence is optional -- a callback can raise should_evaluate --
+            # but selecting a best model reads a metric only an evaluation makes.
             _sampling_eval = bool(getattr(args, "generate_during_eval", False))
-            if (
-                args.load_best_model_at_end
-                or args.early_stopping_patience > 0
-                or (
-                    not _sampling_eval
-                    and (self.eval_dataset is not None or args.eval_steps > 0)
-                )
+            if self.eval_dataset is None and (
+                args.load_best_model_at_end or args.early_stopping_patience > 0
             ):
                 raise ValueError(
-                    "Unsloth MLX preference: evaluation, best-model loading, "
-                    "and early stopping are not supported yet. Set "
-                    "generate_during_eval=True to sample completions from an "
-                    "eval dataset instead of scoring it."
+                    "Unsloth MLX preference: best-model loading and early "
+                    "stopping select on an evaluation metric, so they need an "
+                    "eval_dataset."
+                )
+            _splits = (
+                list(self.eval_dataset.values())
+                if isinstance(self.eval_dataset, dict)
+                else [] if self.eval_dataset is None else [self.eval_dataset]
+            )
+            # Scoring nothing still reports eval_loss 0.0: a best watermark no
+            # real evaluation can beat, and a reset of early stopping's patience.
+            if self.eval_dataset is not None and not _splits:
+                raise ValueError(
+                    "Unsloth MLX preference: evaluation requires at least one "
+                    "eval split to score."
+                )
+            # Read exactly once, by the plan builder, and never indexed. The
+            # declared length stands in for a guarantee the pass ends, which
+            # nothing can establish for an arbitrary iterable. That refuses a
+            # bare generator one traversal would have served; hanging on an
+            # endless one is the worse trade.
+            for _split in _splits:
+                try:
+                    _size = len(_split)
+                except (TypeError, AttributeError) as exc:
+                    raise ValueError(
+                        "Unsloth MLX preference: evaluation requires a finite "
+                        "eval dataset, one that reports its own length."
+                    ) from exc
+                if _size == 0:
+                    raise ValueError(
+                        "Unsloth MLX preference: the eval dataset is empty."
+                    )
+            if (
+                self.eval_dataset is not None
+                and getattr(args, "max_eval_batches", None) is not None
+            ):
+                raise ValueError(
+                    "Unsloth MLX preference: max_eval_batches bounds an "
+                    "unbounded lazy eval stream by batch count, and preference "
+                    "evaluation scores a finite plan instead. Shorten the "
+                    "eval_dataset instead."
                 )
             if _sampling_eval:
                 if self.eval_dataset is None:
@@ -7651,13 +7804,10 @@ class MLXTrainer:
                         "cadence is set; sampling runs only when a callback "
                         "requests an evaluation."
                     )
-                for _unused in ("per_device_eval_batch_size", "max_eval_batches"):
-                    if getattr(args, _unused, None) is not None:
-                        raise ValueError(
-                            f"Unsloth MLX preference: {_unused} does not apply to "
-                            "generate_during_eval, which runs no eval batches."
-                        )
-            if self._batches is not None:
+            if (
+                self._batches is not None
+                or getattr(self, "_eval_batches_labeled", None) is not None
+            ):
                 raise ValueError(
                     "Unsloth MLX preference: prebuilt SFT or response-masked "
                     "batches are not compatible with preference objectives."

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -584,6 +584,7 @@ from .preference import (
     PreferenceRunContext,
     build_reference_policy,
     create_preference_batch_plan,
+    encode_generation_prompt,
     make_dpo_loss_fn,
     make_orpo_loss_fn,
 )
@@ -884,6 +885,37 @@ def _clip_grad_by_leaf_norm(grad, max_grad_leaf_norm):
         return g * scale.astype(g.dtype)
 
     return tree_map(_clip_leaf_norm, grad)
+
+
+def _build_generation_defaults(args):
+    """Build the engine's sampling parameters, validating them as a side effect.
+
+    The engine validates in its own frozen dataclasses, so building them at
+    configuration time turns a crash at the first evaluation into a
+    configuration error. Values stay uncoerced: coercing would hide the type
+    checks this exists to run. Its messages name its own fields, so they are
+    restated against the config field the user set.
+    """
+    from .generate import GenerationDefaults, SamplingParams
+
+    try:
+        sampling = SamplingParams(temperature=args.generation_temperature)
+    except (TypeError, ValueError) as error:
+        raise type(error)(
+            f"Unsloth MLX preference: generation_temperature is invalid: {error}"
+        ) from error
+    try:
+        return GenerationDefaults(max_tokens=args.generation_max_tokens,
+                                  sampling=sampling)
+    except (TypeError, ValueError) as error:
+        raise type(error)(
+            f"Unsloth MLX preference: generation_max_tokens is invalid: {error}"
+        ) from error
+
+
+def _one_line(text, width):
+    flat = " ".join(str(text).split())
+    return flat if len(flat) <= width else flat[: width - 1] + "\u2026"
 
 
 def _global_grad_norm_fp32(grad):
@@ -1246,6 +1278,10 @@ class MLXTrainingConfig:
             "disable_dropout",
             "reference_free",
             "label_smoothing",
+            "generate_during_eval",
+            "num_generation_prompts",
+            "generation_max_tokens",
+            "generation_temperature",
         }
         _field_names = {field.name for field in config_fields}
         copied_all_fields = (_field_names - _appended_fields) <= set(provided)
@@ -1305,6 +1341,13 @@ class MLXORPOConfig(MLXTrainingConfig):
 
     beta: float = field(default=0.1, kw_only=True)
     disable_dropout: bool = field(default=True, kw_only=True)
+    # An eval dataset feeds sampling, not scoring: these objectives report no
+    # eval loss. Batched decoding is not batch-invariant, so a prompt can decode
+    # differently depending on what shares its batch.
+    generate_during_eval: bool = field(default=False, kw_only=True)
+    num_generation_prompts: int = field(default=8, kw_only=True)
+    generation_max_tokens: int = field(default=128, kw_only=True)
+    generation_temperature: float = field(default=0.0, kw_only=True)
 
 
 @dataclass(init=False)
@@ -1315,6 +1358,11 @@ class MLXDPOConfig(MLXTrainingConfig):
     reference_free: bool = field(default=False, kw_only=True)
     label_smoothing: float = field(default=0.0, kw_only=True)
     disable_dropout: bool = field(default=True, kw_only=True)
+    # As MLXORPOConfig; a referenced run also samples the frozen base policy.
+    generate_during_eval: bool = field(default=False, kw_only=True)
+    num_generation_prompts: int = field(default=8, kw_only=True)
+    generation_max_tokens: int = field(default=128, kw_only=True)
+    generation_temperature: float = field(default=0.0, kw_only=True)
 
 
 def _shape_guard_report(
@@ -2085,6 +2133,7 @@ class MLXTrainer:
         # eval (eval_steps=0 or no eval dataset) does not report a prior run's
         # eval_loss/perplexity in its result. Repopulated by _evaluate.
         self._last_eval_metrics = {}
+        self.last_generation_samples = []
         self._early_stopped = False
         self._best_metric = None
         self._best_step = None
@@ -5126,6 +5175,7 @@ class MLXTrainer:
                     f"silently restart from step 0."
                 ) from e
 
+        _sampling_reference = None
         if preference_kind:
             if preference_kind == "orpo":
                 loss_fn = make_orpo_loss_fn(beta=args.beta)
@@ -5144,6 +5194,9 @@ class MLXTrainer:
                     ),
                 )
                 self._preference_reference_provenance = provenance
+                # Sampling borrows this policy's adapter modules so it zeroes
+                # the same ones the loss does. NEFTune is already off in eval.
+                _sampling_reference = reference_policy
                 loss_fn = make_dpo_loss_fn(
                     beta=args.beta,
                     label_smoothing=args.label_smoothing,
@@ -6116,8 +6169,107 @@ class MLXTrainer:
             steps = 0
             train_time = 0
 
+        def _generation_rows():
+            """Yield (split_name, row) — a dict of splits is resolved, not
+            iterated with its keys read as prompts. Positional, so successive
+            evaluations sample the same prompts and drift is readable."""
+            limit = int(args.num_generation_prompts)
+            splits = (
+                self.eval_dataset if isinstance(self.eval_dataset, dict)
+                else {None: self.eval_dataset}
+            )
+            for name, split in splits.items():
+                taken = 0
+                for raw in split:
+                    row = (
+                        self.formatting_func(raw)
+                        if self.formatting_func is not None else raw
+                    )
+                    yield name, row
+                    taken += 1
+                    if taken >= limit:
+                        break
+
+        def _sample_generations(current_step):
+            from .generate import GenerationRequest, generate_batch
+
+            # Prompt building is inside the guard as well as the burst itself: a
+            # temperature > 0 burst advances the global stream by a
+            # token-count-dependent amount, and an augmenting formatting_func or
+            # tokenizer draws from it while rendering. Either would move the
+            # NEFTune noise the next steps draw.
+            with _preserved_preprocessing_rng():
+                labels, prompts, requests = [], [], []
+                for name, row in _generation_rows():
+                    text, prompt_ids = encode_generation_prompt(
+                        self.tokenizer, row,
+                        max_seq_length=args.max_seq_length,
+                        max_new_tokens=args.generation_max_tokens,
+                    )
+                    labels.append(name)
+                    prompts.append(text)
+                    requests.append(GenerationRequest(prompt_token_ids=prompt_ids))
+                if not requests:
+                    _main_print(
+                        "  Gen   eval dataset has no rows to sample; skipping."
+                    )
+                    self.last_generation_samples = []
+                    return
+
+                defaults = self._generation_defaults
+                started = time.perf_counter()
+                policy = generate_batch(
+                    model, self.tokenizer, requests, defaults=defaults,
+                )
+                reference = None
+                modules = tuple(getattr(_sampling_reference, "modules", ()) or ())
+                if modules and not self._distributed_should_stop():
+                    scales = [module.scale for module in modules]
+                    try:
+                        for module in modules:
+                            module.scale = 0.0
+                        reference = generate_batch(
+                            model, self.tokenizer, requests, defaults=defaults,
+                        )
+                    finally:
+                        for module, scale in zip(modules, scales):
+                            module.scale = scale
+            elapsed = time.perf_counter() - started
+
+            samples = [
+                {
+                    "split": labels[index],
+                    "prompt": prompts[index],
+                    "policy": item.text,
+                    "reference": None if reference is None else reference[index].text,
+                }
+                for index, item in enumerate(policy)
+            ]
+            self.last_generation_samples = samples
+            sampled = sum(len(item.token_ids) for item in policy)
+            if reference is not None:
+                sampled += sum(len(item.token_ids) for item in reference)
+            _main_print(
+                f"  Gen   {current_step}/{total_steps} | {len(policy)} prompts | "
+                f"{sampled} tokens | {elapsed:.1f}s"
+            )
+            for index, sample in enumerate(samples):
+                tag = "" if sample["split"] is None else f" [{sample['split']}]"
+                _main_print(f"    {index + 1}{tag} {_one_line(sample['prompt'], 96)}")
+                _main_print(f"        policy    {_one_line(sample['policy'], 96)}")
+                if sample["reference"] is not None:
+                    _main_print(
+                        f"        reference {_one_line(sample['reference'], 96)}"
+                    )
+
         def _run_eval(current_step):
             """Run eval and dispatch MLX/HF eval callbacks in DDP lockstep."""
+            if preference_kind and bool(getattr(args, "generate_during_eval", False)):
+                # No eval loss, so this stops before the metric machinery below.
+                if not self._distributed_should_stop():
+                    _sample_generations(current_step)
+                self.control.should_evaluate = False
+                return False
             current_eval_batches = _prepare_eval_batches()
             if not current_eval_batches:
                 self.control.should_evaluate = False
@@ -7458,16 +7610,53 @@ class MLXTrainer:
                 raise ValueError(
                     "Unsloth MLX preference: streaming datasets are not supported."
                 )
+            # Best-model loading and early stopping need an eval loss this
+            # objective never produces. A cadence is optional: a callback can
+            # raise should_evaluate on its own.
+            _sampling_eval = bool(getattr(args, "generate_during_eval", False))
             if (
-                self.eval_dataset is not None
-                or args.eval_steps > 0
-                or args.load_best_model_at_end
+                args.load_best_model_at_end
                 or args.early_stopping_patience > 0
+                or (
+                    not _sampling_eval
+                    and (self.eval_dataset is not None or args.eval_steps > 0)
+                )
             ):
                 raise ValueError(
                     "Unsloth MLX preference: evaluation, best-model loading, "
-                    "and early stopping are not supported yet."
+                    "and early stopping are not supported yet. Set "
+                    "generate_during_eval=True to sample completions from an "
+                    "eval dataset instead of scoring it."
                 )
+            if _sampling_eval:
+                if self.eval_dataset is None:
+                    raise ValueError(
+                        "Unsloth MLX preference: generate_during_eval needs an "
+                        "eval_dataset to sample prompts from."
+                    )
+                if int(args.generation_max_tokens) >= int(args.max_seq_length):
+                    raise ValueError(
+                        "Unsloth MLX preference: generation_max_tokens must be "
+                        "smaller than max_seq_length, or no prompt tokens remain."
+                    )
+                if int(args.num_generation_prompts) < 1:
+                    raise ValueError(
+                        "Unsloth MLX preference: num_generation_prompts must be "
+                        "at least 1."
+                    )
+                self._generation_defaults = _build_generation_defaults(args)
+                if _resolve_interval_steps(args.eval_steps, 1) <= 0:
+                    print(
+                        "Unsloth: generate_during_eval is on but no evaluation "
+                        "cadence is set; sampling runs only when a callback "
+                        "requests an evaluation."
+                    )
+                for _unused in ("per_device_eval_batch_size", "max_eval_batches"):
+                    if getattr(args, _unused, None) is not None:
+                        raise ValueError(
+                            f"Unsloth MLX preference: {_unused} does not apply to "
+                            "generate_during_eval, which runs no eval batches."
+                        )
             if self._batches is not None:
                 raise ValueError(
                     "Unsloth MLX preference: prebuilt SFT or response-masked "


### PR DESCRIPTION
Stacked on #1011 — please review that one first. Both target `main`, so until #1011 merges GitHub shows its commit here too; the work to review in this PR is the **last two commits**, and the diff to read is `feat/mlx-preference-generate..HEAD`.

ORPO and DPO runs on MLX reported no eval loss and no reward metrics. An eval dataset fed the sampling pass #1011 adds, and nothing else: there was no number to select a best model on, no early-stopping signal, and nothing to compare against the same run on CUDA. This adds the evaluation itself, reporting the metric set TRL logs for these objectives so a run reads the same on either backend.

```
eval_loss  eval_rewards/chosen  eval_rewards/rejected  eval_rewards/accuracies
eval_rewards/margins  eval_logps/chosen  eval_logps/rejected
eval_logits/chosen  eval_logits/rejected
```

ORPO additionally reports `eval_nll_loss`, `eval_log_odds_ratio`, and `eval_log_odds_chosen`, the three terms its loss decomposes into.

## What changed

**A separate eval scorer, not the training loss.** `make_preference_eval_fn` scores one batch and returns `(loss, pairs, stats)`. The training loss is compiled and normalizes across a gradient-accumulation window that evaluation has no equivalent of, so reusing it would report a number that depends on the accumulation setting rather than on the held-out set.

**Every metric is divided by the total it is a mean over.** The scorer reports sums rather than per-batch means, so the eval set's value is one division at the end. Rewards, logps and ORPO's log-odds terms divide by the pair count; the two logit metrics and ORPO's `nll_loss` are means over tokens, so each reports a token count alongside its sum. That distinction only shows on a ragged final batch, where batches hold different numbers of tokens — TRL averages its per-batch means unweighted there, and weighting them by pairs is no closer, because neither can recover a mean over tokens once the counts differ.

**`eval_loss` is the pair-weighted mean of each batch's own objective value.** The scorer returns the batch's pair count as its weight rather than 1. TRL takes a mean of per-batch means; pair weighting agrees with it on every full batch and is more exact on a ragged final one, where weighting batches equally would give a one-pair tail the same say as a full batch of pairs.

**Eval batches are sequential and single-pass.** The held-out set is scored in the order it was declared, every evaluation scores the same batches, and `grad_accum=1` leaves each batch's normalizers describing only itself — which is what the pair weighting assumes.

**No `eval_perplexity`.** A preference loss is not a per-token likelihood, so there is nothing to exponentiate. `add_eval_callback` receives `perplexity=None`, and `report_to` omits the key rather than logging `None` — the W&B call logs eval loss and perplexity together inside one `try/except`, so a rejected `None` would have taken the eval loss down with it and charted nothing at all.

**`generate_during_eval` no longer short-circuits the evaluation.** Sampling is an addition to scoring, and runs after it. Its prompts come from the pass the scoring plan already makes over each split rather than from a second pass over the eval dataset, so evaluation as a whole reads that dataset once — measured, not assumed: a full run iterates the eval dataset exactly one time. The formatting hand-off that makes this work is applied inside the preference branch only, so no VLM or text SFT split is ever wrapped. Each row is formatted once and rendered once, and the prompt that gets sampled is the same text that gets scored — which matters because neither a `formatting_func` nor a chat template is required to return the same thing twice. Because the sampler keeps text and token ids rather than the row, no row is copied and nothing is assumed about what a row is; a dataset that rewrites one buffer per iteration is safe.

**`load_best_model_at_end` and `early_stopping_patience` are accepted** for these objectives now that an evaluation produces a metric to select on. `metric_for_best_model` can name any reported metric, so selecting on `rewards/accuracies` works. Both still require an eval dataset, which must report a length and be non-empty. The length is what stands in for termination — the plan materializes every row and nothing can prove an arbitrary iterable ends — so a bare generator is refused even though a single traversal would now suffice for one. Beyond that the dataset is never indexed and is read exactly once per run.

**`max_eval_batches` stays rejected.** It caps an unbounded stream by batch count. The preference plan is finite and epoch-driven, so honoring a batch cap would wrap into a second epoch and score part of the held-out set twice — silently, as a slightly wrong number.

## Validation

Cross-checked term by term against TRL 0.23.1's `DPOTrainer.dpo_loss` and `ORPOTrainer.odds_ratio_loss` on shared synthetic logits — eight checks, all passing: reference-free DPO, referenced DPO, DPO with label smoothing, and ORPO all agree, including the reward, logp, and log-odds terms and ORPO's NLL over the chosen sequence.

The two logit metrics are checked separately because TRL is not consistent between its own trainers: `DPOTrainer` averages the logit metric over the completion positions only, `ORPOTrainer` over the whole sequence. Each is followed rather than reconciled, so either metric compares directly against the run it mirrors. The DPO one is checked again under per-row response lengths, the fixture shape that separates a token-weighted mean from a row-weighted one, since TRL's is token-weighted across whatever shares the batch.

Every added test was mutation-checked — the production behaviour each one names was reverted or weakened, and exactly that test failed.

**The eval-mode gate is proven by a real Metal run, not by reading.** Evaluation runs the model in eval mode and restores training mode afterwards, which is what keeps NEFTune noise out of a reported eval number. The gate is the embedding's own training flag, so only a real `mlx.nn` module tree exercises it: the simulation shim's `Module.eval()` is a no-op and the class has no `training` attribute at all, so a test there would pass whether the gate worked or not. `test_neftune_noise_is_gated_out_of_the_preference_eval_forward` first proves the gate is live — the embedding is noised while training, redraws every forward, and is bit-identical to its base class while evaluating — then records the flag at every embedding call during a NEFTune-enabled ORPO run with an eval dataset. Removing `self.model.eval()` from `_evaluate` fails it with "NEFTune noise leaked into the eval forward"; removing the paired `self.model.train()` fails it with "_evaluate left the model in eval mode". A companion test covers the path that motivated putting the restoration in a `finally`: an evaluation that raises must still leave the model in training mode, or every step after it trains without NEFTune noise or dropout. This is the failure mode worth a real-model test: it moves an eval number without breaking anything visibly.

```
pytest tests/test_mlx_preference.py -q
102 passed

pytest tests/test_mlx_training_e2e_metal.py -q -k "preference or neftune or failed_evaluation"
3 passed
```

## Not in this PR

Train-side per-step preference metrics. The stats contract added here is reusable for them, but wiring them into the training log is separate work. The remaining CUDA-parity gaps — TRL's config defaults, BOS/EOS tokenization differences, and the CPO/KTO/GRPO trainers — are being handled separately as well.
