### PR TITLE
Check FlashInfer can LINK, not just that nvcc and ninja exist

### DIFF
--- a/tests/test_vllm_flashinfer_linkability.py
+++ b/tests/test_vllm_flashinfer_linkability.py
@@ -32,6 +32,7 @@ the build from the sampler kernels to the attention kernels, and vLLM exposes
 no prefill-specific opt-out.
 """
 
+import contextlib
 import os
 from unittest import mock
 
@@ -44,11 +45,25 @@ def _stub(tmp_path, name = "libcuda.so"):
     return str(path)
 
 
+@contextlib.contextmanager
+def _no_ambient_cuda():
+    """Neutralise the two sources that come from the HOST rather than from the
+    environment: the nvcc-inferred CUDA root and the linker's own defaults.
+
+    The machine running the tests very often has both a real toolkit and a real
+    driver stub, so without this every negative assertion below would pass or
+    fail depending on who ran it."""
+    with mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
+         mock.patch.object(vllm_utils, "_linker_default_dirs", lambda: ()):
+        yield
+
+
 def test_a_runtime_libcuda_without_the_stub_is_not_linkable(tmp_path):
     """The exact shape of the image that motivated this: libcuda.so.1 present,
     libcuda.so absent. Every other check passes and the link cannot."""
     (tmp_path / "libcuda.so.1").write_bytes(b"")
-    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
+    with _no_ambient_cuda(), \
+         mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
                                       "LIBRARY_PATH": ""}, clear = False):
         assert vllm_utils._can_link_libcuda() is False
@@ -57,7 +72,8 @@ def test_a_runtime_libcuda_without_the_stub_is_not_linkable(tmp_path):
 def test_the_stub_beside_the_runtime_is_linkable(tmp_path):
     (tmp_path / "libcuda.so.1").write_bytes(b"")
     _stub(tmp_path)
-    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
+    with _no_ambient_cuda(), \
+         mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
                                       "LIBRARY_PATH": ""}, clear = False):
         assert vllm_utils._can_link_libcuda() is True
@@ -73,7 +89,8 @@ def test_a_stub_supplied_through_library_path_counts(tmp_path):
     _stub(supplied)
     empty = tmp_path / "cuda"
     empty.mkdir()
-    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
+    with _no_ambient_cuda(), \
+         mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
                                       "LIBRARY_PATH": str(supplied)}, clear = False):
         assert vllm_utils._can_link_libcuda() is True
@@ -86,7 +103,8 @@ def test_cuda_home_stubs_count(tmp_path):
     _stub(stubs)
     empty = tmp_path / "nothing"
     empty.mkdir()
-    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
+    with _no_ambient_cuda(), \
+         mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": str(root), "CUDA_PATH": "",
                                       "LIBRARY_PATH": ""}, clear = False):
         assert vllm_utils._can_link_libcuda() is True
@@ -94,15 +112,23 @@ def test_cuda_home_stubs_count(tmp_path):
 
 def test_an_empty_library_path_entry_is_not_a_directory(tmp_path):
     """`LIBRARY_PATH=""` splits to [""], and os.path.join("", "libcuda.so") is a
-    RELATIVE path -- which exists whenever the process happens to be running in
-    a directory that has one. Filtering empties keeps the answer from depending
-    on the working directory."""
+    RELATIVE path -- which exists whenever THIS process happens to be running in
+    a directory that has one.
+
+    GCC really does treat an empty LIBRARY_PATH component as the current
+    directory, but the current directory that matters is not this one:
+    FlashInfer runs the link through `ninja -C <build_dir>` with
+    `cwd=<build_dir>`, so `c++` resolves a relative -L against its own JIT cache
+    directory, never against the directory Python was started in. Filtering
+    empties is therefore correct -- honouring them would answer a question about
+    the wrong directory."""
     empty = tmp_path / "nothing"
     empty.mkdir()
     cwd = tmp_path / "cwd"
     cwd.mkdir()
     _stub(cwd)
-    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
+    with _no_ambient_cuda(), \
+         mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
                                       "LIBRARY_PATH": ""}, clear = False):
         here = os.getcwd()
@@ -111,6 +137,87 @@ def test_an_empty_library_path_entry_is_not_a_directory(tmp_path):
             assert vllm_utils._can_link_libcuda() is False
         finally:
             os.chdir(here)
+
+
+# ------------------------------------------- false negatives are the bad kind
+#
+# Answering False when the link would have succeeded silently disables
+# FlashInfer on a machine where it works. Answering True when the link then
+# fails merely restores the behaviour that existed before this check. The two
+# tests below cover the two ways the first, dangerous mistake was reachable.
+
+
+def test_a_stub_in_a_default_linker_directory_counts(tmp_path):
+    """`c++ ... -lcuda` searches ld's built-in SEARCH_DIRs with no -L at all,
+    and the NVIDIA driver installer puts the unversioned libcuda.so symlink in
+    one of them (/usr/lib/x86_64-linux-gnu on Debian/Ubuntu). A toolkit whose
+    stubs directory is absent still links fine there, so reporting False would
+    disable a working FlashInfer."""
+    default = tmp_path / "usr-lib"
+    default.mkdir()
+    _stub(default)
+    empty = tmp_path / "nothing"
+    empty.mkdir()
+    with mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
+         mock.patch.object(vllm_utils, "_linker_default_dirs",
+                           lambda: (str(default),)), \
+         mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
+         mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
+                                      "LIBRARY_PATH": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is True
+
+
+def test_the_cuda_root_inferred_from_nvcc_counts(tmp_path):
+    """With neither CUDA_HOME nor CUDA_PATH set, FlashInfer's get_cuda_path()
+    falls back to dirname(dirname(which nvcc)). A toolkit at /opt/cuda or in a
+    conda prefix therefore links against its own lib64/stubs, and checking only
+    /usr/local/cuda would call that machine unlinkable."""
+    root = tmp_path / "opt-cuda"
+    stubs = root / "lib64" / "stubs"
+    stubs.mkdir(parents = True)
+    _stub(stubs)
+    empty = tmp_path / "nothing"
+    empty.mkdir()
+    with mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc",
+                           lambda: (str(root),)), \
+         mock.patch.object(vllm_utils, "_linker_default_dirs", lambda: ()), \
+         mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
+         mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
+                                      "LIBRARY_PATH": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is True
+
+
+def test_nvcc_root_is_derived_the_way_flashinfer_derives_it(tmp_path):
+    """dirname(dirname(nvcc)), both as found on PATH and symlink-resolved."""
+    real = tmp_path / "opt" / "cuda"
+    (real / "bin").mkdir(parents = True)
+    nvcc = real / "bin" / "nvcc"
+    nvcc.write_bytes(b"")
+    shim_bin = tmp_path / "usr" / "bin"
+    shim_bin.mkdir(parents = True)
+    shim = shim_bin / "nvcc"
+    shim.symlink_to(nvcc)
+    with mock.patch.object(vllm_utils.shutil, "which", lambda name: str(shim)):
+        roots = vllm_utils._cuda_roots_from_nvcc()
+    assert str(tmp_path / "usr") in roots
+    assert str(real) in roots
+
+
+def test_no_nvcc_means_no_inferred_root():
+    with mock.patch.object(vllm_utils.shutil, "which", lambda name: None):
+        assert vllm_utils._cuda_roots_from_nvcc() == ()
+
+
+def test_linker_defaults_never_come_back_empty():
+    """A parse failure must widen to the fallback list, never narrow to nothing:
+    an empty tuple would silently reintroduce the false negative."""
+    vllm_utils._linker_default_dirs.cache_clear()
+    try:
+        with mock.patch.object(vllm_utils, "re") as fake_re:
+            fake_re.findall.return_value = []
+            assert vllm_utils._linker_default_dirs() == vllm_utils._FALLBACK_LINKER_DIRS
+    finally:
+        vllm_utils._linker_default_dirs.cache_clear()
 
 
 # ------------------------------------------------------------ platform scope
