### PR TITLE
Keep the device constants reachable under UNSLOTH_ZOO_DISABLE_GPU_INIT

### DIFF
--- a/tests/security/test_disable_gpu_init_device_constants.py
+++ b/tests/security/test_disable_gpu_init_device_constants.py
@@ -46,6 +46,13 @@ def _public_upper_names(body) -> set:
 
     Descends into nested `if`s, because those still bind at module level when
     the branch is taken, but not into `def`/`class`, whose locals do not.
+
+    Annotated assignment counts. `device_type.py` declares these very constants
+    as `DEVICE_TYPE : str = get_device_type()`, so a fifth one arriving in the
+    MLX branch in that style is the likely shape, and reading only `ast.Assign`
+    would miss it, shrink the intersection back to four and let this file pass
+    while the skip path is short a name. Unpacked targets count for the same
+    reason. A bare `X: int` with no value only annotates and binds nothing.
     """
     found = set()
     stack = list(body)
@@ -53,11 +60,16 @@ def _public_upper_names(body) -> set:
         node = stack.pop()
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             continue
+        targets = ()
         if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id.isupper():
-                    found.add(target.id)
-        elif isinstance(node, ast.ImportFrom):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = (node.target,)
+        for target in targets:
+            for leaf in ast.walk(target):
+                if isinstance(leaf, ast.Name) and leaf.id.isupper():
+                    found.add(leaf.id)
+        if isinstance(node, ast.ImportFrom):
             for alias in node.names:
                 name = alias.asname or alias.name
                 if name.isupper():
@@ -194,6 +206,26 @@ def test_the_skip_path_covers_every_name_the_other_two_paths_promise():
         f"lazy resolver in unsloth_zoo/__init__.py and _NAMES here to match, or "
         f"the skip path is short a name that every other path defines."
     )
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    (
+        "NEW_CONST = 1",                      # plain assignment
+        "NEW_CONST : bool = True",            # the device_type.py idiom
+        "NEW_CONST, OTHER = 1, 2",            # unpacked
+        "if True:\n    NEW_CONST = 1",        # nested branch
+        "from .device_type import NEW_CONST", # the normal path's shape
+    ),
+)
+def test_the_contract_parser_sees_every_shape_a_constant_can_arrive_in(snippet):
+    """The derivation is only as good as the binding forms it recognises.
+
+    A form it cannot see shrinks the intersection instead of growing it, so the
+    contract test passes while the skip path is missing a name -- the exact
+    failure mode this file was written to close.
+    """
+    assert "NEW_CONST" in _public_upper_names(ast.parse(snippet).body), snippet
 
 
 def test_every_contract_name_actually_resolves_under_the_skip():

--- a/tests/security/test_disable_gpu_init_device_constants.py
+++ b/tests/security/test_disable_gpu_init_device_constants.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""`UNSLOTH_ZOO_DISABLE_GPU_INIT=1` must leave the package fully defined.
+
+This lane sets that flag (see `.github/workflows/security-audit.yml`) so
+`import unsloth_zoo` skips the device init that would otherwise demand
+`unsloth` be installed in a supply-chain-hygiene job. The skip branch used to
+define none of the four device constants that the MLX branch defines eagerly
+and the normal path imports from `.device_type`, so `from unsloth_zoo import
+DEVICE_TYPE` raised ImportError -- which `unsloth_zoo/compiler.py` does at
+import time, taking `test_compile_model_type_sink_guard.py` out at COLLECTION.
+A whole security test module stopped running and the lane reported it as one
+red rather than as missing coverage.
+
+Two properties, and the second is the one that rots quietly. The constants have
+to be reachable, and reaching them has to stay lazy: resolving `.device_type`
+costs ~1.4s and pulls torch into the process, and the download-only child that
+this flag exists for never reads one. Someone "simplifying" the resolver into a
+top-level import would satisfy the first test and silently undo the reason the
+flag is there at all, so the torch check below is not decoration.
+
+Everything runs in a subprocess: both properties are about what happens during
+`import unsloth_zoo`, and this process has already imported it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_NAMES = ("DEVICE_TYPE", "DEVICE_TYPE_TORCH", "DEVICE_COUNT", "ALLOW_PREQUANTIZED_MODELS")
+
+
+def _run(code: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
+    # A CI runner has no accelerator; this is the sentinel `get_device_type`
+    # already honours, and is what `tests/conftest.py` sets for the same reason.
+    env.setdefault("UNSLOTH_ALLOW_CPU", "1")
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd = str(REPO_ROOT),
+        env = env,
+        capture_output = True,
+        text = True,
+        timeout = 600,
+    )
+
+
+@pytest.mark.parametrize("name", _NAMES)
+def test_device_constant_is_importable_under_the_skip(name):
+    """`from unsloth_zoo import <constant>` resolves rather than raising."""
+    result = _run(f"from unsloth_zoo import {name}\nprint(repr({name}))\n")
+    assert result.returncode == 0, (
+        f"`from unsloth_zoo import {name}` failed under "
+        f"UNSLOTH_ZOO_DISABLE_GPU_INIT=1:\n{result.stderr}"
+    )
+
+
+def test_the_module_that_actually_broke_imports():
+    """The concrete regression: compiler.py does `from . import DEVICE_TYPE`."""
+    result = _run("import unsloth_zoo.compiler\nprint('ok')\n")
+    assert result.returncode == 0, (
+        "unsloth_zoo.compiler failed to import under "
+        f"UNSLOTH_ZOO_DISABLE_GPU_INIT=1:\n{result.stderr}"
+    )
+
+
+def test_importing_the_package_does_not_pull_in_torch():
+    """The skip stays a skip: torch is not imported until a constant is read.
+
+    Fails if the lazy resolver is ever replaced by a top-level
+    `from .device_type import ...`, which would pass every test above.
+    """
+    result = _run(
+        "import sys\n"
+        "import unsloth_zoo\n"
+        "print('torch' in sys.modules)\n"
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("False"), (
+        "importing unsloth_zoo under UNSLOTH_ZOO_DISABLE_GPU_INIT=1 pulled torch "
+        "into the process; the device constants are no longer resolved lazily and "
+        "the flag no longer skips the work it exists to skip"
+    )
+
+
+def test_reading_a_constant_is_what_pulls_torch_in():
+    """The other half of the pair, so the check above cannot pass vacuously."""
+    result = _run(
+        "import sys\n"
+        "import unsloth_zoo\n"
+        "unsloth_zoo.DEVICE_TYPE\n"
+        "print('torch' in sys.modules)\n"
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("True"), (
+        "reading unsloth_zoo.DEVICE_TYPE did not import torch, so the previous "
+        f"test proves nothing about laziness:\n{result.stdout}"
+    )
+
+
+def test_an_unknown_attribute_still_raises_attribute_error():
+    """The resolver is a narrow shim, not a catch-all that hides typos."""
+    result = _run(
+        "import unsloth_zoo\n"
+        "try:\n"
+        "    unsloth_zoo.NOT_A_REAL_NAME\n"
+        "except AttributeError:\n"
+        "    print('raised')\n"
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("raised"), result.stdout

--- a/tests/security/test_disable_gpu_init_device_constants.py
+++ b/tests/security/test_disable_gpu_init_device_constants.py
@@ -26,6 +26,7 @@ Everything runs in a subprocess: both properties are about what happens during
 
 from __future__ import annotations
 
+import ast
 import os
 import subprocess
 import sys
@@ -35,8 +36,59 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+INIT_PY = REPO_ROOT / "unsloth_zoo" / "__init__.py"
 
 _NAMES = ("DEVICE_TYPE", "DEVICE_TYPE_TORCH", "DEVICE_COUNT", "ALLOW_PREQUANTIZED_MODELS")
+
+
+def _public_upper_names(body) -> set:
+    """Module-level UPPER_CASE names bound by a branch of `__init__.py`.
+
+    Descends into nested `if`s, because those still bind at module level when
+    the branch is taken, but not into `def`/`class`, whose locals do not.
+    """
+    found = set()
+    stack = list(body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id.isupper():
+                    found.add(target.id)
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                name = alias.asname or alias.name
+                if name.isupper():
+                    found.add(name)
+        stack.extend(ast.iter_child_nodes(node))
+    return {name for name in found if not name.startswith("_")}
+
+
+def _cross_path_contract() -> set:
+    """Names that BOTH the MLX branch and the normal path bind at module level.
+
+    A name bound on only one path is that path's private business:
+    `UNSLOTH_ZOO_IS_PRESENT` is MLX-only (the normal path sets just the
+    environment variable), `IS_HIP_RUNTIME` and the torch-version flags are
+    normal-only. Neither kind is read off the package root anywhere. The
+    intersection is the set every path genuinely promises, and it is therefore
+    the set the skip path has to keep reachable.
+    """
+    tree = ast.parse(INIT_PY.read_text(encoding = "utf-8"))
+    mlx, normal = set(), set()
+    for node in tree.body:
+        if not isinstance(node, ast.If):
+            continue
+        test = ast.unparse(node.test)
+        if "_is_mlx_only" in test:
+            mlx |= _public_upper_names(node.body)
+        elif test == "not _SKIP_GPU_INIT":
+            normal |= _public_upper_names(node.body)
+    assert mlx, "could not find the MLX branch in __init__.py; this test needs rewriting"
+    assert normal, "could not find the normal branch in __init__.py; this test needs rewriting"
+    return mlx & normal
 
 
 def _run(code: str) -> subprocess.CompletedProcess:
@@ -120,3 +172,42 @@ def test_an_unknown_attribute_still_raises_attribute_error():
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip().endswith("raised"), result.stdout
+
+
+def test_the_skip_path_covers_every_name_the_other_two_paths_promise():
+    """The contract is DERIVED from `__init__.py`, not restated here.
+
+    The bug this file exists for was a hardcoded assumption about which names
+    the skip path needs, made in a workflow comment in #1089 and falsified
+    three days later by an ordinary new test in #1108. Hardcoding the same
+    assumption in the resolver would leave the identical trap: add a fifth
+    constant to the MLX branch and the normal path, and the skip path silently
+    lacks it again with nothing to notice.
+
+    So this reads the three branches out of the source. If the cross-path
+    contract grows, this fails until the resolver is extended to match.
+    """
+    contract = _cross_path_contract()
+    assert contract == set(_NAMES), (
+        f"the set of names bound by BOTH the MLX branch and the normal path is "
+        f"{sorted(contract)}, but this suite checks {sorted(_NAMES)}. Extend the "
+        f"lazy resolver in unsloth_zoo/__init__.py and _NAMES here to match, or "
+        f"the skip path is short a name that every other path defines."
+    )
+
+
+def test_every_contract_name_actually_resolves_under_the_skip():
+    """Derivation is worth nothing if nothing checks it against a live import."""
+    names = sorted(_cross_path_contract())
+    code = (
+        "import unsloth_zoo\n"
+        f"for name in {names!r}:\n"
+        "    getattr(unsloth_zoo, name)\n"
+        "print('all resolved')\n"
+    )
+    result = _run(code)
+    assert result.returncode == 0, (
+        f"one of {names} did not resolve under UNSLOTH_ZOO_DISABLE_GPU_INIT=1:\n"
+        f"{result.stderr}"
+    )
+    assert result.stdout.strip().endswith("all resolved"), result.stdout

--- a/tests/security/test_disable_gpu_init_device_constants.py
+++ b/tests/security/test_disable_gpu_init_device_constants.py
@@ -3,25 +3,16 @@
 
 """`UNSLOTH_ZOO_DISABLE_GPU_INIT=1` must leave the package fully defined.
 
