### PR TITLE
Stop every pull request writing a pip cache nobody can read

### DIFF
--- a/.github/actions/pip-cache-restore/action.yml
+++ b/.github/actions/pip-cache-restore/action.yml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Restore half of the pip cache, replacing `actions/setup-python`'s built-in
+# `cache: 'pip'`.
+#
+# The built-in cache is read-write and saves from its own post-step on WHATEVER
+# REF the job ran on. A cache written on a pull_request ref can only be restored
+# by re-runs of that same pull request -- caches created on the base branch are
+# available to the topic branch, but not the other way round -- so every PR
+# writes a copy nobody else can ever read, and that copy competes for the 20 GiB
+# budget against main's copy, which every PR CAN read.
+#
+# Measured on this repo 2026-08-26: 19.97 of 20 GiB, of which merged PR #1084
+# alone held 6.6 GiB on refs/pull/1084/merge. Nothing about that is visible as a
+# failure. Over quota GitHub deletes whole entries by last access date, so main's
+# copy goes, the next PR misses, downloads, and writes its own copy. CI just gets
+# slower and everyone assumes that is the cost.
+#
+# Deleting those entries after the fact -- which cache-janitor.yml now does --
+# treats the symptom. This is the source: restore on every ref, save on main.
+#
+# Adapted from unslothai/unsloth's action of the same name, with one change:
+# `name` is part of the key. There, every job hashes its own dependency files
+# into `pip-<os>-<arch>-py<ver>-<hash>`, so five concurrently-live caches share
+# one prefix and no janitor can rank generations without deleting a live one.
+# Naming the job makes each family a distinct prefix, hence prunable.
+#
+# Pair this with pip-cache-save AFTER the install, passing the outputs below.
+
+name: Restore the pip cache
+description: >-
+  Restore pip's HTTP cache for this runner, interpreter and job, keyed on the
+  files the job actually installs from. Read-only: the save is a separate action
+  and runs on the default branch only.
+
+inputs:
+  name:
+    description: >-
+      Short, stable identifier for the installing job (`repo-tests`, `lint`,
+      ...). Distinguishes families that would otherwise collide on
+      `pip-<os>-<arch>-py<ver>-` and be mistaken for generations of each other.
+      Use lowercase and dashes; it goes into the cache key verbatim.
+    required: true
+  key-files:
+    description: >-
+      Newline-separated glob(s) whose hash keys the cache. Pass the files this
+      job installs from, NOT a repo-wide pattern: hashing dependency files across
+      the whole repo lets an unrelated edit invalidate every interpreter's entry
+      at once and orphan the old ones. Paths resolve from the workspace root, so
+      a job that checks out into a subdirectory must include it.
+    required: true
+
+outputs:
+  dir:
+    description: pip's cache directory on this runner.
+    value: ${{ steps.probe.outputs.dir }}
+  key:
+    description: The full cache key, to hand to pip-cache-save.
+    value: ${{ steps.probe.outputs.key }}
+  prefix:
+    description: The cache key without the dependency hash, i.e. the restore-key.
+    value: ${{ steps.probe.outputs.prefix }}
+  cache-hit:
+    description: 'true when the exact key was restored.'
+    value: ${{ steps.restore.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    # `pip cache dir` rather than a hardcoded path per OS: it differs on Linux,
+    # macOS and Windows, and pip itself is the authority on where it put things.
+    # It is also one directory per runner, not one per interpreter, which is why
+    # a job standing up four venvs needs exactly one of these, not four.
+    - name: Resolve the pip cache directory and key
+      id: probe
+      shell: bash
+      run: |
+        set -euo pipefail
+        dir="$(python -m pip cache dir)"
+        echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+        # Minor, deliberately not patch. Nothing here pins a patch version, so it
+        # is whatever the hosted image happens to ship that week, and carrying it
+        # would duplicate the whole cache every time GitHub bumps it.
+        #
+        # Safe because of WHAT is cached: pip stores downloaded wheels, tagged
+        # cp312 and so ABI-compatible across every 3.12.x, behind an HTTP cache
+        # addressed by URL and hash. A stale entry cannot serve wrong content;
+        # the worst it can do is miss.
+        pyver="$(python -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+
+        name="${{ inputs.name }}"
+        # A key segment that is empty, or that carries a dash-delimited surprise,
+        # collapses distinct jobs onto one key or breaks the janitor's prefix
+        # grouping. Both fail silently, so check here.
+        case "$name" in
+          ''|*[!a-z0-9-]*)
+            echo "::error::pip-cache: name must be lowercase letters, digits and dashes. Given: '$name'"
+            exit 1 ;;
+        esac
+
+        hash="${{ hashFiles(inputs.key-files) }}"
+        # Empty means the globs matched nothing, which would silently collapse
+        # every generation onto one key. Loud here, where the cause is one line away.
+        if [ -z "$hash" ]; then
+          echo "::error::pip-cache: key-files matched no file, so the cache key would not distinguish anything. Given: ${{ inputs.key-files }}"
+          exit 1
+        fi
+        # Emitted separately so the restore-key fallback and the janitor's
+        # grouping are built from the same string as the key, not a copy of it
+        # that can drift.
+        prefix="pip-${name}-${{ runner.os }}-${{ runner.arch }}-py${pyver}-"
+        echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+        echo "key=${prefix}${hash}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore the pip cache
+      id: restore
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # A cache is an optimisation; a cache service blip must not fail the job.
+      continue-on-error: true
+      with:
+        path: ${{ steps.probe.outputs.dir }}
+        key: ${{ steps.probe.outputs.key }}
+        # WITH a prefix fallback, unlike the frontend-dist cache. A dist cache is
+        # a build output: the wrong generation is wrong, so only an exact key will
+        # do. This is pip's HTTP cache, addressed by URL and content hash, where
+        # the previous generation is the current one minus whatever moved. A
+        # dependency bump then costs the changed wheels instead of all of them,
+        # and a stale entry cannot serve wrong content -- the worst it can do is
+        # miss. That is the same argument that lets the key carry 3.12 rather
+        # than 3.12.14.
+        #
+        # `name` is inside the prefix, so the fallback stays within this job's
+        # own family and never hands `lint` the wheels `repo-tests` downloaded.
+        restore-keys: |
+          ${{ steps.probe.outputs.prefix }}

--- a/.github/actions/pip-cache-save/action.yml
+++ b/.github/actions/pip-cache-save/action.yml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Save half of the pip cache. See pip-cache-restore for why this is split out.
+#
+# Runs on the default branch ONLY. That is the whole point: an entry written on a
+# pull_request ref is restorable only by re-runs of that same PR, so it buys no
+# hit rate and evicts the copy on main that every PR can read.
+#
+# This does not make PRs slower. A PR still RESTORES from main's entry -- caches
+# on the base branch are visible to the topic branch -- it just stops writing a
+# private copy afterwards.
+
+name: Save the pip cache
+description: Save pip's cache under the restore step's key, on the default branch only.
+
+inputs:
+  dir:
+    description: pip's cache directory, from pip-cache-restore's `dir` output.
+    required: true
+  key:
+    description: The cache key, from pip-cache-restore's `key` output.
+    required: true
+  cache-hit:
+    description: >-
+      pip-cache-restore's `cache-hit`. Skipped when it is 'true', because the key
+      is already present and re-uploading it would be pure cost. Note this is the
+      EXACT-match flag: a restore-key fallback leaves it 'false', which is what we
+      want, since that run's install filled in whatever the fallback lacked and
+      the result belongs under the new key.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Save the pip cache
+      # always(), so a cache earned by a successful install is not thrown away
+      # because a LATER step in the job failed. The install itself is what fills
+      # this directory, and a failed test does not make its downloads wrong.
+      if: >-
+        always() && github.ref == 'refs/heads/main'
+        && inputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      continue-on-error: true
+      with:
+        path: ${{ inputs.dir }}
+        key: ${{ inputs.key }}

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -44,6 +44,24 @@ name: Cache janitor
 #      A dependency bump on 2026-08-23 left 6.6 GiB of the previous generation
 #      resident behind the new one.
 #
+#   4. Superseded generations of pip-*, the caches written by
+#      .github/actions/pip-cache-save. `name` is inside the prefix, so each
+#      installing job is its own family and its generations rank against each
+#      other and nothing else.
+#
+#      This family is why family 3 is on its way out. Once every job uses the
+#      restore/save pair, nothing writes a setup-python-*-pip-* key again and
+#      the last of them expires within 7 days; the arm stays only to sweep what
+#      is already there. Leaving pip-* unmatched in the meantime would have been
+#      the whole bug back: every pyproject.toml edit would strand the previous
+#      multi-GB entry on main with nothing able to rank it.
+#
+#      Bare pip-*, not a versioned prefix, because this repo has never written a
+#      pip-* key by any other scheme -- checked against the live cache list.
+#      unslothai/unsloth needs pip-v2-* for exactly the opposite reason: it has
+#      pre-existing pip-<os>-... keys, `Linux` is a valid name, and nothing else
+#      tells the two shapes apart.
+#
 # "Older" is not the same as unreachable. rust-cache passes its full key to
 # restoreCache, which tries an exact match first, so a build returning to an
 # earlier dependency state (a re-run of an old commit, a lockfile revert) can
@@ -177,11 +195,15 @@ jobs:
                 pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{40}-[0-9]+-[0-9]+$//') ;;
               v0-rust-*)
                 pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{8,}$//') ;;
