### PR TITLE
Only pip install gguf-py from a trusted llama.cpp checkout

### DIFF
--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -2155,3 +2155,84 @@ def test_macos_helper_keeps_existing_source_tree(monkeypatch, tmp_path):
 
     assert not any(list(c[:2]) == ["git", "clone"] for c in cmds), "must not re-clone an existing source tree"
     assert (folder / "CMakeLists.txt").is_file()
+
+
+def _run_macos_helper_capturing_pip(monkeypatch, folder):
+    """Run the macOS helper against a ready source tree, returning the pip argv."""
+    import subprocess
+    import unsloth_zoo.mlx.utils as mutils
+
+    cmds = []
+
+    def fake_run(cmd, *a, **k):
+        cmds.append(list(cmd))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setitem(sys.modules, "psutil", types.SimpleNamespace(cpu_count=lambda: 2))
+
+    mutils._install_llama_cpp_macos(str(folder))
+
+    return [c for c in cmds if "pip" in c and "install" in c]
+
+
+def _make_source_tree_with_gguf_py(folder):
+    (folder / "gguf-py").mkdir(parents=True)
+    (folder / "CMakeLists.txt").write_text("# source tree")
+
+
+def test_macos_helper_refuses_pip_install_from_untrusted_checkout(monkeypatch, tmp_path):
+    # `pip install <dir>` executes that directory's build backend, so a llama.cpp
+    # checkout we neither manage nor were pointed at (eg a ./llama.cpp that just
+    # happens to sit in the working directory) must never be installed from. The
+    # export still works: gguf comes from the package index instead.
+    import unsloth_zoo.llama_cpp as lcpp
+
+    monkeypatch.setattr(lcpp, "UNSLOTH_HOME", str(tmp_path / "unsloth_home"), raising=False)
+    monkeypatch.delenv("UNSLOTH_LLAMA_CPP_PATH", raising=False)
+
+    folder = tmp_path / "untrusted" / "llama.cpp"
+    _make_source_tree_with_gguf_py(folder)
+
+    pip_cmds = _run_macos_helper_capturing_pip(monkeypatch, folder)
+
+    assert pip_cmds, "expected the helper to install converter deps"
+    installed = pip_cmds[0]
+    assert not any(str(folder) in arg for arg in installed), \
+        f"must not pip install from an untrusted checkout: {installed}"
+    assert "gguf" in installed
+
+
+def test_macos_helper_installs_gguf_py_from_managed_checkout(monkeypatch, tmp_path):
+    # The normal path is unchanged: the managed ~/.unsloth checkout still gets its
+    # in-tree gguf-py installed so gguf stays in sync with llama.cpp.
+    import unsloth_zoo.llama_cpp as lcpp
+
+    home = tmp_path / "unsloth_home"
+    monkeypatch.setattr(lcpp, "UNSLOTH_HOME", str(home), raising=False)
+    monkeypatch.delenv("UNSLOTH_LLAMA_CPP_PATH", raising=False)
+
+    folder = home / "llama.cpp"
+    _make_source_tree_with_gguf_py(folder)
+
+    pip_cmds = _run_macos_helper_capturing_pip(monkeypatch, folder)
+
+    assert pip_cmds, "expected the helper to install converter deps"
+    assert any(str(folder / "gguf-py") in arg for arg in pip_cmds[0]), pip_cmds[0]
+
+
+def test_macos_helper_installs_gguf_py_from_operator_named_checkout(monkeypatch, tmp_path):
+    # An operator who explicitly points UNSLOTH_LLAMA_CPP_PATH at their own
+    # checkout has vouched for it, so the in-tree gguf-py is still used.
+    import unsloth_zoo.llama_cpp as lcpp
+
+    monkeypatch.setattr(lcpp, "UNSLOTH_HOME", str(tmp_path / "unsloth_home"), raising=False)
+
+    folder = tmp_path / "my_llama_cpp"
+    _make_source_tree_with_gguf_py(folder)
+    monkeypatch.setenv("UNSLOTH_LLAMA_CPP_PATH", str(folder))
+
+    pip_cmds = _run_macos_helper_capturing_pip(monkeypatch, folder)
+
+    assert pip_cmds, "expected the helper to install converter deps"
+    assert any(str(folder / "gguf-py") in arg for arg in pip_cmds[0]), pip_cmds[0]

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -2182,10 +2182,9 @@ def _make_source_tree_with_gguf_py(folder):
 
 
 def test_macos_helper_refuses_pip_install_from_untrusted_checkout(monkeypatch, tmp_path):
