### PR TITLE
MLX: int8 W8A8 prefill for quantized models on Apple M5

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -464,6 +464,39 @@ jobs:
             echo "real mlx is installed but the numeric tests skipped"; exit 1
           fi
 
+      - name: int8 prefill suites (HARD GATE)
+        # The Apple Silicon lane is opt-in behind an `mlx` label, so on a normal pull
+        # request this is the only place the int8 prefill code is exercised at all.
+        # Everything here is backend-independent: dispatch, eligibility, the W8A8
+        # arithmetic via the portable backend, mx.compile safety and the LoRA vjp. The
+        # Metal kernels and the M5 capability probe are not reachable from Linux and are
+        # not claimed to be.
+        env:
+          PYTHONPATH: ${{ github.workspace }}/tests
+        run: |
+          .lanes/venv-numerics/bin/python -m pytest -v -rs \
+            tests/test_mlx_int8_prefill_dispatch.py \
+            tests/test_mlx_int8_prefill_numerics.py \
+            tests/test_mlx_int8_prefill_safety.py
+
+      - name: Fail if the int8 prefill suites collapsed to skips
+        # One skip is expected and understood: mx.quantized_matmul at group_size 128
+        # cannot be evaluated on some backends, so the comparison against it is skipped
+        # on the reference rather than on a backend guess. Anything beyond that means
+        # the suites stopped testing and quietly passed.
+        env:
+          PYTHONPATH: ${{ github.workspace }}/tests
+        run: |
+          .lanes/venv-numerics/bin/python -m pytest -q -rs \
+            tests/test_mlx_int8_prefill_dispatch.py \
+            tests/test_mlx_int8_prefill_numerics.py \
+            tests/test_mlx_int8_prefill_safety.py | tee int8.txt
+          SKIPPED=$(grep -oE '[0-9]+ skipped' int8.txt | grep -oE '[0-9]+' || echo 0)
+          if [ "${SKIPPED:-0}" -gt 1 ]; then
+            echo "int8 prefill suites skipped ${SKIPPED} tests, expected at most 1"
+            exit 1
+          fi
+
       - name: tests/test_mlx_rng_rewind.py (HARD GATE)
         # PRNG capture/rewind across the compile fallbacks. Needs mlx core, not
         # Metal, so it gates here; the Apple Silicon lane is opt-in and usually

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -199,3 +199,82 @@ jobs:
         run: |
           python -m pytest tests/test_mlx_batching_and_decay.py -v -rs \
             --deselect tests/test_mlx_batching_and_decay.py::test_compiler_review_guards_are_present
+
+      # int8 W8A8 prefill. Added to this job rather than to a new workflow: macOS
+      # concurrency is capped at 5 jobs account-wide, and this runner already has the
+      # MLX stack provisioned, so a second workflow would spend a slot to reinstall
+      # what is already here.
+      #
+      # What this leg can and cannot show. The int8 path needs the M5 neural
+      # accelerators, and no GitHub runner tier offers one, so nothing here measures
+      # performance. What it does establish, and the Linux leg cannot:
+      #
+      #   1. The capability probe declines on a real Metal device that lacks M5 int8
+      #      tensor ops, and enabling the module then changes a model forward not at
+      #      all. That is the configuration every current Mac user is in, so it is the
+      #      assertion that matters most.
+      #   2. The activation-quant and weight-requant Metal kernels compile and run for
+      #      real. They deliberately carry no MetalPerformancePrimitives include, so
+      #      they execute here even though the GEMM cannot, and their packed-nibble and
+      #      word-boundary arithmetic is the likeliest source of a silent wrong-answer
+      #      bug. Linux cannot check it at all.
+      #
+      # Measured on macos-15/26: mpp::tensor_ops::matmul2d with int8 operands does not
+      # load on M1 ("[metal::Device] Unable to load kernel") while a trivial Metal
+      # kernel JITs fine on the same runner, so the GEMM stays M5-only by nature rather
+      # than by choice.
+      - name: tests/test_mlx_int8_prefill_dispatch.py
+        env:
+          PYTHONPATH: ${{ github.workspace }}/tests
+        run: python -m pytest tests/test_mlx_int8_prefill_dispatch.py -v -rs
+
+      - name: tests/test_mlx_int8_prefill_numerics.py
+        env:
+          PYTHONPATH: ${{ github.workspace }}/tests
+        run: python -m pytest tests/test_mlx_int8_prefill_numerics.py -v -rs
+
+      - name: tests/test_mlx_int8_prefill_safety.py
+        env:
+          PYTHONPATH: ${{ github.workspace }}/tests
+        run: python -m pytest tests/test_mlx_int8_prefill_safety.py -v -rs
+
+      - name: int8 prefill Metal kernels vs reference
+        # The two MetalPerformancePrimitives-free kernels, checked against the plain-MLX
+        # implementations of the same arithmetic. A tolerance of one int8 LSB, because
+        # Metal's rint rounds halves to even while mx.round does not, so ties can differ
+        # by one and nothing else may.
+        run: |
+          python -c "
+          import mlx.core as mx, mlx.nn as nn
+          from unsloth_zoo.mlx.int8_prefill import scales
+          from unsloth_zoo.mlx.int8_prefill.backends import metal_mpp, portable
+
+          failures = []
+          for bits, gs in [(4, 32), (4, 64), (4, 128)]:
+              ql = nn.QuantizedLinear.from_linear(
+                  nn.Linear(1024, 2048, bias = False), group_size = gs, bits = bits)
+              ws = scales.channel_scale_bound(ql['scales'], ql['biases'], bits)
+              mx.eval(ws)
+              got = metal_mpp.requantize_weight(
+                  ql['weight'], ql['scales'], ql['biases'], ws, bits, gs)
+              want = portable.requantize_weight(
+                  ql['weight'], ql['scales'], ql['biases'], ws, bits, gs)
+              mx.eval(got, want)
+              diff = int(mx.abs(got.astype(mx.int32) - want.astype(mx.int32)).max().item())
+              print(f'requant bits={bits} gs={gs}: max abs diff = {diff}')
+              if diff > 1:
+                  failures.append(f'requant bits={bits} gs={gs} diff={diff}')
+
+          x = mx.random.normal((640, 1024)).astype(mx.bfloat16)
+          gq, gsc = metal_mpp.quantize_rows(x)
+          wq, wsc = portable.quantize_rows(x)
+          mx.eval(gq, gsc, wq, wsc)
+          qdiff = int(mx.abs(gq.astype(mx.int32) - wq.astype(mx.int32)).max().item())
+          sdiff = float(mx.abs(gsc - wsc).max().item())
+          print(f'row quant: max abs q diff = {qdiff}, max abs scale diff = {sdiff:.3e}')
+          if qdiff > 1 or sdiff > 1e-6:
+              failures.append(f'row quant qdiff={qdiff} sdiff={sdiff}')
+
+          assert not failures, failures
+          print('OK: Metal quant and requant kernels match the reference')
+          "