-              setup-python-*-pip-*)
-                # Strip only the trailing dependency hash. The interpreter version
-                # stays in the prefix on purpose: 3.10 and 3.13 entries are separate
-                # keys that never substitute for one another, and folding them into
-                # one group would rank four live caches as four generations of one.
+              setup-python-*-pip-*|pip-*)
+                # Strip only the trailing dependency hash. Everything ahead of it
+                # stays in the prefix on purpose: the interpreter version for
+                # setup-python, the job name for pip-*. Those are separate keys
+                # that never substitute for one another, and folding them into one
+                # group would rank several live caches as generations of one.
+                #
+                # The two arms cannot collide: a setup-python key never begins
+                # `pip-`, and a pip-cache key always does.
                 pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{64}$//') ;;
               *) continue ;;
             esac

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -60,25 +60,23 @@ jobs:
       # a lane addresses an interpreter that is no longer the one on PATH -- only the
       # last of these wins PATH, and that is fine because no lane uses it.
       #
-      # `cache: 'pip'` is on the FIRST step only, and must stay that way. All four
-      # interpreters share one `~/.cache/pip` on the runner, so four cache-enabled
-      # steps do not cache four things: they save the identical directory four times
-      # under four python-version keys. Observed on main 2026-08-23, where the 3.10
-      # and 3.11 entries were byte-identical at 2011216266 and 3.13 differed by 1524
-      # bytes -- 3.7 GiB of exact duplicates, against a 20 GiB repo ceiling. (3.12
-      # looked small only because repo-tests-cpu had already written that key four
-      # minutes earlier and the duplicate save was skipped; same-key saves are
+      # None of them carries `cache: 'pip'`, and none should. All four interpreters
+      # share one `~/.cache/pip` on the runner, so four cache-enabled steps do not
+      # cache four things: they save the identical directory four times under four
+      # python-version keys. Observed on main 2026-08-23, where the 3.10 and 3.11
+      # entries were byte-identical at 2011216266 and 3.13 differed by 1524 bytes
+      # -- 3.7 GiB of exact duplicates, against a 20 GiB repo ceiling. (3.12 looked
+      # small only because repo-tests-cpu had already written that key four minutes
+      # earlier and the duplicate save was skipped; same-key saves are
       # first-writer-wins.)
       #
