### PR TITLE
Harden GGUF quantize command, dataset URL fetching and converter introspection

### DIFF
--- a/tests/test_convert_hf_to_gguf_patcher.py
+++ b/tests/test_convert_hf_to_gguf_patcher.py
@@ -348,8 +348,8 @@ def test_package_layout_does_not_require_module_import(tmp_path, monkeypatch):
     dir than the override) and raise ModuleNotFoundError, aborting the
     patcher before AST arch extraction + branding could run.
 
-    We assert the contract by replacing `_load_module_from_path` with a
-    sentinel that fails the test if called, then driving the patcher end-
+    We assert the contract by replacing the monolith-only arch extractor with
+    a sentinel that fails the test if called, then driving the patcher end-
     to-end with `UNSLOTH_LLAMA_CPP_SCRIPTS_DIR` set."""
     llama_cpp = _load_llama_cpp_module()
 
@@ -380,12 +380,12 @@ def test_package_layout_does_not_require_module_import(tmp_path, monkeypatch):
     monkeypatch.setenv("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR", str(root))
 
     # Sentinel: any call here means the patcher fell through to the
-    # module-load path on package layout, which is the bug we're guarding.
+    # monolith path on package layout, which is the bug we're guarding.
     called = {"hit": False}
     def _trap(*a, **kw):
         called["hit"] = True
-        raise AssertionError("monolith-only _load_module_from_path called on package layout")
-    monkeypatch.setattr(llama_cpp, "_load_module_from_path", _trap)
+        raise AssertionError("monolith-only arch extraction ran on package layout")
+    monkeypatch.setattr(llama_cpp, "_extract_archs_from_monolith_source", _trap)
 
     # Cache must be cleared between runs because @lru_cache(1) keys include
     # the resolved local_script_info -- but a stale entry from a previous

--- a/tests/test_gguf_monolith_arch_ast.py
+++ b/tests/test_gguf_monolith_arch_ast.py
@@ -14,14 +14,22 @@ import sys
 from pathlib import Path
 
 
+_MODULE = None
+
+
 def _load_llama_cpp_module():
-    repo_root = Path(__file__).resolve().parents[1]
-    module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
-    spec = importlib.util.spec_from_file_location("llama_cpp_under_test", module_path)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+    """Loaded once per session: re-executing llama_cpp for every test churns
+    global torch state and slows the suite down for no extra coverage."""
+    global _MODULE
+    if _MODULE is None:
+        repo_root = Path(__file__).resolve().parents[1]
+        module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
+        spec = importlib.util.spec_from_file_location("llama_cpp_under_test", module_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        _MODULE = module
+    return _MODULE
 
 
 MONOLITH = '''

--- a/tests/test_gguf_monolith_arch_ast.py
+++ b/tests/test_gguf_monolith_arch_ast.py
@@ -96,3 +96,52 @@ def test_unparseable_source_yields_empty_sets():
 def test_no_in_process_module_loader_remains():
     llama_cpp = _load_llama_cpp_module()
     assert not hasattr(llama_cpp, "_load_module_from_path")
+
+
+STATIC_REGISTRY = '''
+from enum import IntEnum
+
+
+class ModelType(IntEnum):
+    TEXT = 0
+    MMPROJ = 1
+
+
+class ModelBase:
+    _model_classes = {
+        ModelType.TEXT: {"LlamaForCausalLM": object, "MistralForCausalLM": object},
+        ModelType.MMPROJ: {"Gemma3ForConditionalGeneration": object},
+    }
+'''
+
+
+def test_statically_initialized_registries_are_harvested():
+    """Some converters seed _model_classes literally instead of decorating; the
+    old import-based introspection saw those entries, so the parser must too."""
+    llama_cpp = _load_llama_cpp_module()
+    text, vision = llama_cpp._extract_archs_from_monolith_source(STATIC_REGISTRY.encode())
+
+    assert text == {"LlamaForCausalLM", "MistralForCausalLM"}
+    assert vision == {"Gemma3ForConditionalGeneration"}
+
+
+def test_static_and_decorated_registries_combine():
+    llama_cpp = _load_llama_cpp_module()
+    text, vision = llama_cpp._extract_archs_from_monolith_source(
+        (STATIC_REGISTRY + MONOLITH).encode()
+    )
+
+    assert {"LlamaForCausalLM", "MistralForCausalLM", "Qwen2ForCausalLM"} <= text
+    assert {"Gemma3ForConditionalGeneration", "UltravoxModel"} <= vision
+
+
+def test_the_repo_monolith_fixture_still_yields_its_arch():
+    """tests/test_convert_hf_to_gguf_patcher.py models a converter of exactly
+    this shape; it must not regress to an empty allowlist."""
+    llama_cpp = _load_llama_cpp_module()
+    fixture = Path(__file__).with_name("test_convert_hf_to_gguf_patcher.py").read_text()
+    start = fixture.index('_MONOLITH = b"""\\\n') + len('_MONOLITH = b"""\\\n')
+    body = fixture[start:fixture.index('"""', start)]
+
+    text, _ = llama_cpp._extract_archs_from_monolith_source(body.encode())
+    assert "LlamaForCausalLM" in text

--- a/tests/test_gguf_monolith_arch_ast.py
+++ b/tests/test_gguf_monolith_arch_ast.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Architecture discovery must read the converter, never execute it.
 
 convert_hf_to_gguf.py is downloaded from llama.cpp's master branch at runtime.

