### PR TITLE
Vendored FLA: re-resolve kernel closures on modules imported before us

### DIFF
--- a/tests/test_vendor_fla.py
+++ b/tests/test_vendor_fla.py
@@ -883,3 +883,150 @@ def test_force_rebinds_already_loaded_real_fla_subprocess():
     )
     assert "FORCE_REBIND_OK" in proc.stdout, f"stdout=\n{proc.stdout}\nstderr=\n{proc.stderr}"
     assert proc.returncode == 0, f"stderr=\n{proc.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Kernel-hub closures frozen by an import that happened before fla was live
+# ---------------------------------------------------------------------------
+
+def _fake_wrapper(implementation, original, params=("q", "k")):
+    """A stand-in for what use_kernel_func_from_hub_with_fallback builds: a closure
+    over (applicable_params, implementation) with __wrapped__ set to the original."""
+    def wrapped(*args, **kwargs):
+        return implementation(*args, **kwargs)
+    wrapped.__wrapped__ = original
+    # Force a closure with the same shape the real decorator produces.
+    def outer(applicable_params, impl):
+        def inner(*args, **kwargs):
+            return impl(*args, **kwargs)
+        return inner
+    inner = outer(params, implementation)
+    inner.__wrapped__ = original
+    return inner
+
+
+def _fake_modeling(monkeypatch, package, wrapper, attribute="torch_chunk_gated_delta_rule"):
+    import types
+    module = types.ModuleType(f"transformers.models.{package}.modeling_{package}")
+    setattr(module, attribute, wrapper)
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    return module
+
+
+def test_resolved_implementation_reads_the_closure():
+    from unsloth_zoo.temporary_patches.fla_vendor import _resolved_implementation
+
+    def kernel(): return "kernel"
+    def original(): return "torch"
+
+    assert _resolved_implementation(_fake_wrapper(kernel, original)) is kernel
+    assert _resolved_implementation(lambda: None) is None
+    assert _resolved_implementation(object()) is None
+
+
+def test_late_import_repair_rebinds_the_frozen_fallback(monkeypatch):
+    """The whole point: a wrapper still closed over its own torch fallback is rebuilt."""
+    from unsloth_zoo.temporary_patches import fla_vendor
+
+    def original(): return "torch"
+    def kernel(): return "fla"
+
+    module = _fake_modeling(monkeypatch, "qwen3_5", _fake_wrapper(original, original))
+
+    import transformers.integrations.hub_kernels as hub
+    monkeypatch.setattr(
+        hub, "use_kernel_func_from_hub_with_fallback",
+        lambda name, package, internal_path=None: (
+            lambda fn: _fake_wrapper(kernel, fn, params=("q", "k", "v", "g"))
+        ),
+    )
+    repaired = fla_vendor._repair_kernel_hub_closures(packages=("qwen3_5",))
+
+    assert repaired == ("qwen3_5.torch_chunk_gated_delta_rule",), repaired
+    assert fla_vendor._resolved_implementation(module.torch_chunk_gated_delta_rule) is kernel
+
+
+def test_late_import_repair_leaves_a_live_kernel_alone(monkeypatch):
+    """A module imported in the right order already dispatches to fla; do not touch it."""
+    from unsloth_zoo.temporary_patches import fla_vendor
+
+    def original(): return "torch"
+    def kernel(): return "fla"
+
+    wrapper = _fake_wrapper(kernel, original)
+    module = _fake_modeling(monkeypatch, "qwen3_5", wrapper)
+
+    import transformers.integrations.hub_kernels as hub
+    monkeypatch.setattr(
+        hub, "use_kernel_func_from_hub_with_fallback",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not rebuild")),
+    )
+    assert fla_vendor._repair_kernel_hub_closures(packages=("qwen3_5",)) == ()
+    assert module.torch_chunk_gated_delta_rule is wrapper
+
+
+def test_late_import_repair_keeps_the_wrapper_when_nothing_to_bind(monkeypatch):
+    """If the rebuild still resolves to the fallback, fla genuinely has no kernel:
+    keep what was there rather than swapping in an identical object."""
+    from unsloth_zoo.temporary_patches import fla_vendor
+
+    def original(): return "torch"
+    wrapper = _fake_wrapper(original, original)
+    module = _fake_modeling(monkeypatch, "qwen3_5", wrapper)
+
+    import transformers.integrations.hub_kernels as hub
+    monkeypatch.setattr(
+        hub, "use_kernel_func_from_hub_with_fallback",
+        lambda *a, **k: (lambda fn: _fake_wrapper(fn, fn)),
+    )
+    assert fla_vendor._repair_kernel_hub_closures(packages=("qwen3_5",)) == ()
+    assert module.torch_chunk_gated_delta_rule is wrapper
+
+
+def test_late_import_repair_skips_undecorated_attributes(monkeypatch):
+    """On a transformers that predates #47630 there is no __wrapped__ to rebuild from."""
+    from unsloth_zoo.temporary_patches import fla_vendor
+
+    def plain(): return "plain"
+    module = _fake_modeling(monkeypatch, "qwen3_5", plain)
+    assert fla_vendor._repair_kernel_hub_closures(packages=("qwen3_5",)) == ()
+    assert module.torch_chunk_gated_delta_rule is plain
+
+
+def test_late_import_repair_is_scoped_to_vendor_covered_models():
+    """olmo_hybrid imports ShortConvolution, which is not vendored, so its probe must
+    stay False; rebinding vendored kernels into it would contradict that."""
+    from unsloth_zoo.temporary_patches import fla_vendor
+    import inspect
+
+    default = inspect.signature(
+        fla_vendor._repair_kernel_hub_closures
+    ).parameters["packages"].default
+    assert "olmo_hybrid" not in default
+    assert default is fla_vendor._REPAIR_MODELING
+
+
+def test_late_import_repair_survives_missing_hub_kernels(monkeypatch):
+    from unsloth_zoo.temporary_patches import fla_vendor
+
+    real_import = __import__
+
+    def fail(name, *args, **kwargs):
+        if name == "transformers.integrations.hub_kernels":
+            raise ImportError("too old")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fail)
+    assert fla_vendor._repair_kernel_hub_closures(packages=("qwen3_5",)) == ()
+
+
+def test_patch_vendor_fla_survives_a_broken_repair(monkeypatch):
+    """The repair runs in the exit path; it must never take patch_vendor_fla down."""
+    from unsloth_zoo.temporary_patches import fla_vendor
+
+    monkeypatch.setattr(
+        fla_vendor, "_repair_kernel_hub_closures",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(fla_vendor, "_patch_vendor_fla", lambda phase=None: "sentinel")
+    assert fla_vendor.patch_vendor_fla() == "sentinel"

--- a/tests/test_vendor_fla.py
+++ b/tests/test_vendor_fla.py
@@ -889,6 +889,24 @@ def test_force_rebinds_already_loaded_real_fla_subprocess():
 # Kernel-hub closures frozen by an import that happened before fla was live
 # ---------------------------------------------------------------------------
 
+def _has_kernel_hub_fallback() -> bool:
+    # use_kernel_func_from_hub_with_fallback arrived with huggingface/transformers#47630.
+    # On anything older the repair correctly returns () and there is nothing to patch.
+    try:
+        from transformers.integrations.hub_kernels import (  # noqa: F401
+            use_kernel_func_from_hub_with_fallback,
+        )
+        return True
+    except Exception:
+        return False
+
+
+requires_kernel_hub = pytest.mark.skipif(
+    not _has_kernel_hub_fallback(),
+    reason="transformers predates use_kernel_func_from_hub_with_fallback",
+)
+
+
 def _fake_wrapper(implementation, original, params=("q", "k")):
     """A stand-in for what use_kernel_func_from_hub_with_fallback builds: a closure
     over (applicable_params, implementation) with __wrapped__ set to the original."""
@@ -924,6 +942,7 @@ def test_resolved_implementation_reads_the_closure():
     assert _resolved_implementation(object()) is None
 
 
+@requires_kernel_hub
 def test_late_import_repair_rebinds_the_frozen_fallback(monkeypatch):
     """The whole point: a wrapper still closed over its own torch fallback is rebuilt."""
     from unsloth_zoo.temporary_patches import fla_vendor
@@ -946,8 +965,9 @@ def test_late_import_repair_rebinds_the_frozen_fallback(monkeypatch):
     assert fla_vendor._resolved_implementation(module.torch_chunk_gated_delta_rule) is kernel
 
 
-def test_late_import_repair_leaves_a_live_kernel_alone(monkeypatch):
-    """A module imported in the right order already dispatches to fla; do not touch it."""
+@requires_kernel_hub
+def test_late_import_repair_leaves_the_live_kernel_alone(monkeypatch):
+    """A module imported in the right order already dispatches to the live fla."""
     from unsloth_zoo.temporary_patches import fla_vendor
 
     def original(): return "torch"
@@ -955,6 +975,7 @@ def test_late_import_repair_leaves_a_live_kernel_alone(monkeypatch):
 
     wrapper = _fake_wrapper(kernel, original)
     module = _fake_modeling(monkeypatch, "qwen3_5", wrapper)
+    monkeypatch.setattr(fla_vendor, "_live_gated_delta_kernel", lambda name: kernel)
 
     import transformers.integrations.hub_kernels as hub
     monkeypatch.setattr(
@@ -965,6 +986,59 @@ def test_late_import_repair_leaves_a_live_kernel_alone(monkeypatch):
     assert module.torch_chunk_gated_delta_rule is wrapper
 
 
+@requires_kernel_hub
+def test_late_import_repair_replaces_a_purged_install_kernel(monkeypatch):
+    """The case UNSLOTH_FORCE_VENDORED_FLA and the Hopper #640 switch create: the
+    wrapper closed over a real install's kernel that has since been purged. That is
+    not "already dispatching to a real kernel", it is the miscompiled backward we
+    replaced the install to avoid, so it must be rebound onto the live fla."""
+    from unsloth_zoo.temporary_patches import fla_vendor
+
+    def original(): return "torch"
+    def purged(): return "the install we just deleted"
+    def vendored(): return "fla"
+
+    wrapper = _fake_wrapper(purged, original)
+    module = _fake_modeling(monkeypatch, "qwen3_5", wrapper)
+    monkeypatch.setattr(fla_vendor, "_live_gated_delta_kernel", lambda name: vendored)
+
+    import transformers.integrations.hub_kernels as hub
+    monkeypatch.setattr(
+        hub, "use_kernel_func_from_hub_with_fallback",
+        lambda *a, **k: (lambda fn: _fake_wrapper(vendored, fn)),
+    )
+    repaired = fla_vendor._repair_kernel_hub_closures(packages=("qwen3_5",))
+
+    assert repaired == ("qwen3_5.torch_chunk_gated_delta_rule",), repaired
+    assert fla_vendor._resolved_implementation(
+        module.torch_chunk_gated_delta_rule) is vendored
+
+
+@requires_kernel_hub
+def test_late_import_repair_prefers_torch_over_a_purged_kernel(monkeypatch):
+    """Stale kernel, and nothing live to swap in. Pure torch beats calling into an
+    install that is no longer on sys.modules."""
+    from unsloth_zoo.temporary_patches import fla_vendor
+
+    def original(): return "torch"
+    def purged(): return "gone"
+
+    module = _fake_modeling(monkeypatch, "qwen3_5", _fake_wrapper(purged, original))
+    monkeypatch.setattr(fla_vendor, "_live_gated_delta_kernel", lambda name: None)
+
+    import transformers.integrations.hub_kernels as hub
+    monkeypatch.setattr(
+        hub, "use_kernel_func_from_hub_with_fallback",
+        lambda *a, **k: (lambda fn: _fake_wrapper(fn, fn)),
+    )
+    repaired = fla_vendor._repair_kernel_hub_closures(packages=("qwen3_5",))
+
+    assert repaired == ("qwen3_5.torch_chunk_gated_delta_rule",), repaired
+    assert fla_vendor._resolved_implementation(
+        module.torch_chunk_gated_delta_rule) is original
+
+
+@requires_kernel_hub
 def test_late_import_repair_keeps_the_wrapper_when_nothing_to_bind(monkeypatch):
     """If the rebuild still resolves to the fallback, fla genuinely has no kernel:
     keep what was there rather than swapping in an identical object."""
@@ -973,6 +1047,7 @@ def test_late_import_repair_keeps_the_wrapper_when_nothing_to_bind(monkeypatch):
     def original(): return "torch"
     wrapper = _fake_wrapper(original, original)
     module = _fake_modeling(monkeypatch, "qwen3_5", wrapper)
+    monkeypatch.setattr(fla_vendor, "_live_gated_delta_kernel", lambda name: None)
 
     import transformers.integrations.hub_kernels as hub
     monkeypatch.setattr(

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -1028,6 +1028,82 @@ def _alias_missing_gated_delta_names():
     return tuple(added)
 
 
+# The fla kernels Transformers pulls in through the kernel-hub decorator, keyed by
+# the module attribute holding the decorated wrapper. Identical across every model in
+# _REPAIR_MODELING. The causal_conv1d decorators in the same modules are deliberately
+# absent: we do not vendor that package, so there is nothing to re-resolve them to.
+_KERNEL_HUB_DECORATED = {
+    "torch_chunk_gated_delta_rule": "chunk_gated_delta_rule",
+    "torch_recurrent_gated_delta_rule": "recurrent_gated_delta_rule",
+}
+
+
+def _resolved_implementation(wrapper):
+    """The callable a kernel-hub wrapper will actually dispatch to, or None."""
+    for cell in getattr(wrapper, "__closure__", None) or ():
+        try:
+            value = cell.cell_contents
+        except ValueError:      # empty cell
+            continue
+        if callable(value):
+            return value
+    return None
+
+
+def _repair_kernel_hub_closures(packages=_REPAIR_MODELING):
+    """Re-resolve the kernel-hub decorators on modeling modules imported before us.
+
+    Since huggingface/transformers#47630 the gated-delta kernels are bound by
+    ``use_kernel_func_from_hub_with_fallback``, which resolves the implementation at
+    *decoration time* and closes over it. A modeling module imported before fla is
+    live therefore freezes the pure-PyTorch fallback into that closure, and no amount
+    of fixing ``fla`` afterwards can reach it: ``_repair_already_imported_modeling``
+    only rebinds module globals, which these modules no longer have.
+
+    Re-applying the decorator to the undecorated function is what makes this correct
+    rather than poking ``cell_contents``. The wrapper also closes over the
+    implementation's parameter names, and those differ between the fallback and the
+    kernel (10 against 16 for chunk), so patching the implementation alone would
+    silently filter out arguments the kernel needs.
+
+    Scoped to ``_REPAIR_MODELING``: olmo_hybrid is deliberately not vendor-covered.
+    """
+    try:
+        from transformers.integrations.hub_kernels import (
+            use_kernel_func_from_hub_with_fallback,
+        )
+    except Exception:
+        return ()               # transformers predates the decorator
+
+    repaired = []
+    for package in packages:
+        module = sys.modules.get(f"transformers.models.{package}.modeling_{package}")
+        if module is None:
+            continue
+        for attribute, kernel in _KERNEL_HUB_DECORATED.items():
+            wrapper = getattr(module, attribute, None)
+            original = getattr(wrapper, "__wrapped__", None)
+            if original is None:
+                continue        # not decorated on this transformers
+            if _resolved_implementation(wrapper) is not original:
+                continue        # already dispatching to a real kernel
+            try:
+                rebuilt = use_kernel_func_from_hub_with_fallback(kernel, "fla")(original)
+            except Exception:
+                continue
+            if _resolved_implementation(rebuilt) is original:
+                continue        # still nothing to bind; keep what was there
+            setattr(module, attribute, rebuilt)
+            repaired.append(f"{package}.{attribute}")
+
+    if repaired and UNSLOTH_ENABLE_LOGGING:
+        logger.info(
+            f"Unsloth: re-resolved the fla kernels on {', '.join(repaired)}, which "
+            f"were imported before fla was available."
+        )
+    return tuple(repaired)
+
+
 def patch_vendor_fla(phase=None):
     """Register the bundled fla kernels and advertise availability.
 
@@ -1039,11 +1115,17 @@ def patch_vendor_fla(phase=None):
         # Every early return in _patch_vendor_fla leaves some fla live, and all of
         # them are missing the decode name, so the alias goes on the way out rather
         # than at each return, where the next one added would quietly skip it.
+        # The closure repair follows the alias, since it resolves through it.
         try:
             _alias_missing_gated_delta_names()
         except Exception as e:
             if UNSLOTH_ENABLE_LOGGING:
                 logger.warning(f"Unsloth: could not alias gated-delta decode name: {e}")
+        try:
+            _repair_kernel_hub_closures()
+        except Exception as e:
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.warning(f"Unsloth: could not re-resolve fla kernel closures: {e}")
 
 
 def _patch_vendor_fla(phase=None):

--- a/unsloth_zoo/temporary_patches/fla_vendor.py
+++ b/unsloth_zoo/temporary_patches/fla_vendor.py
@@ -1050,23 +1050,36 @@ def _resolved_implementation(wrapper):
     return None
 
 
+def _live_gated_delta_kernel(name):
+    """The kernel ``name`` currently resolves to on the live fla, or None."""
+    module = sys.modules.get("fla.ops.gated_delta_rule")
+    return getattr(module, name, None) if module is not None else None
+
+
 def _repair_kernel_hub_closures(packages=_REPAIR_MODELING):
     """Re-resolve the kernel-hub decorators on modeling modules imported before us.
 
     Since huggingface/transformers#47630 the gated-delta kernels are bound by
     ``use_kernel_func_from_hub_with_fallback``, which resolves the implementation at
-    *decoration time* and closes over it. A modeling module imported before fla is
-    live therefore freezes the pure-PyTorch fallback into that closure, and no amount
-    of fixing ``fla`` afterwards can reach it: ``_repair_already_imported_modeling``
-    only rebinds module globals, which these modules no longer have.
+    *decoration time* and closes over it. A modeling module imported before we ran
+    therefore froze whatever was live then, and no amount of fixing ``fla`` afterwards
+    can reach it: ``_repair_already_imported_modeling`` only rebinds module globals,
+    which these modules no longer have.
 
-    Re-applying the decorator to the undecorated function is what makes this correct
-    rather than poking ``cell_contents``. The wrapper also closes over the
-    implementation's parameter names, and those differ between the fallback and the
-    kernel (10 against 16 for chunk), so patching the implementation alone would
-    silently filter out arguments the kernel needs.
+    Two things get frozen. The pure-PyTorch fallback, when no fla was importable yet.
+    Or a real user install's kernel, when one was live and ``UNSLOTH_FORCE_VENDORED_FLA``
+    (or the Hopper #640 switch) has since purged it -- the case ``replaced_real``
+    exists for, and the one that matters most, since that kernel is exactly the
+    miscompiled backward we replaced it to avoid. So the test is against the fla that
+    is live *now*, not against the fallback: anything else is stale.
 
-    Scoped to ``_REPAIR_MODELING``: olmo_hybrid is deliberately not vendor-covered.
+    Re-applying the decorator rather than poking ``cell_contents`` is what makes this
+    correct. The wrapper also closes over the implementation's parameter names, and
+    those differ between the fallback and the kernel (10 against 16 for chunk), so
+    patching the implementation alone would filter out arguments the kernel needs.
+
+    Scoped to ``_REPAIR_MODELING``: olmo_hybrid is deliberately not vendor-covered,
+    and ``_disable_already_imported_gated_delta`` handles it instead.
     """
     try:
         from transformers.integrations.hub_kernels import (
@@ -1085,21 +1098,26 @@ def _repair_kernel_hub_closures(packages=_REPAIR_MODELING):
             original = getattr(wrapper, "__wrapped__", None)
             if original is None:
                 continue        # not decorated on this transformers
-            if _resolved_implementation(wrapper) is not original:
-                continue        # already dispatching to a real kernel
+            current = _resolved_implementation(wrapper)
+            live = _live_gated_delta_kernel(kernel)
+            if live is not None and current is live:
+                continue        # already dispatching to the fla that is live now
             try:
                 rebuilt = use_kernel_func_from_hub_with_fallback(kernel, "fla")(original)
             except Exception:
                 continue
-            if _resolved_implementation(rebuilt) is original:
-                continue        # still nothing to bind; keep what was there
+            if _resolved_implementation(rebuilt) is current:
+                continue        # nothing would change
+            # Reached with a stale kernel and no live replacement too, where the
+            # rebuild resolves to the fallback. Taking it is the point: pure torch
+            # beats calling into an install that has been purged.
             setattr(module, attribute, rebuilt)
             repaired.append(f"{package}.{attribute}")
 
     if repaired and UNSLOTH_ENABLE_LOGGING:
         logger.info(
             f"Unsloth: re-resolved the fla kernels on {', '.join(repaired)}, which "
-            f"were imported before fla was available."
+            f"were bound before the live fla was in place."
         )
     return tuple(repaired)
 


### PR DESCRIPTION
### Summary

A `qwen3_5` modeling module imported before `patch_vendor_fla()` runs never uses the fla kernels at all, even though everything reports that fla is available.

Since huggingface/transformers#47630 the gated delta kernels are bound by `use_kernel_func_from_hub_with_fallback`, which resolves the implementation inside `decorator()` and closes over it. That happens when the modeling module is imported. If fla is not live at that moment the pure-PyTorch fallback is frozen into the closure, and nothing done to `fla` afterwards can reach it.

`_repair_already_imported_modeling` cannot fix this: it rebinds module globals, and post-#47630 `modeling_qwen3_5` no longer has them. `chunk_gated_delta_rule` and `recurrent_gated_delta_rule` are not module attributes there at all; the live objects are `torch_chunk_gated_delta_rule` and `torch_recurrent_gated_delta_rule`.

This predates the decode alias in #1101 and is not caused by it. The chunked kernel, which is the training path, was already dead on this ordering.

### Measured

Tiny `qwen3_5`, 4 layers, `full_attention_interval = 4`, one forward, counting real entries into `fla.ops.gated_delta_rule.chunk_gated_delta_rule`:

| import order | dispatches to | fla chunk entries |
| --- | --- | --- |
| `patch_vendor_fla` first | `chunk_gated_delta_rule @ fla.ops.gated_delta_rule.chunk` | 3 |
| modeling first, before this PR | `torch_chunk_gated_delta_rule @ transformers...modeling_qwen3_5` | **0** |
| modeling first, with this PR | `chunk_gated_delta_rule @ fla.ops.gated_delta_rule.chunk` | 3 |

Three of four layers are linear attention, so 3 is the expected count. Logits are finite in every case, which is exactly why this is easy to miss: the model works, it is just several times slower and nothing says so.

### Approach

`_repair_kernel_hub_closures` re-applies the decorator to the undecorated function, which `functools.wraps` leaves reachable on `__wrapped__`, once fla is live.

Re-applying rather than writing to `cell_contents` is the substance of the fix, not a style preference. The wrapper closes over the implementation's parameter names as well as the implementation, and it filters `kwargs` down to them. Those lists differ: 10 names for the chunk fallback against 16 for the fla kernel, and 9 against 19 for decode. Swapping only the implementation would leave the fallback's parameter list in place and silently drop arguments the kernel needs.

It runs in the same `finally` as the decode alias and after it, since decode resolves through that alias.

Skips, each deliberate:

- a wrapper already dispatching to something other than its own fallback, so the normal import order is untouched;
- an attribute with no `__wrapped__`, i.e. a transformers predating the decorator;
- a rebuild that still resolves to the fallback, meaning fla genuinely has no such kernel;
- `olmo_hybrid`, by scoping to `_REPAIR_MODELING`. It imports `ShortConvolution`, which is not vendored, so its probe must stay False and binding vendored kernels into it would contradict that.

Failures are caught and logged, like the alias step, so the exit path cannot take `patch_vendor_fla` down.

### Tests

Eight added. The important one asserts the frozen fallback is actually rebuilt; the rest pin the four skips, `_resolved_implementation` on a wrapper with no closure, an absent `hub_kernels`, and that a raising repair still lets `patch_vendor_fla` return.

`tests/test_vendor_fla.py`: 32 passed, 1 failed. The failure is `test_uncovered_model_imports_on_fallback_subprocess`, and I confirmed it fails identically on a clean `main` with this branch stashed, so it is pre-existing drift against transformers 5.15.1.