-      # One restore before any lane installs is all this job needs: the restore lands
-      # in the shared directory ahead of the install step below, so every lane reads
-      # the wheels of every interpreter from it regardless of which step carried the
-      # key. Re-adding `cache:` to the other three buys nothing and costs the ceiling.
+      # One restore for the whole job, from the pip-cache pair below, which also
+      # keeps the save on main. It lands in the shared directory ahead of the
+      # install step, so every lane reads the wheels of every interpreter from it.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         id: py310
         with:
           python-version: '3.10'
-          cache: 'pip'
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         id: py311
@@ -94,6 +92,15 @@ jobs:
         id: py313
         with:
           python-version: '3.13'
+
+      # After all four interpreters, before the one step that installs. The lanes
+      # install `.[core]`, so pyproject.toml is what describes their downloads.
+      - id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          name: collect
+          key-files: |
+            pyproject.toml
 
       - name: Install and collect on every interpreter (concurrently)
         env:
@@ -162,6 +169,17 @@ jobs:
           wait
           echo "all four lanes finished"
 
+      # Immediately after the install, not at the end of the job. A composite step
+      # with no `if:` is SKIPPED once an earlier step has failed, so the action's
+      # own always() only covers steps between the restore and here. Placed after
+      # the lanes, the wheels are saved whenever they were actually downloaded --
+      # including when the next step exits 1 because one interpreter failed.
+      - uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
+
       - name: What each interpreter said
         if: always()
         run: |