-This lane sets that flag (see `.github/workflows/security-audit.yml`) so
-`import unsloth_zoo` skips the device init that would otherwise demand
-`unsloth` be installed in a supply-chain-hygiene job. The skip branch used to
-define none of the four device constants that the MLX branch defines eagerly
-and the normal path imports from `.device_type`, so `from unsloth_zoo import
-DEVICE_TYPE` raised ImportError -- which `unsloth_zoo/compiler.py` does at
-import time, taking `test_compile_model_type_sink_guard.py` out at COLLECTION.
-A whole security test module stopped running and the lane reported it as one
-red rather than as missing coverage.
+The security-audit lane sets that flag, and the skip branch used to define none
+of the four device constants, so `from . import DEVICE_TYPE` in compiler.py
+raised at import time and took a whole security module out at COLLECTION.
 
-Two properties, and the second is the one that rots quietly. The constants have
-to be reachable, and reaching them has to stay lazy: resolving `.device_type`
-costs ~1.4s and pulls torch into the process, and the download-only child that
-this flag exists for never reads one. Someone "simplifying" the resolver into a
-top-level import would satisfy the first test and silently undo the reason the
-flag is there at all, so the torch check below is not decoration.
+Two properties: the constants must be reachable, and reaching them must stay
+lazy (`.device_type` costs ~1.4s and pulls in torch, and the download-only child
+this flag exists for never reads one). Hence the torch checks below.
 
