### PR TITLE
fix(mlx): Restore the HF RMSNorm convention in MLX GGUF exports

### DIFF
--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -297,7 +297,7 @@ def test_sanitize_missing_method_returns_weights_unchanged():
     assert mutils._call_mlx_vlm_sanitize(NoSanitize, {}, weights) is weights
 
 
-# --- Group 4: _prepare_vlm_gguf_export_directory end-to-end (real shards) ---
+# --- Group 4: _prepare_mlx_gguf_export_directory end-to-end (real shards) ---
 
 
 class _ConvAndRenameSanitizer:
@@ -379,7 +379,7 @@ def test_prepare_export_rewrites_real_shards_and_index(monkeypatch, tmp_path):
         },
     )
 
-    rewritten = mutils._prepare_vlm_gguf_export_directory(out)
+    rewritten = mutils._prepare_mlx_gguf_export_directory(out)
     assert rewritten == 1
 
     shard1 = _read_shard(out / "model-00001-of-00002.safetensors")
@@ -435,7 +435,7 @@ def test_prepare_export_restores_stripped_multimodal_namespaces_and_index(
         index={"metadata": {"total_size": 123}, "weight_map": weight_map},
     )
 
-    assert mutils._prepare_vlm_gguf_export_directory(out) == len(tensors)
+    assert mutils._prepare_mlx_gguf_export_directory(out) == len(tensors)
 
     shard = _read_shard(out / shard_name)
     expected_names = {f"model.{name}" for name in tensors}
@@ -476,7 +476,7 @@ def test_prepare_export_duplicate_rewrite_name_raises(monkeypatch, tmp_path):
         },
     )
     with pytest.raises(RuntimeError, match="duplicate tensor name"):
-        mutils._prepare_vlm_gguf_export_directory(out)
+        mutils._prepare_mlx_gguf_export_directory(out)
 
 
 def test_prepare_export_missing_index_is_fine(monkeypatch, tmp_path):
@@ -497,7 +497,7 @@ def test_prepare_export_missing_index_is_fine(monkeypatch, tmp_path):
             },
         },
     )
-    assert mutils._prepare_vlm_gguf_export_directory(out) == 1
+    assert mutils._prepare_mlx_gguf_export_directory(out) == 1
     assert not (out / "model.safetensors.index.json").exists()
 
 
@@ -511,7 +511,7 @@ def test_prepare_export_no_shards_returns_zero(monkeypatch, tmp_path):
     out = _export_dir_with_shards(
         tmp_path, config={"model_type": "fake_vlm"}, shards={}
     )
-    assert mutils._prepare_vlm_gguf_export_directory(out) == 0
+    assert mutils._prepare_mlx_gguf_export_directory(out) == 0
 
 
 def test_prepare_export_unicode_shard_filename(monkeypatch, tmp_path):
@@ -532,7 +532,7 @@ def test_prepare_export_unicode_shard_filename(monkeypatch, tmp_path):
             },
         },
     )
-    assert mutils._prepare_vlm_gguf_export_directory(out) == 1
+    assert mutils._prepare_mlx_gguf_export_directory(out) == 1
     assert list(_read_shard(out / "模型-shard.safetensors")) == [
         "visual.embed.weight"
     ]
@@ -1398,7 +1398,7 @@ def test_prepare_export_accepts_string_path(monkeypatch, tmp_path):
         lambda config, model=None: [],
     )
     out = _export_dir_with_shards(tmp_path, config={"model_type": "t"}, shards={})