-    # `pip install <dir>` executes that directory's build backend, so a llama.cpp
-    # checkout we neither manage nor were pointed at (eg a ./llama.cpp that just
-    # happens to sit in the working directory) must never be installed from. The
-    # export still works: gguf comes from the package index instead.
+    # `pip install <dir>` runs that directory's build backend, so a checkout we
+    # neither manage nor were pointed at must never be installed from. The export
+    # still works: gguf comes from the package index instead.
     import unsloth_zoo.llama_cpp as lcpp
 
     monkeypatch.setattr(lcpp, "UNSLOTH_HOME", str(tmp_path / "unsloth_home"), raising=False)
@@ -2388,10 +2387,9 @@ def test_macos_helper_defaults_to_the_managed_checkout(monkeypatch, tmp_path):
 
 
 def test_trusted_dir_matches_every_llama_cpp_default_dir_spelling(monkeypatch, tmp_path):
-    # The guarantee that nothing changes for real users: save_pretrained_gguf only
-    # ever passes LLAMA_CPP_DEFAULT_DIR, which is UNSLOTH_LLAMA_CPP_PATH verbatim
-    # or ~/.unsloth/llama.cpp. Every spelling of that variable has to come back
-    # trusted, or somebody's export quietly stops using their own gguf-py.
+    # Why nothing changes for real users: save_pretrained_gguf only ever passes
+    # LLAMA_CPP_DEFAULT_DIR, so every spelling of that variable must read as
+    # trusted, or an export quietly stops using the user's own gguf-py.
     home = tmp_path / ".unsloth"
     home.mkdir(parents=True)
     custom = tmp_path / "custom" / "llama.cpp"

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -2183,8 +2183,9 @@ def _make_source_tree_with_gguf_py(folder):
 
 def test_macos_helper_refuses_pip_install_from_untrusted_checkout(monkeypatch, tmp_path):
     # `pip install <dir>` runs that directory's build backend, so a checkout we
