### PR TITLE
Restrict builtins and imports for model generated RL code

### DIFF
--- a/tests/test_rl_locked_down_function.py
+++ b/tests/test_rl_locked_down_function.py
@@ -29,6 +29,13 @@ BLOCKED = [
     # The dunder is a string constant here, so the AST check does not see it.
     # It fails anyway because getattr is not in the allowlist at all.
     ("getattr", 'def matmul(A, B):\n    return getattr(A, "__class__")\n', NameError),
+    # Allowlisted modules re-export unsafe ones: random keeps a private handle
+    # on os, and typing keeps sys. The facade has to deny both.
+    ("random._os", 'def matmul(A, B):\n    import random\n    return random._os.system("echo pwned")\n', AttributeError),
+    ("typing.sys", 'def matmul(A, B):\n    import typing\n    return typing.sys.modules["os"].getpid()\n', AttributeError),
+    # attrgetter takes a dotted string, so it walks dunders without the AST
+    # check ever seeing them. operator is therefore not allowlisted.
+    ("operator", 'def matmul(A, B):\n    import operator\n    return operator.attrgetter("__class__")(1)\n', ImportError),
 ]
 
 
@@ -46,6 +53,32 @@ def test_safe_stdlib_imports_still_work():
         '    return "W"\n'
     )
     assert create_locked_down_function(source)([[0]]) == "W"
+
+
+def test_allowlisted_dotted_submodule_works_both_forms():
+    from_form = (
+        "def strategy(board):\n"
+        "    from collections.abc import Iterable\n"
+        "    return isinstance(board, Iterable)\n"
+    )
+    bare_form = (
+        "def strategy(board):\n"
+        "    import collections.abc\n"
+        "    return isinstance(board, collections.abc.Iterable)\n"
+    )
+    assert create_locked_down_function(from_form)([[0]]) is True
+    assert create_locked_down_function(bare_form)([[0]]) is True
+
+
+def test_public_members_of_allowlisted_modules_still_work():
+    source = (
+        "def strategy(board):\n"
+        "    import math\n"
+        "    import random\n"
+        "    random.seed(0)\n"
+        "    return math.floor(2.7) + random.choice([0])\n"
+    )
+    assert create_locked_down_function(source)([[0]]) == 2
 
 
 def test_generated_matmul_still_runs():

--- a/tests/test_rl_locked_down_function.py
+++ b/tests/test_rl_locked_down_function.py
@@ -38,7 +38,35 @@ BLOCKED = [
     # attrgetter takes a dotted string, so it walks dunders without the AST
     # check ever seeing them. operator is therefore not allowlisted.
     ("operator", 'def matmul(A, B):\n    import operator\n    return operator.attrgetter("__class__")(1)\n', ImportError),
+    # Formatter.get_field resolves a dotted string and returns the object, so
+    # it recovers the real __import__. str.format walks attributes the same way
+    # but only returns text, which is why only this one matters.
+    ("string.Formatter", 'def matmul(A, B):\n    import string\n    q = string.Formatter()\n    return q.get_field("0.get_field.__globals__[__builtins__][__import__]", (q,), {})[0]\n', ImportError),
 ]
+
+
+def test_typing_get_type_hints_is_denied():
+    # Annotations are compiled to strings, and get_type_hints evaluates them,
+    # so this executes without a single dunder appearing in the source.
+    source = (
+        "def matmul(A, B):\n"
+        "    import typing\n"
+        "    class C:\n"
+        '        x: "__import__(chr(111)+chr(115)).system(chr(88))"\n'
+        "    return typing.get_type_hints(C)\n"
+    )
+    with pytest.raises(AttributeError):
+        create_locked_down_function(source)([], [])
+
+
+def test_rest_of_typing_still_works():
+    # typing stays allowlisted because the notebooks' own samples import it.
+    source = (
+        "def strategy(board):\n"
+        "    from typing import Callable\n"
+        '    return "W"\n'
+    )
+    assert create_locked_down_function(source)([[0]]) == "W"
 
 
 @pytest.mark.parametrize("label,source,expected", BLOCKED, ids=[b[0] for b in BLOCKED])

--- a/tests/test_rl_locked_down_function.py
+++ b/tests/test_rl_locked_down_function.py
@@ -36,8 +36,9 @@ BLOCKED = [
     ("random._os", 'def matmul(A, B):\n    import random\n    return random._os.system("echo pwned")\n', RuntimeError),
     ("typing.sys", 'def matmul(A, B):\n    import typing\n    return typing.sys.modules["os"].getpid()\n', AttributeError),
     # attrgetter takes a dotted string, so it walks dunders without the AST
-    # check ever seeing them. operator is therefore not allowlisted.
-    ("operator", 'def matmul(A, B):\n    import operator\n    return operator.attrgetter("__class__")(1)\n', ImportError),
+    # check ever seeing them. The member is denied; operator itself stays.
+    ("operator.attrgetter", 'def matmul(A, B):\n    import operator\n    return operator.attrgetter("__class__.__bases__")(1)\n', AttributeError),
+    ("operator.methodcaller", 'def matmul(A, B):\n    import operator\n    return operator.methodcaller("__str__")(1)\n', AttributeError),
     # Formatter.get_field resolves a dotted string and returns the object, so
     # it recovers the real __import__. str.format walks attributes the same way
     # but only returns text, which is why only this one matters.
@@ -130,6 +131,43 @@ def test_public_members_of_allowlisted_modules_still_work():
         "    return math.floor(2.7) + random.choice([0])\n"
     )
     assert create_locked_down_function(source)([[0]]) == 2
+
+
+def test_operator_itemgetter_still_works():
+    # itemgetter is what generated sorting code actually reaches for, and it
+    # takes an index rather than an attribute path, so only attrgetter and
+    # methodcaller are denied.
+    source = (
+        "def strategy(board):\n"
+        "    import operator\n"
+        '    return sorted([(2, "b"), (1, "a")], key = operator.itemgetter(0))[0][0]\n'
+    )
+    assert create_locked_down_function(source)([[0]]) == 1
+
+
+def test_class_helpers_still_work():
+    # Generated helpers are occasionally written as a small class.
+    source = (
+        "def matmul(A, B):\n"
+        "    class Base:\n"
+        "        def go(self):\n"
+        "            return 1\n"
+        "    class C(Base):\n"
+        "        def go(self):\n"
+        "            return super().go() + 1\n"
+        "    return C().go()\n"
+    )
+    assert create_locked_down_function(source)([], []) == 2
+
+
+def test_hasattr_and_time_are_available():
+    source = (
+        "def matmul(A, B):\n"
+        "    import time\n"
+        "    t = time.monotonic()\n"
+        '    return hasattr(A, "shape") is False and t > 0\n'
+    )
+    assert create_locked_down_function(source)([], []) is True
 
 
 def test_generated_matmul_still_runs():