@@ -207,7 +225,13 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
+
+      - id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          name: repo-tests
+          key-files: |
+            pyproject.toml
 
       - name: Install runtime + test deps
         # --no-deps unsloth satisfies the find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
@@ -218,6 +242,12 @@ jobs:
           pip install -e .[core]
           pip install --no-deps "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
           pip install pytest==9.0.3 pyyaml==6.0.2
+
+      - uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
       - name: pytest tests/security (HARD GATE)
         run: python -m pytest tests/security -v
@@ -367,7 +397,15 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
+
+      # One restore for both venvs: they share the runner's pip cache even though
+      # they must not share an environment.
+      - id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          name: mlx-lanes
+          key-files: |
+            pyproject.toml
 
       - name: Build both environments (concurrently)
         run: |
@@ -434,6 +472,12 @@ jobs:
             rc="$(cat ".lanes/$id.install" 2>/dev/null || echo missing)"
             [ "$rc" = "0" ] || { echo "::error::$id environment could not be built (status $rc)"; exit 1; }
           done
+
+      - uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
       - name: Assert the real MLX runtime is what got installed
         # All the MLX files importorskip mlx.core, and a module that skips
@@ -538,7 +582,22 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
+
+      # pyproject.toml only, even though the transformers/trl/peft specs for two
+      # of the three lanes are written inline below. Adding this workflow file to
+      # the key would roll the cache on every edit to it, including edits to the
+      # other three jobs and to comments -- and buy nothing, because a pip HTTP
+      # cache is addressed by URL and content hash and cannot serve the wrong
+      # wheel. Changing an inline spec just misses on the wheels that actually
+      # changed and still hits on the rest. The hash exists to roll the entry
+      # forward occasionally so stale wheels do not accumulate, not to protect
+      # correctness.
+      - id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          name: core-drift
+          key-files: |
+            pyproject.toml
 
       - name: Run all three upstream pins (concurrently)
         run: |
@@ -672,6 +731,12 @@ jobs:
           wait
           echo "all three lanes finished"
           df -h / | tail -1
+
+      - uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
       - name: What each pin said
         if: always()

--- a/.github/workflows/gemma4-audio-probe.yml
+++ b/.github/workflows/gemma4-audio-probe.yml
@@ -66,7 +66,16 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
+
+      # pyproject.toml only. The mlx-vlm pin comes from the matrix, and a changed
+      # pin simply misses on that one wheel: a pip HTTP cache cannot serve the
+      # wrong content, so it does not need to be in the key.
+      - id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          name: gemma4-audio
+          key-files: |
+            pyproject.toml
 
       - name: Install zoo with the pinned mlx-vlm
         # One resolution, so pip honours this package's transformers cap. torch
@@ -81,6 +90,12 @@ jobs:
           print('mlx-vlm', mlx_vlm.__version__, 'transformers', transformers.__version__)
           assert mlx_vlm.__version__ == '${{ matrix.mlx_vlm }}', mlx_vlm.__version__
           "
+
+      - uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
       - name: Cache the checkpoint
         # 3.4 GB, and every job wants the same one. Shared key on purpose: the

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -40,9 +40,23 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
+
+      # This workflow file is its own key-file: the ruff and pyyaml pins are on
+      # the install line below, so nothing else describes what this job downloads.
+      - id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          name: lint
+          key-files: |
+            .github/workflows/lint-ci.yml
 
       - run: pip install 'ruff==0.15.12' 'pyyaml>=6'
+
+      - uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
       - name: Python AST/syntax check (every committed .py must compile)
         # This runs on 3.12, so it cannot see syntax that is merely newer than the

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -64,7 +64,14 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
+
+      # `.[mlx]` plus a few inline pins; pyproject.toml is what moves.
+      - id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          name: mlx
+          key-files: |
+            pyproject.toml
 
       - name: Install zoo with MLX extras
         # pyproject gates MLX deps on darwin+arm64; `.[mlx]` picks them up
@@ -85,6 +92,12 @@ jobs:
           # The vision model used by tests/test_mlx_generate_metal.py loads
           # remote processor code that imports timm, which .[mlx] does not pull.
           pip install timm
+
+      - uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
       - name: Adopt the newest MLX (detection leg only)
         # pyproject pins mlx and mlx-lm exactly so nobody installing unsloth_zoo is

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -129,12 +129,26 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
+
+      # requests + packaging are pinned nowhere but this file, so it keys itself.
+      # A small entry, so rolling it on any edit here is cheap.
+      - id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          name: pip-scan
+          key-files: |
+            .github/workflows/security-audit.yml
 
       - name: Install scan_packages.py runtime deps
         # requests + packaging for PyPI's JSON API. Scanned packages are
         # downloaded raw and inspected, never `pip install`-ed.
         run: python -m pip install --upgrade pip requests packaging