-    # neither manage nor were pointed at must never be installed from. The export
-    # still works: gguf comes from the package index instead.
+    # neither manage nor were pointed at must never be installed from. gguf comes
+    # from the package index instead; conversion itself is unaffected either way,
+    # since the converter loads its own sibling gguf-py.
     import unsloth_zoo.llama_cpp as lcpp
 
     monkeypatch.setattr(lcpp, "UNSLOTH_HOME", str(tmp_path / "unsloth_home"), raising=False)

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -2236,3 +2236,183 @@ def test_macos_helper_installs_gguf_py_from_operator_named_checkout(monkeypatch,
 
     assert pip_cmds, "expected the helper to install converter deps"
     assert any(str(folder / "gguf-py") in arg for arg in pip_cmds[0]), pip_cmds[0]
+
+
+# --- _is_trusted_local_llama_cpp_dir path semantics -------------------------
+# `pip install <dir>` runs that directory's build backend, so the containment
+# check that guards it has to be exact. These cover the ways a naive prefix
+# comparison goes wrong.
+
+def _trusted(monkeypatch, folder, home, env_value=None):
+    import unsloth_zoo.mlx.utils as mutils
+    import unsloth_zoo.llama_cpp as lcpp
+
+    monkeypatch.setattr(lcpp, "UNSLOTH_HOME", str(home), raising=False)
+    if env_value is None:
+        monkeypatch.delenv("UNSLOTH_LLAMA_CPP_PATH", raising=False)
+    else:
+        monkeypatch.setenv("UNSLOTH_LLAMA_CPP_PATH", str(env_value))
+    return mutils._is_trusted_local_llama_cpp_dir(str(folder))
+
+
+def test_trusted_dir_accepts_managed_checkout(monkeypatch, tmp_path):
+    home = tmp_path / ".unsloth"
+    assert _trusted(monkeypatch, home / "llama.cpp", home) is True
+    assert _trusted(monkeypatch, home, home) is True
+
+
+def test_trusted_dir_rejects_prefix_sibling(monkeypatch, tmp_path):
+    # "~/.unsloth-evil" shares a string prefix with "~/.unsloth" but is not inside
+    # it. A startswith() without the separator would trust it.
+    home = tmp_path / ".unsloth"
+    evil = tmp_path / ".unsloth-evil"
+    evil.mkdir(parents=True)
+    assert _trusted(monkeypatch, evil, home) is False
+    assert _trusted(monkeypatch, evil / "llama.cpp", home) is False
+
+
+def test_trusted_dir_rejects_symlink_escaping_the_managed_root(monkeypatch, tmp_path):
+    # A symlink sitting inside ~/.unsloth that points out of it must not launder
+    # an untrusted directory into the trusted set.
+    home = tmp_path / ".unsloth"
+    home.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = home / "llama.cpp"
+    link.symlink_to(outside)
+    assert _trusted(monkeypatch, link, home) is False
+
+
+def test_trusted_dir_rejects_cwd_relative_checkout(monkeypatch, tmp_path):
+    # The case the whole guard exists for: a llama.cpp that just happens to be in
+    # the working directory is not something anyone vouched for.
+    home = tmp_path / ".unsloth"
+    home.mkdir(parents=True)
+    cwd = tmp_path / "cwd"
+    (cwd / "llama.cpp").mkdir(parents=True)
+    monkeypatch.chdir(cwd)
+    assert _trusted(monkeypatch, "llama.cpp", home) is False
+    assert _trusted(monkeypatch, os.path.join(".", "llama.cpp"), home) is False
+    # An operator who names that same directory does get the local install.
+    assert _trusted(monkeypatch, "llama.cpp", home, env_value=cwd / "llama.cpp") is True
+
+
+def test_trusted_dir_accepts_operator_named_checkout(monkeypatch, tmp_path):
+    # How Unsloth Studio configures this: it exports UNSLOTH_LLAMA_CPP_PATH.
+    home = tmp_path / ".unsloth"
+    studio = tmp_path / "StudioHome" / "llama.cpp"
+    studio.mkdir(parents=True)
+    assert _trusted(monkeypatch, studio, home, env_value=studio) is True
+    assert _trusted(monkeypatch, studio / "gguf-py", home, env_value=studio) is True
+    # Whitespace is stripped, matching how Studio itself reads the variable.
+    assert _trusted(monkeypatch, studio, home, env_value=f"  {studio}  ") is True
+    # An empty or blank value must not trust anything.
+    assert _trusted(monkeypatch, tmp_path / "other", home, env_value="") is False
+    assert _trusted(monkeypatch, tmp_path / "other", home, env_value="   ") is False
+
+
+def test_trusted_dir_handles_a_root_trusted_path(monkeypatch, tmp_path):
+    # os.path.join(parent, "") keeps a root parent as "/" rather than "//", which
+    # a bare parent + os.sep would produce and never match.
+    home = tmp_path / ".unsloth"
+    assert _trusted(monkeypatch, tmp_path / "anywhere", home, env_value=os.sep) is True
+
+
+def test_trusted_dir_is_case_insensitive_on_windows_style_paths(monkeypatch):
+    # Only reached on macOS today, but the comparison should not quietly depend on
+    # that. Drive letter and directory case must not change the verdict.
+    import ntpath
+    import types
+    import unsloth_zoo.mlx.utils as mutils
+    import unsloth_zoo.llama_cpp as lcpp
+
+    fake_os = types.SimpleNamespace(
+        path=types.SimpleNamespace(
+            realpath=ntpath.normpath,
+            normcase=ntpath.normcase,
+            join=ntpath.join,
+        ),
+        sep="\\",
+        environ={},
+    )
+    monkeypatch.setattr(lcpp, "UNSLOTH_HOME", r"C:\Users\Dan\.unsloth", raising=False)
+    monkeypatch.setattr(mutils, "os", fake_os)
+
+    assert mutils._is_trusted_local_llama_cpp_dir(r"c:\users\dan\.UNSLOTH\llama.cpp") is True
+    assert mutils._is_trusted_local_llama_cpp_dir("C:/Users/Dan/.unsloth/llama.cpp") is True
+    assert mutils._is_trusted_local_llama_cpp_dir(r"C:\Users\Dan\.unsloth-evil") is False
+    assert mutils._is_trusted_local_llama_cpp_dir(r"D:\Users\Dan\.unsloth\llama.cpp") is False
+
+
+def test_trusted_dir_never_raises_on_bad_input(monkeypatch, tmp_path):
+    # A bad path must degrade to "untrusted" (which still installs gguf from the
+    # index), never take down an export with an unexpected exception.
+    home = tmp_path / ".unsloth"
+    for bad in ("", None, "/tmp/a\x00b"):
+        assert _trusted(monkeypatch, bad, home) is False
+
+
+def test_macos_helper_defaults_to_the_managed_checkout(monkeypatch, tmp_path):
+    # The default used to be a CWD-relative "llama.cpp", so a no-arg call built and
+    # pip installed out of the process working directory.
+    import subprocess
+    import unsloth_zoo.mlx.utils as mutils
+    import unsloth_zoo.llama_cpp as lcpp
+
+    managed = tmp_path / ".unsloth" / "llama.cpp"
+    managed.mkdir(parents=True)
+    (managed / "CMakeLists.txt").write_text("# source tree")
+    monkeypatch.setattr(lcpp, "UNSLOTH_HOME", str(tmp_path / ".unsloth"), raising=False)
+    monkeypatch.setattr(lcpp, "LLAMA_CPP_DEFAULT_DIR", str(managed), raising=False)
+
+    cwd = tmp_path / "cwd"
+    (cwd / "llama.cpp").mkdir(parents=True)
+    monkeypatch.chdir(cwd)
+
+    cmds = []
+
+    def fake_run(cmd, *a, **k):
+        cmds.append(list(cmd))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setitem(sys.modules, "psutil", types.SimpleNamespace(cpu_count=lambda: 2))
+
+    mutils._install_llama_cpp_macos()
+
+    assert cmds, "expected the helper to run build commands"
+    assert any(str(managed) in " ".join(str(p) for p in c) for c in cmds), \
+        f"no-arg call should target the managed checkout: {cmds}"
+    assert not any(list(c[:2]) == ["git", "clone"] for c in cmds), \
+        "the managed source tree already exists, so nothing should be cloned"
+
+
+def test_trusted_dir_matches_every_llama_cpp_default_dir_spelling(monkeypatch, tmp_path):
+    # The guarantee that nothing changes for real users: save_pretrained_gguf only
+    # ever passes LLAMA_CPP_DEFAULT_DIR, which is UNSLOTH_LLAMA_CPP_PATH verbatim
+    # or ~/.unsloth/llama.cpp. Every spelling of that variable has to come back
+    # trusted, or somebody's export quietly stops using their own gguf-py.
+    home = tmp_path / ".unsloth"
+    home.mkdir(parents=True)
+    custom = tmp_path / "custom" / "llama.cpp"
+    custom.mkdir(parents=True)
+
+    spellings = [
+        None,                                   # unset
+        str(custom),
+        str(custom) + os.sep,
+        f"  {custom}  ",                        # LLAMA_CPP_DEFAULT_DIR does not strip
+        f"\t{custom}\n",
+        os.path.join(str(tmp_path), "custom", ".", "llama.cpp"),
+        os.path.join(str(tmp_path), "custom", "..", "custom", "llama.cpp"),
+        str(tmp_path / "not_created_yet" / "llama.cpp"),
+    ]
+    for value in spellings:
+        if value is None:
+            monkeypatch.delenv("UNSLOTH_LLAMA_CPP_PATH", raising=False)
+            folder = str(home / "llama.cpp")
+        else:
+            monkeypatch.setenv("UNSLOTH_LLAMA_CPP_PATH", value)
+            folder = value  # exactly what LLAMA_CPP_DEFAULT_DIR would hold
+        assert _trusted(monkeypatch, folder, home, env_value=value) is True, \
+            f"UNSLOTH_LLAMA_CPP_PATH={value!r} should stay trusted"

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14658,9 +14658,43 @@ def save_pretrained_merged(
             )
 
 
-def _install_llama_cpp_macos(llama_cpp_folder="llama.cpp"):
+def _is_trusted_local_llama_cpp_dir(llama_cpp_folder):
+    """Whether we may `pip install` a package out of this llama.cpp checkout.
+
+    Installing a local directory runs that directory's own build backend, so we
+    only ever do it for a checkout Unsloth itself manages (under ~/.unsloth) or
+    one the operator explicitly pointed us at via UNSLOTH_LLAMA_CPP_PATH. A
+    CWD-relative ./llama.cpp is deliberately not trusted: the process working
+    directory is not always under the operator's control, and the same package
+    is available from the configured package index anyway.
+    """
+    from unsloth_zoo.llama_cpp import UNSLOTH_HOME
+
+    def _contains(parent, child):
+        parent = os.path.realpath(parent)
+        return child == parent or child.startswith(parent + os.sep)
+
+    try:
+        real_folder = os.path.realpath(llama_cpp_folder)
+        if _contains(UNSLOTH_HOME, real_folder): return True
+        operator_path = os.environ.get("UNSLOTH_LLAMA_CPP_PATH")
+        if operator_path and _contains(operator_path, real_folder): return True
+    except Exception:
+        # On any unexpected error treat the checkout as untrusted -- the index
+        # fallback still produces a working gguf install.
+        pass
+    return False
+
+
+def _install_llama_cpp_macos(llama_cpp_folder=None):
     """Install llama.cpp on macOS by cloning and building with cmake."""
     import subprocess
+    if llama_cpp_folder is None:
+        # Default to the managed checkout (~/.unsloth/llama.cpp) rather than a
+        # CWD-relative "llama.cpp", so we never build or install out of whatever
+        # happens to sit in the process working directory.
+        from unsloth_zoo.llama_cpp import LLAMA_CPP_DEFAULT_DIR
+        llama_cpp_folder = LLAMA_CPP_DEFAULT_DIR
 
     def _clone():
         print("Unsloth: Cloning llama.cpp...")
@@ -14698,9 +14732,12 @@ def _install_llama_cpp_macos(llama_cpp_folder="llama.cpp"):
         shutil.rmtree(llama_cpp_folder, ignore_errors=True)
         _clone()
 
-    # Install deps; prefer gguf from the cloned repo to stay in sync
+    # Install deps; prefer gguf from the cloned repo to stay in sync, but only
+    # when that checkout is one we manage or the operator named -- see
+    # _is_trusted_local_llama_cpp_dir. Otherwise fall back to the package index,
+    # which keeps the export working without building an unvetted local package.
     gguf_py_dir = os.path.join(llama_cpp_folder, "gguf-py")
-    if os.path.exists(gguf_py_dir):
+    if os.path.exists(gguf_py_dir) and _is_trusted_local_llama_cpp_dir(llama_cpp_folder):
         subprocess.run(
             [sys.executable, "-m", "pip", "install", gguf_py_dir,
              "protobuf", "sentencepiece"],

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14661,42 +14661,34 @@ def save_pretrained_merged(
 def _is_trusted_local_llama_cpp_dir(llama_cpp_folder):
     """Whether we may `pip install` a package out of this llama.cpp checkout.
 
-    Installing a local directory runs that directory's own build backend, so we
-    only ever do it for a checkout Unsloth itself manages (under ~/.unsloth) or
-    one the operator explicitly pointed us at via UNSLOTH_LLAMA_CPP_PATH. A
-    CWD-relative ./llama.cpp is deliberately not trusted: the process working
-    directory is not always under the operator's control, and the same package
-    is available from the configured package index anyway.
+    Installing a local directory runs its build backend, so only a checkout we
+    manage (~/.unsloth) or one the operator named via UNSLOTH_LLAMA_CPP_PATH
+    qualifies. A CWD-relative ./llama.cpp does not: the working directory is not
+    always the operator's, and gguf is on the package index anyway.
     """
     from unsloth_zoo.llama_cpp import UNSLOTH_HOME
 
     def _canonical(path):
-        # realpath both sides so a symlinked home, or macOS' /tmp -> /private/tmp,
-        # compares equal. normcase so Windows' case-insensitive, backslash paths
-        # do too (this helper is only reached on macOS today, but the comparison
-        # should not silently depend on that).
+        # realpath so a symlinked home (or macOS' /tmp -> /private/tmp) compares
+        # equal; normcase so Windows' case-insensitive paths do too.
         return os.path.normcase(os.path.realpath(path))
 
     def _contains(parent, child):
         parent = _canonical(parent)
-        # The trailing separator matters: "/home/me/.unsloth-evil" must not read
-        # as being inside "/home/me/.unsloth". os.path.join(parent, "") rather
-        # than parent + os.sep so a root parent stays "/" and not "//".
+        # Trailing separator: "~/.unsloth-evil" is not inside "~/.unsloth".
+        # join(parent, "") keeps a root parent as "/" rather than "//".
         return child == parent or child.startswith(os.path.join(parent, ""))
 
     try:
         real_folder = _canonical(llama_cpp_folder)
         if _contains(UNSLOTH_HOME, real_folder): return True
-        # Both the raw and the stripped value: LLAMA_CPP_DEFAULT_DIR uses the
-        # variable verbatim, while Studio .strip()s it, so a value with stray
-        # whitespace must read as trusted either way rather than falling through
-        # to the index because the two spellings did not compare equal.
+        # Raw and stripped: LLAMA_CPP_DEFAULT_DIR uses the variable verbatim
+        # while Studio strips it, so both spellings must read as trusted.
         raw = os.environ.get("UNSLOTH_LLAMA_CPP_PATH") or ""
         for operator_path in (raw, raw.strip()):
             if operator_path and _contains(operator_path, real_folder): return True
     except Exception:
-        # On any unexpected error treat the checkout as untrusted -- the index
-        # fallback still produces a working gguf install.
+        # Untrusted on any error; the index fallback still installs gguf.
         pass
     return False
 
@@ -14705,9 +14697,8 @@ def _install_llama_cpp_macos(llama_cpp_folder=None):
     """Install llama.cpp on macOS by cloning and building with cmake."""
     import subprocess
     if llama_cpp_folder is None:
-        # Default to the managed checkout (~/.unsloth/llama.cpp) rather than a
-        # CWD-relative "llama.cpp", so we never build or install out of whatever
-        # happens to sit in the process working directory.
+        # The managed checkout, not a CWD-relative "llama.cpp", so we never build
+        # or install out of whatever sits in the working directory.
         from unsloth_zoo.llama_cpp import LLAMA_CPP_DEFAULT_DIR
         llama_cpp_folder = LLAMA_CPP_DEFAULT_DIR
 
@@ -14748,9 +14739,8 @@ def _install_llama_cpp_macos(llama_cpp_folder=None):
         _clone()
 
     # Install deps; prefer gguf from the cloned repo to stay in sync, but only
-    # when that checkout is one we manage or the operator named -- see
-    # _is_trusted_local_llama_cpp_dir. Otherwise fall back to the package index,
-    # which keeps the export working without building an unvetted local package.
+    # from a trusted checkout. Otherwise take the index copy, which keeps the
+    # export working without building an unvetted local package.
     gguf_py_dir = os.path.join(llama_cpp_folder, "gguf-py")
     if os.path.exists(gguf_py_dir) and _is_trusted_local_llama_cpp_dir(llama_cpp_folder):
         subprocess.run(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14670,15 +14670,30 @@ def _is_trusted_local_llama_cpp_dir(llama_cpp_folder):
     """
     from unsloth_zoo.llama_cpp import UNSLOTH_HOME
 
+    def _canonical(path):
+        # realpath both sides so a symlinked home, or macOS' /tmp -> /private/tmp,
+        # compares equal. normcase so Windows' case-insensitive, backslash paths
+        # do too (this helper is only reached on macOS today, but the comparison
+        # should not silently depend on that).
+        return os.path.normcase(os.path.realpath(path))
+
     def _contains(parent, child):
-        parent = os.path.realpath(parent)
-        return child == parent or child.startswith(parent + os.sep)
+        parent = _canonical(parent)
+        # The trailing separator matters: "/home/me/.unsloth-evil" must not read
+        # as being inside "/home/me/.unsloth". os.path.join(parent, "") rather
+        # than parent + os.sep so a root parent stays "/" and not "//".
+        return child == parent or child.startswith(os.path.join(parent, ""))
 
     try:
-        real_folder = os.path.realpath(llama_cpp_folder)
+        real_folder = _canonical(llama_cpp_folder)
         if _contains(UNSLOTH_HOME, real_folder): return True
-        operator_path = os.environ.get("UNSLOTH_LLAMA_CPP_PATH")
-        if operator_path and _contains(operator_path, real_folder): return True
+        # Both the raw and the stripped value: LLAMA_CPP_DEFAULT_DIR uses the
+        # variable verbatim, while Studio .strip()s it, so a value with stray
+        # whitespace must read as trusted either way rather than falling through
+        # to the index because the two spellings did not compare equal.
+        raw = os.environ.get("UNSLOTH_LLAMA_CPP_PATH") or ""
+        for operator_path in (raw, raw.strip()):
+            if operator_path and _contains(operator_path, real_folder): return True
     except Exception:
         # On any unexpected error treat the checkout as untrusted -- the index
         # fallback still produces a working gguf install.


### PR DESCRIPTION
`_install_llama_cpp_macos` runs `pip install <llama_cpp_folder>/gguf-py` when the checkout has an in-tree `gguf-py`. Installing a local directory executes that directory's own PEP 517 build backend, so the contents of that folder get to run code as the exporting process. Until now the folder that gets installed from could be a CWD-relative `llama.cpp`, since that was the helper's default argument.

The main export path was already fine: `save_pretrained_gguf` passes `LLAMA_CPP_DEFAULT_DIR`, which is `~/.unsloth/llama.cpp` unless the operator overrides it. This just closes the remaining way to reach the local install with a directory nobody vouched for.

## Changes

- `_is_trusted_local_llama_cpp_dir()`: the in-tree `gguf-py` is installed only when the checkout resolves under `~/.unsloth`, or under a path the operator explicitly set via `UNSLOTH_LLAMA_CPP_PATH`. Symlinks are resolved before the comparison.
- Anything else falls back to `pip install gguf` from the configured package index, so `import gguf` still resolves. Conversion is unaffected either way: `convert_hf_to_gguf.py` loads its own sibling `gguf-py` unless `NO_LOCAL_GGUF` is set, so which copy pip installed does not change the exported file.
- `_install_llama_cpp_macos` now defaults `llama_cpp_folder` to `LLAMA_CPP_DEFAULT_DIR` instead of the CWD-relative `"llama.cpp"`. No caller in the repo relied on the old default.

## Behaviour

No change for any normal flow. The managed `~/.unsloth` checkout still installs its own `gguf-py` so gguf stays in sync with llama.cpp, and an operator-named checkout still does too. Only an unvetted directory now gets the index package instead of being built. Both branches are plain pip installs, so re-running an export is idempotent.

I deliberately did not turn a missing `gguf` into a hard error. Auto-provisioning llama.cpp and gguf is what makes GGUF export work out of the box in the notebooks, Studio and Desktop, and failing with "install gguf yourself" would break all of them.

## Tests

Three regression tests in `tests/test_mlx_save_export_regressions.py` covering the untrusted checkout, the managed checkout and the operator-named checkout. Full file passes 58/58.

