### PR TITLE
Prune the Actions caches that were holding the repo on its ceiling

### DIFF
--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -4,9 +4,10 @@
 name: Cache janitor
 
 # Keeps Actions cache usage clear of the 20 GiB ceiling. At the ceiling GitHub
-# evicts by LRU regardless of reachability, and a partially evicted cache still
-# restores, then misses on the evicted objects: the hit rate collapses with
-# nothing failing.
+# deletes whole entries by last-access date, regardless of reachability, so the
+# live entry of a family can go between the run that wrote it and the run that
+# needs it. The documented result is cache thrashing: entries created and deleted
+# at a high frequency, the hit rate collapsing with nothing failing.
 #
 # The ceiling is 20 GiB, not the 50 GB this workflow assumed until 2026-08-26.
 # That was not a harmless off-by-a-constant: the warning fired at 40 GiB, so it
@@ -23,14 +24,19 @@ name: Cache janitor
 #      open PR's caches are live no matter how old, and a lookup that errors
 #      keeps the cache.
 #
-#   2. Superseded generations of families that resolve via restore-keys, where
-#      GitHub returns the most recent prefix match so older generations serve no
-#      routine build:
+#   2. Superseded generations of the non-Python families that resolve via
+#      restore-keys, where GitHub returns the most recent prefix match so older
+#      generations serve no routine build:
 #        codeql-overlay-base-database-*  keys embed commit SHA + run id
 #        v0-rust-*                       Swatinem/rust-cache
 #
 #   3. Superseded generations of setup-python-*-pip-*, keyed by a hash over the
-#      dependency files. These were previously left alone on the reasoning that
+#      dependency files. This family resolves by restore-key too: setup-python
+#      v7.0.0 returns exactly one, the primary key minus the trailing hash
+#      (cache-distributions/pip-cache.ts computeKeys), which is the same prefix
+#      this workflow groups by. So the newest generation still answers a changed
+#      hash, and keeping 1 costs nothing routine. These were previously left
+#      alone on the reasoning that
 #      one generation is live at a time and a superseded one expires by itself
 #      after 7 days unused. Both halves are true and the conclusion still does
 #      not hold: 7 days of overlap, times four interpreters, times every ref

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -3,27 +3,56 @@
 
 name: Cache janitor
 
-# Keeps Actions cache usage clear of the 50 GB ceiling. At the ceiling GitHub
+# Keeps Actions cache usage clear of the 20 GiB ceiling. At the ceiling GitHub
 # evicts by LRU regardless of reachability, and a partially evicted cache still
 # restores, then misses on the evicted objects: the hit rate collapses with
 # nothing failing.
 #
-# Deletes only families that resolve via restore-keys, where GitHub returns the
-# most recent prefix match so older generations serve no routine build:
-#   codeql-overlay-base-database-*  keys embed commit SHA + run id
-#   v0-rust-*                       Swatinem/rust-cache
+# The ceiling is 20 GiB, not the 50 GB this workflow assumed until 2026-08-26.
+# That was not a harmless off-by-a-constant: the warning fired at 40 GiB, so it
+# could never fire at all, and the repo sat at 19.97 of 20 GiB -- evicting
+# continuously -- while every scheduled run reported a clean sweep.
+#
+# Three families are pruned.
+#
+#   1. Caches on refs/pull/N/* whose PR is closed or merged. Lookup is scoped by
+#      ref and nothing but that PR's own runs can restore its merge ref, so once
+#      the PR is not open the entry is unreachable for good. GitHub does not
+#      collect these on merge; they sit for the full 7-day idle expiry. Merged
+#      PR #1084 alone held 6.6 GiB this way. The PR state decides, not age: an
+#      open PR's caches are live no matter how old, and a lookup that errors
+#      keeps the cache.
+#
+#   2. Superseded generations of families that resolve via restore-keys, where
+#      GitHub returns the most recent prefix match so older generations serve no
+#      routine build:
+#        codeql-overlay-base-database-*  keys embed commit SHA + run id
+#        v0-rust-*                       Swatinem/rust-cache
+#
+#   3. Superseded generations of setup-python-*-pip-*, keyed by a hash over the
+#      dependency files. These were previously left alone on the reasoning that
+#      one generation is live at a time and a superseded one expires by itself
+#      after 7 days unused. Both halves are true and the conclusion still does
+#      not hold: 7 days of overlap, times four interpreters, times every ref
+#      that ran, is larger than the whole budget. A dependency bump on 2026-08-23
+#      left 6.6 GiB of the previous generation resident behind the new one.
 #
 # "Older" is not the same as unreachable. rust-cache passes its full key to
 # restoreCache, which tries an exact match first, so a build returning to an
 # earlier dependency state (a re-run of an old commit, a lockfile revert) can