@@ -158,7 +265,8 @@ def test_wsl_is_linux_and_is_checked(tmp_path):
     """WSL reports sys.platform == "linux" and uses the POSIX toolchain, so it
     must take the Linux branch rather than be treated as Windows."""
     (tmp_path / "libcuda.so.1").write_bytes(b"")
-    with mock.patch.object(vllm_utils.sys, "platform", "linux"), \
+    with _no_ambient_cuda(), \
+         mock.patch.object(vllm_utils.sys, "platform", "linux"), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
                                       "LIBRARY_PATH": ""}, clear = False):

--- a/tests/test_vllm_flashinfer_linkability.py
+++ b/tests/test_vllm_flashinfer_linkability.py
@@ -52,12 +52,20 @@ def _stub(tmp_path, name = "libcuda.so"):
 
 
 @contextlib.contextmanager
-def _no_ambient_cuda():
-    """Neutralise the two HOST-derived sources: the nvcc-inferred CUDA root and
-    the linker's own defaults. The test machine often has both a real toolkit
-    and a real driver stub, so without this the negative assertions below would
-    pass or fail depending on who ran them."""
-    with mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
+def _linux_with_no_ambient_cuda():
+    """Everything below asserts LINUX semantics, so pin the platform and
+    neutralise the two HOST-derived sources: the nvcc-inferred CUDA root and
+    the linker's own defaults.
+
+    Both halves are load-bearing, and the platform pin was learned the hard
+    way. On macOS and Windows `_can_link_libcuda` returns before any of this
+    runs, so unpinned these tests silently answered a different question: on a
+    macOS runner the two negative assertions went red (darwin returns True) and
+    the positive ones went green for the wrong reason. A test that passes
+    because the function short-circuited is worse than one that fails.
+    """
+    with mock.patch.object(vllm_utils.sys, "platform", "linux"), \
+         mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
          mock.patch.object(vllm_utils, "_linker_default_dirs", lambda: ()):
         yield
 
@@ -66,7 +74,7 @@ def test_a_runtime_libcuda_without_the_stub_is_not_linkable(tmp_path):
     """The image that motivated this: libcuda.so.1 present, libcuda.so absent.
     Every other check passes and the link still cannot."""
     (tmp_path / "libcuda.so.1").write_bytes(b"")
-    with _no_ambient_cuda(), \
+    with _linux_with_no_ambient_cuda(), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
                                       "LIBRARY_PATH": ""}, clear = False):
@@ -76,7 +84,7 @@ def test_a_runtime_libcuda_without_the_stub_is_not_linkable(tmp_path):
 def test_the_stub_beside_the_runtime_is_linkable(tmp_path):
     (tmp_path / "libcuda.so.1").write_bytes(b"")
     _stub(tmp_path)
-    with _no_ambient_cuda(), \
+    with _linux_with_no_ambient_cuda(), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
                                       "LIBRARY_PATH": ""}, clear = False):
@@ -92,7 +100,7 @@ def test_a_stub_supplied_through_library_path_counts(tmp_path):
     _stub(supplied)
     empty = tmp_path / "cuda"
     empty.mkdir()
-    with _no_ambient_cuda(), \
+    with _linux_with_no_ambient_cuda(), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
                                       "LIBRARY_PATH": str(supplied)}, clear = False):
@@ -106,7 +114,7 @@ def test_cuda_home_stubs_count(tmp_path):
     _stub(stubs)
     empty = tmp_path / "nothing"
     empty.mkdir()
-    with _no_ambient_cuda(), \
+    with _linux_with_no_ambient_cuda(), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": str(root), "CUDA_PATH": "",
                                       "LIBRARY_PATH": ""}, clear = False):
@@ -126,7 +134,7 @@ def test_an_empty_library_path_entry_is_not_a_directory(tmp_path):
     cwd = tmp_path / "cwd"
     cwd.mkdir()
     _stub(cwd)
-    with _no_ambient_cuda(), \
+    with _linux_with_no_ambient_cuda(), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
                                       "LIBRARY_PATH": ""}, clear = False):
@@ -157,7 +165,8 @@ def test_a_stub_in_a_default_linker_directory_counts(tmp_path):
     _stub(default)
     empty = tmp_path / "nothing"
     empty.mkdir()
-    with mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
+    with mock.patch.object(vllm_utils.sys, "platform", "linux"), \
+         mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
          mock.patch.object(vllm_utils, "_linker_default_dirs",
                            lambda: (str(default),)), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
@@ -177,7 +186,8 @@ def test_the_cuda_root_inferred_from_nvcc_counts(tmp_path):
     _stub(stubs)
     empty = tmp_path / "nothing"
     empty.mkdir()
-    with mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc",
+    with mock.patch.object(vllm_utils.sys, "platform", "linux"), \
+         mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc",
                            lambda: (str(root),)), \
          mock.patch.object(vllm_utils, "_linker_default_dirs", lambda: ()), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
@@ -283,7 +293,8 @@ def test_a_runtime_only_multiarch_dir_is_still_not_linkable(tmp_path):
     multiarch = tmp_path / "usr-lib-x86_64-linux-gnu"
     multiarch.mkdir()
     (multiarch / "libcuda.so.1").write_bytes(b"")
-    with mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
+    with mock.patch.object(vllm_utils.sys, "platform", "linux"), \
+         mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
          mock.patch.object(vllm_utils, "_linker_default_dirs",
                            lambda: (str(multiarch),)), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", ()), \
@@ -336,7 +347,7 @@ def test_wsl_is_linux_and_is_checked(tmp_path):
     """WSL reports sys.platform == "linux" and uses the POSIX toolchain, so it
     must take the Linux branch, not the Windows one."""
     (tmp_path / "libcuda.so.1").write_bytes(b"")
-    with _no_ambient_cuda(), \
+    with _linux_with_no_ambient_cuda(), \
          mock.patch.object(vllm_utils.sys, "platform", "linux"), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
          mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",

