### PR TITLE
Let UNSLOTH_ZOO_DISABLE_GPU_INIT cover downstream device detection

### DIFF
--- a/tests/security/test_disable_gpu_init_device_constants.py
+++ b/tests/security/test_disable_gpu_init_device_constants.py
@@ -127,9 +127,12 @@ def _cross_path_contract() -> set:
     return mlx & normal
 
 
-def _run(code: str) -> subprocess.CompletedProcess:
+def _run(code: str, skip_gpu_init: bool = True) -> subprocess.CompletedProcess:
     env = dict(os.environ)
-    env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
+    if skip_gpu_init:
+        env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
+    else:
+        env.pop("UNSLOTH_ZOO_DISABLE_GPU_INIT", None)
     # CI runners have no accelerator; `get_device_type` honours this sentinel,
     # and `tests/conftest.py` sets it for the same reason.
     env.setdefault("UNSLOTH_ALLOW_CPU", "1")
@@ -188,17 +191,44 @@ def test_importing_the_package_does_not_pull_in_torch():
 @_needs_lazy_path
 @_needs_torch
 def test_reading_a_constant_is_what_pulls_torch_in():
-    """The other half of the pair, so the check above cannot pass vacuously."""
+    """The other half of the pair, so the check above cannot pass vacuously.
+
+    WITHOUT the flag. `get_device_type` answers `cpu` under it without asking torch
+    anything, which is the whole point of the flag: the download-only child it exists
+    for gets no GPU init and no torch import even if it does read a constant. So the
+    non-vacuousness control is the ordinary path, where reading the constant really is
+    what pulls torch in.
+    """
     result = _run(
         "import sys\n"
         "import unsloth_zoo\n"
         "unsloth_zoo.DEVICE_TYPE\n"
-        "print('torch' in sys.modules)\n"
+        "print('torch' in sys.modules)\n",
+        skip_gpu_init = False,
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip().endswith("True"), (
         "reading unsloth_zoo.DEVICE_TYPE did not import torch, so the previous "
         f"test proves nothing about laziness:\n{result.stdout}"
+    )
+
+
+@_needs_lazy_path
+@_needs_torch
+def test_reading_a_constant_under_the_skip_asks_torch_nothing():
+    """And under the flag it does not: the skip answers `cpu` on its own."""
+    result = _run(
+        "import sys\n"
+        "import unsloth_zoo\n"
+        "print(unsloth_zoo.DEVICE_TYPE, unsloth_zoo.DEVICE_COUNT)\n"
+        "print('torch' in sys.modules)\n"
+    )
+    assert result.returncode == 0, result.stderr
+    lines = result.stdout.strip().splitlines()
+    assert lines[-2].split() == ["cpu", "0"], result.stdout
+    assert lines[-1] == "False", (
+        "reading a device constant under UNSLOTH_ZOO_DISABLE_GPU_INIT=1 pulled torch "
+        f"in, so the flag no longer skips the work it exists to skip:\n{result.stdout}"
     )
 
 

--- a/tests/security/test_disable_gpu_init_device_constants.py
+++ b/tests/security/test_disable_gpu_init_device_constants.py
@@ -188,8 +188,19 @@ def test_importing_the_package_does_not_pull_in_torch():
     )
 
 
+# Without the flag, `unsloth_zoo/__init__.py` raises `ImportError: Please install
+# Unsloth` when unsloth is absent - which is exactly the case in the security-audit
+# lane, where `.[core]` is installed and the flag is what bypasses that check. The
+# control below is the one test here that drops the flag, so it needs unsloth present.
+_needs_unsloth = pytest.mark.skipif(
+    importlib.util.find_spec("unsloth") is None,
+    reason = "unsloth is not installed; importing unsloth_zoo without the skip flag raises",
+)
+
+
 @_needs_lazy_path
 @_needs_torch