+
+      - uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
       - name: Build filtered requirements set
         run: |

--- a/.github/workflows/studio-export-fix-ci.yml
+++ b/.github/workflows/studio-export-fix-ci.yml
@@ -56,7 +56,15 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
-          cache: pip
+
+      # This file is its own key-file: the deps are named on the install line
+      # below and nowhere else. Small entry, so rolling it on any edit is cheap.
+      - id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          name: studio-export-fix
+          key-files: |
+            .github/workflows/studio-export-fix-ci.yml
 
       - name: Install minimal test deps
         run: |
@@ -64,6 +72,12 @@ jobs:
           # Pure-Python tests: monkeypatch subprocess + AST-parse upstream files.
           # No torch / transformers needed. Keep slim so Windows cold start stays under a minute.
           python -m pip install pytest psutil requests tqdm
+
+      - uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
       - name: Run patcher + q2_k_l unit tests
         shell: bash

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -1,0 +1,157 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Pins the pip-cache restore/save contract for every workflow.
+
+The failure this guards is invisible at runtime. `actions/setup-python`'s
+built-in `cache: 'pip'` is read-write and saves from its post-step on
+WHATEVER REF the job ran on, and a cache written on a pull_request ref can
+only be restored by re-runs of that same pull request. So every PR writes a
+copy nobody else can ever read, which then competes for the repo's 20 GiB
+budget against main's copy, which every PR CAN read.
+
+Measured on this repo 2026-08-26: 19.97 of 20 GiB, of which merged PR #1084
+alone held 6.6 GiB on refs/pull/1084/merge. Nothing failed. Over quota GitHub
+deletes whole entries by last access date, so main's copy goes, the next PR
+misses, downloads, and writes its own copy. CI just gets slower.
+
+Nothing about re-adding `cache: 'pip'` looks wrong in review -- it is the
+documented way to do this -- which is why it is asserted here instead.
+"""
+
+import re
+import pathlib
+
+import pytest
+import yaml
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+WORKFLOWS = sorted((REPO / ".github" / "workflows").glob("*.yml"))
+RESTORE = "./.github/actions/pip-cache-restore"
+SAVE = "./.github/actions/pip-cache-save"
+
+
+def _jobs(path):
+    doc = yaml.safe_load(path.read_text()) or {}
+    for name, job in (doc.get("jobs") or {}).items():
+        yield name, (job.get("steps") or [])
+
+
+def _indices(steps, action):
+    return [i for i, s in enumerate(steps) if s.get("uses") == action]
+
+
+def test_workflows_exist():
+    # A glob that matches nothing would make every test below vacuously pass.
+    assert WORKFLOWS, "no workflows found; the layout moved and this file is stale"
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+def test_no_builtin_setup_python_pip_cache(path):
+    for job, steps in _jobs(path):
+        for step in steps:
+            uses = str(step.get("uses", ""))
+            if not uses.startswith("actions/setup-python@"):
+                continue
+            with_ = step.get("with") or {}
+            assert "cache" not in with_, (
+                f"{path.name}:{job} uses setup-python's built-in cache. It saves on "
+                f"the PR ref, where nothing else can read it. Use {RESTORE} plus "
+                f"{SAVE} instead."
+            )
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+def test_restore_and_save_are_paired(path):
+    for job, steps in _jobs(path):
+        restores, saves = _indices(steps, RESTORE), _indices(steps, SAVE)
+        if not restores and not saves:
+            continue
+        assert len(restores) == 1, f"{path.name}:{job} has {len(restores)} restores; expected 1"
+        assert len(saves) == 1, (
+            f"{path.name}:{job} has {len(saves)} saves; expected 1. A restore without a "
+            f"save never writes the cache it just missed, so the job downloads the same "
+            f"wheels on every run of main."
+        )
+        assert saves[0] > restores[0], f"{path.name}:{job} saves before it restores"
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+def test_save_is_not_gated_behind_a_failing_step(path):
+    # A composite step with no `if:` is SKIPPED once an earlier step failed, so
+    # the save action's own always() only covers the steps between the pair.
+    # Anything that can exit non-zero between the install and the save throws
+    # away wheels that were downloaded successfully.
+    for job, steps in _jobs(path):
+        restores, saves = _indices(steps, RESTORE), _indices(steps, SAVE)
+        if not restores or not saves:
+            continue
+        between = steps[restores[0] + 1 : saves[0]]
+        assert len(between) <= 1, (
+            f"{path.name}:{job} has {len(between)} steps between restore and save. "
+            f"Put the save directly after the step that installs, or a failure in "
+            f"between silently skips it."
+        )
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+def test_restore_inputs_are_well_formed(path):
+    for job, steps in _jobs(path):
+        for i in _indices(steps, RESTORE):
+            with_ = steps[i].get("with") or {}
+            name = with_.get("name", "")
+            assert re.fullmatch(r"[a-z0-9-]+", name or ""), (
+                f"{path.name}:{job} restore name={name!r} must be lowercase letters, "
+                f"digits and dashes; it goes into the cache key verbatim."
+            )
+            files = [f for f in (with_.get("key-files") or "").split() if f]
+            assert files, f"{path.name}:{job} passes no key-files; the key would not distinguish anything"
+            for f in files:
+                assert (REPO / f).exists() or "*" in f, (
+                    f"{path.name}:{job} key-files entry {f!r} does not exist. hashFiles "
+                    f"returns '' for a glob that matches nothing, which collapses every "
+                    f"generation onto one key."
+                )
+
+
+def test_cache_names_are_unique_across_all_jobs():
+    # Two jobs sharing a name share a key prefix, which is the exact defect this
+    # `name` input exists to avoid: the janitor cannot then tell two live caches
+    # apart from two generations of one, and pruning deletes a live entry.
+    seen = {}
+    for path in WORKFLOWS:
+        for job, steps in _jobs(path):
+            for i in _indices(steps, RESTORE):
+                name = ((steps[i].get("with") or {}).get("name") or "")
+                where = f"{path.name}:{job}"
+                assert name not in seen, (
+                    f"cache name {name!r} used by both {seen[name]} and {where}; "
+                    f"names must be unique so each job is its own prunable family"
+                )
+                seen[name] = where
+    assert seen, "no pip-cache-restore call sites found; this test is stale"
+
+
+def test_save_runs_on_the_default_branch_only():
+    action = yaml.safe_load((REPO / ".github/actions/pip-cache-save/action.yml").read_text())
+    steps = action["runs"]["steps"]
+    condition = " ".join(str(steps[0].get("if", "")).split())
+    assert "github.ref == 'refs/heads/main'" in condition, (
+        "the save must stay gated to main. Without it every PR writes a private "
+        "copy that only that PR can read, which is the whole defect."
+    )
+    assert "always()" in condition, "a later step failing must not discard a completed install"

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -33,6 +33,7 @@ documented way to do this -- which is why it is asserted here instead.
 """
 
 import re