--- a/tests/test_gguf_monolith_arch_ast.py
+++ b/tests/test_gguf_monolith_arch_ast.py
@@ -1,0 +1,90 @@
+"""Architecture discovery must read the converter, never execute it.
+
+convert_hf_to_gguf.py is downloaded from llama.cpp's master branch at runtime.
+The monolith layout used to import it to read ModelBase._model_classes, which
+executes the freshly downloaded file inside the training process. It is now
+AST-parsed instead, the same way the newer conversion/ package layout already
+is.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_llama_cpp_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
+    spec = importlib.util.spec_from_file_location("llama_cpp_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MONOLITH = '''
+import gguf
+
+class ModelBase:
+    @classmethod
+    def register(cls, *names, **kwargs):
+        def wrap(c): return c
+        return wrap
+
+class MmprojModel(ModelBase): pass
+
+@ModelBase.register("LlamaForCausalLM", "MistralForCausalLM")
+class LlamaModel(ModelBase): pass
+
+@ModelBase.register("Qwen2ForCausalLM")
+class Qwen2Model(ModelBase): pass
+
+@ModelBase.register("Gemma3ForConditionalGeneration", model_type=ModelType.MMPROJ)
+class Gemma3VisionModel(MmprojModel): pass
+
+@ModelBase.register("WhisperForConditionalGeneration")
+class WhisperEncoderModel(MmprojModel): pass
+
+@ModelBase.register("UltravoxModel")
+class UltravoxWhisperEncoderModel(WhisperEncoderModel): pass
+'''
+
+
+def test_registered_archs_are_extracted_statically():
+    llama_cpp = _load_llama_cpp_module()
+    text, vision = llama_cpp._extract_archs_from_monolith_source(MONOLITH.encode())
+
+    assert text == {"LlamaForCausalLM", "MistralForCausalLM", "Qwen2ForCausalLM"}
+    # Direct, keyword-tagged and transitively-inherited mmproj classes all count.
+    assert vision == {
+        "Gemma3ForConditionalGeneration",
+        "WhisperForConditionalGeneration",
+        "UltravoxModel",
+    }
+
+
+def test_source_is_never_executed(tmp_path):
+    llama_cpp = _load_llama_cpp_module()
+    marker = tmp_path / "pwned"
+    hostile = (
+        f"import pathlib\n"
+        f"pathlib.Path({str(marker)!r}).write_text('pwned')\n"
+        + MONOLITH
+    )
+
+    text, _ = llama_cpp._extract_archs_from_monolith_source(hostile.encode())
+
+    assert "LlamaForCausalLM" in text
+    assert not marker.exists(), "the downloaded converter was executed"
+
+
+def test_unparseable_source_yields_empty_sets():
+    llama_cpp = _load_llama_cpp_module()
+    assert llama_cpp._extract_archs_from_monolith_source(b"def broken(:\n") == (set(), set())
+
+
+def test_no_in_process_module_loader_remains():
+    llama_cpp = _load_llama_cpp_module()
+    assert not hasattr(llama_cpp, "_load_module_from_path")

--- a/tests/test_llama_cpp_loader.py
+++ b/tests/test_llama_cpp_loader.py
@@ -14,26 +14,38 @@ def _load_llama_cpp_module():
     return module
 
 
-def test_load_module_from_path_resolves_sibling_imports(tmp_path):
-    llama_cpp = _load_llama_cpp_module()
-    (tmp_path / "conversion.py").write_text("VALUE = 'loaded from sibling'\n")
-    script = tmp_path / "original_gguf_test.py"
-    script.write_text(
-        textwrap.dedent(
-            """
-            from conversion import VALUE
+def test_converter_is_parsed_not_imported(tmp_path):
+    """The downloaded converter is AST-parsed, so a script whose sibling
+    imports cannot resolve (and whose top level has side effects) still yields
+    its registered architectures without executing anything.
 
-            RESULT = VALUE
-            """
-        )
-    )
+    This replaces the old `_load_module_from_path` sibling-import test: that
+    helper imported the freshly downloaded llama.cpp script in-process and has
+    been removed.
+    """
+    llama_cpp = _load_llama_cpp_module()
+    marker = tmp_path / "executed"
+    source = textwrap.dedent(
+        f"""
+        from conversion import VALUE  # unresolvable sibling import
+        import pathlib
+        pathlib.Path({str(marker)!r}).write_text("executed")
+
+        class ModelBase: pass
+
+        @ModelBase.register("LlamaForCausalLM")
+        class LlamaModel(ModelBase): pass
+        """
+    ).encode()
 
     sys.modules.pop("conversion", None)
     original_path = sys.path[:]
     try:
-        module = llama_cpp._load_module_from_path(str(script), "original_gguf_test")
+        text_archs, vision_archs = llama_cpp._extract_archs_from_monolith_source(source)
 
-        assert module.RESULT == "loaded from sibling"
+        assert text_archs == {"LlamaForCausalLM"}
+        assert vision_archs == set()
+        assert not marker.exists()
         assert str(tmp_path) not in sys.path
     finally:
         sys.path[:] = original_path

--- a/tests/test_quantize_gguf_quant_type_validation.py
+++ b/tests/test_quantize_gguf_quant_type_validation.py
@@ -1,0 +1,146 @@
+"""quant_type reaches a shell=True command line, so it must be a bare token.
+
+`quantization_method` is a user facing argument all the way from
+`save_pretrained_gguf(..., quantization_method=...)` down to
+`quantize_gguf(quant_type=...)`, and the command is assembled as a string.
+Every legitimate value (unsloth's ALLOWED_QUANTS / IMATRIX_QUANTS, and the MLX
+quant_map) is `[a-z0-9_]+`, so anything carrying shell metacharacters is
+rejected outright instead of being interpolated.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_llama_cpp_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
+    spec = importlib.util.spec_from_file_location("llama_cpp_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_fake_subprocess_run(monkeypatch, llama_cpp):
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(llama_cpp.subprocess, "run", fake_run)
+    return captured
+
+
+def _stub_output_exists(monkeypatch):
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+    monkeypatch.setattr(Path, "stat", lambda self: SimpleNamespace(st_size=4096))
+
+
+MALICIOUS = [
+    "q4_k_m; touch pwned; #",
+    "q4_k_m && curl http://127.0.0.1/x",
+    "q4_k_m`id`",
+    "q4_k_m $(id)",
+    "q4_k_m | sh",
+    "",
+    "q4 k m",
+]
+
+
+@pytest.mark.parametrize("quant_type", MALICIOUS)
+def test_shell_metacharacters_are_rejected(monkeypatch, quant_type):
+    llama_cpp = _load_llama_cpp_module()
+    captured = _install_fake_subprocess_run(monkeypatch, llama_cpp)
+    _stub_output_exists(monkeypatch)
+
+    with pytest.raises(ValueError):
+        llama_cpp.quantize_gguf(
+            input_gguf="/tmp/in.gguf",
+            output_gguf="/tmp/out.gguf",
+            quant_type=quant_type,
+            quantizer_location="/usr/bin/llama-quantize",
+            n_threads=4,
+            print_output=False,
+        )
+    assert "cmd" not in captured, "subprocess must not run for a rejected quant_type"
+
+
+def test_non_string_quant_type_is_rejected(monkeypatch):
+    llama_cpp = _load_llama_cpp_module()
+    captured = _install_fake_subprocess_run(monkeypatch, llama_cpp)
+    _stub_output_exists(monkeypatch)
+
+    with pytest.raises(ValueError):
+        llama_cpp.quantize_gguf(
+            input_gguf="/tmp/in.gguf",
+            output_gguf="/tmp/out.gguf",
+            quant_type=None,
+            quantizer_location="/usr/bin/llama-quantize",
+            n_threads=4,
+            print_output=False,
+        )
+    assert "cmd" not in captured
+
+
+@pytest.mark.parametrize(
+    "quant_type",
+    ["q4_k_m", "q8_0", "bf16", "f16", "f32", "iq4_xs", "iq1_m", "q6_k", "Q4_K_M"],
+)
+def test_legitimate_quant_types_still_run(monkeypatch, quant_type):
+    llama_cpp = _load_llama_cpp_module()
+    captured = _install_fake_subprocess_run(monkeypatch, llama_cpp)
+    _stub_output_exists(monkeypatch)
+
+    llama_cpp.quantize_gguf(
+        input_gguf="/tmp/in.gguf",
+        output_gguf="/tmp/out.gguf",
+        quant_type=quant_type,
+        quantizer_location="/usr/bin/llama-quantize",
+        n_threads=4,
+        print_output=False,
+    )
+
+    cmd = captured["cmd"]
+    assert cmd == f"/usr/bin/llama-quantize /tmp/in.gguf /tmp/out.gguf {quant_type} 4"
+
+
+def test_surrounding_whitespace_is_trimmed_not_rejected(monkeypatch):
+    llama_cpp = _load_llama_cpp_module()
+    captured = _install_fake_subprocess_run(monkeypatch, llama_cpp)
+    _stub_output_exists(monkeypatch)
+
+    llama_cpp.quantize_gguf(
+        input_gguf="/tmp/in.gguf",
+        output_gguf="/tmp/out.gguf",
+        quant_type="  q4_k_m  ",
+        quantizer_location="/usr/bin/llama-quantize",
+        n_threads=4,
+        print_output=False,
+    )
+    assert captured["cmd"].endswith("q4_k_m 4")
+
+
+def test_n_threads_is_coerced_to_int(monkeypatch):
+    llama_cpp = _load_llama_cpp_module()
+    captured = _install_fake_subprocess_run(monkeypatch, llama_cpp)
+    _stub_output_exists(monkeypatch)
+
+    llama_cpp.quantize_gguf(
+        input_gguf="/tmp/in.gguf",
+        output_gguf="/tmp/out.gguf",
+        quant_type="q4_k_m",
+        quantizer_location="/usr/bin/llama-quantize",
+        n_threads="8",
+        print_output=False,
+    )
+    assert captured["cmd"].endswith(" 8")

--- a/tests/test_quantize_gguf_quant_type_validation.py
+++ b/tests/test_quantize_gguf_quant_type_validation.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """quant_type reaches a shell=True command line, so it must be a bare token.
 
 `quantization_method` is a user facing argument all the way from

--- a/tests/test_quantize_gguf_quant_type_validation.py
+++ b/tests/test_quantize_gguf_quant_type_validation.py
@@ -19,14 +19,22 @@ from types import SimpleNamespace
 import pytest
 
 
+_MODULE = None
+
+
 def _load_llama_cpp_module():
-    repo_root = Path(__file__).resolve().parents[1]
-    module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
-    spec = importlib.util.spec_from_file_location("llama_cpp_under_test", module_path)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+    """Loaded once per session: re-executing llama_cpp for every test churns
+    global torch state and slows the suite down for no extra coverage."""
+    global _MODULE
+    if _MODULE is None:
+        repo_root = Path(__file__).resolve().parents[1]
+        module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
+        spec = importlib.util.spec_from_file_location("llama_cpp_under_test", module_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        _MODULE = module
+    return _MODULE
 
 
 def _install_fake_subprocess_run(monkeypatch, llama_cpp):

--- a/tests/test_quantize_gguf_quant_type_validation.py
+++ b/tests/test_quantize_gguf_quant_type_validation.py
@@ -130,6 +130,29 @@ def test_surrounding_whitespace_is_trimmed_not_rejected(monkeypatch):
     assert captured["cmd"].endswith("q4_k_m 4")
 
 
+@pytest.mark.parametrize("is_windows", [False, True])
+def test_command_is_byte_identical_across_platforms(monkeypatch, is_windows):
+    """The validated token is inserted bare, so cmd.exe and every POSIX shell
+    see exactly the command previous releases produced."""
+    llama_cpp = _load_llama_cpp_module()
+    captured = _install_fake_subprocess_run(monkeypatch, llama_cpp)
+    _stub_output_exists(monkeypatch)
+    monkeypatch.setattr(llama_cpp, "IS_WINDOWS", is_windows)
+
+    if is_windows:
+        quantizer = "C:\\llama\\llama-quantize.exe"
+        src, dst = "C:\\models\\m.BF16.gguf", "C:\\models\\m.Q4_K_M.gguf"
+        expected = f'"{quantizer}" "{src}" "{dst}" q4_k_m 6'
+    else:
+        quantizer = "/usr/bin/llama-quantize"
+        src, dst = "/models/m.BF16.gguf", "/models/m.Q4_K_M.gguf"
+        expected = f"{quantizer} {src} {dst} q4_k_m 6"
+
+    llama_cpp.quantize_gguf(input_gguf=src, output_gguf=dst, quant_type="q4_k_m",
+                            quantizer_location=quantizer, n_threads=6, print_output=False)
+    assert captured["cmd"] == expected
+
+
 def test_n_threads_is_coerced_to_int(monkeypatch):
     llama_cpp = _load_llama_cpp_module()
     captured = _install_fake_subprocess_run(monkeypatch, llama_cpp)

--- a/tests/test_vision_url_ssrf_guard.py
+++ b/tests/test_vision_url_ssrf_guard.py
@@ -67,9 +67,7 @@ BLOCKED_URLS = [
 def _default_policy(monkeypatch):
     monkeypatch.delenv("UNSLOTH_ALLOW_PRIVATE_URL_FETCH", raising=False)
     monkeypatch.delenv("UNSLOTH_MAX_MEDIA_DOWNLOAD_MB", raising=False)
-    vision_utils._resolve_host.cache_clear()
     yield
-    vision_utils._resolve_host.cache_clear()
 
 
 @pytest.fixture
@@ -292,7 +290,10 @@ def test_address_classification_is_explicit(address, blocked):
     assert vision_utils._is_blocked_ip(ipaddress.ip_address(address)) is blocked
 
 
-def test_host_lookup_is_cached(monkeypatch):
+def test_host_resolution_is_not_cached(monkeypatch):
+    """A cached answer would outlive the DNS record it came from, so a host that
+    resolved publicly once would keep passing validation while the connection
+    resolved somewhere else."""
     calls = []
     real = __import__("socket").getaddrinfo
 
@@ -301,13 +302,12 @@ def test_host_lookup_is_cached(monkeypatch):
         return real("127.0.0.1", *args, **kwargs)
 
     monkeypatch.setattr(__import__("socket"), "getaddrinfo", counting)
-    vision_utils._resolve_host.cache_clear()
-    for _ in range(20):
+    for _ in range(3):
         assert vision_utils._is_blocked_address("repeated.example") is True
-    assert len(calls) == 1, "the collator must not re-resolve once per image"
+    assert len(calls) == 3, "each validation must use a fresh answer"
 
 
-def test_resolution_failure_is_cached_too(monkeypatch):
+def test_resolution_failure_is_not_cached_either(monkeypatch):
     calls = []
 
     def failing(host, *args, **kwargs):
@@ -315,10 +315,9 @@ def test_resolution_failure_is_cached_too(monkeypatch):
         raise OSError("no such host")
 
     monkeypatch.setattr(__import__("socket"), "getaddrinfo", failing)
-    vision_utils._resolve_host.cache_clear()
-    for _ in range(10):
+    for _ in range(3):
         assert vision_utils._resolve_host("missing.example") is None
-    assert len(calls) == 1
+    assert len(calls) == 3
 
 
 def test_response_is_closed_on_every_path(monkeypatch, public_dns):
@@ -507,7 +506,6 @@ def test_unresolvable_host_behind_a_proxy_fails_closed(monkeypatch):
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
     monkeypatch.delenv("NO_PROXY", raising=False)
     monkeypatch.delenv("no_proxy", raising=False)
-    vision_utils._resolve_host.cache_clear()
     with pytest.raises(ValueError, match="proxy"):
         vision_utils.assert_fetchable_url("http://intranet.corp.invalid/x.png")
 
@@ -518,7 +516,6 @@ def test_unresolvable_host_without_a_proxy_is_left_to_the_client(monkeypatch):
     for var in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY",
                 "http_proxy", "https_proxy", "all_proxy"):
         monkeypatch.delenv(var, raising=False)
-    vision_utils._resolve_host.cache_clear()
     assert vision_utils.assert_fetchable_url("http://nonexistent.invalid/x.png")
 
 
@@ -554,3 +551,21 @@ def test_video_backend_missing_leaves_no_download(monkeypatch, public_dns, tmp_p
     with pytest.raises(ValueError):
         vision_utils.fetch_video({"video": "https://example.com/clip.mp4"})
     assert glob.glob(str(tmp_path / "unsloth_media_*")) == []
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1\\@example.com/x.png",
+        "http://127.0.0.1:8080\\@example.com/x.png",
+        "http://example.com\\@127.0.0.1/x.png",
+        "https://user\\@evil@example.com/x.png",
+    ],
+)
+def test_backslash_anywhere_in_the_authority_is_refused(url, no_network):
+    """urlparse reads the prefix as userinfo and reports the trailing host,
+    while the client turns the backslash into a path separator and connects to
+    the prefix, so screening only the apparent host misses it."""
+    with pytest.raises(ValueError, match="backslash"):
+        vision_utils.fetch_image({"image": url})
+    assert no_network == []

--- a/tests/test_vision_url_ssrf_guard.py
+++ b/tests/test_vision_url_ssrf_guard.py
@@ -23,11 +23,24 @@ BLOCKED_URLS = [
     "http://127.0.0.1:9/x.png",
     "http://localhost:8080/x.png",
     "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+    "http://metadata.google.internal/computeMetadata/v1/",
     "http://10.0.0.5/x.png",
     "http://192.168.1.10/x.png",
     "http://172.16.3.4/x.png",
+    "http://172.31.255.254/x.png",
     "http://[::1]:8000/x.png",
+    "http://[fd00::1]/x.png",
+    "http://[fe80::1]/x.png",
+    "http://[::ffff:127.0.0.1]/x.png",
     "http://0.0.0.0/x.png",
+    "http://127.1/x.png",
+    "http://2130706433/x.png",
+    "http://user:pass@127.0.0.1/x.png",
+    # RFC 6598 carrier-grade NAT: ipaddress.is_private is False for it on
+    # every Python from 3.9 to 3.13, so the guard needs its own entry.
+    "http://100.64.0.1/x.png",
+    "http://224.0.0.1/x.png",
+    "http://240.0.0.1/x.png",
 ]
 
 
@@ -35,6 +48,9 @@ BLOCKED_URLS = [
 def _default_policy(monkeypatch):
     monkeypatch.delenv("UNSLOTH_ALLOW_PRIVATE_URL_FETCH", raising=False)
     monkeypatch.delenv("UNSLOTH_MAX_MEDIA_DOWNLOAD_MB", raising=False)
+    vision_utils._is_blocked_address.cache_clear()
+    yield
+    vision_utils._is_blocked_address.cache_clear()
 
 
 @pytest.fixture
@@ -197,6 +213,55 @@ def test_local_paths_and_data_uris_are_untouched(tmp_path, no_network):
     import base64
     encoded = base64.b64encode(_png_bytes()).decode()
     assert vision_utils.fetch_image({"image": f"data:image/png;base64,{encoded}"}).size[0] > 0
+
+
+@pytest.mark.parametrize(
+    "address,blocked",
+    [
+        ("127.0.0.1", True), ("10.1.2.3", True), ("172.20.0.1", True),
+        ("192.168.0.1", True), ("169.254.169.254", True), ("100.64.0.1", True),
+        ("0.0.0.0", True), ("224.0.0.1", True), ("240.0.0.1", True),
+        ("192.0.0.1", True), ("198.18.0.1", True), ("::1", True),
+        ("fd00::1", True), ("fe80::1", True), ("::ffff:10.0.0.1", True), ("::", True),
+        ("1.1.1.1", False), ("8.8.8.8", False), ("93.184.216.34", False),
+        ("140.82.121.4", False), ("2606:4700:4700::1111", False),
+        ("2001:4860:4860::8888", False),
+    ],
+)
+def test_address_classification_is_explicit(address, blocked):
+    """Pinned so a stdlib change to ipaddress cannot silently widen the guard."""
+    import ipaddress
+    assert vision_utils._is_blocked_ip(ipaddress.ip_address(address)) is blocked
+
+
+def test_host_lookup_is_cached(monkeypatch):
+    calls = []
+    real = __import__("socket").getaddrinfo
+
+    def counting(host, *args, **kwargs):
+        calls.append(host)
+        return real("127.0.0.1", *args, **kwargs)
+
+    monkeypatch.setattr(__import__("socket"), "getaddrinfo", counting)
+    vision_utils._is_blocked_address.cache_clear()
+    for _ in range(20):
+        assert vision_utils._is_blocked_address("repeated.example") is True
+    assert len(calls) == 1, "the collator must not re-resolve once per image"
+
+
+def test_response_is_closed_on_every_path(monkeypatch, public_dns):
+    closed = []
+
+    class Tracking(_FakeResponse):
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setattr(
+        vision_utils.requests, "get",
+        lambda url, **kwargs: Tracking(_png_bytes()),
+    )
+    vision_utils.fetch_image({"image": "https://example.com/a.png"})
+    assert closed, "a streaming response must not be left open"
 
 
 def test_fetch_video_rejects_internal_url_before_touching_a_backend(monkeypatch):

--- a/tests/test_vision_url_ssrf_guard.py
+++ b/tests/test_vision_url_ssrf_guard.py
@@ -271,3 +271,104 @@ def test_fetch_video_rejects_internal_url_before_touching_a_backend(monkeypatch)
     monkeypatch.setattr(vision_utils, "get_video_reader_backend", boom)
     with pytest.raises(ValueError):
         vision_utils.fetch_video({"video": "http://127.0.0.1:9/clip.mp4"})
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://%31%32%37.0.0.1:8080/x.png",
+        "http://127%2e0%2e0%2e1:8080/x.png",
+        "http://%6c%6f%63%61%6c%68%6f%73%74:8080/x.png",
+        "http://example.com\\@127.0.0.1/x.png",
+        "http://%31%32%37.0.0.1/x.png",
+    ],
+)
+def test_percent_encoded_authority_is_refused(url, no_network):
+    """urlparse leaves the authority encoded while requests decodes it before
+    connecting, so an encoded host would be checked as an unresolvable name and
+    then fetched from 127.0.0.1."""
+    with pytest.raises(ValueError):
+        vision_utils.fetch_image({"image": url})
+    assert no_network == []
+
+
+def test_percent_escapes_in_the_path_are_still_fine(monkeypatch, public_dns):
+    seen = []
+    monkeypatch.setattr(
+        vision_utils.requests, "get",
+        lambda url, **kwargs: seen.append(url) or _FakeResponse(_png_bytes()),
+    )
+    image = vision_utils.fetch_image({"image": "https://example.com/a%20b/logo%20black.png"})
+    assert image.size[0] > 0 and seen == ["https://example.com/a%20b/logo%20black.png"]
+
+
+@pytest.mark.parametrize("value", ["inf", "INF", "nan", "1e400", "-inf", "abc", "0"])
+def test_non_finite_size_limits_do_not_break_every_fetch(monkeypatch, public_dns, value):
+    """float() accepts inf and nan, int() then refuses them, which used to make
+    every remote image raise before its request was issued."""
+    monkeypatch.setenv("UNSLOTH_MAX_MEDIA_DOWNLOAD_MB", value)
+    monkeypatch.setattr(
+        vision_utils.requests, "get",
+        lambda url, **kwargs: _FakeResponse(_png_bytes()),
+    )
+    assert vision_utils.fetch_image({"image": "https://example.com/a.png"}).size[0] > 0
+
+
+def test_video_redirect_chain_is_resolved_and_checked(monkeypatch, public_dns):
+    """The decoders follow redirects internally, so the chain has to be walked
+    here or a public host could bounce ffmpeg to an internal one."""
+    hops = []
+
+    def fake_get(url, **kwargs):
+        hops.append(url)
+        if url.endswith("/public.mp4"):
+            return _FakeResponse(redirect_to="http://127.0.0.1:9/internal.mp4")
+        return _FakeResponse(b"")
+
+    monkeypatch.setattr(vision_utils.requests, "get", fake_get)
+    monkeypatch.setattr(
+        vision_utils, "get_video_reader_backend",
+        lambda: pytest.fail("the decoder must not be reached"),
+    )
+    with pytest.raises(ValueError):
+        vision_utils.fetch_video({"video": "https://example.com/public.mp4"})
+    assert hops == ["https://example.com/public.mp4"]
+
+
+def test_video_redirect_to_a_public_host_is_followed(monkeypatch, public_dns):
+    resolved = {}
+
+    def fake_get(url, **kwargs):
+        if url.endswith("/public.mp4"):
+            return _FakeResponse(redirect_to="https://cdn.example.com/real.mp4")
+        return _FakeResponse(b"")
+
+    monkeypatch.setattr(vision_utils.requests, "get", fake_get)
+
+    def backend(ele):
+        resolved["url"] = ele["video"]
+        raise RuntimeError("stop here, the URL is what we are asserting")
+
+    monkeypatch.setattr(vision_utils, "get_video_reader_backend", lambda: "torchvision")
+    monkeypatch.setitem(vision_utils.VIDEO_READER_BACKENDS, "torchvision", backend)
+    with pytest.raises(Exception):
+        vision_utils.fetch_video({"video": "https://example.com/public.mp4"})
+    assert resolved["url"] == "https://cdn.example.com/real.mp4"
+
+
+def test_fetch_video_does_not_mutate_the_caller_dict(monkeypatch, public_dns):
+    monkeypatch.setattr(
+        vision_utils.requests, "get",
+        lambda url, **kwargs: _FakeResponse(b""),
+    )
+    def backend(ele):
+        raise RuntimeError("decoded nothing, that is fine")
+
+    monkeypatch.setattr(vision_utils, "get_video_reader_backend", lambda: "torchvision")
+    monkeypatch.setitem(vision_utils.VIDEO_READER_BACKENDS, "torchvision", backend)
+    ele = {"video": "https://example.com/clip.mp4"}
+    try:
+        vision_utils.fetch_video(ele)
+    except Exception:
+        pass
+    assert ele["video"] == "https://example.com/clip.mp4"

--- a/tests/test_vision_url_ssrf_guard.py
+++ b/tests/test_vision_url_ssrf_guard.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Dataset supplied image/video URLs must not reach internal addresses.
 
 A VLM dataset row can carry `{"type": "image_url", "image_url": "http://..."}`,

--- a/tests/test_vision_url_ssrf_guard.py
+++ b/tests/test_vision_url_ssrf_guard.py
@@ -25,7 +25,10 @@ URLs and every local-file form must keep working unchanged.
 
 from __future__ import annotations
 
+import glob
 import io
+import os
+import tempfile
 
 import pytest
 
@@ -330,9 +333,10 @@ def test_non_finite_size_limits_do_not_break_every_fetch(monkeypatch, public_dns
     assert vision_utils.fetch_image({"image": "https://example.com/a.png"}).size[0] > 0
 
 
-def test_video_redirect_chain_is_resolved_and_checked(monkeypatch, public_dns):
-    """The decoders follow redirects internally, so the chain has to be walked
-    here or a public host could bounce ffmpeg to an internal one."""
+def test_video_download_is_guarded_not_delegated(monkeypatch, public_dns):
+    """The decoders follow redirects with no way to refuse, so a server that
+    answers our probe cleanly could still bounce them internally. The bytes are
+    fetched here instead and the decoder only ever sees a local file."""
     hops = []
 
     def fake_get(url, **kwargs):
@@ -351,25 +355,64 @@ def test_video_redirect_chain_is_resolved_and_checked(monkeypatch, public_dns):
     assert hops == ["https://example.com/public.mp4"]
 
 
-def test_video_redirect_to_a_public_host_is_followed(monkeypatch, public_dns):
-    resolved = {}
+def test_video_decoder_receives_a_local_file_not_a_url(monkeypatch, public_dns, tmp_path):
+    """Even for a wholly public chain the decoder gets a downloaded file, so a
+    second request it makes cannot be answered differently."""
+    seen = {}
+    payload = b"\x00\x00\x00\x20ftypisom fake container bytes"
 
     def fake_get(url, **kwargs):
         if url.endswith("/public.mp4"):
             return _FakeResponse(redirect_to="https://cdn.example.com/real.mp4")
-        return _FakeResponse(b"")
+        return _FakeResponse(payload)
 
     monkeypatch.setattr(vision_utils.requests, "get", fake_get)
 
     def backend(ele):
-        resolved["url"] = ele["video"]
-        raise RuntimeError("stop here, the URL is what we are asserting")
+        seen["path"] = ele["video"]
+        seen["bytes"] = open(ele["video"], "rb").read()
+        raise RuntimeError("stop here, the handed-over path is what we assert")
 
     monkeypatch.setattr(vision_utils, "get_video_reader_backend", lambda: "torchvision")
     monkeypatch.setitem(vision_utils.VIDEO_READER_BACKENDS, "torchvision", backend)
     with pytest.raises(Exception):
         vision_utils.fetch_video({"video": "https://example.com/public.mp4"})
-    assert resolved["url"] == "https://cdn.example.com/real.mp4"
+
+    assert not seen["path"].startswith("http"), seen["path"]
+    assert seen["path"].endswith(".mp4"), "the container extension must survive"
+    assert seen["bytes"] == payload
+    assert not os.path.exists(seen["path"]), "the temp file must be cleaned up"
+
+
+def test_video_download_honours_the_size_cap(monkeypatch, public_dns):
+    monkeypatch.setenv("UNSLOTH_MAX_MEDIA_DOWNLOAD_MB", "0.0001")
+    monkeypatch.setattr(
+        vision_utils.requests, "get",
+        lambda url, **kwargs: _FakeResponse(b"x" * 4096),
+    )
+    monkeypatch.setattr(
+        vision_utils, "get_video_reader_backend",
+        lambda: pytest.fail("not reached"),
+    )
+    with pytest.raises(ValueError):
+        vision_utils.fetch_video({"video": "https://example.com/big.mp4"})
+
+
+def test_failed_video_download_leaves_no_temp_file(monkeypatch, public_dns, tmp_path):
+    import glob
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path), raising=False)
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.setattr(
+        vision_utils.requests, "get",
+        lambda url, **kwargs: _FakeResponse(b"", status=500),
+    )
+    monkeypatch.setattr(
+        vision_utils, "get_video_reader_backend",
+        lambda: pytest.fail("not reached"),
+    )
+    with pytest.raises(Exception):
+        vision_utils.fetch_video({"video": "https://example.com/broken.mp4"})
+    assert glob.glob(str(tmp_path / "unsloth_media_*")) == []
 
 
 def test_fetch_video_does_not_mutate_the_caller_dict(monkeypatch, public_dns):

--- a/tests/test_vision_url_ssrf_guard.py
+++ b/tests/test_vision_url_ssrf_guard.py
@@ -1,0 +1,208 @@
+"""Dataset supplied image/video URLs must not reach internal addresses.
+
+A VLM dataset row can carry `{"type": "image_url", "image_url": "http://..."}`,
+and the collators resolve it server side through fetch_image()/fetch_video().
+Without a destination check that lets a dataset drive requests from the
+training worker to localhost, the LAN, or the cloud metadata endpoint. Public
+URLs and every local-file form must keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+PIL = pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402
+
+from unsloth_zoo import vision_utils  # noqa: E402
+
+
+BLOCKED_URLS = [
+    "http://127.0.0.1:9/x.png",
+    "http://localhost:8080/x.png",
+    "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+    "http://10.0.0.5/x.png",
+    "http://192.168.1.10/x.png",
+    "http://172.16.3.4/x.png",
+    "http://[::1]:8000/x.png",
+    "http://0.0.0.0/x.png",
+]
+
+
+@pytest.fixture(autouse=True)
+def _default_policy(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_ALLOW_PRIVATE_URL_FETCH", raising=False)
+    monkeypatch.delenv("UNSLOTH_MAX_MEDIA_DOWNLOAD_MB", raising=False)
+
+
+@pytest.fixture
+def no_network(monkeypatch):
+    """Fail loudly if anything actually issues a request."""
+    calls = []
+
+    def boom(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError(f"network call escaped the guard: {args} {kwargs}")
+
+    monkeypatch.setattr(vision_utils.requests, "get", boom)
+    return calls
+
+
+def _png_bytes(size=(32, 32), color=(1, 2, 3)):
+    buffer = io.BytesIO()
+    Image.new("RGB", size, color).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+class _FakeResponse:
+    is_redirect = False
+    is_permanent_redirect = False
+
+    def __init__(self, content=b"", status=200, headers=None, redirect_to=None):
+        self._content = content
+        self.status_code = status
+        self.headers = headers or {}
+        if redirect_to is not None:
+            self.is_redirect = True
+            self.headers["location"] = redirect_to
+
+    def iter_content(self, chunk_size=1):
+        for i in range(0, len(self._content), chunk_size):
+            yield self._content[i : i + chunk_size]
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise AssertionError(f"HTTP {self.status_code}")
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def public_dns(monkeypatch):
+    """Resolve every host to a public address unless it is a literal IP."""
+    import ipaddress
+    import socket
+
+    real = socket.getaddrinfo
+
+    def fake_getaddrinfo(host, *args, **kwargs):
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+        return real(host, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+
+@pytest.mark.parametrize("url", BLOCKED_URLS)
+def test_fetch_image_blocks_internal_urls(url, no_network):
+    with pytest.raises(ValueError):
+        vision_utils.fetch_image({"image": url})
+    assert no_network == []
+
+
+@pytest.mark.parametrize("url", BLOCKED_URLS)
+def test_fetch_image_blocks_internal_urls_via_image_url_dict(url, no_network):
+    with pytest.raises(ValueError):
+        vision_utils.fetch_image({"image_url": {"url": url}})
+    assert no_network == []
+
+
+def test_fetch_image_blocks_non_http_scheme_in_url_dict(no_network):
+    # The dict {"url": ...} branch previously had no scheme check at all.
+    with pytest.raises(ValueError):
+        vision_utils.fetch_image({"image": {"url": "file:///etc/passwd"}})
+    assert no_network == []
+
+
+def test_process_vision_info_blocks_internal_urls(no_network):
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "describe"},
+            {"type": "image_url", "image_url": "http://169.254.169.254/metadata"},
+        ],
+    }]
+    with pytest.raises(ValueError):
+        vision_utils.process_vision_info(messages)
+    assert no_network == []
+
+
+def test_public_url_is_still_fetched(monkeypatch, public_dns):
+    seen = []
+
+    def fake_get(url, **kwargs):
+        seen.append(url)
+        return _FakeResponse(_png_bytes())
+
+    monkeypatch.setattr(vision_utils.requests, "get", fake_get)
+
+    image = vision_utils.fetch_image({"image": "https://example.com/cat.png"})
+    assert seen == ["https://example.com/cat.png"]
+    assert image.size[0] > 0 and image.size[1] > 0
+
+
+def test_redirect_to_internal_address_is_blocked(monkeypatch, public_dns):
+    seen = []
+
+    def fake_get(url, **kwargs):
+        seen.append(url)
+        return _FakeResponse(redirect_to="http://127.0.0.1:9/secret.png")
+
+    monkeypatch.setattr(vision_utils.requests, "get", fake_get)
+
+    with pytest.raises(ValueError):
+        vision_utils.fetch_image({"image": "https://example.com/redir.png"})
+    assert seen == ["https://example.com/redir.png"], "the internal hop must not be requested"
+
+
+def test_size_cap_is_enforced(monkeypatch, public_dns):
+    monkeypatch.setenv("UNSLOTH_MAX_MEDIA_DOWNLOAD_MB", "0.0001")  # ~100 bytes
+    monkeypatch.setattr(
+        vision_utils.requests, "get",
+        lambda url, **kwargs: _FakeResponse(_png_bytes((256, 256), (7, 8, 9))),
+    )
+    with pytest.raises(ValueError):
+        vision_utils.fetch_image({"image": "https://example.com/big.png"})
+
+
+def test_opt_out_env_var_allows_private_urls(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_ALLOW_PRIVATE_URL_FETCH", "1")
+    seen = []
+
+    def fake_get(url, **kwargs):
+        seen.append(url)
+        return _FakeResponse(_png_bytes())
+
+    monkeypatch.setattr(vision_utils.requests, "get", fake_get)
+
+    image = vision_utils.fetch_image({"image": "http://127.0.0.1:8000/local.png"})
+    assert seen == ["http://127.0.0.1:8000/local.png"]
+    assert image.size[0] > 0
+
+
+def test_local_paths_and_data_uris_are_untouched(tmp_path, no_network):
+    path = tmp_path / "img.png"
+    path.write_bytes(_png_bytes(color=(9, 9, 9)))
+
+    assert vision_utils.fetch_image({"image": str(path)}).size[0] > 0
+    assert vision_utils.fetch_image({"image": path.as_uri()}).size[0] > 0
+    assert vision_utils.fetch_image({"image": {"path": str(path)}}).size[0] > 0
+    assert vision_utils.fetch_image({"image": {"bytes": _png_bytes()}}).size[0] > 0
+
+    import base64
+    encoded = base64.b64encode(_png_bytes()).decode()
+    assert vision_utils.fetch_image({"image": f"data:image/png;base64,{encoded}"}).size[0] > 0
+
+
+def test_fetch_video_rejects_internal_url_before_touching_a_backend(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("video backend must not be reached")
+
+    monkeypatch.setattr(vision_utils, "get_video_reader_backend", boom)
+    with pytest.raises(ValueError):
+        vision_utils.fetch_video({"video": "http://127.0.0.1:9/clip.mp4"})

--- a/tests/test_vision_url_ssrf_guard.py
+++ b/tests/test_vision_url_ssrf_guard.py
@@ -67,9 +67,9 @@ BLOCKED_URLS = [
 def _default_policy(monkeypatch):
     monkeypatch.delenv("UNSLOTH_ALLOW_PRIVATE_URL_FETCH", raising=False)
     monkeypatch.delenv("UNSLOTH_MAX_MEDIA_DOWNLOAD_MB", raising=False)
-    vision_utils._is_blocked_address.cache_clear()
+    vision_utils._resolve_host.cache_clear()
     yield
-    vision_utils._is_blocked_address.cache_clear()
+    vision_utils._resolve_host.cache_clear()
 
 
 @pytest.fixture
@@ -113,6 +113,45 @@ class _FakeResponse:
 
     def close(self):
         pass
+
+
+class _FakeSession:
+    """Forwards to requests.get so tests can keep patching that one symbol."""
+
+    instances = []
+
+    def __init__(self):
+        type(self).instances.append(self)
+        self.closed = False
+
+    def get(self, url, **kwargs):
+        return vision_utils.requests.get(url, **kwargs)
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+@pytest.fixture(autouse=True)
+def _fake_session(monkeypatch):
+    _FakeSession.instances = []
+    monkeypatch.setattr(vision_utils.requests, "Session", _FakeSession)
+    return _FakeSession
+
+
+def _decoder_must_not_run(monkeypatch):
+    """Backend selection happens before the download now, so the assertion has
+    to sit on the decoder itself rather than on the selector."""
+    def boom(ele):
+        raise AssertionError(f"the decoder must not be reached, got {ele['video']!r}")
+
+    monkeypatch.setattr(vision_utils, "get_video_reader_backend", lambda: "torchvision")
+    monkeypatch.setitem(vision_utils.VIDEO_READER_BACKENDS, "torchvision", boom)
 
 
 @pytest.fixture
@@ -262,10 +301,24 @@ def test_host_lookup_is_cached(monkeypatch):
         return real("127.0.0.1", *args, **kwargs)
 
     monkeypatch.setattr(__import__("socket"), "getaddrinfo", counting)
-    vision_utils._is_blocked_address.cache_clear()
+    vision_utils._resolve_host.cache_clear()
     for _ in range(20):
         assert vision_utils._is_blocked_address("repeated.example") is True
     assert len(calls) == 1, "the collator must not re-resolve once per image"
+
+
+def test_resolution_failure_is_cached_too(monkeypatch):
+    calls = []
+
+    def failing(host, *args, **kwargs):
+        calls.append(host)
+        raise OSError("no such host")
+
+    monkeypatch.setattr(__import__("socket"), "getaddrinfo", failing)
+    vision_utils._resolve_host.cache_clear()
+    for _ in range(10):
+        assert vision_utils._resolve_host("missing.example") is None
+    assert len(calls) == 1
 
 
 def test_response_is_closed_on_every_path(monkeypatch, public_dns):
@@ -283,13 +336,11 @@ def test_response_is_closed_on_every_path(monkeypatch, public_dns):
     assert closed, "a streaming response must not be left open"
 
 
-def test_fetch_video_rejects_internal_url_before_touching_a_backend(monkeypatch):
-    def boom(*args, **kwargs):
-        raise AssertionError("video backend must not be reached")
-
-    monkeypatch.setattr(vision_utils, "get_video_reader_backend", boom)
+def test_fetch_video_rejects_internal_url_before_touching_a_decoder(monkeypatch, no_network):
+    _decoder_must_not_run(monkeypatch)
     with pytest.raises(ValueError):
         vision_utils.fetch_video({"video": "http://127.0.0.1:9/clip.mp4"})
+    assert no_network == []
 
 
 @pytest.mark.parametrize(
@@ -346,10 +397,7 @@ def test_video_download_is_guarded_not_delegated(monkeypatch, public_dns):
         return _FakeResponse(b"")
 
     monkeypatch.setattr(vision_utils.requests, "get", fake_get)
-    monkeypatch.setattr(
-        vision_utils, "get_video_reader_backend",
-        lambda: pytest.fail("the decoder must not be reached"),
-    )
+    _decoder_must_not_run(monkeypatch)
     with pytest.raises(ValueError):
         vision_utils.fetch_video({"video": "https://example.com/public.mp4"})
     assert hops == ["https://example.com/public.mp4"]
@@ -390,10 +438,7 @@ def test_video_download_honours_the_size_cap(monkeypatch, public_dns):
         vision_utils.requests, "get",
         lambda url, **kwargs: _FakeResponse(b"x" * 4096),
     )
-    monkeypatch.setattr(
-        vision_utils, "get_video_reader_backend",
-        lambda: pytest.fail("not reached"),
-    )
+    _decoder_must_not_run(monkeypatch)
     with pytest.raises(ValueError):
         vision_utils.fetch_video({"video": "https://example.com/big.mp4"})
 
@@ -406,10 +451,7 @@ def test_failed_video_download_leaves_no_temp_file(monkeypatch, public_dns, tmp_
         vision_utils.requests, "get",
         lambda url, **kwargs: _FakeResponse(b"", status=500),
     )
-    monkeypatch.setattr(
-        vision_utils, "get_video_reader_backend",
-        lambda: pytest.fail("not reached"),
-    )
+    _decoder_must_not_run(monkeypatch)
     with pytest.raises(Exception):
         vision_utils.fetch_video({"video": "https://example.com/broken.mp4"})
     assert glob.glob(str(tmp_path / "unsloth_media_*")) == []
@@ -431,3 +473,84 @@ def test_fetch_video_does_not_mutate_the_caller_dict(monkeypatch, public_dns):
     except Exception:
         pass
     assert ele["video"] == "https://example.com/clip.mp4"
+
+
+def test_site_local_ipv6_is_blocked():
+    """fec0::/10 is deprecated but still routed in places, and ipaddress reports
+    it only through is_site_local, not is_private."""
+    import ipaddress
+    assert vision_utils._is_blocked_ip(ipaddress.ip_address("fec0::1")) is True
+
+
+def test_percent_escapes_in_credentials_are_allowed(monkeypatch, public_dns):
+    """`https://user:p%40ss@example.com/x.png` is a valid authenticated URL that
+    worked before the guard existed; only the host portion is suspect."""
+    seen = []
+    monkeypatch.setattr(
+        vision_utils.requests, "get",
+        lambda url, **kwargs: seen.append(url) or _FakeResponse(_png_bytes()),
+    )
+    image = vision_utils.fetch_image({"image": "https://user:p%40ss@example.com/x.png"})
+    assert image.size[0] > 0
+    assert seen == ["https://user:p%40ss@example.com/x.png"]
+
+
+def test_encoded_host_still_refused_even_with_credentials(no_network):
+    with pytest.raises(ValueError):
+        vision_utils.fetch_image({"image": "http://user:pass@%31%32%37.0.0.1/x.png"})
+    assert no_network == []
+
+
+def test_unresolvable_host_behind_a_proxy_fails_closed(monkeypatch):
+    """A proxy resolves the name instead of us, so nothing was ever checked."""
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.internal:3128")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    vision_utils._resolve_host.cache_clear()
+    with pytest.raises(ValueError, match="proxy"):
+        vision_utils.assert_fetchable_url("http://intranet.corp.invalid/x.png")
+
+
+def test_unresolvable_host_without_a_proxy_is_left_to_the_client(monkeypatch):
+    """No proxy means the request cannot reach anywhere either, so the HTTP
+    client should report its own error rather than us inventing one."""
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY",
+                "http_proxy", "https_proxy", "all_proxy"):
+        monkeypatch.delenv(var, raising=False)
+    vision_utils._resolve_host.cache_clear()
+    assert vision_utils.assert_fetchable_url("http://nonexistent.invalid/x.png")
+
+
+def test_one_session_spans_the_whole_redirect_chain(monkeypatch, public_dns, _fake_session):
+    """requests used to carry the cookie jar across hops itself, and
+    signed-cookie CDNs depend on that."""
+    def fake_get(url, **kwargs):
+        if url.endswith("/signed.png"):
+            return _FakeResponse(redirect_to="https://cdn.example.com/real.png")
+        return _FakeResponse(_png_bytes())
+
+    monkeypatch.setattr(vision_utils.requests, "get", fake_get)
+    image = vision_utils.fetch_image({"image": "https://example.com/signed.png"})
+    assert image.size[0] > 0
+    assert len(_fake_session.instances) == 1, "every hop must share one session"
+    assert _fake_session.instances[0].closed, "the session must be closed"
+
+
+def test_video_backend_missing_leaves_no_download(monkeypatch, public_dns, tmp_path):
+    """Backend selection happens before the download, so a machine with no
+    decoder installed does not strand a file."""
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path), raising=False)
+    monkeypatch.setattr(
+        vision_utils.requests, "get",
+        lambda url, **kwargs: _FakeResponse(b"video bytes"),
+    )
+
+    def no_backend():
+        raise ValueError("Unsloth: No video reader backend available")
+
+    monkeypatch.setattr(vision_utils, "get_video_reader_backend", no_backend)
+    with pytest.raises(ValueError):
+        vision_utils.fetch_video({"video": "https://example.com/clip.mp4"})
+    assert glob.glob(str(tmp_path / "unsloth_media_*")) == []

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2619,8 +2619,7 @@ def convert_to_gguf(
             )
     pass
 