-    assert mutils._prepare_vlm_gguf_export_directory(str(out)) == 0
+    assert mutils._prepare_mlx_gguf_export_directory(str(out)) == 0
 
 
 def test_repair_with_backslash_path_string_returns_processor_unchanged():

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1512,6 +1512,81 @@ def test_already_converted_recovery_is_exact_in_low_precision(tmp_path, dtype_na
     assert mutils._mlx_arrays_match(recovered, source), recovered
 
 
+@pytest.mark.parametrize("bad", ["nan", "inf"])
+def test_norm_offsets_reject_a_non_finite_constant(tmp_path, bad):
+    # The probe hands zeros to a third-party sanitizer, so a division by a
+    # weight it zeroed comes back inf or NaN. NaN fails every comparison, so an
+    # unguarded spread check reads it as a constant and the export writes it
+    # into the real tensor.
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class DividingSanitizer:
+        def __init__(self, src_path):
+            self._src_path = str(src_path)
+
+        def sanitize(self, weights):
+            out = dict(weights)
+            out["model.layers.0.normed"] = (
+                weights["model.layers.0.normed"] / weights["model.layers.0.scale"]
+            )
+            return out
+
+    numerator = 0.0 if bad == "nan" else 4.0
+    weights = {
+        "model.layers.0.scale": mx.array([2.0, 2.0]),
+        "model.layers.0.normed": mx.array([numerator, numerator]),
+    }
+    src = tmp_path / "src"
+    _write_weights(mx, src, weights)
+    model = DividingSanitizer(src)
+
+    assert mutils._mlx_sanitizer_norm_offsets(model) == {}
+
+    export = tmp_path / "export"
+    _write_weights(mx, export, weights)
+    (export / "config.json").write_text(json.dumps({"model_type": "stub"}))
+
+    assert mutils._prepare_mlx_gguf_export_directory(
+        export, model=model, replay_sanitizers=False
+    ) == 0
+    exported = mx.load(str(export / "model.safetensors"))
+    for key, expected in weights.items():
+        assert mutils._mlx_arrays_match(exported[key], expected), key
+
+
+def test_norm_offsets_fail_closed_when_the_model_cannot_be_copied(tmp_path):
+    # Falling back to the live instance would sanitize the model this exists to
+    # protect. Unmeasurable is the safe answer: it is what the export did before
+    # any of this landed.
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class Uncopyable:
+        def __init__(self, src_path):
+            self._src_path = str(src_path)
+            self.cached_weights = {"trained": "weights"}
+
+        def __copy__(self):
+            raise TypeError("this model cannot be shallow-copied")
+
+        def sanitize(self, weights):
+            self.cached_weights = dict(weights)
+            return {
+                key: (value + 1.0 if value.ndim == 1 else value)
+                for key, value in weights.items()
+            }
+
+    src = tmp_path / "src"
+    _write_weights(mx, src, {"model.norm.weight": mx.array([0.5, 0.25])})
+    model = Uncopyable(src)
+
+    assert mutils._mlx_sanitizer_norm_offsets(model) is None
+    assert model.cached_weights == {"trained": "weights"}
+
+
 def test_norm_offsets_survive_a_zero_length_tensor(tmp_path):
     # mx.min refuses a zero-size reduce. Letting that raise would discard every
     # offset measured alongside it and silently drop the whole correction.

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1316,10 +1316,10 @@ def test_gguf_export_unshifts_an_already_converted_source(tmp_path, source_conve
 
 
 def test_gguf_export_removes_a_measured_offset_that_is_not_one(tmp_path):
-    # The export threads the MEASURED offset into the replay candidates. A
-    # hardcoded ``- 1`` reproduces every 1.0 case, so pin a shift that is not
-    # 1.0: there the wrong constant makes no candidate round-trip, and the
-    # tensor keeps its MLX name and never reaches the export at all.
+    # The export threads the MEASURED offset into the replay candidates, and a
+    # hardcoded ``- 1`` reproduces every 1.0 case. Pin a shift that is not 1.0:
+    # there the wrong constant makes no candidate round-trip, so the tensor
+    # keeps its MLX name and never reaches the export.
     import unsloth_zoo.mlx.utils as mutils
 
     mx = mutils.mx
@@ -1472,21 +1472,17 @@ def test_norm_offsets_do_not_mutate_the_model(tmp_path):
 
 @pytest.mark.parametrize("dtype_name", ["bfloat16", "float16", "float32"])
 def test_already_converted_recovery_is_exact_in_low_precision(tmp_path, dtype_name):
-    # The recovery offers ``tensor - 1.0`` and accepts it only if replaying the
-    # sanitizer reproduces the stored tensor EXACTLY. That looks fragile --
-    # ``(t - c) + c == t`` is not a floating-point identity in general -- but
-    # the stored tensor is itself ``source + c`` computed in this same dtype,
-    # and over every finite bfloat16 and float16 value the only sources that
-    # fail are |source| = 258 and 2050 respectively. So the exact check is
-    # right and must not be loosened into a tolerance, which would let a
-    # near-miss candidate through.
+    # The recovery accepts ``tensor - 1.0`` only if replaying the sanitizer
+    # reproduces the stored tensor EXACTLY. ``(t - c) + c == t`` is not a
+    # floating-point identity, but the stored tensor is itself ``source + c`` in
+    # this dtype, and across every finite bfloat16 and float16 value the only
+    # sources that fail are |source| = 258 and 2050. So the exact check is right
+    # and must not be loosened into a tolerance.
     #
-    # Values here span the range the shifting families actually occupy: the
-    # published Qwen3-Next input_layernorm runs -0.154 to 0.781. A |source|
-    # above 1 is a different matter -- 1.8984375 + 1 does not fit bfloat16 and
-    # the low bit is gone before Unsloth sees the checkpoint at all -- so the
-    # recovery returns what mlx-lm's load left, which is what upstream
-    # inference runs on too.
+    # These values span the range the shifting families occupy (the published
+    # Qwen3-Next input_layernorm runs -0.154 to 0.781). Above |source| = 1 the
+    # low bit is gone before Unsloth sees the checkpoint, so the recovery
+    # returns what mlx-lm's load left, which is what inference runs on too.
     import unsloth_zoo.mlx.utils as mutils
 
     mx = mutils.mx

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1097,6 +1097,192 @@ def test_vlm_rewrite_prefers_hf_alias_before_current_name(monkeypatch):
     assert mutils._mlx_arrays_match(new_tensor, tensor)
 
 
+_MTP_NORM_SUFFIXES = (
+    ".input_layernorm.weight",
+    ".post_attention_layernorm.weight",
+    "model.norm.weight",
+    ".q_norm.weight",
+    ".k_norm.weight",
+)
+
+_MTP_SHIFTED_KEYS = (
+    "model.layers.0.input_layernorm.weight",
+    "model.layers.1.post_attention_layernorm.weight",
+    "model.layers.0.self_attn.q_norm.weight",
+    "model.layers.0.self_attn.k_norm.weight",
+    "model.norm.weight",
+)
+
+
+class _MtpGatedNormSanitizer:
+    """Shaped like the MTP families': an MTP shard or a still-unsanitized
+    conv1d marks the source as HF convention, which one tensor cannot show."""
+
+    def __init__(self, src_path):
+        self._src_path = str(src_path)
+
+    def sanitize(self, weights):
+        shift = any("mtp." in key for key in weights) or any(
+            "conv1d.weight" in key and value.shape[-1] != 1
+            for key, value in weights.items()
+        )
+        sanitized = {}
+        for key, value in weights.items():
+            if "mtp." in key:
+                continue
+            if "conv1d.weight" in key and value.shape[-1] != 1:
+                value = value.moveaxis(2, 1)
+            if shift and value.ndim == 1 and key.endswith(_MTP_NORM_SUFFIXES):
+                value = value + 1.0
+            sanitized[key] = value
+        return sanitized
+
+
+def _mtp_source_weights(mx, *, gate):
+    """``gate`` selects what puts the source in HF convention, if anything."""
+    weights = {key: mx.array([0.5, 0.25]) for key in _MTP_SHIFTED_KEYS}
+    weights.update({
+        # Norm-named but unshifted: catches a correction keyed on the name.
+        "model.layers.0.linear_attn.norm.weight": mx.array([0.5, 0.25]),
+        "vision_tower.blocks.0.norm1.weight": mx.array([0.5, 0.25]),
+        # 1-D float but not a norm: catches a blanket 1-D correction.
+        "model.layers.0.linear_attn.dt_bias": mx.array([0.5, 0.25]),
+        "model.layers.0.self_attn.q_proj.weight": mx.array([[0.5, 0.25]]),
+    })
+    if gate == "mtp":
+        weights["mtp.0.input_layernorm.weight"] = mx.array([0.5, 0.25])
+    elif gate == "conv1d":
+        weights["model.layers.0.linear_attn.conv1d.weight"] = mx.zeros((2, 1, 4))
+    return weights
+
+
+def _write_weights(mx, directory, weights):
+    directory.mkdir(parents=True, exist_ok=True)
+    mx.save_safetensors(str(directory / "model.safetensors"), weights)
+
+
+@pytest.mark.parametrize("gate", ["mtp", "conv1d", None])
+def test_norm_offsets_follow_the_source_checkpoint_gate(tmp_path, gate):
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    src = tmp_path / "src"
+    _write_weights(mx, src, _mtp_source_weights(mx, gate=gate))
+
+    offsets = mutils._mlx_sanitizer_norm_offsets(_MtpGatedNormSanitizer(src))
+
+    expected = dict.fromkeys(_MTP_SHIFTED_KEYS, 1.0) if gate else {}
+    assert offsets == expected
+
+
+@pytest.mark.parametrize("gate", ["mtp", "conv1d", None])
+def test_gguf_export_restores_the_hf_norm_convention(tmp_path, gate):
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    src = tmp_path / "src"
+    source_weights = _mtp_source_weights(mx, gate=gate)
+    _write_weights(mx, src, source_weights)
+    model = _MtpGatedNormSanitizer(src)
+
+    export = tmp_path / "export"
+    merged = model.sanitize(dict(source_weights))
+    _write_weights(mx, export, merged)
+    (export / "config.json").write_text(json.dumps({"model_type": "stub"}))
+
+    rewritten = mutils._prepare_mlx_gguf_export_directory(
+        export, model=model, replay_sanitizers=False
+    )
+
+    assert rewritten == (len(_MTP_SHIFTED_KEYS) if gate else 0)
+    exported = mx.load(str(export / "model.safetensors"))
+    assert sorted(exported) == sorted(merged)
+    for key, value in exported.items():
+        # conv1d is relayouted rather than offset.
+        expected = source_weights[key]
+        if "conv1d.weight" in key:
+            expected = merged[key]
+        assert mutils._mlx_arrays_match(value, expected), key
+
+
+def test_gguf_export_does_not_subtract_a_replayed_offset_twice(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class RenamingNormSanitizer:
+        """Renames and shifts, so the single-tensor replay recovers the value
+        on its own and the measured offset must not be applied again."""
+
+        def __init__(self, src_path):
+            self._src_path = str(src_path)
+
+        def sanitize(self, weights):
+            sanitized = {}
+            for key, value in weights.items():
+                key = key.replace("model.", "renamed.", 1)
+                if value.ndim == 1 and key.endswith(_MTP_NORM_SUFFIXES):
+                    value = value + 1.0
+                sanitized[key] = value
+            return sanitized
+
+    src = tmp_path / "src"
+    source_weights = {
+        "model.layers.0.input_layernorm.weight": mx.array([0.5, 0.25]),
+        "model.layers.0.linear_attn.dt_bias": mx.array([0.5, 0.25]),
+    }
+    _write_weights(mx, src, source_weights)
+    model = RenamingNormSanitizer(src)
+
+    export = tmp_path / "export"
+    _write_weights(mx, export, model.sanitize(dict(source_weights)))
+    (export / "config.json").write_text(json.dumps({"model_type": "stub"}))
+
+    mutils._prepare_mlx_gguf_export_directory(export, model=model)
+
+    exported = mx.load(str(export / "model.safetensors"))
+    assert mutils._mlx_arrays_match(
+        exported["renamed.layers.0.input_layernorm.weight"],
+        source_weights["model.layers.0.input_layernorm.weight"],
+    )
+    assert mutils._mlx_arrays_match(
+        exported["renamed.layers.0.linear_attn.dt_bias"],
+        source_weights["model.layers.0.linear_attn.dt_bias"],
+    )
+
+
+class _StopAfterExportPrep(Exception):
+    """Ends save_pretrained_gguf once the export prep has been observed."""
+
+
+@pytest.mark.parametrize("is_vlm", [True, False])
+def test_gguf_save_prepares_the_export_directory_for_every_model(
+    monkeypatch, tmp_path, is_vlm
+):
+    import unsloth_zoo.mlx.utils as mutils
+
+    calls = {}
+
+    def fake_prepare(path, model=None, replay_sanitizers=True):
+        calls["path"] = Path(path)
+        calls["model"] = model
+        calls["replay_sanitizers"] = replay_sanitizers
+        raise _StopAfterExportPrep
+
+    monkeypatch.setattr(mutils, "_is_vlm_model", lambda _model: is_vlm)
+    monkeypatch.setattr(
+        mutils, "save_merged_model", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(mutils, "_prepare_mlx_gguf_export_directory", fake_prepare)
+
+    model = object()
+    with pytest.raises(_StopAfterExportPrep):
+        mutils.save_pretrained_gguf(model, object(), tmp_path / "out")
+
+    assert calls["model"] is model
+    assert calls["replay_sanitizers"] is is_vlm
+
+
 def test_vlm_rewrite_handles_same_name_layout_transforms(monkeypatch):
     import torch
     import unsloth_zoo.mlx.utils as mutils
@@ -1630,7 +1816,7 @@ def test_save_merged_model_detects_nested_vlm_config(monkeypatch, tmp_path):
     assert calls["config"]["thinker_config"]["vision_config"]["hidden_size"] == 8
 
 
-def test_prepare_vlm_gguf_export_directory_writes_nextn_config_without_tensors(
+def test_prepare_mlx_gguf_export_directory_writes_nextn_config_without_tensors(
     monkeypatch,
     tmp_path,
 ):
@@ -1659,7 +1845,7 @@ def test_prepare_vlm_gguf_export_directory_writes_nextn_config_without_tensors(
         lambda config, model=None: [],
     )
 
-    rewritten = mutils._prepare_vlm_gguf_export_directory(tmp_path, model=object())
+    rewritten = mutils._prepare_mlx_gguf_export_directory(tmp_path, model=object())
 
     assert rewritten == 0
     updated = json.loads(config_path.read_text(encoding="utf-8"))
@@ -1668,7 +1854,7 @@ def test_prepare_vlm_gguf_export_directory_writes_nextn_config_without_tensors(
     assert "nextn_predict_layers" not in updated["text_config"]
 
 
-def test_prepare_vlm_gguf_export_directory_ignores_malformed_thinker_config(
+def test_prepare_mlx_gguf_export_directory_ignores_malformed_thinker_config(
     monkeypatch,
     tmp_path,
 ):
@@ -1696,7 +1882,7 @@ def test_prepare_vlm_gguf_export_directory_ignores_malformed_thinker_config(
         lambda config, model=None: [],
     )
 
-    assert mutils._prepare_vlm_gguf_export_directory(tmp_path, model=object()) == 0
+    assert mutils._prepare_mlx_gguf_export_directory(tmp_path, model=object()) == 0
 
 
 def test_copy_source_sidecars_preserves_image_processor_metadata(tmp_path):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1470,6 +1470,58 @@ def test_norm_offsets_do_not_mutate_the_model(tmp_path):
     assert model["lm_head"] == "the real lm_head module"
 
 
+def test_norm_offsets_survive_a_zero_length_tensor(tmp_path):
+    # mx.min refuses a zero-size reduce. Letting that raise would discard every
+    # offset measured alongside it and silently drop the whole correction.
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class ShiftEveryNorm:
+        def __init__(self, src_path):
+            self._src_path = str(src_path)
+
+        def sanitize(self, weights):
+            return {
+                key: (value + 1.0 if key.endswith("norm.weight") else value)
+                for key, value in weights.items()
+            }
+
+    src = tmp_path / "src"
+    _write_weights(mx, src, {
+        "model.norm.weight": mx.array([0.5, 0.25]),
+        "model.layers.0.empty_bias": mx.zeros((0,)),
+    })
+
+    assert mutils._mlx_sanitizer_norm_offsets(ShiftEveryNorm(src)) == {
+        "model.norm.weight": 1.0,
+    }
+
+
+def test_norm_offsets_replay_once_when_nothing_is_shifted(tmp_path):
+    # The confirming replay only runs when the first one found something to
+    # confirm. Sanitizers that shift nothing are the common case, and some of
+    # them dequantize the whole checkpoint on the way through.
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    calls = []
+
+    class CountingPassthrough:
+        def __init__(self, src_path):
+            self._src_path = str(src_path)
+
+        def sanitize(self, weights):
+            calls.append(len(weights))
+            return dict(weights)
+
+    src = tmp_path / "src"
+    _write_weights(mx, src, {"model.norm.weight": mx.array([0.5, 0.25])})
+
+    assert mutils._mlx_sanitizer_norm_offsets(CountingPassthrough(src)) == {}
+    assert len(calls) == 1
+
+
 class _StopAfterExportPrep(Exception):
     """Ends save_pretrained_gguf once the export prep has been observed."""
 

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1251,6 +1251,65 @@ def test_gguf_export_does_not_subtract_a_replayed_offset_twice(tmp_path):
     )
 
 
+class _KeyGatedNormSanitizer:
+    """Shaped like the Qwen3.5 family's: the RMSNorm shift is decided by the
+    pre-sanitize key, so it survives a checkpoint that was already converted."""
+
+    def __init__(self, src_path):
+        self._src_path = str(src_path)
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for original_key, value in weights.items():
+            key = original_key
+            if key.startswith("model.language_model."):
+                key = "language_model.model." + key[len("model.language_model."):]
+            if (
+                value.ndim == 1
+                and key.endswith(_MTP_NORM_SUFFIXES)
+                and not original_key.startswith("language_model.")
+            ):
+                value = value + 1.0
+            sanitized[key] = value
+        return sanitized
+
+
+@pytest.mark.parametrize("source_convention", ["hf", "mlx"])
+def test_gguf_export_unshifts_an_already_converted_source(tmp_path, source_convention):
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    hf_weights = {
+        "model.language_model.layers.0.input_layernorm.weight": mx.array([0.5, 0.25]),
+        "model.language_model.norm.weight": mx.array([0.125, 0.75]),
+        "model.language_model.layers.0.linear_attn.dt_bias": mx.array([0.5, 0.25]),
+    }
+    model_of = _KeyGatedNormSanitizer
+
+    src = tmp_path / "src"
+    if source_convention == "hf":
+        _write_weights(mx, src, hf_weights)
+    else:
+        # An mlx-community style checkpoint: already sanitized, so reloading it
+        # shifts nothing and the measurement comes back bare.
+        _write_weights(mx, src, model_of(src).sanitize(dict(hf_weights)))
+    model = model_of(src)
+
+    if source_convention == "mlx":
+        assert mutils._mlx_sanitizer_norm_offsets(model) == {}
+
+    export = tmp_path / "export"
+    _write_weights(mx, export, model.sanitize(dict(hf_weights)))
+    (export / "config.json").write_text(json.dumps({"model_type": "stub"}))
+
+    mutils._prepare_mlx_gguf_export_directory(export, model=model)
+
+    exported = mx.load(str(export / "model.safetensors"))
+    for key, expected in hf_weights.items():
+        assert key in exported, key
+        assert mutils._mlx_arrays_match(exported[key], expected), key
+
+
 class _StopAfterExportPrep(Exception):
     """Ends save_pretrained_gguf once the export prep has been observed."""
 

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1470,6 +1470,48 @@ def test_norm_offsets_do_not_mutate_the_model(tmp_path):
     assert model["lm_head"] == "the real lm_head module"
 
 
+@pytest.mark.parametrize("dtype_name", ["bfloat16", "float16", "float32"])
+def test_already_converted_recovery_is_exact_in_low_precision(tmp_path, dtype_name):
+    # The recovery offers ``tensor - 1.0`` and accepts it only if replaying the
+    # sanitizer reproduces the stored tensor EXACTLY. That looks fragile --
+    # ``(t - c) + c == t`` is not a floating-point identity in general -- but
+    # the stored tensor is itself ``source + c`` computed in this same dtype,
+    # and over every finite bfloat16 and float16 value the only sources that
+    # fail are |source| = 258 and 2050 respectively. So the exact check is
+    # right and must not be loosened into a tolerance, which would let a
+    # near-miss candidate through.
+    #
+    # Values here span the range the shifting families actually occupy: the
+    # published Qwen3-Next input_layernorm runs -0.154 to 0.781. A |source|
+    # above 1 is a different matter -- 1.8984375 + 1 does not fit bfloat16 and
+    # the low bit is gone before Unsloth sees the checkpoint at all -- so the
+    # recovery returns what mlx-lm's load left, which is what upstream
+    # inference runs on too.
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    dtype = getattr(mx, dtype_name)
+    source = mx.array([-0.953125, -0.7, 0.046875, 0.25, 0.5, 0.78125], dtype=dtype)
+    hf_weights = {"model.language_model.norm.weight": source}
+
+    src = tmp_path / "src"
+    # An mlx-community style checkpoint: already sanitized on disk, so the
+    # measurement is empty and only the replay can recover the shift.
+    _write_weights(mx, src, _KeyGatedNormSanitizer(src).sanitize(dict(hf_weights)))
+    model = _KeyGatedNormSanitizer(src)
+    assert mutils._mlx_sanitizer_norm_offsets(model) == {}
+
+    export = tmp_path / "export"
+    _write_weights(mx, export, model.sanitize(dict(hf_weights)))
+    (export / "config.json").write_text(json.dumps({"model_type": "stub"}))
+
+    assert mutils._prepare_mlx_gguf_export_directory(export, model=model) == 1
+
+    exported = mx.load(str(export / "model.safetensors"))
+    recovered = exported["model.language_model.norm.weight"]
+    assert mutils._mlx_arrays_match(recovered, source), recovered
+
+
 def test_norm_offsets_survive_a_zero_length_tensor(tmp_path):
     # mx.min refuses a zero-size reduce. Letting that raise would discard every
     # offset measured alongside it and silently drop the whole correction.

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1253,10 +1253,15 @@ def test_gguf_export_does_not_subtract_a_replayed_offset_twice(tmp_path):
 
 class _KeyGatedNormSanitizer:
     """Shaped like the Qwen3.5 family's: the RMSNorm shift is decided by the
-    pre-sanitize key, so it survives a checkpoint that was already converted."""
+    pre-sanitize key, so it survives a checkpoint that was already converted.
 
-    def __init__(self, src_path):
+    ``shift`` is parametrized rather than fixed at 1.0 so the tests can tell a
+    measured offset apart from the 1.0 the export falls back to.
+    """
+
+    def __init__(self, src_path, shift=1.0):
         self._src_path = str(src_path)
+        self._shift = shift
 
     def sanitize(self, weights):
         sanitized = {}
@@ -1269,7 +1274,7 @@ class _KeyGatedNormSanitizer:
                 and key.endswith(_MTP_NORM_SUFFIXES)
                 and not original_key.startswith("language_model.")
             ):
-                value = value + 1.0
+                value = value + self._shift
             sanitized[key] = value
         return sanitized
 
@@ -1308,6 +1313,161 @@ def test_gguf_export_unshifts_an_already_converted_source(tmp_path, source_conve
     for key, expected in hf_weights.items():
         assert key in exported, key
         assert mutils._mlx_arrays_match(exported[key], expected), key
+
+
+def test_gguf_export_removes_a_measured_offset_that_is_not_one(tmp_path):
+    # The export threads the MEASURED offset into the replay candidates. A
+    # hardcoded ``- 1`` reproduces every 1.0 case, so pin a shift that is not
+    # 1.0: there the wrong constant makes no candidate round-trip, and the
+    # tensor keeps its MLX name and never reaches the export at all.
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    hf_weights = {
+        "model.language_model.layers.0.input_layernorm.weight": mx.array([0.5, 0.25]),
+        "model.language_model.norm.weight": mx.array([0.125, 0.75]),
+    }
+    src = tmp_path / "src"
+    _write_weights(mx, src, hf_weights)
+    model = _KeyGatedNormSanitizer(src, shift=0.5)
+
+    assert mutils._mlx_sanitizer_norm_offsets(model) == {
+        "language_model.model.layers.0.input_layernorm.weight": 0.5,
+        "language_model.model.norm.weight": 0.5,
+    }
+
+    export = tmp_path / "export"
+    _write_weights(mx, export, model.sanitize(dict(hf_weights)))
+    (export / "config.json").write_text(json.dumps({"model_type": "stub"}))
+
+    mutils._prepare_mlx_gguf_export_directory(export, model=model)
+
+    exported = mx.load(str(export / "model.safetensors"))
+    for key, expected in hf_weights.items():
+        assert key in exported, key
+        assert mutils._mlx_arrays_match(exported[key], expected), key
+
+
+class _SynthesizedScaleSanitizer:
+    """Shaped like mlx-vlm's Inkling: the sanitizer CREATES 1-D scale vectors
+    that the source checkpoint never held, filled with ones, under names that
+    are real model parameters. They are constant and non-zero, so a measurement
+    that only looks at its own output reads them as an added offset."""
+
+    def __init__(self, src_path):
+        self._src_path = str(src_path)
+
+    def sanitize(self, weights):
+        import unsloth_zoo.mlx.utils as mutils
+
+        out = dict(weights)
+        for key in [k for k in out if k.endswith("switch_mlp.gate_proj.weight")]:
+            prefix = key[: -len("gate_proj.weight")]
+            ones = mutils.mx.ones((out[key].shape[0],))
+            out.setdefault(prefix + "gate_scale", ones)
+            out.setdefault(prefix + "out_scale", ones)
+        return out
+
+
+_SWITCH_MLP = "language_model.model.layers.0.mlp.switch_mlp."
+
+
+def test_norm_offsets_ignore_a_sanitizer_created_constant(tmp_path):
+    # A created tensor is not an offset: nothing in the source was shifted to
+    # produce it, so subtracting it annihilates a real parameter.
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    src = tmp_path / "src"
+    _write_weights(mx, src, {_SWITCH_MLP + "gate_proj.weight": mx.zeros((2, 3))})
+
+    assert mutils._mlx_sanitizer_norm_offsets(_SynthesizedScaleSanitizer(src)) == {}
+
+
+@pytest.mark.parametrize("replay_sanitizers", [True, False])
+def test_gguf_export_keeps_sanitizer_created_scales(tmp_path, replay_sanitizers):
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    src = tmp_path / "src"
+    _write_weights(mx, src, {_SWITCH_MLP + "gate_proj.weight": mx.zeros((2, 3))})
+    model = _SynthesizedScaleSanitizer(src)
+
+    export = tmp_path / "export"
+    merged = {
+        _SWITCH_MLP + "gate_proj.weight": mx.zeros((2, 3)),
+        _SWITCH_MLP + "gate_scale": mx.array([1.0, 1.0]),
+        _SWITCH_MLP + "out_scale": mx.array([1.0, 1.0]),
+    }
+    _write_weights(mx, export, merged)
+    (export / "config.json").write_text(json.dumps({"model_type": "stub"}))
+
+    mutils._prepare_mlx_gguf_export_directory(
+        export, model=model, replay_sanitizers=replay_sanitizers
+    )
+
+    exported = mx.load(str(export / "model.safetensors"))
+    for key, expected in merged.items():
+        assert mutils._mlx_arrays_match(exported[key], expected), key
+
+
+def test_norm_offsets_ignore_a_non_additive_transform(tmp_path):
+    # ``A_log = -exp(A_log)`` maps a zeroed probe to a constant -1.0. Reading
+    # that as an offset would shift a real state-space parameter by +1.
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class NegExpSanitizer:
+        def __init__(self, src_path):
+            self._src_path = str(src_path)
+
+        def sanitize(self, weights):
+            return {
+                key: (-mx.exp(value) if key.endswith("A_log") else value)
+                for key, value in weights.items()
+            }
+
+    src = tmp_path / "src"
+    _write_weights(mx, src, {
+        "model.layers.0.mixer.A_log": mx.array([0.5, 0.25]),
+        "model.layers.0.input_layernorm.weight": mx.array([0.5, 0.25]),
+    })
+
+    assert mutils._mlx_sanitizer_norm_offsets(NegExpSanitizer(src)) == {}
+
+
+def test_norm_offsets_do_not_mutate_the_model(tmp_path):
+    # Real sanitizers write to ``self``: mlx-vlm's phi4mm caches its LoRA
+    # weights, and mlx-lm's gemma3_text drops the lm_head submodule for a tied
+    # checkpoint. Measuring must not leave the caller holding a model rebuilt
+    # from the all-zero probe.
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class SelfMutatingSanitizer(dict):
+        def __init__(self, src_path):
+            super().__init__({"lm_head": "the real lm_head module"})
+            self._src_path = str(src_path)
+            self.cached_weights = {"trained": "weights"}
+
+        def sanitize(self, weights):
+            self.cached_weights = dict(weights)
+            self.pop("lm_head", None)
+            return {
+                key: (value + 1.0 if value.ndim == 1 else value)
+                for key, value in weights.items()
+            }
+
+    src = tmp_path / "src"
+    _write_weights(mx, src, {"model.norm.weight": mx.array([0.5, 0.25])})
+    model = SelfMutatingSanitizer(src)
+
+    assert mutils._mlx_sanitizer_norm_offsets(model) == {"model.norm.weight": 1.0}
+
+    assert model.cached_weights == {"trained": "weights"}
+    assert model["lm_head"] == "the real lm_head module"
 
 
 class _StopAfterExportPrep(Exception):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -13990,7 +13990,7 @@ def _vlm_gguf_name_candidates(name):
     return candidates
 
 
-def _vlm_gguf_tensor_candidates(name, tensor):
+def _vlm_gguf_tensor_candidates(name, tensor, norm_offset=1.0):
     """Yield HF-layout tensor candidates for an MLX VLM tensor."""
     candidates = []
     shape = getattr(tensor, "shape", ())
@@ -14002,8 +14002,8 @@ def _vlm_gguf_tensor_candidates(name, tensor):
     elif len(shape) == 3 and "depthwise_conv1d.weight" in name:
         candidates.append(mx.transpose(tensor, (0, 2, 1)))
 
-    if len(shape) == 1 and mx.issubdtype(tensor.dtype, mx.floating):
-        candidates.append(tensor - 1)
+    if norm_offset and len(shape) == 1 and mx.issubdtype(tensor.dtype, mx.floating):
+        candidates.append(tensor - norm_offset)
 
     candidates.append(tensor)
     return candidates
@@ -14060,13 +14060,15 @@ def _normalize_mlx_vlm_sanitize_pipelines(sanitize_steps):
     return sanitize_steps
 
 
-def _rewrite_mlx_vlm_tensor_for_gguf(name, tensor, sanitize_steps):
+def _rewrite_mlx_vlm_tensor_for_gguf(name, tensor, sanitize_steps, norm_offset=1.0):
     """Invert mlx-vlm sanitizers to recover HF tensor names/layouts for GGUF."""
     if not _has_vlm_gguf_rewrite_candidate(name, tensor):
         return name, tensor, False
 
     for candidate_name in _vlm_gguf_name_candidates(name):
-        for candidate_tensor in _vlm_gguf_tensor_candidates(name, tensor):
+        for candidate_tensor in _vlm_gguf_tensor_candidates(
+            name, tensor, norm_offset
+        ):
             for pipeline in _normalize_mlx_vlm_sanitize_pipelines(sanitize_steps):
                 sanitized = _apply_mlx_vlm_sanitizers(
                     pipeline,
@@ -14088,6 +14090,56 @@ def _rewrite_mlx_vlm_tensor_for_gguf(name, tensor, sanitize_steps):
                 return candidate_name, candidate_tensor, True
 
     return name, tensor, False
+
+
+_MLX_NORM_OFFSET_TOLERANCE = 1e-6
+
+
+def _mlx_sanitizer_norm_offsets(model):
+    """Measure the constants a model's sanitizer adds to its 1-D float weights.
+
+    The MTP families shift RMSNorm weights by +1 when loading an HF checkpoint,
+    gated on the source checkpoint's contents rather than on the model class, so
+    zero the 1-D floats and replay the real sanitizer: each 1-D output is then
+    the constant it added. None means unmeasurable, not unshifted.
+    """
+    src_path = _get_src_path(model)
+    sanitize = getattr(model, "sanitize", None)
+    if src_path is None or not callable(sanitize):
+        return None
+
+    try:
+        weights = {}
+        for weight_file in sorted(Path(src_path).glob("*.safetensors")):
+            weights.update(mx.load(str(weight_file)))
+        if not weights:
+            return None
+
+        probe = {
+            key: (
+                mx.zeros(value.shape, dtype=value.dtype)
+                if value.ndim == 1 and mx.issubdtype(value.dtype, mx.floating)
+                else value
+            )
+            for key, value in weights.items()
+        }
+
+        offsets = {}
+        for key, value in sanitize(probe).items():
+            if getattr(value, "ndim", None) != 1:
+                continue
+            if not mx.issubdtype(value.dtype, mx.floating):
+                continue
+            low = mx.min(value).item()
+            if abs(low - mx.max(value).item()) > _MLX_NORM_OFFSET_TOLERANCE:
+                continue
+            if abs(low) > _MLX_NORM_OFFSET_TOLERANCE:
+                offsets[key] = low
+    except Exception as exc:
+        print(f"Unsloth: Could not measure MLX norm offsets ({exc}); continuing.")
+        return None
+
+    return offsets
 
 
 def _sync_gguf_nextn_layer_config(config, model):
@@ -14143,8 +14195,12 @@ def _sync_gguf_nextn_layer_config(config, model):
     return changed
 
 
-def _prepare_vlm_gguf_export_directory(path, model=None):
-    """Rewrite MLX-native VLM tensor names in the temporary GGUF export dir."""
+def _prepare_mlx_gguf_export_directory(path, model=None, replay_sanitizers=True):
+    """Restore HF tensor names, layouts and norm convention in the export dir.
+
+    ``replay_sanitizers`` gates the mlx-vlm name/layout inversion, VLM-only; the
+    norm correction runs for every model.
+    """
     path = Path(path)
     config_path = path / "config.json"
     if not config_path.exists():
@@ -14152,8 +14208,13 @@ def _prepare_vlm_gguf_export_directory(path, model=None):
     with open(config_path, "r") as f:
         config = json.load(f)
     config_changed = _sync_gguf_nextn_layer_config(config, model)
-    sanitize_steps = _build_mlx_vlm_sanitize_pipelines(config, model=model)
-    if not sanitize_steps:
+    sanitize_steps = (
+        _build_mlx_vlm_sanitize_pipelines(config, model=model)
+        if replay_sanitizers
+        else []
+    )
+    norm_offsets = _mlx_sanitizer_norm_offsets(model)
+    if not sanitize_steps and not norm_offsets:
         if config_changed:
             with open(config_path, "w") as f:
                 json.dump(config, f, indent=4)
@@ -14166,12 +14227,25 @@ def _prepare_vlm_gguf_export_directory(path, model=None):
         updated = {}
         file_rewritten = 0
         for name, tensor in tensors.items():
+            original_tensor = tensor
+            # An empty measurement is ambiguous: an already-converted MLX
+            # source shifts nothing at load yet still holds shifted norms.
+            offset = 1.0 if not norm_offsets else norm_offsets.get(name, 0.0)
             new_name, tensor, changed = _rewrite_mlx_vlm_tensor_for_gguf(
-                name, tensor, sanitize_steps
+                name, tensor, sanitize_steps, offset
             )
+            # The replay cannot observe a gate that spans the whole checkpoint,
+            # so a value it left alone is one the measurement has to recover.
+            if (
+                norm_offsets
+                and offset
+                and _mlx_arrays_match(tensor, original_tensor)
+            ):
+                tensor = tensor - offset
+                changed = True
             if new_name in updated:
                 raise RuntimeError(
-                    f"Unsloth: duplicate tensor name after GGUF VLM rewrite: {new_name}"
+                    f"Unsloth: duplicate tensor name after GGUF rewrite: {new_name}"
                 )
             updated[new_name] = tensor
             name_map[name] = new_name
@@ -14194,7 +14268,7 @@ def _prepare_vlm_gguf_export_directory(path, model=None):
             new_name = name_map.get(name, name)
             if new_name in weight_map:
                 raise RuntimeError(
-                    f"Unsloth: duplicate index tensor name after GGUF VLM rewrite: {new_name}"
+                    f"Unsloth: duplicate index tensor name after GGUF rewrite: {new_name}"
                 )
             weight_map[new_name] = shard
         index_data["weight_map"] = dict(sorted(weight_map.items()))
@@ -14845,13 +14919,14 @@ def save_pretrained_gguf(
         is_vlm_model = _is_vlm_model(model)
         print("Unsloth: Merging LoRA weights and saving to 16-bit...")
         save_merged_model(model, tokenizer, tmp_path, dequantize=True)
-        if is_vlm_model:
-            rewritten = _prepare_vlm_gguf_export_directory(tmp_path, model=model)
-            if rewritten:
-                print(
-                    "Unsloth: Rewrote "
-                    f"{rewritten} MLX VLM tensors for llama.cpp GGUF export."
-                )
+        rewritten = _prepare_mlx_gguf_export_directory(
+            tmp_path, model=model, replay_sanitizers=is_vlm_model
+        )
+        if rewritten:
+            print(
+                f"Unsloth: Rewrote {rewritten} MLX tensors "
+                "for llama.cpp GGUF export."
+            )
 
         # Restore architectures from the original HF config since mlx-vlm's
         # save_config strips that key. convert_to_gguf reconciles MTP metadata

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14135,7 +14135,13 @@ def _mlx_constant_1d_value(value):
     if value.shape[0] == 0:
         return None
     low = mx.min(value).item()
-    if abs(low - mx.max(value).item()) > _MLX_NORM_OFFSET_TOLERANCE:
+    high = mx.max(value).item()
+    # The probe feeds zeros to a third-party sanitizer, so a division can hand
+    # back inf or NaN. NaN fails every comparison, so an unguarded spread check
+    # reads it as constant and the export subtracts it into the real weight.
+    if not math.isfinite(low) or not math.isfinite(high):
+        return None
+    if abs(low - high) > _MLX_NORM_OFFSET_TOLERANCE:
         return None
     return low
 
@@ -14149,12 +14155,12 @@ def _mlx_sanitize_probe(model, weights):
     measuring on the model itself would rebuild the live model out of the probe
     values, halfway through an export. A shallow copy keeps every read the
     sanitizer does and sends those writes to a throwaway.
+
+    A model that cannot be copied is not measured. Falling back to the live
+    instance would do the exact thing this exists to prevent, and the caller
+    treats the failure as unmeasurable, which is the pre-existing behaviour.
     """
-    try:
-        model = copy.copy(model)
-    except Exception:
-        pass
-    return model.sanitize(weights)
+    return copy.copy(model).sanitize(weights)
 
 
 def _mlx_sanitizer_norm_offsets(model):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14103,15 +14103,67 @@ def _rewrite_mlx_vlm_tensor_for_gguf(name, tensor, sanitize_steps, norm_offset=1
 
 
 _MLX_NORM_OFFSET_TOLERANCE = 1e-6
+_MLX_NORM_OFFSET_PROBE = 1.0
+
+
+def _mlx_norm_offset_probe(weights, fill):
+    """Replace every 1-D float weight with ``fill``, passing the rest through.
+
+    Keys, shapes and dtypes survive, and those are what the real sanitizer gates
+    read -- key names, the presence of a key elsewhere in the checkpoint, shape
+    and dtype -- so the replay reproduces the gate while carrying a value we
+    chose.
+    """
+    return {
+        key: (
+            mx.zeros(value.shape, dtype=value.dtype) + fill
+            if value.ndim == 1 and mx.issubdtype(value.dtype, mx.floating)
+            else value
+        )
+        for key, value in weights.items()
+    }
+
+
+def _mlx_constant_1d_value(value):
+    """Return the single value a 1-D float array holds, or None if it varies."""
+    if getattr(value, "ndim", None) != 1:
+        return None
+    if not mx.issubdtype(value.dtype, mx.floating):
+        return None
+    low = mx.min(value).item()
+    if abs(low - mx.max(value).item()) > _MLX_NORM_OFFSET_TOLERANCE:
+        return None
+    return low
+
+
+def _mlx_sanitize_probe(model, weights):
+    """Replay ``model.sanitize`` where its writes to ``self`` cannot escape.
+
+    Sanitizers are not pure. mlx-vlm's phi4mm caches its split LoRA weights on
+    the instance (``self._base_weights`` and friends) and mlx-lm's gemma3_text
+    pops the ``lm_head`` submodule when the checkpoint ties embeddings, so
+    measuring on the model itself would rebuild the live model out of the probe
+    values, halfway through an export. A shallow copy keeps every read the
+    sanitizer does and sends those writes to a throwaway.
+    """
+    try:
+        model = copy.copy(model)
+    except Exception:
+        pass
+    return model.sanitize(weights)
 
 
 def _mlx_sanitizer_norm_offsets(model):
-    """Measure the constants a model's sanitizer adds to its 1-D float weights.
+    """Measure the constants a model's sanitizer ADDS to its 1-D float weights.
 
     The MTP families shift RMSNorm weights by +1 when loading an HF checkpoint,
     gated on the source checkpoint's contents rather than on the model class, so
-    zero the 1-D floats and replay the real sanitizer: each 1-D output is then
-    the constant it added. None means unmeasurable, not unshifted.
+    replay the real sanitizer over two probes -- 1-D floats all zero, then all
+    one -- and keep a key only where the output rose by the difference between
+    the probes. Rising is what makes the constant an ADDED one: a sanitizer that
+    invents a 1-D tensor the source never held, as mlx-vlm's Inkling does for
+    its expert scales, or that transforms one non-additively, does not track its
+    input and is rejected. None means unmeasurable, not unshifted.
     """
     src_path = _get_src_path(model)
     sanitize = getattr(model, "sanitize", None)
@@ -14125,26 +14177,25 @@ def _mlx_sanitizer_norm_offsets(model):
         if not weights:
             return None
 
-        probe = {
-            key: (
-                mx.zeros(value.shape, dtype=value.dtype)
-                if value.ndim == 1 and mx.issubdtype(value.dtype, mx.floating)
-                else value
-            )
-            for key, value in weights.items()
-        }
+        zeroed = _mlx_sanitize_probe(model, _mlx_norm_offset_probe(weights, 0.0))
+        raised = _mlx_sanitize_probe(
+            model, _mlx_norm_offset_probe(weights, _MLX_NORM_OFFSET_PROBE)
+        )
 
         offsets = {}
-        for key, value in sanitize(probe).items():
-            if getattr(value, "ndim", None) != 1:
+        for key, value in zeroed.items():
+            offset = _mlx_constant_1d_value(value)
+            if offset is None or abs(offset) <= _MLX_NORM_OFFSET_TOLERANCE:
                 continue
-            if not mx.issubdtype(value.dtype, mx.floating):
+            raised_value = raised.get(key)
+            if getattr(raised_value, "shape", None) != value.shape:
                 continue
-            low = mx.min(value).item()
-            if abs(low - mx.max(value).item()) > _MLX_NORM_OFFSET_TOLERANCE:
+            delta = _mlx_constant_1d_value(raised_value - value)
+            if delta is None:
                 continue
-            if abs(low) > _MLX_NORM_OFFSET_TOLERANCE:
-                offsets[key] = low
+            if abs(delta - _MLX_NORM_OFFSET_PROBE) > _MLX_NORM_OFFSET_TOLERANCE:
+                continue
+            offsets[key] = offset
     except Exception as exc:
         print(f"Unsloth: Could not measure MLX norm offsets ({exc}); continuing.")
         return None

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -13986,6 +13986,16 @@ def _vlm_gguf_name_candidates(name):
         add(f"model.language_model.visual.{suffix}")
         add(f"vit.{suffix}")
 
+    # Pre-fold text-tower names. Sanitizers that decide the RMSNorm shift from
+    # the key, as the Qwen3.5 family does, only apply it under these, so they
+    # are what lets the replay recover the shift from an already-converted MLX
+    # checkpoint, where nothing was shifted at load and the measurement is bare.
+    if name.startswith("language_model.model."):
+        suffix = name[len("language_model.model."):]
+        add(f"model.language_model.{suffix}")
+    if name.startswith("language_model.lm_head"):
+        add(name[len("language_model."):])
+
     add(name)
     return candidates
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -13986,10 +13986,9 @@ def _vlm_gguf_name_candidates(name):
         add(f"model.language_model.visual.{suffix}")
         add(f"vit.{suffix}")
 
-    # Pre-fold text-tower names. Sanitizers that decide the RMSNorm shift from
-    # the key, as the Qwen3.5 family does, only apply it under these, so they
-    # are what lets the replay recover the shift from an already-converted MLX
-    # checkpoint, where nothing was shifted at load and the measurement is bare.
+    # Pre-fold text-tower names. Key-gated sanitizers (Qwen3.5) shift only under
+    # these, so they are what lets the replay recover the shift from an
+    # already-converted MLX checkpoint, where the measurement comes back bare.
     if name.startswith("language_model.model."):
         suffix = name[len("language_model.model."):]
         add(f"model.language_model.{suffix}")
@@ -14109,10 +14108,8 @@ _MLX_NORM_OFFSET_PROBE = 1.0
 def _mlx_norm_offset_probe(weights, fill):
     """Replace every 1-D float weight with ``fill``, passing the rest through.
 
-    Keys, shapes and dtypes survive, and those are what the real sanitizer gates
-    read -- key names, the presence of a key elsewhere in the checkpoint, shape
-    and dtype -- so the replay reproduces the gate while carrying a value we
-    chose.
+    Keys, shapes and dtypes survive, and every real sanitizer gate reads only
+    those, so the replay reproduces the gate while carrying a value we chose.
     """
     return {
         key: (
@@ -14130,15 +14127,15 @@ def _mlx_constant_1d_value(value):
         return None
     if not mx.issubdtype(value.dtype, mx.floating):
         return None
-    # mx.min refuses a zero-size reduce, and one such tensor anywhere in the
-    # checkpoint would otherwise discard every offset measured alongside it.
+    # mx.min refuses a zero-size reduce, and the raise would discard every
+    # offset measured alongside this one.
     if value.shape[0] == 0:
         return None
     low = mx.min(value).item()
     high = mx.max(value).item()
-    # The probe feeds zeros to a third-party sanitizer, so a division can hand
-    # back inf or NaN. NaN fails every comparison, so an unguarded spread check
-    # reads it as constant and the export subtracts it into the real weight.
+    # A sanitizer dividing by a weight the probe zeroed returns inf or NaN, and
+    # NaN fails every comparison, so the spread check below would read it as
+    # constant and the export would subtract it into a real weight.
     if not math.isfinite(low) or not math.isfinite(high):
         return None
     if abs(low - high) > _MLX_NORM_OFFSET_TOLERANCE:
@@ -14149,16 +14146,12 @@ def _mlx_constant_1d_value(value):
 def _mlx_sanitize_probe(model, weights):
     """Replay ``model.sanitize`` where its writes to ``self`` cannot escape.
 
-    Sanitizers are not pure. mlx-vlm's phi4mm caches its split LoRA weights on
-    the instance (``self._base_weights`` and friends) and mlx-lm's gemma3_text
-    pops the ``lm_head`` submodule when the checkpoint ties embeddings, so
-    measuring on the model itself would rebuild the live model out of the probe
-    values, halfway through an export. A shallow copy keeps every read the
-    sanitizer does and sends those writes to a throwaway.
-
-    A model that cannot be copied is not measured. Falling back to the live
-    instance would do the exact thing this exists to prevent, and the caller
-    treats the failure as unmeasurable, which is the pre-existing behaviour.
+    Sanitizers are not pure: phi4mm caches its split LoRA weights on the
+    instance and gemma3_text pops the ``lm_head`` submodule for a tied
+    checkpoint, so measuring on the model itself would rebuild it out of the
+    probe halfway through an export. A model that cannot be copied is left
+    unmeasured; the caller treats that as unmeasurable, which is what the export
+    did before this existed.
     """
     return copy.copy(model).sanitize(weights)
 
@@ -14166,14 +14159,13 @@ def _mlx_sanitize_probe(model, weights):
 def _mlx_sanitizer_norm_offsets(model):
     """Measure the constants a model's sanitizer ADDS to its 1-D float weights.
 
-    The MTP families shift RMSNorm weights by +1 when loading an HF checkpoint,
-    gated on the source checkpoint's contents rather than on the model class, so
-    replay the real sanitizer over two probes -- 1-D floats all zero, then all
-    one -- and keep a key only where the output rose by the difference between
-    the probes. Rising is what makes the constant an ADDED one: a sanitizer that
-    invents a 1-D tensor the source never held, as mlx-vlm's Inkling does for
-    its expert scales, or that transforms one non-additively, does not track its
-    input and is rejected. None means unmeasurable, not unshifted.
+    The MTP families shift RMSNorm weights by +1 on load, gated on the source
+    checkpoint's contents rather than the model class, so replay the real
+    sanitizer over two probes -- 1-D floats all zero, then all one -- and keep a
+    key only where the output rose by the difference. Rising is what makes the
+    constant an ADDED one, so a sanitizer that invents a 1-D tensor the source
+    never held (Inkling's expert scales) or transforms one non-additively is
+    rejected. None means unmeasurable, not unshifted.
     """
     src_path = _get_src_path(model)
     sanitize = getattr(model, "sanitize", None)
@@ -14195,9 +14187,8 @@ def _mlx_sanitizer_norm_offsets(model):
                 continue
             candidates[key] = (value, offset)
         if not candidates:
-            # Nothing to confirm, so skip the second replay: the sanitizers that
-            # shift nothing are the common case and some of them dequantize the
-            # whole checkpoint on the way through.
+            # Nothing to confirm. Shifting nothing is the common case, so skip
+            # the second replay rather than pay for it on every model.
             return {}
 
         raised = _mlx_sanitize_probe(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14130,6 +14130,10 @@ def _mlx_constant_1d_value(value):
         return None
     if not mx.issubdtype(value.dtype, mx.floating):
         return None
+    # mx.min refuses a zero-size reduce, and one such tensor anywhere in the
+    # checkpoint would otherwise discard every offset measured alongside it.
+    if value.shape[0] == 0:
+        return None
     low = mx.min(value).item()
     if abs(low - mx.max(value).item()) > _MLX_NORM_OFFSET_TOLERANCE:
         return None
@@ -14178,15 +14182,24 @@ def _mlx_sanitizer_norm_offsets(model):
             return None
 
         zeroed = _mlx_sanitize_probe(model, _mlx_norm_offset_probe(weights, 0.0))
+        candidates = {}
+        for key, value in zeroed.items():
+            offset = _mlx_constant_1d_value(value)
+            if offset is None or abs(offset) <= _MLX_NORM_OFFSET_TOLERANCE:
+                continue
+            candidates[key] = (value, offset)
+        if not candidates:
+            # Nothing to confirm, so skip the second replay: the sanitizers that
+            # shift nothing are the common case and some of them dequantize the
+            # whole checkpoint on the way through.
+            return {}
+
         raised = _mlx_sanitize_probe(
             model, _mlx_norm_offset_probe(weights, _MLX_NORM_OFFSET_PROBE)
         )
 
         offsets = {}
-        for key, value in zeroed.items():
-            offset = _mlx_constant_1d_value(value)
-            if offset is None or abs(offset) <= _MLX_NORM_OFFSET_TOLERANCE:
-                continue
+        for key, (value, offset) in candidates.items():
             raised_value = raised.get(key)
             if getattr(raised_value, "shape", None) != value.shape:
                 continue


### PR DESCRIPTION
## The bug

For a handful of MTP architectures, mlx-lm and mlx-vlm add `1.0` to every RMSNorm weight while loading an HF checkpoint. That is MLX's on-disk convention rather than a defect — an already-shifted checkpoint reports no shift on reload, so MLX round-trips itself correctly, and published MLX repos store the shifted form.

`save_merged_model` writes the in-memory weights straight out, so a merged save of these families holds norms one above the HF convention. llama.cpp's converter then adds its own `+1` (`convert_hf_to_gguf`, for `*norm.weight` excluding `linear_attn.norm.weight`), so the exported GGUF lands at `source + 2.0` where it should be `source + 1.0`, and generated text is gibberish.

Measured on `Qwen/Qwen3.5-4B`, exported GGUF against the published reference built from the same source checkpoint:

```text
tensor                                reference      this export (before)
blk.16.attn_norm.weight               source + 1.0   source + 2.0
blk.31.attn_norm.weight               source + 1.0   source + 2.0
blk.32.attn_norm.weight    (grafted)  source + 1.0   source + 1.0
```

Grafted MTP tensors are copied byte-wise from the source and never pass through the MLX model, so a single exported file disagrees with itself: trunk norms at `+2.0`, MTP block norms at `+1.0`.

## Why the fix is in the export path, not in the merged save

The merged directory is an MLX-format checkpoint on three axes, not one: MLX key names (`language_model.model.X` where HF has `model.language_model.X`), MLX conv1d layout (`(C, K, 1)` where the source has `(C, 1, K)`), and the shifted norms. Reloading it through mlx-vlm reproduces the original in-memory weights bit for bit.

Un-shifting at save time would therefore break the documented "can be reloaded with `mlx_lm.load()`" contract while still not producing a checkpoint `transformers` could read, since the key names remain MLX-native. The GGUF export is the only place where HF convention is actually required, so the correction lives there.

## What changed

`_mlx_sanitizer_norm_offsets` measures the shift instead of hardcoding which families apply it. It loads the source checkpoint, replaces every 1-D float tensor with zeros of the same shape and dtype, replays the model's own `sanitize`, and reads each sanitized 1-D output as exactly the constant that was added — keyed by the name the merged save writes.

Measuring rather than enumerating is deliberate. The shift is gated differently per family, and two of the three gates in mlx-lm depend on the source checkpoint's contents rather than on the model class, so no static list is correct for a given checkpoint. Measuring also covers families a list would have missed: nine files across mlx-lm and mlx-vlm apply this shift, including the MoE and MiniCPM-V variants.

The export rewrite subtracts the measured offset from tensors whose value the existing single-tensor sanitizer replay left untouched — that replay cannot observe a gate spanning the whole checkpoint. `save_pretrained_gguf` now runs the export prep for every model rather than VLMs only; the mlx-vlm name and layout replay stays VLM-only via `replay_sanitizers`.

Models whose MLX implementation applies the offset at compute time instead, as Gemma does with `mx.fast.rms_norm(x, 1.0 + self.weight, eps)`, never rewrite the checkpoint and are unaffected. When the offsets cannot be measured the export keeps its previous behavior rather than applying an unverified correction.

## Already-converted MLX sources

A checkpoint that is already in MLX format stores its norms shifted, so loading it applies no further shift and the measured offset is empty — the same corrupt export by a different route. The second commit covers that by offering the pre-fold text-tower names as rewrite candidates: sanitizers that decide the shift from the pre-sanitize key, as the Qwen3.5 family does, only apply it under those names, so the existing replay can reproduce and invert the shift without consulting the source at all. Candidates are still accepted only when replaying the real sanitizer reproduces the stored name and tensor exactly, and the measured offset wins wherever it applies, so an HF source is never corrected twice.

Verified both ways on real checkpoints. From `mlx-community/Qwen3.5-2B-MLX-8bit`, whose norms sit exactly `+1.0` above `Qwen/Qwen3.5-2B` on disk, 49 norms are checked against the HF original and all land at the source value, with `linear_attn.norm.weight`, `dt_bias` and vision norms untouched. The HF-source path is unchanged.

Confirmed on a second, unrelated shifting family as well. `mlx-community/MiniCPM-V-4.6-mxfp4` is also an already-converted source, so its measured offset is likewise empty; exactly 61 tensors move and every one of them by `-1.0`, with no non-norm tensor moved and no norm tensor left behind.

The widened candidate set is neutral for families that do not shift. On `mlx-community/FastVLM-0.5B-bf16`, comparing the export with and without the new candidates over all 879 tensors gives zero differences in value under the name normalization llama.cpp itself applies, and an identical rewrite count.

Sanitizers that instead gate on whole-checkpoint content still depend on the measurement, so an already-converted source for one of those exports unchanged. That remains a known limit.

## Risks and limits

The measurement covers 1-D float tensors, which is what every RMSNorm weight is and what llama.cpp's own handling assumes. Widening it would require materializing the whole checkpoint and would cost the property that makes it cheap.

The added name candidates rewrite text-tower tensors in the export directory to their HF spelling. This is behaviour-neutral downstream: llama.cpp's converter strips `language_model.` from anywhere in a tensor name, so both spellings resolve to the same target.

## Validation

End-to-end on `Qwen/Qwen3.5-0.8B`, comparing the export directory against the HF source:

```text
layers.23.input_layernorm.weight        median(export - source) = +0.000000
model.norm.weight                       median(export - source) = +0.000000
layers.12.linear_attn.norm.weight       median(export - source) = +0.000549   (bf16 noise, correctly not shifted)
visual.blocks.0.norm1.weight            median(export - source) = +0.000000
layers.0.mlp.gate_proj.weight           median(export - source) = +0.000000
```

All 61 shifted norms return to the source value; `linear_attn.norm.weight`, `A_log`, `dt_bias`, vision norms and 2-D weights are untouched. llama.cpp then adds its own `+1`, giving the reference convention.

The measurement was also exercised against the real upstream sanitizers for `qwen3_5` (text), `qwen3_next` and `step3p5`, at both polarities of each gate — MTP shard present and absent, unsanitized conv1d present, Step3.5 vanilla and already-remapped — and reports an offset only when the sanitizer actually shifts.

Cost on a 9.32 GB checkpoint is 0.16 s with no measurable resident-memory growth, because `mx.load` stays lazy and only the 1-D tensors are ever materialized.

```bash
python -m pytest tests/test_mlx_save_export_regressions.py -q
```

Added tests cover both gates and the no-gate case, `q_norm`/`k_norm`, norm-named tensors that must not move, the double-subtraction guard, and the call site's `replay_sanitizers` polarity. Each was mutation-checked: reverting the production change fails exactly the intended tests.


### End-to-end GGUF export and generation

`mlx-community/Qwen3.5-4B-8bit` exercises the harder path: the source is itself an already-converted MLX checkpoint, so nothing is shifted at load time and the measurement legitimately reports no offsets. The replay recovers the shift from the key-gated sanitizer instead.

Exported with `save_pretrained_gguf(..., quantization_method="not_quantized")`, then compared against `Qwen/Qwen3.5-4B`:

```text
tensor                                median(gguf - hf_source)
blk.{0,7,16,31}.attn_norm.weight                      +1.00000
blk.{0,7,16,31}.post_attention_norm.weight            +1.00000
output_norm.weight                                    +1.00000
blk.{0,16}.ssm_norm.weight                            +0.00000
```

`ssm_norm` is `linear_attn.norm.weight`, which neither the MLX sanitizer nor llama.cpp shifts (`conversion/qwen.py` excludes it explicitly), so `+0.00000` is the correct result there.

Every norm in the GGUF is at exactly `source + 1.0`, matching the reference `unsloth/Qwen3.5-4B-MTP-GGUF` convention, and the resulting model generates coherent text under `llama-server` at `temperature=0`:

```text
"What is the capital of France? Answer in one sentence."  ->  "The capital of France is Paris."
"What is 17 * 23? Just the number."                       ->  "391"
```

This replaces the gibberish (`hôur眼 Rank���ون的人类1.闰го临床holmIr蝶и`) the double-shifted export produced. Reproducing the export also needs an unrelated fix for the converter asserting on an absent MTP head, which is tracked separately and is not part of this PR.