+import fnmatch
 import pathlib
 
 import pytest
@@ -144,6 +145,39 @@ def test_cache_names_are_unique_across_all_jobs():
                 )
                 seen[name] = where
     assert seen, "no pip-cache-restore call sites found; this test is stale"
+
+
+def test_the_janitor_ranks_the_pip_family():
+    # The keys this action mints are `pip-<name>-...`, which matched none of the
+    # janitor's original arms and so fell through to `*) continue`. Left that way,
+    # every pyproject.toml edit strands the previous multi-GB entry on main with
+    # nothing able to rank it -- and once every job here uses the restore/save
+    # pair, nothing writes a setup-python-* key again, so the janitor would prune
+    # no pip cache at all. Caught in review on #1109.
+    #
+    # Asserted by MATCHING a representative key against the arms, not by looking
+    # for the text `pip-*)`. That substring is already inside
+    # `setup-python-*-pip-*)`, so a textual check passes on the broken version and
+    # proves nothing.
+    janitor = (REPO / ".github/workflows/cache-janitor.yml").read_text()
+    block = re.search(r'case "\$key" in(.+?)\n\s*esac', janitor, re.S)
+    assert block, "the janitor's key dispatch moved; this assertion is stale"
+
+    patterns = []
+    for line in block.group(1).splitlines():
+        line = line.strip()
+        if not line.endswith(")") or line.startswith("#") or line.startswith("pre="):
+            continue
+        patterns.extend(line[:-1].split("|"))
+
+    for key in (
+        "pip-repo-tests-Linux-X64-py3.12-" + "a" * 64,
+        "pip-lint-Linux-X64-py3.12-" + "b" * 64,
+    ):
+        assert any(fnmatch.fnmatchcase(key, p) for p in patterns if p != "*"), (
+            f"cache-janitor.yml does not rank {key!r}. Its superseded generations "
+            f"would accumulate untouched, which is the pressure this PR removes."
+        )
 
 
 def test_save_runs_on_the_default_branch_only():

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -16,20 +16,15 @@
 
 """Pins the pip-cache restore/save contract for every workflow.
 
-The failure this guards is invisible at runtime. `actions/setup-python`'s
-built-in `cache: 'pip'` is read-write and saves from its post-step on
-WHATEVER REF the job ran on, and a cache written on a pull_request ref can
-only be restored by re-runs of that same pull request. So every PR writes a
-copy nobody else can ever read, which then competes for the repo's 20 GiB
-budget against main's copy, which every PR CAN read.
+`actions/setup-python`'s built-in `cache: 'pip'` saves from its post-step on
+whatever ref the job ran on, and a cache written on a pull_request ref can only
+be restored by re-runs of that same PR. So every PR writes a copy nobody else
+can read, competing for the 20 GiB budget against main's copy, which every PR
+can read. Measured 2026-08-26: 19.97 of 20 GiB, merged PR #1084 holding 6.6 GiB
+of it. Nothing failed; CI just got slower.
 
-Measured on this repo 2026-08-26: 19.97 of 20 GiB, of which merged PR #1084
-alone held 6.6 GiB on refs/pull/1084/merge. Nothing failed. Over quota GitHub
-deletes whole entries by last access date, so main's copy goes, the next PR
-misses, downloads, and writes its own copy. CI just gets slower.
-
-Nothing about re-adding `cache: 'pip'` looks wrong in review -- it is the
-documented way to do this -- which is why it is asserted here instead.
+Re-adding `cache: 'pip'` looks right in review -- it is the documented way to
+do this -- which is why it is asserted here instead.
 """
 
 import re