-Everything runs in a subprocess: both properties are about what happens during
-`import unsloth_zoo`, and this process has already imported it.
+Everything runs in a subprocess, since both properties are about what happens
+during `import unsloth_zoo` and this process already imported it.
 """
 
 from __future__ import annotations
@@ -44,15 +35,12 @@ _NAMES = ("DEVICE_TYPE", "DEVICE_TYPE_TORCH", "DEVICE_COUNT", "ALLOW_PREQUANTIZE
 def _public_upper_names(body) -> set:
     """Module-level UPPER_CASE names bound by a branch of `__init__.py`.
 
-    Descends into nested `if`s, because those still bind at module level when
-    the branch is taken, but not into `def`/`class`, whose locals do not.
+    Descends into nested `if`s (still module-level bindings) but not `def`/`class`.
 
-    Annotated assignment counts. `device_type.py` declares these very constants
-    as `DEVICE_TYPE : str = get_device_type()`, so a fifth one arriving in the
-    MLX branch in that style is the likely shape, and reading only `ast.Assign`
-    would miss it, shrink the intersection back to four and let this file pass
-    while the skip path is short a name. Unpacked targets count for the same
-    reason. A bare `X: int` with no value only annotates and binds nothing.
+    Annotated assignment and unpacked targets count: `device_type.py` uses
+    `DEVICE_TYPE : str = ...`, and a binding form we miss shrinks the
+    intersection, letting the contract test pass while the skip path is short a
+    name. A bare `X: int` with no value binds nothing.
     """
     found = set()
     stack = list(body)
@@ -81,12 +69,10 @@ def _public_upper_names(body) -> set:
 def _cross_path_contract() -> set:
     """Names that BOTH the MLX branch and the normal path bind at module level.
 