-# still hit an older generation exactly. Pruning trades those rare exact hits
-# for headroom, which is the point; keep is the dial.
+# still hit an older generation exactly. setup-python is the same shape. Pruning
+# trades those rare exact hits for headroom, which is the point; keep is the dial.
+#
+# setup-python keeps 1 generation rather than keep, deliberately. The usual
+# reason to hold a second -- an in-flight run losing the cache it just resolved
+# -- does not apply: restore happens at the top of a job, so a job that resolved
+# the old generation already holds the files on disk, and its own save writes a
+# new key. Holding a second generation of a family whose entries are ~2 GiB each
+# is what put this repo on the ceiling.
 #
 # Everything else is left alone. The hf-* / *-gguf-* model caches use exact keys,
 # so an entry that looks superseded is the only one its key will ever match and
-# deleting it costs a multi-GB re-download. setup-python does resolve by
-# restore-keys, but its hash is over the dependency file: one generation is live
-# at a time, and a superseded one expires by itself after 7 days unused.
+# deleting it costs a multi-GB re-download.
 
 on:
   schedule:
@@ -36,7 +65,7 @@ on:
         options: [report, delete]
         default: report
       keep:
-        description: 'Generations kept per prefix. 2 so an in-flight run cannot lose the cache it just resolved.'
+        description: 'Generations kept per prefix. 2 so an in-flight run cannot lose the cache it just resolved. setup-python always keeps 1.'
         type: string
         default: '2'
 
@@ -55,6 +84,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       actions: write
+      pull-requests: read
     steps:
       - name: Prune
         continue-on-error: true  # housekeeping must never page anyone
@@ -68,6 +98,7 @@ jobs:
           set -euo pipefail
           repo="$GITHUB_REPOSITORY"
           all="$RUNNER_TEMP/caches.tsv"
+          live="$RUNNER_TEMP/live.tsv"
           grouped="$RUNNER_TEMP/grouped.tsv"
 
           # Whitelist 1..99. Anything `[ n -le KEEP ]` cannot compare exits 2,
@@ -76,6 +107,8 @@ jobs:
           # exit 0. All-digit is not enough, since a value past bash's integer
           # range fails the same way.
           case "$KEEP" in [1-9]|[1-9][0-9]) ;; *) echo "::warning::invalid keep=$KEEP, using 2"; KEEP=2 ;; esac
+
+          gib() { awk -v b="${1:-0}" 'BEGIN { printf "%.1f", b / 1073741824 }'; }
 
           # Report a failed inventory. Deleting nothing is the safe direction,
           # but silence means a broken janitor looks identical to a clean repo
@@ -89,16 +122,67 @@ jobs:
 
           total=$(awk -F'\t' '{s+=$3} END {printf "%d", s+0}' "$all")
           count=$(grep -c . "$all" || true)
-          echo "$count caches, $(( total / 1073741824 )) GiB, delete=$DELETE keep=$KEEP"
+          echo "$count caches, $(gib "$total") GiB, delete=$DELETE keep=$KEEP"
 
+          freed=0; deleted=0; stale_pr=0
+
+          # Pass 1: caches belonging to a PR that is no longer open. Unreachable
+          # regardless of generation, so this runs before ranking and removes
+          # them from it -- otherwise a merged PR's entries occupy the keep slots
+          # of their own (ref, version, prefix) group and shield each other.
+          declare -A prstate=()
+          : > "$live"
+          while IFS=$'\t' read -r id created size ref ver key; do
+            [ -z "${id:-}" ] && continue
+            num=""
+            case "$ref" in
+              refs/pull/*/merge|refs/pull/*/head)
+                num="${ref#refs/pull/}"; num="${num%/*}" ;;
+            esac
+            if [ -n "$num" ]; then
+              case "$num" in
+                ''|*[!0-9]*) num="" ;;  # not a PR number; fall through to ranking
+              esac
+            fi
+            if [ -n "$num" ]; then
+              if [ -z "${prstate[$num]:-}" ]; then
+                # An error must not read as "closed". Default to open so a rate
+                # limit or a transient 5xx keeps the cache instead of freeing it.
+                prstate[$num]=$(gh api "repos/$repo/pulls/$num" -q '.state' < /dev/null 2>/dev/null || echo open)
+                [ -n "${prstate[$num]}" ] || prstate[$num]=open
+              fi
+              if [ "${prstate[$num]}" != "open" ]; then
+                echo "stale PR #$num ($(gib "$size") GiB): $key"
+                stale_pr=$(( stale_pr + 1 ))
+                if [ "$DELETE" != "yes" ]; then
+                  freed=$(( freed + size )); deleted=$(( deleted + 1 )); continue
+                fi
+                if gh api -X DELETE "repos/$repo/actions/caches/$id" --silent < /dev/null 2>/dev/null; then
+                  freed=$(( freed + size )); deleted=$(( deleted + 1 ))
+                fi
+                continue
+              fi
+            fi
+            printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$id" "$created" "$size" "$ref" "$ver" "$key" >> "$live"
+          done < "$all"
+
+          # Pass 2: rank the survivors by generation within each family.
           : > "$grouped"
           while IFS=$'\t' read -r id created size ref ver key; do
             [ -z "${id:-}" ] && continue