@@ -94,9 +89,8 @@ def test_restore_and_save_are_paired(path):
 @pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
 def test_save_is_not_gated_behind_a_failing_step(path):
     # A composite step with no `if:` is SKIPPED once an earlier step failed, so
-    # the save action's own always() only covers the steps between the pair.
-    # Anything that can exit non-zero between the install and the save throws
-    # away wheels that were downloaded successfully.
+    # the save's own always() covers only what sits between the pair. Anything
+    # that can exit non-zero in there discards a completed install.
     for job, steps in _jobs(path):
         restores, saves = _indices(steps, RESTORE), _indices(steps, SAVE)
         if not restores or not saves:
@@ -130,9 +124,9 @@ def test_restore_inputs_are_well_formed(path):
 
 
 def test_cache_names_are_unique_across_all_jobs():
-    # Two jobs sharing a name share a key prefix, which is the exact defect this
-    # `name` input exists to avoid: the janitor cannot then tell two live caches
-    # apart from two generations of one, and pruning deletes a live entry.
+    # A shared name is a shared prefix, which is the defect `name` exists to
+    # avoid: the janitor cannot tell two live caches from two generations of one,
+    # and pruning then deletes a live entry.
     seen = {}
     for path in WORKFLOWS:
         for job, steps in _jobs(path):
@@ -148,17 +142,15 @@ def test_cache_names_are_unique_across_all_jobs():
 
 
 def test_the_janitor_ranks_the_pip_family():
-    # The keys this action mints are `pip-<name>-...`, which matched none of the
-    # janitor's original arms and so fell through to `*) continue`. Left that way,
-    # every pyproject.toml edit strands the previous multi-GB entry on main with
-    # nothing able to rank it -- and once every job here uses the restore/save
-    # pair, nothing writes a setup-python-* key again, so the janitor would prune
-    # no pip cache at all. Caught in review on #1109.
+    # These keys are `pip-<name>-...`, which matched none of the janitor's
+    # original arms and fell through to `*) continue`. Left that way, every
+    # pyproject.toml edit strands the previous multi-GB entry on main unrankable
+    # -- and once every job uses the restore/save pair nothing writes a
+    # setup-python-* key again, so no pip cache would be pruned at all.
     #