-    A name bound on only one path is that path's private business:
-    `UNSLOTH_ZOO_IS_PRESENT` is MLX-only (the normal path sets just the
-    environment variable), `IS_HIP_RUNTIME` and the torch-version flags are
-    normal-only. Neither kind is read off the package root anywhere. The
-    intersection is the set every path genuinely promises, and it is therefore
-    the set the skip path has to keep reachable.
+    A name bound on only one path (`UNSLOTH_ZOO_IS_PRESENT` is MLX-only,
+    `IS_HIP_RUNTIME` normal-only) is that path's private business and is not read
+    off the package root. The intersection is what every path promises, so it is
+    what the skip path has to keep reachable.
     """
     tree = ast.parse(INIT_PY.read_text(encoding = "utf-8"))
     mlx, normal = set(), set()
@@ -106,8 +92,8 @@ def _cross_path_contract() -> set:
 def _run(code: str) -> subprocess.CompletedProcess:
     env = dict(os.environ)
     env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
-    # A CI runner has no accelerator; this is the sentinel `get_device_type`
-    # already honours, and is what `tests/conftest.py` sets for the same reason.
+    # CI runners have no accelerator; `get_device_type` honours this sentinel,
+    # and `tests/conftest.py` sets it for the same reason.
     env.setdefault("UNSLOTH_ALLOW_CPU", "1")
     env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
     return subprocess.run(
@@ -142,8 +128,8 @@ def test_the_module_that_actually_broke_imports():
 def test_importing_the_package_does_not_pull_in_torch():
     """The skip stays a skip: torch is not imported until a constant is read.
 