-    # Empty means the allowlist is unknown, not that nothing is supported.
-    if is_vlm and supported_vision_archs:
+    if is_vlm and supported_vision_archs is not None:
         if "architectures" in config_file:
             arch = config_file["architectures"][0]
         else:

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -1562,7 +1562,9 @@ def _extract_archs_from_monolith_source(source_bytes):
             elif isinstance(value, ast.Name): name = value.id
             elif isinstance(value, ast.Constant) and isinstance(value.value, str):
                 name = value.value
-            if name is not None and "mmproj" in name.lower(): return True
+            # An explicit model_type wins over the base classes: a vision model
+            # registered as TEXT is a text entry however it is spelled.
+            if name is not None: return "mmproj" in name.lower()
         return _inherits_mmproj(class_node.name)
 
     for node in ast.walk(tree):
@@ -3009,7 +3011,11 @@ def quantize_gguf(
 
     command = (
         f"{_quote(quantizer_location)} {_extra_flags}"
-        f"{_quote(input_gguf)} {_quote(output_gguf)} {_quote(quant_type)} {n_threads}"
+        # quant_type is validated at the top of this function to be a bare
+        # token, so it needs no quoting; leaving it bare also keeps the command
+        # byte-identical to previous releases on cmd.exe, which would otherwise
+        # see an extra pair of quotes.
+        f"{_quote(input_gguf)} {_quote(output_gguf)} {quant_type} {n_threads}"
     )
 
     if print_output:

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -1501,26 +1501,82 @@ def install_llama_cpp(
 pass
 
 
-def _load_module_from_path(filepath, module_name):
-    spec = importlib.util.spec_from_file_location(module_name, filepath)
-    if spec is None or spec.loader is None:
-            raise ImportError(f"Could not load spec for module {module_name} at {filepath}")
-    module = importlib.util.module_from_spec(spec)
-    script_dir = os.path.dirname(os.path.abspath(filepath))
-    original_path = sys.path[:]
-    if script_dir not in sys.path:
-        sys.path.insert(0, script_dir)
-    # Register module before execution to handle circular imports within the script if any
-    sys.modules[module_name] = module
+def _extract_archs_from_monolith_source(source_bytes):
+    """AST-parse a monolithic convert_hf_to_gguf.py for its registered
+    architectures, returning (text_archs, vision_archs).
+
+    Reads the `@ModelBase.register("Arch", ...)` / `@Model.register(...)`
+    decorators statically. Parsing rather than importing matters: the file is
+    downloaded from llama.cpp's master branch at runtime, and importing it
+    would execute whatever that download happens to contain inside this
+    process. Mirrors _extract_dict_keys_from_conversion_init, which already
+    does the same for the newer conversion/ package layout.
+    """
     try:
-        spec.loader.exec_module(module)
-    except Exception as e:
-        # Clean up registry if exec fails
-        del sys.modules[module_name]
-        raise ImportError(f"Failed to execute module {module_name} from {filepath}") from e
-    finally:
-        sys.path[:] = original_path
-    return module
+        tree = ast.parse(source_bytes)
+    except Exception:
+        return set(), set()
+
+    text_archs   = set()
+    vision_archs = set()
+
+    def _is_register_call(node):
+        # Matches ModelBase.register(...) / Model.register(...) / <X>.register(...)
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "register"
+            and isinstance(node.func.value, ast.Name)
+        )
+
+    def _base_names(class_node):
+        names = []
+        for base in class_node.bases:
+            if   isinstance(base, ast.Attribute): names.append(base.attr)
+            elif isinstance(base, ast.Name):      names.append(base.id)
+        return names
+
+    # class name -> base names, so `class X(WhisperEncoderModel)` is still
+    # recognised as an mmproj model two hops away from MmprojModel.
+    class_bases = {
+        node.name : _base_names(node)
+        for node in ast.walk(tree) if isinstance(node, ast.ClassDef)
+    }
+
+    def _inherits_mmproj(class_name, _seen = None):
+        if _seen is None: _seen = set()
+        if class_name in _seen: return False
+        _seen.add(class_name)
+        for base in class_bases.get(class_name, []):
+            if base.lower() in ("mmprojmodel", "visionmodel"): return True
+            if _inherits_mmproj(base, _seen): return True
+        return False
+
+    def _is_mmproj(class_node, call_node):
+        for keyword in call_node.keywords:
+            if keyword.arg != "model_type": continue
+            value = keyword.value
+            # model_type=ModelType.MMPROJ, or a bare MMPROJ / "mmproj"
+            name = None
+            if isinstance(value, ast.Attribute): name = value.attr
+            elif isinstance(value, ast.Name): name = value.id
+            elif isinstance(value, ast.Constant) and isinstance(value.value, str):
+                name = value.value
+            if name is not None and "mmproj" in name.lower(): return True
+        return _inherits_mmproj(class_node.name)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef): continue
+        for decorator in node.decorator_list:
+            if not _is_register_call(decorator): continue
+            names = [
+                arg.value for arg in decorator.args
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+            ]
+            if not names: continue
+            if _is_mmproj(node, decorator): vision_archs.update(names)
+            else: text_archs.update(names)
+    return text_archs, vision_archs
 pass
 
 
