### PR TITLE
fix(gguf): Retry GGUF conversion with --no-mtp when the converter asserts on an absent MTP head

### DIFF
--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -472,10 +472,9 @@ def test_convert_to_gguf_still_strips_the_declaration_for_legacy_converters(llam
 
 
 def _write_asserting_converter(path: Path) -> Path:
-    """A stub that fails with llama.cpp's MTP assertion until `--no-mtp` is passed.
+    """Fails with llama.cpp's MTP assertion until `--no-mtp` is passed.
 
-    It replays the traceback rather than re-deriving it, so it pins the retry
-    wiring, not the upstream condition.
+    Replays the traceback, so it pins the retry wiring, not the upstream condition.
     """
     converter = path / "asserting_convert.py"
     command_log = path / "converter_commands.jsonl"
@@ -542,10 +541,10 @@ def test_convert_to_gguf_retries_with_no_mtp_after_the_inference_assertion(llama
     first, second = _read_converter_commands(tmp_path)
     assert "--no-mtp" not in first
     assert "--no-mtp" in second
-    # The model directory stays the trailing positional argument.
+    # The model directory stays the trailing positional.
     assert second[-1] == str(model_dir)
     assert (tmp_path / "output.gguf").exists()
-    # Dropping the head is the one thing this retry does that a user cannot see.
+    # Dropping the head is the one effect a user cannot otherwise see.
     assert "--no-mtp" in capsys.readouterr().out
 
 
@@ -555,8 +554,8 @@ def test_convert_to_gguf_retries_with_no_mtp_after_the_inference_assertion(llama
         ("  File \"qwen.py\", line 303\n    assert self.opt_num_mtp_layers != 0\nAssertionError\n", True),
         ("AssertionError: something else entirely\n", False),
         ("INFO:hf-to-gguf:opt_num_mtp_layers resolved to 1\n", False),
-        # Both words, different lines: a checkpoint whose head was recognised and
-        # which then failed for another reason keeps it.
+        # Both words, different lines: a recognised head that then failed for
+        # another reason keeps it.
         (
             "INFO:hf-to-gguf:opt_num_mtp_layers resolved to 1\n"
             "AssertionError: tensor shape mismatch\n",
@@ -614,14 +613,13 @@ def test_add_no_mtp_refuses_to_loop(llama_cpp):
 
 
 def test_convert_to_gguf_refuses_to_retry_when_the_checkpoint_has_mtp_tensors(llama_cpp, tmp_path):
-    """The assertion proves the converter recognised zero canonical
-    `mtp.layers.<i>`, not that there is nothing to keep. `--no-mtp` makes it
-    discard every `mtp.*`, so a checkpoint that does carry a head must surface
-    the disagreement instead of exporting a quietly reduced GGUF."""
+    """The assertion proves zero *recognised* `mtp.layers.<i>`, not a headless
+    checkpoint. `--no-mtp` discards every `mtp.*`, so a checkpoint that does
+    carry a head must surface the disagreement, not export a reduced GGUF."""
     model_dir = tmp_path / "model"
     model_dir.mkdir()
-    # No declaration -- exactly the shape that reaches the assertion -- but the
-    # head is there, indexed past the trunk.
+    # No declaration, the shape that reaches the assertion, but the head is
+    # there, indexed past the trunk.
     (model_dir / "config.json").write_text(
         json.dumps(
             {
@@ -659,7 +657,7 @@ def test_convert_to_gguf_refuses_to_retry_when_the_checkpoint_has_mtp_tensors(ll
 
 def test_convert_to_gguf_never_sends_no_mtp_to_the_projector(llama_cpp, tmp_path):
     """`--no-mtp` was always kept off the mmproj command; the retry must not
-    reintroduce it there just because the projector pass quoted the assertion."""
+    reintroduce it when the projector pass quotes the assertion."""
     model_dir = tmp_path / "model"
     _write_headless_model(model_dir)
     command_log = tmp_path / "converter_commands.jsonl"
@@ -711,8 +709,8 @@ def test_convert_to_gguf_never_sends_no_mtp_to_the_projector(llama_cpp, tmp_path
 
 
 def test_converter_needs_no_mtp_will_not_straddle_a_line_break(llama_cpp):
-    """`captured` joins stderr and stdout. A comparison split across that join
-    is two unrelated fragments, not the assertion."""
+    """A comparison split across the stderr/stdout join is two unrelated
+    fragments, not the assertion."""
     assert llama_cpp._converter_needs_no_mtp(
         "    assert self.opt_num_mtp_layers !=\n 0 tensors were written\n") is False
     assert llama_cpp._converter_needs_no_mtp(
@@ -755,8 +753,8 @@ def test_convert_to_gguf_joins_converter_streams_on_a_newline(llama_cpp, tmp_pat
 
 def test_convert_to_gguf_clears_the_failed_attempts_output_before_retrying(llama_cpp, tmp_path):
     """The converter truncates `--outfile` at header time and, when splitting,
-    writes shards beside it. Callers scan the output directory for `*.gguf`, so
-    anything the failed attempt left would be shipped as if it were valid."""
+    writes shards beside it. Callers scan for `*.gguf`, so anything the failed
+    attempt left would be shipped as valid."""
     model_dir = tmp_path / "model"
     _write_headless_model(model_dir)
     output_dir = tmp_path / "out"
@@ -807,8 +805,8 @@ def test_convert_to_gguf_clears_the_failed_attempts_output_before_retrying(llama
 
 
 def test_convert_to_gguf_keeps_the_first_failure_when_the_retry_also_fails(llama_cpp, tmp_path):
-    """A converter that has the assertion but not the flag turns the retry into
-    an argparse error. The assertion is the useful half; keep both."""
+    """A converter with the assertion but not the flag turns the retry into an
+    argparse error. The assertion is the useful half; keep both."""
     model_dir = tmp_path / "model"
     _write_headless_model(model_dir)
     command_log = tmp_path / "converter_commands.jsonl"

--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -469,3 +469,145 @@ def test_convert_to_gguf_still_strips_the_declaration_for_legacy_converters(llam
     assert "mtp_num_hidden_layers" not in updated["text_config"]
     command, = _read_converter_commands(tmp_path)
     assert "--no-mtp" not in command
+
+
+def _write_asserting_converter(path: Path) -> Path:
+    """A stub that fails with llama.cpp's MTP assertion until `--no-mtp` is passed.
+
+    It replays the traceback rather than re-deriving it, so it pins the retry
+    wiring, not the upstream condition.
+    """
+    converter = path / "asserting_convert.py"
+    command_log = path / "converter_commands.jsonl"
+    converter.write_text(
+        textwrap.dedent(
+            f"""
+            import argparse
+            import json
+            import sys
+            from pathlib import Path
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--outfile")
+            parser.add_argument("--outtype")
+            parser.add_argument("--split-max-size")
+            parser.add_argument("--no-mtp", action="store_true")
+            parser.add_argument("--mmproj", action="store_true")
+            parser.add_argument("model_dir")
+            args = parser.parse_args()
+            with Path({str(command_log)!r}).open("a", encoding="utf-8") as log:
+                log.write(json.dumps(sys.argv[1:]) + "\\n")
+            if not args.no_mtp:
+                sys.stderr.write(
+                    'Traceback (most recent call last):\\n'
+                    '  File "conversion/qwen.py", line 303, in __init__\\n'
+                    '    assert self.opt_num_mtp_layers != 0\\n'
+                    'AssertionError\\n'
+                )
+                raise SystemExit(1)
+            Path(args.outfile).write_bytes(b"GGUF")
+            """
+        ).strip() + "\n",
+        encoding = "utf-8",
+    )
+    return converter
+
+
+def _write_headless_model(model_dir: Path) -> None:
+    """A merged MLX save: no declaration left, and no `mtp.*` tensors."""
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "text_config": {"num_hidden_layers": 24},
+            }
+        ),
+        encoding = "utf-8",
+    )
+    _write_index(model_dir, "model.language_model.layers.23.self_attn.q_proj.weight")
+
+
+def test_convert_to_gguf_retries_with_no_mtp_after_the_inference_assertion(llama_cpp, tmp_path, capsys):
+    model_dir = tmp_path / "model"
+    _write_headless_model(model_dir)
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(tmp_path / "output.gguf"),
+        input_folder = str(model_dir),
+        converter_location = str(_write_asserting_converter(tmp_path)),
+        quantization_type = "bf16",
+    )
+
+    first, second = _read_converter_commands(tmp_path)
+    assert "--no-mtp" not in first
+    assert "--no-mtp" in second
+    # The model directory stays the trailing positional argument.
+    assert second[-1] == str(model_dir)
+    assert (tmp_path / "output.gguf").exists()
+    # Dropping the head is the one thing this retry does that a user cannot see.
+    assert "--no-mtp" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("captured", "expected"),
+    (
+        ("  File \"qwen.py\", line 303\n    assert self.opt_num_mtp_layers != 0\nAssertionError\n", True),
+        ("AssertionError: something else entirely\n", False),
+        ("INFO:hf-to-gguf:opt_num_mtp_layers resolved to 1\n", False),
+        # Both words, different lines: a checkpoint whose head was recognised and
+        # which then failed for another reason keeps it.
+        (
+            "INFO:hf-to-gguf:opt_num_mtp_layers resolved to 1\n"
+            "AssertionError: tensor shape mismatch\n",
+            False,
+        ),
+        # Same line, but a different invariant over the same counter.
+        ("    assert self.opt_num_mtp_layers == len(recognized)\n", False),
+        # An unterminated stream spliced onto the next one.
+        ("INFO:hf-to-gguf:opt_num_mtp_layers resolved to 1AssertionError: boom\n", False),
+        ("", False),
+        (None, False),
+    ),
+)
+def test_converter_needs_no_mtp_matches_only_the_inference_assertion(llama_cpp, captured, expected):
+    assert llama_cpp._converter_needs_no_mtp(captured) is expected
+
+
+def test_convert_to_gguf_does_not_splice_unterminated_converter_streams(llama_cpp, tmp_path):
+    model_dir = tmp_path / "model"
+    _write_headless_model(model_dir)
+    command_log = tmp_path / "converter_commands.jsonl"
+    converter = tmp_path / "splicing_convert.py"
+    converter.write_text(
+        textwrap.dedent(
+            f"""
+            import json
+            import sys
+            from pathlib import Path
+
+            with Path({str(command_log)!r}).open("a", encoding="utf-8") as log:
+                log.write(json.dumps(sys.argv[1:]) + "\\n")
+            # No trailing newline, so a naive concatenation splices the streams.
+            sys.stderr.write("INFO:opt_num_mtp_layers resolved to 1")
+            sys.stdout.write("AssertionError: unrelated failure\\n")
+            raise SystemExit(1)
+            """
+        ).strip() + "\n",
+        encoding = "utf-8",
+    )
+
+    with pytest.raises(RuntimeError):
+        llama_cpp.convert_to_gguf(
+            model_name = str(tmp_path / "output.gguf"),
+            input_folder = str(model_dir),
+            converter_location = str(converter),
+            quantization_type = "bf16",
+        )
+
+    # One run: the unrelated failure must not be read as the MTP assertion.
+    assert len(_read_converter_commands(tmp_path)) == 1
+
+
+def test_add_no_mtp_refuses_to_loop(llama_cpp):
+    assert llama_cpp._add_no_mtp(["python", "conv.py", "--no-mtp", "/model"]) is None

--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -611,3 +611,242 @@ def test_convert_to_gguf_does_not_splice_unterminated_converter_streams(llama_cp
 
 def test_add_no_mtp_refuses_to_loop(llama_cpp):
     assert llama_cpp._add_no_mtp(["python", "conv.py", "--no-mtp", "/model"]) is None
+
+
+def test_convert_to_gguf_refuses_to_retry_when_the_checkpoint_has_mtp_tensors(llama_cpp, tmp_path):
+    """The assertion proves the converter recognised zero canonical
+    `mtp.layers.<i>`, not that there is nothing to keep. `--no-mtp` makes it
+    discard every `mtp.*`, so a checkpoint that does carry a head must surface
+    the disagreement instead of exporting a quietly reduced GGUF."""
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    # No declaration -- exactly the shape that reaches the assertion -- but the
+    # head is there, indexed past the trunk.
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "text_config": {"num_hidden_layers": 24},
+            }
+        ),
+        encoding = "utf-8",
+    )
+    (model_dir / "model-00001-of-00001.safetensors").touch()
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.language_model.layers.23.self_attn.q_proj.weight": "model-00001-of-00001.safetensors",
+                    "model.language_model.layers.24.eh_proj.weight": "model-00001-of-00001.safetensors",
+                },
+            }
+        ),
+        encoding = "utf-8",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        llama_cpp.convert_to_gguf(
+            model_name = str(tmp_path / "output.gguf"),
+            input_folder = str(model_dir),
+            converter_location = str(_write_asserting_converter(tmp_path)),
+            quantization_type = "bf16",
+        )
+
+    # One run: the head is never dropped behind the user's back.
+    assert len(_read_converter_commands(tmp_path)) == 1
+    assert "does contain MTP tensors" in str(excinfo.value)
+
+
+def test_convert_to_gguf_never_sends_no_mtp_to_the_projector(llama_cpp, tmp_path):
+    """`--no-mtp` was always kept off the mmproj command; the retry must not
+    reintroduce it there just because the projector pass quoted the assertion."""
+    model_dir = tmp_path / "model"
+    _write_headless_model(model_dir)
+    command_log = tmp_path / "converter_commands.jsonl"
+    converter = tmp_path / "mmproj_asserting_convert.py"
+    converter.write_text(
+        textwrap.dedent(
+            f"""
+            import argparse
+            import json
+            import sys
+            from pathlib import Path
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--outfile")
+            parser.add_argument("--outtype")
+            parser.add_argument("--split-max-size")
+            parser.add_argument("--no-mtp", action="store_true")
+            parser.add_argument("--mmproj", action="store_true")
+            parser.add_argument("model_dir")
+            args = parser.parse_args()
+            with Path({str(command_log)!r}).open("a", encoding="utf-8") as log:
+                log.write(json.dumps(sys.argv[1:]) + "\\n")
+            if args.mmproj:
+                sys.stderr.write(
+                    '  File "conversion/qwen.py", line 303, in __init__\\n'
+                    '    assert self.opt_num_mtp_layers != 0\\n'
+                    'AssertionError\\n'
+                )
+                raise SystemExit(1)
+            Path(args.outfile).write_bytes(b"GGUF")
+            """
+        ).strip() + "\n",
+        encoding = "utf-8",
+    )
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(tmp_path / "output.gguf"),
+        input_folder = str(model_dir),
+        converter_location = str(converter),
+        supported_vision_archs = {"Qwen3_5ForConditionalGeneration"},
+        quantization_type = "bf16",
+        is_vlm = True,
+    )
+
+    commands = _read_converter_commands(tmp_path)
+    # The text model still converts; the projector degrades, and is tried once.
+    assert sum("--mmproj" in command for command in commands) == 1
+    assert not any("--no-mtp" in command for command in commands if "--mmproj" in command)
+
+
+def test_converter_needs_no_mtp_will_not_straddle_a_line_break(llama_cpp):
+    """`captured` joins stderr and stdout. A comparison split across that join
+    is two unrelated fragments, not the assertion."""
+    assert llama_cpp._converter_needs_no_mtp(
+        "    assert self.opt_num_mtp_layers !=\n 0 tensors were written\n") is False
+    assert llama_cpp._converter_needs_no_mtp(
+        "    assert self.opt_num_mtp_layers\n != 0\n") is False
+
+
+def test_convert_to_gguf_joins_converter_streams_on_a_newline(llama_cpp, tmp_path):
+    """An unterminated stderr line must not be completed by stdout's first."""
+    model_dir = tmp_path / "model"
+    _write_headless_model(model_dir)
+    command_log = tmp_path / "converter_commands.jsonl"
+    converter = tmp_path / "splicing_comparison_convert.py"
+    converter.write_text(
+        textwrap.dedent(
+            f"""
+            import json
+            import sys
+            from pathlib import Path
+
+            with Path({str(command_log)!r}).open("a", encoding="utf-8") as log:
+                log.write(json.dumps(sys.argv[1:]) + "\\n")
+            sys.stderr.write("    assert self.opt_num_mtp_layers !=")
+            sys.stdout.write(" 0 tensors written; failing for another reason\\n")
+            raise SystemExit(1)
+            """
+        ).strip() + "\n",
+        encoding = "utf-8",
+    )
+
+    with pytest.raises(RuntimeError):
+        llama_cpp.convert_to_gguf(
+            model_name = str(tmp_path / "output.gguf"),
+            input_folder = str(model_dir),
+            converter_location = str(converter),
+            quantization_type = "bf16",
+        )
+
+    assert len(_read_converter_commands(tmp_path)) == 1
+
+
+def test_convert_to_gguf_clears_the_failed_attempts_output_before_retrying(llama_cpp, tmp_path):
+    """The converter truncates `--outfile` at header time and, when splitting,
+    writes shards beside it. Callers scan the output directory for `*.gguf`, so
+    anything the failed attempt left would be shipped as if it were valid."""
+    model_dir = tmp_path / "model"
+    _write_headless_model(model_dir)
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    command_log = tmp_path / "converter_commands.jsonl"
+    converter = tmp_path / "partial_output_convert.py"
+    converter.write_text(
+        textwrap.dedent(
+            f"""
+            import argparse
+            import json
+            import sys
+            from pathlib import Path
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--outfile")
+            parser.add_argument("--outtype")
+            parser.add_argument("--split-max-size")
+            parser.add_argument("--no-mtp", action="store_true")
+            parser.add_argument("--mmproj", action="store_true")
+            parser.add_argument("model_dir")
+            args = parser.parse_args()
+            with Path({str(command_log)!r}).open("a", encoding="utf-8") as log:
+                log.write(json.dumps(sys.argv[1:]) + "\\n")
+            if not args.no_mtp:
+                Path(args.outfile).write_bytes(b"PARTIAL")
+                Path(str(args.outfile).replace(".gguf", "-00002-of-00002.gguf")).write_bytes(b"PARTIAL")
+                sys.stderr.write(
+                    '    assert self.opt_num_mtp_layers != 0\\n'
+                    'AssertionError\\n'
+                )
+                raise SystemExit(1)
+            Path(args.outfile).write_bytes(b"GGUF")
+            """
+        ).strip() + "\n",
+        encoding = "utf-8",
+    )
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(output_dir / "model"),
+        input_folder = str(model_dir),
+        converter_location = str(converter),
+        quantization_type = "bf16",
+    )
+
+    leftovers = [p.name for p in output_dir.rglob("*.gguf") if p.read_bytes() == b"PARTIAL"]
+    assert leftovers == []
+
+
+def test_convert_to_gguf_keeps_the_first_failure_when_the_retry_also_fails(llama_cpp, tmp_path):
+    """A converter that has the assertion but not the flag turns the retry into
+    an argparse error. The assertion is the useful half; keep both."""
+    model_dir = tmp_path / "model"
+    _write_headless_model(model_dir)
+    command_log = tmp_path / "converter_commands.jsonl"
+    converter = tmp_path / "no_flag_convert.py"
+    converter.write_text(
+        textwrap.dedent(
+            f"""
+            import argparse
+            import json
+            import sys
+            from pathlib import Path
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--outfile")
+            parser.add_argument("--outtype")
+            parser.add_argument("--split-max-size")
+            parser.add_argument("model_dir")
+            args = parser.parse_args()
+            with Path({str(command_log)!r}).open("a", encoding="utf-8") as log:
+                log.write(json.dumps(sys.argv[1:]) + "\\n")
+            sys.stderr.write(
+                '    assert self.opt_num_mtp_layers != 0\\n'
+                'AssertionError\\n'
+            )
+            raise SystemExit(1)
+            """
+        ).strip() + "\n",
+        encoding = "utf-8",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        llama_cpp.convert_to_gguf(
+            model_name = str(tmp_path / "output.gguf"),
+            input_folder = str(model_dir),
+            converter_location = str(converter),
+            quantization_type = "bf16",
+        )
+
+    message = str(excinfo.value)
+    assert "unrecognized arguments" in message
+    assert "opt_num_mtp_layers" in message

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2387,22 +2387,16 @@ def _converter_was_oom_killed(exc):
     return "sigkill" in f"{exc}".lower()
 
 
-# Matched with its comparison: a failure that merely names the counter leaves
-# the checkpoint's head intact, and retrying without it would drop that head.
-# `[^\S\r\n]` is horizontal whitespace only -- plain `\s` matches a newline, so
-# it would let the comparison straddle two lines and re-open the very splice
-# the single-line `[^\r\n]*` is there to prevent.
+# One line only: a failure that merely names the counter must not match, and
+# `[^\S\r\n]` (not `\s`, which spans newlines) keeps the comparison off the
+# stderr/stdout join.
 _MTP_INFERENCE_ASSERTION = re.compile(
     r"\bassert\b[^\r\n]*\bopt_num_mtp_layers[^\S\r\n]*!=[^\S\r\n]*0"
 )
 
 
 def _converter_needs_no_mtp(text):
-    """Did the converter abort inferring an MTP head the checkpoint does not have?
-
-    The assertion is what proves the head is absent: a declaration would have
-    skipped the branch, and a recognised `mtp.layers.<i>` made the count positive.
-    """
+    """Did the converter abort while inferring an MTP head it could not find?"""
     if not text: return False
     return _MTP_INFERENCE_ASSERTION.search(text) is not None
 
@@ -2433,18 +2427,11 @@ def _add_no_mtp(command):
 
 
 def _checkpoint_has_mtp_tensors(input_folder, num_layers):
-    """Does the checkpoint physically carry an MTP head, whatever it declares?
+    """Does the checkpoint carry an MTP head, whatever it declares?
 
-    The converter's assertion only proves it recognised zero canonical
-    `mtp.layers.<i>` tensors, not that there is nothing to keep, so `--no-mtp`
-    -- which makes it discard every `mtp.*` -- must not be sent on the strength
-    of the assertion alone. Unlike `_keep_mtp` this ignores the declaration,
-    because the checkpoints that reach the assertion are exactly the ones that
-    declare nothing.
-
-    Only consulted after the converter has already failed, so an unreadable
-    index answers "no evidence of a head" and leaves the retry to proceed
-    rather than turning a recoverable export into a hard error.
+    Unlike `_keep_mtp` this ignores the declaration, since the checkpoints that
+    reach the assertion declare nothing. Only consulted after a failure, so an
+    unreadable index answers "no evidence" and lets the retry proceed.
     """
     if not isinstance(num_layers, int) or isinstance(num_layers, bool) or num_layers <= 0:
         return False
@@ -2760,9 +2747,9 @@ def convert_to_gguf(
                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 break
             except subprocess.CalledProcessError as e:
-                # Joined on a newline, never concatenated: an unterminated
-                # stderr line glued to stdout's first one splices two harmless
-                # fragments into a line that matches a self-heal signature.
+                # Joined, never concatenated: an unterminated stderr line glued
+                # to stdout's first splices two harmless fragments into a line
+                # that matches a self-heal signature.
                 captured_streams = []
                 for stream in (getattr(e, "stderr", None), getattr(e, "stdout", None)):
                     if stream:
@@ -2792,15 +2779,13 @@ def convert_to_gguf(
                         command = retry
                         continue
 
-                # The converter recognised no MTP head while inferring one.
                 # Text runs only: `--no-mtp` never belonged on the projector
                 # command, and a projector failure is degraded, not repaired.
                 if not attempted_no_mtp_add and required and _converter_needs_no_mtp(captured):
                     retry = _add_no_mtp(command)
                     if retry is not None and _checkpoint_has_mtp_tensors(input_folder, _num_layers):
-                        # The converter recognised none, but there are `mtp.*`
-                        # tensors here; `--no-mtp` would discard them and call
-                        # the lossy export a success. Surface the disagreement.
+                        # `--no-mtp` would discard the `mtp.*` tensors that are
+                        # here and call the lossy export a success.
                         no_mtp_note = (
                             "\n--- unsloth ---\nThe converter could not infer this "
                             "checkpoint's multi-token prediction (MTP) head, but the "
@@ -2812,20 +2797,18 @@ def convert_to_gguf(
                         attempted_no_mtp_add = True
                     elif retry is not None:
                         attempted_no_mtp_add = True
-                        # The one self-heal that changes what the GGUF contains,
-                        # so say so rather than dropping the head silently.
+                        # The one self-heal that changes what the GGUF contains.
                         print(
                             "Unsloth: The GGUF converter recognised no multi-token "
                             "prediction (MTP) head in this checkpoint. Retrying with "
                             "--no-mtp; if it succeeds the GGUF will have no MTP head."
                         )
-                        # The failed attempt can leave a truncated --outfile and,
-                        # with --split-max-size, extra shards beside it. Studio's
-                        # export scans the whole output directory for *.gguf, so
-                        # anything left here is shipped as if it were valid.
+                        # The failed attempt leaves a truncated --outfile and,
+                        # when splitting, shards beside it. Callers scan the
+                        # output directory for *.gguf and would ship them.
                         _remove_gguf_outputs(output_file)
-                        # Keep the assertion: if the retry fails for its own
-                        # reason, the original cause is otherwise discarded.
+                        # Else a retry that fails for its own reason discards
+                        # the assertion that caused it.
                         no_mtp_note = (
                             f"\n--- first attempt, before retrying with --no-mtp ---\n"
                             f"{captured.strip()}"

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2387,6 +2387,23 @@ def _converter_was_oom_killed(exc):
     return "sigkill" in f"{exc}".lower()
 
 
+# Matched with its comparison: a failure that merely names the counter leaves
+# the checkpoint's head intact, and retrying without it would drop that head.
+_MTP_INFERENCE_ASSERTION = re.compile(
+    r"\bassert\b[^\r\n]*\bopt_num_mtp_layers\s*!=\s*0"
+)
+
+
+def _converter_needs_no_mtp(text):
+    """Did the converter abort inferring an MTP head the checkpoint does not have?
+
+    The assertion is what proves the head is absent: a declaration would have
+    skipped the branch, and a recognised `mtp.layers.<i>` made the count positive.
+    """
+    if not text: return False
+    return _MTP_INFERENCE_ASSERTION.search(text) is not None
+
+
 def _converter_rejected_no_mtp(text):
     """Did the converter refuse `--no-mtp` because this architecture has no MTP?"""
     if not text: return False
@@ -2403,6 +2420,13 @@ def _drop_no_mtp(command):
     """The same command without `--no-mtp`, or None when it has none to drop."""
     if "--no-mtp" not in command: return None
     return [token for token in command if token != "--no-mtp"]
+
+
+def _add_no_mtp(command):
+    """The same command with `--no-mtp`, or None when it already has it."""
+    if "--no-mtp" in command: return None
+    # The positional model directory must stay last.
+    return command[:-1] + ["--no-mtp", command[-1]]
 
 
 def _retry_with_temp_file(command):
@@ -2692,6 +2716,7 @@ def convert_to_gguf(
         attempted_repair = False
         attempted_temp_file = False
         attempted_no_mtp_drop = False
+        attempted_no_mtp_add = False
         repair_note = ""
         optional_failed = False
         while True:
@@ -2733,6 +2758,20 @@ def convert_to_gguf(
                     retry = _drop_no_mtp(command)
                     if retry is not None:
                         attempted_no_mtp_drop = True
+                        command = retry
+                        continue
+
+                # The converter indexed the tensors and found no head to keep.
+                if not attempted_no_mtp_add and _converter_needs_no_mtp(captured):
+                    retry = _add_no_mtp(command)
+                    if retry is not None:
+                        attempted_no_mtp_add = True
+                        # Otherwise the head is dropped silently.
+                        print(
+                            "Unsloth: The GGUF converter found no multi-token "
+                            "prediction (MTP) head in this checkpoint. Retrying "
+                            "with --no-mtp; the GGUF will have no MTP head."
+                        )
                         command = retry
                         continue
 

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2389,8 +2389,11 @@ def _converter_was_oom_killed(exc):
 
 # Matched with its comparison: a failure that merely names the counter leaves
 # the checkpoint's head intact, and retrying without it would drop that head.
+# `[^\S\r\n]` is horizontal whitespace only -- plain `\s` matches a newline, so
+# it would let the comparison straddle two lines and re-open the very splice
+# the single-line `[^\r\n]*` is there to prevent.
 _MTP_INFERENCE_ASSERTION = re.compile(
-    r"\bassert\b[^\r\n]*\bopt_num_mtp_layers\s*!=\s*0"
+    r"\bassert\b[^\r\n]*\bopt_num_mtp_layers[^\S\r\n]*!=[^\S\r\n]*0"
 )
 
 
@@ -2427,6 +2430,28 @@ def _add_no_mtp(command):
     if "--no-mtp" in command: return None
     # The positional model directory must stay last.
     return command[:-1] + ["--no-mtp", command[-1]]
+
+
+def _checkpoint_has_mtp_tensors(input_folder, num_layers):
+    """Does the checkpoint physically carry an MTP head, whatever it declares?
+
+    The converter's assertion only proves it recognised zero canonical
+    `mtp.layers.<i>` tensors, not that there is nothing to keep, so `--no-mtp`
+    -- which makes it discard every `mtp.*` -- must not be sent on the strength
+    of the assertion alone. Unlike `_keep_mtp` this ignores the declaration,
+    because the checkpoints that reach the assertion are exactly the ones that
+    declare nothing.
+
+    Only consulted after the converter has already failed, so an unreadable
+    index answers "no evidence of a head" and leaves the retry to proceed
+    rather than turning a recoverable export into a hard error.
+    """
+    if not isinstance(num_layers, int) or isinstance(num_layers, bool) or num_layers <= 0:
+        return False
+    try:
+        return _has_mtp_weight_tensors(input_folder, num_layers)
+    except Exception:
+        return False
 
 
 def _retry_with_temp_file(command):
@@ -2718,6 +2743,7 @@ def convert_to_gguf(
         attempted_no_mtp_drop = False
         attempted_no_mtp_add = False
         repair_note = ""
+        no_mtp_note = ""
         optional_failed = False
         while True:
             try:
@@ -2734,10 +2760,15 @@ def convert_to_gguf(
                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 break
             except subprocess.CalledProcessError as e:
-                captured = ""
+                # Joined on a newline, never concatenated: an unterminated
+                # stderr line glued to stdout's first one splices two harmless
+                # fragments into a line that matches a self-heal signature.
+                captured_streams = []
                 for stream in (getattr(e, "stderr", None), getattr(e, "stdout", None)):
                     if stream:
-                        captured += stream if isinstance(stream, str) else stream.decode("utf-8", errors="replace")
+                        captured_streams.append(
+                            stream if isinstance(stream, str) else stream.decode("utf-8", errors="replace"))
+                captured = "\n".join(captured_streams)
 
                 # Self-heal: reinstall the converter deps (command[0] = its
                 # interpreter) and retry once instead of failing.
@@ -2761,16 +2792,43 @@ def convert_to_gguf(
                         command = retry
                         continue
 
-                # The converter indexed the tensors and found no head to keep.
-                if not attempted_no_mtp_add and _converter_needs_no_mtp(captured):
+                # The converter recognised no MTP head while inferring one.
+                # Text runs only: `--no-mtp` never belonged on the projector
+                # command, and a projector failure is degraded, not repaired.
+                if not attempted_no_mtp_add and required and _converter_needs_no_mtp(captured):
                     retry = _add_no_mtp(command)
-                    if retry is not None:
+                    if retry is not None and _checkpoint_has_mtp_tensors(input_folder, _num_layers):
+                        # The converter recognised none, but there are `mtp.*`
+                        # tensors here; `--no-mtp` would discard them and call
+                        # the lossy export a success. Surface the disagreement.
+                        no_mtp_note = (
+                            "\n--- unsloth ---\nThe converter could not infer this "
+                            "checkpoint's multi-token prediction (MTP) head, but the "
+                            "checkpoint does contain MTP tensors, so retrying with "
+                            "--no-mtp would silently drop them. Convert with an "
+                            "explicit `mtp_num_hidden_layers` in config.json, or "
+                            "remove the MTP tensors, and try again."
+                        )
                         attempted_no_mtp_add = True
-                        # Otherwise the head is dropped silently.
+                    elif retry is not None:
+                        attempted_no_mtp_add = True
+                        # The one self-heal that changes what the GGUF contains,
+                        # so say so rather than dropping the head silently.
                         print(
-                            "Unsloth: The GGUF converter found no multi-token "
-                            "prediction (MTP) head in this checkpoint. Retrying "
-                            "with --no-mtp; the GGUF will have no MTP head."
+                            "Unsloth: The GGUF converter recognised no multi-token "
+                            "prediction (MTP) head in this checkpoint. Retrying with "
+                            "--no-mtp; if it succeeds the GGUF will have no MTP head."
+                        )
+                        # The failed attempt can leave a truncated --outfile and,
+                        # with --split-max-size, extra shards beside it. Studio's
+                        # export scans the whole output directory for *.gguf, so
+                        # anything left here is shipped as if it were valid.
+                        _remove_gguf_outputs(output_file)
+                        # Keep the assertion: if the retry fails for its own
+                        # reason, the original cause is otherwise discarded.
+                        no_mtp_note = (
+                            f"\n--- first attempt, before retrying with --no-mtp ---\n"
+                            f"{captured.strip()}"
                         )
                         command = retry
                         continue
@@ -2828,7 +2886,7 @@ def convert_to_gguf(
                         f"(image/audio) input is unavailable in this GGUF."
                     )
                     break
-                raise RuntimeError(f"Unsloth: Failed to convert {description} to GGUF with command `{cmd}`: {e}{details}{repair_note}")
+                raise RuntimeError(f"Unsloth: Failed to convert {description} to GGUF with command `{cmd}`: {e}{details}{repair_note}{no_mtp_note}")
 
         # Its partial output was just removed, so validation would fail for nothing.
         if optional_failed:


### PR DESCRIPTION
## The bug

GGUF export aborts for Qwen MTP models. Exporting a merged `Qwen/Qwen3.5-4B` save fails with:

```text
  File "conversion/qwen.py", line 303, in __init__
    assert self.opt_num_mtp_layers != 0
AssertionError
```

The export produces nothing at all — this is a hard failure, not a degraded GGUF.

## Root cause

llama.cpp's shared `_QwenMtpMixin` sizes the speculative block from `mtp_num_hidden_layers`, and when that key is absent falls back to counting `mtp.layers.<i>` tensors. It has no way to express "this architecture can carry an MTP head and this checkpoint does not have one", so when both signals come up empty it asserts instead of exporting a headless model.

A merged MLX save lands in exactly that state, and legitimately so: the `mlx-lm` and `mlx-vlm` sanitizers discard every `mtp.*` weight at load time, so the merged weights genuinely contain no head, and the staged config's speculative-layer sync drops the now-false declaration to match. Both halves are correct on their own; the converter simply cannot represent the result.

This is not specific to unsloth. A pristine Hugging Face checkpoint shaped like `Qwen/Qwen3-Coder-Next` — registered as `Qwen3NextForCausalLM`, no `mtp_num_hidden_layers`, and no `mtp.*` tensors — hits the same assertion under the stock `convert_hf_to_gguf.py` with no unsloth involvement.

The reason this surfaced now is upstream `4ed2b13f` ("model: MTP support for Qwen3-Next"), which removed Qwen3.5's own mixin — it did `block_count += hparams.get("mtp_num_hidden_layers", 0)` and so tolerated a missing key — and folded Qwen3.5 onto the shared class, which treats `0` as "infer or assert".

## What changed

One case is added to the converter self-heal loop in `convert_to_gguf`, symmetric to the existing case that drops `--no-mtp` when an architecture refuses the flag: when the converter fails on that assertion, retry once passing `--no-mtp` to state the head's absence explicitly.

Reacting to the converter's own failure, rather than predicting the situation from the config, is deliberate. Predicting it would need either a hardcoded list of the architectures llama.cpp routes to a speculative-block class — duplicating a registry upstream has already reorganised once — or a scan of every export's checkpoint for tensors that almost no model has. It also covers the checkpoints whose config never declares a head at all, which no config-derived signal can see.

The retry only widens the export's capability; it never narrows it. A checkpoint that does have a head either declares one or has recognisable `mtp.*` tensors, and in both cases the converter succeeds on the first attempt and this code is never reached.

## Risks and tradeoffs

The retry silently changes what the GGUF contains — it is the only self-heal case that alters the output rather than the process — so it prints a notice saying the resulting GGUF has no MTP head. The first run's traceback is still discarded along with the failed attempt, as with the other retries.

Matching is narrow by design. The pattern requires the assertion and its `!= 0` comparison on one line, so a run that logs an inferred count and then fails for an unrelated reason, or a same-line assertion over the same counter with a different invariant, keeps its head and surfaces its real error. An unterminated stderr stream concatenated onto stdout cannot splice the two words together into a false match either.

This is a workaround for a defect that belongs upstream. If `_QwenMtpMixin` gains a way to represent a headless checkpoint, this case becomes dead code and should be deleted rather than maintained.

## Validation

Focused suite, plus mutation checks — five mutations of the production change, each caught by a distinct test:

```bash
python -m pytest tests/test_convert_to_gguf_mtp_reconcile.py -q
```

End-to-end against the real converter with `Qwen/Qwen3.5-0.8B`, tracing the converter's argv:

```text
1: flags=['--outfile', '--outtype', '--split-max-size']
2: flags=['--outfile', '--outtype', '--split-max-size', '--no-mtp']
3: flags=['--outfile', '--outtype', '--mmproj', '--split-max-size']
```

The retry fires exactly once, the separate mmproj pass is unaffected, and the resulting file reports `qwen35.block_count = 24` with 320 tensors and a maximum block of `blk.23` — the text stack intact, no speculative head.
