### PR TITLE
Make the concurrent CI lanes record the failure that actually happened

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -92,6 +92,29 @@ jobs:
         run: |
           mkdir -p .lanes
 
+          # A lane records its own exit status, so every command in it has to be
+          # able to set that status. A brace group reports only its LAST command,
+          # and `set -e` inside it would be ignored because the group sits on the
+          # left of `|| rc=$?` (POSIX: errexit does not apply there). So the steps
+          # are `&&`-chained: the first failure both stops the lane and becomes rc.
+          #
+          # retry(): pip's own --retries only covers ESTABLISHING a connection, so
+          # a response body truncated mid-download (ProtocolError / IncompleteRead)
+          # is never retried and the install just dies. Wrap the network-bound
+          # installs so a truncated wheel costs a retry instead of a red run.
+          retry() {
+            attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge 3 ]; then
+                echo "retry: giving up after $attempt attempts: $*"
+                return 1
+              fi
+              echo "retry: attempt $attempt failed, retrying in 15s: $*"
+              attempt=$((attempt + 1))
+              sleep 15
+            done
+          }
+
           # CPU index avoids the multi-GB CUDA wheel set. `--no-deps unsloth`
           # satisfies the find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
           lane() {
@@ -101,14 +124,14 @@ jobs:
             (
               rc=0
               {
-                "$interpreter" -m venv "$venv"
-                "$venv/bin/python" -m pip install --upgrade pip
-                "$venv/bin/pip" install --index-url https://download.pytorch.org/whl/cpu \
-                  "torch>=2.4.0,<2.11.0"
-                "$venv/bin/pip" install -e .[core]
-                "$venv/bin/pip" install --no-deps \
-                  "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
-                "$venv/bin/pip" install pytest==9.0.3
+                "$interpreter" -m venv "$venv" &&
+                "$venv/bin/python" -m pip install --upgrade pip &&
+                retry "$venv/bin/pip" install --index-url https://download.pytorch.org/whl/cpu \
+                  "torch>=2.4.0,<2.11.0" &&
+                retry "$venv/bin/pip" install -e .[core] &&
+                { "$venv/bin/pip" install --no-deps \
+                  "unsloth @ git+https://github.com/unslothai/unsloth@main" || true; } &&
+                retry "$venv/bin/pip" install pytest==9.0.3
               } > "$log" 2>&1 || rc=$?
               echo "$rc" > ".lanes/$version.install"
 
@@ -342,18 +365,35 @@ jobs:
         run: |
           mkdir -p .lanes
 
+          # See the interpreter lane for why these are `&&`-chained and what retry()
+          # is for: a brace group reports only its last command, `set -e` is
+          # ignored on the left of `|| rc=$?`, and pip's --retries does not cover a
+          # download truncated mid-body.
+          retry() {
+            attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge 3 ]; then
+                echo "retry: giving up after $attempt attempts: $*"
+                return 1
+              fi
+              echo "retry: attempt $attempt failed, retrying in 15s: $*"
+              attempt=$((attempt + 1))
+              sleep 15
+            done
+          }
+
           # numerics: minimal on purpose -- mlx core only, no mlx-lm / mlx-vlm.
           (
             rc=0
             {
-              python -m venv .lanes/venv-numerics
-              .lanes/venv-numerics/bin/python -m pip install --upgrade pip
-              .lanes/venv-numerics/bin/pip install --index-url https://download.pytorch.org/whl/cpu \
-                "torch>=2.4.0,<2.11.0"
-              .lanes/venv-numerics/bin/pip install -e .[core]
-              .lanes/venv-numerics/bin/pip install --no-deps \
-                "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
-              .lanes/venv-numerics/bin/pip install pytest==9.0.3 "mlx>=0.22.0" mlx-cpu
+              python -m venv .lanes/venv-numerics &&
+              .lanes/venv-numerics/bin/python -m pip install --upgrade pip &&
+              retry .lanes/venv-numerics/bin/pip install --index-url https://download.pytorch.org/whl/cpu \
+                "torch>=2.4.0,<2.11.0" &&
+              retry .lanes/venv-numerics/bin/pip install -e .[core] &&
+              { .lanes/venv-numerics/bin/pip install --no-deps \
+                "unsloth @ git+https://github.com/unslothai/unsloth@main" || true; } &&
+              retry .lanes/venv-numerics/bin/pip install pytest==9.0.3 "mlx>=0.22.0" mlx-cpu
             } > .lanes/numerics-install.log 2>&1 || rc=$?
             echo "$rc" > .lanes/numerics.install
           ) < /dev/null > /dev/null 2>&1 &
@@ -367,15 +407,15 @@ jobs:
           (
             rc=0
             {
-              python -m venv .lanes/venv-suites
-              .lanes/venv-suites/bin/python -m pip install --upgrade pip
-              .lanes/venv-suites/bin/pip install --index-url https://download.pytorch.org/whl/cpu \
-                "torch>=2.4.0,<2.11.0"
-              .lanes/venv-suites/bin/pip install -e .[core] \
-                "mlx>=0.22.0" mlx-cpu "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4"
-              .lanes/venv-suites/bin/pip install --no-deps \
-                "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
-              .lanes/venv-suites/bin/pip install pytest==9.0.3
+              python -m venv .lanes/venv-suites &&
+              .lanes/venv-suites/bin/python -m pip install --upgrade pip &&
+              retry .lanes/venv-suites/bin/pip install --index-url https://download.pytorch.org/whl/cpu \
+                "torch>=2.4.0,<2.11.0" &&
+              retry .lanes/venv-suites/bin/pip install -e .[core] \
+                "mlx>=0.22.0" mlx-cpu "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4" &&
+              { .lanes/venv-suites/bin/pip install --no-deps \
+                "unsloth @ git+https://github.com/unslothai/unsloth@main" || true; } &&
+              retry .lanes/venv-suites/bin/pip install pytest==9.0.3
             } > .lanes/suites-install.log 2>&1 || rc=$?
             echo "$rc" > .lanes/suites.install
           ) < /dev/null > /dev/null 2>&1 &
@@ -536,6 +576,21 @@ jobs:
           PY
           }
 
