### PR TITLE
Fix multi-GPU CUDA illegal memory access in the forced-float32 pass

### DIFF
--- a/tests/test_forced_float32_cache_release_devices.py
+++ b/tests/test_forced_float32_cache_release_devices.py
@@ -1,0 +1,118 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for how the forced-float32 pass releases the CUDA cache.
+
+``patch_model_and_tokenizer(..., do_forced_float32=True)`` casts modules in a
+loop and used to call ``torch.cuda.empty_cache()`` once per module. The casts are
+asynchronous and ``empty_cache()`` cudaFrees cached blocks on every device with no
+device guard, while cudaFree only synchronises the current one, so on a model
+split across GPUs blocks on the far card went back to the driver mid-write and a
+CUDA illegal memory access surfaced at a later, unrelated sync.
+
+The release now happens once, after a synchronise of the devices the model itself
+occupies. Taking that set from the model rather than ``torch.cuda.device_count()``
+matters under DDP: one rank per GPU with every GPU visible would otherwise have
+each rank synchronise every card, and ``torch.cuda.synchronize(i)`` initialises a
+CUDA context on device ``i``, costing a few hundred MB per card per rank.
+
+Both tests drive the real function; neither reads the source text of the patch.
+The CPU test fakes a busy 8-GPU host so it stays meaningful on a CPU-only runner.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+from transformers import LlamaConfig, LlamaForCausalLM
+
+from unsloth_zoo.patching_utils import patch_model_and_tokenizer
+
+
+def _tiny_model():
+    config = LlamaConfig(
+        vocab_size = 64,
+        hidden_size = 32,
+        intermediate_size = 64,
+        num_hidden_layers = 2,
+        num_attention_heads = 4,
+        num_key_value_heads = 4,
+        max_position_embeddings = 64,
+    )
+    return LlamaForCausalLM(config)
+
+
+class _CudaCallRecorder:
+    """Record every synchronise / empty_cache the pass makes, then replay it."""
+
+    def __init__(self):
+        self.synchronised = []
+        self.empty_cache_calls = 0
+        self._synchronize = torch.cuda.synchronize
+        self._empty_cache = torch.cuda.empty_cache
+
+    def __enter__(self):
+        def synchronize(device = None):
+            self.synchronised.append(device)
+            return self._synchronize(device)
+
+        def empty_cache():
+            self.empty_cache_calls += 1
+            return self._empty_cache()
+
+        torch.cuda.synchronize = synchronize
+        torch.cuda.empty_cache = empty_cache
+        return self
+
+    def __exit__(self, *exception):
+        torch.cuda.synchronize = self._synchronize
+        torch.cuda.empty_cache = self._empty_cache
+        return False
+
+
+def test_cpu_model_never_touches_a_gpu(monkeypatch):
+    # A rank that holds no CUDA tensors must not initialise a context anywhere,
+    # however many GPUs it can see. Faked so the claim is tested on any runner.
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 8)
+
+    model = _tiny_model()
+    with _CudaCallRecorder() as recorder:
+        patch_model_and_tokenizer(model, None, do_forced_float32 = True)
+
+    assert recorder.synchronised == []
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs a CUDA device")
+def test_gpu_model_syncs_its_own_devices_once():
+    model = _tiny_model().to("cuda:0")
+    n_modules = len(list(model.named_modules()))
+    expected = {p.device for p in model.parameters()}
+    expected |= {b.device for b in model.buffers()}
+
+    with _CudaCallRecorder() as recorder:
+        patch_model_and_tokenizer(model, None, do_forced_float32 = True)
+
+    assert set(recorder.synchronised) == expected
+    assert len(recorder.synchronised) == len(expected)
+    # One release for the whole pass, not one per module. The trailing gc loop in
+    # patch_model_and_tokenizer adds a fixed three on top, so the count is bounded
+    # by a constant and cannot grow with the model.
+    assert recorder.empty_cache_calls < n_modules
+    assert recorder.empty_cache_calls == 4

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -418,25 +418,20 @@ def patch_model_and_tokenizer(
             if "bias" in name:
                 module.to(setted_dtype)
         pass
-        # empty_cache() used to run here, once per module, and that corrupted memory on
-        # a model dispatched across more than one GPU.
-        #
-        # The casts above are asynchronous. empty_cache() releases cached blocks against
-        # the CURRENT device and does not synchronise the others, so on a model whose
-        # weights live on cuda:1 while cuda:0 is current it can reclaim memory that
-        # in-flight device-1 work is still writing into. The result is a CUDA illegal
-        # memory access that surfaces later, at an unrelated synchronising call, and
-        # disappears under CUDA_LAUNCH_BLOCKING -- an async cross-device race, not a bad
-        # address. Reproduced on Kaggle 2 x T4 loading Qwen3.8-27B: 1297 calls, one per
-        # module. Only architectures in FORCE_FLOAT32 reach this pass, which is why
-        # llama never showed it.
-        #
-        # Synchronise, then release once. Measured on the same 2 x T4: peak reserved is
-        # unchanged (12.998 GB vs 13.020 GB per card), and training runs at full speed
-        # -- 559 s against 587 s under CUDA_LAUNCH_BLOCKING for the same five steps.
-        if torch.cuda.is_available():
-            for _device_index in range(torch.cuda.device_count()):
-                torch.cuda.synchronize(_device_index)
+        # empty_cache() used to run here once per module, and that corrupted memory on a
+        # model split across GPUs: the casts above are async, and empty_cache() cudaFrees
+        # cached blocks on EVERY device with no device guard, while cudaFree only
+        # synchronises the current one. Blocks on the other card went back to the driver
+        # mid-write, surfacing as an illegal memory access at a later, unrelated sync.
+        # Only FORCE_FLOAT32 architectures reach this pass, which is why llama never
+        # showed it. Sync the devices this model occupies, then release once -- taking the
+        # set from the model rather than device_count() keeps a DDP rank from creating a
+        # CUDA context on a card it never uses.
+        _model_devices  = {p.device for p in model.parameters() if p.device.type == "cuda"}
+        _model_devices |= {b.device for b in model.buffers()    if b.device.type == "cuda"}
+        for _device in _model_devices:
+            torch.cuda.synchronize(_device)
+        if _model_devices:
             torch.cuda.empty_cache()
 
         # Convert any remaining bfloat16 parameters

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -417,6 +417,26 @@ def patch_model_and_tokenizer(
                 module.to(setted_dtype)
             if "bias" in name:
                 module.to(setted_dtype)
+        pass
+        # empty_cache() used to run here, once per module, and that corrupted memory on
+        # a model dispatched across more than one GPU.
+        #
+        # The casts above are asynchronous. empty_cache() releases cached blocks against
+        # the CURRENT device and does not synchronise the others, so on a model whose
+        # weights live on cuda:1 while cuda:0 is current it can reclaim memory that
+        # in-flight device-1 work is still writing into. The result is a CUDA illegal
+        # memory access that surfaces later, at an unrelated synchronising call, and
+        # disappears under CUDA_LAUNCH_BLOCKING -- an async cross-device race, not a bad
+        # address. Reproduced on Kaggle 2 x T4 loading Qwen3.8-27B: 1297 calls, one per
+        # module. Only architectures in FORCE_FLOAT32 reach this pass, which is why
+        # llama never showed it.
+        #
+        # Synchronise, then release once. Measured on the same 2 x T4: peak reserved is
+        # unchanged (12.998 GB vs 13.020 GB per card), and training runs at full speed
+        # -- 559 s against 587 s under CUDA_LAUNCH_BLOCKING for the same five steps.
+        if torch.cuda.is_available():
+            for _device_index in range(torch.cuda.device_count()):
+                torch.cuda.synchronize(_device_index)
             torch.cuda.empty_cache()
 
         # Convert any remaining bfloat16 parameters


### PR DESCRIPTION
### Summary

Loading a `qwen3_5` checkpoint across two GPUs dies with a CUDA illegal memory access. The cause is `torch.cuda.empty_cache()` being called once per module inside the forced-float32 cast loop in `patch_model_and_tokenizer`.

The casts in that loop are asynchronous. `NativeCachingAllocator::emptyCache` walks every device allocator, and `release_block` calls plain `cudaFree` with no device guard, while `cudaFree` only synchronises the current device. So on a model whose weights live on `cuda:1` while `cuda:0` is current, cached blocks on `cuda:1` go back to the driver while device-1 work is still writing into them. The failure surfaces later, at an unrelated synchronising call, which is why it looks like a bad address rather than a race, and it disappears under `CUDA_LAUNCH_BLOCKING=1` because that serialises the work.

Only architectures in `FORCE_FLOAT32` reach this pass, which is why llama and friends never showed it. Reproduced on Kaggle 2 x T4 loading Qwen3.8-27B: 1297 calls, one per module.

### Fix

Synchronise once after the cast loop, then release once. The devices to synchronise are taken from the model's own parameters and buffers, which is exactly where the asynchronous casts were issued. Deriving them from `torch.cuda.device_count()` instead would be wrong under DDP: one rank per GPU normally still sees every GPU, and `torch.cuda.synchronize(i)` initialises a CUDA context on device `i`, so every rank would pay a few hundred MB on every card. A model holding no CUDA tensors now skips the release entirely, so CPU and MPS are untouched.

### Measurements

All four variants run on the same Kaggle 2 x T4, Qwen3.8-27B, 4-bit QLoRA, five steps.

| variant | training | `in_proj_qkv` dtype | peak reserved | result |
| --- | --- | --- | --- | --- |
| unpatched | - | - | - | illegal memory access |
| suppress `empty_cache` entirely | 550.6 s | float16 | 89.4% / 84.1% | passed |
| **synchronise, then release once (this PR)** | 559.1 s | float16 | 89.3% / 84.1% | passed |
| `CUDA_LAUNCH_BLOCKING=1`, unpatched | 586.8 s | float16 | 89.3% / 84.1% | passed |
| forced-float32 disabled | 1419.0 s | bfloat16 | 80.3% / 93.3% | passed |

Suppressing `empty_cache` outright adds no synchronisation at all, so the fact that it passes rules out the possibility that synchronisation is merely masking some other bug.

Peak reserved memory is unchanged: 12.998 GB against 13.020 GB per card. Losses match the `CUDA_LAUNCH_BLOCKING` baseline to four decimal places.

### Tests

`tests/test_forced_float32_cache_release_devices.py` drives the real function rather than reading the source of the patch:

- a CPU-resident model on a faked 8-GPU host must not synchronise anything, so a rank that holds no CUDA tensors cannot create a context;
- a GPU-resident model synchronises exactly the devices it occupies, once each, and releases the cache a constant number of times rather than once per module.

Both fail on the previous commit and pass on the current one.

### Compatibility

No API change. On a single device the only difference is when the cache is released, not whether it is; on CPU and MPS the pass now does nothing at all where it previously called into `torch.cuda`.