+            fam=other
             case "$key" in
               codeql-overlay-base-database-*)
                 pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{40}-[0-9]+-[0-9]+$//') ;;
               v0-rust-*)
                 pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{8,}$//') ;;
+              setup-python-*-pip-*)
+                # Strip only the trailing dependency hash. The interpreter version
+                # stays in the prefix on purpose: 3.10 and 3.13 entries are separate
+                # keys that never substitute for one another, and folding them into
+                # one group would rank four live caches as four generations of one.
+                fam=setup-python
+                pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{64}$//') ;;
               *) continue ;;
             esac
             # Unshortened means the suffix did not match, which would make
@@ -109,16 +193,18 @@ jobs:
             # compression change mints a new version that is restored
             # independently. Ranking them together lets two entries from one
             # scope evict every usable entry of another.
-            printf '%s\t%s\t%s\t%s\n' "$ref|$ver|$pre" "$created" "$id" "$size" >> "$grouped"
-          done < "$all"
+            printf '%s\t%s\t%s\t%s\t%s\n' "$ref|$ver|$pre" "$created" "$id" "$size" "$fam" >> "$grouped"
+          done < "$live"
 
           sort -t"$(printf '\t')" -k1,1 -k2,2r -o "$grouped" "$grouped"
 
-          prev=""; n=0; freed=0; deleted=0
-          while IFS=$'\t' read -r pre created id size; do
+          prev=""; n=0; superseded=0
+          while IFS=$'\t' read -r pre created id size fam; do
             [ -z "${pre:-}" ] && continue
             if [ "$pre" != "$prev" ]; then prev="$pre"; n=1; else n=$(( n + 1 )); fi
-            [ "$n" -le "$KEEP" ] && continue
+            lim="$KEEP"; [ "$fam" = "setup-python" ] && lim=1
+            [ "$n" -le "$lim" ] && continue
+            superseded=$(( superseded + 1 ))
             if [ "$DELETE" != "yes" ]; then
               freed=$(( freed + size )); deleted=$(( deleted + 1 )); continue
             fi
@@ -130,21 +216,25 @@ jobs:
 
           after=$(( total - freed ))
           verb="pruned"; [ "$DELETE" = "yes" ] || verb="would prune"