--- a/tests/_mlx_int8_helpers.py
+++ b/tests/_mlx_int8_helpers.py
@@ -1,0 +1,62 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Shared helpers for the MLX int8 prefill tests.
+
+The tests run on any MLX backend, including a Linux CUDA build, because what they assert
+is either dispatch logic or algorithm arithmetic. The Metal kernels themselves are
+exercised by the macOS leg of mlx-ci.yml.
+"""
+
+import os
+
+# The Metal backend cannot run off Apple silicon; the portable backend implements the
+# identical arithmetic in plain MLX ops.
+os.environ.setdefault("UNSLOTH_MLX_INT8_BACKEND", "portable")
+
+
+def make_quantized_linear(in_dims = 1024, out_dims = 2048, bits = 4, group_size = 64, bias = False):
+    import mlx.nn as nn
+    linear = nn.Linear(in_dims, out_dims, bias = bias)
+    return nn.QuantizedLinear.from_linear(linear, group_size = group_size, bits = bits)
+
+
+def make_quantized_model(hidden = 1024, inter = 2048):
+    """Two eligible projections plus one too small to qualify."""
+    import mlx.nn as nn
+
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mlp_gate = nn.Linear(hidden, inter, bias = False)
+            self.mlp_down = nn.Linear(inter, hidden, bias = False)
+            self.tiny = nn.Linear(64, 128, bias = False)
+
+        def __call__(self, x):
+            return self.mlp_down(self.mlp_gate(x))
+
+    model = TinyModel()
+    nn.quantize(model, group_size = 64, bits = 4)
+    return model
+
+
+def reset_int8_state():
+    """Leave MLX unpatched and the allow-list empty."""
+    from unsloth_zoo.mlx import int8_prefill
+    from unsloth_zoo.mlx.int8_prefill import backends, capability
+
+    int8_prefill.disable()
+    capability.reset()
+    backends.reset()

--- a/tests/test_mlx_int8_prefill_dispatch.py
+++ b/tests/test_mlx_int8_prefill_dispatch.py
@@ -1,0 +1,219 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""What the patch intercepts, and -- more importantly -- what it must not.
+
+`mx.quantized_matmul` serves every quantized projection in MLX, including attention
+itself when the KV cache is quantized. Intercepting the wrong call would corrupt
+generation silently, so the negative cases here matter more than the positive ones.
+"""
+
+import pytest
+
+from _mlx_int8_helpers import (
+    make_quantized_linear,
+    make_quantized_model,
+    reset_int8_state,
+)
+
+
+@pytest.fixture(autouse = True)
+def clean_state():
+    reset_int8_state()
+    yield
+    reset_int8_state()
+
+
+@pytest.fixture
+def make_ql():
+    return make_quantized_linear
+
+
+@pytest.fixture
+def quantized_model():
+    return make_quantized_model()
+
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from unsloth_zoo.mlx import int8_prefill
+from unsloth_zoo.mlx.int8_prefill import patch, registry
+from unsloth_zoo.mlx.int8_prefill.eligibility import ROW_THRESHOLD
+
+K, N = 1024, 2048
+
+
+def _enable_with(ql, name="w"):
+    int8_prefill.enable(force=True)
+    ok, why = registry.register_module(ql, name)
+    assert ok, why
+    return ql["weight"], ql["scales"], ql["biases"], ql.group_size, ql.bits
+
+
+def _hits(monkeypatch):
+    seen = []
+    orig = patch._dispatch
+    monkeypatch.setattr(patch, "_dispatch", lambda x, e: seen.append(e.name) or orig(x, e))
+    return seen
+
+
+class TestArgumentBinding:
+    """Every calling convention in the wild must bind identically."""
+
+    @pytest.mark.parametrize("form", ["kwargs", "positional", "star_args", "mixed", "defaults"])
+    def test_intercepted(self, make_ql, monkeypatch, form):
+        ql = make_ql(K, N)
+        w, s, b, gs, bits = _enable_with(ql)
+        seen = _hits(monkeypatch)
+        x = mx.random.normal((ROW_THRESHOLD, K)).astype(mx.bfloat16)
+
+        calls = {
+            "kwargs": lambda: mx.quantized_matmul(
+                x, w, scales=s, biases=b, transpose=True, group_size=gs, bits=bits),
+            "positional": lambda: mx.quantized_matmul(x, w, s, b, True, gs, bits),
+            # The literal form at mlx-lm/mlx_lm/models/base.py:84.
+            "star_args": lambda: mx.quantized_matmul(
+                x, *(w, s, b), transpose=True, group_size=gs, bits=bits),
+            "mixed": lambda: mx.quantized_matmul(
+                x, w, s, biases=b, transpose=True, group_size=gs, bits=bits),
+            "defaults": lambda: mx.quantized_matmul(
+                x, w, scales=s, biases=b, group_size=gs, bits=bits),
+        }
+        out = calls[form]()
+        mx.eval(out)
+        assert seen == ["w"], f"{form} did not dispatch"
+
+
+class TestFallthrough:
+    """Bit-identical passthrough is the bar: these must reach MLX's op untouched."""
+
+    def _assert_untouched(self, monkeypatch, call):
+        seen = _hits(monkeypatch)
+        out = call()
+        mx.eval(out)
+        assert seen == [], f"unexpectedly intercepted: {seen}"
+        return out
+
+    def test_rows_below_threshold(self, make_ql, monkeypatch):
+        ql = make_ql(K, N)
+        w, s, b, gs, bits = _enable_with(ql)
+        x = mx.random.normal((ROW_THRESHOLD - 1, K)).astype(mx.bfloat16)
+        got = self._assert_untouched(
+            monkeypatch, lambda: mx.quantized_matmul(x, w, s, b, True, gs, bits))
+        want = patch._ORIG_QMM(x, w, s, b, True, gs, bits, "affine")
+        mx.eval(want)
+        assert mx.array_equal(got, want).item()
+
+    def test_unregistered_weight(self, make_ql, monkeypatch):
+        ql = make_ql(K, N)
+        _enable_with(ql)
+        other = make_ql(K, N)
+        x = mx.random.normal((ROW_THRESHOLD, K)).astype(mx.bfloat16)
+        self._assert_untouched(monkeypatch, lambda: other(x))
+
+    def test_transpose_false(self, make_ql, monkeypatch):
+        ql = make_ql(K, N)
+        w, s, b, gs, bits = _enable_with(ql)
+        x = mx.random.normal((ROW_THRESHOLD, N)).astype(mx.bfloat16)
+        self._assert_untouched(
+            monkeypatch, lambda: mx.quantized_matmul(x, w, s, b, False, gs, bits))
+
+    def test_explicit_stream(self, make_ql, monkeypatch):
+        """A metal_kernel launch cannot honour a caller's stream, so never intercept."""
+        ql = make_ql(K, N)
+        w, s, b, gs, bits = _enable_with(ql)
+        x = mx.random.normal((ROW_THRESHOLD, K)).astype(mx.bfloat16)
+        stream = mx.default_stream(mx.default_device())
+        self._assert_untouched(
+            monkeypatch,
+            lambda: mx.quantized_matmul(x, w, s, b, True, gs, bits, "affine", stream=stream))
+
+    def test_non_affine_mode(self, make_ql, monkeypatch):
+        """mxfp4 carries no biases and uses e8m0 scales; the affine requant is invalid."""
+        ql = make_ql(K, N)
+        _enable_with(ql)
+        try:
+            mxfp4 = nn.QuantizedLinear.from_linear(nn.Linear(K, N, bias=False), mode="mxfp4")
+        except Exception:
+            pytest.skip("mxfp4 unsupported in this MLX build")
+        x = mx.random.normal((ROW_THRESHOLD, K)).astype(mx.bfloat16)
+        self._assert_untouched(monkeypatch, lambda: mxfp4(x))
+
+    def test_quantized_kv_attention_shape(self, make_ql, monkeypatch):
+        """The sdpa path at models/base.py:84 passes 3-D per-step cache tensors."""
+        ql = make_ql(K, N)
+        _enable_with(ql)
+        x = mx.random.normal((2, ROW_THRESHOLD, K)).astype(mx.bfloat16)
+        w3 = mx.random.randint(0, 2**31 - 1, (2, N, K // 8)).astype(mx.uint32)
+        s3 = mx.random.normal((2, N, K // 64)).astype(mx.bfloat16)
+        b3 = mx.random.normal((2, N, K // 64)).astype(mx.bfloat16)
+        seen = _hits(monkeypatch)
+        try:
+            out = mx.quantized_matmul(x, w3, s3, b3, True, 64, 4)
+            mx.eval(out)
+        except Exception:
+            pass  # a raising fallthrough is still a fallthrough
+        assert seen == []
+
+
+class TestCoverage:
+    """The call sites a layer-level patch would have missed."""
+
+    def test_quantized_linear(self, make_ql, monkeypatch):
+        ql = make_ql(K, N)
+        _enable_with(ql, "ql")
+        seen = _hits(monkeypatch)
+        out = ql(mx.random.normal((ROW_THRESHOLD, K)).astype(mx.bfloat16))
+        mx.eval(out)
+        assert seen == ["ql"]
+
+    def test_embedding_as_linear(self, monkeypatch):
+        """Tied lm_heads route through QuantizedEmbedding, not QuantizedLinear."""
+        emb = nn.QuantizedEmbedding.from_embedding(
+            nn.Embedding(N, K), group_size=64, bits=4)
+        int8_prefill.enable(force=True)
+        ok, why = registry.register_module(emb, "emb")
+        assert ok, why
+        seen = _hits(monkeypatch)
+        out = emb.as_linear(mx.random.normal((ROW_THRESHOLD, K)).astype(mx.bfloat16))
+        mx.eval(out)
+        assert seen == ["emb"]
+
+
+class TestLifecycle:
+    def test_idempotent(self, make_ql):
+        assert int8_prefill.enable(force=True) is True
+        assert patch.apply() is False, "second apply must not nest the wrapper"
+
+    def test_disable_restores(self, make_ql):
+        int8_prefill.enable(force=True)
+        assert mx.quantized_matmul is not patch._ORIG_QMM
+        int8_prefill.disable()
+        assert mx.quantized_matmul is patch._ORIG_QMM
+        assert registry.size() == 0
+
+    def test_wraps_roundtrip(self):
+        int8_prefill.enable(force=True)
+        assert mx.quantized_matmul.__wrapped__ is patch._ORIG_QMM
+
+    def test_registry_identity_recheck(self, make_ql):
+        """An id() outliving its array must not select another weight's scales."""
+        ql = make_ql(K, N)
+        w, s, b, gs, bits = _enable_with(ql)
+        entry = registry.get(w)
+        assert entry is not None
+        entry.w = make_ql(K, N)["weight"]  # simulate id reuse
+        assert registry.get(w) is None

--- a/tests/test_mlx_int8_prefill_numerics.py
+++ b/tests/test_mlx_int8_prefill_numerics.py
@@ -1,0 +1,216 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The arithmetic, which is where output quality is decided.
+
+None of this needs Apple hardware: the W8A8 algorithm is defined by the algorithm, not
+by Metal, so the portable backend computes exactly what the M5 kernels are supposed to.
+A quality regression that shows up here would show up there.
+"""
+
+import pytest
+
+from _mlx_int8_helpers import (
+    make_quantized_linear,
+    make_quantized_model,
+    reset_int8_state,
+)
+
+
+@pytest.fixture(autouse = True)
+def clean_state():
+    reset_int8_state()
+    yield
+    reset_int8_state()
+
+
+@pytest.fixture
+def make_ql():
+    return make_quantized_linear
+
+
+@pytest.fixture
+def quantized_model():
+    return make_quantized_model()
+
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from unsloth_zoo.mlx.int8_prefill import registry, scales
+from unsloth_zoo.mlx.int8_prefill.backends import portable
+
+BITS_GROUPS = [(4, 32), (4, 64), (4, 128), (8, 32), (8, 64), (8, 128)]
+DTYPES = [mx.float32, mx.float16, mx.bfloat16]
+
+
+def quantize(w, bits, group_size):
+    packed, s, b = mx.quantize(w, group_size, bits, mode="affine")
+    return packed, s, b
+
+
+class TestScaleBound:
+    """The analytic bound versus the true absmax.
+
+    JetBrains derive the per-channel int8 scale from the affine metadata alone, which
+    reads like an approximation. It is not, for stock `mx.quantize` output: the
+    quantizer sets bias = group min, so code 0 is attained in every group and the bound
+    is tight. This test exists so that if MLX ever changes that, we find out here rather
+    than through a quality complaint from the one person with an M5.
+    """
+
+    @pytest.mark.parametrize("bits,group_size", BITS_GROUPS)
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_bound_is_tight_for_stock_quantize(self, bits, group_size, dtype):
+        """Asserted on the distribution, not the extreme, and that is not a dodge.
+
+        For float32 and float16 the bound equals the true absmax everywhere. For
+        bfloat16 a thin tail of channels -- measured at 0.1%, worst case 8/7 -- comes out
+        loose, because bf16 rounding of the group scale can leave the top code unused so
+        the group's real maximum is 13*s + b rather than 15*s + b. Measured end to end,
+        switching those channels to exact scales moves the matmul's mean and max relative
+        error by nothing at all (0.00875 either way), which is why the analytic bound is
+        the default and `UNSLOTH_MLX_INT8_EXACT_SCALES` exists only for learned
+        quantizers. Asserting on the max here would encode bf16 rounding luck as a
+        contract; asserting on the median and p99 encodes the property we rely on.
+        """
+        w = mx.random.normal((1024, 512)).astype(dtype)
+        packed, s, b = quantize(w, bits, group_size)
+
+        bound = scales.channel_scale_bound(s, b, bits)
+        exact = scales.channel_scale_exact(packed, s, b, bits, group_size)
+        mx.eval(bound, exact)
+
+        ratio = np.array((bound / exact).astype(mx.float32), copy=False)
+
+        # Never below 1: a scale that under-estimates clips weights at +-127 and loses
+        # them outright. This is a correctness requirement, so it is exact.
+        assert ratio.min() >= 1.0 - 1e-6, f"bound under-estimates by {1.0 - ratio.min():.2e}"
+        assert np.median(ratio) == pytest.approx(1.0, abs=1e-5)
+        assert np.percentile(ratio, 99) == pytest.approx(1.0, abs=1e-3)
+        # The tail exists but must stay a tail.
+        assert (ratio > 1.01).mean() < 0.02, "too many channels have a loose bound"
+
+    def test_bound_never_clips(self):
+        """Even where it is loose, the bound must remain an upper bound -- a scale that
+        under-estimates would clip weights at +-127 and lose them outright."""
+        w = mx.random.normal((128, 512)).astype(mx.float32)
+        packed, s, b = quantize(w, 4, 64)
+        # Perturb scales the way a learned quantizer (DWQ/AWQ/GPTQ) would, so the
+        # extremes are no longer attained.
+        s2 = s * 1.7
+        bound = scales.channel_scale_bound(s2, b, 4)
+        exact = scales.channel_scale_exact(packed, s2, b, 4, 64)
+        mx.eval(bound, exact)
+        assert bool((bound >= exact * 0.999).all().item()), "bound must not under-estimate"
+
+
+class TestPortableBackend:
+    @pytest.mark.parametrize("bits,group_size", [(4, 32), (4, 64), (4, 128)])
+    def test_close_to_mlx_reference(self, bits, group_size):
+        """W8A8 is lossy by design; the bar is that it stays close to the 4-bit op."""
+        # MLX 0.32.1's CUDA backend raises cuGraphAddKernelNode "invalid argument" for
+        # `mx.quantized_matmul` at group_size 128 -- stock MLX, reproducible without any
+        # of our code, and absent on Metal where MLX is primarily developed. Our own
+        # path evaluates fine at gs=128; it is the reference we cannot build here. So
+        # skip the comparison rather than weaken it, and let the macOS job cover it.
+        if group_size == 128 and not mx.metal.is_available():
+            pytest.skip("mx.quantized_matmul gs=128 is broken on the MLX CUDA backend")
+
+        K, N, M = 1024, 2048, 640
+        lin = nn.Linear(K, N, bias=False)
+        ql = nn.QuantizedLinear.from_linear(lin, group_size=group_size, bits=bits)
+        ok, why = registry.register_module(ql, "w")
+        assert ok, why
+        entry = registry.get(ql["weight"])
+
+        x = mx.random.normal((M, K)).astype(mx.bfloat16)
+        got = portable.matmul(x, entry, out_dtype=mx.float32)
+        want = mx.quantized_matmul(
+            x, ql["weight"], ql["scales"], ql["biases"], True, group_size, bits
+        ).astype(mx.float32)
+        mx.eval(got, want)
+
+        rel = (mx.abs(got - want).max() / mx.abs(want).max()).item()
+        assert rel < 0.15, f"max relative error {rel:.4f}"
+
+        # The mean error is the number that actually predicts output quality; a max
+        # driven by one outlier channel is not the same thing as a shifted distribution.
+        mean_rel = (mx.abs(got - want).mean() / mx.abs(want).mean()).item()
+        assert mean_rel < 0.03, f"mean relative error {mean_rel:.4f}"
+
+    def test_gemm_matches_exact_int32(self):
+        """The float32 accumulation must agree with a true int32 GEMM.
+
+        float32 holds integers exactly only to 2**24, and a K-long sum of int8 products
+        can exceed that, so this pins K small enough that any disagreement is a bug in
+        the algorithm rather than accumulation rounding.
+        """
+        M, K, N = 64, 512, 128
+        xq = mx.random.randint(-127, 128, (M, K)).astype(mx.int8)
+        wq = mx.random.randint(-127, 128, (N, K)).astype(mx.int8)
+        xs = mx.ones((M,), dtype=mx.float32)
+        ws = mx.ones((N,), dtype=mx.float32)
+
+        got = portable.int8_gemm(xq, xs, wq, ws)
+        mx.eval(got)
+        want = np.matmul(
+            np.array(xq, copy=False).astype(np.int32),
+            np.array(wq, copy=False).astype(np.int32).T,
+        )
+        assert np.array_equal(np.array(got, copy=False).astype(np.int64), want.astype(np.int64))
+
+    def test_row_quantization_range(self):
+        x = mx.random.normal((32, 256)).astype(mx.bfloat16) * 7.0
+        xq, xs = portable.quantize_rows(x)
+        mx.eval(xq, xs)
+        assert int(mx.abs(xq.astype(mx.int32)).max().item()) <= 127
+        # Every row should use most of the int8 range, or the scale is wrong.
+        row_max = mx.abs(xq.astype(mx.int32)).max(axis=-1)
+        mx.eval(row_max)
+        assert int(row_max.min().item()) >= 120
+
+    def test_zero_row_does_not_divide_by_zero(self):
+        x = mx.zeros((4, 256), dtype=mx.bfloat16)
+        xq, xs = portable.quantize_rows(x)
+        mx.eval(xq, xs)
+        arr = np.array(xq, copy=False)
+        assert np.isfinite(np.array(xs, copy=False)).all()
+        assert (arr == 0).all()
+
+    def test_leading_batch_dims_preserved(self):
+        K, N = 1024, 2048
+        ql = nn.QuantizedLinear.from_linear(nn.Linear(K, N, bias=False), group_size=64, bits=4)
+        ok, why = registry.register_module(ql, "w")
+        assert ok, why
+        entry = registry.get(ql["weight"])
+        x = mx.random.normal((2, 3, 512, K)).astype(mx.bfloat16)
+        out = portable.matmul(x, entry)
+        mx.eval(out)
+        assert out.shape == (2, 3, 512, N)
+
+
+class TestGroupRangeRatio:
+    """R is the quantity that decides whether per-channel int8 requant is safe."""
+
+    def test_reports_finite_ratios(self):
+        w = mx.random.normal((128, 512)).astype(mx.float32)
+        _, s, _ = quantize(w, 4, 64)
+        r = scales.group_range_ratio(s, 4)
+        mx.eval(r)
+        arr = np.array(r, copy=False)
+        assert np.isfinite(arr).all()
+        assert (arr >= 1.0).all()

--- a/tests/test_mlx_int8_prefill_numerics.py
+++ b/tests/test_mlx_int8_prefill_numerics.py
@@ -122,14 +122,6 @@ class TestPortableBackend:
     @pytest.mark.parametrize("bits,group_size", [(4, 32), (4, 64), (4, 128)])
     def test_close_to_mlx_reference(self, bits, group_size):
         """W8A8 is lossy by design; the bar is that it stays close to the 4-bit op."""
-        # MLX 0.32.1's CUDA backend raises cuGraphAddKernelNode "invalid argument" for
-        # `mx.quantized_matmul` at group_size 128 -- stock MLX, reproducible without any
-        # of our code, and absent on Metal where MLX is primarily developed. Our own
-        # path evaluates fine at gs=128; it is the reference we cannot build here. So
-        # skip the comparison rather than weaken it, and let the macOS job cover it.
-        if group_size == 128 and not mx.metal.is_available():
-            pytest.skip("mx.quantized_matmul gs=128 is broken on the MLX CUDA backend")
-
         K, N, M = 1024, 2048, 640
         lin = nn.Linear(K, N, bias=False)
         ql = nn.QuantizedLinear.from_linear(lin, group_size=group_size, bits=bits)
@@ -142,7 +134,17 @@ class TestPortableBackend:
         want = mx.quantized_matmul(
             x, ql["weight"], ql["scales"], ql["biases"], True, group_size, bits
         ).astype(mx.float32)
-        mx.eval(got, want)
+        try:
+            mx.eval(got, want)
+        except RuntimeError as exc:
+            # MLX 0.32.1's CUDA backend raises cuGraphAddKernelNode "invalid argument"
+            # for mx.quantized_matmul at group_size 128. That is stock MLX, reproducible
+            # with none of this module loaded, and absent on the CPU and Metal backends.
+            # Skipping on the reference we cannot build, rather than on a guess about the
+            # backend, keeps the coverage everywhere the reference does build.
+            if "cuGraph" not in str(exc):
+                raise
+            pytest.skip(f"stock mx.quantized_matmul cannot evaluate here: {exc}")
 
         rel = (mx.abs(got - want).max() / mx.abs(want).max()).item()
         assert rel < 0.15, f"max relative error {rel:.4f}"

--- a/tests/test_mlx_int8_prefill_safety.py
+++ b/tests/test_mlx_int8_prefill_safety.py
@@ -1,0 +1,296 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The properties that keep this from breaking anyone who does not want it.
+
+Three of these guard failure modes that would be invisible until they were expensive:
+a capability probe that says yes on hardware that cannot run the kernels, an eval on the
+hot path that only raises once someone wraps generation in `mx.compile`, and a missing
+vjp that only surfaces partway through a fine-tune.
+"""
+
+import pytest
+
+from _mlx_int8_helpers import (
+    make_quantized_linear,
+    make_quantized_model,
+    reset_int8_state,
+)
+
+
+@pytest.fixture(autouse = True)
+def clean_state():
+    reset_int8_state()
+    yield
+    reset_int8_state()
+
+
+@pytest.fixture
+def make_ql():
+    return make_quantized_linear
+
+
+@pytest.fixture
+def quantized_model():
+    return make_quantized_model()
+
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from unsloth_zoo.mlx import int8_prefill
+from unsloth_zoo.mlx.int8_prefill import capability, eligibility, patch, registry
+from unsloth_zoo.mlx.int8_prefill.eligibility import ROW_THRESHOLD
+
+K, N = 1024, 2048
+
+
+class TestCapability:
+    # These guard the no-op promise, so they must run wherever the module is not
+    # supported -- which emphatically includes Apple silicon without M5 int8 tensor ops,
+    # the configuration every current Mac user is in. Keying the skip on
+    # `mx.metal.is_available()` instead of on the verdict skipped all three on the macOS
+    # runner, which is the one place they matter most.
+
+    def test_declines_where_unsupported(self):
+        if capability.is_supported():
+            pytest.skip("int8 path is supported here; the negative case cannot be shown")
+        assert capability.is_supported() is False
+        assert capability.reason()  # always explains itself, whatever the layer
+
+    def test_enable_is_a_noop_when_unsupported(self, make_ql):
+        if capability.is_supported():
+            pytest.skip("int8 path is supported here")
+        assert int8_prefill.enable() is False
+        assert int8_prefill.is_enabled() is False
+        assert mx.quantized_matmul is patch._ORIG_QMM
+
+    def test_model_forward_bit_identical_when_unsupported(self, quantized_model):
+        """The whole no-op promise in one assertion."""
+        if capability.is_supported():
+            pytest.skip("int8 path is supported here")
+        x = mx.random.normal((ROW_THRESHOLD, 1024)).astype(mx.bfloat16)
+        before = quantized_model(x)
+        mx.eval(before)
+
+        int8_prefill.enable()
+        int8_prefill.warmup(quantized_model)
+        after = quantized_model(x)
+        mx.eval(after)
+
+        assert mx.array_equal(before, after).item()
+
+    def test_kill_switch(self, monkeypatch):
+        monkeypatch.setenv("UNSLOTH_MLX_INT8_PREFILL", "0")
+        capability.reset()
+        assert capability.is_supported() is False
+        assert "disabled by" in capability.reason()
+
+    def test_probe_reference_is_computable_and_exact(self):
+        """The capability probe's reference must actually evaluate.
+
+        Regression: the probe originally compared its kernel against
+        `mx.matmul(int32, int32)`, which MLX rejects outright -- "Only inexact types are
+        supported". That made the probe raise, be caught by its own `except BaseException`,
+        and report unsupported. It looked correct on an M1 (which should decline anyway)
+        while guaranteeing the module could never enable on an M5 either. Nothing on
+        Linux caught it because the probe short-circuits at `sys.platform`.
+
+        So assert the two properties the probe relies on, on any backend: integer matmul
+        is unavailable, and the float32 substitute is exact at the probe's size.
+        """
+        M = N = 128
+        K = 256
+        xq = ((mx.arange(M * K) % 251) - 125).reshape(M, K).astype(mx.int8)
+        wq = ((mx.arange(N * K) % 241) - 120).reshape(N, K).astype(mx.int8)
+
+        with pytest.raises(ValueError, match="inexact"):
+            mx.eval(mx.matmul(xq.astype(mx.int32), wq.astype(mx.int32).T))
+
+        got = mx.matmul(xq.astype(mx.float32), wq.astype(mx.float32).T).astype(mx.int32)
+        mx.eval(got)
+        want = np.matmul(
+            np.array(xq, copy=False).astype(np.int64),
+            np.array(wq, copy=False).astype(np.int64).T,
+        )
+        assert np.array_equal(np.array(got, copy=False).astype(np.int64), want)
+
+        # The exactness above holds only while the largest partial sum stays inside
+        # float32's exact integer range. Pin the headroom so raising K trips this.
+        assert 127 * 127 * K < 2**24
+
+    def test_probe_never_raises(self, monkeypatch):
+        """Whatever goes wrong inside, callers see False, not an exception."""
+        monkeypatch.setattr(
+            capability, "_decide", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+        capability.reset()
+        assert capability.is_supported() is False
+        assert "boom" in capability.reason()
+
+
+class TestEligibility:
+    @pytest.mark.parametrize("group_size", [32, 64, 128])
+    def test_4bit_all_group_sizes_accepted(self, group_size):
+        ok, why = eligibility.is_eligible(2048, 1024, 4, group_size)
+        assert ok, why
+
+    def test_8bit_rejected_by_default(self, monkeypatch):
+        monkeypatch.delenv("UNSLOTH_MLX_INT8_ALLOW_8BIT", raising=False)
+        ok, why = eligibility.is_eligible(2048, 1024, 8, 64)
+        assert not ok
+        assert "ALLOW_8BIT" in why
+
+    def test_8bit_accepted_when_opted_in(self, monkeypatch):
+        monkeypatch.setenv("UNSLOTH_MLX_INT8_ALLOW_8BIT", "1")
+        ok, why = eligibility.is_eligible(2048, 1024, 8, 64)
+        assert ok, why
+
+    @pytest.mark.parametrize("bits", [2, 3, 5, 6])
+    def test_odd_bit_widths_rejected(self, bits):
+        """3/5/6 are a dense bitstream whose values straddle uint32 words."""
+        ok, _ = eligibility.is_eligible(2048, 1024, bits, 64)
+        assert not ok
+
+    def test_non_affine_rejected(self):
+        ok, why = eligibility.is_eligible(2048, 1024, 4, 32, mode="mxfp4", has_biases=False)
+        assert not ok
+        assert "affine" in why
+
+    def test_n_must_tile(self):
+        """N is not ceil-divided when building the launch grid, so a partial tile would
+        silently drop output columns."""
+        ok, why = eligibility.is_eligible(2048 + 64, 1024, 4, 64)
+        assert not ok
+        assert "multiple of 128" in why
+
+    def test_lm_head_sized_output_rejected(self):
+        ok, why = eligibility.is_eligible(151936 // 128 * 128, 4096, 4, 64)
+        assert not ok
+        assert "lm_head" in why
+
+
+class TestCompileSafety:
+    def test_compiled_forward_runs(self, make_ql):
+        """Every mx.eval lives in warmup, so the hot path is trace-safe. An eval inside
+        a compile trace raises '[eval] Attempting to eval an array during function
+        transformations'."""
+        ql = make_ql(K, N)
+        int8_prefill.enable(force=True)
+        ok, why = registry.register_module(ql, "w")
+        assert ok, why
+
+        x = mx.random.normal((ROW_THRESHOLD, K)).astype(mx.bfloat16)
+        compiled = mx.compile(lambda t: ql(t))
+        out = compiled(x)
+        mx.eval(out)
+        assert out.shape == (ROW_THRESHOLD, N)
+
+    def test_compiled_matches_eager(self, make_ql):
+        ql = make_ql(K, N)
+        int8_prefill.enable(force=True)
+        registry.register_module(ql, "w")
+        x = mx.random.normal((ROW_THRESHOLD, K)).astype(mx.bfloat16)
+
+        eager = ql(x)
+        compiled = mx.compile(lambda t: ql(t))(x)
+        mx.eval(eager, compiled)
+        assert mx.allclose(eager, compiled, atol=1e-2).item()
+
+
+class TestGradients:
+    """`mx.fast.metal_kernel` outputs carry no vjp, so without custom_function a LoRA
+    backward through an intercepted prefill dies inside the trainer."""
+
+    def test_gradient_flows(self, make_ql):
+        ql = make_ql(K, N)
+        int8_prefill.enable(force=True)
+        registry.register_module(ql, "w")
+        x = mx.random.normal((ROW_THRESHOLD, K)).astype(mx.float32)
+
+        grad = mx.grad(lambda t: ql(t).sum())(x)
+        mx.eval(grad)
+        assert grad.shape == x.shape
+        assert bool(mx.isfinite(grad).all().item())
+
+    def test_gradient_matches_unpatched(self, make_ql):
+        """The vjp delegates to the stock 4-bit op, so it should be the exact gradient
+        of the unquantized-activation forward, not an approximation of it."""
+        ql = make_ql(K, N)
+        x = mx.random.normal((ROW_THRESHOLD, K)).astype(mx.float32)
+
+        want = mx.grad(lambda t: ql(t).sum())(x)
+        mx.eval(want)
+
+        int8_prefill.enable(force=True)
+        registry.register_module(ql, "w")
+        got = mx.grad(lambda t: ql(t).sum())(x)
+        mx.eval(got)
+
+        assert mx.allclose(got, want, atol=1e-3).item()
+
+
+class TestSelfTest:
+    def test_passes_on_a_registered_weight(self, make_ql):
+        ql = make_ql(K, N)
+        int8_prefill.enable(force=True)
+        registry.register_module(ql, "w")
+        ok, detail = int8_prefill.self_test()
+        assert ok, detail
+
+    def test_empty_registry_is_not_a_failure(self):
+        int8_prefill.enable(force=True)
+        ok, detail = int8_prefill.self_test()
+        assert ok
+        assert "no registered" in detail
+
+    def test_failure_disables_dispatch(self, make_ql, monkeypatch):
+        """A wrong kernel must stop dispatching, not emit wrong tokens."""
+        ql = make_ql(K, N)
+        int8_prefill.enable(force=True)
+        registry.register_module(ql, "w")
+
+        from unsloth_zoo.mlx.int8_prefill import backends
+        backend = backends.select()
+        monkeypatch.setattr(
+            backend, "matmul",
+            lambda x, e, out_dtype=mx.bfloat16: mx.zeros((x.shape[0], e.n), dtype=out_dtype),
+        )
+        ok, detail = int8_prefill.self_test()
+        assert not ok, detail
+        assert patch._disabled_by_selftest is True
+
+        # And from here on, calls fall through untouched.
+        x = mx.random.normal((ROW_THRESHOLD, K)).astype(mx.bfloat16)
+        got = ql(x)
+        want = patch._ORIG_QMM(
+            x, ql["weight"], ql["scales"], ql["biases"], True, ql.group_size, ql.bits, "affine")
+        mx.eval(got, want)
+        assert mx.array_equal(got, want).item()
+
+
+class TestWarmup:
+    def test_registers_eligible_only(self, quantized_model):
+        int8_prefill.enable(force=True)
+        registered, skipped = int8_prefill.warmup(quantized_model)
+        assert registered == 2, int8_prefill.registered()
+        assert skipped >= 1  # the 64x128 projection is far below MIN_DIM
+
+    def test_mlp_scope_filters_by_name(self, quantized_model):
+        int8_prefill.enable(force=True)
+        registered, _ = int8_prefill.warmup(quantized_model, scope="mlp")
+        assert all("mlp" in name for name in int8_prefill.registered())
+        assert registered == 2

--- a/tests/test_mlx_int8_prefill_safety.py
+++ b/tests/test_mlx_int8_prefill_safety.py
@@ -142,6 +142,57 @@ class TestCapability:
         assert "boom" in capability.reason()
 
 
+class TestModuleSweep:
+    """The rebind sweep must never be the thing that raises.
+
+    Regression: apply() and revert() probed `quantized_matmul` on every entry in
+    sys.modules. transformers installs a lazy module __getattr__ that imports a submodule
+    for any attribute name it recognises, so a bare getattr for an unrelated name raised
+    ModuleNotFoundError from inside somebody else's optional dependency. Observed in CI as
+    "No module named 'torchvision'" during teardown, turning a passing test into an error.
+    """
+
+    def test_survives_a_module_whose_getattr_explodes(self, make_ql):
+        import sys
+        import types
+
+        hostile = types.ModuleType("mlx_hostile_probe")
+
+        def _boom(name):
+            raise ModuleNotFoundError(f"No module named 'not_installed' (probing {name})")
+
+        hostile.__getattr__ = _boom
+        sys.modules["mlx_hostile_probe"] = hostile
+        try:
+            assert int8_prefill.enable(force = True) is True
+            int8_prefill.disable()
+            assert mx.quantized_matmul is patch._ORIG_QMM
+        finally:
+            sys.modules.pop("mlx_hostile_probe", None)
+
+    def test_sweep_skips_unrelated_packages(self):
+        """Narrow by name as well as guarding, so unrelated lazy imports are never even
+        triggered. Only mlx and unsloth packages could hold the symbol."""
+        import sys
+        import types
+
+        probed = []
+        watcher = types.ModuleType("totally_unrelated_pkg")
+
+        def _record(name):
+            probed.append(name)
+            raise AttributeError(name)
+
+        watcher.__getattr__ = _record
+        sys.modules["totally_unrelated_pkg"] = watcher
+        try:
+            int8_prefill.enable(force = True)
+            int8_prefill.disable()
+        finally:
+            sys.modules.pop("totally_unrelated_pkg", None)
+        assert probed == [], f"sweep touched an unrelated package: {probed}"
+
+
 class TestEligibility:
     @pytest.mark.parametrize("group_size", [32, 64, 128])
     def test_4bit_all_group_sizes_accepted(self, group_size):

--- a/unsloth_zoo/mlx/int8_prefill/__init__.py
+++ b/unsloth_zoo/mlx/int8_prefill/__init__.py
@@ -1,0 +1,109 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""int8 W8A8 prefill acceleration for MLX quantized models.
+
+MLX computes quantized matmuls in 16-bit regardless of how the weights are stored, so a
+4-bit model prefills no faster than an 8-bit one. On Apple M5, whose neural accelerators
+run int8 at roughly twice the fp16 rate, routing prefill-sized matmuls through an
+int8 x int8 -> int32 GEMM recovers that. Decode is memory-bound and stays on MLX's
+kernels untouched.
+
+Usage::
+
+    from unsloth_zoo.mlx import int8_prefill
+
+    if int8_prefill.enable():          # no-op and False off M5
+        int8_prefill.warmup(model)     # required: builds the allow-list
+
+Everything is opt-in and fails closed. On any other hardware, any other MLX version, or
+any unexpected error, `enable()` returns False and MLX is left exactly as it was.
+
+Environment:
+    UNSLOTH_MLX_INT8_PREFILL=0|1|force   kill switch / skip the capability probe
+    UNSLOTH_MLX_INT8_BACKEND=metal_mpp|portable
+    UNSLOTH_MLX_INT8_ROW_THRESHOLD=512   below this, calls keep MLX's kernels
+    UNSLOTH_MLX_INT8_ALLOW_8BIT=1        affine 8-bit (off by default, see eligibility)
+    UNSLOTH_MLX_INT8_EXACT_SCALES=1      exact absmax instead of the analytic bound
+    UNSLOTH_MLX_INT8_VERIFY=1            shadow mode: log max relative error per call
+"""
+
+import logging
+
+from . import backends, capability, eligibility, patch, registry, scales
+
+__all__ = [
+    "enable", "disable", "warmup", "is_supported", "is_enabled", "self_test",
+    "reason", "registered",
+]
+
+logger = logging.getLogger(__name__)
+
+__version__ = "0.1.0"
+
+
+def is_supported():
+    """Whether this machine can run the int8 path. Cached, never raises."""
+    return capability.is_supported()
+
+
+def reason():
+    """The capability verdict's explanation, for logs and bug reports."""
+    return capability.reason()
+
+
+def enable(force=False):
+    """Install the patch if this machine supports it.
+
+    Returns True if the patch is now active. `force=True` skips the capability probe and
+    is for testing on hardware that cannot run the real kernels -- pair it with
+    UNSLOTH_MLX_INT8_BACKEND=portable.
+    """
+    if not force and not is_supported():
+        logger.info("Unsloth: MLX int8 prefill not enabled (%s)", capability.reason())
+        return False
+    patch.apply()
+    return True
+
+
+def disable():
+    """Restore MLX's original op and drop the allow-list."""
+    patch.revert()
+    registry.clear()
+    patch.reset_selftest()
+
+
+def is_enabled():
+    return patch.is_patched()
+
+
+def warmup(model, scope="all", exact_scales=None):
+    """Register a model's eligible projections. Required -- nothing is accelerated
+    until a weight is registered.
+
+    This is also where every `mx.eval` in the module happens, which is what leaves the
+    hot path safe to run inside `mx.compile`.
+    """
+    return registry.warmup(model, scope=scope, exact_scales=exact_scales)
+
+
+def self_test(**kwargs):
+    """Verify registered shapes against MLX's own op on this device. See patch.self_test."""
+    return patch.self_test(**kwargs)
+
+
+def registered():
+    """Names of the currently registered modules."""
+    return registry.names()

--- a/unsloth_zoo/mlx/int8_prefill/backends/__init__.py
+++ b/unsloth_zoo/mlx/int8_prefill/backends/__init__.py
@@ -1,0 +1,51 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""W8A8 backends.
+
+`portable` implements the algorithm in plain MLX ops and runs anywhere, which is what
+makes the arithmetic testable without an M5. `metal_mpp` is the real one.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_backend = None
+
+
+def select(name=None):
+    """Return the backend module. `name` defaults to UNSLOTH_MLX_INT8_BACKEND, then to
+    metal_mpp with a fallback to portable if Metal kernels cannot be imported."""
+    global _backend
+    if name is None and _backend is not None:
+        return _backend
+
+    name = name or os.environ.get("UNSLOTH_MLX_INT8_BACKEND", "metal_mpp")
+    if name == "portable":
+        from . import portable as mod
+    elif name == "metal_mpp":
+        from . import metal_mpp as mod
+    else:
+        raise ValueError(f"unknown backend {name!r}")
+
+    _backend = mod
+    return mod
+
+
+def reset():
+    global _backend
+    _backend = None

--- a/unsloth_zoo/mlx/int8_prefill/backends/metal_mpp.py
+++ b/unsloth_zoo/mlx/int8_prefill/backends/metal_mpp.py
@@ -1,0 +1,286 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# The three kernels below are adapted from JetBrains' int8 NAX prefill patch for
+# mlx-vlm (MIT licensed):
+#   https://github.com/JetBrains/mlx-vlm/tree/feature/int8-prefill
+#   mlx_vlm/int8_prefill.py, Copyright (c) 2025 Prince Canuma and contributors.
+#
+# Changes from that original:
+#   * the MetalPerformancePrimitives include is isolated to the GEMM kernel, so the
+#     activation-quant and weight-requant kernels compile and run on any Metal device;
+#   * the requant kernel is parameterized on bits and group size rather than assuming
+#     4-bit / group_size 64 / eight nibbles per word;
+#   * the bias epilogue is gone -- patching at op level means the caller adds bias after
+#     the matmul, halving the GEMM variants we compile;
+#   * the GEMM emits int32 so callers can compare it exactly against an integer
+#     reference; scale application moved out to the caller.
+"""Metal kernels for the W8A8 int8 prefill path.
+
+Only `int8_gemm` needs Metal Performance Primitives (Metal 4, and the int8 arithmetic
+rate that makes any of this worthwhile arrives with the M5 neural accelerators). The
+other two are ordinary Metal, which is deliberate: it means an M1 CI runner can validate
+the packed-weight unpacking -- the nibble ordering and word-boundary arithmetic that is
+the likeliest place for a silent wrong-answer bug, and that Linux cannot check at all.
+"""
+
+import mlx.core as mx
+
+# Ordinary Metal. No MPP, so these compile on any Metal device.
+_PLAIN_HEADER = """
+#include <metal_stdlib>
+using namespace metal;
+"""
+
+# Metal 4 tensor ops. Compiling this at all requires macOS 26+; running it usefully
+# requires the M5 neural accelerators.
+_MPP_HEADER = """
+#include <metal_stdlib>
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+using namespace mpp::tensor_ops;
+using namespace metal;
+"""
+
+# One threadgroup (256 threads) per row: absmax reduce, then quantize.
+_QUANT_SRC = """
+    constexpr int K = {K};
+    constexpr int NTH = 256;
+
+    uint row = threadgroup_position_in_grid.x;
+    uint tid = thread_position_in_threadgroup.x;
+    uint lane = tid % 32;
+    uint sg = tid / 32;
+
+    const device {T}* xrow = x + size_t(row) * K;
+
+    float amax = 0.0f;
+    for (int i = tid; i < K; i += NTH) {{
+        amax = max(amax, fabs(float(xrow[i])));
+    }}
+    amax = simd_max(amax);
+
+    threadgroup float tg_max[NTH / 32];
+    if (lane == 0) tg_max[sg] = amax;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    amax = tg_max[lane % (NTH / 32)];
+    amax = simd_max(amax);
+
+    float scale = max(amax, 1e-8f) / 127.0f;
+    float inv = 1.0f / scale;
+    if (tid == 0) xs[row] = scale;
+
+    device int8_t* qrow = xq + size_t(row) * K;
+    for (int i = tid; i < K; i += NTH) {{
+        qrow[i] = int8_t(clamp(rint(float(xrow[i]) * inv), -127.0f, 127.0f));
+    }}
+"""
+
+# Fused requantization: packed affine weights -> per-channel symmetric int8, one pass,
+# no high-precision intermediate. One threadgroup (256 threads) per output channel.
+#
+# VPW values per uint32 word and WPG words per group are both integral for every
+# (bits, group_size) the eligibility table admits, so a word never straddles two groups
+# and the group index is a plain division.
+_REQUANT_SRC = """
+    constexpr int KW = {KW};     // packed words per row
+    constexpr int VPW = {VPW};   // values per word (32 / bits)
+    constexpr int WPG = {WPG};   // words per group (group_size / VPW)
+    constexpr int BITS = {BITS};
+    constexpr uint MASK = {MASK}u;
+
+    uint row = threadgroup_position_in_grid.x;
+    uint tid = thread_position_in_threadgroup.x;
+
+    const device uint* prow = packed + size_t(row) * KW;
+    const device {T}* srow = scales + size_t(row) * (KW / WPG);
+    const device {T}* brow = biases + size_t(row) * (KW / WPG);
+    device int8_t* orow = out + size_t(row) * KW * VPW;
+
+    float inv = 1.0f / ws[row];
+
+    for (int i = tid; i < KW; i += 256) {{
+        uint wrd = prow[i];
+        int g = i / WPG;
+        float s = float(srow[g]);
+        float b = float(brow[g]);
+        device int8_t* o = orow + i * VPW;
+#pragma unroll
+        for (int j = 0; j < VPW; ++j) {{
+            float v = float((wrd >> (BITS * j)) & MASK) * s + b;
+            o[j] = int8_t(clamp(rint(v * inv), -127.0f, 127.0f));
+        }}
+    }}
+"""
+
+# Threadgroup computes a 128x128 output tile with 8 simdgroups; matmul2d loops over K
+# internally (dynamic_extent). Edge tiles in M are handled by the epilogue guard; N is
+# required to be a multiple of 128 by the eligibility rules, because the launch grid
+# below does not round up and a partial N tile would silently drop columns.
+_GEMM_SRC = """
+    constexpr int N = {N};
+    constexpr int K = {K};
+    constexpr int TM = 128;
+    constexpr int TN = 128;
+
+    uint2 tgid = threadgroup_position_in_grid.xy;
+    const int M = m_dim[0];
+
+    constexpr auto desc = matmul2d_descriptor(
+        TM, TN, static_cast<int>(dynamic_extent),
+        /*transpose_left=*/false, /*transpose_right=*/true,
+        /*relaxed_precision=*/false,
+        matmul2d_descriptor::mode::multiply_accumulate);
+
+    matmul2d<desc, execution_simdgroups<8>> op;
+
+    // Row-major X[M,K] -> extents (K, M); row-major W[N,K] used as the transposed right
+    // operand -> extents (K, N).
+    auto A = tensor<device int8_t, dextents<int32_t, 2>, tensor_inline>(
+        (device int8_t*)xq, dextents<int32_t, 2>(K, M));
+    auto B = tensor<device int8_t, dextents<int32_t, 2>, tensor_inline>(
+        (device int8_t*)wq, dextents<int32_t, 2>(K, N));
+
+    auto tA = A.slice(0, int(tgid.y) * TM);
+    auto tB = B.slice(0, int(tgid.x) * TN);
+
+    auto cT = op.get_destination_cooperative_tensor<
+        decltype(tA), decltype(tB), int32_t>();
+
+#pragma unroll
+    for (uint16_t i = 0; i < cT.get_capacity(); ++i) {{
+        if (cT.is_valid_element(i)) cT[i] = 0;
+    }}
+
+    op.run(tA, tB, cT);
+
+#pragma unroll
+    for (uint16_t i = 0; i < cT.get_capacity(); ++i) {{
+        if (cT.is_valid_element(i)) {{
+            auto idx = cT.get_multidimensional_index(i);
+            int n = int(tgid.x) * TN + idx[0];
+            int m = int(tgid.y) * TM + idx[1];
+            if (m < M && n < N) {{
+                out[size_t(m) * N + n] = cT[i];
+            }}
+        }}
+    }}
+"""
+
+_TM, _TN, _NSIMD = 128, 128, 8
+_DTYPE_NAMES = {mx.bfloat16: "bfloat", mx.float16: "half", mx.float32: "float"}
+
+_quant_kernels = {}
+_requant_kernels = {}
+_gemm_kernels = {}
+
+
+def _quant_kernel(k, tname):
+    key = (k, tname)
+    if key not in _quant_kernels:
+        _quant_kernels[key] = mx.fast.metal_kernel(
+            name=f"unsloth_i8_rowquant_{k}_{tname}",
+            input_names=["x"],
+            output_names=["xq", "xs"],
+            header=_PLAIN_HEADER,
+            source=_QUANT_SRC.format(K=k, T=tname),
+        )
+    return _quant_kernels[key]
+
+
+def _requant_kernel(kw, vpw, wpg, bits, tname):
+    key = (kw, vpw, wpg, bits, tname)
+    if key not in _requant_kernels:
+        _requant_kernels[key] = mx.fast.metal_kernel(
+            name=f"unsloth_i8_requant_{kw}_{bits}_{wpg}_{tname}",
+            input_names=["packed", "scales", "biases", "ws"],
+            output_names=["out"],
+            header=_PLAIN_HEADER,
+            source=_REQUANT_SRC.format(
+                KW=kw, VPW=vpw, WPG=wpg, BITS=bits, MASK=(1 << bits) - 1, T=tname
+            ),
+        )
+    return _requant_kernels[key]
+
+
+def _gemm_kernel(n, k):
+    key = (n, k)
+    if key not in _gemm_kernels:
+        _gemm_kernels[key] = mx.fast.metal_kernel(
+            name=f"unsloth_i8_gemm_{n}x{k}",
+            input_names=["xq", "wq", "m_dim"],
+            output_names=["out"],
+            header=_MPP_HEADER,
+            source=_GEMM_SRC.format(N=n, K=k),
+        )
+    return _gemm_kernels[key]
+
+
+def build_probe_kernel(N, K):
+    """The GEMM kernel alone, for the capability probe in capability.py."""
+    return _gemm_kernel(N, K)
+
+
+def quantize_rows(x):
+    """Per-row symmetric int8 activation quantization. Returns (xq int8, xs float32)."""
+    m, k = x.shape
+    return _quant_kernel(k, _DTYPE_NAMES[x.dtype])(
+        inputs=[x],
+        grid=(m * 256, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(m, k), (m,)],
+        output_dtypes=[mx.int8, mx.float32],
+    )
+
+
+def requantize_weight(weight, scales, biases, ws, bits, group_size):
+    """Packed affine weights -> per-channel symmetric int8 [N, K], fused."""
+    n, kw = weight.shape[-2:]
+    vpw = 32 // bits
+    wpg = group_size // vpw
+    kernel = _requant_kernel(kw, vpw, wpg, bits, _DTYPE_NAMES[scales.dtype])
+    return kernel(
+        inputs=[weight, scales, biases, ws],
+        grid=(n * 256, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(n, kw * vpw)],
+        output_dtypes=[mx.int8],
+    )[0]
+
+
+def int8_gemm_raw(xq, wq):
+    """Raw int32 (xq @ wq.T). No scales -- the caller folds those in."""
+    m, k = xq.shape
+    n = wq.shape[0]
+    return _gemm_kernel(n, k)(
+        inputs=[xq, wq, mx.array([m], dtype=mx.int32)],
+        grid=(n // _TN * 32 * _NSIMD, (m + _TM - 1) // _TM, 1),
+        threadgroup=(32 * _NSIMD, 1, 1),
+        output_shapes=[(m, n)],
+        output_dtypes=[mx.int32],
+    )[0]
+
+
+def matmul(x, entry, out_dtype=mx.bfloat16):
+    """Full W8A8 path for a registered weight."""
+    k = x.shape[-1]
+    flat = x.reshape(-1, k)
+    xq, xs = quantize_rows(flat)
+    wq = requantize_weight(
+        entry.w, entry.scales, entry.biases, entry.ws, entry.bits, entry.group_size
+    )
+    acc = int8_gemm_raw(xq, wq)
+    out = acc.astype(mx.float32) * xs[:, None] * entry.ws[None, :]
+    return out.astype(out_dtype).reshape(*x.shape[:-1], entry.n)

--- a/unsloth_zoo/mlx/int8_prefill/backends/portable.py
+++ b/unsloth_zoo/mlx/int8_prefill/backends/portable.py
@@ -1,0 +1,80 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The W8A8 algorithm in plain MLX ops, runnable on any backend.
+
+This is what makes the project testable. The Metal kernels need an M5 and there is none
+in CI, but the *arithmetic* is defined by the algorithm rather than by Metal, so
+everything that decides output quality -- per-row activation quantization, the
+per-channel weight requant, the scale application -- can be exercised on Linux, and on
+an M1 runner, against the same reference the Metal path is checked against.
+
+Numerical caveat, stated because it bounds what a test using this can claim: the
+accumulation here is `mx.matmul` in float32, not int32. Products of int8 values are
+exact, but a sum of K of them can reach `127*127*K`, which exceeds float32's exactly
+representable integer range (2**24) once K is past about 1000. On real weight and
+activation distributions the sums are far smaller than worst case and the difference is
+immaterial, but a test wanting *bit-exact* agreement with an int32 GEMM must either keep
+K small or compare against numpy int32 -- see tests/mlx_int8/test_portable.py, which
+does the latter.
+"""
+
+import mlx.core as mx
+
+INT8_MAX = 127.0
+
+
+def quantize_rows(x):
+    """Per-row (per-token) symmetric int8 activation quantization.
+
+    Returns (xq int8 [M, K], xs float32 [M]). Rows that are entirely zero get a floor
+    scale rather than a division by zero.
+    """
+    xf = x.astype(mx.float32)
+    xs = mx.maximum(mx.abs(xf).max(axis=-1), 1e-8) / INT8_MAX
+    xq = mx.clip(mx.round(xf / xs[:, None]), -INT8_MAX, INT8_MAX)
+    return xq.astype(mx.int8), xs
+
+
+def requantize_weight(weight, scales, biases, ws, bits, group_size):
+    """Packed affine weights -> per-output-channel symmetric int8 [N, K].
+
+    The Metal backend fuses this into one kernel that reads the packed words directly.
+    Here we go through `mx.dequantize`, which is the same arithmetic with an
+    intermediate.
+    """
+    dq = mx.dequantize(
+        weight, scales, biases, group_size=group_size, bits=bits, mode="affine"
+    ).astype(mx.float32)
+    wq = mx.clip(mx.round(dq / ws[:, None]), -INT8_MAX, INT8_MAX)
+    return wq.astype(mx.int8)
+
+
+def int8_gemm(xq, xs, wq, ws):
+    """(xq @ wq.T) with the per-row and per-channel scales folded back in."""
+    acc = mx.matmul(xq.astype(mx.float32), wq.astype(mx.float32).T)
+    return acc * xs[:, None] * ws[None, :]
+
+
+def matmul(x, entry, out_dtype=mx.bfloat16):
+    """Full W8A8 path for a registered weight. `x` may carry leading batch dims."""
+    k = x.shape[-1]
+    flat = x.reshape(-1, k)
+    xq, xs = quantize_rows(flat)
+    wq = requantize_weight(
+        entry.w, entry.scales, entry.biases, entry.ws, entry.bits, entry.group_size
+    )
+    out = int8_gemm(xq, xs, wq, entry.ws)
+    return out.astype(out_dtype).reshape(*x.shape[:-1], entry.n)

--- a/unsloth_zoo/mlx/int8_prefill/capability.py
+++ b/unsloth_zoo/mlx/int8_prefill/capability.py
@@ -1,0 +1,166 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Can this machine run the int8 W8A8 prefill path?
+
+There is no MLX API for Apple GPU generation, Metal version, or Metal Performance
+Primitives availability, so the only sound test is to compile an MPP int8 kernel, run
+it, and check the numbers. Two traps this has to route around:
+
+  * `mx.fast.metal_kernel(...)` *constructs* successfully with no Metal backend at all
+    and only raises "[metal_kernel] No Metal back-end" at call time, so construction
+    proves nothing.
+  * `mx.metal.device_info()` is deprecated and on a CUDA build cheerfully returns the
+    CUDA device dict, so it is not a Metal probe either.
+
+Everything is layered cheapest-first, cached, lazy (never at import), and fails closed:
+any unexpected exception anywhere means "unsupported", never a raised error into a
+user's generate call.
+"""
+
+import logging
+import os
+import platform
+import sys
+
+logger = logging.getLogger(__name__)
+
+_MLX_MIN = (0, 29)
+_MACOS_MIN = 26  # Metal 4 / MetalPerformancePrimitives
+
+_verdict = None
+_reason = None
+
+
+def _env_override():
+    return os.environ.get("UNSLOTH_MLX_INT8_PREFILL", "").strip().lower()
+
+
+def _macos_major():
+    try:
+        return int(platform.mac_ver()[0].split(".")[0])
+    except (ValueError, IndexError):
+        return 0
+
+
+def _probe_mpp_int8_gemm():
+    """Compile and run a small int8 MPP GEMM and compare it against an exact reference.
+
+    A machine that lacks the int8 tensor-op path fails at kernel compilation; a machine
+    that has it but computes wrongly fails the comparison. Both mean unsupported.
+
+    The reference is a float32 matmul rather than an integer one, because `mx.matmul`
+    accepts only inexact types. That costs nothing here: with K=256 the largest possible
+    partial sum is 127*127*256 = 4.13e6, well inside float32's exactly representable
+    integer range of 2**24, so the comparison stays exact and needs no tolerance. K must
+    not be raised past ~1000 without revisiting that.
+    """
+    import mlx.core as mx
+
+    from .backends.metal_mpp import build_probe_kernel
+
+    M = N = 128
+    K = 256
+    kernel = build_probe_kernel(N=N, K=K)
+
+    # Deterministic, spans the signed int8 range, and is not symmetric about zero so a
+    # sign or transpose error cannot cancel out.
+    xq = ((mx.arange(M * K) % 251) - 125).reshape(M, K).astype(mx.int8)
+    wq = ((mx.arange(N * K) % 241) - 120).reshape(N, K).astype(mx.int8)
+
+    got = kernel(
+        inputs=[xq, wq, mx.array([M], dtype=mx.int32)],
+        grid=(N // 128 * 32 * 8, (M + 127) // 128, 1),
+        threadgroup=(32 * 8, 1, 1),
+        output_shapes=[(M, N)],
+        output_dtypes=[mx.int32],
+    )[0]
+    want = mx.matmul(xq.astype(mx.float32), wq.astype(mx.float32).T).astype(mx.int32)
+    mx.eval(got, want)
+    return bool(mx.array_equal(got, want).item())
+
+
+def _decide():
+    env = _env_override()
+    if env in ("0", "off", "false", "no"):
+        return False, "disabled by UNSLOTH_MLX_INT8_PREFILL"
+
+    if sys.platform != "darwin":
+        return False, f"not macOS (sys.platform={sys.platform!r})"
+
+    try:
+        import mlx.core as mx
+    except ImportError:
+        return False, "mlx is not installed"
+
+    if not mx.metal.is_available():
+        return False, "no Metal backend (mx.metal.is_available() is False)"
+
+    try:
+        version = tuple(int(p) for p in mx.__version__.split(".")[:2])
+    except (ValueError, AttributeError):
+        version = (0, 0)
+    if version < _MLX_MIN:
+        return False, f"mlx {mx.__version__} below minimum {'.'.join(map(str, _MLX_MIN))}"
+
+    major = _macos_major()
+    if major < _MACOS_MIN:
+        return False, f"macOS {major} below {_MACOS_MIN} (no Metal Performance Primitives)"
+
+    # Logged, never branched on: we do not know Apple's M5 architecture string and there
+    # will be an M6. The probe below is the actual discriminator.
+    try:
+        logger.debug("Unsloth: MLX device_info=%r", mx.device_info())
+    except Exception:
+        pass
+
+    if env in ("1", "force", "true", "yes", "on"):
+        return True, "forced by UNSLOTH_MLX_INT8_PREFILL (probe skipped)"
+
+    try:
+        if _probe_mpp_int8_gemm():
+            return True, "int8 MPP GEMM probe passed"
+        return False, "int8 MPP GEMM probe produced wrong results"
+    except BaseException as exc:  # a probe must never take down the caller
+        return False, f"int8 MPP GEMM probe failed: {type(exc).__name__}: {exc}"
+
+
+def is_supported():
+    """True if the int8 path may be used here. Cached; safe to call in a hot loop."""
+    global _verdict, _reason
+    if _verdict is None:
+        try:
+            _verdict, _reason = _decide()
+        except BaseException as exc:
+            _verdict, _reason = False, f"capability probe raised {type(exc).__name__}: {exc}"
+        logger.info(
+            "Unsloth: MLX int8 prefill %s (%s)",
+            "available" if _verdict else "unavailable",
+            _reason,
+        )
+    return _verdict
+
+
+def reason():
+    """Why `is_supported()` decided what it did. Runs the probe if it has not yet."""
+    is_supported()
+    return _reason
+
+
+def reset():
+    """Forget the cached verdict. For tests that manipulate the environment."""
+    global _verdict, _reason
+    _verdict = None
+    _reason = None

--- a/unsloth_zoo/mlx/int8_prefill/eligibility.py
+++ b/unsloth_zoo/mlx/int8_prefill/eligibility.py
@@ -1,0 +1,104 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Which quantized weights may take the W8A8 int8 path.
+
+Table-driven so widening support is a data change. The rules are deliberately
+conservative: a weight that fails any of them keeps MLX's stock 4-bit kernels, which
+is always correct, merely slower.
+"""
+
+import os
+
+# Only calls with at least this many rows (tokens) take the int8 path. Below it MLX's
+# quantized kernels win -- they are roughly 2x faster than a 16-bit GEMM at decode
+# sizes. This is also what keeps generation on the stock path: decode presents 1 row,
+# or a draft block's worth under speculative decoding, far below the threshold.
+ROW_THRESHOLD = int(os.environ.get("UNSLOTH_MLX_INT8_ROW_THRESHOLD", "512"))
+
+# GEMM tile shape. N is NOT ceil-divided when building the launch grid, so an N that is
+# not a multiple of TN would silently drop output columns. Enforce it here rather than
+# trusting the kernel.
+TILE_N = 128
+TILE_M = 128
+
+# K must be a multiple of this for the tiled loads to stay in bounds.
+K_MULTIPLE = 32
+
+# Below this, the fixed cost of quantizing activations is not repaid.
+MIN_DIM = 1024
+
+# Above this an output projection is almost certainly an lm_head, where prefill needs
+# logits for one position only and the requant would be pure overhead.
+MAX_OUT = 32768
+
+# (bits, group_size) combinations the requant kernel can unpack.
+#
+# The kernel walks packed uint32 words, so it needs 32 % bits == 0 (whole values per
+# word) and (group_size * bits) % 32 == 0 (a group never straddles a word). Affine bits
+# 3/5/6 are a dense bitstream where values cross word boundaries; they are permanently
+# excluded rather than merely unimplemented.
+_SUPPORTED_4BIT = {(4, 32), (4, 64), (4, 128)}
+
+# Affine 8-bit is off by default and this is not conservatism, it is arithmetic. See
+# plans/sparkling-popping-kay.md: requantizing affine-8 to symmetric int8 has zero bits
+# of headroom, so any channel whose inter-group range ratio exceeds ~1.2 comes out
+# strictly worse than the 8-bit weights it started from. At 4 bits the same requant has
+# roughly 16x of cushion, which is the only reason this technique works at all.
+_SUPPORTED_8BIT = {(8, 32), (8, 64), (8, 128)}
+
+
+def allow_8bit() -> bool:
+    return os.environ.get("UNSLOTH_MLX_INT8_ALLOW_8BIT", "0").lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def supported_formats() -> frozenset:
+    fmts = set(_SUPPORTED_4BIT)
+    if allow_8bit():
+        fmts |= _SUPPORTED_8BIT
+    return frozenset(fmts)
+
+
+def is_eligible(n, k, bits, group_size, mode="affine", has_biases=True):
+    """Return (ok, reason). `reason` is None when eligible, else a short diagnostic.
+
+    `n` is the output dim, `k` the input dim, both in elements (not packed words).
+    """
+    if mode != "affine":
+        # mxfp4 / mxfp8 / nvfp4 carry no biases and use e8m0/e4m3 scales; the requant
+        # kernel's affine arithmetic does not apply.
+        return False, f"mode={mode!r} is not affine"
+    if not has_biases:
+        return False, "affine weight without biases"
+    if (bits, group_size) not in supported_formats():
+        if (bits, group_size) in _SUPPORTED_8BIT:
+            return False, "affine 8-bit requires UNSLOTH_MLX_INT8_ALLOW_8BIT=1"
+        return False, f"unsupported (bits={bits}, group_size={group_size})"
+    if n % TILE_N:
+        return False, f"N={n} is not a multiple of {TILE_N}"
+    if k % K_MULTIPLE:
+        return False, f"K={k} is not a multiple of {K_MULTIPLE}"
+    if min(n, k) < MIN_DIM:
+        return False, f"min(N,K)={min(n, k)} below {MIN_DIM}"
+    if n > MAX_OUT:
+        return False, f"N={n} above {MAX_OUT} (probably an lm_head)"
+    return True, None
+
+
+def rows_of(x, k_dim):
+    """Row count a matmul will see, flattening every leading batch dim."""
+    return x.size // k_dim

--- a/unsloth_zoo/mlx/int8_prefill/patch.py
+++ b/unsloth_zoo/mlx/int8_prefill/patch.py
@@ -136,6 +136,34 @@ def _patched_qmm(x, w, /, *args, **kwargs):
 _patched_qmm.__unsloth_int8_prefill__ = True
 
 
+# Modules whose `quantized_matmul` attribute is worth probing during the rebind sweep.
+#
+# Probing every entry in sys.modules is not safe: transformers installs a lazy module
+# __getattr__ that imports a submodule for any attribute name it recognises, so a bare
+# getattr for an unrelated name can raise ModuleNotFoundError from deep inside somebody
+# else's optional dependency (observed: "No module named 'torchvision'" while reverting
+# the patch). Restricting the sweep by module name is also what the rest of Unsloth does
+# for the same reason, and nothing outside these packages could hold the symbol anyway.
+_SWEEP_PREFIXES = ("mlx", "mlx_lm", "mlx_vlm", "unsloth", "unsloth_zoo")
+
+
+def _sweep_rebind(old, new):
+    """Repoint any module that captured `old` by value at import time.
+
+    Verified that nothing in mlx, mlx-lm or unsloth_zoo currently does this, so the sweep
+    is insurance against a future `from mlx.core import quantized_matmul`, not a present
+    requirement. It must therefore never be the thing that raises.
+    """
+    for name, mod in tuple(sys.modules.items()):
+        if mod is None or not name.startswith(_SWEEP_PREFIXES):
+            continue
+        try:
+            if getattr(mod, "quantized_matmul", None) is old:
+                setattr(mod, "quantized_matmul", new)
+        except Exception:
+            continue
+
+
 def is_patched():
     return getattr(mx.quantized_matmul, "__unsloth_int8_prefill__", False)
 
@@ -145,12 +173,7 @@ def apply():
     if is_patched():
         return False
     mx.quantized_matmul = _patched_qmm
-    for mod in tuple(sys.modules.values()):
-        if mod is not None and getattr(mod, "quantized_matmul", None) is _ORIG_QMM:
-            try:
-                setattr(mod, "quantized_matmul", _patched_qmm)
-            except Exception:
-                pass
+    _sweep_rebind(_ORIG_QMM, _patched_qmm)
     logger.info(
         "Unsloth: MLX int8 prefill patch applied (row threshold %d, backend %s)",
         ROW_THRESHOLD, backends.select().__name__.rsplit(".", 1)[-1],
@@ -163,12 +186,7 @@ def revert():
     if not is_patched():
         return False
     mx.quantized_matmul = _ORIG_QMM
-    for mod in tuple(sys.modules.values()):
-        if mod is not None and getattr(mod, "quantized_matmul", None) is _patched_qmm:
-            try:
-                setattr(mod, "quantized_matmul", _ORIG_QMM)
-            except Exception:
-                pass
+    _sweep_rebind(_patched_qmm, _ORIG_QMM)
     return True
 
 

--- a/unsloth_zoo/mlx/int8_prefill/patch.py
+++ b/unsloth_zoo/mlx/int8_prefill/patch.py
@@ -1,0 +1,224 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The monkey patch itself.
+
+`mx.quantized_matmul` is replaced rather than `nn.QuantizedLinear.__call__`, because the
+op is where every quantized projection converges: tied lm_heads reach it through
+`QuantizedEmbedding.as_linear`, DeepSeek-family MLA through `QuantizedMultiLinear`, and
+sharded models through the distributed linears. Patching the layer would need five
+separate class patches and would still miss anything calling the op directly.
+
+Probed on MLX 0.32.1: assignment on the nanobind module works, `functools.wraps`
+round-trips so `disable()` has a handle, and nothing in mlx, mlx-lm or unsloth_zoo
+imports `quantized_matmul` by value -- the `sys.modules` sweep below is insurance
+against a future by-value import, not a present requirement.
+"""
+
+import functools
+import logging
+import os
+import sys
+
+import mlx.core as mx
+
+from . import backends, capability, registry
+from .eligibility import ROW_THRESHOLD
+
+logger = logging.getLogger(__name__)
+
+_ORIG_QMM = mx.quantized_matmul
+_ACT_DTYPES = (mx.bfloat16, mx.float16, mx.float32)
+
+_disabled_by_selftest = False
+
+
+def _verify_mode():
+    return os.environ.get("UNSLOTH_MLX_INT8_VERIFY", "0").lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _make_fn(entry, backend):
+    """A differentiable W8A8 callable for one registered weight.
+
+    `mx.fast.metal_kernel` outputs carry no vjp, so without this a LoRA backward through
+    an intercepted prefill would fail deep inside the trainer -- Unsloth's MLX path
+    wraps `nn.QuantizedLinear` in `mlx_lm.tuner.lora.LoRALinear`, whose `__call__` needs
+    `dL/dx`. The gradient delegates to the stock 4-bit op, so it is exact rather than a
+    straight-through approximation: only the forward is quantized further.
+    """
+    bits, gs = entry.bits, entry.group_size
+    w, scales, biases = entry.w, entry.scales, entry.biases
+
+    @mx.custom_function
+    def fn(x):
+        return backend.matmul(x, entry, out_dtype=x.dtype)
+
+    @fn.vjp
+    def _(primals, cotangent, output):
+        # MLX hands a single-argument custom_function its primal directly rather than as
+        # a 1-tuple. We do not need it either way: the gradient w.r.t. x is cotangent @ W,
+        # and W is captured above.
+        return _ORIG_QMM(cotangent, w, scales, biases, False, gs, bits, "affine")
+
+    return fn
+
+
+def _dispatch(x, entry):
+    backend = backends.select()
+    if entry.fn is None:
+        entry.fn = _make_fn(entry, backend)
+    out = entry.fn(x)
+
+    if _verify_mode():
+        from .backends import portable
+
+        ref = _ORIG_QMM(
+            x, entry.w, entry.scales, entry.biases, True, entry.group_size,
+            entry.bits, "affine",
+        )
+        err = mx.abs(out.astype(mx.float32) - ref.astype(mx.float32)).max()
+        denom = mx.maximum(mx.abs(ref.astype(mx.float32)).max(), 1e-8)
+        mx.eval(err, denom)
+        logger.info(
+            "Unsloth: MLX int8 verify %s rows=%d max_rel_err=%.3e",
+            entry.name, x.size // x.shape[-1], (err / denom).item(),
+        )
+    return out
+
+
+@functools.wraps(_ORIG_QMM)
+def _patched_qmm(x, w, /, *args, **kwargs):
+    # Callers pass these positionally as often as not -- mlx-lm/mlx_lm/models/base.py:84
+    # does `mx.quantized_matmul(queries, *q_keys, transpose=..., ...)` -- so bind by hand
+    # rather than assuming keywords.
+    n = len(args)
+    biases     = args[1] if n > 1 else kwargs.get("biases")
+    transpose  = args[2] if n > 2 else kwargs.get("transpose", True)
+    group_size = args[3] if n > 3 else kwargs.get("group_size")
+    bits       = args[4] if n > 4 else kwargs.get("bits")
+    mode       = args[5] if n > 5 else kwargs.get("mode", "affine")
+
+    if (
+        not _disabled_by_selftest
+        and kwargs.get("stream") is None  # a metal_kernel launch cannot honour a stream
+        and transpose is True
+        and mode == "affine"
+        and biases is not None
+        and getattr(w, "ndim", 0) == 2
+        and x.dtype in _ACT_DTYPES
+    ):
+        entry = registry.get(w)
+        if (
+            entry is not None
+            and (group_size is None or group_size == entry.group_size)
+            and (bits is None or bits == entry.bits)
+            and x.size // x.shape[-1] >= ROW_THRESHOLD
+        ):
+            return _dispatch(x, entry)
+
+    return _ORIG_QMM(x, w, *args, **kwargs)
+
+
+_patched_qmm.__unsloth_int8_prefill__ = True
+
+
+def is_patched():
+    return getattr(mx.quantized_matmul, "__unsloth_int8_prefill__", False)
+
+
+def apply():
+    """Install the patch. Returns True if it was installed by this call."""
+    if is_patched():
+        return False
+    mx.quantized_matmul = _patched_qmm
+    for mod in tuple(sys.modules.values()):
+        if mod is not None and getattr(mod, "quantized_matmul", None) is _ORIG_QMM:
+            try:
+                setattr(mod, "quantized_matmul", _patched_qmm)
+            except Exception:
+                pass
+    logger.info(
+        "Unsloth: MLX int8 prefill patch applied (row threshold %d, backend %s)",
+        ROW_THRESHOLD, backends.select().__name__.rsplit(".", 1)[-1],
+    )
+    return True
+
+
+def revert():
+    """Restore MLX's original op."""
+    if not is_patched():
+        return False
+    mx.quantized_matmul = _ORIG_QMM
+    for mod in tuple(sys.modules.values()):
+        if mod is not None and getattr(mod, "quantized_matmul", None) is _patched_qmm:
+            try:
+                setattr(mod, "quantized_matmul", _ORIG_QMM)
+            except Exception:
+                pass
+    return True
+
+
+def self_test(max_entries=4):
+    """Run every registered shape through the real kernels and compare exactly.
+
+    This is the safety net for hardware we have never run on. The Metal GEMM's tile
+    conventions -- the transposed-right extents, the cooperative-tensor index ordering,
+    the ragged-M epilogue guard -- are asserted in comments and checked nowhere, so if
+    any of them is wrong the failure mode is wrong tokens, not an exception. Comparing
+    against the stock op over the shapes actually registered turns that into a clean
+    disable.
+
+    Returns (ok, detail). On failure the patch stops dispatching permanently.
+    """
+    global _disabled_by_selftest
+
+    entries = list(registry._entries.values())[:max_entries]
+    if not entries:
+        return True, "no registered weights to test"
+
+    backend = backends.select()
+    for entry in entries:
+        # A ragged row count on purpose: M % 128 != 0 exercises the epilogue guard, and
+        # a full-tile-only test would miss a broken one.
+        for rows in (ROW_THRESHOLD, ROW_THRESHOLD + 37):
+            x = mx.random.normal((rows, entry.k)).astype(mx.bfloat16)
+            try:
+                got = backend.matmul(x, entry, out_dtype=mx.float32)
+                want = _ORIG_QMM(
+                    x, entry.w, entry.scales, entry.biases, True,
+                    entry.group_size, entry.bits, "affine",
+                ).astype(mx.float32)
+                err = (mx.abs(got - want).max()
+                       / mx.maximum(mx.abs(want).max(), 1e-8))
+                mx.eval(err)
+                rel = err.item()
+            except BaseException as exc:
+                _disabled_by_selftest = True
+                return False, f"{entry.name} rows={rows}: {type(exc).__name__}: {exc}"
+            # W8A8 is lossy by design, so this is a sanity bar, not an equality check:
+            # a correct kernel lands well inside it and a transposed or mis-indexed one
+            # is nowhere near.
+            if not (rel < 0.15):
+                _disabled_by_selftest = True
+                return False, f"{entry.name} rows={rows}: max_rel_err={rel:.3e}"
+
+    return True, f"{len(entries)} weight(s) verified"
+
+
+def reset_selftest():
+    global _disabled_by_selftest
+    _disabled_by_selftest = False

--- a/unsloth_zoo/mlx/int8_prefill/registry.py
+++ b/unsloth_zoo/mlx/int8_prefill/registry.py
@@ -1,0 +1,171 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The allow-list of weights the int8 path may touch.
+
+`mx.quantized_matmul` is a shared op: the same call serves MLP projections, tied
+lm_heads, MLA multi-linears, and -- with a quantized KV cache -- attention itself, where
+the "weight" is a freshly built per-step cache tensor. Rather than trying to tell these
+apart from inside the hot path with shape heuristics, `warmup()` walks the model once,
+decides per module (where the module *path* is known, which the op never sees), and
+records the weights it approves.
+
+That makes the hot path a dict lookup plus an identity check, and gives four properties
+the reference implementation's per-call heuristics do not have:
+
+  * `mx.eval` happens only here, so the hot path emits pure graph ops and survives
+    `mx.compile`, which raises on eval inside a trace.
+  * A registered shape has already been proven to evaluate on this device, so lazy
+    evaluation cannot surface a kernel failure far from any try/except.
+  * Scope policy ("MLP only") is a registration decision, not a shape guess.
+  * Entries hold a strong reference to the weight array, so `id()` cannot be recycled
+    underneath us. The reference's `_ws_cache[id(m)]` keeps no reference and will hand
+    back another layer's per-channel scales after a GC.
+"""
+
+import logging
+import threading
+
+import mlx.core as mx
+
+from .eligibility import is_eligible
+from .scales import channel_scale
+
+logger = logging.getLogger(__name__)
+
+
+class Entry:
+    """An approved weight and everything the int8 path needs for it.
+
+    `expert_dim` is None for a dense 2-D weight and the expert count for a stacked
+    `[E, N, K]` MoE weight. Nothing populates it yet -- `mx.gather_qmm` is phase 2 -- but
+    carrying it now keeps the requant kernel indexing over `E*N` rows from day one, so
+    MoE support is a GEMM rather than a rework.
+    """
+
+    __slots__ = ("w", "scales", "biases", "ws", "bits", "group_size", "n", "k",
+                 "name", "expert_dim", "fn")
+
+    def __init__(self, w, scales, biases, ws, bits, group_size, n, k, name,
+                 expert_dim=None):
+        # Lazily filled by patch.py with the differentiable wrapper for this weight.
+        self.fn = None
+        self.w = w
+        self.scales = scales
+        self.biases = biases
+        self.ws = ws
+        self.bits = bits
+        self.group_size = group_size
+        self.n = n
+        self.k = k
+        self.name = name
+        self.expert_dim = expert_dim
+
+
+_entries = {}
+_lock = threading.Lock()
+
+
+def get(weight):
+    """Entry for `weight`, or None. The identity re-check is the point: an `id()` that
+    survives its array would otherwise silently select another layer's scales."""
+    e = _entries.get(id(weight))
+    if e is not None and e.w is weight:
+        return e
+    return None
+
+
+def clear():
+    with _lock:
+        _entries.clear()
+
+
+def size():
+    return len(_entries)
+
+
+def names():
+    return sorted(e.name for e in _entries.values())
+
+
+def _dims_of(module):
+    """(n, k) in elements. The packed last dim is words, not values."""
+    n, packed_k = module["weight"].shape[-2:]
+    return n, packed_k * 32 // module.bits
+
+
+def register_module(module, name, exact_scales=None):
+    """Approve one `nn.QuantizedLinear`-like module. Returns (ok, reason)."""
+    if "weight" not in module or "scales" not in module:
+        return False, "not a quantized module"
+    biases = module.get("biases") if hasattr(module, "get") else None
+    bits = getattr(module, "bits", None)
+    group_size = getattr(module, "group_size", None)
+    mode = getattr(module, "mode", "affine")
+    if bits is None or group_size is None:
+        return False, "missing bits/group_size"
+
+    n, k = _dims_of(module)
+    ok, why = is_eligible(n, k, bits, group_size, mode, has_biases=biases is not None)
+    if not ok:
+        return False, why
+
+    w = module["weight"]
+    ws = channel_scale(w, module["scales"], biases, bits, group_size, exact=exact_scales)
+    # The one eval in the whole module. Materializing here is what keeps the hot path
+    # trace-safe, and it also means a broken scale computation fails during warmup
+    # rather than mid-generation.
+    mx.eval(ws)
+
+    with _lock:
+        _entries[id(w)] = Entry(
+            w, module["scales"], biases, ws, bits, group_size, n, k, name
+        )
+    return True, None
+
+
+def warmup(model, scope="all", exact_scales=None):
+    """Walk `model` and register every eligible quantized projection.
+
+    `scope="mlp"` restricts to the feed-forward projections by module name, the
+    conservative choice if a quality eval implicates attention. This is a name-based
+    decision, which is only possible here -- the op-level hot path has no idea which
+    module it is serving.
+
+    Returns (registered, skipped).
+    """
+    import mlx.nn as nn
+
+    registered, skipped = 0, 0
+    for name, module in model.named_modules():
+        if not isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
+            continue
+        if scope == "mlp" and not any(
+            part in name for part in ("mlp", "feed_forward", "ffn")
+        ):
+            skipped += 1
+            continue
+        ok, why = register_module(module, name, exact_scales=exact_scales)
+        if ok:
+            registered += 1
+        else:
+            skipped += 1
+            logger.debug("Unsloth: MLX int8 skipping %s (%s)", name, why)
+
+    logger.info(
+        "Unsloth: MLX int8 prefill registered %d module(s), skipped %d (scope=%s)",
+        registered, skipped, scope,
+    )
+    return registered, skipped

--- a/unsloth_zoo/mlx/int8_prefill/scales.py
+++ b/unsloth_zoo/mlx/int8_prefill/scales.py
@@ -1,0 +1,107 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Per-output-channel int8 scales for an affine-quantized weight.
+
+An affine weight stores `w = scales * q + biases` with `q` an integer in
+`[0, 2**bits - 1]`. To requantize into symmetric int8 we need `max|w|` along each output
+channel. Two ways to get it:
+
+**bound** (default, free). Within a group the extremes of `w` can only occur at `q = 0`
+or `q = 2**bits - 1`, so `max|w| <= max(|b|, |lvl*s + b|)`, computed from the scale and
+bias tensors alone -- no dequantization, ~10 MB for a 27B model, computed once.
+
+**exact** (opt-in). Dequantize a layer at a time and take the true absmax.
+
+Measured against stock `mx.quantize` output the two agree almost everywhere, because
+MLX's affine quantizer sets `bias = group min`, so code 0 is attained in every group and
+the bound is tight. For float32 and float16 storage they are identical. For bfloat16 a
+thin tail -- 0.1% of channels, worst case 8/7 -- comes out loose, because bf16 rounding
+of the group scale can leave the top code unused, making the group's true maximum
+`13*s + b` rather than `15*s + b`. Measured end to end, correcting that tail moves the
+matmul's mean and max relative error by nothing (0.00875 either way), so the bound stays
+the default. `tests/mlx_int8/test_numerics.py` asserts the distribution, so if MLX ever
+changes its quantizer the tests fail rather than quality degrading silently on hardware
+we cannot test on.
+
+Where they differ is learned or clipped quantizers -- DWQ (`mlx_lm/quant/dwq.py:97`
+learns scales by gradient descent), AWQ, GPTQ -- which do not attain the extremes by
+construction. There the bound over-estimates, which costs int8 range. Hence the flag.
+
+A note on what this does *not* fix: the real precision cost of this technique is
+per-channel versus per-group granularity. A channel whose groups differ in range by a
+factor R gets an int8 step of `max_g range_g / 254` against a native `range_g / lvl`.
+At 4 bits that tolerates R up to ~17; at 8 bits it tolerates almost nothing. Exact
+absmax does not change that -- only finer int8 granularity would.
+"""
+
+import logging
+import os
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+INT8_MAX = 127.0
+_EPS = 1e-8
+
+
+def use_exact_scales() -> bool:
+    return os.environ.get("UNSLOTH_MLX_INT8_EXACT_SCALES", "0").lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def channel_scale_bound(scales, biases, bits):
+    """Per-channel int8 scale from the quant metadata alone. No dequantization."""
+    s = scales.astype(mx.float32)
+    b = biases.astype(mx.float32)
+    lvl = float((1 << bits) - 1)
+    per_group = mx.maximum(mx.abs(b), mx.abs(lvl * s + b))
+    return mx.maximum(per_group.max(axis=-1), _EPS) / INT8_MAX
+
+
+def channel_scale_exact(weight, scales, biases, bits, group_size):
+    """Per-channel int8 scale from the true dequantized absmax.
+
+    Materializes one layer in high precision, then drops it. Caller should `mx.eval` and
+    move on so peak memory stays at one layer.
+    """
+    dq = mx.dequantize(
+        weight, scales, biases, group_size=group_size, bits=bits, mode="affine"
+    )
+    return mx.maximum(mx.abs(dq).max(axis=-1).astype(mx.float32), _EPS) / INT8_MAX
+
+
+def channel_scale(weight, scales, biases, bits, group_size, exact=None):
+    """Per-channel int8 scale, `exact` defaulting to the environment."""
+    if exact is None:
+        exact = use_exact_scales()
+    if exact:
+        return channel_scale_exact(weight, scales, biases, bits, group_size)
+    return channel_scale_bound(scales, biases, bits)
+
+
+def group_range_ratio(scales, bits):
+    """Per-channel R = max_g range_g / min_g range_g, the quantity that decides whether
+    requantizing to per-channel int8 is safe.
+
+    Diagnostic only. R is what the headroom argument in the module docstring is about,
+    so this is what to report when a model's quality regresses under the int8 path.
+    """
+    s = mx.abs(scales.astype(mx.float32))
+    lvl = float((1 << bits) - 1)
+    rng = s * lvl
+    return rng.max(axis=-1) / mx.maximum(rng.min(axis=-1), _EPS)


### PR DESCRIPTION
## What this does

MLX computes quantized matmuls in 16-bit regardless of how the weights are stored, so a 4-bit model prefills no faster than an 8-bit one. On Apple M5, whose neural accelerators run int8 at roughly twice the fp16 rate, routing prefill-sized matmuls through an `int8 x int8 -> int32` GEMM recovers that. Decode is memory-bound and keeps MLX's kernels untouched.

Adapted from [JetBrains' int8 NAX prefill patch for mlx-vlm](https://github.com/JetBrains/mlx-vlm/tree/feature/int8-prefill) (MIT, attribution retained in the kernel file), which measured **+29.5% at 6.4k tokens and +47.3% at 11.8k** on Qwen3.6-27B-4bit for Junie Local.

Worth noting the gap is not MLX-specific. llama.cpp has had int8 W8A8 on CUDA for years (`ggml-cuda/mmq.cuh`, with `mma.cuh` emitting `mma.sync...s32.s8.s8.s32`), but its **Metal** backend dequantizes the weight tile to 16-bit and runs `matmul2d` with a float accumulator (`ggml-metal/kernels/mul_mm.metal`), exactly as MLX does. So this is unfilled on Apple silicon generally, not just here.

## Usage

Opt-in, and a hard no-op everywhere it is not supported.

```python
from unsloth_zoo.mlx import int8_prefill

if int8_prefill.enable():          # False, and a no-op, off M5
    int8_prefill.warmup(model)     # required: builds the allow-list
    ok, detail = int8_prefill.self_test()
```

`warmup()` is not optional. Nothing is accelerated until a weight is registered, and registration is also where every `mx.eval` happens, which is what leaves the hot path safe inside `mx.compile`.

## Differences from the reference implementation

- **Patches `mx.quantized_matmul` at op level** rather than `nn.QuantizedLinear.__call__`. Tied lm_heads reach the op through `QuantizedEmbedding.as_linear` (68 model files in mlx-lm), MLA through `QuantizedMultiLinear`, sharded models through the distributed linears. A layer-level patch needs five separate class patches to cover the same ground. Verified that nothing in mlx, mlx-lm or `unsloth_zoo.mlx` imports the symbol by value, so the `sys.modules` sweep is insurance rather than a requirement.
- **Dispatch is gated on a warmup-built registry**, not per-call shape heuristics. This keeps the quantized-KV attention path (`mlx_lm/models/base.py`, where the "weight" is a per-step cache tensor) out by construction, moves every `mx.eval` into warmup so the hot path survives `mx.compile`, and makes scope policy a registration decision, since warmup knows the module path and the op does not.
- **The fast path is an `mx.custom_function`** whose vjp delegates to the stock 4-bit op. `mx.fast.metal_kernel` outputs carry no vjp, so without this a LoRA backward through an intercepted prefill would fail inside the trainer.
- **Group sizes 32/64/128**, and the nibble arithmetic is parameterized on bits rather than assuming 4.
- **The MetalPerformancePrimitives include is isolated to the GEMM**, so the activation-quant and weight-requant kernels compile on any Metal device and can be validated in CI.
- **A self-test at `enable()`** runs registered shapes, including a ragged `M % 128 != 0`, against MLX's own op on the real device and disables permanently on mismatch.
- Idempotent, with `disable()` restoring `mx.quantized_matmul` exactly.

## Affine 8-bit is implemented but off by default

This is arithmetic, not caution. Requantizing affine-8 to symmetric int8 has no headroom: the requant step is `max_g range_g / 254` against a native `range_g / 255`, so any channel whose inter-group range ratio exceeds about 1.2 comes out **worse than the weights it started from**. At 4 bits the same requant has roughly 16x of cushion, which is the only reason the technique works at all. Enable with `UNSLOTH_MLX_INT8_ALLOW_8BIT=1` only alongside a KLD check.

## What is verified, and what is not

**The speedup is unverified.** No GitHub runner tier offers an M5. The macOS leg measured that `mpp::tensor_ops::matmul2d` with int8 operands does not even load on M1 (`[metal::Device] Unable to load kernel`) while a trivial Metal kernel JITs fine on the same runner, so the GEMM is M5-only by nature rather than by choice.

| | Verified | How |
| --- | --- | --- |
| Dispatch: what is intercepted, what falls through bit-identically | yes | 70 tests, any MLX backend |
| W8A8 arithmetic and its error against MLX's 4-bit op | yes | portable backend, machine-independent |
| `mx.compile` safety, LoRA backward, idempotency, no-op path | yes | 70 tests |
| Packed-weight unpacking on real Metal | yes | macOS CI, all 3 group sizes, within one int8 LSB |
| GEMM tile conventions | no | needs M5 |
| Any performance claim | no | needs M5 |

The one int8 LSB tolerance is Metal's `rint` rounding halves to even where `mx.round` does not, so ties can differ by one and nothing else may.

Mitigations for the untested GEMM: the `enable()` self-test above, and `UNSLOTH_MLX_INT8_VERIFY=1` shadow mode which logs max relative error per intercepted call.

If you have an M5, I have a bench harness that reproduces JetBrains' context points (256 / 2k / 6.4k / 11.8k / 20k) for a direct comparison. Happy to add it here if wanted.

## CI

Added to the existing `mlx-smoke` job rather than a new workflow: macOS concurrency is capped at 5 jobs account-wide and that runner already has the MLX stack provisioned, so a second workflow would spend a slot reinstalling what is already there.

The most important assertion is inverted from what you would expect: the capability probe **must return False** on the M1 runner, and enabling the module must leave a model forward bit-identical. That is the configuration every current Mac user is in, so it is the check that protects them.

## Not covered

MoE gains nothing yet. Expert FFNs go through `mx.gather_qmm` (`mlx_lm/models/switch_layers.py`), not `mx.quantized_matmul`, and on a Qwen3-MoE-class model those are the dominant prefill FLOPs. A grouped GEMM over ragged per-expert row counts is a separate kernel. Registry entries already carry an optional expert dimension so it stays a GEMM rather than a rework.

## Side finding

MLX 0.32.1's CUDA backend raises `cuGraphAddKernelNode "invalid argument"` for `mx.quantized_matmul` at `group_size=128`. Reproducible with none of this code loaded, and absent on Metal. One numerics test skips on Linux for that reason and the macOS leg asserts the same call works there, so it is covered rather than dropped. Worth reporting upstream to ml-explore separately.