--- a/tests/test_vllm_flashinfer_linkability.py
+++ b/tests/test_vllm_flashinfer_linkability.py
@@ -1,0 +1,113 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""FlashInfer needs to LINK, not merely compile.
+
+The pre-existing guard checks that nvcc and ninja exist. Both do on plenty of
+container images that still cannot build FlashInfer, because the link passes
+`-lcuda` and therefore needs the driver STUB `libcuda.so` -- not the runtime
+`libcuda.so.1` that every machine with a driver has.
+
+Observed on Kaggle's GPU image: nvcc present, ninja present, every .cu file
+compiled cleanly for sm_75, and the final step died on
+
+    /usr/bin/ld: cannot find -lcuda
+
+reported as `RuntimeError: Ninja build failed` after minutes of nvcc work. No
+environment variable avoids it: `VLLM_USE_FLASHINFER_SAMPLER=0` merely moves
+the build from the sampler kernels to the attention kernels, and vLLM exposes
+no prefill-specific opt-out.
+"""
+
+import os
+from unittest import mock
+
+from unsloth_zoo import vllm_utils
+
+
+def _stub(tmp_path, name = "libcuda.so"):
+    path = tmp_path / name
+    path.write_bytes(b"")
+    return str(path)
+
+
+def test_a_runtime_libcuda_without_the_stub_is_not_linkable(tmp_path):
+    """The exact shape of the image that motivated this: libcuda.so.1 present,
+    libcuda.so absent. Every other check passes and the link cannot."""
+    (tmp_path / "libcuda.so.1").write_bytes(b"")
+    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
+         mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
+                                      "LIBRARY_PATH": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is False
+
+
+def test_the_stub_beside_the_runtime_is_linkable(tmp_path):
+    (tmp_path / "libcuda.so.1").write_bytes(b"")
+    _stub(tmp_path)
+    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
+         mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
+                                      "LIBRARY_PATH": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is True
+
+
+def test_a_stub_supplied_through_library_path_counts(tmp_path):
+    """LIBRARY_PATH is what the linker consults beyond its defaults, so a caller
+    who has already supplied a stub there must not be told FlashInfer is
+    unavailable. Unsloth's own Kaggle GRPO payload does exactly this, which is
+    why that path works where a bare probe does not."""
+    supplied = tmp_path / "shim"
+    supplied.mkdir()
+    _stub(supplied)
+    empty = tmp_path / "cuda"
+    empty.mkdir()
+    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
+         mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
+                                      "LIBRARY_PATH": str(supplied)}, clear = False):
+        assert vllm_utils._can_link_libcuda() is True
+
+
+def test_cuda_home_stubs_count(tmp_path):
+    root = tmp_path / "cuda"
+    stubs = root / "lib64" / "stubs"
+    stubs.mkdir(parents = True)
+    _stub(stubs)
+    empty = tmp_path / "nothing"
+    empty.mkdir()
+    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
+         mock.patch.dict(os.environ, {"CUDA_HOME": str(root), "CUDA_PATH": "",
+                                      "LIBRARY_PATH": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is True
+
+
+def test_an_empty_library_path_entry_is_not_a_directory(tmp_path):
+    """`LIBRARY_PATH=""` splits to [""], and os.path.join("", "libcuda.so") is a
+    RELATIVE path -- which exists whenever the process happens to be running in
+    a directory that has one. Filtering empties keeps the answer from depending
+    on the working directory."""
+    empty = tmp_path / "nothing"
+    empty.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _stub(cwd)
+    with mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(empty),)), \
+         mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
+                                      "LIBRARY_PATH": ""}, clear = False):
+        here = os.getcwd()
+        os.chdir(cwd)
+        try:
+            assert vllm_utils._can_link_libcuda() is False
+        finally:
+            os.chdir(here)

--- a/tests/test_vllm_flashinfer_linkability.py
+++ b/tests/test_vllm_flashinfer_linkability.py
@@ -111,3 +111,55 @@ def test_an_empty_library_path_entry_is_not_a_directory(tmp_path):
             assert vllm_utils._can_link_libcuda() is False
         finally:
             os.chdir(here)
+
+
+# ------------------------------------------------------------ platform scope
+
+
+def test_windows_looks_for_cuda_lib_not_a_posix_stub(tmp_path):
+    """Windows links `cuda.lib` from the toolkit and searches LIB. Probing for
+    libcuda.so there would find nothing and disable FlashInfer on a platform
+    where it works, which is worse than not checking at all."""
+    libdir = tmp_path / "lib" / "x64"
+    libdir.mkdir(parents = True)
+    (libdir / "cuda.lib").write_bytes(b"")
+    with mock.patch.object(vllm_utils.sys, "platform", "win32"), \
+         mock.patch.dict(os.environ, {"CUDA_PATH": str(tmp_path), "CUDA_HOME": "",
+                                      "LIB": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is True
+
+
+def test_windows_without_cuda_lib_is_not_linkable(tmp_path):
+    root = tmp_path / "cuda"
+    (root / "lib" / "x64").mkdir(parents = True)
+    with mock.patch.object(vllm_utils.sys, "platform", "win32"), \
+         mock.patch.dict(os.environ, {"CUDA_PATH": str(root), "CUDA_HOME": "",
+                                      "LIB": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is False
+
+
+def test_windows_with_nothing_to_go_on_does_not_claim_failure():
+    """No CUDA_PATH and no LIB means no evidence either way. Returning False
+    would disable FlashInfer on the strength of a missing env var."""
+    with mock.patch.object(vllm_utils.sys, "platform", "win32"), \
+         mock.patch.dict(os.environ, {"CUDA_PATH": "", "CUDA_HOME": "",
+                                      "LIB": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is True
+
+
+def test_macos_never_claims_the_link_will_fail():
+    """CUDA is not in play on Darwin, so a negative would be an invention. This
+    keeps behaviour byte-identical to before the check existed."""
+    with mock.patch.object(vllm_utils.sys, "platform", "darwin"):
+        assert vllm_utils._can_link_libcuda() is True
+
+
+def test_wsl_is_linux_and_is_checked(tmp_path):
+    """WSL reports sys.platform == "linux" and uses the POSIX toolchain, so it
+    must take the Linux branch rather than be treated as Windows."""
+    (tmp_path / "libcuda.so.1").write_bytes(b"")
+    with mock.patch.object(vllm_utils.sys, "platform", "linux"), \
+         mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
+         mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
+                                      "LIBRARY_PATH": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is False

--- a/tests/test_vllm_flashinfer_linkability.py
+++ b/tests/test_vllm_flashinfer_linkability.py
@@ -16,10 +16,10 @@
 
 """FlashInfer needs to LINK, not merely compile.
 
-The pre-existing guard checks that nvcc and ninja exist. Both do on plenty of
-container images that still cannot build FlashInfer, because the link passes
-`-lcuda` and therefore needs the driver STUB `libcuda.so` -- not the runtime
-`libcuda.so.1` that every machine with a driver has.
+The pre-existing guard checks nvcc and ninja exist. Both do on container images
+that still cannot build FlashInfer, because the link passes `-lcuda` and so
+needs the driver STUB `libcuda.so`, not the runtime `libcuda.so.1` that every
+machine with a driver has.
 
 Observed on Kaggle's GPU image: nvcc present, ninja present, every .cu file
 compiled cleanly for sm_75, and the final step died on
@@ -27,9 +27,9 @@ compiled cleanly for sm_75, and the final step died on
     /usr/bin/ld: cannot find -lcuda
 
 reported as `RuntimeError: Ninja build failed` after minutes of nvcc work. No
-environment variable avoids it: `VLLM_USE_FLASHINFER_SAMPLER=0` merely moves
-the build from the sampler kernels to the attention kernels, and vLLM exposes
-no prefill-specific opt-out.
+env var avoids it: `VLLM_USE_FLASHINFER_SAMPLER=0` merely moves the build from
+the sampler kernels to the attention kernels, and vLLM exposes no
+prefill-specific opt-out.
 """
 
 import contextlib
@@ -47,20 +47,18 @@ def _stub(tmp_path, name = "libcuda.so"):
 
 @contextlib.contextmanager
 def _no_ambient_cuda():
-    """Neutralise the two sources that come from the HOST rather than from the
-    environment: the nvcc-inferred CUDA root and the linker's own defaults.
-
-    The machine running the tests very often has both a real toolkit and a real
-    driver stub, so without this every negative assertion below would pass or
-    fail depending on who ran it."""
+    """Neutralise the two HOST-derived sources: the nvcc-inferred CUDA root and
+    the linker's own defaults. The test machine often has both a real toolkit
+    and a real driver stub, so without this the negative assertions below would
+    pass or fail depending on who ran them."""
     with mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
          mock.patch.object(vllm_utils, "_linker_default_dirs", lambda: ()):
         yield
 
 
 def test_a_runtime_libcuda_without_the_stub_is_not_linkable(tmp_path):
-    """The exact shape of the image that motivated this: libcuda.so.1 present,
-    libcuda.so absent. Every other check passes and the link cannot."""
+    """The image that motivated this: libcuda.so.1 present, libcuda.so absent.
+    Every other check passes and the link still cannot."""
     (tmp_path / "libcuda.so.1").write_bytes(b"")
     with _no_ambient_cuda(), \
          mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", (str(tmp_path),)), \
@@ -81,9 +79,8 @@ def test_the_stub_beside_the_runtime_is_linkable(tmp_path):
 
 def test_a_stub_supplied_through_library_path_counts(tmp_path):
     """LIBRARY_PATH is what the linker consults beyond its defaults, so a caller