-          echo "$verb $deleted caches, $(( freed / 1073741824 )) GiB"
+          echo "$verb $deleted caches, $(gib "$freed") GiB"
           {
             echo "### Cache janitor"
             echo ""
             echo "| metric | value |"
             echo "| --- | --- |"
             echo "| mode | $([ "$DELETE" = yes ] && echo delete || echo 'report only') |"
-            echo "| kept per prefix | $KEEP |"
+            echo "| kept per prefix | $KEEP (setup-python: 1) |"
             echo "| caches total | $count |"
+            echo "| closed-PR candidates | $stale_pr |"
+            echo "| superseded candidates | $superseded |"
             echo "| candidates $verb | $deleted |"
-            echo "| freed | $(( freed / 1073741824 )) GiB |"
-            echo "| usage before | $(( total / 1073741824 )) GiB of 50 GB |"
-            echo "| usage after | $(( after / 1073741824 )) GiB of 50 GB |"
+            echo "| freed | $(gib "$freed") GiB |"
+            echo "| usage before | $(gib "$total") GiB of 20 GiB |"
+            echo "| usage after | $(gib "$after") GiB of 20 GiB |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "$after" -gt 42949672960 ]; then
-            echo "::warning::Cache usage is $(( after / 1073741824 )) GiB of 50 GB after pruning. Lower keep to 1, or find the family that grew."
+          # 80% of the ceiling. Above this a single dependency bump can push the
+          # repo over between two scheduled sweeps.
+          if [ "$after" -gt 17179869184 ]; then
+            echo "::warning::Cache usage is $(gib "$after") GiB of 20 GiB after pruning. Lower keep to 1, or find the family that grew."
           fi

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -31,30 +31,26 @@ name: Cache janitor
 #        v0-rust-*                       Swatinem/rust-cache
 #
 #   3. Superseded generations of setup-python-*-pip-*, keyed by a hash over the
-#      dependency files. This family resolves by restore-key too: setup-python
-#      v7.0.0 returns exactly one, the primary key minus the trailing hash
-#      (cache-distributions/pip-cache.ts computeKeys), which is the same prefix
-#      this workflow groups by. So the newest generation still answers a changed
-#      hash, and keeping 1 costs nothing routine. These were previously left
-#      alone on the reasoning that
-#      one generation is live at a time and a superseded one expires by itself
-#      after 7 days unused. Both halves are true and the conclusion still does
-#      not hold: 7 days of overlap, times four interpreters, times every ref
-#      that ran, is larger than the whole budget. A dependency bump on 2026-08-23
-#      left 6.6 GiB of the previous generation resident behind the new one.
+#      dependency files, beyond the same keep. This family resolves by
+#      restore-key too: setup-python v7.0.0 returns exactly one, the primary key
+#      minus the trailing hash (cache-distributions/pip-cache.ts computeKeys),
+#      which is the same prefix this workflow groups by. So generation N-1 never
+#      answers a CHANGED hash -- the newest prefix match wins -- and generation
+#      N-2 and older answer nothing at all. These were previously left alone on
+#      the reasoning that one generation is live at a time and a superseded one
+#      expires by itself after 7 days unused. Both halves are true and the
+#      conclusion still does not hold: 7 days of overlap, times four
+#      interpreters, times every ref that ran, is larger than the whole budget.
+#      A dependency bump on 2026-08-23 left 6.6 GiB of the previous generation
+#      resident behind the new one.
 #
 # "Older" is not the same as unreachable. rust-cache passes its full key to
 # restoreCache, which tries an exact match first, so a build returning to an
 # earlier dependency state (a re-run of an old commit, a lockfile revert) can
-# still hit an older generation exactly. setup-python is the same shape. Pruning
-# trades those rare exact hits for headroom, which is the point; keep is the dial.
-#
-# setup-python keeps 1 generation rather than keep, deliberately. The usual
-# reason to hold a second -- an in-flight run losing the cache it just resolved
-# -- does not apply: restore happens at the top of a job, so a job that resolved
-# the old generation already holds the files on disk, and its own save writes a
-# new key. Holding a second generation of a family whose entries are ~2 GiB each
-# is what put this repo on the ceiling.
+# still hit an older generation exactly. setup-python is the same shape. keep is
+# the dial, and it is set for hit rate, not for headroom: the budget exists to be
+# spent, so a generation that can still answer something stays. What goes is what
+# can answer nothing -- unreachable refs, and generations past keep.
 #
 # Everything else is left alone. The hf-* / *-gguf-* model caches use exact keys,
 # so an entry that looks superseded is the only one its key will ever match and
@@ -71,7 +67,7 @@ on:
         options: [report, delete]
         default: report
       keep:
-        description: 'Generations kept per prefix. 2 so an in-flight run cannot lose the cache it just resolved. setup-python always keeps 1.'
+        description: 'Generations kept per prefix. 2 so an in-flight run cannot lose the cache it just resolved, and so a reverted dependency bump still hits.'
         type: string
         default: '2'
 
@@ -176,7 +172,6 @@ jobs:
           : > "$grouped"
           while IFS=$'\t' read -r id created size ref ver key; do
             [ -z "${id:-}" ] && continue
-            fam=other
             case "$key" in
               codeql-overlay-base-database-*)
                 pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{40}-[0-9]+-[0-9]+$//') ;;
@@ -187,7 +182,6 @@ jobs:
                 # stays in the prefix on purpose: 3.10 and 3.13 entries are separate
                 # keys that never substitute for one another, and folding them into
                 # one group would rank four live caches as four generations of one.
-                fam=setup-python
                 pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{64}$//') ;;
               *) continue ;;
             esac