+@_needs_unsloth
 def test_reading_a_constant_is_what_pulls_torch_in():
     """The other half of the pair, so the check above cannot pass vacuously.
 

--- a/tests/security/test_disable_gpu_init_device_constants.py
+++ b/tests/security/test_disable_gpu_init_device_constants.py
@@ -188,10 +188,7 @@ def test_importing_the_package_does_not_pull_in_torch():
     )
 
 
-# Without the flag, `unsloth_zoo/__init__.py` raises `ImportError: Please install
-# Unsloth` when unsloth is absent - which is exactly the case in the security-audit
-# lane, where `.[core]` is installed and the flag is what bypasses that check. The
-# control below is the one test here that drops the flag, so it needs unsloth present.
+# Without the flag the init raises when unsloth is absent, as in the security lane.
 _needs_unsloth = pytest.mark.skipif(
     importlib.util.find_spec("unsloth") is None,
     reason = "unsloth is not installed; importing unsloth_zoo without the skip flag raises",
@@ -202,14 +199,7 @@ _needs_unsloth = pytest.mark.skipif(
 @_needs_torch
 @_needs_unsloth
 def test_reading_a_constant_is_what_pulls_torch_in():
-    """The other half of the pair, so the check above cannot pass vacuously.
-
-    WITHOUT the flag. `get_device_type` answers `cpu` under it without asking torch
-    anything, which is the whole point of the flag: the download-only child it exists
-    for gets no GPU init and no torch import even if it does read a constant. So the
-    non-vacuousness control is the ordinary path, where reading the constant really is
-    what pulls torch in.
-    """
+    """The non-vacuous half: without the flag, reading a constant does pull torch in."""
     result = _run(
         "import sys\n"
         "import unsloth_zoo\n"

--- a/tests/security/test_skipped_gpu_init_keeps_device_constants.py
+++ b/tests/security/test_skipped_gpu_init_keeps_device_constants.py
@@ -19,6 +19,7 @@ CPU-only and network-free: this reads source and runs a subprocess with the flag
 from __future__ import annotations
 
 import ast
+import importlib.util
 import os
 import pathlib
 import subprocess
@@ -28,6 +29,20 @@ import pytest
 
 
 _ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+# The MLX branch of `__init__.py` runs BEFORE the skip flag is consulted and answers
+# "mlx", deliberately, so the CPU expectations below are not the right ones there.
+# Read without importing torch: `is_mlx_available` is import-light.
+try:
+    from unsloth_zoo.mlx.runtime import is_mlx_available as _is_mlx_available
+    _IS_MLX_HOST = bool(_is_mlx_available())
+except Exception:
+    _IS_MLX_HOST = False
+
+# The security lane installs `.[core]` and NOT `unsloth`, and the full init ends in
+# `find_spec("unsloth") is None -> ImportError`. Only the tests that deliberately turn
+# the skip flag OFF reach that, so they are the only ones guarded.
+_HAS_UNSLOTH = importlib.util.find_spec("unsloth") is not None
 _INIT = _ROOT / "unsloth_zoo" / "__init__.py"
 
 # Bound by the MLX branch and by the skip branch alike, and by the real init below
@@ -64,6 +79,7 @@ def test_a_module_that_reads_them_still_imports():
     assert result.returncode == 0, result.stderr[-2000:]
 
 
+@pytest.mark.skipif(_IS_MLX_HOST, reason = "MLX takes precedence over the skip flag")
 def test_the_two_device_type_spellings_agree_on_the_skip_path():
     """One process must not hold two different answers for the same question.
 
@@ -82,6 +98,39 @@ def test_the_two_device_type_spellings_agree_on_the_skip_path():
     assert package == direct == torch_name == "cpu", (package, direct, torch_name)
 
 
