### PR TITLE
Vendored FLA: fix 65535 grid block cap in the gated delta rule kernels

### DIFF
--- a/unsloth_zoo/_vendored/fla/ops/common/chunk_delta_h.py
+++ b/unsloth_zoo/_vendored/fla/ops/common/chunk_delta_h.py
@@ -77,14 +77,11 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    # Unsloth: backported from fla PR #1077. N*HV used to sit on grid axis 1,
-    # which CUDA caps at 65535 blocks, so a batch of more than 65535/HV sequences
-    # failed the launch with "Triton Error [CUDA]: invalid argument". With HV=32
-    # that is 2047 packed documents in one varlen batch, which sequence packing
-    # reaches easily. Decode both indices from a flattened axis 0 instead.
-    # Keeping i_v as the fastest-varying index preserves the dispatch order of the
-    # old 2D grid, so the V-blocks of a sequence-head pair still land adjacently
-    # and their shared k / w loads stay in L2.
+    # Unsloth: backported from fla PR #1077. N*HV on grid axis 1 hit the 65535
+    # block cap, so a varlen batch of more than 65535/HV sequences failed to
+    # launch (2047 at HV=32, which sequence packing reaches). i_v stays
+    # fastest-varying, preserving the old dispatch order and the L2 reuse of a
+    # sequence-head pair's shared k / w loads.
     pid = tl.program_id(0)
     NV = tl.cdiv(V, BV)
     i_v, i_nh = pid % NV, (pid // NV).to(tl.int64)
@@ -364,14 +361,11 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    # Unsloth: backported from fla PR #1077. N*HV used to sit on grid axis 1,
-    # which CUDA caps at 65535 blocks, so a batch of more than 65535/HV sequences
-    # failed the launch with "Triton Error [CUDA]: invalid argument". With HV=32
-    # that is 2047 packed documents in one varlen batch, which sequence packing
-    # reaches easily. Decode both indices from a flattened axis 0 instead.
-    # Keeping i_v as the fastest-varying index preserves the dispatch order of the
-    # old 2D grid, so the V-blocks of a sequence-head pair still land adjacently
-    # and their shared k / w loads stay in L2.
+    # Unsloth: backported from fla PR #1077. N*HV on grid axis 1 hit the 65535
+    # block cap, so a varlen batch of more than 65535/HV sequences failed to
+    # launch (2047 at HV=32, which sequence packing reaches). i_v stays
+    # fastest-varying, preserving the old dispatch order and the L2 reuse of a
+    # sequence-head pair's shared k / w loads.
     pid = tl.program_id(0)
     NV = tl.cdiv(V, BV)
     i_v, i_nh = pid % NV, (pid // NV).to(tl.int64)

--- a/unsloth_zoo/_vendored/fla/ops/common/chunk_delta_h.py
+++ b/unsloth_zoo/_vendored/fla/ops/common/chunk_delta_h.py
@@ -77,7 +77,17 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    # Unsloth: backported from fla PR #1077. N*HV used to sit on grid axis 1,
+    # which CUDA caps at 65535 blocks, so a batch of more than 65535/HV sequences
+    # failed the launch with "Triton Error [CUDA]: invalid argument". With HV=32
+    # that is 2047 packed documents in one varlen batch, which sequence packing
+    # reaches easily. Decode both indices from a flattened axis 0 instead.
+    # Keeping i_v as the fastest-varying index preserves the dispatch order of the
+    # old 2D grid, so the V-blocks of a sequence-head pair still land adjacently
+    # and their shared k / w loads stay in L2.
+    pid = tl.program_id(0)
+    NV = tl.cdiv(V, BV)
+    i_v, i_nh = pid % NV, (pid // NV).to(tl.int64)
     i_n, i_h = i_nh // HV, i_nh % HV
     if IS_VARLEN:
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
@@ -354,7 +364,17 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    # Unsloth: backported from fla PR #1077. N*HV used to sit on grid axis 1,
+    # which CUDA caps at 65535 blocks, so a batch of more than 65535/HV sequences
+    # failed the launch with "Triton Error [CUDA]: invalid argument". With HV=32
+    # that is 2047 packed documents in one varlen batch, which sequence packing
+    # reaches easily. Decode both indices from a flattened axis 0 instead.
+    # Keeping i_v as the fastest-varying index preserves the dispatch order of the
+    # old 2D grid, so the V-blocks of a sequence-head pair still land adjacently
+    # and their shared k / w loads stay in L2.
+    pid = tl.program_id(0)
+    NV = tl.cdiv(V, BV)
+    i_v, i_nh = pid % NV, (pid // NV).to(tl.int64)
     i_n, i_h = i_nh // HV, i_nh % HV
     if IS_VARLEN:
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
@@ -644,7 +664,7 @@ def chunk_gated_delta_rule_fwd_h(
         final_state = k.new_zeros(N, HV, K, V, dtype=torch.float32) if output_final_state else None
 
     v_new = torch.empty_like(u) if save_new_value else None
-    def grid(meta): return (triton.cdiv(V, meta['BV']), N*HV)
+    def grid(meta): return (triton.cdiv(V, meta['BV']) * N * HV, )
     chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
         k=k,
         v=u,
@@ -703,7 +723,7 @@ def chunk_gated_delta_rule_bwd_dhu(
     dh0 = torch.empty_like(h0, dtype=torch.float32) if h0 is not None else None
     dv2 = torch.empty_like(dv)
 
-    def grid(meta): return (triton.cdiv(V, meta['BV']), N*HV)
+    def grid(meta): return (triton.cdiv(V, meta['BV']) * N * HV, )
     chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64[grid](
         q=q,
         k=k,

--- a/unsloth_zoo/_vendored/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/unsloth_zoo/_vendored/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -63,7 +63,13 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     APPLY_BETA_SIGMOID: tl.constexpr,
     ALLOW_NEG_EIGVAL: tl.constexpr,
 ):
-    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    # Unsloth: backported from fla PR #1097. Same 65535 grid-axis-1 cap as the
+    # state kernels (PR #1077): a decode batch of more than 65535/HV sequences
+    # failed the launch with "Triton Error [CUDA]: invalid argument". Decode both
+    # indices from a flattened axis 0, keeping i_v fastest-varying.
+    pid = tl.program_id(0)
+    NV = tl.cdiv(V, BV)
+    i_v, i_nh = pid % NV, (pid // NV).to(tl.int64)
     i_n, i_hv = i_nh // HV, i_nh % HV
     i_h = i_hv // (HV // H)
 
@@ -214,7 +220,7 @@ def fused_recurrent_gated_delta_rule_fwd(
     else:
         final_state = None
 
-    grid = (NV, N * HV)
+    grid = (NV * N * HV,)
     fused_recurrent_gated_delta_rule_fwd_kernel[grid](
         q=q,
         k=k,

--- a/unsloth_zoo/_vendored/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/unsloth_zoo/_vendored/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -63,10 +63,9 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     APPLY_BETA_SIGMOID: tl.constexpr,
     ALLOW_NEG_EIGVAL: tl.constexpr,
 ):
-    # Unsloth: backported from fla PR #1097. Same 65535 grid-axis-1 cap as the
-    # state kernels (PR #1077): a decode batch of more than 65535/HV sequences
-    # failed the launch with "Triton Error [CUDA]: invalid argument". Decode both
-    # indices from a flattened axis 0, keeping i_v fastest-varying.
+    # Unsloth: backported from fla PR #1097. Same 65535 grid cap as the state
+    # kernels (PR #1077): a decode batch of more than 65535/HV sequences failed
+    # to launch. i_v stays fastest-varying.
     pid = tl.program_id(0)
     NV = tl.cdiv(V, BV)
     i_v, i_nh = pid % NV, (pid // NV).to(tl.int64)


### PR DESCRIPTION
Backports two upstream flash-linear-attention fixes into the vendored snapshot in `unsloth_zoo/_vendored/fla`. Both are launch failures rather than numerical issues, and both are reachable from paths we already ship.

## The problem

`chunk_gated_delta_rule_fwd_h`, `chunk_gated_delta_rule_bwd_dhu` and `fused_recurrent_gated_delta_rule` all put `N * HV` on grid axis 1. CUDA caps that axis at 65535 blocks, so a batch of more than `65535 / HV` sequences fails the launch with:

```
RuntimeError: Triton Error [CUDA]: invalid argument
```

Qwen3-Next has 32 linear attention value heads, which puts the ceiling at 2047 sequences. That is very reachable from `unsloth/utils/packing.py`, which exists specifically to pack many short sequences into one varlen batch for gated delta models. Packing short samples at long total context walks straight into it, and the error points at Triton rather than at the batch composition, so it is hard to diagnose from the traceback.

## The fix

Flatten the grid onto axis 0 and decode `i_v` / `i_nh` inside the kernels. `i_v` stays the fastest varying index, so the dispatch order of the old 2D grid is preserved and the V blocks of a sequence-head pair still land adjacently, keeping their shared `k` / `w` loads in L2.

Upstream equivalents: fla PR #1077 for the state kernels, fla PR #1097 for the decode kernels.

## Testing

On a B200 with torch 2.9.1 and triton 3.5.1, at HV=32 so the cap is 2047:

| case | before | after |
| --- | --- | --- |
| chunk, 2039 sequences (under cap) | ok | ok |
| chunk, 2111 sequences (over cap) | `Triton Error [CUDA]: invalid argument` | ok |
| fused_recurrent, 2039 sequences | ok | ok |
| fused_recurrent, 2111 sequences | `Triton Error [CUDA]: invalid argument` | ok |

Numerics are unchanged. Comparing forward output, final state and all five gradients before and after across four shapes including a varlen case and a non multiple of chunk length, the forward output and final state are bitwise identical on three of four shapes. The remaining differences are at bf16 sub-ULP level, and a control run comparing the unpatched snapshot against itself in two independent processes produces differences of the same magnitude or larger, so they are pre-existing autotune nondeterminism rather than anything introduced here.

No performance change: `chunk_gated_delta_rule` fwd+bwd at B=2, T=16384, H=16, head dim 128 measures 3.978 ms before and 3.923 ms after, each in its own process with a fresh `TRITON_CACHE_DIR`.

## Not included

fla PR #1082 widens pointer arithmetic to int64, which matters because `B * T * HV * V` crosses 2^31 at ordinary long context shapes. The current snapshot does fault there, reproduced on B200 at B=20, T=16384, HV=64, V=128 with an illegal memory access.

That one cannot be backported onto this base on its own. Upstream landed it after fla PR #1062 migrated the kernels off `tl.make_block_ptr`, and block pointers only accept 32 bit offsets, so casting the program ids to int64 makes almost every kernel in this snapshot fail to compile:

```
Block pointers only support 32 bit `offsets/block_shape`, add a `.to(tl.int32)`
or use regular indexing for 64 bit support
```

Fixing it properly means taking fla PR #1062 as well, which rewrites the indexing across 11 of the vendored files. Given the size of that change, re-vendoring a newer fla-core wholesale is probably the better route than backporting both, so I have left it out of this PR. Until then the practical workaround is keeping `B * T * HV * V` under 2^31.