@@ -199,17 +193,16 @@ jobs:
             # compression change mints a new version that is restored
             # independently. Ranking them together lets two entries from one
             # scope evict every usable entry of another.
-            printf '%s\t%s\t%s\t%s\t%s\n' "$ref|$ver|$pre" "$created" "$id" "$size" "$fam" >> "$grouped"
+            printf '%s\t%s\t%s\t%s\n' "$ref|$ver|$pre" "$created" "$id" "$size" >> "$grouped"
           done < "$live"
 
           sort -t"$(printf '\t')" -k1,1 -k2,2r -o "$grouped" "$grouped"
 
           prev=""; n=0; superseded=0
-          while IFS=$'\t' read -r pre created id size fam; do
+          while IFS=$'\t' read -r pre created id size; do
             [ -z "${pre:-}" ] && continue
             if [ "$pre" != "$prev" ]; then prev="$pre"; n=1; else n=$(( n + 1 )); fi
-            lim="$KEEP"; [ "$fam" = "setup-python" ] && lim=1
-            [ "$n" -le "$lim" ] && continue
+            [ "$n" -le "$KEEP" ] && continue
             superseded=$(( superseded + 1 ))
             if [ "$DELETE" != "yes" ]; then
               freed=$(( freed + size )); deleted=$(( deleted + 1 )); continue
@@ -229,7 +222,7 @@ jobs:
             echo "| metric | value |"
             echo "| --- | --- |"
             echo "| mode | $([ "$DELETE" = yes ] && echo delete || echo 'report only') |"
-            echo "| kept per prefix | $KEEP (setup-python: 1) |"
+            echo "| kept per prefix | $KEEP |"
             echo "| caches total | $count |"
             echo "| closed-PR candidates | $stale_pr |"
             echo "| superseded candidates | $superseded |"

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -59,6 +59,21 @@ jobs:
       # Four interpreters on one runner. Each `id` exposes python-path, which is how
       # a lane addresses an interpreter that is no longer the one on PATH -- only the
       # last of these wins PATH, and that is fine because no lane uses it.
+      #
+      # `cache: 'pip'` is on the FIRST step only, and must stay that way. All four
+      # interpreters share one `~/.cache/pip` on the runner, so four cache-enabled
+      # steps do not cache four things: they save the identical directory four times
+      # under four python-version keys. Observed on main 2026-08-23, where the 3.10
+      # and 3.13 entries were byte-identical at 2011216266 and 3.11 differed by 1524
+      # bytes -- 3.8 GiB of exact duplicates, against a 20 GiB repo ceiling. (3.12
+      # looked small only because repo-tests-cpu had already written that key four
+      # minutes earlier and the duplicate save was skipped; same-key saves are
+      # first-writer-wins.)
+      #
+      # One restore before any lane installs is all this job needs: the restore lands
+      # in the shared directory ahead of the install step below, so every lane reads
+      # the wheels of every interpreter from it regardless of which step carried the
+      # key. Re-adding `cache:` to the other three buys nothing and costs the ceiling.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         id: py310
         with:
@@ -69,19 +84,16 @@ jobs:
         id: py311
         with:
           python-version: '3.11'
-          cache: 'pip'
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         id: py312
         with:
           python-version: '3.12'
-          cache: 'pip'
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         id: py313
         with:
           python-version: '3.13'
-          cache: 'pip'
 
       - name: Install and collect on every interpreter (concurrently)
         env:

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -64,8 +64,8 @@ jobs:
       # interpreters share one `~/.cache/pip` on the runner, so four cache-enabled
       # steps do not cache four things: they save the identical directory four times
       # under four python-version keys. Observed on main 2026-08-23, where the 3.10
-      # and 3.13 entries were byte-identical at 2011216266 and 3.11 differed by 1524
-      # bytes -- 3.8 GiB of exact duplicates, against a 20 GiB repo ceiling. (3.12
+      # and 3.11 entries were byte-identical at 2011216266 and 3.13 differed by 1524
+      # bytes -- 3.7 GiB of exact duplicates, against a 20 GiB repo ceiling. (3.12
       # looked small only because repo-tests-cpu had already written that key four
       # minutes earlier and the duplicate save was skipped; same-key saves are
       # first-writer-wins.)


### PR DESCRIPTION
## What happened

`https://github.com/unslothai/unsloth-zoo/actions/caches` was at **19.97 of 20 GiB** (21,446,023,553 bytes across 22 entries). At the ceiling GitHub evicts by LRU regardless of reachability, and a partially evicted cache still restores and then misses on the evicted objects, so the hit rate degrades with nothing failing.

