### PR TITLE
Fix text-only loading for VLM-only MLX models

### DIFF
--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -105,6 +105,19 @@ def test_vlm_detection_requires_a_real_modality(monkeypatch, tmp_path):
     assert not loader._is_vlm({"vision_config": {}, "model_type": "text_only"})
 
 
+def test_text_only_vlm_load_stays_on_vlm_path_when_mlx_lm_has_no_model(monkeypatch):
+    import unsloth_zoo.mlx.loader as loader
+
+    monkeypatch.setattr(loader, "_get_mlx_lm_model_class", lambda _: None)
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: object())
+
+    config = {"model_type": "gemma4_unified", "vision_config": {"hidden_size": 32}}
+    assert loader._prefer_vlm_loader_for_text(config, "gemma4_unified")
+
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: None)
+    assert not loader._prefer_vlm_loader_for_text(config, "unsupported_vlm")
+
+
 def test_apply_mlx_distributed_sharding_modes_and_guards():
     from unsloth_zoo.mlx.loader import (
         _apply_mlx_distributed_sharding,

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2622,7 +2622,7 @@ def _prefer_vlm_loader_for_text(config: dict, model_type: str) -> bool:
 
     cls = _get_mlx_lm_model_class(model_type)
     if cls is None:
-        return False
+        return _resolve_mlx_vlm_model_class(model_type) is not None
 
     return _has_multimodal_strip_sanitize(cls)
 


### PR DESCRIPTION
## Summary

- keep text-only training on the `mlx-vlm` load path when the model type has no `mlx-lm` implementation
- preserve the existing `mlx-lm` sanitizer detection for model types available in both packages
- add a regression test for `gemma4_unified`-style VLM-only model types

## Reproduction

With `unsloth_zoo==2026.8.13`, `mlx-lm==0.31.3`, and `mlx-vlm==0.6.15`, loading `OBLITERATUS/Gemma-4-12B-OBLITERATED` for text-only LoRA training detects a VLM but then selects `mlx-lm`. `mlx_lm.models.gemma4_unified` does not exist, while `mlx_vlm.models.gemma4_unified.Model` does.

The fallback now checks whether `mlx-vlm` can resolve the model before leaving the VLM path.

## Verification

```text
tests/test_mlx_distributed_loader.py: 8 passed
```

The same model completed an 11-step MLX QLoRA run after applying this change together with the corresponding Gemma 4 vision-key fix in `mlx-vlm`.