-    who has already supplied a stub there must not be told FlashInfer is
-    unavailable. Unsloth's own Kaggle GRPO payload does exactly this, which is
-    why that path works where a bare probe does not."""
+    who supplied a stub there must not be told FlashInfer is unavailable.
+    Unsloth's own Kaggle GRPO payload does exactly this."""
     supplied = tmp_path / "shim"
     supplied.mkdir()
     _stub(supplied)
@@ -111,17 +108,13 @@ def test_cuda_home_stubs_count(tmp_path):
 
 
 def test_an_empty_library_path_entry_is_not_a_directory(tmp_path):
-    """`LIBRARY_PATH=""` splits to [""], and os.path.join("", "libcuda.so") is a
-    RELATIVE path -- which exists whenever THIS process happens to be running in
-    a directory that has one.
-
-    GCC really does treat an empty LIBRARY_PATH component as the current
-    directory, but the current directory that matters is not this one:
-    FlashInfer runs the link through `ninja -C <build_dir>` with
-    `cwd=<build_dir>`, so `c++` resolves a relative -L against its own JIT cache
-    directory, never against the directory Python was started in. Filtering
-    empties is therefore correct -- honouring them would answer a question about
-    the wrong directory."""
+    """`LIBRARY_PATH=""` splits to [""], and os.path.join("", "libcuda.so") is
+    RELATIVE, so it exists whenever THIS process runs in a directory that has
+    one. GCC does treat an empty component as the current directory, but the
+    one that matters is not this one: FlashInfer links via `ninja -C
+    <build_dir>` with `cwd=<build_dir>`, so `c++` resolves a relative -L
+    against its JIT cache directory. Honouring empties would answer a question
+    about the wrong directory."""
     empty = tmp_path / "nothing"
     empty.mkdir()
     cwd = tmp_path / "cwd"
@@ -141,18 +134,18 @@ def test_an_empty_library_path_entry_is_not_a_directory(tmp_path):
 
 # ------------------------------------------- false negatives are the bad kind
 #
-# Answering False when the link would have succeeded silently disables
-# FlashInfer on a machine where it works. Answering True when the link then
-# fails merely restores the behaviour that existed before this check. The two
-# tests below cover the two ways the first, dangerous mistake was reachable.
+# False when the link would have succeeded silently disables FlashInfer on a
+# machine where it works; True when the link then fails merely restores the
+# pre-check behaviour. The two tests below cover the two ways the first,
+# dangerous mistake was reachable.
 
 
 def test_a_stub_in_a_default_linker_directory_counts(tmp_path):
     """`c++ ... -lcuda` searches ld's built-in SEARCH_DIRs with no -L at all,
     and the NVIDIA driver installer puts the unversioned libcuda.so symlink in
-    one of them (/usr/lib/x86_64-linux-gnu on Debian/Ubuntu). A toolkit whose
-    stubs directory is absent still links fine there, so reporting False would
-    disable a working FlashInfer."""
+    one of them (/usr/lib/x86_64-linux-gnu on Debian/Ubuntu). A toolkit with no
+    stubs directory still links there, so False would disable a working
+    FlashInfer."""
     default = tmp_path / "usr-lib"
     default.mkdir()
     _stub(default)
@@ -170,7 +163,7 @@ def test_a_stub_in_a_default_linker_directory_counts(tmp_path):
 def test_the_cuda_root_inferred_from_nvcc_counts(tmp_path):
     """With neither CUDA_HOME nor CUDA_PATH set, FlashInfer's get_cuda_path()
     falls back to dirname(dirname(which nvcc)). A toolkit at /opt/cuda or in a
-    conda prefix therefore links against its own lib64/stubs, and checking only
+    conda prefix links against its own lib64/stubs, so checking only
     /usr/local/cuda would call that machine unlinkable."""
     root = tmp_path / "opt-cuda"
     stubs = root / "lib64" / "stubs"
@@ -209,8 +202,8 @@ def test_no_nvcc_means_no_inferred_root():
 
 
 def test_linker_defaults_never_come_back_empty():
-    """A parse failure must widen to the fallback list, never narrow to nothing:
-    an empty tuple would silently reintroduce the false negative."""
+    """A parse failure must widen to the fallback list: an empty tuple would
+    silently reintroduce the false negative."""
     vllm_utils._linker_default_dirs.cache_clear()
     try:
         with mock.patch.object(vllm_utils, "re") as fake_re:
@@ -226,7 +219,7 @@ def test_linker_defaults_never_come_back_empty():
 def test_windows_looks_for_cuda_lib_not_a_posix_stub(tmp_path):
     """Windows links `cuda.lib` from the toolkit and searches LIB. Probing for
     libcuda.so there would find nothing and disable FlashInfer on a platform
-    where it works, which is worse than not checking at all."""
+    where it works."""
     libdir = tmp_path / "lib" / "x64"
     libdir.mkdir(parents = True)
     (libdir / "cuda.lib").write_bytes(b"")
@@ -246,8 +239,8 @@ def test_windows_without_cuda_lib_is_not_linkable(tmp_path):
 
 
 def test_windows_with_nothing_to_go_on_does_not_claim_failure():
-    """No CUDA_PATH and no LIB means no evidence either way. Returning False
-    would disable FlashInfer on the strength of a missing env var."""
+    """No CUDA_PATH and no LIB is no evidence either way. False would disable
+    FlashInfer on the strength of a missing env var."""
     with mock.patch.object(vllm_utils.sys, "platform", "win32"), \
          mock.patch.dict(os.environ, {"CUDA_PATH": "", "CUDA_HOME": "",
                                       "LIB": ""}, clear = False):
@@ -255,15 +248,14 @@ def test_windows_with_nothing_to_go_on_does_not_claim_failure():
 
 
 def test_macos_never_claims_the_link_will_fail():