--- a/tests/test_rl_locked_down_function.py
+++ b/tests/test_rl_locked_down_function.py
@@ -30,8 +30,10 @@ BLOCKED = [
     # It fails anyway because getattr is not in the allowlist at all.
     ("getattr", 'def matmul(A, B):\n    return getattr(A, "__class__")\n', NameError),
     # Allowlisted modules re-export unsafe ones: random keeps a private handle
-    # on os, and typing keeps sys. The facade has to deny both.
-    ("random._os", 'def matmul(A, B):\n    import random\n    return random._os.system("echo pwned")\n', AttributeError),
+    # on os, and typing keeps sys. random._os is caught statically by the
+    # private-attribute rule; typing.sys is not private, so the facade is what
+    # stops it. Both layers are load bearing.
+    ("random._os", 'def matmul(A, B):\n    import random\n    return random._os.system("echo pwned")\n', RuntimeError),
     ("typing.sys", 'def matmul(A, B):\n    import typing\n    return typing.sys.modules["os"].getpid()\n', AttributeError),
     # attrgetter takes a dotted string, so it walks dunders without the AST
     # check ever seeing them. operator is therefore not allowlisted.
@@ -68,6 +70,27 @@ def test_allowlisted_dotted_submodule_works_both_forms():
     )
     assert create_locked_down_function(from_form)([[0]]) is True
     assert create_locked_down_function(bare_form)([[0]]) is True
+
+
+def test_private_attribute_access_is_rejected():
+    # Single underscore, not two: private attributes reach modules and
+    # internals just as well as dunders do.
+    source = "def matmul(A, B):\n    import abc\n    return abc.ABCMeta._abc_impl\n"
+    with pytest.raises(RuntimeError):
+        create_locked_down_function(source)([], [])
+
+
+def test_underscore_locals_are_still_allowed():
+    # The Name check stays at two underscores, so ordinary throwaway and
+    # private-ish locals keep working.
+    source = (
+        "def strategy(board):\n"
+        "    _total = 0\n"
+        "    for _ in board:\n"
+        "        _total += 1\n"
+        "    return _total\n"
+    )
+    assert create_locked_down_function(source)([[0], [0], [0]]) == 3
 
 
 def test_public_members_of_allowlisted_modules_still_work():

--- a/tests/test_rl_locked_down_function.py
+++ b/tests/test_rl_locked_down_function.py
@@ -213,3 +213,46 @@ def test_full_policy_remains_available():
         builtins_policy = "full",
     )
     assert isinstance(fn([], []), str)
+
+
+def test_dunder_method_definitions_are_denied():
+    # A method name is FunctionDef.name, not a Name or Attribute node, so the
+    # walk cannot see it. Without the fail-closed rule, a custom __setattr__
+    # captures what functools.update_wrapper copies.
+    source = (
+        "def matmul(A, B):\n"
+        "    import functools\n"
+        "    import statistics\n"
+        "    box = []\n"
+        "    class W:\n"
+        "        def __setattr__(self, k, v):\n"
+        "            box.append(v)\n"
+        "    w = W()\n"
+        '    functools.update_wrapper(w, statistics.mean, assigned=("__globals__",), updated=())\n'
+        '    return box[0]["__builtins__"]["__import__"]("os")\n'
+    )
+    with pytest.raises(RuntimeError):
+        create_locked_down_function(source)([], [])
+
+
+def test_ordinary_dunder_methods_still_allowed():
+    # __init__ and the comparison protocol are ordinary in helper classes.
+    source = (
+        "def matmul(A, B):\n"
+        "    class Node:\n"
+        "        def __init__(self, v):\n"
+        "            self.v = v\n"
+        "        def __lt__(self, o):\n"
+        "            return self.v < o.v\n"
+        "    return sorted([Node(3), Node(1)])[0].v\n"
+    )
+    assert create_locked_down_function(source)([], []) == 1
+
+
+def test_functools_reduce_still_works():
+    source = (
+        "def matmul(A, B):\n"
+        "    import functools\n"
+        "    return functools.reduce(lambda a, b: a + b, [1, 2, 3])\n"
+    )
+    assert create_locked_down_function(source)([], []) == 6

--- a/tests/test_rl_locked_down_function.py
+++ b/tests/test_rl_locked_down_function.py
@@ -256,3 +256,56 @@ def test_functools_reduce_still_works():
         "    return functools.reduce(lambda a, b: a + b, [1, 2, 3])\n"
     )
     assert create_locked_down_function(source)([], []) == 6
+
+
+def test_frame_traversal_is_denied():
+    # A running generator reaches gi_frame.f_back.f_back.f_builtins, which is
+    # the trusted caller's real builtins. No module is involved and no name
+    # starts with an underscore, so this needs its own rule.
+    source = (
+        "def matmul(A, B):\n"
+        "    holder = []\n"
+        "    def g():\n"
+        "        fr = holder[0].gi_frame.f_back.f_back\n"
+        "        yield fr.f_builtins\n"
+        "    gen = g()\n"
+        "    holder.append(gen)\n"
+        '    return next(gen)["__import__"]("os")\n'
+    )
+    with pytest.raises(RuntimeError):
+        create_locked_down_function(source)([], [])
+
+
+def test_ordinary_generators_still_work():
+    source = (
+        "def matmul(A, B):\n"
+        "    def g():\n"
+        "        yield 1\n"
+        "        yield 2\n"
+        "    return sum(g())\n"
+    )
+    assert create_locked_down_function(source)([], []) == 3
+
+
+def test_clock_setters_denied_but_clocks_readable():
+    with pytest.raises(AttributeError):
+        create_locked_down_function(
+            "def matmul(A, B):\n    import time\n    return time.clock_settime\n"
+        )([], [])
+    readable = "def matmul(A, B):\n    import time\n    return time.monotonic() > 0\n"
+    assert create_locked_down_function(readable)([], []) is True
+
+
+def test_not_implemented_is_available():
+    # The comparison dunders we allow are expected to return NotImplemented
+    # for operands they do not handle.
+    source = (
+        "def matmul(A, B):\n"
+        "    class N:\n"
+        "        def __eq__(self, o):\n"
+        "            if not isinstance(o, N):\n"
+        "                return NotImplemented\n"
+        "            return True\n"
+        "    return N() == 5\n"
+    )
+    assert create_locked_down_function(source)([], []) is False

--- a/tests/test_rl_locked_down_function.py
+++ b/tests/test_rl_locked_down_function.py
@@ -60,6 +60,19 @@ def test_typing_get_type_hints_is_denied():
         create_locked_down_function(source)([], [])
 
 