-    Fails if the lazy resolver is ever replaced by a top-level
-    `from .device_type import ...`, which would pass every test above.
+    Fails if the lazy resolver becomes a top-level `from .device_type import
+    ...`, which would pass every test above.
     """
     result = _run(
         "import sys\n"
@@ -189,15 +175,9 @@ def test_an_unknown_attribute_still_raises_attribute_error():
 def test_the_skip_path_covers_every_name_the_other_two_paths_promise():
     """The contract is DERIVED from `__init__.py`, not restated here.
 
-    The bug this file exists for was a hardcoded assumption about which names
-    the skip path needs, made in a workflow comment in #1089 and falsified
-    three days later by an ordinary new test in #1108. Hardcoding the same
-    assumption in the resolver would leave the identical trap: add a fifth
-    constant to the MLX branch and the normal path, and the skip path silently
-    lacks it again with nothing to notice.
-
-    So this reads the three branches out of the source. If the cross-path
-    contract grows, this fails until the resolver is extended to match.
+    A hardcoded list of names is the trap that caused the original bug: add a
+    fifth constant to the MLX branch and the normal path, and the skip path
+    silently lacks it. Reading the branches from source fails loudly instead.
     """
     contract = _cross_path_contract()
     assert contract == set(_NAMES), (
@@ -221,9 +201,8 @@ def test_the_skip_path_covers_every_name_the_other_two_paths_promise():
 def test_the_contract_parser_sees_every_shape_a_constant_can_arrive_in(snippet):
     """The derivation is only as good as the binding forms it recognises.
 