@@ -1696,8 +1752,6 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info, _conversion_in
     supported_types = set()
     text_archs = set()
     vision_archs = set()
-    temp_original_file_path = None # for the finally block
-    original_module_name = None    # Only set on the monolith branch
     # Default to 'monolith' so a failed introspection still drives the legacy
     # patches; set by introspection and read by Patch 2 + Patch 3 below.
     _layout = "monolith"
@@ -1759,63 +1813,18 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info, _conversion_in
                     "allowlist will be empty; conversion will still attempt to run."
                 )
         else:
-            # Monolith layout: original behaviour. Write the entrypoint to a
-            # temp file under LLAMA_CPP_DEFAULT_DIR and import it to read
-            # ModelBase._model_classes.
-            with tempfile.NamedTemporaryFile(
-                mode='wb', suffix=".py", prefix="original_gguf_", dir=LLAMA_CPP_DEFAULT_DIR, delete=False
-            ) as temp_file:
-                temp_original_file_path = temp_file.name
-                temp_file.write(original_content)
-                temp_file.flush()
-
-            logger.debug(f"Loading module from temporary file: {temp_original_file_path}")
-            original_module_name = f"convert_hf_to_gguf_{os.path.basename(temp_original_file_path).split('.')[0]}"
-
-            # Set NO_LOCAL_GGUF to prevent the script from adding path again
-            old_env = os.environ.get('NO_LOCAL_GGUF')
-            os.environ['NO_LOCAL_GGUF'] = '1'
-
-            try:
-                module = _load_module_from_path(temp_original_file_path, original_module_name)
-            finally:
-                if old_env is None:
-                    os.environ.pop('NO_LOCAL_GGUF', None)
-                else:
-                    os.environ['NO_LOCAL_GGUF'] = old_env
-            ModelBase = getattr(module, 'ModelBase', None)
-            ModelType = getattr(module, 'ModelType', None)
-
-            if ModelBase is None or ModelType is None:
-                logger.warning(
-                    f"Unsloth: Failed to find 'ModelBase' or 'ModelType' in the original downloaded script. "
-                    f"Structure might have changed. Cannot determine supported architectures."
-                )
-            elif not hasattr(ModelBase, '_model_classes') or not isinstance(ModelBase._model_classes, dict):
-                 logger.warning(
-                    f"Unsloth: 'ModelBase._model_classes' not found or not a dictionary in original script."
-                     " Cannot determine supported architectures."
-                )
-            else:
-                # Check for TEXT models
-                if hasattr(ModelType, 'TEXT') and ModelType.TEXT in ModelBase._model_classes:
-                    if isinstance(ModelBase._model_classes[ModelType.TEXT], dict):
-                        text_archs = set(ModelBase._model_classes[ModelType.TEXT].keys())
-                        supported_types.update(text_archs)
-                    else:
-                        logger.warning("Unsloth: ModelBase._model_classes[ModelType.TEXT] is not a dictionary.")
-                else:
-                    logger.info("Unsloth: No TEXT model architectures found registered in the original script.")
-
-                # Check for VISION models
-                if hasattr(ModelType, 'MMPROJ') and ModelType.MMPROJ in ModelBase._model_classes:
-                    if isinstance(ModelBase._model_classes[ModelType.MMPROJ], dict):
-                        vision_archs = set(ModelBase._model_classes[ModelType.MMPROJ].keys())
-                        supported_types.update(vision_archs)
-                    else:
-                        logger.warning("Unsloth: ModelBase._model_classes[ModelType.MMPROJ] is not a dictionary.")
-                else:
-                     logger.info("Unsloth: No VISION model architectures found registered in the original script.")
+            # Monolith layout: archs come from AST-parsing the
+            # @ModelBase.register(...) decorators in the entrypoint itself.
+            # This file is downloaded from llama.cpp master at runtime, so it
+            # is read, never imported - importing it would execute whatever
+            # the download contained inside this process.
+            text_archs, vision_archs = _extract_archs_from_monolith_source(original_content)
+            supported_types.update(text_archs)
+            supported_types.update(vision_archs)
+            if not text_archs:
+                logger.info("Unsloth: No TEXT model architectures found registered in the original script.")
+            if not vision_archs:
+                logger.info("Unsloth: No VISION model architectures found registered in the original script.")
         # --- End Architecture Extraction ---
 
         # Convert final set to frozenset for immutability (good practice for cache keys/return values)