+@pytest.mark.skipif(_IS_MLX_HOST, reason = "MLX takes precedence over the skip flag")
+@pytest.mark.parametrize("name", _CONSTANTS)
+def test_both_import_paths_publish_the_same_constant(name):
+    """Not just the device NAME: a reader cannot tell which spelling it got.
+
+    `DEVICE_COUNT` and `ALLOW_PREQUANTIZED_MODELS` disagreed - the package published
+    0 and False, and `device_type` computed 1 and left True - so two modules in one
+    process could hold contradictory device capabilities.
+    """
+    result = _child(
+        "import unsloth_zoo, unsloth_zoo.device_type as d;"
+        f"print(unsloth_zoo.{name}, d.{name})"
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    package, direct = result.stdout.strip().splitlines()[-1].split()
+    assert package == direct, (name, package, direct)
+
+
+@pytest.mark.skipif(_IS_MLX_HOST, reason = "MLX takes precedence over the skip flag")
+def test_the_compiler_binds_its_old_arch_flag_on_the_skip_path():
+    """`fuse_lm_head = True` reads `OLD_CUDA_ARCH_VERSION`, which only the CUDA, HIP
+    and XPU branches used to bind, so the "cpu" value raised NameError."""
+    result = _child(
+        "import unsloth_zoo.compiler as c; print(c.OLD_CUDA_ARCH_VERSION)"
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert result.stdout.strip().splitlines()[-1] == "False"
+
+
+@pytest.mark.skipif(
+    not _HAS_UNSLOTH,
+    reason = "this one turns the skip flag off, so the init needs `unsloth` installed",
+)
 def test_the_legacy_cpu_hatch_still_answers_cuda(monkeypatch):
     """`UNSLOTH_ALLOW_CPU=1` keeps its own meaning, unchanged by the skip flag."""
     environment = dict(os.environ)

--- a/tests/security/test_skipped_gpu_init_keeps_device_constants.py
+++ b/tests/security/test_skipped_gpu_init_keeps_device_constants.py
@@ -43,6 +43,19 @@ except Exception:
 # `find_spec("unsloth") is None -> ImportError`. Only the tests that deliberately turn
 # the skip flag OFF reach that, so they are the only ones guarded.
 _HAS_UNSLOTH = importlib.util.find_spec("unsloth") is not None
+
+# `UNSLOTH_ALLOW_CPU=1` is a fallback for a host with NO accelerator, so it is only
+# reached where none is visible. Clearing `CUDA_VISIBLE_DEVICES` does that for CUDA
+# and not for XPU, which stays available and is answered before the hatch.
+def _has_non_cuda_accelerator():
+    try:
+        import torch
+    except Exception:
+        return False
+    return bool(getattr(getattr(torch, "xpu", None), "is_available", bool)())
+
+
+_HAS_NON_CUDA_ACCELERATOR = _has_non_cuda_accelerator()
 _INIT = _ROOT / "unsloth_zoo" / "__init__.py"
 
 # Bound by the MLX branch and by the skip branch alike, and by the real init below
@@ -130,6 +143,11 @@ def test_the_compiler_binds_its_old_arch_flag_on_the_skip_path():
 @pytest.mark.skipif(
     not _HAS_UNSLOTH,
     reason = "this one turns the skip flag off, so the init needs `unsloth` installed",
+)
+@pytest.mark.skipif(_IS_MLX_HOST, reason = "MLX answers before the CPU hatch is read")
+@pytest.mark.skipif(
+    _HAS_NON_CUDA_ACCELERATOR,
+    reason = "clearing CUDA_VISIBLE_DEVICES leaves another accelerator visible",
 )
 def test_the_legacy_cpu_hatch_still_answers_cuda(monkeypatch):
     """`UNSLOTH_ALLOW_CPU=1` keeps its own meaning, unchanged by the skip flag."""

--- a/tests/security/test_skipped_gpu_init_keeps_device_constants.py
+++ b/tests/security/test_skipped_gpu_init_keeps_device_constants.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""`UNSLOTH_ZOO_DISABLE_GPU_INIT=1` must not remove the device constants.
+
+The flag skips the heavy torch/device init. It is what CI sets to run this very
+suite, because the runner has no GPU and the init ends in
+`find_spec("unsloth") is None -> ImportError`.
+
+But modules that are otherwise import-safe read those constants at module scope -
+`compiler.py` does `from . import DEVICE_TYPE` - so skipping the init used to turn
+any such import into `ImportError: cannot import name 'DEVICE_TYPE'`. The whole
+security job then failed during COLLECTION, which means it was not running at all
+while still reporting a result.
+
+CPU-only and network-free: this reads source and runs a subprocess with the flag set.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_INIT = _ROOT / "unsloth_zoo" / "__init__.py"
+
+# Bound by the MLX branch and by the skip branch alike, and by the real init below
+# both. A module reading any of them must not care which path ran.
+_CONSTANTS = ("DEVICE_TYPE", "DEVICE_TYPE_TORCH", "DEVICE_COUNT", "ALLOW_PREQUANTIZED_MODELS")
+
+
+def _child(code: str):
+    environment = dict(os.environ)
+    environment["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
+    # `tests/conftest.py` sets `UNSLOTH_ALLOW_CPU=1` for the whole run, and inheriting
+    # it here would have let that unrelated escape hatch stand in for the skip path
+    # this test is about: the promise is that `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` alone
+    # keeps the module importable, so the child is asked exactly that question.
+    environment.pop("UNSLOTH_ALLOW_CPU", None)
+    # A subprocess, not an import: this package is already imported in-process with
+    # the flag unset, so an in-process check would prove nothing about the flag.
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd = _ROOT, env = environment, capture_output = True, text = True, timeout = 300,
+    )
+
+
+@pytest.mark.parametrize("name", _CONSTANTS)
+def test_the_constant_survives_a_skipped_init(name):
+    result = _child(f"import unsloth_zoo; print(unsloth_zoo.{name})")
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert result.stdout.strip(), f"{name} is bound but empty"
+
+
+def test_a_module_that_reads_them_still_imports():
+    """`compiler.py` is the one CI actually tripped over."""
+    result = _child("import unsloth_zoo.compiler")
+    assert result.returncode == 0, result.stderr[-2000:]
+
+
+def test_the_skip_branch_binds_every_constant_the_mlx_branch_does():
+    """Read off the source, so a constant added to one branch cannot be forgotten.
+
+    The two branches answer the same question - "the heavy init did not run" - and a
+    reader of these names cannot tell which one it got.
+    """
+    tree = ast.parse(_INIT.read_text(encoding = "utf-8"))
+
+    bound = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        names = {
+            target.id
+            for statement in node.body
+            if isinstance(statement, ast.Assign)
+            for target in statement.targets
+            if isinstance(target, ast.Name)
+        }
+        if any(constant in names for constant in _CONSTANTS):
+            bound.append(names)
+
+    assert len(bound) >= 2, (
+        "expected both the MLX branch and the skipped-init branch to bind the device "
+        f"constants, found {len(bound)} branch(es) that bind any of them"
+    )
+    for names in bound:
+        missing = sorted(set(_CONSTANTS) - names)
+        assert not missing, f"a branch binds only part of the device constants: {missing}"

--- a/tests/security/test_skipped_gpu_init_keeps_device_constants.py
+++ b/tests/security/test_skipped_gpu_init_keeps_device_constants.py
@@ -86,6 +86,7 @@ def test_the_constant_survives_a_skipped_init(name):
     assert result.stdout.strip(), f"{name} is bound but empty"
 
 
+@pytest.mark.skipif(_IS_MLX_HOST, reason = "the MLX install ships no torch to import")
 def test_a_module_that_reads_them_still_imports():
     """`compiler.py` is the one CI actually tripped over."""
     result = _child("import unsloth_zoo.compiler")
@@ -130,6 +131,7 @@ def test_both_import_paths_publish_the_same_constant(name):
 
 
 @pytest.mark.skipif(_IS_MLX_HOST, reason = "MLX takes precedence over the skip flag")
+@pytest.mark.skipif(_IS_MLX_HOST, reason = "the MLX install ships no torch to import")
 def test_the_compiler_binds_its_old_arch_flag_on_the_skip_path():
     """`fuse_lm_head = True` reads `OLD_CUDA_ARCH_VERSION`, which only the CUDA, HIP
     and XPU branches used to bind, so the "cpu" value raised NameError."""

--- a/tests/security/test_skipped_gpu_init_keeps_device_constants.py
+++ b/tests/security/test_skipped_gpu_init_keeps_device_constants.py
@@ -3,17 +3,8 @@
 
 """`UNSLOTH_ZOO_DISABLE_GPU_INIT=1` must not remove the device constants.
 
-The flag skips the heavy torch/device init. It is what CI sets to run this very
-suite, because the runner has no GPU and the init ends in
-`find_spec("unsloth") is None -> ImportError`.
-
-But modules that are otherwise import-safe read those constants at module scope -
-`compiler.py` does `from . import DEVICE_TYPE` - so skipping the init used to turn
-any such import into `ImportError: cannot import name 'DEVICE_TYPE'`. The whole
-security job then failed during COLLECTION, which means it was not running at all
-while still reporting a result.
-
-CPU-only and network-free: this reads source and runs a subprocess with the flag set.
+CI sets the flag to run this suite, and `compiler.py` imports `DEVICE_TYPE` at module
+scope, so the job failed during COLLECTION while still reporting a result.
 """
 
 from __future__ import annotations
@@ -30,23 +21,17 @@ import pytest
 
 _ROOT = pathlib.Path(__file__).resolve().parents[2]
 
-# The MLX branch of `__init__.py` runs BEFORE the skip flag is consulted and answers
-# "mlx", deliberately, so the CPU expectations below are not the right ones there.
-# Read without importing torch: `is_mlx_available` is import-light.
+# MLX answers before the skip flag is read, so the CPU expectations do not hold there.
 try:
     from unsloth_zoo.mlx.runtime import is_mlx_available as _is_mlx_available
     _IS_MLX_HOST = bool(_is_mlx_available())
 except Exception:
     _IS_MLX_HOST = False
 
-# The security lane installs `.[core]` and NOT `unsloth`, and the full init ends in
-# `find_spec("unsloth") is None -> ImportError`. Only the tests that deliberately turn
-# the skip flag OFF reach that, so they are the only ones guarded.
+# The security lane installs `.[core]` and not `unsloth`, so the full init raises.
 _HAS_UNSLOTH = importlib.util.find_spec("unsloth") is not None
 
-# `UNSLOTH_ALLOW_CPU=1` is a fallback for a host with NO accelerator, so it is only
-# reached where none is visible. Clearing `CUDA_VISIBLE_DEVICES` does that for CUDA
-# and not for XPU, which stays available and is answered before the hatch.
+# Clearing `CUDA_VISIBLE_DEVICES` hides CUDA but not XPU, answered before the hatch.
 def _has_non_cuda_accelerator():
     try:
         import torch
@@ -58,21 +43,14 @@ def _has_non_cuda_accelerator():
 _HAS_NON_CUDA_ACCELERATOR = _has_non_cuda_accelerator()
 _INIT = _ROOT / "unsloth_zoo" / "__init__.py"
 
-# Bound by the MLX branch and by the skip branch alike, and by the real init below
-# both. A module reading any of them must not care which path ran.
 _CONSTANTS = ("DEVICE_TYPE", "DEVICE_TYPE_TORCH", "DEVICE_COUNT", "ALLOW_PREQUANTIZED_MODELS")
 
 
 def _child(code: str):
     environment = dict(os.environ)
     environment["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
-    # `tests/conftest.py` sets `UNSLOTH_ALLOW_CPU=1` for the whole run, and inheriting
-    # it here would have let that unrelated escape hatch stand in for the skip path
-    # this test is about: the promise is that `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` alone
-    # keeps the module importable, so the child is asked exactly that question.
+    # conftest sets this run-wide; inheriting it would stand in for the skip path.
     environment.pop("UNSLOTH_ALLOW_CPU", None)
-    # A subprocess, not an import: this package is already imported in-process with
-    # the flag unset, so an in-process check would prove nothing about the flag.
     return subprocess.run(
         [sys.executable, "-c", code],
         cwd = _ROOT, env = environment, capture_output = True, text = True, timeout = 300,
@@ -95,14 +73,7 @@ def test_a_module_that_reads_them_still_imports():
 
 @pytest.mark.skipif(_IS_MLX_HOST, reason = "MLX takes precedence over the skip flag")
 def test_the_two_device_type_spellings_agree_on_the_skip_path():
-    """One process must not hold two different answers for the same question.
-
-    `__init__.py` publishes `DEVICE_TYPE = "cpu"` on the skip path, and
-    `device_type.get_device_type()` has to say the same, or a module reading one and a
-    module reading the other take different device branches in the same run. The older
-    `UNSLOTH_ALLOW_CPU=1` hatch deliberately answers `"cuda"`; that is a different
-    question and is checked separately below.
-    """
+    """One process must not hold two answers: two modules would branch differently."""
     result = _child(
         "import unsloth_zoo, unsloth_zoo.device_type as d;"
         "print(unsloth_zoo.DEVICE_TYPE, d.DEVICE_TYPE, d.DEVICE_TYPE_TORCH)"
@@ -115,12 +86,7 @@ def test_the_two_device_type_spellings_agree_on_the_skip_path():
 @pytest.mark.skipif(_IS_MLX_HOST, reason = "MLX takes precedence over the skip flag")
 @pytest.mark.parametrize("name", _CONSTANTS)
 def test_both_import_paths_publish_the_same_constant(name):
-    """Not just the device NAME: a reader cannot tell which spelling it got.
-
-    `DEVICE_COUNT` and `ALLOW_PREQUANTIZED_MODELS` disagreed - the package published
-    0 and False, and `device_type` computed 1 and left True - so two modules in one
-    process could hold contradictory device capabilities.
-    """
+    """`DEVICE_COUNT` and `ALLOW_PREQUANTIZED_MODELS` disagreed too: 0/False vs 1/True."""
     result = _child(
         "import unsloth_zoo, unsloth_zoo.device_type as d;"
         f"print(unsloth_zoo.{name}, d.{name})"
@@ -133,8 +99,7 @@ def test_both_import_paths_publish_the_same_constant(name):
 @pytest.mark.skipif(_IS_MLX_HOST, reason = "MLX takes precedence over the skip flag")
 @pytest.mark.skipif(_IS_MLX_HOST, reason = "the MLX install ships no torch to import")
 def test_the_compiler_binds_its_old_arch_flag_on_the_skip_path():
-    """`fuse_lm_head = True` reads `OLD_CUDA_ARCH_VERSION`, which only the CUDA, HIP
-    and XPU branches used to bind, so the "cpu" value raised NameError."""
+    """`fuse_lm_head` reads `OLD_CUDA_ARCH_VERSION`, which "cpu" left unbound."""
     result = _child(
         "import unsloth_zoo.compiler as c; print(c.OLD_CUDA_ARCH_VERSION)"
     )
@@ -166,11 +131,7 @@ def test_the_legacy_cpu_hatch_still_answers_cuda(monkeypatch):
 
 
 def test_the_skip_branch_binds_every_constant_the_mlx_branch_does():
-    """Read off the source, so a constant added to one branch cannot be forgotten.
-
-    The two branches answer the same question - "the heavy init did not run" - and a
-    reader of these names cannot tell which one it got.
-    """
+    """Read off the source, so a constant added to one branch cannot be forgotten."""
     tree = ast.parse(_INIT.read_text(encoding = "utf-8"))
 
     bound = []

--- a/tests/security/test_skipped_gpu_init_keeps_device_constants.py
+++ b/tests/security/test_skipped_gpu_init_keeps_device_constants.py
@@ -64,6 +64,38 @@ def test_a_module_that_reads_them_still_imports():
     assert result.returncode == 0, result.stderr[-2000:]
 
 
+def test_the_two_device_type_spellings_agree_on_the_skip_path():
+    """One process must not hold two different answers for the same question.
+
+    `__init__.py` publishes `DEVICE_TYPE = "cpu"` on the skip path, and
+    `device_type.get_device_type()` has to say the same, or a module reading one and a
+    module reading the other take different device branches in the same run. The older
+    `UNSLOTH_ALLOW_CPU=1` hatch deliberately answers `"cuda"`; that is a different
+    question and is checked separately below.
+    """
+    result = _child(
+        "import unsloth_zoo, unsloth_zoo.device_type as d;"
+        "print(unsloth_zoo.DEVICE_TYPE, d.DEVICE_TYPE, d.DEVICE_TYPE_TORCH)"
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    package, direct, torch_name = result.stdout.strip().splitlines()[-1].split()
+    assert package == direct == torch_name == "cpu", (package, direct, torch_name)
+
+
+def test_the_legacy_cpu_hatch_still_answers_cuda(monkeypatch):
+    """`UNSLOTH_ALLOW_CPU=1` keeps its own meaning, unchanged by the skip flag."""
+    environment = dict(os.environ)
+    environment.pop("UNSLOTH_ZOO_DISABLE_GPU_INIT", None)
+    environment["UNSLOTH_ALLOW_CPU"] = "1"
+    environment["CUDA_VISIBLE_DEVICES"] = ""
+    result = subprocess.run(
+        [sys.executable, "-c", "import unsloth_zoo.device_type as d; print(d.DEVICE_TYPE)"],
+        cwd = _ROOT, env = environment, capture_output = True, text = True, timeout = 300,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert result.stdout.strip().splitlines()[-1] == "cuda"
+
+
 def test_the_skip_branch_binds_every_constant_the_mlx_branch_does():
     """Read off the source, so a constant added to one branch cannot be forgotten.
 

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -179,15 +179,8 @@ else:
     _SKIP_GPU_INIT = os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT", "0") == "1"
     del _is_mlx_only, is_mlx_available
     if _SKIP_GPU_INIT:
-        # The device constants still have to EXIST. They are set below by the init
-        # this flag skips, and modules that are otherwise import-safe read them -
-        # `compiler.py` does `from . import DEVICE_TYPE` at module scope - so
-        # skipping the init turned any such import into
-        # `ImportError: cannot import name 'DEVICE_TYPE'`. That is what broke the
-        # security suite in CI, which sets this flag precisely because it has no
-        # device. The MLX branch above already binds them for the same reason;
-        # these are the honest values for "GPU init was skipped", and they are
-        # plain literals, so nothing heavy is imported to produce them.
+        # `compiler.py` does `from . import DEVICE_TYPE` at module scope, so the
+        # constants must still exist when the init that sets them is skipped.
         DEVICE_TYPE = "cpu"
         DEVICE_TYPE_TORCH = "cpu"
         DEVICE_COUNT = 0

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -178,6 +178,20 @@ else:
     # The HF cache redirect above still runs, so the child shares the parent's cache.
     _SKIP_GPU_INIT = os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT", "0") == "1"
     del _is_mlx_only, is_mlx_available
+    if _SKIP_GPU_INIT:
+        # The device constants still have to EXIST. They are set below by the init
+        # this flag skips, and modules that are otherwise import-safe read them -
+        # `compiler.py` does `from . import DEVICE_TYPE` at module scope - so
+        # skipping the init turned any such import into
+        # `ImportError: cannot import name 'DEVICE_TYPE'`. That is what broke the
+        # security suite in CI, which sets this flag precisely because it has no
+        # device. The MLX branch above already binds them for the same reason;
+        # these are the honest values for "GPU init was skipped", and they are
+        # plain literals, so nothing heavy is imported to produce them.
+        DEVICE_TYPE = "cpu"
+        DEVICE_TYPE_TORCH = "cpu"
+        DEVICE_COUNT = 0
+        ALLOW_PREQUANTIZED_MODELS = False
 
 # Stub the CUDA-only imports whenever GPU init is skipped (MLX host or the opt-in
 # download child), so they resolve to a loud no-op instead of a hard ImportError. On a

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -85,10 +85,8 @@ OLD_TORCH_VERSION = Version(torch.__version__) < Version("2.5.0")
 # device capability
 major = None
 minor = None
-# Bound before the branches, so no DEVICE_TYPE can leave it undefined. "cpu" is one:
-# `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` publishes that value, and `fuse_lm_head = True`
-# then read this global and raised NameError. There is no arch to read without a GPU,
-# and the old-arch workarounds only ever run on a real one, so False changes nothing.
+# Bound before the branches: DEVICE_TYPE == "cpu" takes none of them, and
+# `fuse_lm_head` then read this global and raised NameError.
 OLD_CUDA_ARCH_VERSION = False
 if DEVICE_TYPE == "cuda":
     if torch.cuda.is_available():

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -85,6 +85,11 @@ OLD_TORCH_VERSION = Version(torch.__version__) < Version("2.5.0")
 # device capability
 major = None
 minor = None
+# Bound before the branches, so no DEVICE_TYPE can leave it undefined. "cpu" is one:
+# `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` publishes that value, and `fuse_lm_head = True`
+# then read this global and raised NameError. There is no arch to read without a GPU,
+# and the old-arch workarounds only ever run on a real one, so False changes nothing.
+OLD_CUDA_ARCH_VERSION = False
 if DEVICE_TYPE == "cuda":
     if torch.cuda.is_available():
         major, minor = torch.cuda.get_device_capability()

--- a/unsloth_zoo/device_type.py
+++ b/unsloth_zoo/device_type.py
@@ -347,21 +347,29 @@ def get_amd_flash_attn_func():
     return None
 
 
-def _cpu_fallback_requested():
-    """True when this process has declared it has no accelerator and wants none.
+def _cpu_fallback():
+    """The device name to fall back to on a host with no accelerator, or None.
 
-    `UNSLOTH_ALLOW_CPU=1` is the long standing test-only escape hatch.
+    Two flags reach here and they do NOT mean the same thing, so they do not give the
+    same answer.
+
+    `UNSLOTH_ALLOW_CPU=1` is the long standing test-only escape hatch, and it answers
+    `"cuda"` deliberately: callers keep taking their CUDA branches against a CPU torch.
+    That is unchanged.
+
     `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` is the newer flag a download-only child (and the
-    CPU security job) sets to skip the heavy GPU init entirely; `__init__.py` already
-    binds the package level device constants for it. Importing a module that reads
-    `device_type` directly - `temporary_patches.gpt_oss` does - then still ran this
-    detection and raised, so the flag only half kept its promise. Both flags mean the
-    same thing here, so both are honoured.
+    CPU security job) sets to skip the heavy GPU init entirely. Importing a module that
+    reads `device_type` directly - `temporary_patches.gpt_oss` does - still ran this
+    detection and raised, so the flag only half kept its promise. It answers `"cpu"`,
+    which is what `__init__.py` already publishes as the package level `DEVICE_TYPE` on
+    that path. Answering `"cuda"` here instead left one process holding both values at
+    once, so two modules picked different device branches.
     """
-    return (
-        os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1" or
-        os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT", "0") == "1"
-    )
+    if os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1":
+        return "cuda"
+    if os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT", "0") == "1":
+        return "cpu"
+    return None
 
 
 @functools.cache
@@ -378,8 +386,9 @@ def get_device_type():
         if not torch.accelerator.is_available():
             # Test-only CPU fallback. The env vars are read exactly once per
             # process because get_device_type is @functools.cache'd.
-            if _cpu_fallback_requested():
-                return "cuda"
+            fallback = _cpu_fallback()
+            if fallback is not None:
+                return fallback
             amd_hint = _amd_installation_hint()
             if amd_hint is not None:
                 raise NotImplementedError(amd_hint)
@@ -391,8 +400,9 @@ def get_device_type():
                 f"But `torch.accelerator.current_accelerator()` works with it being = `{accelerator}`\n"\
                 f"Please reinstall torch - it's most likely broken :("
             )
-    if _cpu_fallback_requested():
-        return "cuda"
+    fallback = _cpu_fallback()
+    if fallback is not None:
+        return fallback
     amd_hint = _amd_installation_hint()
     if amd_hint is not None:
         raise NotImplementedError(amd_hint)

--- a/unsloth_zoo/device_type.py
+++ b/unsloth_zoo/device_type.py
@@ -372,10 +372,25 @@ def _cpu_fallback():
     return None
 
 
+# Read once, at module scope, so every reader below agrees. `get_device_type` is
+# `@functools.cache`d, so it would read the environment once per process anyway.
+_GPU_INIT_SKIPPED = os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT", "0") == "1"
+
+
 @functools.cache
 def get_device_type():
     if _IS_MLX:
+        # MLX keeps its precedence: a macOS/arm64 host answers "mlx" whatever the
+        # skip flag says, which is what `__init__.py` publishes there too.
         return "mlx"
+    if _GPU_INIT_SKIPPED:
+        # BEFORE the hardware probes, not after. `__init__.py` publishes
+        # `DEVICE_TYPE = "cpu"` on this path unconditionally, so consulting the flag
+        # only in the no-accelerator fallback left a CUDA or XPU host holding both
+        # answers at once: the package said "cpu" and a direct
+        # `import unsloth_zoo.device_type` said "cuda". It also ran the very
+        # detection the flag promises to skip.
+        return "cpu"
     if hasattr(torch, "cuda") and torch.cuda.is_available():
         if is_hip():
             return "hip"
@@ -425,10 +440,20 @@ def get_device_count():
 pass
 
 DEVICE_COUNT : int = get_device_count()
+if _GPU_INIT_SKIPPED and DEVICE_TYPE == "cpu":
+    # `get_device_count` answers 1 for anything that is not CUDA/HIP/XPU, which is the
+    # right answer for a real CPU run and the wrong one here: no device was looked for
+    # at all. `__init__.py` publishes 0 on this path, and a reader cannot tell which of
+    # the two spellings it got.
+    DEVICE_COUNT = 0
 
 # Check blocksize for 4bit -> 64 for CUDA, 128 for AMD
 # If AMD, we cannot load pre-quantized models for now :(
 ALLOW_PREQUANTIZED_MODELS : bool = True
+if _GPU_INIT_SKIPPED and DEVICE_TYPE == "cpu":
+    # Same argument as `DEVICE_COUNT` above: `__init__.py` publishes False here, and
+    # the two import paths must not disagree about what the process can load.
+    ALLOW_PREQUANTIZED_MODELS = False
 # HSA_STATUS_ERROR_EXCEPTION checks - sometimes AMD fails for BnB
 ALLOW_BITSANDBYTES : bool = True
 if DEVICE_TYPE == "hip":

--- a/unsloth_zoo/device_type.py
+++ b/unsloth_zoo/device_type.py
@@ -347,6 +347,23 @@ def get_amd_flash_attn_func():
     return None
 
 
+def _cpu_fallback_requested():
+    """True when this process has declared it has no accelerator and wants none.
+
+    `UNSLOTH_ALLOW_CPU=1` is the long standing test-only escape hatch.
+    `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` is the newer flag a download-only child (and the
+    CPU security job) sets to skip the heavy GPU init entirely; `__init__.py` already
+    binds the package level device constants for it. Importing a module that reads
+    `device_type` directly - `temporary_patches.gpt_oss` does - then still ran this
+    detection and raised, so the flag only half kept its promise. Both flags mean the
+    same thing here, so both are honoured.
+    """
+    return (
+        os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1" or
+        os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT", "0") == "1"
+    )
+
+
 @functools.cache
 def get_device_type():
     if _IS_MLX:
@@ -359,9 +376,9 @@ def get_device_type():
         return "xpu"
     if hasattr(torch, "accelerator"):
         if not torch.accelerator.is_available():
-            # Test-only CPU fallback. The env var is read exactly once per
+            # Test-only CPU fallback. The env vars are read exactly once per
             # process because get_device_type is @functools.cache'd.
-            if os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1":
+            if _cpu_fallback_requested():
                 return "cuda"
             amd_hint = _amd_installation_hint()
             if amd_hint is not None:
@@ -374,7 +391,7 @@ def get_device_type():
                 f"But `torch.accelerator.current_accelerator()` works with it being = `{accelerator}`\n"\
                 f"Please reinstall torch - it's most likely broken :("
             )
-    if os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1":
+    if _cpu_fallback_requested():
         return "cuda"
     amd_hint = _amd_installation_hint()
     if amd_hint is not None:

--- a/unsloth_zoo/device_type.py
+++ b/unsloth_zoo/device_type.py
@@ -431,6 +431,11 @@ elif DEVICE_TYPE_TORCH == "mlx": DEVICE_TYPE_TORCH = "mps"
 
 @functools.cache
 def get_device_count():
+    if _GPU_INIT_SKIPPED and DEVICE_TYPE == "cpu":
+        # Answered HERE, not only on the constant below: a caller using the getter was
+        # being handed 1 while `DEVICE_COUNT` said 0 in the same process. No device
+        # was looked for at all on this path, which is what 0 says.
+        return 0
     if DEVICE_TYPE in ("cuda", "hip"):
         return torch.cuda.device_count()
     elif DEVICE_TYPE == "xpu":
@@ -440,12 +445,6 @@ def get_device_count():
 pass
 
 DEVICE_COUNT : int = get_device_count()
-if _GPU_INIT_SKIPPED and DEVICE_TYPE == "cpu":
-    # `get_device_count` answers 1 for anything that is not CUDA/HIP/XPU, which is the
-    # right answer for a real CPU run and the wrong one here: no device was looked for
-    # at all. `__init__.py` publishes 0 on this path, and a reader cannot tell which of
-    # the two spellings it got.
-    DEVICE_COUNT = 0
 
 # Check blocksize for 4bit -> 64 for CUDA, 128 for AMD
 # If AMD, we cannot load pre-quantized models for now :(

--- a/unsloth_zoo/device_type.py
+++ b/unsloth_zoo/device_type.py
@@ -348,22 +348,10 @@ def get_amd_flash_attn_func():
 
 
 def _cpu_fallback():
-    """The device name to fall back to on a host with no accelerator, or None.
+    """The device name for a host with no accelerator, or None.
 
-    Two flags reach here and they do NOT mean the same thing, so they do not give the
-    same answer.
-
-    `UNSLOTH_ALLOW_CPU=1` is the long standing test-only escape hatch, and it answers
-    `"cuda"` deliberately: callers keep taking their CUDA branches against a CPU torch.
-    That is unchanged.
-
-    `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` is the newer flag a download-only child (and the
-    CPU security job) sets to skip the heavy GPU init entirely. Importing a module that
-    reads `device_type` directly - `temporary_patches.gpt_oss` does - still ran this
-    detection and raised, so the flag only half kept its promise. It answers `"cpu"`,
-    which is what `__init__.py` already publishes as the package level `DEVICE_TYPE` on
-    that path. Answering `"cuda"` here instead left one process holding both values at
-    once, so two modules picked different device branches.
+    `UNSLOTH_ALLOW_CPU=1` answers "cuda" so callers keep their CUDA branches against a
+    CPU torch. `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` answers "cpu" to match `__init__.py`.
     """
     if os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1":
         return "cuda"
@@ -372,24 +360,16 @@ def _cpu_fallback():
     return None
 
 
-# Read once, at module scope, so every reader below agrees. `get_device_type` is
-# `@functools.cache`d, so it would read the environment once per process anyway.
 _GPU_INIT_SKIPPED = os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT", "0") == "1"
 
 
 @functools.cache
 def get_device_type():
     if _IS_MLX:
-        # MLX keeps its precedence: a macOS/arm64 host answers "mlx" whatever the
-        # skip flag says, which is what `__init__.py` publishes there too.
         return "mlx"
     if _GPU_INIT_SKIPPED:
-        # BEFORE the hardware probes, not after. `__init__.py` publishes
-        # `DEVICE_TYPE = "cpu"` on this path unconditionally, so consulting the flag
-        # only in the no-accelerator fallback left a CUDA or XPU host holding both
-        # answers at once: the package said "cpu" and a direct
-        # `import unsloth_zoo.device_type` said "cuda". It also ran the very
-        # detection the flag promises to skip.
+        # BEFORE the hardware probes: `__init__.py` publishes "cpu" unconditionally, so
+        # checking only in the no-accelerator fallback left a CUDA host with both.
         return "cpu"
     if hasattr(torch, "cuda") and torch.cuda.is_available():
         if is_hip():
@@ -399,8 +379,7 @@ def get_device_type():
         return "xpu"
     if hasattr(torch, "accelerator"):
         if not torch.accelerator.is_available():
-            # Test-only CPU fallback. The env vars are read exactly once per
-            # process because get_device_type is @functools.cache'd.
+            # Test-only CPU fallback; get_device_type is @functools.cache'd.
             fallback = _cpu_fallback()
             if fallback is not None:
                 return fallback
@@ -432,9 +411,7 @@ elif DEVICE_TYPE_TORCH == "mlx": DEVICE_TYPE_TORCH = "mps"
 @functools.cache
 def get_device_count():
     if _GPU_INIT_SKIPPED and DEVICE_TYPE == "cpu":
-        # Answered HERE, not only on the constant below: a caller using the getter was
-        # being handed 1 while `DEVICE_COUNT` said 0 in the same process. No device
-        # was looked for at all on this path, which is what 0 says.
+        # The getter too, not only the constant below: they were handed 1 and 0.
         return 0
     if DEVICE_TYPE in ("cuda", "hip"):
         return torch.cuda.device_count()
@@ -450,8 +427,7 @@ DEVICE_COUNT : int = get_device_count()
 # If AMD, we cannot load pre-quantized models for now :(
 ALLOW_PREQUANTIZED_MODELS : bool = True
 if _GPU_INIT_SKIPPED and DEVICE_TYPE == "cpu":
-    # Same argument as `DEVICE_COUNT` above: `__init__.py` publishes False here, and
-    # the two import paths must not disagree about what the process can load.
+    # As with DEVICE_COUNT: the two import paths must not disagree.
     ALLOW_PREQUANTIZED_MODELS = False
 # HSA_STATUS_ERROR_EXCEPTION checks - sometimes AMD fails for BnB
 ALLOW_BITSANDBYTES : bool = True


### PR DESCRIPTION
### Summary

`UNSLOTH_ZOO_DISABLE_GPU_INIT=1` is what a download-only helper child, and the CPU security job, set to skip the heavy torch / transformers / device init they never use. `#1108` made `__init__.py` bind the package-level device constants on that path so `compiler.py`'s `from . import DEVICE_TYPE` still resolves.

That was only half the promise. A module that imports `unsloth_zoo.device_type` directly still ran the detection, and `temporary_patches.gpt_oss` does, so on a host with no accelerator:

```
UNSLOTH_ZOO_DISABLE_GPU_INIT=1 python -c "import unsloth_zoo.compiler"
NotImplementedError: Unsloth cannot find any torch accelerator? You need a GPU.
```

### The fix

`get_device_type()` now honours `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` alongside the existing `UNSLOTH_ALLOW_CPU=1`, through one named helper used at both fallback sites. A process that has declared it wants no GPU init does not then get a hard failure from device detection.

`tests/security/test_skipped_gpu_init_keeps_device_constants.py` asks exactly the question the flag promises: the child runs with `UNSLOTH_ALLOW_CPU` removed from its environment, so that unrelated escape hatch cannot stand in for the skip path being tested.

### Scope

This PR was originally the lint follow-up to #1108. The lint half is now #1113, so what remains here is the runtime fix above: `unsloth_zoo/__init__.py`, `unsloth_zoo/device_type.py` and the one test.

### Testing

`tests/security/test_skipped_gpu_init_keeps_device_constants.py` passes 6/6 with `UNSLOTH_ALLOW_CPU` unset and no visible device, and `import unsloth_zoo.compiler` succeeds under the flag on a CPU-only host. Full suite on this content: 5654 passed, 200 skipped.