-    A form it cannot see shrinks the intersection instead of growing it, so the
-    contract test passes while the skip path is missing a name -- the exact
-    failure mode this file was written to close.
+    A missed form shrinks the intersection rather than growing it, so the
+    contract test passes while the skip path is missing a name.
     """
     assert "NEW_CONST" in _public_upper_names(ast.parse(snippet).body), snippet
 

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -545,30 +545,19 @@ if not _SKIP_GPU_INIT:
     del os, warnings, re
 
 
-# Device constants under UNSLOTH_ZOO_DISABLE_GPU_INIT.
+# Device constants under UNSLOTH_ZOO_DISABLE_GPU_INIT. The MLX branch sets these
+# four eagerly and the normal path imports them from `.device_type`; the skip
+# branch did neither, so `from . import DEVICE_TYPE` (compiler.py) raised.
 #
-# The MLX branch near the top sets these four eagerly, and the normal path
-# imports them from `.device_type`. The opt-in skip branch did neither, so
-# `from unsloth_zoo import DEVICE_TYPE` raised ImportError there -- and
-# `unsloth_zoo/compiler.py` does exactly that on line 58, which is how the
-# security-audit lane lost `tests/security/test_compile_model_type_sink_guard.py`
-# at collection. The skip was only ever meant to defer work, not to leave the
-# package half-defined.
+# Lazy, not a top-level import: `.device_type` costs ~1.4s and pulls in torch,
+# and the download-only child the flag exists for never reads a constant.
 #
-# Resolved lazily rather than eagerly on purpose: importing `.device_type`
-# costs ~1.4s and pulls torch into the process, and the download-only child
-# (hf_xet_fallback) that the flag exists for never reads one of these. Import
-# stays at ~20ms for that child and the constants are still there for anything
-# that actually asks.
+# PEP 562: __getattr__ runs only when normal lookup fails, so the MLX and normal
+# paths, where all four are real globals, are unaffected.
 #
-# PEP 562 semantics: consulted only when normal attribute lookup fails, so on
-# the MLX and normal paths -- where all four are real globals -- this never
-# runs, and `from . import DEVICE_TYPE` goes through it unchanged.
-#
-# No CPU fallback here. A driverless host is expected to opt in with
-# UNSLOTH_ALLOW_CPU=1, which `get_device_type` already honours by returning the
-# "cuda" sentinel; inventing a "cpu" value instead would fall through every
-# branch in compiler.py, none of which has a cpu arm.
+# No "cpu" fallback: compiler.py has cuda/hip/xpu arms only, so "cpu" would fall
+# through all three. Driverless hosts opt in with UNSLOTH_ALLOW_CPU=1, which
+# `get_device_type` honours by returning the "cuda" sentinel.
 _LAZY_DEVICE_CONSTANTS = frozenset((
     "DEVICE_TYPE",
     "DEVICE_TYPE_TORCH",

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -543,3 +543,44 @@ if not _SKIP_GPU_INIT:
         pass
 
     del os, warnings, re
+
+
+# Device constants under UNSLOTH_ZOO_DISABLE_GPU_INIT.
+#
+# The MLX branch near the top sets these four eagerly, and the normal path
+# imports them from `.device_type`. The opt-in skip branch did neither, so
+# `from unsloth_zoo import DEVICE_TYPE` raised ImportError there -- and
+# `unsloth_zoo/compiler.py` does exactly that on line 58, which is how the
+# security-audit lane lost `tests/security/test_compile_model_type_sink_guard.py`
+# at collection. The skip was only ever meant to defer work, not to leave the
+# package half-defined.
+#
+# Resolved lazily rather than eagerly on purpose: importing `.device_type`
+# costs ~1.4s and pulls torch into the process, and the download-only child
+# (hf_xet_fallback) that the flag exists for never reads one of these. Import
+# stays at ~20ms for that child and the constants are still there for anything
+# that actually asks.
+#
+# PEP 562 semantics: consulted only when normal attribute lookup fails, so on
+# the MLX and normal paths -- where all four are real globals -- this never
+# runs, and `from . import DEVICE_TYPE` goes through it unchanged.
+#
+# No CPU fallback here. A driverless host is expected to opt in with
+# UNSLOTH_ALLOW_CPU=1, which `get_device_type` already honours by returning the
+# "cuda" sentinel; inventing a "cpu" value instead would fall through every
+# branch in compiler.py, none of which has a cpu arm.
+_LAZY_DEVICE_CONSTANTS = frozenset((
+    "DEVICE_TYPE",
+    "DEVICE_TYPE_TORCH",
+    "DEVICE_COUNT",
+    "ALLOW_PREQUANTIZED_MODELS",
+))
+
+
+def __getattr__(name):
+    if name not in _LAZY_DEVICE_CONSTANTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from . import device_type as _device_type
+    value = getattr(_device_type, name)
+    globals()[name] = value # resolve once; later lookups skip __getattr__
+    return value


### PR DESCRIPTION
## The lane was not just red, it was missing 43 tests

`Security audit` on main fails, and the failure is a **collection error**, not an assertion:

```
ERROR collecting tests/security/test_compile_model_type_sink_guard.py
unsloth_zoo/compiler.py:58: in <module>
    from . import DEVICE_TYPE
E   ImportError: cannot import name 'DEVICE_TYPE' from 'unsloth_zoo'
```

pytest reports that as one red. What it actually means is that a whole security test module never ran. Those 43 tests are the ones guarding `unsloth_compile_transformers` and `create_new_function` against a `model_type` string reaching an import path or a file write outside the compiled cache, added in #1108. They have not executed on CI since.

## Why the name is missing

`security-audit.yml` sets `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` (added in #1089) so `import unsloth_zoo` skips the device init that ends in `find_spec("unsloth") is None -> ImportError`, which is the only reason a supply-chain-hygiene job would need `unsloth` installed. That reasoning is still correct and the flag stays.

The problem is what the skip branch leaves behind. `__init__.py` has three paths:

| path | `DEVICE_TYPE` and friends |
| --- | --- |
| MLX | set eagerly, all four |
| normal | imported from `.device_type`, all four |
| `UNSLOTH_ZOO_DISABLE_GPU_INIT=1` | **none of them** |

So the skip left the package half-defined. It was meant to defer work, not to remove names. The flag's own comment promises the stubbed imports resolve to "a loud no-op instead of a hard ImportError", and that promise was kept for triton and bitsandbytes but not for the device constants.

Only four names are read off the package root by other modules (`DEVICE_TYPE`, `DEVICE_TYPE_TORCH`, `DEVICE_COUNT`, `ALLOW_PREQUANTIZED_MODELS`), so the fix is narrow.

## Two obvious fixes that are both wrong

**Import `.device_type` eagerly in the skip branch.** Measured on this tree:

```
import unsloth_zoo (skip path):   22 ms,  torch loaded: False
+ from .device_type import ...  1382 ms,  torch loaded: True
```

That is precisely the work the flag exists to skip for the download-only `hf_xet_fallback` child, which never reads one of these constants. So the resolver is lazy (PEP 562 module `__getattr__`), and import stays at ~20 ms for that child.

**Define `DEVICE_TYPE = "cpu"`.** `compiler.py` branches on `cuda`, `hip` and `xpu` and has no cpu arm, so a "cpu" value would fall through all three silently. This repo already has a convention for a driverless host: `UNSLOTH_ALLOW_CPU=1`, which `get_device_type` honours by returning the `"cuda"` sentinel, and which `tests/conftest.py` sets at module scope before collection. Nothing new is needed and the workflow is unchanged.

## The change

`unsloth_zoo/__init__.py` gains a module-level `__getattr__` that resolves those four names from `.device_type` on first read and caches into `globals()`. PEP 562 only consults it when normal lookup fails, so on the MLX and normal paths, where all four are real globals, it never runs and nothing about those paths changes. Anything not in the set still raises `AttributeError`, so it does not become a catch-all that hides typos.

## Tests

`tests/security/test_disable_gpu_init_device_constants.py`, 8 tests, all in subprocesses since both properties are about what happens during `import unsloth_zoo`.

The laziness pair is the point. `test_importing_the_package_does_not_pull_in_torch` would pass vacuously on its own, so it is paired with `test_reading_a_constant_is_what_pulls_torch_in`. Together they fail if anyone ever replaces the resolver with a top-level `from .device_type import ...`, which would satisfy every other test here while silently undoing the reason the flag exists.

## Evidence

Run driverless (`CUDA_VISIBLE_DEVICES=""`) with the flag set, as the runner does.

```
tests/security/test_compile_model_type_sink_guard.py    43 passed
tests/security/test_disable_gpu_init_device_constants.py 8 passed
tests/security (whole lane)                            103 passed in 366s
```

Mutation-tested rather than trusted. With the `__init__.py` change reverted from a byte snapshot:

```
ERROR tests/security/test_compile_model_type_sink_guard.py
Interrupted: 1 error during collection
6 failed, 2 passed
```

and restored (md5 verified identical to the snapshot) all 8 pass again. The 2 that pass under revert are the laziness check, vacuously true when nothing resolves at all, and the `AttributeError` check, which the default lookup satisfies. That is exactly the hole the paired positive test covers.

## Not in scope

The other main red, `Core drift (3 upstream pins)` on `Tests CI`, is unrelated (transformers 5.16.1 moved `mxfp4` symbols) and is being handled separately.