@@ -1828,23 +1837,9 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info, _conversion_in
                 f"Unsloth: No supported architectures (TEXT or VISION) could be determined from the original script."
             )
 
-        # Cleanup module reference (only set on the monolith branch)
-        if original_module_name is not None and original_module_name in sys.modules:
-             del sys.modules[original_module_name]
-
     except Exception as e:
          logger.error(f"Unsloth: Error during loading or introspecting the original script: {e}", exc_info=True)
-         if temp_original_file_path and os.path.exists(temp_original_file_path):
-             try: os.remove(temp_original_file_path)
-             except OSError as remove_error: logger.warning(f"Could not remove temp file {temp_original_file_path}: {remove_error}")
          raise RuntimeError(f"Failed during loading/introspection of original script: {e}") from e
-    finally:
-        if temp_original_file_path and os.path.exists(temp_original_file_path):
-            try:
-                os.remove(temp_original_file_path)
-                logger.debug(f"Cleaned up temporary file: {temp_original_file_path}")
-            except OSError as remove_error:
-                logger.warning(f"Could not remove temporary file {temp_original_file_path}: {remove_error}")
 
 
     # --- Proceed with patching and saving ---
@@ -2603,7 +2598,9 @@ def convert_to_gguf(
             )
     pass
 
-    if is_vlm and supported_vision_archs is not None:
+    # An empty set means "we could not determine the allowlist", not "nothing is
+    # supported" - matching the text-arch check above, don't gate on it.
+    if is_vlm and supported_vision_archs:
         if "architectures" in config_file:
             arch = config_file["architectures"][0]
         else:
@@ -2947,6 +2944,18 @@ def quantize_gguf(
     # All Unsloth Zoo code licensed under LGPLv3
     # Use llama-quantize for fast quantization of GGUF files.
 
+    # quant_type lands in a shell command below, and callers pass it straight
+    # through from user facing arguments (`quantization_method=...`). Every
+    # legitimate value is a bare token like q4_k_m / iq3_xxs / bf16, so reject
+    # anything else rather than letting shell metacharacters through.
+    if not isinstance(quant_type, str) or \
+        re.fullmatch(r"[A-Za-z0-9_.\-]+", quant_type.strip()) is None:
+        raise ValueError(
+            f"Unsloth: Invalid quantization type `{quant_type}`. Quantization types are "
+            f"single tokens like `q4_k_m`, `q8_0`, `iq4_xs`, `bf16`."
+        )
+    quant_type = quant_type.strip()
+
     # Fix default path on Windows: binaries are in build/bin/Release/
     default_quantizer = os.path.join(LLAMA_CPP_DEFAULT_DIR, "llama-quantize")
     # H3: Use normpath for reliable path comparison on Windows (/ vs \)
@@ -2960,6 +2969,7 @@ def quantize_gguf(
         if n_threads is None:
             n_threads = 1
         n_threads *= 2
+    n_threads = int(n_threads)
 
     def _quote(s):
         """Quote a path for shell usage (the command runs under shell=True)."""
@@ -2999,7 +3009,7 @@ def quantize_gguf(
 
     command = (
         f"{_quote(quantizer_location)} {_extra_flags}"
-        f"{_quote(input_gguf)} {_quote(output_gguf)} {quant_type} {n_threads}"
+        f"{_quote(input_gguf)} {_quote(output_gguf)} {_quote(quant_type)} {n_threads}"
     )
 
     if print_output:

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -1502,15 +1502,11 @@ pass
 
 
 def _extract_archs_from_monolith_source(source_bytes):
-    """AST-parse a monolithic convert_hf_to_gguf.py for its registered
-    architectures, returning (text_archs, vision_archs).
+    """Read (text_archs, vision_archs) out of a monolithic convert_hf_to_gguf.py.
 
-    Reads the `@ModelBase.register("Arch", ...)` / `@Model.register(...)`
-    decorators statically. Parsing rather than importing matters: the file is
-    downloaded from llama.cpp's master branch at runtime, and importing it
-    would execute whatever that download happens to contain inside this
-    process. Mirrors _extract_dict_keys_from_conversion_init, which already
-    does the same for the newer conversion/ package layout.
+    Parsed, not imported: the file is downloaded from llama.cpp master at
+    runtime, so importing it would execute whatever the download contained.
+    Mirrors _extract_dict_keys_from_conversion_init for the package layout.
     """
     try:
         tree = ast.parse(source_bytes)
@@ -1536,8 +1532,7 @@ def _extract_archs_from_monolith_source(source_bytes):
             elif isinstance(base, ast.Name):      names.append(base.id)
         return names
 
-    # class name -> base names, so `class X(WhisperEncoderModel)` is still
-    # recognised as an mmproj model two hops away from MmprojModel.
+    # class -> bases, so a class two hops below MmprojModel still counts as vision.
     class_bases = {
         node.name : _base_names(node)
         for node in ast.walk(tree) if isinstance(node, ast.ClassDef)
@@ -1562,8 +1557,7 @@ def _extract_archs_from_monolith_source(source_bytes):
             elif isinstance(value, ast.Name): name = value.id
             elif isinstance(value, ast.Constant) and isinstance(value.value, str):
                 name = value.value
-            # An explicit model_type wins over the base classes: a vision model
-            # registered as TEXT is a text entry however it is spelled.
+            # An explicit model_type wins over the base classes.
             if name is not None: return "mmproj" in name.lower()
         return _inherits_mmproj(class_node.name)
 
@@ -1579,11 +1573,8 @@ def _extract_archs_from_monolith_source(source_bytes):
             if _is_mmproj(node, decorator): vision_archs.update(names)
             else: text_archs.update(names)
 
-    # A converter may also seed the registry literally,
-    # `_model_classes = {ModelType.TEXT: {"LlamaForCausalLM": ...}, ...}`,
-    # instead of (or as well as) decorating. The import-based introspection saw
-    # those entries, so harvest them too rather than reporting an empty
-    # allowlist for such a checkout.
+    # A converter may seed `_model_classes` literally instead of decorating. The
+    # import path saw those entries, so harvest them rather than report nothing.
     def _bucket_for(key_node):
         name = None
         if   isinstance(key_node, ast.Attribute): name = key_node.attr
@@ -1846,11 +1837,8 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info, _conversion_in
                     "allowlist will be empty; conversion will still attempt to run."
                 )
         else:
-            # Monolith layout: archs come from AST-parsing the
-            # @ModelBase.register(...) decorators in the entrypoint itself.
-            # This file is downloaded from llama.cpp master at runtime, so it
-            # is read, never imported - importing it would execute whatever
-            # the download contained inside this process.
+            # Monolith layout: read the registrations out of the entrypoint. It is
+            # downloaded from llama.cpp master at runtime, so parse, never import.
             text_archs, vision_archs = _extract_archs_from_monolith_source(original_content)
             supported_types.update(text_archs)
             supported_types.update(vision_archs)
@@ -2631,8 +2619,7 @@ def convert_to_gguf(
             )
     pass
 
-    # An empty set means "we could not determine the allowlist", not "nothing is
-    # supported" - matching the text-arch check above, don't gate on it.
+    # Empty means the allowlist is unknown, not that nothing is supported.
     if is_vlm and supported_vision_archs:
         if "architectures" in config_file:
             arch = config_file["architectures"][0]
@@ -2977,10 +2964,8 @@ def quantize_gguf(
     # All Unsloth Zoo code licensed under LGPLv3
     # Use llama-quantize for fast quantization of GGUF files.
 
-    # quant_type lands in a shell command below, and callers pass it straight
-    # through from user facing arguments (`quantization_method=...`). Every
-    # legitimate value is a bare token like q4_k_m / iq3_xxs / bf16, so reject
-    # anything else rather than letting shell metacharacters through.
+    # quant_type reaches the shell command below straight from the user facing
+    # quantization_method, and every real value is a bare token, so require one.
     if not isinstance(quant_type, str) or \
         re.fullmatch(r"[A-Za-z0-9_.\-]+", quant_type.strip()) is None:
         raise ValueError(
@@ -3042,10 +3027,8 @@ def quantize_gguf(
 
     command = (
         f"{_quote(quantizer_location)} {_extra_flags}"
-        # quant_type is validated at the top of this function to be a bare
-        # token, so it needs no quoting; leaving it bare also keeps the command
-        # byte-identical to previous releases on cmd.exe, which would otherwise
-        # see an extra pair of quotes.
+        # Validated above as a bare token, so quoting would only add a pair of
+        # quotes that cmd.exe did not see in previous releases.
         f"{_quote(input_gguf)} {_quote(output_gguf)} {quant_type} {n_threads}"
     )
 

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -1578,6 +1578,37 @@ def _extract_archs_from_monolith_source(source_bytes):
             if not names: continue
             if _is_mmproj(node, decorator): vision_archs.update(names)
             else: text_archs.update(names)
+
+    # A converter may also seed the registry literally,
+    # `_model_classes = {ModelType.TEXT: {"LlamaForCausalLM": ...}, ...}`,
+    # instead of (or as well as) decorating. The import-based introspection saw
+    # those entries, so harvest them too rather than reporting an empty
+    # allowlist for such a checkout.
+    def _bucket_for(key_node):
+        name = None
+        if   isinstance(key_node, ast.Attribute): name = key_node.attr
+        elif isinstance(key_node, ast.Name):      name = key_node.id
+        elif isinstance(key_node, ast.Constant) and isinstance(key_node.value, str):
+            name = key_node.value
+        if name is None: return None
+        return vision_archs if "mmproj" in name.lower() else text_archs
+
+    for node in ast.walk(tree):
+        targets = node.targets if isinstance(node, ast.Assign) else \
+                  [node.target] if isinstance(node, ast.AnnAssign) else []
+        named = any(
+            (isinstance(t, ast.Name) and t.id == "_model_classes") or
+            (isinstance(t, ast.Attribute) and t.attr == "_model_classes")
+            for t in targets
+        )
+        if not named or not isinstance(node.value, ast.Dict): continue
+        for key, value in zip(node.value.keys, node.value.values):
+            bucket = _bucket_for(key)
+            if bucket is None or not isinstance(value, ast.Dict): continue
+            bucket.update(
+                k.value for k in value.keys
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)
+            )
     return text_archs, vision_archs
 pass
 

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -129,6 +129,26 @@ UNSLOTH_ALLOW_PRIVATE_URL_FETCH_VAR = "UNSLOTH_ALLOW_PRIVATE_URL_FETCH"
 UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR   = "UNSLOTH_MAX_MEDIA_DOWNLOAD_MB"
 _MAX_MEDIA_REDIRECTS = 5
 
+# Spelled out rather than relying only on ipaddress properties. is_private is
+# documented to be False for the RFC 6598 shared address space 100.64.0.0/10
+# (both is_private and is_global are False there), and that classification was
+# backported across the 3.8 - 3.13 series, so an explicit list is the only way
+# to get the same answer on every interpreter.
+_BLOCKED_CIDRS = (
+    "0.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8", "169.254.0.0/16",
+    "172.16.0.0/12", "192.0.0.0/24", "192.168.0.0/16", "198.18.0.0/15",
+    "224.0.0.0/4", "240.0.0.0/4",
+    "::/128", "::1/128", "fc00::/7", "fe80::/10", "ff00::/8",
+)
+
+# Cloud metadata services answer on a fixed name as well as a fixed IP. The
+# name matters when an HTTP proxy is configured, because then the proxy, not
+# this process, does the DNS resolution.
+_BLOCKED_HOSTNAMES = frozenset((
+    "metadata.google.internal", "metadata.goog", "metadata",
+    "instance-data", "instance-data.ec2.internal",
+))
+
 
 def _allow_private_url_fetch() -> bool:
     # Read at call time, not import time: notebooks routinely set the env var
@@ -145,10 +165,34 @@ def _max_media_download_bytes() -> int:
     return int(megabytes * 1024 * 1024)
 
 
+@lru_cache(maxsize = 1)
+def _blocked_networks():
+    import ipaddress
+    return tuple(ipaddress.ip_network(cidr) for cidr in _BLOCKED_CIDRS)
+
+
+def _is_blocked_ip(ip) -> bool:
+    if (
+        ip.is_loopback or ip.is_private or ip.is_link_local
+        or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+    ):
+        return True
+    for network in _blocked_networks():
+        if ip.version == network.version and ip in network: return True
+    # IPv4-mapped / 6to4 wrappers around an internal v4 address
+    mapped = getattr(ip, "ipv4_mapped", None) or getattr(ip, "sixtofour", None)
+    if mapped is not None and _is_blocked_ip(mapped): return True
+    return False
+
+
+@lru_cache(maxsize = 1024)
 def _is_blocked_address(host: str) -> bool:
+    # Cached: a URL dataset hits the same handful of hosts thousands of times
+    # and this runs inside the collator, once per image per epoch.
     import ipaddress
     import socket
 
+    if host.lower().rstrip(".") in _BLOCKED_HOSTNAMES: return True
     try:
         infos = socket.getaddrinfo(host, None)
     except Exception:
@@ -160,18 +204,7 @@ def _is_blocked_address(host: str) -> bool:
             ip = ipaddress.ip_address(address.split("%", 1)[0])
         except ValueError:
             continue
-        if (
-            ip.is_loopback or ip.is_private or ip.is_link_local
-            or ip.is_reserved or ip.is_multicast or ip.is_unspecified
-        ):
-            return True
-        # IPv4-mapped/6to4 wrappers around a private v4 address
-        mapped = getattr(ip, "ipv4_mapped", None) or getattr(ip, "sixtofour", None)
-        if mapped is not None and (
-            mapped.is_loopback or mapped.is_private or mapped.is_link_local
-            or mapped.is_reserved or mapped.is_multicast or mapped.is_unspecified
-        ):
-            return True
+        if _is_blocked_ip(ip): return True
     return False
 
 
@@ -207,26 +240,30 @@ def fetch_remote_media_bytes(url: str, timeout: int = 30) -> BytesIO:
     for _ in range(_MAX_MEDIA_REDIRECTS + 1):
         assert_fetchable_url(current)
         response = requests.get(current, stream = True, timeout = timeout, allow_redirects = False)
-        if response.is_redirect or response.is_permanent_redirect:
-            location = response.headers.get("location")
+        try:
+            if response.is_redirect or response.is_permanent_redirect:
+                location = response.headers.get("location")
+                if not location:
+                    raise ValueError(f"Unsloth: Redirect without a Location header while fetching `{url}`")
+                current = urljoin(current, location)
+                continue
+            response.raise_for_status()
+            data = BytesIO()
+            for chunk in response.iter_content(chunk_size = 1024 * 1024):
+                if not chunk: continue
+                data.write(chunk)
+                if max_bytes and data.tell() > max_bytes:
+                    raise ValueError(
+                        f"Unsloth: Media at `{url}` is larger than the "
+                        f"{max_bytes} byte limit. Raise "
+                        f"{UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR} to allow larger downloads."
+                    )
+            data.seek(0)
+            return data
+        finally:
+            # Close every hop: the collator fetches thousands of images and a
+            # leaked streaming response holds its connection open.
             response.close()
-            if not location:
-                raise ValueError(f"Unsloth: Redirect without a Location header while fetching `{url}`")
-            current = urljoin(current, location)
-            continue
-        response.raise_for_status()
-        data = BytesIO()
-        for chunk in response.iter_content(chunk_size = 1024 * 1024):
-            if not chunk: continue
-            data.write(chunk)
-            if max_bytes and data.tell() > max_bytes:
-                response.close()
-                raise ValueError(
-                    f"Unsloth: Media at `{url}` exceeds {max_bytes // (1024 * 1024)}MB. "
-                    f"Raise {UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR} to allow larger downloads."
-                )
-        data.seek(0)
-        return data
     raise ValueError(f"Unsloth: Too many redirects while fetching `{url}`")
 
 

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -119,21 +119,17 @@ def resolve_file_uri_to_path(path):
     return url2pathname(path_part) or path
 
 
-# Dataset rows can carry arbitrary http(s) URLs (`{"type": "image_url", ...}`),
-# and the collators fetch them server side. Without a destination check that is
-# an SSRF primitive: a dataset can make the training worker hit 127.0.0.1, a
-# LAN host, or the cloud metadata endpoint. Public URLs and every local-file
-# form keep working exactly as before; users who really do serve training media
-# from localhost or a private host set UNSLOTH_ALLOW_PRIVATE_URL_FETCH=1.
+# Dataset rows carry arbitrary http(s) URLs and the collators fetch them server
+# side, so without a destination check a row can reach 127.0.0.1, the LAN or the
+# metadata endpoint. Public URLs and local files are unaffected; serving media
+# from a private host needs UNSLOTH_ALLOW_PRIVATE_URL_FETCH=1.
 UNSLOTH_ALLOW_PRIVATE_URL_FETCH_VAR = "UNSLOTH_ALLOW_PRIVATE_URL_FETCH"
 UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR   = "UNSLOTH_MAX_MEDIA_DOWNLOAD_MB"
 _MAX_MEDIA_REDIRECTS = 5
 
-# Spelled out rather than relying only on ipaddress properties. is_private is
-# documented to be False for the RFC 6598 shared address space 100.64.0.0/10
-# (both is_private and is_global are False there), and that classification was
-# backported across the 3.8 - 3.13 series, so an explicit list is the only way
-# to get the same answer on every interpreter.
+# Spelled out, not left to ipaddress alone: is_private is documented False for
+# the RFC 6598 range 100.64.0.0/10, so only an explicit list answers the same on
+# every interpreter.
 _BLOCKED_CIDRS = (
     "0.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8", "169.254.0.0/16",
     "172.16.0.0/12", "192.0.0.0/24", "192.168.0.0/16", "198.18.0.0/15",
@@ -141,9 +137,8 @@ _BLOCKED_CIDRS = (
     "::/128", "::1/128", "fc00::/7", "fe80::/10", "ff00::/8",
 )
 
-# Cloud metadata services answer on a fixed name as well as a fixed IP. The
-# name matters when an HTTP proxy is configured, because then the proxy, not
-# this process, does the DNS resolution.
+# Metadata services answer on a fixed name too, which is what a configured HTTP
+# proxy resolves instead of us.
 _BLOCKED_HOSTNAMES = frozenset((
     "metadata.google.internal", "metadata.goog", "metadata",
     "instance-data", "instance-data.ec2.internal",
@@ -151,8 +146,7 @@ _BLOCKED_HOSTNAMES = frozenset((
 
 
 def _allow_private_url_fetch() -> bool:
-    # Read at call time, not import time: notebooks routinely set the env var
-    # after `import unsloth`.
+    # Read per call: notebooks set the env var after `import unsloth`.
     return os.environ.get(UNSLOTH_ALLOW_PRIVATE_URL_FETCH_VAR, "0") == "1"
 
 
@@ -161,8 +155,7 @@ def _max_media_download_bytes() -> int:
         megabytes = float(os.environ.get(UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR, 256))
     except ValueError:
         megabytes = 256.0
-    # float() happily accepts "inf" and "nan", which int() then refuses. Someone
-    # writing inf means "no cap", so treat both like any other unusable value.
+    # float() accepts inf and nan, int() then refuses them; inf means no cap.
     if not math.isfinite(megabytes): megabytes = 0.0
     if megabytes <= 0: return 0  # 0 disables the cap
     return int(megabytes * 1024 * 1024)
@@ -190,8 +183,7 @@ def _is_blocked_ip(ip) -> bool:
 
 @lru_cache(maxsize = 1024)
 def _is_blocked_address(host: str) -> bool:
-    # Cached: a URL dataset hits the same handful of hosts thousands of times
-    # and this runs inside the collator, once per image per epoch.
+    # Cached: the collator would otherwise re-resolve per image per epoch.
     import ipaddress
     import socket
 
@@ -222,10 +214,9 @@ def assert_fetchable_url(url: str) -> str:
             f"Unsloth: Refusing to fetch media over the `{parsed.scheme}` scheme. "
             f"Only http and https URLs are fetched; use a local path for local files."
         )
-    # urlparse leaves the authority percent-encoded while the HTTP client
-    # decodes it before connecting, so `http://%31%32%37.0.0.1/` would be
-    # checked as an unresolvable name and then fetched from 127.0.0.1. A real
-    # hostname never contains either character (IDNs arrive as xn-- punycode).
+    # urlparse leaves the authority encoded, the client decodes it, so
+    # `http://%31%32%37.0.0.1/` would check as unresolvable then fetch 127.0.0.1.
+    # A real host has neither character (IDNs arrive as xn-- punycode).
     for character in ("%", "\\"):
         if character in parsed.netloc:
             raise ValueError(
@@ -274,8 +265,7 @@ def fetch_remote_media_bytes(url: str, timeout: int = 30) -> BytesIO:
             data.seek(0)
             return data
         finally:
-            # Close every hop: the collator fetches thousands of images and a
-            # leaked streaming response holds its connection open.
+            # Close every hop; a leaked streaming response holds its connection.
             response.close()
     raise ValueError(f"Unsloth: Too many redirects while fetching `{url}`")
 
@@ -283,11 +273,9 @@ def fetch_remote_media_bytes(url: str, timeout: int = 30) -> BytesIO:
 def resolve_media_redirects(url: str, timeout: int = 30) -> str:
     """Walk an http(s) redirect chain, checking every hop, and return the final URL.
 
-    For video the decoder does its own I/O (decord and torchcodec go through
-    ffmpeg, whose http protocol follows redirects by default), so validating
-    only the URL we were handed would let a public host bounce the decoder to
-    an internal one. Following the chain here means the decoder is handed a
-    destination that has already been checked.
+    The video decoders do their own I/O through ffmpeg, which follows redirects
+    by default, so checking only the handed-in URL would let a public host bounce
+    them to an internal one.
     """
     from urllib.parse import urljoin
 
@@ -637,9 +625,8 @@ def get_video_reader_backend() -> str:
 
 def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> Union[torch.Tensor, list[Image.Image]]:
     if isinstance(ele["video"], str):
-        # The backends (torchvision / decord / torchcodec+ffmpeg) fetch remote
-        # URLs themselves and follow redirects internally, so resolve the whole
-        # chain here (checking every hop) and hand over the settled URL.
+        # The decoders fetch and follow redirects themselves, so settle the chain
+        # here and hand over a destination that has been checked.
         if ele["video"].startswith("http://") or ele["video"].startswith("https://"):
             ele = dict(ele)
             ele["video"] = resolve_media_redirects(ele["video"])

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -128,14 +128,12 @@ UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR   = "UNSLOTH_MAX_MEDIA_DOWNLOAD_MB"
 _MAX_MEDIA_REDIRECTS = 5
 
 # Spelled out, not left to ipaddress alone: is_private is documented False for
-# the RFC 6598 range 100.64.0.0/10, so only an explicit list answers the same on
-# every interpreter.
+# the RFC 6598 range 100.64.0.0/10, and only a list answers the same everywhere.
 _BLOCKED_CIDRS = (
     "0.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8", "169.254.0.0/16",
     "172.16.0.0/12", "192.0.0.0/24", "192.168.0.0/16", "198.18.0.0/15",
     "224.0.0.0/4", "240.0.0.0/4",
-    # fec0::/10 is deprecated site-local, still routed on some networks, and
-    # ipaddress reports it only through is_site_local, not is_private.
+    # fec0::/10 is deprecated but still routed, and only is_site_local sees it.
     "::/128", "::1/128", "fc00::/7", "fe80::/10", "fec0::/10", "ff00::/8",
 )
 
@@ -187,10 +185,9 @@ def _is_blocked_ip(ip) -> bool:
 def _resolve_host(host: str):
     """Addresses for `host`, or None when this machine cannot resolve it.
 
-    Deliberately not cached. Caching would let a validation answer outlive the
-    DNS record it came from, so a host that resolved publicly once would keep
-    passing while the connection resolved somewhere else entirely. The OS
-    resolver already absorbs the repeat cost.
+    Deliberately uncached: a remembered answer would outlive its DNS record, so
+    a host that resolved publicly once would keep passing while the connection
+    resolved elsewhere. The OS resolver absorbs the repeat cost.
     """
     import ipaddress
     import socket
@@ -238,18 +235,17 @@ def assert_fetchable_url(url: str) -> str:
             f"Unsloth: Refusing to fetch media over the `{parsed.scheme}` scheme. "
             f"Only http and https URLs are fetched; use a local path for local files."
         )
-    # A backslash anywhere in the authority is a parser differential: urlparse
-    # reads `http://127.0.0.1\@example.com/` as userinfo plus host example.com,
-    # while the client turns the backslash into a path separator and connects to
-    # 127.0.0.1. It is not legal in an authority at all, so refuse it outright.
+    # Parser differential: urlparse reads `http://127.0.0.1\@example.com/` as
+    # userinfo plus host example.com, the client makes the backslash a path
+    # separator and connects to 127.0.0.1. Not legal in an authority anyway.
     if "\\" in parsed.netloc:
         raise ValueError(
             f"Unsloth: Refusing to fetch media from `{url}` since its authority contains "
             f"a backslash, which HTTP clients and URL parsers disagree about."
         )
-    # Percent escapes are the same story for the host (`http://%31%32%37.0.0.1/`
-    # checks as unresolvable then fetches 127.0.0.1) but are legitimate in
-    # userinfo, as in `https://user:p%40ss@example.com/`, so only screen the host.
+    # Same story for an encoded host (`http://%31%32%37.0.0.1/` checks as
+    # unresolvable then fetches 127.0.0.1), but userinfo may legitimately carry
+    # escapes, so screen only the host.
     if "%" in parsed.netloc.rpartition("@")[2]:
         raise ValueError(
             f"Unsloth: Refusing to fetch media from `{url}` since its host is "
@@ -264,9 +260,8 @@ def assert_fetchable_url(url: str) -> str:
             f"loopback, private, link-local or otherwise internal address. "
             f"Set {UNSLOTH_ALLOW_PRIVATE_URL_FETCH_VAR}=1 to allow it."
         )
-    # An unresolvable host is normally harmless, since the request cannot go
-    # anywhere either. Behind a proxy it can: the proxy resolves the name for
-    # us, so nothing was ever checked.
+    # Unresolvable is harmless on its own, since the request goes nowhere either.
+    # Behind a proxy it is not: the proxy resolves the name, so nothing was checked.
     if _resolve_host(host) is None and _proxy_applies(url):
         raise ValueError(
             f"Unsloth: Refusing to fetch media from `{host}` since this machine cannot "
@@ -287,8 +282,8 @@ def _stream_guarded_media(url: str, sink, timeout: int = 30) -> int:
     max_bytes = _max_media_download_bytes()
     written = 0
     current = url
-    # One session for the whole chain: requests used to follow redirects itself
-    # and carry the cookie jar with it, which signed-cookie CDNs rely on.
+    # One session for the chain: requests used to carry the cookie jar across
+    # hops itself, and signed-cookie CDNs rely on it.
     with requests.Session() as session:
         for _ in range(_MAX_MEDIA_REDIRECTS + 1):
             assert_fetchable_url(current)
@@ -329,11 +324,10 @@ def fetch_remote_media_bytes(url: str, timeout: int = 30) -> BytesIO:
 def fetch_remote_media_to_file(url: str, timeout: int = 30) -> str:
     """Download an http(s) URL through the guard and return a temp file path.
 
-    Handing a decoder the URL is not enough, even after resolving its redirects:
-    the decoder issues its own request, and a server that answered ours cleanly
-    can redirect that one to an internal address. ffmpeg follows redirects by
-    default and exposes no way to refuse them, so the only way to bind the
-    decoder to a checked destination is to fetch the bytes ourselves.
+    Handing over the URL is not enough even after resolving redirects: the
+    decoder makes its own request, and a server that answered ours cleanly can
+    redirect that one inward. ffmpeg follows redirects with no way to refuse, so
+    fetching the bytes ourselves is the only way to bind it to a checked source.
     """
     import tempfile
     from urllib.parse import urlparse
@@ -679,8 +673,7 @@ def get_video_reader_backend() -> str:
 
 def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> Union[torch.Tensor, list[Image.Image]]:
     if isinstance(ele["video"], str):
-        # Pick the decoder before downloading: if none is installed this raises,
-        # and a temp file created first would be stranded.
+        # Pick the decoder first: if none is installed, a temp file would strand.
         video_reader_backend = get_video_reader_backend()
         # The decoders fetch remote URLs themselves and follow redirects with no
         # way to refuse, so download through the guard and decode a local file.

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -184,11 +184,13 @@ def _is_blocked_ip(ip) -> bool:
     return False
 
 
-@lru_cache(maxsize = 1024)
 def _resolve_host(host: str):
     """Addresses for `host`, or None when this machine cannot resolve it.
 
-    Cached: the collator would otherwise re-resolve per image per epoch.
+    Deliberately not cached. Caching would let a validation answer outlive the
+    DNS record it came from, so a host that resolved publicly once would keep
+    passing while the connection resolved somewhere else entirely. The OS
+    resolver already absorbs the repeat cost.
     """
     import ipaddress
     import socket
@@ -236,17 +238,23 @@ def assert_fetchable_url(url: str) -> str:
             f"Unsloth: Refusing to fetch media over the `{parsed.scheme}` scheme. "
             f"Only http and https URLs are fetched; use a local path for local files."
         )
-    # urlparse leaves the authority encoded, the client decodes it, so
-    # `http://%31%32%37.0.0.1/` would check as unresolvable then fetch 127.0.0.1.
-    # Only the host is examined: percent escapes are legitimate in userinfo,
-    # as in `https://user:p%40ss@example.com/`.
-    host_part = parsed.netloc.rpartition("@")[2]
-    for character in ("%", "\\"):
-        if character in host_part:
-            raise ValueError(
-                f"Unsloth: Refusing to fetch media from `{url}` since its host contains "
-                f"`{character}`, which HTTP clients and URL parsers disagree about."
-            )
+    # A backslash anywhere in the authority is a parser differential: urlparse
+    # reads `http://127.0.0.1\@example.com/` as userinfo plus host example.com,
+    # while the client turns the backslash into a path separator and connects to
+    # 127.0.0.1. It is not legal in an authority at all, so refuse it outright.
+    if "\\" in parsed.netloc:
+        raise ValueError(
+            f"Unsloth: Refusing to fetch media from `{url}` since its authority contains "
+            f"a backslash, which HTTP clients and URL parsers disagree about."
+        )
+    # Percent escapes are the same story for the host (`http://%31%32%37.0.0.1/`
+    # checks as unresolvable then fetches 127.0.0.1) but are legitimate in
+    # userinfo, as in `https://user:p%40ss@example.com/`, so only screen the host.
+    if "%" in parsed.netloc.rpartition("@")[2]:
+        raise ValueError(
+            f"Unsloth: Refusing to fetch media from `{url}` since its host is "
+            f"percent-encoded, which HTTP clients and URL parsers disagree about."
+        )
     host = parsed.hostname
     if host is None:
         raise ValueError(f"Unsloth: Refusing to fetch media from a URL with no host: `{url}`")

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -161,6 +161,9 @@ def _max_media_download_bytes() -> int:
         megabytes = float(os.environ.get(UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR, 256))
     except ValueError:
         megabytes = 256.0
+    # float() happily accepts "inf" and "nan", which int() then refuses. Someone
+    # writing inf means "no cap", so treat both like any other unusable value.
+    if not math.isfinite(megabytes): megabytes = 0.0
     if megabytes <= 0: return 0  # 0 disables the cap
     return int(megabytes * 1024 * 1024)
 
@@ -219,6 +222,16 @@ def assert_fetchable_url(url: str) -> str:
             f"Unsloth: Refusing to fetch media over the `{parsed.scheme}` scheme. "
             f"Only http and https URLs are fetched; use a local path for local files."
         )
+    # urlparse leaves the authority percent-encoded while the HTTP client
+    # decodes it before connecting, so `http://%31%32%37.0.0.1/` would be
+    # checked as an unresolvable name and then fetched from 127.0.0.1. A real
+    # hostname never contains either character (IDNs arrive as xn-- punycode).
+    for character in ("%", "\\"):
+        if character in parsed.netloc:
+            raise ValueError(
+                f"Unsloth: Refusing to fetch media from `{url}` since its host contains "
+                f"`{character}`, which HTTP clients and URL parsers disagree about."
+            )
     host = parsed.hostname
     if host is None:
         raise ValueError(f"Unsloth: Refusing to fetch media from a URL with no host: `{url}`")
@@ -263,6 +276,36 @@ def fetch_remote_media_bytes(url: str, timeout: int = 30) -> BytesIO:
         finally:
             # Close every hop: the collator fetches thousands of images and a
             # leaked streaming response holds its connection open.
+            response.close()
+    raise ValueError(f"Unsloth: Too many redirects while fetching `{url}`")
+
+
+def resolve_media_redirects(url: str, timeout: int = 30) -> str:
+    """Walk an http(s) redirect chain, checking every hop, and return the final URL.
+
+    For video the decoder does its own I/O (decord and torchcodec go through
+    ffmpeg, whose http protocol follows redirects by default), so validating
+    only the URL we were handed would let a public host bounce the decoder to
+    an internal one. Following the chain here means the decoder is handed a
+    destination that has already been checked.
+    """
+    from urllib.parse import urljoin
+
+    current = url
+    for _ in range(_MAX_MEDIA_REDIRECTS + 1):
+        assert_fetchable_url(current)
+        try:
+            response = requests.get(current, stream = True, timeout = timeout, allow_redirects = False)
+        except requests.RequestException:
+            # Unreachable now is the decoder's error to report, not ours.
+            return current
+        try:
+            if not (response.is_redirect or response.is_permanent_redirect):
+                return current
+            location = response.headers.get("location")
+            if not location: return current
+            current = urljoin(current, location)
+        finally:
             response.close()
     raise ValueError(f"Unsloth: Too many redirects while fetching `{url}`")
 
@@ -595,9 +638,11 @@ def get_video_reader_backend() -> str:
 def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> Union[torch.Tensor, list[Image.Image]]:
     if isinstance(ele["video"], str):
         # The backends (torchvision / decord / torchcodec+ffmpeg) fetch remote
-        # URLs themselves, so vet the destination before handing it over.
+        # URLs themselves and follow redirects internally, so resolve the whole
+        # chain here (checking every hop) and hand over the settled URL.
         if ele["video"].startswith("http://") or ele["video"].startswith("https://"):
-            assert_fetchable_url(ele["video"])
+            ele = dict(ele)
+            ele["video"] = resolve_media_redirects(ele["video"])
         video_reader_backend = get_video_reader_backend()
         try:
             video, sample_fps = VIDEO_READER_BACKENDS[video_reader_backend](ele)

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -235,11 +235,16 @@ def assert_fetchable_url(url: str) -> str:
     return url
 
 
-def fetch_remote_media_bytes(url: str, timeout: int = 30) -> BytesIO:
-    """Fetch an http(s) URL into memory, checking every redirect hop."""
+def _stream_guarded_media(url: str, sink, timeout: int = 30) -> int:
+    """Write an http(s) body into `sink`, checking every redirect hop.
+
+    Single implementation of the fetch policy: scheme and destination checked on
+    the original URL and on each hop, size capped, response always closed.
+    """
     from urllib.parse import urljoin
 
     max_bytes = _max_media_download_bytes()
+    written = 0
     current = url
     for _ in range(_MAX_MEDIA_REDIRECTS + 1):
         assert_fetchable_url(current)
@@ -252,49 +257,54 @@ def fetch_remote_media_bytes(url: str, timeout: int = 30) -> BytesIO:
                 current = urljoin(current, location)
                 continue
             response.raise_for_status()
-            data = BytesIO()
             for chunk in response.iter_content(chunk_size = 1024 * 1024):
                 if not chunk: continue
-                data.write(chunk)
-                if max_bytes and data.tell() > max_bytes:
+                sink.write(chunk)
+                written += len(chunk)
+                if max_bytes and written > max_bytes:
                     raise ValueError(
                         f"Unsloth: Media at `{url}` is larger than the "
                         f"{max_bytes} byte limit. Raise "
                         f"{UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR} to allow larger downloads."
                     )
-            data.seek(0)
-            return data
+            return written
         finally:
             # Close every hop; a leaked streaming response holds its connection.
             response.close()
     raise ValueError(f"Unsloth: Too many redirects while fetching `{url}`")
 
 
-def resolve_media_redirects(url: str, timeout: int = 30) -> str:
-    """Walk an http(s) redirect chain, checking every hop, and return the final URL.
+def fetch_remote_media_bytes(url: str, timeout: int = 30) -> BytesIO:
+    """Fetch an http(s) URL into memory, checking every redirect hop."""
+    data = BytesIO()
+    _stream_guarded_media(url, data, timeout = timeout)
+    data.seek(0)
+    return data
 
-    The video decoders do their own I/O through ffmpeg, which follows redirects
-    by default, so checking only the handed-in URL would let a public host bounce
-    them to an internal one.
+
+def fetch_remote_media_to_file(url: str, timeout: int = 30) -> str:
+    """Download an http(s) URL through the guard and return a temp file path.
+
+    Handing a decoder the URL is not enough, even after resolving its redirects:
+    the decoder issues its own request, and a server that answered ours cleanly
+    can redirect that one to an internal address. ffmpeg follows redirects by
+    default and exposes no way to refuse them, so the only way to bind the
+    decoder to a checked destination is to fetch the bytes ourselves.
     """
-    from urllib.parse import urljoin
+    import tempfile
+    from urllib.parse import urlparse
 
-    current = url
-    for _ in range(_MAX_MEDIA_REDIRECTS + 1):
-        assert_fetchable_url(current)
-        try:
-            response = requests.get(current, stream = True, timeout = timeout, allow_redirects = False)
-        except requests.RequestException:
-            # Unreachable now is the decoder's error to report, not ours.
-            return current
-        try:
-            if not (response.is_redirect or response.is_permanent_redirect):
-                return current
-            location = response.headers.get("location")
-            if not location: return current
-            current = urljoin(current, location)
-        finally:
-            response.close()
+    # Keep the extension: ffmpeg and torchvision sniff the container from it.
+    suffix = os.path.splitext(urlparse(url).path)[1][:16] or ".bin"
+    handle = tempfile.NamedTemporaryFile(prefix = "unsloth_media_", suffix = suffix, delete = False)
+    try:
+        with handle as sink:
+            _stream_guarded_media(url, sink, timeout = timeout)
+    except BaseException:
+        try: os.unlink(handle.name)
+        except OSError: pass
+        raise
+    return handle.name
     raise ValueError(f"Unsloth: Too many redirects while fetching `{url}`")
 
 
@@ -625,18 +635,25 @@ def get_video_reader_backend() -> str:
 
 def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> Union[torch.Tensor, list[Image.Image]]:
     if isinstance(ele["video"], str):
-        # The decoders fetch and follow redirects themselves, so settle the chain
-        # here and hand over a destination that has been checked.
+        # The decoders fetch remote URLs themselves and follow redirects with no
+        # way to refuse, so download through the guard and decode a local file.
+        downloaded = None
         if ele["video"].startswith("http://") or ele["video"].startswith("https://"):
+            downloaded = fetch_remote_media_to_file(ele["video"])
             ele = dict(ele)
-            ele["video"] = resolve_media_redirects(ele["video"])
+            ele["video"] = downloaded
         video_reader_backend = get_video_reader_backend()
         try:
-            video, sample_fps = VIDEO_READER_BACKENDS[video_reader_backend](ele)
-        except Exception as e:
-            if UNSLOTH_ENABLE_LOGGING:
-                logger.warning(f"Unsloth: video_reader_backend {video_reader_backend} error, use torchvision as default, msg: {e}")
-            video, sample_fps = VIDEO_READER_BACKENDS["torchvision"](ele)
+            try:
+                video, sample_fps = VIDEO_READER_BACKENDS[video_reader_backend](ele)
+            except Exception as e:
+                if UNSLOTH_ENABLE_LOGGING:
+                    logger.warning(f"Unsloth: video_reader_backend {video_reader_backend} error, use torchvision as default, msg: {e}")
+                video, sample_fps = VIDEO_READER_BACKENDS["torchvision"](ele)
+        finally:
+            if downloaded is not None:
+                try: os.unlink(downloaded)
+                except OSError: pass
 
         nframes, _, height, width = video.shape
         min_pixels = ele.get("min_pixels", VIDEO_MIN_PIXELS)

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -134,7 +134,9 @@ _BLOCKED_CIDRS = (
     "0.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8", "169.254.0.0/16",
     "172.16.0.0/12", "192.0.0.0/24", "192.168.0.0/16", "198.18.0.0/15",
     "224.0.0.0/4", "240.0.0.0/4",
-    "::/128", "::1/128", "fc00::/7", "fe80::/10", "ff00::/8",
+    # fec0::/10 is deprecated site-local, still routed on some networks, and
+    # ipaddress reports it only through is_site_local, not is_private.
+    "::/128", "::1/128", "fc00::/7", "fe80::/10", "fec0::/10", "ff00::/8",
 )
 
 # Metadata services answer on a fixed name too, which is what a configured HTTP
@@ -171,6 +173,7 @@ def _is_blocked_ip(ip) -> bool:
     if (
         ip.is_loopback or ip.is_private or ip.is_link_local
         or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+        or getattr(ip, "is_site_local", False)
     ):
         return True
     for network in _blocked_networks():
@@ -182,25 +185,44 @@ def _is_blocked_ip(ip) -> bool:
 
 
 @lru_cache(maxsize = 1024)
-def _is_blocked_address(host: str) -> bool:
-    # Cached: the collator would otherwise re-resolve per image per epoch.
+def _resolve_host(host: str):
+    """Addresses for `host`, or None when this machine cannot resolve it.
+
+    Cached: the collator would otherwise re-resolve per image per epoch.
+    """
     import ipaddress
     import socket
 
-    if host.lower().rstrip(".") in _BLOCKED_HOSTNAMES: return True
     try:
         infos = socket.getaddrinfo(host, None)
     except Exception:
-        # Unresolvable: let the HTTP client produce its own error.
-        return False
+        return None
+    addresses = []
     for info in infos:
-        address = info[4][0]
         try:
-            ip = ipaddress.ip_address(address.split("%", 1)[0])
+            addresses.append(ipaddress.ip_address(info[4][0].split("%", 1)[0]))
         except ValueError:
             continue
-        if _is_blocked_ip(ip): return True
-    return False
+    return tuple(addresses)
+
+
+def _proxy_applies(url: str) -> bool:
+    """True when requests would send `url` through an environment proxy."""
+    try:
+        from requests.utils import get_environ_proxies
+        from urllib.parse import urlparse
+
+        proxies = get_environ_proxies(url, no_proxy = None)
+        return bool(proxies.get(urlparse(url).scheme) or proxies.get("all"))
+    except Exception:
+        return False
+
+
+def _is_blocked_address(host: str) -> bool:
+    if host.lower().rstrip(".") in _BLOCKED_HOSTNAMES: return True
+    addresses = _resolve_host(host)
+    if addresses is None: return False  # unresolvable, see assert_fetchable_url
+    return any(_is_blocked_ip(ip) for ip in addresses)
 
 
 def assert_fetchable_url(url: str) -> str:
@@ -216,9 +238,11 @@ def assert_fetchable_url(url: str) -> str:
         )
     # urlparse leaves the authority encoded, the client decodes it, so
     # `http://%31%32%37.0.0.1/` would check as unresolvable then fetch 127.0.0.1.
-    # A real host has neither character (IDNs arrive as xn-- punycode).
+    # Only the host is examined: percent escapes are legitimate in userinfo,
+    # as in `https://user:p%40ss@example.com/`.
+    host_part = parsed.netloc.rpartition("@")[2]
     for character in ("%", "\\"):
-        if character in parsed.netloc:
+        if character in host_part:
             raise ValueError(
                 f"Unsloth: Refusing to fetch media from `{url}` since its host contains "
                 f"`{character}`, which HTTP clients and URL parsers disagree about."
@@ -231,6 +255,15 @@ def assert_fetchable_url(url: str) -> str:
             f"Unsloth: Refusing to fetch media from `{host}` since it resolves to a "
             f"loopback, private, link-local or otherwise internal address. "
             f"Set {UNSLOTH_ALLOW_PRIVATE_URL_FETCH_VAR}=1 to allow it."
+        )
+    # An unresolvable host is normally harmless, since the request cannot go
+    # anywhere either. Behind a proxy it can: the proxy resolves the name for
+    # us, so nothing was ever checked.
+    if _resolve_host(host) is None and _proxy_applies(url):
+        raise ValueError(
+            f"Unsloth: Refusing to fetch media from `{host}` since this machine cannot "
+            f"resolve it and a proxy is configured, so its address is never checked. "
+            f"Set {UNSLOTH_ALLOW_PRIVATE_URL_FETCH_VAR}=1 if the proxy is trusted."
         )
     return url
 
@@ -246,31 +279,34 @@ def _stream_guarded_media(url: str, sink, timeout: int = 30) -> int:
     max_bytes = _max_media_download_bytes()
     written = 0
     current = url
-    for _ in range(_MAX_MEDIA_REDIRECTS + 1):
-        assert_fetchable_url(current)
-        response = requests.get(current, stream = True, timeout = timeout, allow_redirects = False)
-        try:
-            if response.is_redirect or response.is_permanent_redirect:
-                location = response.headers.get("location")
-                if not location:
-                    raise ValueError(f"Unsloth: Redirect without a Location header while fetching `{url}`")
-                current = urljoin(current, location)
-                continue
-            response.raise_for_status()
-            for chunk in response.iter_content(chunk_size = 1024 * 1024):
-                if not chunk: continue
-                sink.write(chunk)
-                written += len(chunk)
-                if max_bytes and written > max_bytes:
-                    raise ValueError(
-                        f"Unsloth: Media at `{url}` is larger than the "
-                        f"{max_bytes} byte limit. Raise "
-                        f"{UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR} to allow larger downloads."
-                    )
-            return written
-        finally:
-            # Close every hop; a leaked streaming response holds its connection.
-            response.close()
+    # One session for the whole chain: requests used to follow redirects itself
+    # and carry the cookie jar with it, which signed-cookie CDNs rely on.
+    with requests.Session() as session:
+        for _ in range(_MAX_MEDIA_REDIRECTS + 1):
+            assert_fetchable_url(current)
+            response = session.get(current, stream = True, timeout = timeout, allow_redirects = False)
+            try:
+                if response.is_redirect or response.is_permanent_redirect:
+                    location = response.headers.get("location")
+                    if not location:
+                        raise ValueError(f"Unsloth: Redirect without a Location header while fetching `{url}`")
+                    current = urljoin(current, location)
+                    continue
+                response.raise_for_status()
+                for chunk in response.iter_content(chunk_size = 1024 * 1024):
+                    if not chunk: continue
+                    sink.write(chunk)
+                    written += len(chunk)
+                    if max_bytes and written > max_bytes:
+                        raise ValueError(
+                            f"Unsloth: Media at `{url}` is larger than the "
+                            f"{max_bytes} byte limit. Raise "
+                            f"{UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR} to allow larger downloads."
+                        )
+                return written
+            finally:
+                # Close every hop; a leaked streaming response holds its connection.
+                response.close()
     raise ValueError(f"Unsloth: Too many redirects while fetching `{url}`")
 
 
@@ -635,6 +671,9 @@ def get_video_reader_backend() -> str:
 
 def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> Union[torch.Tensor, list[Image.Image]]:
     if isinstance(ele["video"], str):
+        # Pick the decoder before downloading: if none is installed this raises,
+        # and a temp file created first would be stranded.
+        video_reader_backend = get_video_reader_backend()
         # The decoders fetch remote URLs themselves and follow redirects with no
         # way to refuse, so download through the guard and decode a local file.
         downloaded = None
@@ -642,7 +681,6 @@ def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample
             downloaded = fetch_remote_media_to_file(ele["video"])
             ele = dict(ele)
             ele["video"] = downloaded
-        video_reader_backend = get_video_reader_backend()
         try:
             try:
                 video, sample_fps = VIDEO_READER_BACKENDS[video_reader_backend](ele)

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -119,6 +119,117 @@ def resolve_file_uri_to_path(path):
     return url2pathname(path_part) or path
 
 
+# Dataset rows can carry arbitrary http(s) URLs (`{"type": "image_url", ...}`),
+# and the collators fetch them server side. Without a destination check that is
+# an SSRF primitive: a dataset can make the training worker hit 127.0.0.1, a
+# LAN host, or the cloud metadata endpoint. Public URLs and every local-file
+# form keep working exactly as before; users who really do serve training media
+# from localhost or a private host set UNSLOTH_ALLOW_PRIVATE_URL_FETCH=1.
+UNSLOTH_ALLOW_PRIVATE_URL_FETCH_VAR = "UNSLOTH_ALLOW_PRIVATE_URL_FETCH"
+UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR   = "UNSLOTH_MAX_MEDIA_DOWNLOAD_MB"
+_MAX_MEDIA_REDIRECTS = 5
+
+
+def _allow_private_url_fetch() -> bool:
+    # Read at call time, not import time: notebooks routinely set the env var
+    # after `import unsloth`.
+    return os.environ.get(UNSLOTH_ALLOW_PRIVATE_URL_FETCH_VAR, "0") == "1"
+
+
+def _max_media_download_bytes() -> int:
+    try:
+        megabytes = float(os.environ.get(UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR, 256))
+    except ValueError:
+        megabytes = 256.0
+    if megabytes <= 0: return 0  # 0 disables the cap
+    return int(megabytes * 1024 * 1024)
+
+
+def _is_blocked_address(host: str) -> bool:
+    import ipaddress
+    import socket
+
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except Exception:
+        # Unresolvable: let the HTTP client produce its own error.
+        return False
+    for info in infos:
+        address = info[4][0]
+        try:
+            ip = ipaddress.ip_address(address.split("%", 1)[0])
+        except ValueError:
+            continue
+        if (
+            ip.is_loopback or ip.is_private or ip.is_link_local
+            or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+        ):
+            return True
+        # IPv4-mapped/6to4 wrappers around a private v4 address
+        mapped = getattr(ip, "ipv4_mapped", None) or getattr(ip, "sixtofour", None)
+        if mapped is not None and (
+            mapped.is_loopback or mapped.is_private or mapped.is_link_local
+            or mapped.is_reserved or mapped.is_multicast or mapped.is_unspecified
+        ):
+            return True
+    return False
+
+
+def assert_fetchable_url(url: str) -> str:
+    """Reject non-http(s) URLs and URLs pointing at loopback/private hosts."""
+    if _allow_private_url_fetch(): return url
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Unsloth: Refusing to fetch media over the `{parsed.scheme}` scheme. "
+            f"Only http and https URLs are fetched; use a local path for local files."
+        )
+    host = parsed.hostname
+    if host is None:
+        raise ValueError(f"Unsloth: Refusing to fetch media from a URL with no host: `{url}`")
+    if _is_blocked_address(host):
+        raise ValueError(
+            f"Unsloth: Refusing to fetch media from `{host}` since it resolves to a "
+            f"loopback, private, link-local or otherwise internal address. "
+            f"Set {UNSLOTH_ALLOW_PRIVATE_URL_FETCH_VAR}=1 to allow it."
+        )
+    return url
+
+
+def fetch_remote_media_bytes(url: str, timeout: int = 30) -> BytesIO:
+    """Fetch an http(s) URL into memory, checking every redirect hop."""
+    from urllib.parse import urljoin
+
+    max_bytes = _max_media_download_bytes()
+    current = url
+    for _ in range(_MAX_MEDIA_REDIRECTS + 1):
+        assert_fetchable_url(current)
+        response = requests.get(current, stream = True, timeout = timeout, allow_redirects = False)
+        if response.is_redirect or response.is_permanent_redirect:
+            location = response.headers.get("location")
+            response.close()
+            if not location:
+                raise ValueError(f"Unsloth: Redirect without a Location header while fetching `{url}`")
+            current = urljoin(current, location)
+            continue
+        response.raise_for_status()
+        data = BytesIO()
+        for chunk in response.iter_content(chunk_size = 1024 * 1024):
+            if not chunk: continue
+            data.write(chunk)
+            if max_bytes and data.tell() > max_bytes:
+                response.close()
+                raise ValueError(
+                    f"Unsloth: Media at `{url}` exceeds {max_bytes // (1024 * 1024)}MB. "
+                    f"Raise {UNSLOTH_MAX_MEDIA_DOWNLOAD_MB_VAR} to allow larger downloads."
+                )
+        data.seek(0)
+        return data
+    raise ValueError(f"Unsloth: Too many redirects while fetching `{url}`")
+
+
 def round_by_factor(number: int, factor: int) -> int:
     """Returns the closest integer to 'number' that is divisible by 'factor'."""
     return round(number / factor) * factor
@@ -175,7 +286,7 @@ def fetch_image(
         image_obj = image
     elif isinstance(image, str):
         if image.startswith("http://") or image.startswith("https://"):
-            image_obj = Image.open(requests.get(image, stream=True, timeout=30).raw)
+            image_obj = Image.open(fetch_remote_media_bytes(image))
         elif image.startswith("file://"):
             image_obj = Image.open(resolve_file_uri_to_path(image))
         elif image.startswith("data:image"):
@@ -193,7 +304,7 @@ def fetch_image(
         elif "path" in image and image["path"]:
             image_obj = Image.open(image["path"])
         elif "url" in image and image["url"]:
-            image_obj = Image.open(requests.get(image["url"], stream=True, timeout=30).raw)
+            image_obj = Image.open(fetch_remote_media_bytes(image["url"]))
 
     if image_obj is None:
         raise ValueError(f"Unrecognized image input. We support local path, http url, base64 and PIL.Image, bytes and dict formats. Instead we got `{type(image).__name__}`")
@@ -446,6 +557,10 @@ def get_video_reader_backend() -> str:
 
 def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> Union[torch.Tensor, list[Image.Image]]:
     if isinstance(ele["video"], str):
+        # The backends (torchvision / decord / torchcodec+ffmpeg) fetch remote
+        # URLs themselves, so vet the destination before handing it over.
+        if ele["video"].startswith("http://") or ele["video"].startswith("https://"):
+            assert_fetchable_url(ele["video"])
         video_reader_backend = get_video_reader_backend()
         try:
             video, sample_fps = VIDEO_READER_BACKENDS[video_reader_backend](ele)


### PR DESCRIPTION
Hardens three sinks that take user or dataset controlled input. All of it is behaviour preserving for normal use: no new required arguments, no removed features, and the fixes are idempotent.

### 1. `quantize_gguf` interpolates `quant_type` into a `shell=True` command

`unsloth_zoo/llama_cpp.py:3000` builds the llama-quantize command as a string. Paths are `shlex.quote`d but `quant_type` is not, and it arrives straight from the user facing `quantization_method` argument (MLX `save_pretrained_gguf` / `push_to_hub_gguf` pass anything that is not one of the four friendly aliases through verbatim). A value like `q4_k_m; touch pwned; #` runs.

Fix: reject any `quant_type` that is not a bare token (`[A-Za-z0-9_.-]+`), then quote it anyway, and coerce `n_threads` to `int`. Every legitimate value is `[a-z0-9_]+` (unsloth's `ALLOWED_QUANTS` and `IMATRIX_QUANTS`, and the MLX `quant_map`), so nothing real is rejected. `shell=True` and the `_extra_flags` string are left alone so the Q2_K_L preset and `--imatrix` keep working exactly as they do today.

### 2. Dataset supplied image and video URLs are fetched with no destination check

A VLM row can carry `{"type": "image_url", "image_url": "http://..."}`, and both the CUDA `UnslothVisionDataCollator` and the MLX collator resolve it server side through `fetch_image` / `fetch_video`. `unsloth_zoo/vision_utils.py:178` and `:196` called `requests.get` on whatever string was in the row, so a dataset could drive requests from the training worker to `127.0.0.1`, the LAN, or `169.254.169.254`. The `{"url": ...}` dict branch had no scheme check at all.

Fix: `assert_fetchable_url` allows only http and https, resolves the host, and refuses loopback, private, link-local, reserved, multicast and unspecified addresses. `fetch_remote_media_bytes` re-checks every redirect hop and caps the download size. `fetch_video` vets the URL before handing it to torchvision / decord / torchcodec, which do their own I/O.

What is deliberately unchanged: `file://`, bare local paths, `data:image`, bytes, PIL objects, and the `process_vision_info` fallback in `_extract_vlm_images`. Local dataset images are a core feature, not a flaw, and removing the fallback would break `image_url` datasets that work today. Anyone genuinely serving training media from localhost or a private host sets `UNSLOTH_ALLOW_PRIVATE_URL_FETCH=1`; `UNSLOTH_MAX_MEDIA_DOWNLOAD_MB` tunes the cap (default 256). Both are read at call time so setting them in a notebook cell after import works.

### 3. The downloaded `convert_hf_to_gguf.py` was imported into the training process

`_download_convert_hf_to_gguf_cached` fetches the converter from llama.cpp master at runtime. The package layout already AST-parses `conversion/__init__.py`, but the monolith branch wrote the downloaded bytes to a temp file and `exec_module`d them to read `ModelBase._model_classes`.

Fix: new `_extract_archs_from_monolith_source` AST-parses the `@ModelBase.register(...)` decorators instead, so the download is read and never executed. `_load_module_from_path` is removed. Verified against real checkouts: b4800 gives 81 text archs, b6000 gives 130 text and 13 vision (transitive `MmprojModel` subclasses included).

This also fixes a live failure. On main, `_download_convert_hf_to_gguf()` with no local llama.cpp checkout raises today, because upstream master is now a thin package entrypoint and importing it hits `ModuleNotFoundError: conversion`. Confirmed against a clean worktree of main; with the AST path it completes.

Related: `convert_to_gguf` now treats an empty `supported_vision_archs` as "allowlist unknown, do not gate" rather than "nothing is supported", matching how the text arch check above it already behaves. Otherwise a failed arch extraction would silently downgrade a VLM export to text only.

### Tests

Three new CPU only files:

- `tests/test_quantize_gguf_quant_type_validation.py` - metacharacter payloads raise and `subprocess.run` is never reached; legitimate quant types produce the identical command as before; whitespace trimming and `n_threads` coercion.
- `tests/test_vision_url_ssrf_guard.py` - loopback, private, link-local, metadata, IPv6 and `0.0.0.0` targets blocked through `fetch_image`, the `image_url` dict form and `process_vision_info`, with a fixture that fails the test if any request escapes; public URLs still fetch; redirect to an internal address blocked; size cap; opt-out env var; local paths, `file://`, `data:` and bytes untouched; `fetch_video` refuses before touching a backend.
- `tests/test_gguf_monolith_arch_ast.py` - archs extracted statically, a hostile top level side effect never runs, unparseable source yields empty sets.

Two existing tests referenced the removed loader and were updated to the new contract (`test_llama_cpp_loader.py`, `test_convert_hf_to_gguf_patcher.py`).

Regression runs, all green: 242 passed / 10 skipped and 225 passed / 1 skipped across the vision collator, MLX save and export, GGUF patcher, llama.cpp and `tests/security/` suites.

Live smoke: a real public image URL that redirects to a CDN still loads at 3192x980, and `http://169.254.169.254/latest/meta-data/` is refused with a message naming the opt-out.

Not addressed on purpose: DNS rebinding races, audio URL handling, and local file reads from dataset rows.