+def test_typing_forward_ref_evaluators_are_denied():
+    # ForwardRef.evaluate and evaluate_forward_ref are the same evaluator, made
+    # public in 3.14. On 3.13 the entry point is the private _evaluate, which
+    # the private-attribute rule already covers, but this package supports 3.14
+    # so the names are denied on every version.
+    for source in (
+        'def matmul(A, B):\n    import typing\n    return typing.ForwardRef("1+1")\n',
+        'def matmul(A, B):\n    import typing\n    return typing.evaluate_forward_ref\n',
+    ):
+        with pytest.raises(AttributeError):
+            create_locked_down_function(source)([], [])
+
+
 def test_rest_of_typing_still_works():
     # typing stays allowlisted because the notebooks' own samples import it.
     source = (

--- a/tests/test_rl_locked_down_function.py
+++ b/tests/test_rl_locked_down_function.py
@@ -1,0 +1,80 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import pytest
+
+from unsloth_zoo.rl_environments import create_locked_down_function
+
+BLOCKED = [
+    ("import os", "def matmul(A, B):\n    import os\n    return os.getpid()\n", ImportError),
+    ("dunder import", 'def matmul(A, B):\n    return __import__("os")\n', RuntimeError),
+    ("subclasses walk", "def matmul(A, B):\n    return (1).__class__.__bases__[0].__subclasses__()\n", RuntimeError),
+    ("open", 'def matmul(A, B):\n    return open("/etc/passwd").read()\n', NameError),
+    ("eval", 'def matmul(A, B):\n    return eval("1+1")\n', NameError),
+    ("subprocess", "def matmul(A, B):\n    import subprocess\n    return subprocess.run\n", ImportError),
+    ("socket", "def matmul(A, B):\n    import socket\n    return socket.socket()\n", ImportError),
+    # The dunder is a string constant here, so the AST check does not see it.
+    # It fails anyway because getattr is not in the allowlist at all.
+    ("getattr", 'def matmul(A, B):\n    return getattr(A, "__class__")\n', NameError),
+]
+
+
+@pytest.mark.parametrize("label,source,expected", BLOCKED, ids=[b[0] for b in BLOCKED])
+def test_escape_is_blocked(label, source, expected):
+    with pytest.raises(expected):
+        create_locked_down_function(source)([], [])
+
+
+def test_safe_stdlib_imports_still_work():
+    source = (
+        "def strategy(board):\n"
+        "    import math\n"
+        "    from typing import Callable\n"
+        '    return "W"\n'
+    )
+    assert create_locked_down_function(source)([[0]]) == "W"
+
+
+def test_generated_matmul_still_runs():
+    source = (
+        "def matmul(A, B):\n"
+        "    z, s = zip, sum\n"
+        "    Bt = list(z(*B))\n"
+        "    return [[s(a*b for a, b in z(row, col)) for col in Bt] for row in A]\n"
+    )
+    fn = create_locked_down_function(source)
+    assert fn([[1, 2], [3, 4]], [[5, 6], [7, 8]]) == [[19, 22], [43, 50]]
+
+
+def test_positional_defaults_survive_lockdown():
+    fn = create_locked_down_function("def strategy(board, depth = 7):\n    return depth\n")
+    assert fn([[0]]) == 7
+
+
+def test_keyword_only_defaults_survive_lockdown():
+    # A literal keyword-only default passes validation, so the locked down
+    # function must keep it; otherwise calling it raises TypeError.
+    fn = create_locked_down_function("def strategy(board, *, depth = 3):\n    return depth\n")
+    assert fn.__kwdefaults__ == {"depth": 3}
+    assert fn([[0]]) == 3
+
+
+def test_full_policy_remains_available():
+    fn = create_locked_down_function(
+        "def matmul(A, B):\n    import os\n    return os.sep\n",
+        builtins_policy = "full",
+    )
+    assert isinstance(fn([], []), str)

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -486,25 +486,73 @@ pass
 
 # Importable by generated code. Excludes any stdlib module that reaches the
 # filesystem, network or another process (os, subprocess, socket, ctypes, ...).
+# Also excludes two that look harmless but are not: `operator`, whose attrgetter
+# takes a dotted string and so walks dunders without the AST check ever seeing
+# them, and `dataclasses`, which resolves annotations through
+# sys.modules[cls.__module__] and cannot work for synthetic globals.
 _SAFE_IMPORT_MODULES = frozenset({
-    "abc", "array", "bisect", "cmath", "collections", "copy", "dataclasses",
+    "abc", "array", "bisect", "cmath", "collections", "collections.abc", "copy",
     "decimal", "enum", "fractions", "functools", "heapq", "itertools", "math",
-    "numbers", "operator", "random", "re", "statistics", "string", "textwrap",
-    "typing", "unicodedata",
+    "numbers", "random", "re", "statistics", "string", "textwrap", "typing",
+    "unicodedata",
 })
+
+
+class _SafeModule:
+    """
+    Facade over an allowlisted module.
+
+    Handing back the real module object is not enough, because modules
+    re-export other modules: `random._os` and `typing.sys` both lead straight
+    back to the process and filesystem capabilities the allowlist removes. So
+    deny private names, and deny nested modules unless their dotted name is
+    itself allowlisted.
+    """
+    __slots__ = ("_module", "_name")
+
+    def __init__(self, module, name):
+        object.__setattr__(self, "_module", module)
+        object.__setattr__(self, "_name", name)
+
+    def __getattr__(self, attr):
+        if attr.startswith("_"):
+            raise AttributeError(
+                f"Access to '{self._name}.{attr}' is not allowed in generated code."
+            )
+        value = getattr(self._module, attr)
+        if isinstance(value, types.ModuleType):
+            dotted = f"{self._name}.{attr}"
+            if dotted not in _SAFE_IMPORT_MODULES:
+                raise AttributeError(
+                    f"Access to module '{dotted}' is not allowed in generated code."
+                )
+            return _SafeModule(value, dotted)
+        return value
+
+    def __repr__(self):
+        return f"<safe module '{self._name}'>"
+pass
 
 
 def _safe_import(name, globals = None, locals = None, fromlist = (), level = 0):
     """
     __import__ replacement for generated code: only _SAFE_IMPORT_MODULES
-    resolve. Covers `import math` and `from typing import X` alike, since both
-    call __import__ with the top-level name.
+    resolve, and always behind a _SafeModule facade.
+
+    Dotted names reach here in full (`import collections.abc` passes
+    "collections.abc"), so allowlist membership is checked on the whole name.
     """
     if level != 0:
         raise ImportError("Relative imports are not allowed in generated code.")
     if name not in _SAFE_IMPORT_MODULES:
         raise ImportError(f"Import of '{name}' is not allowed in generated code.")
-    return importlib.import_module(name)
+    if fromlist:
+        return _SafeModule(importlib.import_module(name), name)
+    # A bare `import a.b` binds `a`, so hand back the root; the facade re-checks
+    # `a.b` when the attribute is reached.
+    root = name.split(".")[0]
+    importlib.import_module(name)
+    return _SafeModule(importlib.import_module(root), root)
 pass
 
 

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -30,6 +30,7 @@ import sys
 import sysconfig
 from pathlib import Path
 import functools
+import importlib
 import types
 import __future__
 import builtins as _py_builtins
@@ -483,6 +484,88 @@ def validate_single_function_source(
 pass
 
 
+# Modules a generated function may import. Deliberately excludes every stdlib
+# module that can touch the filesystem, the network or another process, so
+# os / subprocess / socket / shutil / ctypes / importlib are all unreachable.
+_SAFE_IMPORT_MODULES = frozenset({
+    "abc", "array", "bisect", "cmath", "collections", "copy", "dataclasses",
+    "decimal", "enum", "fractions", "functools", "heapq", "itertools", "math",
+    "numbers", "operator", "random", "re", "statistics", "string", "textwrap",
+    "typing", "unicodedata",
+})
+
+
+def _safe_import(name, globals = None, locals = None, fromlist = (), level = 0):
+    """
+    Replacement for __import__ exposed to generated code.
+
+    Only top-level modules in _SAFE_IMPORT_MODULES resolve; everything else
+    raises ImportError. Handles both `import math` and `from typing import X`,
+    since both call __import__ with the top-level module name.
+    """
+    if level != 0:
+        raise ImportError("Relative imports are not allowed in generated code.")
+    if name not in _SAFE_IMPORT_MODULES:
+        raise ImportError(f"Import of '{name}' is not allowed in generated code.")
+    return importlib.import_module(name)
+pass
+
+
+def _allowlist_builtins():
+    """
+    A small safe builtins mapping for generated code.
+
+    Covers what the RL notebook prompts actually ask the model to use (list and
+    numeric work, comprehensions, sorting, exception handling) while omitting
+    every capability primitive: no __import__ except the shim above, and no
+    open / eval / exec / compile / input / getattr / setattr / globals / vars /
+    locals / breakpoint / memoryview.
+    """
+    names = (
+        "abs", "all", "any", "ascii", "bin", "bool", "bytes", "callable", "chr",
+        "complex", "dict", "divmod", "enumerate", "filter", "float", "format",
+        "frozenset", "hash", "hex", "id", "int", "isinstance", "issubclass",
+        "iter", "len", "list", "map", "max", "min", "next", "oct", "ord", "pow",
+        "print", "range", "repr", "reversed", "round", "set", "slice", "sorted",
+        "str", "sum", "tuple", "type", "zip",
+        # Exception machinery: generated code routinely uses try/except.
+        "ArithmeticError", "AssertionError", "AttributeError", "BaseException",
+        "Exception", "FloatingPointError", "IndexError", "KeyError",
+        "MemoryError", "NotImplementedError", "OverflowError", "RecursionError",
+        "RuntimeError", "StopIteration", "TypeError", "ValueError",
+        "ZeroDivisionError",
+    )
+    exposed = {name: getattr(_py_builtins, name) for name in names}
+    # Needed for `class` statements inside the generated function.
+    exposed["__build_class__"] = _py_builtins.__build_class__
+    exposed["__name__"] = "__user_code__"
+    exposed["__import__"] = _safe_import
+    return exposed
+pass
+
+
+def _reject_dunder_access(tree):
+    """
+    Reject dunder attribute/name access in generated code.
+
+    Restricting builtins alone does not contain the classic escape
+    `().__class__.__bases__[0].__subclasses__()`, which walks from any literal
+    to arbitrary already-imported classes (subprocess.Popen among them) using
+    nothing but attribute access. Generated matmul/strategy code has no reason
+    to touch dunders, so refuse them outright.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+            raise RuntimeError(
+                f"Attribute '{node.attr}' is not allowed in generated code."
+            )
+        if isinstance(node, ast.Name) and node.id.startswith("__"):
+            raise RuntimeError(
+                f"Name '{node.id}' is not allowed in generated code."
+            )
+pass
+
+
 def load_single_function(
     source: str,
     *,
@@ -508,28 +591,9 @@ def load_single_function(
     if builtins_policy == "full":
         exposed_builtins = _py_builtins.__dict__
     elif builtins_policy == "allowlist":
-        exposed_builtins = {
-            "abs": _py_builtins.abs,
-            "all": _py_builtins.all,
-            "any": _py_builtins.any,
-            "bool": _py_builtins.bool,
-            "dict": _py_builtins.dict,
-            "enumerate": _py_builtins.enumerate,
-            "float": _py_builtins.float,
-            "int": _py_builtins.int,
-            "len": _py_builtins.len,
-            "list": _py_builtins.list,
-            "max": _py_builtins.max,
-            "min": _py_builtins.min,
-            "pow": _py_builtins.pow,
-            "range": _py_builtins.range,
-            "reversed": _py_builtins.reversed,
-            "round": _py_builtins.round,
-            "str": _py_builtins.str,
-            "sum": _py_builtins.sum,
-            "tuple": _py_builtins.tuple,
-            "zip": _py_builtins.zip,
-        }
+        exposed_builtins = _allowlist_builtins()
+        # Only meaningful alongside the restricted builtins above.
+        _reject_dunder_access(tree)
     else:
         raise ValueError("builtins_policy must be 'full' or 'allowlist'")
 
@@ -554,13 +618,34 @@ def load_single_function(
     return fn
 pass
 
-def create_locked_down_function(function):
+def create_locked_down_function(function, *, builtins_policy: str = "allowlist"):
     """
     Creates a singular Python function which disallows globals.
+
+    Defaults to the "allowlist" builtins policy, so model-generated code cannot
+    reach __import__ / open / eval / exec / compile, cannot import anything
+    outside _SAFE_IMPORT_MODULES, and cannot walk dunder attributes. Pass
+    builtins_policy = "full" to restore the old permissive behaviour.
+
+    This is defence in depth, not a real sandbox: it does not bound CPU, memory
+    or recursion, and it is not a substitute for OS-level isolation. Run
+    genuinely untrusted code in a container.
     """
-    f = load_single_function(function)
-    # Locks down function so it can see global variables of nothingness
-    f = types.FunctionType(f.__code__, {})
+    f = load_single_function(function, builtins_policy = builtins_policy)
+    # Lock the function down to only the builtins the policy allows. Binding to
+    # an empty dict is not sufficient: CPython injects the real builtins module
+    # into any globals mapping that has no __builtins__ key, which would hand
+    # back everything the policy just removed.
+    exposed_builtins = (
+        _py_builtins.__dict__ if builtins_policy == "full" else _allowlist_builtins()
+    )
+    f = types.FunctionType(
+        f.__code__,
+        {"__builtins__": exposed_builtins},
+        f.__name__,
+        f.__defaults__,
+        f.__closure__,
+    )
     return f
 pass
 

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -517,12 +517,32 @@ _SAFE_IMPORT_MODULES = frozenset({
 #     entry point is the private _evaluate and the private-attribute rule
 #     already covers it, but this package supports up to 3.14, so deny the
 #     names outright rather than have the hole open on the newer runtime.
+#   functools.update_wrapper and wraps copy attributes named by their
+#     `assigned` argument, so assigned=("__globals__",) plus a class with a
+#     custom __setattr__ captures a real module globals dict, and indexing
+#     "__builtins__" out of it recovers the unrestricted __import__.
 _DENIED_MODULE_ATTRS = frozenset({
+    "functools.update_wrapper",
+    "functools.wraps",
     "operator.attrgetter",
     "operator.methodcaller",
     "typing.ForwardRef",
     "typing.evaluate_forward_ref",
     "typing.get_type_hints",
+})
+
+# Dunder methods a generated helper class may define. A method name is
+# FunctionDef.name, not a Name or Attribute node, so the walk below cannot see
+# it; without this, generated code defines __setattr__ or __getattr__ and hooks
+# the attribute machinery that copy helpers drive. __init__ and the comparison
+# and arithmetic protocol are ordinary in helper classes, so they stay.
+_ALLOWED_DUNDER_DEFS = frozenset({
+    "__abs__", "__add__", "__bool__", "__call__", "__contains__", "__enter__",
+    "__eq__", "__exit__", "__float__", "__floordiv__", "__ge__", "__getitem__",
+    "__gt__", "__hash__", "__index__", "__init__", "__int__", "__iter__",
+    "__le__", "__len__", "__lt__", "__mod__", "__mul__", "__ne__", "__neg__",
+    "__next__", "__pos__", "__pow__", "__repr__", "__round__", "__setitem__",
+    "__str__", "__sub__", "__truediv__",
 })
 
 
@@ -631,6 +651,13 @@ def _reject_dunder_access(tree):
     dunders, so refuse them outright.
     """
     for node in ast.walk(tree):
+        # Definition names are strings on the node, invisible to the Name and
+        # Attribute checks below, so they get their own fail-closed rule.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name.startswith("__") and node.name not in _ALLOWED_DUNDER_DEFS:
+                raise RuntimeError(
+                    f"Defining '{node.name}' is not allowed in generated code."
+                )
         # One underscore for attributes: private ones reach modules and
         # internals just as well (random._os, ABCMeta._abc_impl).
         if isinstance(node, ast.Attribute) and node.attr.startswith("_"):

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -484,9 +484,8 @@ def validate_single_function_source(
 pass
 
 
-# Modules a generated function may import. Deliberately excludes every stdlib
-# module that can touch the filesystem, the network or another process, so
-# os / subprocess / socket / shutil / ctypes / importlib are all unreachable.
+# Importable by generated code. Excludes any stdlib module that reaches the
+# filesystem, network or another process (os, subprocess, socket, ctypes, ...).
 _SAFE_IMPORT_MODULES = frozenset({
     "abc", "array", "bisect", "cmath", "collections", "copy", "dataclasses",
     "decimal", "enum", "fractions", "functools", "heapq", "itertools", "math",
@@ -497,11 +496,9 @@ _SAFE_IMPORT_MODULES = frozenset({
 
 def _safe_import(name, globals = None, locals = None, fromlist = (), level = 0):
     """
-    Replacement for __import__ exposed to generated code.
-
-    Only top-level modules in _SAFE_IMPORT_MODULES resolve; everything else
-    raises ImportError. Handles both `import math` and `from typing import X`,
-    since both call __import__ with the top-level module name.
+    __import__ replacement for generated code: only _SAFE_IMPORT_MODULES
+    resolve. Covers `import math` and `from typing import X` alike, since both
+    call __import__ with the top-level name.
     """
     if level != 0:
         raise ImportError("Relative imports are not allowed in generated code.")
@@ -513,13 +510,10 @@ pass
 
 def _allowlist_builtins():
     """
-    A small safe builtins mapping for generated code.
-
-    Covers what the RL notebook prompts actually ask the model to use (list and
-    numeric work, comprehensions, sorting, exception handling) while omitting
-    every capability primitive: no __import__ except the shim above, and no
-    open / eval / exec / compile / input / getattr / setattr / globals / vars /
-    locals / breakpoint / memoryview.
+    Safe builtins for generated code: enough for the list/numeric/sorting work
+    the RL prompts ask for, minus every capability primitive (open, eval, exec,
+    compile, input, getattr, globals, vars, breakpoint, and __import__ except
+    the shim above).
     """
     names = (
         "abs", "all", "any", "ascii", "bin", "bool", "bytes", "callable", "chr",
@@ -528,7 +522,7 @@ def _allowlist_builtins():
         "iter", "len", "list", "map", "max", "min", "next", "oct", "ord", "pow",
         "print", "range", "repr", "reversed", "round", "set", "slice", "sorted",
         "str", "sum", "tuple", "type", "zip",
-        # Exception machinery: generated code routinely uses try/except.
+        # Generated code routinely uses try/except.
         "ArithmeticError", "AssertionError", "AttributeError", "BaseException",
         "Exception", "FloatingPointError", "IndexError", "KeyError",
         "MemoryError", "NotImplementedError", "OverflowError", "RecursionError",
@@ -536,7 +530,7 @@ def _allowlist_builtins():
         "ZeroDivisionError",
     )
     exposed = {name: getattr(_py_builtins, name) for name in names}
-    # Needed for `class` statements inside the generated function.
+    # Required for `class` statements.
     exposed["__build_class__"] = _py_builtins.__build_class__
     exposed["__name__"] = "__user_code__"
     exposed["__import__"] = _safe_import
@@ -546,13 +540,10 @@ pass
 
 def _reject_dunder_access(tree):
     """
-    Reject dunder attribute/name access in generated code.
-
-    Restricting builtins alone does not contain the classic escape
-    `().__class__.__bases__[0].__subclasses__()`, which walks from any literal
-    to arbitrary already-imported classes (subprocess.Popen among them) using
-    nothing but attribute access. Generated matmul/strategy code has no reason
-    to touch dunders, so refuse them outright.
+    Restricted builtins alone do not stop `().__class__.__bases__[0].__subclasses__()`,
+    which walks from any literal to already-imported classes (subprocess.Popen
+    included) using only attribute access. Generated code has no reason to touch
+    dunders, so refuse them outright.
     """
     for node in ast.walk(tree):
         if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
@@ -622,20 +613,18 @@ def create_locked_down_function(function, *, builtins_policy: str = "allowlist")
     """
     Creates a singular Python function which disallows globals.
 
-    Defaults to the "allowlist" builtins policy, so model-generated code cannot
-    reach __import__ / open / eval / exec / compile, cannot import anything
-    outside _SAFE_IMPORT_MODULES, and cannot walk dunder attributes. Pass
-    builtins_policy = "full" to restore the old permissive behaviour.
+    Defaults to builtins_policy = "allowlist": generated code cannot reach
+    __import__ / open / eval / exec / compile, import outside
+    _SAFE_IMPORT_MODULES, or walk dunder attributes. Pass "full" for the old
+    permissive behaviour.
 
-    This is defence in depth, not a real sandbox: it does not bound CPU, memory
-    or recursion, and it is not a substitute for OS-level isolation. Run
-    genuinely untrusted code in a container.
+    Defence in depth, not a real sandbox. It does not bound CPU, memory or
+    recursion. Run genuinely untrusted code in a container.
     """
     f = load_single_function(function, builtins_policy = builtins_policy)
-    # Lock the function down to only the builtins the policy allows. Binding to
-    # an empty dict is not sufficient: CPython injects the real builtins module
-    # into any globals mapping that has no __builtins__ key, which would hand
-    # back everything the policy just removed.
+    # Binding to an empty dict is not enough: CPython injects the real builtins
+    # module into any globals mapping without a __builtins__ key, handing back
+    # everything the policy just removed.
     exposed_builtins = (
         _py_builtins.__dict__ if builtins_policy == "full" else _allowlist_builtins()
     )

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -485,16 +485,14 @@ pass
 
 
 # Importable by generated code. Excludes anything reaching the filesystem,
-# network or another process (os, subprocess, socket, ctypes, ...).
-#
-# Excludes `string`, whose Formatter.get_field resolves a dotted RUNTIME STRING
-# and returns the object, walking straight back to the real builtins with
-# nothing in the source for the AST check to match. str.format resolves
-# attributes the same way but only ever returns formatted text, never the
-# object, so it is not an execution path and stays.
-#
-# dataclasses is excluded for a different reason: it resolves annotations via
-# sys.modules[cls.__module__], which cannot work for synthetic globals.
+# network or another process (os, subprocess, socket, ctypes, ...), plus two
+# whose whole module has to go:
+#   string -- Formatter.get_field resolves a dotted runtime string and returns
+#     the object, reaching the real builtins with nothing in the source to
+#     match. str.format resolves the same way but only returns text, never the
+#     object, so it is not an execution path and stays.
+#   dataclasses -- resolves annotations via sys.modules[cls.__module__], which
+#     cannot work for synthetic globals.
 _SAFE_IMPORT_MODULES = frozenset({
     "abc", "array", "bisect", "cmath", "collections", "collections.abc", "copy",
     "decimal", "enum", "fractions", "functools", "heapq", "itertools", "math",
@@ -502,28 +500,18 @@ _SAFE_IMPORT_MODULES = frozenset({
     "typing", "unicodedata",
 })
 
-# Public members that turn a runtime string into an object, or evaluate one.
-# Same AST blind spot as `string` above, but these sit in modules worth
-# keeping, so deny the member instead of the whole module:
-#   operator.attrgetter("__class__.__bases__")(x) walks dunders from a string,
-#     while itemgetter, the one generated sorting code actually reaches for,
-#     takes an index and is fine.
-#   typing.get_type_hints evaluates string annotations, and since this module
-#     compiles annotations to strings, a class annotated with
-#     "__import__('os').system(...)" executes on the call. The notebooks' own
-#     samples do `from typing import Callable`, so typing itself stays.
-#   typing.ForwardRef.evaluate and typing.evaluate_forward_ref are the same
-#     evaluator, made public in 3.14. They do not exist on 3.13, where the
-#     entry point is the private _evaluate and the private-attribute rule
-#     already covers it, but this package supports up to 3.14, so deny the
-#     names outright rather than have the hole open on the newer runtime.
-#   functools.update_wrapper and wraps copy attributes named by their
-#     `assigned` argument, so assigned=("__globals__",) plus a class with a
-#     custom __setattr__ captures a real module globals dict, and indexing
-#     "__builtins__" out of it recovers the unrestricted __import__.
-#   time.clock_settime and clock_settime_ns mutate the host clock. They need
-#     privilege, which a container running as root has, and no generated
-#     strategy needs to set the time. The read-only clocks stay.
+# Members denied individually, where the module itself is worth keeping.
+# Three reasons, all of them invisible to the AST check:
+#   string-to-object resolvers -- operator.attrgetter walks dunders from a
+#     dotted string (itemgetter takes an index and stays); functools
+#     update_wrapper/wraps copy whatever `assigned` names, so ("__globals__",)
+#     plus a custom __setattr__ yields a real globals dict to index.
+#   evaluators -- typing.get_type_hints runs string annotations, and
+#     ForwardRef/evaluate_forward_ref are the same evaluator made public in
+#     3.14. Denied on every version; 3.13 reaches it only via private
+#     _evaluate, which the private-attribute rule already covers.
+#   mutators -- time.clock_settime(_ns) sets the host clock given the
+#     privilege a root container has. Read-only clocks stay.
 _DENIED_MODULE_ATTRS = frozenset({
     "functools.update_wrapper",
     "functools.wraps",

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -512,9 +512,16 @@ _SAFE_IMPORT_MODULES = frozenset({
 #     compiles annotations to strings, a class annotated with
 #     "__import__('os').system(...)" executes on the call. The notebooks' own
 #     samples do `from typing import Callable`, so typing itself stays.
+#   typing.ForwardRef.evaluate and typing.evaluate_forward_ref are the same
+#     evaluator, made public in 3.14. They do not exist on 3.13, where the
+#     entry point is the private _evaluate and the private-attribute rule
+#     already covers it, but this package supports up to 3.14, so deny the
+#     names outright rather than have the hole open on the newer runtime.
 _DENIED_MODULE_ATTRS = frozenset({
     "operator.attrgetter",
     "operator.methodcaller",
+    "typing.ForwardRef",
+    "typing.evaluate_forward_ref",
     "typing.get_type_hints",
 })
 

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -521,14 +521,35 @@ _SAFE_IMPORT_MODULES = frozenset({
 #     `assigned` argument, so assigned=("__globals__",) plus a class with a
 #     custom __setattr__ captures a real module globals dict, and indexing
 #     "__builtins__" out of it recovers the unrestricted __import__.
+#   time.clock_settime and clock_settime_ns mutate the host clock. They need
+#     privilege, which a container running as root has, and no generated
+#     strategy needs to set the time. The read-only clocks stay.
 _DENIED_MODULE_ATTRS = frozenset({
     "functools.update_wrapper",
     "functools.wraps",
+    "time.clock_settime",
+    "time.clock_settime_ns",
     "operator.attrgetter",
     "operator.methodcaller",
     "typing.ForwardRef",
     "typing.evaluate_forward_ref",
     "typing.get_type_hints",
+})
+
+# Attributes that walk the interpreter's own object graph. None of these start
+# with an underscore, and none of them go through a module, so neither the
+# private-attribute rule nor the import allowlist can see them: a running
+# generator reaches gi_frame.f_back.f_back.f_builtins, which is the trusted
+# caller's real builtins, and indexing "__import__" out of it restores
+# everything. Frames, generators, coroutines, async generators and tracebacks
+# all expose the same walk.
+_DENIED_ATTR_NAMES = frozenset({
+    "ag_await", "ag_code", "ag_frame",
+    "cr_await", "cr_code", "cr_frame", "cr_origin",
+    "f_back", "f_builtins", "f_code", "f_globals", "f_lasti", "f_lineno",
+    "f_locals", "f_trace",
+    "gi_code", "gi_frame", "gi_running", "gi_yieldfrom",
+    "tb_frame", "tb_lasti", "tb_lineno", "tb_next",
 })
 
 # Dunder methods a generated helper class may define. A method name is
@@ -635,6 +656,10 @@ def _allowlist_builtins():
         "ZeroDivisionError",
     )
     exposed = {name: getattr(_py_builtins, name) for name in names}
+    # The comparison and arithmetic dunders allowed below are expected to
+    # return NotImplemented for operands they do not handle, so the singleton
+    # has to be reachable. It is a value, not a capability.
+    exposed["NotImplemented"] = _py_builtins.NotImplemented
     # Required for `class` statements.
     exposed["__build_class__"] = _py_builtins.__build_class__
     exposed["__name__"] = "__user_code__"
@@ -661,6 +686,10 @@ def _reject_dunder_access(tree):
         # One underscore for attributes: private ones reach modules and
         # internals just as well (random._os, ABCMeta._abc_impl).
         if isinstance(node, ast.Attribute) and node.attr.startswith("_"):
+            raise RuntimeError(
+                f"Attribute '{node.attr}' is not allowed in generated code."
+            )
+        if isinstance(node, ast.Attribute) and node.attr in _DENIED_ATTR_NAMES:
             raise RuntimeError(
                 f"Attribute '{node.attr}' is not allowed in generated code."
             )

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -594,10 +594,15 @@ def _reject_dunder_access(tree):
     dunders, so refuse them outright.
     """
     for node in ast.walk(tree):
-        if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+        # Attributes are checked on a single underscore, not two: private
+        # attributes reach modules and internals just as well (random._os,
+        # ABCMeta._abc_impl), and generated code never needs them.
+        if isinstance(node, ast.Attribute) and node.attr.startswith("_"):
             raise RuntimeError(
                 f"Attribute '{node.attr}' is not allowed in generated code."
             )
+        # Names stay at two, because a bare `_` or `_total` local is ordinary
+        # in generated code and reaches nothing on its own.
         if isinstance(node, ast.Name) and node.id.startswith("__"):
             raise RuntimeError(
                 f"Name '{node.id}' is not allowed in generated code."

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -487,31 +487,34 @@ pass
 # Importable by generated code. Excludes anything reaching the filesystem,
 # network or another process (os, subprocess, socket, ctypes, ...).
 #
-# Also excludes every module that resolves attributes from a RUNTIME STRING and
-# hands back the object, because _reject_dunder_access works on the AST and
-# there is nothing in the source for it to match:
-#   operator.attrgetter("__class__.__bases__")(x)
-#   string.Formatter().get_field("0.get_field.__globals__[...]", (x,), {})
-# Both walk straight back to the real builtins. str.format resolves attributes
-# the same way but only ever returns the formatted text, never the object, so
-# it is not an execution path.
+# Excludes `string`, whose Formatter.get_field resolves a dotted RUNTIME STRING
+# and returns the object, walking straight back to the real builtins with
+# nothing in the source for the AST check to match. str.format resolves
+# attributes the same way but only ever returns formatted text, never the
+# object, so it is not an execution path and stays.
 #
 # dataclasses is excluded for a different reason: it resolves annotations via
 # sys.modules[cls.__module__], which cannot work for synthetic globals.
 _SAFE_IMPORT_MODULES = frozenset({
     "abc", "array", "bisect", "cmath", "collections", "collections.abc", "copy",
     "decimal", "enum", "fractions", "functools", "heapq", "itertools", "math",
-    "numbers", "random", "re", "statistics", "textwrap", "typing",
-    "unicodedata",
+    "numbers", "operator", "random", "re", "statistics", "textwrap", "time",
+    "typing", "unicodedata",
 })
 
-# Public members of otherwise-safe modules that turn a runtime string into an
-# object, or evaluate one. Same blind spot as the excluded modules above, but
-# these live in modules worth keeping: typing.get_type_hints evaluates string
-# annotations, and since this module compiles annotations to strings, a class
-# annotated with "__import__('os').system(...)" executes on the call.
-# typing itself stays, because the notebooks' own samples import from it.
+# Public members that turn a runtime string into an object, or evaluate one.
+# Same AST blind spot as `string` above, but these sit in modules worth
+# keeping, so deny the member instead of the whole module:
+#   operator.attrgetter("__class__.__bases__")(x) walks dunders from a string,
+#     while itemgetter, the one generated sorting code actually reaches for,
+#     takes an index and is fine.
+#   typing.get_type_hints evaluates string annotations, and since this module
+#     compiles annotations to strings, a class annotated with
+#     "__import__('os').system(...)" executes on the call. The notebooks' own
+#     samples do `from typing import Callable`, so typing itself stays.
 _DENIED_MODULE_ATTRS = frozenset({
+    "operator.attrgetter",
+    "operator.methodcaller",
     "typing.get_type_hints",
 })
 
@@ -591,6 +594,12 @@ def _allowlist_builtins():
         "iter", "len", "list", "map", "max", "min", "next", "oct", "ord", "pow",
         "print", "range", "repr", "reversed", "round", "set", "slice", "sorted",
         "str", "sum", "tuple", "type", "zip",
+        # Class machinery: generated helpers are occasionally written as a
+        # small class. hasattr only ever answers yes or no, and object/super
+        # hand back nothing that is not already reachable, since getting
+        # anywhere from them needs a dunder the AST check rejects.
+        "bytearray", "classmethod", "hasattr", "object", "property",
+        "staticmethod", "super",
         # Generated code routinely uses try/except.
         "ArithmeticError", "AssertionError", "AttributeError", "BaseException",
         "Exception", "FloatingPointError", "IndexError", "KeyError",

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -628,14 +628,18 @@ def create_locked_down_function(function, *, builtins_policy: str = "allowlist")
     exposed_builtins = (
         _py_builtins.__dict__ if builtins_policy == "full" else _allowlist_builtins()
     )
-    f = types.FunctionType(
+    locked = types.FunctionType(
         f.__code__,
         {"__builtins__": exposed_builtins},
         f.__name__,
         f.__defaults__,
         f.__closure__,
     )
-    return f
+    # Assigned rather than passed: the constructor only grew a kwdefaults
+    # parameter recently, but the attribute is writable on every version we
+    # support. Without it `def f(x, *, k = 1)` loses k and raises TypeError.
+    locked.__kwdefaults__ = f.__kwdefaults__
+    return locked
 pass
 
 

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -484,12 +484,11 @@ def validate_single_function_source(
 pass
 
 
-# Importable by generated code. Excludes any stdlib module that reaches the
-# filesystem, network or another process (os, subprocess, socket, ctypes, ...).
-# Also excludes two that look harmless but are not: `operator`, whose attrgetter
-# takes a dotted string and so walks dunders without the AST check ever seeing
-# them, and `dataclasses`, which resolves annotations through
-# sys.modules[cls.__module__] and cannot work for synthetic globals.
+# Importable by generated code. Excludes anything reaching the filesystem,
+# network or another process (os, subprocess, socket, ctypes, ...), plus two
+# that only look harmless: `operator`, whose attrgetter takes a dotted string
+# and so walks dunders unseen by the AST check, and `dataclasses`, which
+# resolves annotations via sys.modules[cls.__module__] and cannot work here.
 _SAFE_IMPORT_MODULES = frozenset({
     "abc", "array", "bisect", "cmath", "collections", "collections.abc", "copy",
     "decimal", "enum", "fractions", "functools", "heapq", "itertools", "math",
@@ -502,11 +501,10 @@ class _SafeModule:
     """
     Facade over an allowlisted module.
 
-    Handing back the real module object is not enough, because modules
-    re-export other modules: `random._os` and `typing.sys` both lead straight
-    back to the process and filesystem capabilities the allowlist removes. So
-    deny private names, and deny nested modules unless their dotted name is
-    itself allowlisted.
+    Returning the real module is not enough: modules re-export other modules,
+    and `random._os` / `typing.sys` lead straight back to the capabilities the
+    allowlist removes. Denies private names, and nested modules unless their
+    dotted name is allowlisted too.
     """
     __slots__ = ("_module", "_name")
 
@@ -594,15 +592,14 @@ def _reject_dunder_access(tree):
     dunders, so refuse them outright.
     """
     for node in ast.walk(tree):
-        # Attributes are checked on a single underscore, not two: private
-        # attributes reach modules and internals just as well (random._os,
-        # ABCMeta._abc_impl), and generated code never needs them.
+        # One underscore for attributes: private ones reach modules and
+        # internals just as well (random._os, ABCMeta._abc_impl).
         if isinstance(node, ast.Attribute) and node.attr.startswith("_"):
             raise RuntimeError(
                 f"Attribute '{node.attr}' is not allowed in generated code."
             )
-        # Names stay at two, because a bare `_` or `_total` local is ordinary
-        # in generated code and reaches nothing on its own.
+        # Two for names: a bare `_` or `_total` local is ordinary and reaches
+        # nothing on its own.
         if isinstance(node, ast.Name) and node.id.startswith("__"):
             raise RuntimeError(
                 f"Name '{node.id}' is not allowed in generated code."

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -485,15 +485,34 @@ pass
 
 
 # Importable by generated code. Excludes anything reaching the filesystem,
-# network or another process (os, subprocess, socket, ctypes, ...), plus two
-# that only look harmless: `operator`, whose attrgetter takes a dotted string
-# and so walks dunders unseen by the AST check, and `dataclasses`, which
-# resolves annotations via sys.modules[cls.__module__] and cannot work here.
+# network or another process (os, subprocess, socket, ctypes, ...).
+#
+# Also excludes every module that resolves attributes from a RUNTIME STRING and
+# hands back the object, because _reject_dunder_access works on the AST and
+# there is nothing in the source for it to match:
+#   operator.attrgetter("__class__.__bases__")(x)
+#   string.Formatter().get_field("0.get_field.__globals__[...]", (x,), {})
+# Both walk straight back to the real builtins. str.format resolves attributes
+# the same way but only ever returns the formatted text, never the object, so
+# it is not an execution path.
+#
+# dataclasses is excluded for a different reason: it resolves annotations via
+# sys.modules[cls.__module__], which cannot work for synthetic globals.
 _SAFE_IMPORT_MODULES = frozenset({
     "abc", "array", "bisect", "cmath", "collections", "collections.abc", "copy",
     "decimal", "enum", "fractions", "functools", "heapq", "itertools", "math",
-    "numbers", "random", "re", "statistics", "string", "textwrap", "typing",
+    "numbers", "random", "re", "statistics", "textwrap", "typing",
     "unicodedata",
+})
+
+# Public members of otherwise-safe modules that turn a runtime string into an
+# object, or evaluate one. Same blind spot as the excluded modules above, but
+# these live in modules worth keeping: typing.get_type_hints evaluates string
+# annotations, and since this module compiles annotations to strings, a class
+# annotated with "__import__('os').system(...)" executes on the call.
+# typing itself stays, because the notebooks' own samples import from it.
+_DENIED_MODULE_ATTRS = frozenset({
+    "typing.get_type_hints",
 })
 
 
@@ -514,6 +533,10 @@ class _SafeModule:
 
     def __getattr__(self, attr):
         if attr.startswith("_"):
+            raise AttributeError(
+                f"Access to '{self._name}.{attr}' is not allowed in generated code."
+            )
+        if f"{self._name}.{attr}" in _DENIED_MODULE_ATTRS:
             raise AttributeError(
                 f"Access to '{self._name}.{attr}' is not allowed in generated code."
             )


### PR DESCRIPTION
`create_locked_down_function` is what executes the Python our GRPO and RL game notebooks get back from the model. It is the one place where a reward hacking or otherwise bad completion turns into code running on the user's Colab or Kaggle box, and right now it does not actually restrict anything.

## The problem

Three separate things line up badly:

**1. The policy default is permissive.** `create_locked_down_function` calls `load_single_function(function)` with no keyword arguments, so it takes the default `builtins_policy = "full"`, which maps to the real `builtins.__dict__`. Generated code can reach `__import__`, `open`, `eval`, `exec`, `compile` and `getattr`.

**2. The lock down line is worse than a no-op.**

```python
f = types.FunctionType(f.__code__, {})
```

CPython injects the real builtins module into any globals mapping that has no `__builtins__` key, so binding to an empty dict hands everything straight back. This also means the `allowlist` branch already present in the file could never have worked even if something selected it, and nothing ever did.

**3. `check_python_modules` is not a security check.** It exists to stop reward hacking via numpy and torch. It accepts `os`, `subprocess`, `socket`, `shutil` and `ctypes` because those are all stdlib, and it only walks `Import` and `ImportFrom` nodes, so `__import__("os")` is invisible to it. Its `ok` return value is also computed and then discarded at every call site in the notebooks.

The result is that a completion like this passes every check we have and runs:

```python
def matmul(A, B):
    import os
    os.system("...")
```

I confirmed this against the current code before changing anything. `import os` inside a generated function returned a live pid, and `__import__("socket").gethostname()` returned the hostname.

## The fix

- **`_safe_import`**, a replacement for `__import__` that resolves only the 23 modules in `_SAFE_IMPORT_MODULES`. This part matters for compatibility. Simply dropping `__import__` would break the 2048 notebook's own documented sample, which does `import math` and `from typing import Callable`. Those still work; `os` and `subprocess` do not.
- **Extended allowlist builtins**, covering what the notebook prompts actually ask the model for (list and numeric work, comprehensions, sorting, `try`/`except`) while leaving out every capability primitive.
- **`_reject_dunder_access`.** Restricting builtins on its own does not stop `().__class__.__bases__[0].__subclasses__()`, which walks from any literal to `subprocess.Popen` using nothing but attribute access. Generated matmul and strategy code has no reason to touch dunders.
- **Globals rebound onto the allowlist** instead of `{}`, so the restriction survives the call.
- **`create_locked_down_function` now defaults to the allowlist policy.** Pass `builtins_policy = "full"` to restore the previous behaviour. Existing positional calls keep working.

## Compatibility

No user facing behaviour changes. The two in tree importers of `create_locked_down_function`, `unsloth/_gpu_init.py` and `unsloth/models/_utils.py`, are re-exports rather than call sites, so nothing internal depended on the permissive default.

Legitimate generated code is unaffected: the notebook prompts ask for self contained functions using builtins plus at most math and typing, and all of that still runs. Code that reaches for numpy or torch now fails with `ImportError`, which the reward functions already catch and score, rather than crashing training.

## Verification

Checked on CPU, no GPU and no training run required.

Blocked:

| Case | Result |
| --- | --- |
| `import os` then `os.system` | `ImportError: Import of 'os' is not allowed` |
| `__import__("os").listdir(".")` | `RuntimeError: Name '__import__' is not allowed` |
| `(1).__class__.__bases__[0].__subclasses__()` | `RuntimeError: Attribute '__subclasses__' is not allowed` |
| `open("/etc/passwd")` | `NameError: name 'open' is not defined` |
| `eval("1+1")` | `NameError: name 'eval' is not defined` |
| `import subprocess` | `ImportError` |
| `import socket` | `ImportError` |
| `getattr(A, "__class__")` | `NameError: name 'getattr' is not defined` |
| `import numpy` | `ImportError`, scored by the reward function as before |

Still working:

| Case | Result |
| --- | --- |
| 2048 sample, `import math` and `from typing import Callable` | returns `"W"` |
| The matmul sample embedded in the gpt-oss GRPO notebook | returns `[[19, 22], [43, 50]]` |
| Sudoku sample, pure builtins | returns `(0, 0, 1)` |
| `sorted` / `set` / `try`-`except` strategy | returns `3` |

## Scope

This is defence in depth, not a real sandbox, and the docstring now says so plainly. It does not bound CPU, memory or recursion. Genuinely untrusted code still belongs in a container.

The companion notebooks change is unslothai/notebooks, which switches the four gpt-oss matmul GRPO notebooks off their own inline copy of this helper and onto this one. The 2048 and Sudoku notebooks already import from here, so they pick this up with no notebook change at all.
