### PR TITLE
Drop the vision and audio tensors from a text_only merged_16bit export

### DIFF
--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -153,7 +153,9 @@ def test_text_only_export_drops_the_vision_tower(tmp_path):
 
 
 def test_text_only_export_is_smaller_than_the_base(tmp_path):
-    """Halving the checkpoint is the point of the drop, so measure it rather than assume it."""
+    """The saving is the point, so measure it. How large it is depends on the model: the
+    tower is 10% of gemma-3-4b-it and most of an omni checkpoint, so only pin the direction.
+    """
     H.set_offline_cpu_env()
     base_dir, cfg = _write_vlm_base(tmp_path)
     out_dir = os.path.join(str(tmp_path), "merged")

--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -192,6 +192,26 @@ def test_index_and_shards_agree_after_the_drop(tmp_path):
         "the index and the shards disagree about which tensors exist")
 
 
+def test_low_disk_space_still_drops_without_a_push(tmp_path):
+    """Only the upload half of low_disk_space_usage blocks the drop, so keep the guard narrow.
+
+    That combination uploads and removes each shard inside the merge loop under a name chosen
+    before the drop changes how many shards there are, which is why it stands down. Saving to
+    a local directory removes nothing early, so there is no reason to give up the drop there.
+    """
+    H.set_offline_cpu_env()
+    base_dir, cfg = _write_vlm_base(tmp_path)
+    out_dir = os.path.join(str(tmp_path), "merged")
+
+    pm = _attach_lora(_text_only_model(cfg, base_dir))
+    H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32, low_disk_space_usage=True)
+
+    written = list(H.read_safetensors_dir(out_dir))
+    assert written, "the export wrote nothing"
+    assert not [k for k in written if "vision" in k], "low_disk_space_usage skipped the drop"
+    _assert_clean_reload(out_dir)
+
+
 def test_remap_failure_keeps_the_whole_checkpoint(tmp_path, monkeypatch):
     """When the text weights cannot be placed, fall back to #1073 rather than guess.
 

--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -14,12 +14,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""The merged_16bit config must describe the weights the merge actually writes (#969).
+"""The merged_16bit config and weights must describe the same model (#969).
 
 `merge_and_overwrite_lora` takes its weights from the resolved base checkpoint but used to
 save `model.config`, which `text_only = True` has already replaced with the nested text
 config, so a `gemma3_text` config landed next to full VLM weights. Nothing raised: every
 tensor was silently re-initialized on reload, so a finetune could be served untrained.
+
+There are two ways to make the pair agree, and this suite covers both. A `text_only` merge
+drops the vision and audio tensors and exports the text model that was asked for. When the
+text weights cannot be located in the base checkpoint the drop stands down, and the export
+falls back to the whole VLM under a config that describes it -- correct, just larger.
 
 The fixture is the real shape -- a text-only decoder whose `_name_or_path` points at a VLM
 checkpoint. Passing is not "no exception" (the bug threw none) but the saved architecture
@@ -94,15 +99,33 @@ def _saved_config(out_dir):
 
 
 def _reload_info(out_dir):
-    """Reload as the architecture the saved config declares and return loading info."""
+    """Reload as the architecture the saved config declares and return loading info.
+
+    Which class that is depends on what the export decided to be: a text_only merge writes a
+    causal LM and the fallback writes the VLM. Reading it off `architectures` keeps the test
+    honest about the checkpoint in front of it instead of assuming either one.
+    """
     import transformers as T
-    _, info = T.AutoModelForImageTextToText.from_pretrained(
-        out_dir, output_loading_info=True, local_files_only=True)
+    declared = (_saved_config(out_dir).get("architectures") or [None])[0]
+    auto = getattr(T, declared, None) if declared else None
+    if auto is None: auto = T.AutoModelForImageTextToText
+    _, info = auto.from_pretrained(out_dir, output_loading_info=True, local_files_only=True)
     return info
 
 
-def test_text_only_export_config_matches_written_weights(tmp_path):
-    """#969: a text_only export must declare the VLM it actually wrote."""
+def _assert_clean_reload(out_dir):
+    info = _reload_info(out_dir)
+    for field in ("missing_keys", "unexpected_keys", "mismatched_keys", "error_msgs"):
+        assert not info.get(field), f"{field}: {info.get(field)[:6]}"
+
+
+def test_text_only_export_drops_the_vision_tower(tmp_path):
+    """#969 second direction: a text_only export is the text model that was asked for.
+
+    The config and the weights have to agree, which #1073 achieved by declaring the VLM the
+    merge had written. This is the other way round: the vision tensors go, the text tensors
+    take their text-only names, and the export becomes the causal LM the load requested.
+    """
     H.set_offline_cpu_env()
     base_dir, cfg = _write_vlm_base(tmp_path)
     out_dir = os.path.join(str(tmp_path), "merged")
@@ -110,19 +133,94 @@ def test_text_only_export_config_matches_written_weights(tmp_path):
     pm = _attach_lora(_text_only_model(cfg, base_dir))
     H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
 
-    # transformers 5 flattens the VLM prefixes, so match on a substring, not the key name.
+    base_written = list(H.read_safetensors_dir(base_dir))
+    assert any("vision" in k for k in base_written), "fixture holds no vision weights to drop"
+
     written = list(H.read_safetensors_dir(out_dir))
-    assert any("vision" in k for k in written), f"fixture wrote no vision weights: {written[:4]}"
+    assert written, "the export wrote nothing"
+    leftover = [k for k in written if "vision" in k or "audio" in k or "projector" in k]
+    assert not leftover, f"vision/audio tensors survived the text_only export: {leftover[:4]}"
+    assert any(k.startswith("model.layers.") for k in written), (
+        f"text tensors were not renamed into the text-only namespace: {written[:4]}")
 
-    base, saved = _saved_config(base_dir), _saved_config(out_dir)
-    assert saved.get("model_type") == base.get("model_type") != "gemma3_text", (
+    saved = _saved_config(out_dir)
+    assert saved.get("model_type") == "gemma3_text", (
         f"saved config describes {saved.get('model_type')!r}, not the written weights")
-    assert saved.get("architectures") == base.get("architectures") and saved.get("architectures"), (
-        f"saved architectures {saved.get('architectures')!r} do not match the weights")
+    assert saved.get("architectures") == ["Gemma3ForCausalLM"], (
+        f"saved architectures {saved.get('architectures')!r} do not name the written model")
 
-    info = _reload_info(out_dir)
-    for field in ("missing_keys", "unexpected_keys", "mismatched_keys", "error_msgs"):
-        assert not info.get(field), f"{field}: {info.get(field)[:6]}"
+    _assert_clean_reload(out_dir)
+
+
+def test_text_only_export_is_smaller_than_the_base(tmp_path):
+    """Halving the checkpoint is the point of the drop, so measure it rather than assume it."""
+    H.set_offline_cpu_env()
+    base_dir, cfg = _write_vlm_base(tmp_path)
+    out_dir = os.path.join(str(tmp_path), "merged")
+
+    pm = _attach_lora(_text_only_model(cfg, base_dir))
+    H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
+
+    def weight_bytes(d):
+        return sum(os.path.getsize(os.path.join(d, f)) for f in os.listdir(d)
+                   if f.endswith(".safetensors"))
+
+    assert weight_bytes(out_dir) < weight_bytes(base_dir), (
+        "the text_only export is no smaller than the VLM it came from")
+
+
+def test_index_and_shards_agree_after_the_drop(tmp_path):
+    """A stale index outlives the tensors it names, and the reload dies on files not there."""
+    H.set_offline_cpu_env()
+    base_dir, cfg = _write_vlm_base(tmp_path)
+    out_dir = os.path.join(str(tmp_path), "merged")
+
+    pm = _attach_lora(_text_only_model(cfg, base_dir))
+    H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
+
+    index_path = os.path.join(out_dir, "model.safetensors.index.json")
+    shards = sorted(f for f in os.listdir(out_dir) if f.endswith(".safetensors"))
+    if not os.path.exists(index_path):
+        assert shards == ["model.safetensors"], (
+            f"no index, so there must be exactly one shard, found {shards}")
+        return
+    with open(index_path) as f:
+        weight_map = json.load(f)["weight_map"]
+    assert sorted(set(weight_map.values())) == shards, (
+        f"index names {sorted(set(weight_map.values()))} but the directory holds {shards}")
+    assert set(weight_map) == set(H.read_safetensors_dir(out_dir)), (
+        "the index and the shards disagree about which tensors exist")
+
+
+def test_remap_failure_keeps_the_whole_checkpoint(tmp_path, monkeypatch):
+    """When the text weights cannot be placed, fall back to #1073 rather than guess.
+
+    Writing a checkpoint whose tensors the code could not account for is what #969 was, so
+    the drop is the thing that gives way, and it has to say so.
+    """
+    import unsloth_zoo.saving_utils as SU
+
+    H.set_offline_cpu_env()
+    base_dir, cfg = _write_vlm_base(tmp_path)
+    out_dir = os.path.join(str(tmp_path), "merged")
+    pm = _attach_lora(_text_only_model(cfg, base_dir))
+
+    def boom(*args, **kwargs):
+        raise SU.TextOnlyRemapError("forced remap failure")
+
+    monkeypatch.setattr(SU, "_text_only_key_map", boom)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
+
+    assert any("could not separate the text weights" in str(w.message) for w in caught), (
+        "the export silently kept the vision tensors")
+    written = list(H.read_safetensors_dir(out_dir))
+    assert any("vision" in k for k in written), "the fallback dropped weights anyway"
+    assert _saved_config(out_dir).get("model_type") == _saved_config(base_dir).get("model_type"), (
+        "the fallback must still describe the weights it wrote (#1073)")
+
+    _assert_clean_reload(out_dir)
 
 
 def test_text_only_export_preserves_resized_vocab(tmp_path):
@@ -148,7 +246,7 @@ def test_text_only_export_preserves_resized_vocab(tmp_path):
     assert embed.shape[0] == new_vocab, "the merge did not write the resized embedding"
 
     saved = _saved_config(out_dir)
-    declared = saved.get("text_config", {}).get("vocab_size", saved.get("vocab_size"))
+    declared = saved.get("text_config", {}).get("vocab_size") or saved.get("vocab_size")
     assert declared == new_vocab, (
         f"config declares vocab {declared} beside {embed.shape[0]} embedding rows")
 

--- a/tests/test_text_only_key_map.py
+++ b/tests/test_text_only_key_map.py
@@ -140,6 +140,19 @@ def test_a_text_key_with_no_counterpart_is_an_error():
         _text_only_key_map(TEXT_KEYS, base_keys, tie_word_embeddings = False)
 
 
+def test_two_complete_readings_are_an_error():
+    """Qwen Omni carries a second decoder under `talker`, and it only fails to match because
+    it is a different shape. One that matched would give two equally valid answers, and
+    picking either would be a coin flip over which model the user gets.
+    """
+    base_keys = set()
+    for tower in ("thinker.", "talker."):
+        base_keys |= {tower + k for k in TEXT_KEYS - {"lm_head.weight"}}
+        base_keys.add(tower + "lm_head.weight")
+    with pytest.raises(TextOnlyRemapError):
+        _text_only_key_map(TEXT_KEYS, base_keys, tie_word_embeddings = False)
+
+
 def test_an_already_text_only_checkpoint_is_an_error():
     """There is nothing to drop, and an identity map would rewrite every shard to achieve it."""
     with pytest.raises(TextOnlyRemapError):

--- a/tests/test_text_only_key_map.py
+++ b/tests/test_text_only_key_map.py
@@ -1,0 +1,146 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Where a VLM checkpoint keeps its text weights, across every layout we have seen (#969).
+
+A `text_only` export has to find the text tensors inside a composite checkpoint before it can
+drop the rest, and there is no one place they live. The layout is fixed when the checkpoint is
+written, not by the transformers doing the reading, so a published gemma3 and one saved locally
+by the same code disagree. Hardcoding any single prefix silently mismaps the others, which is
+the failure #969 reported in the first place.
+
+The key sets below are trimmed to one layer, but the prefixes are the real ones, read off the
+published `model.safetensors.index.json` of each checkpoint. Each case pins both halves of the
+answer: a rule that maps the text weights correctly and still keeps the vision tower is wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from unsloth_zoo.saving_utils import TextOnlyRemapError, _text_only_key_map
+
+TEXT_KEYS = {
+    "model.embed_tokens.weight",
+    "model.layers.0.self_attn.q_proj.weight",
+    "model.layers.0.mlp.down_proj.weight",
+    "model.layers.0.input_layernorm.weight",
+    "model.norm.weight",
+    "lm_head.weight",
+}
+
+
+def _text(text_prefix, base_prefix, head = None):
+    """The text tensors after `text_prefix` is swapped for `base_prefix`, plus the head, if any.
+
+    That swap is the whole shape of the problem: some layouts prepend a component to every text
+    key, others replace the leading `model.` with a deeper path, and the head can be tied away,
+    left at the top level, or carried along under the prefix.
+    """
+    keys = {base_prefix + k[len(text_prefix):] for k in TEXT_KEYS - {"lm_head.weight"}}
+    return keys if head is None else keys | {head}
+
+
+def _vision(prefix):
+    return {prefix + "encoder.layers.0.self_attn.q_proj.weight", prefix + "post_layernorm.weight"}
+
+
+LAYOUTS = [
+    # unsloth/gemma-3-4b-it as published: no lm_head anywhere, because the head is tied.
+    ("gemma3-published", True,
+     _text("", "language_model."),
+     _vision("vision_tower.vision_model.") | {"multi_modal_projector.mm_input_projection_weight"}),
+
+    # The same family written by save_pretrained on transformers 5.5.0: one component deeper.
+    ("gemma3-save-pretrained", True,
+     _text("", "model.language_model."),
+     _vision("model.vision_tower.vision_model.") |
+     {"model.multi_modal_projector.mm_input_projection_weight"}),
+
+    # An in-memory Gemma3ForConditionalGeneration, which keeps lm_head at the top level.
+    ("gemma3-in-memory", False,
+     _text("model.", "model.language_model.", head = "lm_head.weight"),
+     _vision("model.vision_tower.vision_model.") |
+     {"model.multi_modal_projector.mm_input_projection_weight"}),
+
+    # HuggingFaceM4/Idefics3-8B-Llama3: text under model.text_model, head unprefixed.
+    ("idefics3", False,
+     _text("model.", "model.text_model.", head = "lm_head.weight"),
+     _vision("model.vision_model.") | {"model.connector.modality_projection.proj.weight"}),
+
+    # Qwen/Qwen2.5-Omni-3B: the text model is one of five top-level towers, audio included.
+    ("qwen-omni", False,
+     _text("", "thinker.", head = "thinker.lm_head.weight"),
+     _vision("thinker.visual.") | {
+         "thinker.audio_tower.layers.0.self_attn.q_proj.weight",
+         "talker.model.layers.0.self_attn.q_proj.weight",
+         "token2wav.code2wav_bigvgan_model.conv_pre.weight",
+     }),
+]
+
+
+@pytest.mark.parametrize("name, tied, text_base, other", LAYOUTS, ids = [l[0] for l in LAYOUTS])
+def test_the_text_weights_are_found_and_only_those_are_kept(name, tied, text_base, other):
+    key_map = _text_only_key_map(TEXT_KEYS, text_base | other, tie_word_embeddings = tied)
+
+    expected = TEXT_KEYS - {"lm_head.weight"} if tied else TEXT_KEYS
+    assert set(key_map) == expected, f"{name}: the reload would be missing {expected - set(key_map)}"
+    assert set(key_map.values()) == text_base, (
+        f"{name}: kept {sorted(set(key_map.values()) - text_base)}, "
+        f"lost {sorted(text_base - set(key_map.values()))}")
+    assert not (set(key_map.values()) & other), f"{name}: a vision or audio tensor was kept"
+
+
+def test_the_tied_head_is_left_out_rather_than_invented():
+    """gemma3 ships 883 tensors and not one is an lm_head, because the head is tied."""
+    _, tied, text_base, other = LAYOUTS[0]
+    key_map = _text_only_key_map(TEXT_KEYS, text_base | other, tie_word_embeddings = tied)
+    assert "lm_head.weight" not in key_map, "the export would write a head the base does not have"
+
+
+def test_a_missing_head_that_is_not_tied_is_an_error():
+    """Without the tie there is no tensor to fall back on, so guessing would ship a broken head."""
+    _, _, text_base, other = LAYOUTS[0]
+    with pytest.raises(TextOnlyRemapError):
+        _text_only_key_map(TEXT_KEYS, text_base | other, tie_word_embeddings = False)
+
+
+def test_text_weights_under_two_prefixes_are_an_error():
+    """No single substitution reaches both halves, and picking one would drop the other."""
+    base_keys = {
+        "language_model.model.embed_tokens.weight",
+        "language_model.model.layers.0.self_attn.q_proj.weight",
+        "decoder.model.layers.0.mlp.down_proj.weight",
+        "decoder.model.layers.0.input_layernorm.weight",
+        "language_model.model.norm.weight",
+        "language_model.lm_head.weight",
+    }
+    with pytest.raises(TextOnlyRemapError):
+        _text_only_key_map(TEXT_KEYS, base_keys, tie_word_embeddings = False)
+
+
+def test_a_text_key_with_no_counterpart_is_an_error():
+    """A tensor the reload needs and the checkpoint lacks is exactly #969, so refuse to write it."""
+    _, _, text_base, other = LAYOUTS[4]
+    base_keys = {k for k in text_base | other if "mlp.down_proj" not in k}
+    with pytest.raises(TextOnlyRemapError):
+        _text_only_key_map(TEXT_KEYS, base_keys, tie_word_embeddings = False)
+
+
+def test_an_already_text_only_checkpoint_is_an_error():
+    """There is nothing to drop, and an identity map would rewrite every shard to achieve it."""
+    with pytest.raises(TextOnlyRemapError):
+        _text_only_key_map(TEXT_KEYS, set(TEXT_KEYS), tie_word_embeddings = False)

--- a/tests/test_text_only_shard_rewrite.py
+++ b/tests/test_text_only_shard_rewrite.py
@@ -1,0 +1,130 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""What happens to the files when a text_only export drops a whole shard (#969).
+
+`unsloth/gemma-3-4b-it` keeps text weights in both of its two shards, so the end-to-end run
+never deletes one, never renumbers, and never has to decide whether the index should still
+exist. Those are the branches most likely to leave a directory that no longer loads, and a
+checkpoint whose index names a file that is not there fails at load with no useful message.
+
+So drive them directly, on real safetensors files small enough to be free. The shard layout
+here is the one the drop is for: some shards mixed, at least one pure vision.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from unsloth_zoo.saving_utils import (
+    _rewrite_shards_text_only,
+    _write_text_only_index,
+    renumber_safetensor_files,
+)
+
+TEXT = ["model.embed_tokens.weight", "model.layers.0.self_attn.q_proj.weight",
+        "model.norm.weight"]
+KEY_MAP = {k : "language_model." + k for k in TEXT}
+
+
+def _write_shards(directory, layout):
+    """Write one tiny tensor per key and return the filenames, in order."""
+    os.makedirs(directory, exist_ok = True)
+    names = []
+    for i, keys in enumerate(layout):
+        name = f"model-{i+1:05d}-of-{len(layout):05d}.safetensors"
+        save_file({k : torch.ones(2) for k in keys},
+                  os.path.join(directory, name), metadata = {"format" : "pt"})
+        names.append(name)
+    return names
+
+
+def _vision(n):
+    return [f"vision_tower.vision_model.encoder.layers.{i}.q_proj.weight" for i in range(n)]
+
+
+def _keys_in(path):
+    with safe_open(path, framework = "pt", device = "cpu") as f:
+        return set(f.keys())
+
+
+def test_a_shard_holding_only_vision_weights_is_deleted(tmp_path):
+    d = str(tmp_path)
+    names = _write_shards(d, [
+        [KEY_MAP[TEXT[0]]] + _vision(1),
+        _vision(3),
+        [KEY_MAP[TEXT[1]], KEY_MAP[TEXT[2]]],
+    ])
+
+    kept = _rewrite_shards_text_only(d, names, KEY_MAP)
+
+    assert kept == [names[0], names[2]], f"kept {kept}"
+    assert not os.path.exists(os.path.join(d, names[1])), "the all-vision shard is still on disk"
+    assert _keys_in(os.path.join(d, names[0])) == {TEXT[0]}, "the kept tensors were not renamed"
+    assert _keys_in(os.path.join(d, names[2])) == {TEXT[1], TEXT[2]}
+
+
+def test_the_index_follows_the_shards_through_the_renumber(tmp_path):
+    """The renumber closes the gap the deletion left, and the index has to move with it."""
+    d = str(tmp_path)
+    names = _write_shards(d, [
+        [KEY_MAP[TEXT[0]]],
+        _vision(2),
+        [KEY_MAP[TEXT[1]], KEY_MAP[TEXT[2]]],
+    ])
+    # A pre-drop index, exactly as Step 6 or the copied original would have left it.
+    with open(os.path.join(d, "model.safetensors.index.json"), "w") as f:
+        json.dump({"metadata" : {}, "weight_map" : {
+            **{KEY_MAP[TEXT[0]] : names[0]},
+            **{k : names[1] for k in _vision(2)},
+            **{KEY_MAP[TEXT[1]] : names[2], KEY_MAP[TEXT[2]] : names[2]},
+        }}, f)
+
+    kept = _rewrite_shards_text_only(d, names, KEY_MAP)
+    final = renumber_safetensor_files(kept, d)
+    _write_text_only_index(d, final)
+
+    assert final == ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"]
+    on_disk = sorted(f for f in os.listdir(d) if f.endswith(".safetensors"))
+    assert on_disk == final, f"directory holds {on_disk}, index was written for {final}"
+
+    with open(os.path.join(d, "model.safetensors.index.json")) as f:
+        weight_map = json.load(f)["weight_map"]
+    assert set(weight_map) == set(TEXT), f"index lists {sorted(weight_map)}"
+    for key, filename in weight_map.items():
+        assert key in _keys_in(os.path.join(d, filename)), f"{key} is not in {filename}"
+
+
+def test_a_single_surviving_shard_loses_the_index_entirely(tmp_path):
+    """One file needs no index, and a leftover one would name shards that no longer exist."""
+    d = str(tmp_path)
+    names = _write_shards(d, [_vision(2), [KEY_MAP[k] for k in TEXT]])
+    index_path = os.path.join(d, "model.safetensors.index.json")
+    with open(index_path, "w") as f:
+        json.dump({"metadata" : {}, "weight_map" : {k : names[0] for k in _vision(2)}}, f)
+
+    final = renumber_safetensor_files(_rewrite_shards_text_only(d, names, KEY_MAP), d)
+    _write_text_only_index(d, final)
+
+    assert final == ["model.safetensors"], f"final list is {final}"
+    assert sorted(f for f in os.listdir(d) if f.endswith(".safetensors")) == ["model.safetensors"]
+    assert not os.path.exists(index_path), "a one-shard checkpoint kept its index"
+    assert _keys_in(os.path.join(d, "model.safetensors")) == set(TEXT)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2954,7 +2954,6 @@ def _carry_over_vocab_size(base_config, trained_config):
 pass
 
 
-
 class TextOnlyRemapError(RuntimeError):
     """The text-only key remap could not be derived, so the merge keeps the VLM tensors."""
 pass
@@ -3160,6 +3159,7 @@ def _export_text_only_config(save_directory, config, architecture):
     _remove_quantization_config(config_path = Path(save_directory) / "config.json")
     _remove_transformers_version(config_path = Path(save_directory) / "config.json")
 pass
+
 
 @torch.inference_mode
 def merge_and_overwrite_lora(
@@ -3885,11 +3885,11 @@ def merge_and_overwrite_lora(
             )
         else:
             _text_only_key_plan = None
+            _text_only_before = _shard_keys_on_disk(save_directory, final_safetensors_list)
             try:
                 _text_only_keys, _text_only_architecture = _text_only_expected_keys(config)
                 _text_only_key_plan = _text_only_key_map(
-                    _text_only_keys,
-                    _shard_keys_on_disk(save_directory, final_safetensors_list),
+                    _text_only_keys, _text_only_before,
                     tie_word_embeddings = _merge_tie_word_embeddings,
                 )
             except Exception as text_only_error:
@@ -3902,7 +3902,6 @@ def merge_and_overwrite_lora(
                 )
             pass
             if _text_only_key_plan is not None:
-                _before = len(_shard_keys_on_disk(save_directory, final_safetensors_list))
                 _kept_files = _rewrite_shards_text_only(
                     save_directory, final_safetensors_list, _text_only_key_plan,
                 )
@@ -3923,7 +3922,8 @@ def merge_and_overwrite_lora(
                 # Step 7 uploads by name, and the names just changed.
                 safetensors_list = final_safetensors_list
                 print(
-                    f"Unsloth: text_only export dropped {_before - len(_written)} vision/audio "
+                    f"Unsloth: text_only export dropped "
+                    f"{len(_text_only_before) - len(_written)} vision/audio "
                     f"tensor(s) and kept {len(_written)} as {_text_only_architecture}."
                 )
                 if push_to_hub: upload_items("config.json")

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3047,6 +3047,103 @@ def _text_only_key_map(text_keys, base_keys, tie_word_embeddings = False):
     return key_map
 pass
 
+
+def _text_only_expected_keys(config):
+    """The keys a reload of the exported text config will look for.
+
+    Built from `config` rather than from the model in memory because `config` is what gets
+    written, so this is the reload contract itself: whatever `AutoModelForCausalLM` builds
+    from the saved config is exactly the set of tensors that must be on disk. Meta device,
+    so no weights are allocated.
+    """
+    from transformers import AutoModelForCausalLM
+    with torch.device("meta"):
+        text_model = AutoModelForCausalLM.from_config(config)
+    return set(text_model.state_dict().keys()), text_model.__class__.__name__
+pass
+
+
+def _shard_keys_on_disk(save_directory, filenames):
+    keys = set()
+    for filename in filenames:
+        file_path = os.path.join(save_directory, filename)
+        if not os.path.exists(file_path): continue
+        with safe_open(file_path, framework = "pt", device = "cpu") as f:
+            keys.update(f.keys())
+    return keys
+pass
+
+
+def _rewrite_shards_text_only(save_directory, filenames, key_map):
+    """Rewrite each shard to hold only the text tensors, under their text-only names.
+
+    One shard is read at a time, which is the same working set as `split_safetensors_to_shards`
+    already uses on this path. A shard that was pure vision or pure audio keeps nothing and is
+    deleted outright, which is where most of the size saving comes from.
+    """
+    to_text_key = {base_key : text_key for text_key, base_key in key_map.items()}
+    kept_files = []
+    for filename in filenames:
+        file_path = os.path.join(save_directory, filename)
+        if not os.path.exists(file_path): continue
+        tensors = OrderedDict()
+        with safe_open(file_path, framework = "pt", device = "cpu") as f:
+            for key in f.keys():
+                text_key = to_text_key.get(key)
+                if text_key is not None: tensors[text_key] = f.get_tensor(key)
+        pass
+        if not tensors:
+            os.remove(file_path)
+            continue
+        temp_path = file_path + ".text_only"
+        save_file(tensors, temp_path, metadata = {"format" : "pt"})
+        del tensors
+        os.replace(temp_path, file_path)
+        kept_files.append(filename)
+    pass
+    return kept_files
+pass
+
+
+def _write_text_only_index(save_directory, filenames):
+    """Point the index at the surviving shards, or remove it when a single file is left.
+
+    A stale index is not a cosmetic problem: it still lists the vision keys and the shard
+    names from before the drop, so the reload it drives fails on files that no longer exist.
+    """
+    index_path = os.path.join(save_directory, "model.safetensors.index.json")
+    if len(filenames) <= 1:
+        if os.path.exists(index_path): os.remove(index_path)
+        return None
+    weight_map = {}
+    for filename in filenames:
+        file_path = os.path.join(save_directory, filename)
+        with safe_open(file_path, framework = "pt", device = "cpu") as f:
+            for key in f.keys(): weight_map[key] = filename
+    pass
+    # Same shape the dequant/split path writes at Step 6, empty metadata included.
+    with open(index_path, "w", encoding = "utf-8") as f:
+        json.dump({"metadata" : {}, "weight_map" : weight_map}, f, indent = 4)
+    return index_path
+pass
+
+
+def _export_text_only_config(save_directory, config, architecture):
+    """Write the text config the dropped weights now match, naming its architecture.
+
+    #969 saw `architectures: null` beside the text config, so an `AutoModel` load had only
+    `model_type` to go on. The class is known here because the expected key set was built
+    from it, so say so. The config is copied first: this is a save path and must not leave
+    the caller's live model carrying an architecture it did not have.
+    """
+    import copy
+    text_config = copy.deepcopy(config)
+    text_config.architectures = [architecture]
+    text_config.save_pretrained(save_directory)
+    _remove_quantization_config(config_path = Path(save_directory) / "config.json")
+    _remove_transformers_version(config_path = Path(save_directory) / "config.json")
+pass
+
 @torch.inference_mode
 def merge_and_overwrite_lora(
     get_model_name,
@@ -3383,6 +3480,7 @@ def merge_and_overwrite_lora(
 
     # Default handle 16 bit merge and save/push
     # Step 1: Save base model config/architecture (no weights needed here)
+    _text_only_base_config = None
     if save_method == "merged_16bit":
         # `config` is `model.config`, already the nested text config under `text_only = True`,
         # while the weights come from `model_name` and keep their VLM prefixes. Saving it wrote
@@ -3404,6 +3502,10 @@ def merge_and_overwrite_lora(
             base_config = config
         else:
             _carry_over_vocab_size(base_config, config)
+        # Kept for the text-only drop after the merge, which needs to know the weights came
+        # from a composite checkpoint. The `except` above sets this to `config` itself, and
+        # `_is_text_only_export` reads that as "not composite", which is right.
+        _text_only_base_config = base_config
         base_config.save_pretrained(save_directory)
         _remove_quantization_config(config_path = Path(save_directory) / "config.json")
         _remove_transformers_version(config_path = Path(save_directory) / "config.json")
@@ -3749,6 +3851,68 @@ def merge_and_overwrite_lora(
 
         if push_to_hub:
             upload_items("model.safetensors.index.json")
+
+    # `text_only = True` asked for a text model. #1073 made the export loadable by declaring
+    # the VLM architecture the weights actually carry; this brings the weights to the request
+    # instead, dropping the vision and audio tensors and renaming what is left into the
+    # text-only namespace, so the checkpoint is the model that was asked for at roughly half
+    # the size (#969, second direction). Anything that cannot be mapped leaves the export
+    # exactly as #1073 writes it.
+    if save_method == "merged_16bit" and _is_text_only_export(config, _text_only_base_config):
+        if low_disk_space_usage and push_to_hub:
+            warnings.warn(
+                "Unsloth: keeping the vision/audio tensors in this `text_only` export, "
+                "because `low_disk_space_usage` uploads and removes each shard inside the "
+                "merge loop and the shards cannot be renumbered once the drop changes how "
+                "many there are. The checkpoint is correct, just larger than asked for (#969)."
+            )
+        else:
+            _text_only_key_plan = None
+            try:
+                _text_only_keys, _text_only_architecture = _text_only_expected_keys(config)
+                _text_only_key_plan = _text_only_key_map(
+                    _text_only_keys,
+                    _shard_keys_on_disk(save_directory, final_safetensors_list),
+                    tie_word_embeddings = _merge_tie_word_embeddings,
+                )
+            except Exception as text_only_error:
+                # Degrade to the #1073 export rather than write weights we could not place.
+                warnings.warn(
+                    f"Unsloth: could not separate the text weights of `{model_name}` "
+                    f"({text_only_error}). Keeping the full checkpoint and its own config, "
+                    f"which reloads correctly but carries the vision/audio tensors that "
+                    f"`text_only = True` asked to skip (#969)."
+                )
+            pass
+            if _text_only_key_plan is not None:
+                _before = len(_shard_keys_on_disk(save_directory, final_safetensors_list))
+                _kept_files = _rewrite_shards_text_only(
+                    save_directory, final_safetensors_list, _text_only_key_plan,
+                )
+                final_safetensors_list = renumber_safetensor_files(_kept_files, save_directory)
+                # The bug this follows from was silent, so prove the drop landed instead of
+                # trusting it: what is on disk now must be the mapped set exactly.
+                _written = _shard_keys_on_disk(save_directory, final_safetensors_list)
+                _expected = set(_text_only_key_plan)
+                if _written != _expected:
+                    raise RuntimeError(
+                        f"Unsloth: the text_only export wrote {len(_written)} tensor(s) but "
+                        f"its config describes {len(_expected)}. Missing: "
+                        f"{sorted(_expected - _written)[:4]}. Unexpected: "
+                        f"{sorted(_written - _expected)[:4]}. Please file a bug report!"
+                    )
+                _write_text_only_index(save_directory, final_safetensors_list)
+                _export_text_only_config(save_directory, config, _text_only_architecture)
+                # Step 7 uploads by name, and the names just changed.
+                safetensors_list = final_safetensors_list
+                print(
+                    f"Unsloth: text_only export dropped {_before - len(_written)} vision/audio "
+                    f"tensor(s) and kept {len(_written)} as {_text_only_architecture}."
+                )
+                if push_to_hub: upload_items("config.json")
+            pass
+        pass
+    pass
 
     # Step 7: Final upload of all shards if not using low disk space mode and pushing
     if not low_disk_space_usage and push_to_hub:

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2984,67 +2984,84 @@ pass
 def _text_only_key_map(text_keys, base_keys, tie_word_embeddings = False):
     """Map every expected text-only key onto its key in the composite base checkpoint.
 
-    Published VLM checkpoints put the text weights in at least four different places, and
-    the arrangement is fixed when the checkpoint is written rather than by the installed
-    transformers, so nothing here may be hardcoded:
+    Where a VLM keeps its text weights is decided when the checkpoint is written, not by the
+    installed transformers, and the arrangements genuinely differ. Observed on real files:
 
-        language_model.model.*                     gemma3 (no lm_head at all, tied)
-        model.text_model.*      + lm_head.weight   idefics3
-        thinker.model.*         + thinker.lm_head  qwen2_5_omni
-        model.language_model.*  + lm_head.weight   gemma3 built in-memory today
+        language_model.model.*                     gemma3 on the Hub (tied, so no lm_head)
+        model.text_model.*      + lm_head.weight   idefics3 on the Hub
+        thinker.model.*         + thinker.lm_head  qwen2_5_omni on the Hub
+        model.language_model.*  + lm_head.weight   gemma3 in memory
+        model.language_model.model.*               gemma3 written by save_pretrained on 4.57/5.5
 
-    Every one of them is the text key with a SINGLE path component inserted at a fixed
-    index, and `lm_head` either takes the same insertion or is already top level. So derive
-    that one (component, index) from the two key sets instead of guessing it: collect the
-    candidate insertions each unmatched text key admits, intersect, and require the result
-    to name exactly one. Anything else raises, which is the caller's signal to leave the
-    export alone rather than write a checkpoint whose weights it could not place.
+    All five are the text key with one prefix swapped for another, so derive that pair from
+    the two key sets rather than hardcoding any of them: for each text key the base does not
+    already hold, offer every (text prefix, base prefix) that lands it on a real tensor, keep
+    only the pairs every such key agrees on, and require the survivors to describe the same
+    mapping. Anything else raises, which tells the caller to leave the export alone instead of
+    writing a checkpoint whose weights it could not place.
     """
     base_keys = set(base_keys)
-    # Every way of deleting one component from a base key, so a text key can be looked up
-    # directly instead of scanned for.
-    without_one = {}
+    text_keys = set(text_keys)
+    # A tied head owns no tensor anywhere: gemma3 ships 883 keys and not one is an lm_head,
+    # because the reload reties it from the embeddings. Its absence is the checkpoint being
+    # right, not a key this failed to place.
+    tied = {
+        key for key in text_keys
+        if tie_word_embeddings and key.rpartition(".")[0].rpartition(".")[2] == "lm_head"
+    }
+
+    # Component suffix -> the prefixes it appears under, so a text key can be looked up.
+    by_suffix = {}
     for key in base_keys:
         parts = key.split(".")
-        if len(parts) < 2: continue
         for i in range(len(parts)):
-            without_one.setdefault(tuple(parts[:i] + parts[i+1:]), []).append((key, parts[i], i))
+            by_suffix.setdefault(".".join(parts[i:]), set()).add(".".join(parts[:i] + [""]) if i else "")
     pass
 
-    verbatim = {k for k in text_keys if k in base_keys}
-    # A tied head has no tensor of its own anywhere: gemma3 ships 883 keys and not one of
-    # them is an lm_head. Reloading reties it from the embeddings, so its absence is the
-    # checkpoint being correct rather than a key this map failed to place.
-    tied = {k for k in text_keys if tie_word_embeddings and k.rpartition(".")[0].rpartition(".")[2] == "lm_head"}
     candidates = None
-    for key in text_keys:
-        if key in verbatim or key in tied: continue
-        options = {(name, i) for _, name, i in without_one.get(tuple(key.split(".")), ())}
+    for key in text_keys - base_keys - tied:
+        parts = key.split(".")
+        options = set()
+        for i in range(len(parts)):
+            text_prefix = ".".join(parts[:i] + [""]) if i else ""
+            for base_prefix in by_suffix.get(".".join(parts[i:]), ()):
+                if base_prefix != text_prefix: options.add((text_prefix, base_prefix))
+        pass
         if not options:
             raise TextOnlyRemapError(f"no tensor in the base checkpoint corresponds to `{key}`")
         candidates = options if candidates is None else (candidates & options)
         if not candidates:
-            raise TextOnlyRemapError("the text weights are not under one common prefix in the base checkpoint")
+            raise TextOnlyRemapError(
+                "the text weights are not under one common prefix in the base checkpoint"
+            )
     pass
     if candidates is None:
-        # Every text key already matches verbatim, so there is no composite prefix to strip
-        # and dropping by this map would be a no-op the caller should not run.
+        # Nothing to strip, so dropping by this map would be a no-op the caller must not run.
         raise TextOnlyRemapError("the base checkpoint is already text-only")
-    if len(candidates) != 1:
-        raise TextOnlyRemapError(f"the text prefix is ambiguous between {sorted(candidates)}")
-    name, index = next(iter(candidates))
 
-    key_map = {}
-    for key in text_keys:
-        if key in verbatim: key_map[key] = key; continue
-        parts = key.split(".")
-        candidate = ".".join(parts[:index] + [name] + parts[index:])
-        if candidate not in base_keys:
-            if key in tied: continue
-            raise TextOnlyRemapError(f"no tensor in the base checkpoint corresponds to `{key}`")
-        key_map[key] = candidate
+    def _build(text_prefix, base_prefix):
+        key_map = {}
+        for key in text_keys:
+            if text_prefix and not key.startswith(text_prefix): candidate = key
+            else: candidate = base_prefix + key[len(text_prefix):]
+            if candidate in base_keys: key_map[key] = candidate
+            elif key not in tied: return None
+        return key_map
     pass
-    return key_map
+
+    # Several prefix pairs can describe the same rewrite (a longer text prefix against a
+    # correspondingly longer base one). That is harmless while they agree; disagreeing means
+    # the checkpoint admits two readings and guessing between them is how #969 happened.
+    resolved = []
+    for text_prefix, base_prefix in sorted(candidates):
+        key_map = _build(text_prefix, base_prefix)
+        if key_map is not None and key_map not in resolved: resolved.append(key_map)
+    pass
+    if not resolved:
+        raise TextOnlyRemapError("no prefix places every text tensor in the base checkpoint")
+    if len(resolved) != 1:
+        raise TextOnlyRemapError("the base checkpoint admits more than one text-weight prefix")
+    return resolved[0]
 pass
 
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2954,6 +2954,99 @@ def _carry_over_vocab_size(base_config, trained_config):
 pass
 
 
+
+class TextOnlyRemapError(RuntimeError):
+    """The text-only key remap could not be derived, so the merge keeps the VLM tensors."""
+pass
+
+
+def _is_text_only_export(config, base_config):
+    """True when the in-memory config is the text section of a composite base config.
+
+    That is the `text_only = True` signature seen from inside the merge: the weights come
+    from a composite checkpoint while `model.config` has already been replaced by its
+    nested text config. A normal VLM save has `config is` the composite one, so this is
+    False and nothing below runs.
+    """
+    if config is None or base_config is None or config is base_config: return False
+    base_text = None
+    for holder in _text_configs(base_config):
+        if holder is not base_config: base_text = holder; break
+    if base_text is None: return False
+    base_type = getattr(base_config, "model_type", None)
+    text_type = getattr(base_text, "model_type", None)
+    this_type = getattr(config, "model_type", None)
+    if this_type is None or text_type is None or base_type is None: return False
+    return this_type == text_type and this_type != base_type
+pass
+
+
+def _text_only_key_map(text_keys, base_keys, tie_word_embeddings = False):
+    """Map every expected text-only key onto its key in the composite base checkpoint.
+
+    Published VLM checkpoints put the text weights in at least four different places, and
+    the arrangement is fixed when the checkpoint is written rather than by the installed
+    transformers, so nothing here may be hardcoded:
+
+        language_model.model.*                     gemma3 (no lm_head at all, tied)
+        model.text_model.*      + lm_head.weight   idefics3
+        thinker.model.*         + thinker.lm_head  qwen2_5_omni
+        model.language_model.*  + lm_head.weight   gemma3 built in-memory today
+
+    Every one of them is the text key with a SINGLE path component inserted at a fixed
+    index, and `lm_head` either takes the same insertion or is already top level. So derive
+    that one (component, index) from the two key sets instead of guessing it: collect the
+    candidate insertions each unmatched text key admits, intersect, and require the result
+    to name exactly one. Anything else raises, which is the caller's signal to leave the
+    export alone rather than write a checkpoint whose weights it could not place.
+    """
+    base_keys = set(base_keys)
+    # Every way of deleting one component from a base key, so a text key can be looked up
+    # directly instead of scanned for.
+    without_one = {}
+    for key in base_keys:
+        parts = key.split(".")
+        if len(parts) < 2: continue
+        for i in range(len(parts)):
+            without_one.setdefault(tuple(parts[:i] + parts[i+1:]), []).append((key, parts[i], i))
+    pass
+
+    verbatim = {k for k in text_keys if k in base_keys}
+    # A tied head has no tensor of its own anywhere: gemma3 ships 883 keys and not one of
+    # them is an lm_head. Reloading reties it from the embeddings, so its absence is the
+    # checkpoint being correct rather than a key this map failed to place.
+    tied = {k for k in text_keys if tie_word_embeddings and k.rpartition(".")[0].rpartition(".")[2] == "lm_head"}
+    candidates = None
+    for key in text_keys:
+        if key in verbatim or key in tied: continue
+        options = {(name, i) for _, name, i in without_one.get(tuple(key.split(".")), ())}
+        if not options:
+            raise TextOnlyRemapError(f"no tensor in the base checkpoint corresponds to `{key}`")
+        candidates = options if candidates is None else (candidates & options)
+        if not candidates:
+            raise TextOnlyRemapError("the text weights are not under one common prefix in the base checkpoint")
+    pass
+    if candidates is None:
+        # Every text key already matches verbatim, so there is no composite prefix to strip
+        # and dropping by this map would be a no-op the caller should not run.
+        raise TextOnlyRemapError("the base checkpoint is already text-only")
+    if len(candidates) != 1:
+        raise TextOnlyRemapError(f"the text prefix is ambiguous between {sorted(candidates)}")
+    name, index = next(iter(candidates))
+
+    key_map = {}
+    for key in text_keys:
+        if key in verbatim: key_map[key] = key; continue
+        parts = key.split(".")
+        candidate = ".".join(parts[:index] + [name] + parts[index:])
+        if candidate not in base_keys:
+            if key in tied: continue
+            raise TextOnlyRemapError(f"no tensor in the base checkpoint corresponds to `{key}`")
+        key_map[key] = candidate
+    pass
+    return key_map
+pass
+
 @torch.inference_mode
 def merge_and_overwrite_lora(
     get_model_name,

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3872,9 +3872,11 @@ def merge_and_overwrite_lora(
     # `text_only = True` asked for a text model. #1073 made the export loadable by declaring
     # the VLM architecture the weights actually carry; this brings the weights to the request
     # instead, dropping the vision and audio tensors and renaming what is left into the
-    # text-only namespace, so the checkpoint is the model that was asked for at roughly half
-    # the size (#969, second direction). Anything that cannot be mapped leaves the export
-    # exactly as #1073 writes it.
+    # text-only namespace, so the checkpoint is the model that was asked for (#969, second
+    # direction). How much smaller that makes it is entirely the model's business: it is 10%
+    # off gemma-3-4b-it, whose SigLIP tower is small next to the decoder, and far more off an
+    # omni model carrying audio and speech stacks. Anything that cannot be mapped leaves the
+    # export exactly as #1073 writes it.
     if save_method == "merged_16bit" and _is_text_only_export(config, _text_only_base_config):
         if low_disk_space_usage and push_to_hub:
             warnings.warn(

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3881,9 +3881,9 @@ def merge_and_overwrite_lora(
         if low_disk_space_usage and push_to_hub:
             warnings.warn(
                 "Unsloth: keeping the vision/audio tensors in this `text_only` export, "
-                "because `low_disk_space_usage` uploads and removes each shard inside the "
-                "merge loop and the shards cannot be renumbered once the drop changes how "
-                "many there are. The checkpoint is correct, just larger than asked for (#969)."
+                "because `low_disk_space_usage` uploads and deletes each shard inside the "
+                "merge loop, so there is nothing left on disk here to read the text weights "
+                "out of. The checkpoint is correct, just larger than asked for (#969)."
             )
         else:
             _text_only_key_plan = None
@@ -3917,7 +3917,9 @@ def merge_and_overwrite_lora(
                         f"Unsloth: the text_only export wrote {len(_written)} tensor(s) but "
                         f"its config describes {len(_expected)}. Missing: "
                         f"{sorted(_expected - _written)[:4]}. Unexpected: "
-                        f"{sorted(_written - _expected)[:4]}. Please file a bug report!"
+                        f"{sorted(_written - _expected)[:4]}. The shards in "
+                        f"`{save_directory}` have already been rewritten, so delete it and "
+                        f"merge again rather than loading it. Please file a bug report!"
                     )
                 _write_text_only_index(save_directory, final_safetensors_list)
                 _export_text_only_config(save_directory, config, _text_only_architecture)


### PR DESCRIPTION
Follows #1073, which fixed the first half of #969. Please read the second paragraph before the rest: this changes what a `text_only = True` merge writes, on a path Studio is on.

#969 had two directions. #1073 took the first one: the merge writes VLM weights, so save a config that describes them. That made the export loadable. This takes the second one, for the `text_only = True` case only: bring the weights to the request instead. The vision and audio tensors go, the text tensors are renamed into the text-only namespace, and the export becomes the causal LM that `text_only = True` asked for.

So for a `text_only` merge the config that lands is the text config again, not the composite one #1073 saves. That is a deliberate reversal of #1073 on this one path. #1073 stays load-bearing: whenever the text weights cannot be located in the base checkpoint, this stands down with a warning and the export is exactly what #1073 writes today. Since Studio passes `text_only = True` for any non-image dataset, that fallback is the part I would most like reviewed.

One correction to my own framing on the #1073 thread, where I said this halves the export. It does not, or not reliably: dropping 439 of `unsloth/gemma-3-4b-it`'s 883 tensors takes it from 8.60 GB to 7.76 GB, because SigLIP is small next to a 3.9B decoder. Tensor count is not bytes. The saving scales with how much of the checkpoint is not the text model, so an omni checkpoint carrying audio, speech and talker stacks gives back far more. The reason to do this is that the export is the model that was asked for. What it costs on disk is a side effect, and how big a one depends on the checkpoint.

## Finding the text weights

The hard part is that there is no one place a VLM keeps them. The layout is decided when the checkpoint is written, not by the transformers doing the reading, so two checkpoints from the same family disagree. Five arrangements turned up in real files:

| where the text weights live | head | seen on |
|---|---|---|
| `language_model.model.*` | tied, no tensor | `unsloth/gemma-3-4b-it` as published |
| `model.text_model.*` | `lm_head.weight` | `HuggingFaceM4/Idefics3-8B-Llama3` |
| `thinker.model.*` | `thinker.lm_head.weight` | `Qwen/Qwen2.5-Omni-3B` |
| `model.language_model.*` | `lm_head.weight` | `Gemma3ForConditionalGeneration` in memory |
| `model.language_model.model.*` | tied, no tensor | gemma3 written by `save_pretrained` |

`_checkpoint_conversion_mapping` is `None` on both Gemma3 classes, so there is nothing upstream to borrow. Hardcoding any one of these silently mismaps the others, which is the same class of bug #969 reported.

All five are the text key with one prefix swapped for another, so `_text_only_key_map` derives that pair from the two key sets rather than assuming it. The expected text keys come from meta-instantiating `AutoModelForCausalLM.from_config(config)`, which is the reload contract itself: `config` is what gets written, so whatever a reloader builds from it is exactly the set of tensors that must be on disk. For each text key the base does not already hold, it offers every (text prefix, base prefix) pair that lands it on a real tensor, keeps only the pairs every such key agrees on, and requires the survivors to describe one mapping. Anything else raises, and the caller falls back.

A tied head is handled explicitly rather than by accident: `unsloth/gemma-3-4b-it` ships 883 tensors and not one is an `lm_head`, because the reload reties it from the embeddings.

## After the map

Post-pass after the Step 5 merge loop rather than inside `_merge_and_overwrite_lora`, which is shared with the mxfp4 and fp8 paths. One shard is read at a time, so the working set is what `split_safetensors_to_shards` already uses on this path. Shards that were pure vision keep nothing and are deleted, `renumber_safetensor_files` closes the gaps, and the index is rewritten to the surviving shards or removed when one file is left. A stale index is not cosmetic here: it still names shards that no longer exist.

The config is flipped to the text config only after the drop succeeds, so a failed remap leaves nothing half-written. `architectures` is set from the class the expected key set was built from, since #969 saw `architectures: null` beside the text config.

One combination stands down and warns: `low_disk_space_usage` together with `push_to_hub` uploads and deletes each shard inside the merge loop, so by the time this post-pass runs there is nothing left on disk to read the text weights out of. The warning says that, and the export is the correct #1073 one, just larger than asked for. `low_disk_space_usage` on its own still drops, and there is a test pinning that, because an over-broad guard here would quietly cost everyone saving locally.

One family maps successfully and still deserves a flag. `MllamaForCausalLM` built from an `MllamaTextConfig` carries `model.layers.N.cross_attn.*`, because on mllama the cross-attention into the vision tower lives in the text stack. So a `text_only` mllama export keeps those weights: the checkpoint is self-consistent and reloads, and mllama skips cross-attention when there are no vision states, but the tensors are along for the ride. I have not run this on real mllama weights, only confirmed the shape of the expected key set. If you would rather that family stand down too, it is a `model_type` check in `_is_text_only_export`.

## Files changed

- `unsloth_zoo/saving_utils.py`: `TextOnlyRemapError`, `_is_text_only_export`, `_text_only_key_map`, `_text_only_expected_keys`, `_shard_keys_on_disk`, `_rewrite_shards_text_only`, `_write_text_only_index`, `_export_text_only_config`, and the post-pass wired in before Step 7.
- `tests/test_text_only_key_map.py`: new. The five layouts above plus five negatives, each one a case where the mapping is not uniquely determined and the code has to raise instead of picking. Key sets only, no weights, no network.
- `tests/test_text_only_shard_rewrite.py`: new. `unsloth/gemma-3-4b-it` keeps text weights in both its shards, so an end-to-end run never deletes a shard, never renumbers, and never has to decide whether the index should still exist. These drive those three branches directly on tiny real safetensors, because a checkpoint whose index names a file that is not there fails at load with nothing useful to say.
- `tests/test_merge_e2e_text_only_config.py`: extended to the new contract. `_reload_info` now resolves the class from the saved `architectures` instead of assuming the VLM, so it reads whichever checkpoint is in front of it.

## Test results

Full suite on Linux, Python 3.12.3, torch 2.11.0+cu130, transformers 5.5.0, peft 0.20.0, run twice in two separate clones so neither run could touch the other's tree:

| | passed | failed | skipped | time |
|---|---|---|---|---|
| `c1dca718`, the base this branches from | 5175 | 12 | 193 | 12:43 |
| this branch | 5193 | 12 | 193 | 13:04 |

The two failure lists are the same twelve node IDs, `diff` clean: five in `test_allow_cpu_import_driverless`, four in `test_pretokenized_bypass_collator`, and one each in `test_fla_hopper_tile`, `test_temporary_patches_imports`, `test_zoo_source_upstream_refs`. None of them import `saving_utils`, and they fail the same way on the base commit, so this change neither causes nor fixes them. I am listing them rather than describing the suite as green.

The 18 extra passes are 19 tests added and one removed, which is the next section.

Key sets can agree with each other and still be wrong about a real file, so there is also a run on real weights: `unsloth/gemma-3-4b-it` merged with `text_only = True` drops 439 tensors and keeps 444 as `Gemma3ForCausalLM`, config `gemma3_text`, two shards, every `weight_map` entry naming a file that exists and holding the key it claims, and the reload reports 0 missing, 0 unexpected, 0 mismatched.

## One test from #1073 is deleted

`test_text_only_export_config_matches_written_weights` asserts `model_type != "gemma3_text"` for a `text_only` export. That is precisely the contract this PR inverts, so it cannot survive as written, and I would rather delete it in the open than weaken it until it passes. `test_text_only_export_drops_the_vision_tower` replaces it: same fixture, same shape, the opposite config assertion, and the reload check carried over unchanged. If you would rather keep the #1073 behavior reachable than replace it, that is a reasonable call and I will rework this behind a flag.

## Credit

#969's second direction and its framing are kgt392's, from the #1073 thread. The `get_text_config` catch and the wider family sweep are danielhanchen's.