-    """CUDA is not in play on Darwin, so a negative would be an invention. This
-    keeps behaviour byte-identical to before the check existed."""
+    """CUDA is not in play on Darwin, so a negative would be an invention."""
     with mock.patch.object(vllm_utils.sys, "platform", "darwin"):
         assert vllm_utils._can_link_libcuda() is True
 
 
 def test_wsl_is_linux_and_is_checked(tmp_path):
     """WSL reports sys.platform == "linux" and uses the POSIX toolchain, so it
-    must take the Linux branch rather than be treated as Windows."""
+    must take the Linux branch, not the Windows one."""
     (tmp_path / "libcuda.so.1").write_bytes(b"")
     with _no_ambient_cuda(), \
          mock.patch.object(vllm_utils.sys, "platform", "linux"), \

--- a/tests/test_vllm_flashinfer_linkability.py
+++ b/tests/test_vllm_flashinfer_linkability.py
@@ -34,7 +34,13 @@ prefill-specific opt-out.
 
 import contextlib
 import os
+import platform
+import subprocess
+import sys
+import sysconfig
 from unittest import mock
+
+import pytest
 
 from unsloth_zoo import vllm_utils
 
@@ -211,6 +217,79 @@ def test_linker_defaults_never_come_back_empty():
             assert vllm_utils._linker_default_dirs() == vllm_utils._FALLBACK_LINKER_DIRS
     finally:
         vllm_utils._linker_default_dirs.cache_clear()
+
+
+def test_multiarch_dirs_cover_the_debian_ubuntu_driver_location():
+    """`/usr/lib/x86_64-linux-gnu` is where the NVIDIA driver puts the
+    unversioned `libcuda.so`, and it is in ld's built-in SEARCH_DIRs, so
+    `c++ ... -lcuda` resolves there with no -L at all."""
+    with mock.patch.object(vllm_utils.sys, "platform", "linux"), \
+         mock.patch.object(platform, "machine", lambda: "x86_64"), \
+         mock.patch.object(sysconfig, "get_config_var",
+                           lambda name: "x86_64-linux-gnu" if name == "MULTIARCH" else None):
+        dirs = vllm_utils._multiarch_linker_dirs()
+    assert "/usr/lib/x86_64-linux-gnu" in dirs
+    assert "/lib/x86_64-linux-gnu" in dirs
+
+
+def test_multiarch_dirs_cover_aarch64_without_a_configured_triplet():
+    """manylinux and conda interpreters have no MULTIARCH; the triplet is then
+    derived from the machine so Jetson / GH200 are still covered."""
+    with mock.patch.object(vllm_utils.sys, "platform", "linux"), \
+         mock.patch.object(platform, "machine", lambda: "aarch64"), \
+         mock.patch.object(sysconfig, "get_config_var", lambda name: None):
+        dirs = vllm_utils._multiarch_linker_dirs()
+    assert "/usr/lib/aarch64-linux-gnu" in dirs
+
+
+def test_multiarch_dirs_are_empty_off_linux():
+    """Windows and macOS never reach the `-lcuda` branch; do not invent paths."""
+    for fake in ("win32", "darwin"):
+        with mock.patch.object(vllm_utils.sys, "platform", fake):
+            assert vllm_utils._multiarch_linker_dirs() == ()
+
+
+def test_the_fallback_includes_the_multiarch_dir_when_ld_cannot_be_consulted():
+    """The regression. `ld --verbose` is unavailable whenever the image has no
+    binutils, or whenever `ld` is really lld -- lld carries no built-in linker
+    script and so emits no SEARCH_DIR (llvm/llvm-project#101661). The fallback
+    is then the entire default-directory search, and it used to list only
+    /usr/lib, /lib, /usr/lib64, /lib64, /usr/local/lib, /usr/local/lib64 --
+    none of which is where Debian/Ubuntu keep libcuda.so. On such a host
+    `_can_link_libcuda()` answered False while `c++ -shared -lcuda` links."""
+    vllm_utils._linker_default_dirs.cache_clear()
+    try:
+        with mock.patch.object(subprocess, "run",
+                               side_effect = FileNotFoundError("no ld")):
+            dirs = vllm_utils._linker_default_dirs()
+    finally:
+        vllm_utils._linker_default_dirs.cache_clear()
+    assert dirs == vllm_utils._FALLBACK_LINKER_DIRS
+    if not sys.platform.startswith("linux"):
+        pytest.skip("multiarch layout is Linux-only")
+    triplet = sysconfig.get_config_var("MULTIARCH") or (platform.machine() + "-linux-gnu")
+    assert "/usr/lib/" + triplet in dirs
+    # The pre-existing entries must survive: RHEL/Fedora and the .run installer
+    # use /usr/lib64, which has no triplet.
+    for kept in ("/usr/lib", "/lib", "/usr/lib64", "/lib64",
+                 "/usr/local/lib", "/usr/local/lib64"):
+        assert kept in dirs
+
+
+def test_a_runtime_only_multiarch_dir_is_still_not_linkable(tmp_path):
+    """The Kaggle constraint, restated against the widened fallback: adding
+    /usr/lib/<triplet> must not make a runtime-only image look linkable.
+    `libcuda.so.1` present and `libcuda.so` absent stays False."""
+    multiarch = tmp_path / "usr-lib-x86_64-linux-gnu"
+    multiarch.mkdir()
+    (multiarch / "libcuda.so.1").write_bytes(b"")
+    with mock.patch.object(vllm_utils, "_cuda_roots_from_nvcc", lambda: ()), \
+         mock.patch.object(vllm_utils, "_linker_default_dirs",
+                           lambda: (str(multiarch),)), \
+         mock.patch.object(vllm_utils, "_FLASHINFER_LINK_DIRS", ()), \
+         mock.patch.dict(os.environ, {"CUDA_HOME": "", "CUDA_PATH": "",
+                                      "LIBRARY_PATH": ""}, clear = False):
+        assert vllm_utils._can_link_libcuda() is False
 
 
 # ------------------------------------------------------------ platform scope

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2031,6 +2031,52 @@ def _install_vllm_decompose_size_nodes_fix():
     return True
 
 
+# The directories `-L` reaches when FlashInfer links its JIT-compiled objects.
+# `/usr/local/cuda/compat` is deliberately NOT among them upstream, which is
+# what makes the check below necessary rather than paranoid.
+_FLASHINFER_LINK_DIRS = (
+    "/usr/local/cuda/lib64",
+    "/usr/local/cuda/lib64/stubs",
+)
+
+
+def _can_link_libcuda() -> bool:
+    """Can a FlashInfer JIT build actually LINK, not merely compile?
+
+    nvcc and ninja being present says the compile step will work. It says
+    nothing about the link, which passes `-lcuda` and therefore needs the
+    driver STUB `libcuda.so` -- not the runtime `libcuda.so.1` that every
+    machine with a driver has.
+
+    Container images routinely ship the runtime and omit the stub. On those,
+    every check above passes, FlashInfer compiles each .cu file cleanly, and
+    the build dies at the final step with
+
+        /usr/bin/ld: cannot find -lcuda
+
+    surfacing as `RuntimeError: Ninja build failed` after minutes of nvcc work.
+    Four separate Kaggle sessions were spent on that failure before the cause
+    was identified, and no environment variable avoids it: disabling the
+    FlashInfer SAMPLER simply moves the build to the attention kernels, and
+    vLLM exposes no prefill-specific opt-out.
+
+    So probe for the stub the linker will actually look for, and treat its
+    absence exactly like a missing compiler: skip FlashInfer and use a backend
+    that works. A false negative here costs some throughput; a false positive
+    costs the whole run.
+    """
+    search = list(_FLASHINFER_LINK_DIRS)
+    for var in ("CUDA_HOME", "CUDA_PATH"):
+        root = os.environ.get(var, "")
+        if root:
+            search.append(os.path.join(root, "lib64"))
+            search.append(os.path.join(root, "lib64", "stubs"))
+    # LIBRARY_PATH is what the linker consults beyond its defaults, so a caller
+    # that has already supplied a stub there is correctly treated as fine.
+    search += [d for d in os.environ.get("LIBRARY_PATH", "").split(os.pathsep) if d]
+    return any(os.path.exists(os.path.join(d, "libcuda.so")) for d in search)
+
+
 def _clear_flashinfer_env_on_hip():
     # AMD ROCm: FlashInfer requires the CUDA nvcc compiler and never applies here.
     # Remove any forced FlashInfer selection unconditionally, even when the package
@@ -2456,11 +2502,14 @@ def load_vllm(
             or os.path.isfile("/usr/local/cuda/bin/nvcc")
         )
         _has_ninja = shutil.which("ninja") is not None
+        # Compiling is not the same as linking; see _can_link_libcuda.
+        _can_link = _can_link_libcuda()
 
-        if not _has_nvcc or not _has_ninja:
+        if not _has_nvcc or not _has_ninja or not _can_link:
             _missing = []
             if not _has_nvcc:  _missing.append("nvcc (CUDA compiler)")
             if not _has_ninja: _missing.append("ninja (build tool)")
+            if not _can_link:  _missing.append("libcuda.so (the CUDA driver stub that -lcuda needs)")
             print(
                 f"Unsloth: FlashInfer requires JIT compilation but {' and '.join(_missing)} "
                 f"{'is' if len(_missing) == 1 else 'are'} not found.\n"
@@ -2468,6 +2517,10 @@ def load_vllm(
                 f"  To enable FlashInfer, install the missing tools:\n"
                 f"    nvcc  - install the CUDA toolkit or set CUDA_HOME to your CUDA installation\n"
                 f"    ninja - pip install ninja\n"
+                f"    libcuda.so - this image has the CUDA runtime but not the driver stub.\n"
+                f"      Install cuda-compat / the CUDA toolkit's stubs, or point LIBRARY_PATH\n"
+                f"      at a directory containing libcuda.so (a symlink to libcuda.so.1 or to\n"
+                f"      /usr/local/cuda/compat/libcuda.so is enough).\n"
                 f"  To silence this warning: set UNSLOTH_VLLM_NO_FLASHINFER=1"
             )
             # Clear any externally-set FlashInfer env vars so vLLM uses defaults

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2031,12 +2031,19 @@ def _install_vllm_decompose_size_nodes_fix():
     return True
 
 
-# The directories `-L` reaches when FlashInfer links its JIT-compiled objects.
-# `/usr/local/cuda/compat` is deliberately NOT among them upstream, which is
-# what makes the check below necessary rather than paranoid.
+# The directories `-L` reaches when FlashInfer links its JIT-compiled objects
+# ON LINUX. `/usr/local/cuda/compat` is deliberately NOT among them upstream,
+# which is what makes the check below necessary rather than paranoid.
 _FLASHINFER_LINK_DIRS = (
     "/usr/local/cuda/lib64",
     "/usr/local/cuda/lib64/stubs",
+)
+
+# Windows links `cuda.lib` out of the toolkit, not a driver stub, and the
+# linker's search path comes from LIB rather than LIBRARY_PATH.
+_FLASHINFER_LINK_DIRS_WINDOWS_SUBDIRS = (
+    os.path.join("lib", "x64"),
+    os.path.join("lib", "Win32"),
 )
 
 
@@ -2044,8 +2051,8 @@ def _can_link_libcuda() -> bool:
     """Can a FlashInfer JIT build actually LINK, not merely compile?
 
     nvcc and ninja being present says the compile step will work. It says
-    nothing about the link, which passes `-lcuda` and therefore needs the
-    driver STUB `libcuda.so` -- not the runtime `libcuda.so.1` that every
+    nothing about the link, which on Linux passes `-lcuda` and therefore needs
+    the driver STUB `libcuda.so` -- not the runtime `libcuda.so.1` that every
     machine with a driver has.
 
     Container images routinely ship the runtime and omit the stub. On those,
@@ -2060,11 +2067,32 @@ def _can_link_libcuda() -> bool:
     FlashInfer SAMPLER simply moves the build to the attention kernels, and
     vLLM exposes no prefill-specific opt-out.
 
-    So probe for the stub the linker will actually look for, and treat its
-    absence exactly like a missing compiler: skip FlashInfer and use a backend
-    that works. A false negative here costs some throughput; a false positive
-    costs the whole run.
+    PLATFORM SCOPE MATTERS, and getting it wrong would be worse than not
+    checking at all. The `-lcuda`/`libcuda.so` mechanism is a Linux one. On
+    Windows the link resolves `cuda.lib` from the toolkit and searches LIB, so
+    a probe for `libcuda.so` there would find nothing and disable FlashInfer on
+    a platform where it works. Anywhere this cannot be checked positively --
+    macOS, or any future platform -- return True, i.e. do not claim the link
+    will fail. That keeps behaviour identical to before this check existed
+    everywhere except where the failure was actually observed.
     """
+    if sys.platform.startswith("win"):
+        search = [d for d in os.environ.get("LIB", "").split(os.pathsep) if d]
+        for var in ("CUDA_PATH", "CUDA_HOME"):
+            root = os.environ.get(var, "")
+            if root:
+                search += [os.path.join(root, sub)
+                           for sub in _FLASHINFER_LINK_DIRS_WINDOWS_SUBDIRS]
+        if not search:
+            # Nothing to go on. Stay out of the way rather than guess.
+            return True
+        return any(os.path.exists(os.path.join(d, "cuda.lib")) for d in search)
+
+    if not sys.platform.startswith("linux"):
+        # macOS and anything else: CUDA is not in play, and a negative here
+        # would be an invention rather than an observation.
+        return True
+
     search = list(_FLASHINFER_LINK_DIRS)
     for var in ("CUDA_HOME", "CUDA_PATH"):
         root = os.environ.get(var, "")
@@ -2075,7 +2103,6 @@ def _can_link_libcuda() -> bool:
     # that has already supplied a stub there is correctly treated as fine.
     search += [d for d in os.environ.get("LIBRARY_PATH", "").split(os.pathsep) if d]
     return any(os.path.exists(os.path.join(d, "libcuda.so")) for d in search)
-
 
 def _clear_flashinfer_env_on_hip():
     # AMD ROCm: FlashInfer requires the CUDA nvcc compiler and never applies here.

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2046,6 +2046,79 @@ _FLASHINFER_LINK_DIRS_WINDOWS_SUBDIRS = (
     os.path.join("lib", "Win32"),
 )
 
+# The only two `-L` directories FlashInfer emits, verbatim from its generated
+# build.ninja: `-L$cuda_home/lib64 -L$cuda_home/lib64/stubs`. Matching it
+# exactly rather than guessing extra layouts keeps this predicate honest.
+_CUDA_ROOT_LIB_SUBDIRS = (
+    "lib64",
+    os.path.join("lib64", "stubs"),
+)
+
+# Last-resort default linker directories, used only when `ld --verbose` cannot
+# be run. Deliberately generous: a directory that does not exist costs nothing,
+# a missing one costs a working FlashInfer.
+_FALLBACK_LINKER_DIRS = (
+    "/usr/lib",
+    "/lib",
+    "/usr/lib64",
+    "/lib64",
+    "/usr/local/lib",
+    "/usr/local/lib64",
+)
+
+
+def _cuda_roots_from_nvcc() -> "Tuple[str, ...]":
+    """The CUDA root FlashInfer infers when neither CUDA_HOME nor CUDA_PATH is
+    set: the grandparent of whichever nvcc is on PATH.
+
+    flashinfer/jit/cpp_ext.py get_cuda_path() is CUDA_HOME, then CUDA_PATH,
+    then `dirname(dirname(which nvcc))`, then /usr/local/cuda. Without this
+    third case a toolkit installed anywhere other than /usr/local/cuda --
+    /opt/cuda on Arch, a conda prefix -- has its stubs directory missed
+    entirely and FlashInfer is disabled on a machine that links fine.
+
+    Both the literal and the symlink-resolved grandparent are returned:
+    FlashInfer does not resolve symlinks, but a /usr/bin/nvcc shim pointing
+    into the real toolkit is common enough that ignoring it would reintroduce
+    the same false negative.
+    """
+    nvcc = shutil.which("nvcc")
+    if not nvcc: return ()
+    roots = []
+    for path in (nvcc, os.path.realpath(nvcc)):
+        root = os.path.dirname(os.path.dirname(path))
+        if root and root not in roots: roots.append(root)
+    return tuple(roots)
+
+
+@functools.cache
+def _linker_default_dirs() -> "Tuple[str, ...]":
+    """The directories `ld` searches with no -L at all.
+
+    The NVIDIA driver installer creates the unversioned `libcuda.so` symlink in
+    a default directory (/usr/lib/x86_64-linux-gnu on Debian/Ubuntu), so
+    `c++ ... -lcuda` frequently succeeds with no toolkit stubs directory in
+    sight. Ignoring these paths turns those machines into false negatives,
+    which is the one direction this predicate must never get wrong.
+
+    `ld --verbose` prints the built-in linker script, whose SEARCH_DIR entries
+    are exactly that list; the leading `=` on each is the sysroot placeholder
+    and is empty for a native link.
+    """
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["ld", "--verbose"],
+            capture_output = True, text = True, timeout = 20,
+        ).stdout
+    except Exception:
+        out = ""
+    dirs = [d.replace("=", "", 1) if d.startswith("=") else d
+            for d in re.findall(r'SEARCH_DIR\("([^"]*)"\)', out)]
+    # Never return an empty tuple on a parse failure; fall back rather than
+    # silently narrowing the search.
+    return tuple(dirs) if dirs else _FALLBACK_LINKER_DIRS
+
 
 def _can_link_libcuda() -> bool:
     """Can a FlashInfer JIT build actually LINK, not merely compile?
@@ -2094,14 +2167,19 @@ def _can_link_libcuda() -> bool:
         return True
 
     search = list(_FLASHINFER_LINK_DIRS)
-    for var in ("CUDA_HOME", "CUDA_PATH"):
-        root = os.environ.get(var, "")
-        if root:
-            search.append(os.path.join(root, "lib64"))
-            search.append(os.path.join(root, "lib64", "stubs"))
+    roots = [os.environ.get(var, "") for var in ("CUDA_HOME", "CUDA_PATH")]
+    # Neither variable set is the common case, and then FlashInfer infers the
+    # root from nvcc rather than assuming /usr/local/cuda.
+    roots += list(_cuda_roots_from_nvcc())
+    for root in roots:
+        if not root: continue
+        search += [os.path.join(root, sub) for sub in _CUDA_ROOT_LIB_SUBDIRS]
     # LIBRARY_PATH is what the linker consults beyond its defaults, so a caller
     # that has already supplied a stub there is correctly treated as fine.
     search += [d for d in os.environ.get("LIBRARY_PATH", "").split(os.pathsep) if d]
+    # And the defaults themselves, which is where the driver's own unversioned
+    # libcuda.so lives on a normal bare-metal install.
+    search += list(_linker_default_dirs())
     return any(os.path.exists(os.path.join(d, "libcuda.so")) for d in search)
 
 def _clear_flashinfer_env_on_hip():

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2052,9 +2052,44 @@ _CUDA_ROOT_LIB_SUBDIRS = (
     os.path.join("lib64", "stubs"),
 )
 
+
+def _multiarch_linker_dirs() -> "Tuple[str, ...]":
+    """`<base>/<triplet>` for this machine, e.g. /usr/lib/x86_64-linux-gnu.
+
+    On Debian/Ubuntu the NVIDIA driver's unversioned `libcuda.so` lives in the
+    multiarch directory and nowhere else, and ld's built-in SEARCH_DIRs list
+    it, so `c++ ... -lcuda` links there with no -L at all. The fallback below
+    is what runs when ld cannot be consulted -- no binutils in the image, or an
+    `ld` that is really lld, which has no built-in linker script and so prints
+    no SEARCH_DIR at all -- and omitting the one directory that actually holds
+    the stub would answer False on a machine that links fine. That is the false
+    negative this whole check exists to avoid.
+
+    Both the interpreter's own MULTIARCH triplet (set on Debian/Ubuntu, absent
+    on manylinux and conda builds) and a triplet derived from the machine are
+    tried, so aarch64 hosts -- Jetson, GH200 -- are covered too.
+    """
+    if not sys.platform.startswith("linux"): return ()
+    import platform
+    import sysconfig
+    machine = platform.machine() or ""
+    triplets = []
+    for triplet in (sysconfig.get_config_var("MULTIARCH") or "",
+                    (machine + "-linux-gnu") if machine else ""):
+        if triplet and "/" not in triplet and triplet not in triplets:
+            triplets.append(triplet)
+    return tuple(
+        base + "/" + triplet
+        for base in ("/usr/lib", "/lib", "/usr/local/lib")
+        for triplet in triplets
+    )
+
+
 # Used only when `ld --verbose` cannot be run. Deliberately generous: a
 # directory that does not exist costs nothing, a missing one costs FlashInfer.
-_FALLBACK_LINKER_DIRS = (
+# The multiarch entries come first because on the most common CUDA platform
+# they are the only place the driver's unversioned libcuda.so ever appears.
+_FALLBACK_LINKER_DIRS = _multiarch_linker_dirs() + (
     "/usr/lib",
     "/lib",
     "/usr/lib64",

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2031,32 +2031,29 @@ def _install_vllm_decompose_size_nodes_fix():
     return True
 
 
-# The directories `-L` reaches when FlashInfer links its JIT-compiled objects
-# ON LINUX. `/usr/local/cuda/compat` is deliberately NOT among them upstream,
-# which is what makes the check below necessary rather than paranoid.
+# Where `-L` reaches on Linux. `/usr/local/cuda/compat` is deliberately NOT
+# among them upstream, which is what makes the check below necessary.
 _FLASHINFER_LINK_DIRS = (
     "/usr/local/cuda/lib64",
     "/usr/local/cuda/lib64/stubs",
 )
 
-# Windows links `cuda.lib` out of the toolkit, not a driver stub, and the
-# linker's search path comes from LIB rather than LIBRARY_PATH.
+# Windows links `cuda.lib` from the toolkit, not a driver stub, and searches
+# LIB rather than LIBRARY_PATH.
 _FLASHINFER_LINK_DIRS_WINDOWS_SUBDIRS = (
     os.path.join("lib", "x64"),
     os.path.join("lib", "Win32"),
 )
 
-# The only two `-L` directories FlashInfer emits, verbatim from its generated
-# build.ninja: `-L$cuda_home/lib64 -L$cuda_home/lib64/stubs`. Matching it
-# exactly rather than guessing extra layouts keeps this predicate honest.
+# The only two `-L` dirs FlashInfer emits, verbatim from its generated
+# build.ninja: `-L$cuda_home/lib64 -L$cuda_home/lib64/stubs`.
 _CUDA_ROOT_LIB_SUBDIRS = (
     "lib64",
     os.path.join("lib64", "stubs"),
 )
 
-# Last-resort default linker directories, used only when `ld --verbose` cannot
-# be run. Deliberately generous: a directory that does not exist costs nothing,
-# a missing one costs a working FlashInfer.
+# Used only when `ld --verbose` cannot be run. Deliberately generous: a
+# directory that does not exist costs nothing, a missing one costs FlashInfer.
 _FALLBACK_LINKER_DIRS = (
     "/usr/lib",
     "/lib",
@@ -2068,19 +2065,16 @@ _FALLBACK_LINKER_DIRS = (
 
 
 def _cuda_roots_from_nvcc() -> "Tuple[str, ...]":
-    """The CUDA root FlashInfer infers when neither CUDA_HOME nor CUDA_PATH is
-    set: the grandparent of whichever nvcc is on PATH.
+    """The CUDA root FlashInfer infers with neither CUDA_HOME nor CUDA_PATH set.
 
-    flashinfer/jit/cpp_ext.py get_cuda_path() is CUDA_HOME, then CUDA_PATH,
-    then `dirname(dirname(which nvcc))`, then /usr/local/cuda. Without this
-    third case a toolkit installed anywhere other than /usr/local/cuda --
-    /opt/cuda on Arch, a conda prefix -- has its stubs directory missed
-    entirely and FlashInfer is disabled on a machine that links fine.
+    flashinfer/jit/cpp_ext.py get_cuda_path() resolves CUDA_HOME, CUDA_PATH,
+    `dirname(dirname(which nvcc))`, then /usr/local/cuda. Without that third
+    case a toolkit outside /usr/local/cuda (/opt/cuda, a conda prefix) has its
+    stubs directory missed and FlashInfer is disabled on a machine that links.
 
     Both the literal and the symlink-resolved grandparent are returned:
     FlashInfer does not resolve symlinks, but a /usr/bin/nvcc shim pointing
-    into the real toolkit is common enough that ignoring it would reintroduce
-    the same false negative.
+    into the real toolkit would otherwise reintroduce the same false negative.
     """
     nvcc = shutil.which("nvcc")
     if not nvcc: return ()
@@ -2097,13 +2091,12 @@ def _linker_default_dirs() -> "Tuple[str, ...]":
 
     The NVIDIA driver installer creates the unversioned `libcuda.so` symlink in
     a default directory (/usr/lib/x86_64-linux-gnu on Debian/Ubuntu), so
-    `c++ ... -lcuda` frequently succeeds with no toolkit stubs directory in
-    sight. Ignoring these paths turns those machines into false negatives,
-    which is the one direction this predicate must never get wrong.
+    `c++ ... -lcuda` often succeeds with no toolkit stubs directory in sight.
+    Ignoring these paths would make those machines false negatives.
 
     `ld --verbose` prints the built-in linker script, whose SEARCH_DIR entries
-    are exactly that list; the leading `=` on each is the sysroot placeholder
-    and is empty for a native link.
+    are exactly that list; the leading `=` is the sysroot placeholder, empty
+    for a native link.
     """
     import subprocess
     try:
@@ -2115,39 +2108,32 @@ def _linker_default_dirs() -> "Tuple[str, ...]":
         out = ""
     dirs = [d.replace("=", "", 1) if d.startswith("=") else d
             for d in re.findall(r'SEARCH_DIR\("([^"]*)"\)', out)]
-    # Never return an empty tuple on a parse failure; fall back rather than
-    # silently narrowing the search.
+    # On a parse failure fall back rather than silently narrowing the search.
     return tuple(dirs) if dirs else _FALLBACK_LINKER_DIRS
 
 
 def _can_link_libcuda() -> bool:
     """Can a FlashInfer JIT build actually LINK, not merely compile?
 
-    nvcc and ninja being present says the compile step will work. It says
-    nothing about the link, which on Linux passes `-lcuda` and therefore needs
-    the driver STUB `libcuda.so` -- not the runtime `libcuda.so.1` that every
-    machine with a driver has.
+    nvcc and ninja being present only covers the compile. The link passes
+    `-lcuda` on Linux and so needs the driver STUB `libcuda.so`, not the
+    runtime `libcuda.so.1` that every machine with a driver has.
 
-    Container images routinely ship the runtime and omit the stub. On those,
-    every check above passes, FlashInfer compiles each .cu file cleanly, and
-    the build dies at the final step with
+    Container images routinely ship the runtime and omit the stub. Observed on
+    Kaggle: every check above passes, each .cu file compiles cleanly, and the
+    final step dies on
 
         /usr/bin/ld: cannot find -lcuda
 
     surfacing as `RuntimeError: Ninja build failed` after minutes of nvcc work.
-    Four separate Kaggle sessions were spent on that failure before the cause
-    was identified, and no environment variable avoids it: disabling the
-    FlashInfer SAMPLER simply moves the build to the attention kernels, and
-    vLLM exposes no prefill-specific opt-out.
+    No env var avoids it: disabling the FlashInfer SAMPLER just moves the build
+    to the attention kernels, and vLLM has no prefill-specific opt-out.
 
-    PLATFORM SCOPE MATTERS, and getting it wrong would be worse than not
-    checking at all. The `-lcuda`/`libcuda.so` mechanism is a Linux one. On
-    Windows the link resolves `cuda.lib` from the toolkit and searches LIB, so
-    a probe for `libcuda.so` there would find nothing and disable FlashInfer on
-    a platform where it works. Anywhere this cannot be checked positively --
-    macOS, or any future platform -- return True, i.e. do not claim the link
-    will fail. That keeps behaviour identical to before this check existed
-    everywhere except where the failure was actually observed.
+    Platform scope matters. The `-lcuda`/`libcuda.so` mechanism is Linux-only;
+    on Windows the link resolves `cuda.lib` and searches LIB, so probing for
+    `libcuda.so` there would disable FlashInfer on a platform where it works.
+    Where the link cannot be checked positively, return True rather than claim
+    it will fail, keeping behaviour as before this check existed.
     """
     if sys.platform.startswith("win"):
         search = [d for d in os.environ.get("LIB", "").split(os.pathsep) if d]
@@ -2162,23 +2148,23 @@ def _can_link_libcuda() -> bool:
         return any(os.path.exists(os.path.join(d, "cuda.lib")) for d in search)
 
     if not sys.platform.startswith("linux"):
-        # macOS and anything else: CUDA is not in play, and a negative here
-        # would be an invention rather than an observation.
+        # macOS and anything else: CUDA is not in play, so a negative would be
+        # an invention rather than an observation.
         return True
 
     search = list(_FLASHINFER_LINK_DIRS)
     roots = [os.environ.get(var, "") for var in ("CUDA_HOME", "CUDA_PATH")]
-    # Neither variable set is the common case, and then FlashInfer infers the
-    # root from nvcc rather than assuming /usr/local/cuda.
+    # Neither var set is the common case; FlashInfer then infers the root from
+    # nvcc rather than assuming /usr/local/cuda.
     roots += list(_cuda_roots_from_nvcc())
     for root in roots:
         if not root: continue
         search += [os.path.join(root, sub) for sub in _CUDA_ROOT_LIB_SUBDIRS]
-    # LIBRARY_PATH is what the linker consults beyond its defaults, so a caller
-    # that has already supplied a stub there is correctly treated as fine.
+    # LIBRARY_PATH is what the linker consults beyond its defaults, so a stub
+    # already supplied there counts.
     search += [d for d in os.environ.get("LIBRARY_PATH", "").split(os.pathsep) if d]
-    # And the defaults themselves, which is where the driver's own unversioned
-    # libcuda.so lives on a normal bare-metal install.
+    # The defaults themselves hold the driver's own unversioned libcuda.so on a
+    # normal bare-metal install.
     search += list(_linker_default_dirs())
     return any(os.path.exists(os.path.join(d, "libcuda.so")) for d in search)
 


### PR DESCRIPTION
The guard in `patch_vllm` checks for the CUDA compiler and the build tool:

```python
_has_nvcc  = shutil.which("nvcc") is not None or ...
_has_ninja = shutil.which("ninja") is not None
```

Both are present on plenty of container images that still cannot build FlashInfer, because the link passes `-lcuda` and therefore needs the driver **stub** `libcuda.so` — not the runtime `libcuda.so.1` that every machine with a driver has.

## What that looks like

On Kaggle's GPU image, every check above passes, FlashInfer compiles each `.cu` file cleanly for `sm_75`, and the final step dies:

```
ninja: Entering directory `.../flashinfer/0.6.6/75/cached_ops/sampling'
[1/1] c++ ... -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib64/stubs -lcudart -lcuda -o ...
/usr/bin/ld: cannot find -lcuda
RuntimeError: Ninja build failed.
```

after minutes of nvcc work.

**No environment variable avoids it.** `VLLM_USE_FLASHINFER_SAMPLER=0` stops the sampler build and the failure simply moves to `cached_ops/batch_prefill_with_kv_cache_...`, i.e. attention — which is selected by `VLLM_ATTENTION_BACKEND`, and vLLM exposes a sampler knob and a family of MoE knobs but nothing prefill-specific. Setting either variable before `patch_vllm` also does not help, since it assigns both itself.

## The change

`_can_link_libcuda()` probes the directories the link actually reaches:

- the two paths FlashInfer passes with `-L`
- `lib64` and `lib64/stubs` under `CUDA_HOME` and `CUDA_PATH`
- `LIBRARY_PATH`, which is what the linker consults beyond its defaults

That last one matters: a caller that has already supplied a stub there is correctly treated as able to link, which is how a working setup avoids this today. Empty `LIBRARY_PATH` entries are filtered, because `os.path.join("", "libcuda.so")` is a relative path and would otherwise make the answer depend on the working directory.

A missing stub is now treated exactly like a missing compiler: skip FlashInfer, use a backend that works, and say which piece is missing and how to supply it.

The asymmetry justifies the conservative choice — a false negative costs some throughput, a false positive costs the whole run.

## Tests

Five, covering the observed image shape (`libcuda.so.1` present, `libcuda.so` absent), both ways of supplying a stub, and the working-directory trap.