+          # See the interpreter lane for why these are `&&`-chained and what retry()
+          # is for.
+          retry() {
+            attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge 3 ]; then
+                echo "retry: giving up after $attempt attempts: $*"
+                return 1
+              fi
+              echo "retry: attempt $attempt failed, retrying in 15s: $*"
+              attempt=$((attempt + 1))
+              sleep 15
+            done
+          }
+
           # Two-phase install, exactly as the matrix job did it: `-e .[core]` for the
           # pyproject defaults, then `-U <resolved>` to override. The -U is what lets
           # pip DOWNGRADE transformers for the 4.57.6 cell.
@@ -545,31 +600,30 @@ jobs:
             (
               rc=0
               {
-                set -x
-                specs="$(resolve "$@")"
-                spec_t="$(echo "$specs" | sed -n 1p)"
-                spec_r="$(echo "$specs" | sed -n 2p)"
-                spec_p="$(echo "$specs" | sed -n 3p)"
-                echo "resolved: $spec_t | $spec_r | $spec_p"
-
-                python -m venv "$venv"
-                "$venv/bin/python" -m pip install --upgrade pip
+                set -x &&
+                specs="$(resolve "$@")" &&
+                spec_t="$(echo "$specs" | sed -n 1p)" &&
+                spec_r="$(echo "$specs" | sed -n 2p)" &&
+                spec_p="$(echo "$specs" | sed -n 3p)" &&
+                echo "resolved: $spec_t | $spec_r | $spec_p" &&
+                python -m venv "$venv" &&
+                "$venv/bin/python" -m pip install --upgrade pip &&
                 # torchvision: transformers' qwen2_vl / qwen2_5_vl image processors
                 # import it at module top, so without it the existence probes go red
                 # on ModuleNotFoundError rather than on drift. CPU build is plenty.
-                "$venv/bin/pip" install --index-url https://download.pytorch.org/whl/cpu \
-                  "torch>=2.4.0,<2.11.0" "torchvision<0.26"
-                "$venv/bin/pip" install -e .[core]
-                "$venv/bin/pip" install --no-deps \
-                  "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
-                "$venv/bin/pip" install -U "$spec_t" "$spec_r" "$spec_p"
+                retry "$venv/bin/pip" install --index-url https://download.pytorch.org/whl/cpu \
+                  "torch>=2.4.0,<2.11.0" "torchvision<0.26" &&
+                retry "$venv/bin/pip" install -e .[core] &&
+                { "$venv/bin/pip" install --no-deps \
+                  "unsloth @ git+https://github.com/unslothai/unsloth@main" || true; } &&
+                retry "$venv/bin/pip" install -U "$spec_t" "$spec_r" "$spec_p" &&
                 # bitsandbytes: imported at module scope in saving_utils.py.
                 # IPython + ipywidgets: logging_utils.py:50 imports
                 # transformers.utils.notebook. Both so the drift detector fires on
                 # real drift and not on a missing CI dep.
-                "$venv/bin/pip" install 'bitsandbytes>=0.45' 'ipython>=8' 'ipywidgets>=8'
-                "$venv/bin/pip" install pytest==9.0.3 packaging
-                set +x
+                retry "$venv/bin/pip" install 'bitsandbytes>=0.45' 'ipython>=8' 'ipywidgets>=8' &&
+                retry "$venv/bin/pip" install pytest==9.0.3 packaging &&
+                set +x &&
                 "$venv/bin/pip" show transformers trl peft torch
               } > "$log" 2>&1 || rc=$?
               echo "$rc" > ".lanes/$id.install"

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -92,16 +92,12 @@ jobs:
         run: |
           mkdir -p .lanes
 
-          # A lane records its own exit status, so every command in it has to be
-          # able to set that status. A brace group reports only its LAST command,
-          # and `set -e` inside it would be ignored because the group sits on the
-          # left of `|| rc=$?` (POSIX: errexit does not apply there). So the steps
-          # are `&&`-chained: the first failure both stops the lane and becomes rc.
+          # `&&`-chained, not newline-separated: a brace group reports only its LAST
+          # command, and `set -e` would be ignored here because the group sits on
+          # the left of `|| rc=$?`. Chaining makes the first failure the lane's rc.
           #
-          # retry(): pip's own --retries only covers ESTABLISHING a connection, so
-          # a response body truncated mid-download (ProtocolError / IncompleteRead)
-          # is never retried and the install just dies. Wrap the network-bound
-          # installs so a truncated wheel costs a retry instead of a red run.
+          # retry(): pip's --retries only covers ESTABLISHING a connection, so a
+          # body truncated mid-download (IncompleteRead) is never retried.
           retry() {
             attempt=1
             until "$@"; do

--- a/tests/test_ci_lane_scripts_parse.py
+++ b/tests/test_ci_lane_scripts_parse.py
@@ -132,3 +132,121 @@ def test_the_fused_core_job_still_runs_every_drift_file() -> None:
         "the pytest output is no longer redirected into the lane log, so a failing "
         "lane would report a status with nothing to read"
     )
+
+
+# A lane runs in the background and records its own exit status, so the status it
+# records is the only thing the job ever learns about it. That capture is
+#
+#     { cmd1; cmd2; ...; cmdN } > "$log" 2>&1 || rc=$?
+#
+# and a brace group reports only cmdN. Written that way, every failure except the
+# last one is invisible: the lane records rc=0, the "environment could not be
+# built" guard never fires, and the job walks into the next step with a half-built
+# venv. That is exactly how a truncated mlx download surfaced two steps later as
+# `ModuleNotFoundError: No module named 'mlx'` from an assert step, with the build
+# step green.
+#
+# `set -e` inside the group does NOT fix it: the group sits on the left of
+# `|| rc=$?`, and POSIX says errexit is ignored for a compound command in a
+# `&&`/`||` list. The fix that works is `&&`-chaining, so the first failure both
+# stops the lane and becomes the recorded status.
+
+def _capture_groups(run: str) -> list[str]:
+    """Bodies of every `{ ... } > ... || rc=$?` status-capture group in a lane."""
+    lines = run.splitlines()
+    groups, buf, depth = [], [], 0
+    for line in lines:
+        stripped = line.strip()
+        if depth == 0 and stripped == "{":
+            depth, buf = 1, []
+            continue
+        if depth:
+            if stripped.startswith("}") and "rc=$?" in stripped:
+                groups.append("\n".join(buf))
+                depth = 0
+            else:
+                buf.append(line)
+    return groups
+
+
+def _statements(body: str) -> list[str]:
+    """Logical statements: continuations joined, blanks and comment lines dropped.
+
+    A comment between two `&&`-chained commands is legal shell (the newline after
+    `&&` may be followed by comments), so it is not a statement for this purpose.
+    """
+    joined = body.replace("\\\n", " ")
+    return [
+        ln.strip() for ln in joined.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+
+
+def test_lane_status_capture_sees_every_failure() -> None:
+    """
+    Every command in a status-capture group must be `&&`-chained to the next, so a
+    failure anywhere becomes the lane's recorded status rather than being masked by
+    a later command that happens to succeed.
+    """
+    checked = 0
+    for workflow, job, name, run in _lane_steps():
+        for body in _capture_groups(run):
+            statements = _statements(body)
+            assert statements, f"{workflow}: job '{job}' step '{name}' has an empty capture group"
+            checked += 1
+            for stmt in statements[:-1]:
+                assert stmt.endswith("&&"), (
+                    f"{workflow}: job '{job}' step '{name}': the status-capture group has a "
+                    f"statement that is not chained to the next one:\n    {stmt}\n"
+                    "A brace group reports only its last command, so this failure would be "
+                    "recorded as success. Chain it with `&&` (`set -e` does not work here: "
+                    "errexit is ignored on the left of `|| rc=$?`)."
+                )
+            assert not statements[-1].endswith("&&"), (
+                f"{workflow}: job '{job}' step '{name}': capture group ends with a dangling `&&`"
+            )
+    assert checked >= 3, f"only {checked} status-capture groups found; the detector looks broken"
+
+
+def test_the_chaining_idiom_actually_propagates_failure() -> None:
+    """
+    Pins the shell semantics the test above relies on, so the reasoning is checked
+    rather than asserted: the old form swallows, `set -e` does not rescue it, and
+    `&&`-chaining does, while still tolerating a deliberate `|| true` step.
+    """
+    def rc_of(script: str) -> int:
+        return subprocess.run(
+            [ "bash", "-c", f"rc=0; {script} || rc=$?; exit $rc" ],
+            capture_output = True, text = True,
+        ).returncode
+
+    assert rc_of("{ false; true; }") == 0, "brace group should mask an early failure"
+    assert rc_of("( set -e; false; true; )") == 0, "errexit is ignored left of ||"
+    assert rc_of("{ false && true; }") != 0, "&&-chaining must propagate the failure"
+    assert rc_of("{ true && { false || true; } && false; }") != 0, (
+        "a real failure after a tolerated `|| true` step must still propagate"
+    )
+    assert rc_of("{ true && { false || true; } && true; }") == 0, (
+        "an all-succeeding chain with a tolerated step must stay green"
+    )
+
+
+def test_network_bound_installs_are_retried() -> None:
+    """
+    pip's `--retries` only covers establishing a connection, so a body truncated
+    mid-download (ProtocolError / IncompleteRead) is not retried and the install
+    dies. The lanes wrap those installs in retry().
+    """
+    for workflow, job, name, run in _lane_steps():
+        for body in _capture_groups(run):
+            installs = [
+                stmt for stmt in _statements(body)
+                if "pip" in stmt and " install " in stmt
+                and "--upgrade pip" not in stmt
+                and "--no-deps" not in stmt      # deliberately `|| true`
+            ]
+            for stmt in installs:
+                assert stmt.startswith("retry "), (
+                    f"{workflow}: job '{job}' step '{name}': network-bound install is not "
+                    f"wrapped in retry():\n    {stmt}"
+                )

--- a/tests/test_ci_lane_scripts_parse.py
+++ b/tests/test_ci_lane_scripts_parse.py
@@ -134,22 +134,15 @@ def test_the_fused_core_job_still_runs_every_drift_file() -> None:
     )
 
 
-# A lane runs in the background and records its own exit status, so the status it
-# records is the only thing the job ever learns about it. That capture is
+# A lane records its own exit status in the background, and that status is all the
+# job ever learns about it. The capture is `{ cmd1; ...; cmdN } > "$log" || rc=$?`,
+# and a brace group reports only cmdN -- so every earlier failure was recorded as
+# rc=0, the "could not be built" guard never fired, and the job continued with a
+# half-built venv. A truncated mlx download surfaced two steps later as
+# ModuleNotFoundError, with the build step green.
 #
-#     { cmd1; cmd2; ...; cmdN } > "$log" 2>&1 || rc=$?
-#
-# and a brace group reports only cmdN. Written that way, every failure except the
-# last one is invisible: the lane records rc=0, the "environment could not be
-# built" guard never fires, and the job walks into the next step with a half-built
-# venv. That is exactly how a truncated mlx download surfaced two steps later as
-# `ModuleNotFoundError: No module named 'mlx'` from an assert step, with the build
-# step green.
-#
-# `set -e` inside the group does NOT fix it: the group sits on the left of
-# `|| rc=$?`, and POSIX says errexit is ignored for a compound command in a
-# `&&`/`||` list. The fix that works is `&&`-chaining, so the first failure both
-# stops the lane and becomes the recorded status.
+# `set -e` inside the group does NOT help: it sits on the left of `|| rc=$?`, where
+# POSIX ignores errexit. `&&`-chaining does, so the first failure becomes rc.
 
 def _capture_groups(run: str) -> list[str]:
     """Bodies of every `{ ... } > ... || rc=$?` status-capture group in a lane."""


### PR DESCRIPTION
## The bug

Each fused CI lane runs in the background and writes its own exit status, which is the only thing the job ever learns about it. The capture looks like this:

```bash
{ cmd1; cmd2; ...; cmdN } > "$log" 2>&1 || rc=$?
echo "$rc" > ".lanes/$id.install"
```

A brace group reports the status of its **last** command only, and there is no `set -e` inside it, so execution continues past a failure and `rc` ends up being whatever `cmdN` returned. Every failure except the last one was recorded as `rc=0`. The guard immediately below it:

```bash
[ "$rc" = "0" ] || { echo "::error::$id environment could not be built (status $rc)"; exit 1; }
```

could therefore never fire, and the job continued with a half-built venv.

This is what it looked like in practice on #1092. The suites lane's pip install died with:

```
ERROR: Could not install packages due to an OSError: ('Connection broken:
IncompleteRead(323825 bytes read, 889 more expected)', ...)
```

The lane then ran `pip install pytest==9.0.3`, which succeeded, so `rc` was 0 and "Build both environments (concurrently)" reported **success**. The run went red two steps later in "Assert the real MLX runtime is what got installed" with `ModuleNotFoundError: No module named 'mlx'`, a step that had nothing to do with the actual failure.

## Why not `set -e`

Adding `set -e` inside the group does not work, and it is worth writing down because it is the obvious fix. The group sits on the left of `|| rc=$?`, and POSIX specifies that errexit is ignored for a compound command that is part of an AND-OR list. Verified:

```
{ false; true; }              -> rc=0    # today: failure masked
( set -e; false; true; )      -> rc=0    # still masked, on the left of ||
{ false && true; }            -> rc=1    # propagates
```

`&&`-chaining is what actually works: the first failure both stops the lane and becomes the recorded status. A deliberately optional step keeps its `|| true` by wrapping it, `{ cmd || true; } &&`, so it stays tolerated without breaking the chain.

## Scope

All three fused lanes had it:

| job | step | introduced in |
| --- | --- | --- |
| `interpreter-collect` | Install and collect on every interpreter | #1074 |
| `mlx-cpu-linux` | Build both environments | #1075 |
| `core-upstream-matrix` | Run all three upstream pins | #1075 |

The `core-upstream-matrix` lane was the worst of the three: its last command is `pip show transformers trl peft torch`, so a failed install was reported as `pip show`'s status. The `interpreter-collect` lane then gates its collect on `rc -eq 0`, and a collect failure is reported without failing the job, so a broken install there could go fully green.

Worth being clear that #1074 and #1075 were right in design. Recording a per-lane status and failing loudly on a missing one is the correct shape, and the comment in #1074 says so explicitly ("A lane that dies without recording a status is a failure, not a pass. Backgrounding is only safe if a missing result is loud."). Only the capture itself was inert.

## The transient

The trigger was a genuine network flake, so the lanes now wrap their network-bound installs in a small `retry()` (3 attempts, 15s apart). Note that bumping pip's own `--retries` would not have helped here: per `pip install --help` it is the "Maximum attempts to establish a new HTTP connection", so a response body truncated mid-download is not covered by it at all.

## Tests

`tests/test_ci_lane_scripts_parse.py` gains three checks:

- every statement in a status-capture group is `&&`-chained to the next
- every network-bound install is wrapped in `retry()`
- the shell semantics the first check relies on, pinned by executing them, so the reasoning above is verified rather than asserted

The first check found the `core-upstream-matrix` lane, which I had not spotted by reading. Both new checks were confirmed against injected regressions: removing one `&&` fails the chaining check, removing one `retry` fails the retry check, and the restored file passes.

```
31 passed
```