-    # Asserted by MATCHING a representative key against the arms, not by looking
-    # for the text `pip-*)`. That substring is already inside
-    # `setup-python-*-pip-*)`, so a textual check passes on the broken version and
-    # proves nothing.
+    # Asserted by MATCHING a representative key against the arms, not by grepping
+    # for `pip-*)`: that substring already sits inside `setup-python-*-pip-*)`,
+    # so a textual check passes on the broken version and proves nothing.
     janitor = (REPO / ".github/workflows/cache-janitor.yml").read_text()
     block = re.search(r'case "\$key" in(.+?)\n\s*esac', janitor, re.S)
     assert block, "the janitor's key dispatch moved; this assertion is stale"


### PR DESCRIPTION
Stacked on #1107 (base is `cache-janitor-20gib-ceiling`, not `main`). The diff here is only this change; merge #1107 first.

## The problem

`actions/setup-python`'s `cache: 'pip'` is read-write, and it saves from its own post-step on **whatever ref the job ran on**. A cache written on a `pull_request` ref is restorable only by re-runs of that same pull request, because caches created on the base branch are available to the topic branch and not the other way round.

So every PR writes a private copy that nobody else can ever read, and that copy competes for the repo's 20 GiB budget against main's copy, which every PR **can** read.

Nothing about it fails. Over quota GitHub deletes whole entries by last access date, so main's copy goes, the next PR misses, downloads, and writes its own copy. CI gets slower and that reads as the cost of CI. Merged PR #1084 alone held **6.6 GiB** this way, against a repo sitting at 19.97 of 20 GiB.

The closed-PR sweep added in #1107 deletes those entries after the fact. This is the source.

## The change

Restore on every ref, save on `refs/heads/main` only. A PR still restores from main's entry, it just stops writing one. Ported from `unslothai/unsloth`'s `pip-cache-restore` / `pip-cache-save` pair, with two deliberate differences.

**`name` is part of the key, and required.** In unsloth every job hashes its own dependency files into `pip-<os>-<arch>-py<ver>-<hash>`, so five concurrently-live caches share one prefix and no janitor can rank generations without deleting a live one. That is exactly why ~14 GiB of superseded pip entries accumulated there with nothing able to touch them. Naming the job makes each family its own prefix, so `cache-janitor.yml` can prune it the way it prunes everything else.

**The restore takes a prefix fallback.** unsloth's does not, and for its `frontend-dist` cache that is correct: a dist cache is a build output, so the wrong generation is wrong. This is pip's HTTP cache, addressed by URL and content hash, where the previous generation is the current one minus whatever moved. A dependency bump then costs the changed wheels instead of all of them, and a stale entry cannot serve wrong content. It is the same argument that already lets the key carry `3.12` rather than `3.12.14`.

For the same reason most jobs key on `pyproject.toml` alone even where inline pins exist. Adding the workflow file would roll the cache on every edit to it, comments included, and buy nothing: the hash exists to roll the entry forward so stale wheels do not accumulate, not to protect correctness. The three jobs whose deps are named nowhere else (`lint`, `pip-scan`, `studio-export-fix`) do key on their own file, and their entries are small.

## Call sites

Nine, across seven workflows:

| workflow | job | `name` | key-files |
| --- | --- | --- | --- |
| consolidated-tests-ci | python-version-collect | `collect` | pyproject.toml |
| consolidated-tests-ci | repo-tests-cpu | `repo-tests` | pyproject.toml |
| consolidated-tests-ci | mlx-cpu-linux | `mlx-lanes` | pyproject.toml |
| consolidated-tests-ci | core-upstream-matrix | `core-drift` | pyproject.toml |
| gemma4-audio-probe | probe | `gemma4-audio` | pyproject.toml |
| mlx-ci | mlx-smoke | `mlx` | pyproject.toml |
| lint-ci | source-lint | `lint` | (its own file) |
| security-audit | pip-scan-packages | `pip-scan` | (its own file) |
| studio-export-fix-ci | studio-export-fix | `studio-export-fix` | (its own file) |

Each save sits **directly after the step that installs**, not at the end of the job. A composite step with no `if:` is skipped once an earlier step has failed, so the save action's own `always()` only covers what sits between the pair. Putting it at the end would silently discard a completed install whenever a later test failed.

## Test

`tests/test_pip_cache_actions.py` (39 cases) pins the contract: no workflow uses the built-in cache, every restore has exactly one save after it, at most one step sits between them, `name` is well-formed and unique across all jobs, every `key-files` entry resolves, and the save stays gated to main with `always()`.

That last one is not tidiness. The grep for `cache: 'pip'` missed `studio-export-fix-ci.yml`, which spells it unquoted as `cache: pip`. The YAML-aware assertion is what found it.