`cache-janitor.yml` was written against a **50 GB** ceiling. Its summary printed "of 50 GB" and its warning fired only above 40 GiB, so at the real ceiling it could never fire. It also matched only `codeql-overlay-base-database-*` and `v0-rust-*`, neither of which exists in this repo, so every nightly sweep pruned exactly zero and reported success.

## What the 19.97 GiB actually was

Every entry was a `setup-python` pip cache. Two thirds of it was unreachable.

**6.6 GiB on `refs/pull/1084/merge`**, from a PR merged 2026-08-23T14:18. Cache lookup is scoped by ref, so nothing but that PR's own runs can restore its merge ref. GitHub does not collect these on merge; they sit for the full 7-day idle expiry.

**6.6 GiB in the superseded `86707e27...` dependency-hash generation**, left resident behind the new `4373e0c6...` generation by the dependency bump in #1084.

Backlog cleared by hand: 11 caches, 13.24 GiB. Usage is now **6.7 of 20 GiB**, 11 entries.

## The duplication underneath it

`python-version-collect` called `setup-python` four times with `cache: 'pip'`. All four interpreters share one `~/.cache/pip` on the runner, so that did not cache four things: it saved the identical directory four times under four python-version keys.

| ref | key | size (bytes) |
| --- | --- | --- |
| main | `...python-3.10.21-pip-4373e0c6` | 2011216266 |
| main | `...python-3.11.16-pip-4373e0c6` | 2011216266 |
| main | `...python-3.13.15-pip-4373e0c6` | 2011214742 |
| main | `...python-3.12.14-pip-4373e0c6` | 594688925 |

3.10 and 3.11 are byte-identical; 3.13 differs by 1524 bytes. 3.12 looked small only because `repo-tests-cpu` (one venv, one interpreter's wheels) had written that key at 14:18, four minutes before the collect job's 1.9 GiB save at 14:22, and same-key saves are first-writer-wins. Same fingerprint on the PR-1084 set. That is 3.7 GiB of exact duplicates per ref.

## Changes

**`cache-janitor.yml`**

- Ceiling corrected to 20 GiB throughout; warn at 80% of it (16 GiB); report fractional GiB, since integer GiB is too coarse at this size.
- Prune caches on `refs/pull/N/*` whose PR is closed or merged. The PR state decides, not age, so an open PR's caches are live no matter how old, and a lookup that errors keeps the cache. This pass runs *before* generation ranking: otherwise a merged PR's entries occupy the keep slots of their own `(ref, version, prefix)` group and shield each other.
- Prune superseded `setup-python-*-pip-*` generations, on the same `keep` as every other family. The goal is hit rate, not headroom: what gets deleted is what can answer nothing (unreachable refs, generations past `keep`), not what is merely large. Generation N-1 can still answer something, because setup-python passes the full key to `restoreCache`, which tries an exact match before falling back to the restore-key prefix, so a re-run of an older commit or a reverted dependency bump hits it exactly. That is the trade this workflow already documents for rust-cache. One generation of setup-python on main is about 3 GiB once the duplicate saves stop, so two fit comfortably in 20 GiB.
- The interpreter version stays in the grouping prefix on purpose, so 3.10 and 3.13 are not ranked as two generations of one family.

**`consolidated-tests-ci.yml`**

- `cache: 'pip'` on the first `setup-python` step of `python-version-collect` only. The restore lands in the shared `~/.cache/pip` ahead of the install step, so every lane still reads every interpreter's wheels from it; only the three duplicate saves go away. Comment explains why re-adding it would be a regression.

## Verification

The janitor's `run` block was extracted and executed against a fixture reproducing the 2026-08-26 pre-cleanup inventory, with `gh` stubbed:

- `delete` mode selects exactly the 11 entries that were cleared by hand, plus the closed-PR entries for #1089/#1091/#1094: `pruned 14 caches, 13.2 GiB`, `20.0 GiB -> 6.7 GiB`.
- All four current-generation `main` pip caches survive, confirming the interpreter version is not folded into one group.
- A cache on an open PR survives.
- A PR whose state lookup errors keeps its cache rather than being freed.
- `report` mode issues zero DELETEs.
- Invalid `keep` warns and falls back to 2.
- Empty inventory exits 0.

Both files pass the YAML round-trip gate in `lint-ci.yml`.
