### PR TITLE
Lint: close the bypasses found after #1108, and restructure the checker

### DIFF
--- a/scripts/dynamic_exec_allowlist.json
+++ b/scripts/dynamic_exec_allowlist.json
@@ -188,6 +188,14 @@
     {
       "path": "unsloth_zoo/compiler.py",
       "qualname": "unsloth_compile_transformers",
+      "sink": "eval",
+      "kind": "f-string via `model_location` through create_new_function()",
+      "hash": "c946cc38b4163e28",
+      "reason": "`model_location` is built one screen above as f\"transformers.models.{model_type}.modeling_{model_type}\", and `model_type` is rejected here unless it matches [a-z0-9_]+ before that line runs; the eval inside create_new_function only resolves that module name."
+    },
+    {
+      "path": "unsloth_zoo/compiler.py",
+      "qualname": "unsloth_compile_transformers",
       "sink": "exec",
       "kind": "string concatenation",
       "hash": "ffa18102ffbe15dd",
@@ -235,7 +243,7 @@
       "kind": ".join() via `source` via `source` via `source`",
       "hash": "7a5e305efb369e7f",
       "reason": "Self-generated source: `source` is `inspect.getsource` of the INSTALLED torch._dynamo.compiled_autograd function, with literal replacements applied, and the import list is built from `dir()` of that same installed module. No value from a config, a download or the environment reaches either string.",
-      "origin": "5b0eb651+addd479f",
+      "origin": "7a303ade",
       "count": 2
     },
     {
@@ -312,7 +320,7 @@
       "kind": "string concatenation via `save_pretrained` via `save_pretrained` via `save_pretrained`",
       "hash": "b9fff86a8c82eb0d",
       "reason": "Self-generated source: `save_pretrained` is `inspect.getsource` of the installed transformers method with two literal renames applied. The one external pair, `repo_id` and `revision` in `incremental_save_pretrained`, goes through `repr` before it is formatted in.",
-      "origin": "94841545"
+      "origin": "a658f03b"
     },
     {
       "path": "unsloth_zoo/temporary_patches/misc.py",

--- a/scripts/dynamic_exec_allowlist.json
+++ b/scripts/dynamic_exec_allowlist.json
@@ -127,7 +127,8 @@
       "sink": "exec",
       "kind": "f-string",
       "hash": "002343bd43161592",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
+      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint.",
+      "origin": "3eadeb9f"
     },
     {
       "path": "unsloth_zoo/compiler.py",
@@ -135,7 +136,8 @@
       "sink": "eval",
       "kind": "f-string",
       "hash": "03e6d133b778a53e",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
+      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint.",
+      "origin": "3eadeb9f"
     },
     {
       "path": "unsloth_zoo/compiler.py",
@@ -143,7 +145,8 @@
       "sink": "exec",
       "kind": "f-string",
       "hash": "07325163fcae29ba",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
+      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint.",
+      "origin": "3eadeb9f"
     },
     {
       "path": "unsloth_zoo/compiler.py",
@@ -152,6 +155,7 @@
       "kind": "f-string",
       "hash": "41335056252b5222",
       "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint.",
+      "origin": "3eadeb9f",
       "count": 9
     },
     {
@@ -169,7 +173,8 @@
       "sink": "exec",
       "kind": "f-string",
       "hash": "aec8dc650544d15a",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
+      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint.",
+      "origin": "3eadeb9f"
     },
     {
       "path": "unsloth_zoo/compiler.py",
@@ -177,7 +182,8 @@
       "sink": "eval",
       "kind": "f-string",
       "hash": "b4ffe1845a490edc",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
+      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint.",
+      "origin": "3eadeb9f"
     },
     {
       "path": "unsloth_zoo/compiler.py",
@@ -193,7 +199,8 @@
       "sink": "exec",
       "kind": "f-string via `source`",
       "hash": "3725bba562bb6fff",
-      "reason": "Both operands are self-generated from the INSTALLED gguf package: `source` is inspect.getsource(GGUFReader.__init__) with one literal edit, and `functions` is dir(gguf.gguf_reader) filtered to names that appear in that source. Nothing downloaded or user supplied reaches either."
+      "reason": "Both operands are self-generated from the INSTALLED gguf package: `source` is inspect.getsource(GGUFReader.__init__) with one literal edit, and `functions` is dir(gguf.gguf_reader) filtered to names that appear in that source. Nothing downloaded or user supplied reaches either.",
+      "origin": "6cab0fdc"
     },
     {
       "path": "unsloth_zoo/llama_cpp.py",
@@ -201,7 +208,8 @@
       "sink": "exec",
       "kind": "f-string via `functions`",
       "hash": "7330700d494b9249",
-      "reason": "Both operands are self-generated from the INSTALLED gguf package: `source` is inspect.getsource(GGUFReader.__init__) with one literal edit, and `functions` is dir(gguf.gguf_reader) filtered to names that appear in that source. Nothing downloaded or user supplied reaches either."
+      "reason": "Both operands are self-generated from the INSTALLED gguf package: `source` is inspect.getsource(GGUFReader.__init__) with one literal edit, and `functions` is dir(gguf.gguf_reader) filtered to names that appear in that source. Nothing downloaded or user supplied reaches either.",
+      "origin": "8cd5eb16"
     },
     {
       "path": "unsloth_zoo/patching_utils.py",
@@ -209,7 +217,8 @@
       "sink": "exec",
       "kind": "f-string",
       "hash": "70146d03d161750a",
-      "reason": "Imports names selected by `x in source` from dir(transformers.integrations.bitsandbytes), i.e. attributes of the installed transformers."
+      "reason": "Imports names selected by `x in source` from dir(transformers.integrations.bitsandbytes), i.e. attributes of the installed transformers.",
+      "origin": "0f013019"
     },
     {
       "path": "unsloth_zoo/patching_utils.py",
@@ -226,6 +235,7 @@
       "kind": ".join() via `source` via `source` via `source`",
       "hash": "7a5e305efb369e7f",
       "reason": "Self-generated source: `source` is `inspect.getsource` of the INSTALLED torch._dynamo.compiled_autograd function, with literal replacements applied, and the import list is built from `dir()` of that same installed module. No value from a config, a download or the environment reaches either string.",
+      "origin": "5b0eb651+addd479f",
       "count": 2
     },
     {
@@ -242,7 +252,8 @@
       "sink": "exec",
       "kind": "f-string",
       "hash": "45bbd24d7d803e73",
-      "reason": "`item` is 'peft.tuners.lora.' plus a filename stem from os.listdir of the installed peft package; `modules` is dir() filtered to Linear-ish names."
+      "reason": "`item` is 'peft.tuners.lora.' plus a filename stem from os.listdir of the installed peft package; `modules` is dir() filtered to Linear-ish names.",
+      "origin": "a43c9531"
     },
     {
       "path": "unsloth_zoo/peft_utils.py",
@@ -250,7 +261,8 @@
       "sink": "eval",
       "kind": "f-string via `item`",
       "hash": "81cdac2f6f8a2c32",
-      "reason": "`item` is `peft.tuners.lora.<file>` where <file> is a .py filename listed from the INSTALLED peft package directory, and `modules` is dir() of that module filtered to Linear* names. Both are properties of the installed dependency."
+      "reason": "`item` is `peft.tuners.lora.<file>` where <file> is a .py filename listed from the INSTALLED peft package directory, and `modules` is dir() of that module filtered to Linear* names. Both are properties of the installed dependency.",
+      "origin": "a43c9531"
     },
     {
       "path": "unsloth_zoo/peft_utils.py",
@@ -258,7 +270,8 @@
       "sink": "exec",
       "kind": "f-string",
       "hash": "d467bcd0b437db95",
-      "reason": "`item` is 'peft.tuners.lora.' plus a filename stem from os.listdir of the installed peft package; `modules` is dir() filtered to Linear-ish names."
+      "reason": "`item` is 'peft.tuners.lora.' plus a filename stem from os.listdir of the installed peft package; `modules` is dir() filtered to Linear-ish names.",
+      "origin": "a43c9531"
     },
     {
       "path": "unsloth_zoo/peft_utils.py",
@@ -298,7 +311,8 @@
       "sink": "exec",
       "kind": "string concatenation via `save_pretrained` via `save_pretrained` via `save_pretrained`",
       "hash": "b9fff86a8c82eb0d",
-      "reason": "Self-generated source: `save_pretrained` is `inspect.getsource` of the installed transformers method with two literal renames applied. The one external pair, `repo_id` and `revision` in `incremental_save_pretrained`, goes through `repr` before it is formatted in."
+      "reason": "Self-generated source: `save_pretrained` is `inspect.getsource` of the installed transformers method with two literal renames applied. The one external pair, `repo_id` and `revision` in `incremental_save_pretrained`, goes through `repr` before it is formatted in.",
+      "origin": "94841545"
     },
     {
       "path": "unsloth_zoo/temporary_patches/misc.py",
@@ -314,7 +328,8 @@
       "sink": "exec",
       "kind": "string concatenation via `source`",
       "hash": "7a5e305efb369e7f",
-      "reason": "`source` is inspect.getsource of the installed transformers quantizer method, reindented and with the classmethod `cls` parameter stripped. Self-generated source, same category as the compiler sites."
+      "reason": "`source` is inspect.getsource of the installed transformers quantizer method, reindented and with the classmethod `cls` parameter stripped. Self-generated source, same category as the compiler sites.",
+      "origin": "d383e04a"
     },
     {
       "path": "unsloth_zoo/vllm_utils.py",

--- a/scripts/dynamic_exec_allowlist.json
+++ b/scripts/dynamic_exec_allowlist.json
@@ -320,7 +320,7 @@
       "kind": "string concatenation via `save_pretrained` via `save_pretrained` via `save_pretrained`",
       "hash": "b9fff86a8c82eb0d",
       "reason": "Self-generated source: `save_pretrained` is `inspect.getsource` of the installed transformers method with two literal renames applied. The one external pair, `repo_id` and `revision` in `incremental_save_pretrained`, goes through `repr` before it is formatted in.",
-      "origin": "a658f03b"
+      "origin": "a658f03b+afd58bef"
     },
     {
       "path": "unsloth_zoo/temporary_patches/misc.py",

--- a/scripts/dynamic_exec_allowlist.json
+++ b/scripts/dynamic_exec_allowlist.json
@@ -301,6 +301,22 @@
       "path": "unsloth_zoo/patching_utils.py",
       "qualname": "patch_compiled_autograd",
       "sink": "exec",
+      "kind": ".join() via `source` via `source` via `source`",
+      "hash": "7a5e305efb369e7f",
+      "reason": "Self-generated source: `source` is `inspect.getsource` of the INSTALLED torch._dynamo.compiled_autograd function, with literal replacements applied, and the import list is built from `dir()` of that same installed module. No value from a config, a download or the environment reaches either string."
+    },
+    {
+      "path": "unsloth_zoo/patching_utils.py",
+      "qualname": "patch_compiled_autograd",
+      "sink": "exec",
+      "kind": ".join() via `source` via `source` via `source`",
+      "hash": "7a5e305efb369e7f",
+      "reason": "Self-generated source: `source` is `inspect.getsource` of the INSTALLED torch._dynamo.compiled_autograd function, with literal replacements applied, and the import list is built from `dir()` of that same installed module. No value from a config, a download or the environment reaches either string."
+    },
+    {
+      "path": "unsloth_zoo/patching_utils.py",
+      "qualname": "patch_compiled_autograd",
+      "sink": "exec",
       "kind": "string concatenation",
       "hash": "d5c91cdf1f94e789",
       "reason": "Imports names selected by `x in source` from dir() of the installed torch._dynamo modules being patched."
@@ -360,6 +376,14 @@
       "kind": "f-string",
       "hash": "691766359b82b093",
       "reason": "Imports names from dir(transformers.modeling_utils); the generated save_pretrained interpolates only output_dtype (checked against four torch dtypes above) and two ints."
+    },
+    {
+      "path": "unsloth_zoo/saving_utils.py",
+      "qualname": "merge_and_dequantize_lora",
+      "sink": "exec",
+      "kind": "string concatenation via `save_pretrained` via `save_pretrained` via `save_pretrained`",
+      "hash": "b9fff86a8c82eb0d",
+      "reason": "Self-generated source: `save_pretrained` is `inspect.getsource` of the installed transformers method with two literal renames applied. Nothing external is spliced in."
     },
     {
       "path": "unsloth_zoo/temporary_patches/misc.py",

--- a/scripts/dynamic_exec_allowlist.json
+++ b/scripts/dynamic_exec_allowlist.json
@@ -383,7 +383,7 @@
       "sink": "exec",
       "kind": "string concatenation via `save_pretrained` via `save_pretrained` via `save_pretrained`",
       "hash": "b9fff86a8c82eb0d",
-      "reason": "Self-generated source: `save_pretrained` is `inspect.getsource` of the installed transformers method with two literal renames applied. Nothing external is spliced in."
+      "reason": "Self-generated source: `save_pretrained` is `inspect.getsource` of the installed transformers method with two literal renames applied. The one external pair, `repo_id` and `revision` in `incremental_save_pretrained`, goes through `repr` before it is formatted in."
     },
     {
       "path": "unsloth_zoo/temporary_patches/misc.py",

--- a/scripts/dynamic_exec_allowlist.json
+++ b/scripts/dynamic_exec_allowlist.json
@@ -151,71 +151,8 @@
       "sink": "eval",
       "kind": "f-string",
       "hash": "41335056252b5222",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "41335056252b5222",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "41335056252b5222",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "41335056252b5222",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "41335056252b5222",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "41335056252b5222",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "41335056252b5222",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "41335056252b5222",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "41335056252b5222",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
+      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint.",
+      "count": 9
     },
     {
       "path": "unsloth_zoo/compiler.py",
@@ -223,23 +160,8 @@
       "sink": "eval",
       "kind": "f-string",
       "hash": "ae0dc524263f37f6",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "ae0dc524263f37f6",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
-    },
-    {
-      "path": "unsloth_zoo/compiler.py",
-      "qualname": "unsloth_compile_transformers",
-      "sink": "eval",
-      "kind": "f-string",
-      "hash": "ae0dc524263f37f6",
-      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint."
+      "reason": "`model_location` is built from `model_type`, re-validated against [a-z0-9_]+ at the top of this function (see PR #1083); `module` / `check` / `key` come from dir() of the imported modeling file or from class and dict regexes over its inspect.getsource. Nothing here is read from a downloaded config or checkpoint.",
+      "count": 3
     },
     {
       "path": "unsloth_zoo/compiler.py",
@@ -303,15 +225,8 @@
       "sink": "exec",
       "kind": ".join() via `source` via `source` via `source`",
       "hash": "7a5e305efb369e7f",
-      "reason": "Self-generated source: `source` is `inspect.getsource` of the INSTALLED torch._dynamo.compiled_autograd function, with literal replacements applied, and the import list is built from `dir()` of that same installed module. No value from a config, a download or the environment reaches either string."
-    },
-    {
-      "path": "unsloth_zoo/patching_utils.py",
-      "qualname": "patch_compiled_autograd",
-      "sink": "exec",
-      "kind": ".join() via `source` via `source` via `source`",
-      "hash": "7a5e305efb369e7f",
-      "reason": "Self-generated source: `source` is `inspect.getsource` of the INSTALLED torch._dynamo.compiled_autograd function, with literal replacements applied, and the import list is built from `dir()` of that same installed module. No value from a config, a download or the environment reaches either string."
+      "reason": "Self-generated source: `source` is `inspect.getsource` of the INSTALLED torch._dynamo.compiled_autograd function, with literal replacements applied, and the import list is built from `dir()` of that same installed module. No value from a config, a download or the environment reaches either string.",
+      "count": 2
     },
     {
       "path": "unsloth_zoo/patching_utils.py",

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -136,6 +136,16 @@ _MATCHSEQUENCE = _node_type("MatchSequence")
 # `memoryview(f"...".encode()).tobytes()` stopped one call short of the sink.
 _CONVERSIONS = ("encode", "decode", "tobytes")
 
+# How many positional arguments each conversion takes, from the CPython docs. Outside
+# its range the call raises before the sink: `"...".encode("utf-8", "strict", "extra")`
+# is a TypeError, and reporting it blocked CI on code that cannot run. `encode` and
+# `decode` document `encoding` and `errors` as keywords; `tobytes` documents `order`.
+_CONVERSION_ARITY = {
+    "encode": (0, 2, {"encoding", "errors"}),
+    "decode": (0, 2, {"encoding", "errors"}),
+    "tobytes": (0, 1, {"order"}),
+}
+
 # The dunder spellings of the conversions above. `f"...".__str__()` returns the same
 # string and `bytes.__str__` is not a conversion at all, so only the ones whose
 # receiver is the text itself are listed here.
@@ -913,6 +923,10 @@ def _split_piece_is_literal(inner: ast.Call, index_node) -> bool:
         else:
             break
     method = inner.func.attr
+    if method in ("partition", "rpartition") and not -3 <= index <= 2:
+        # Both always return a three-element tuple, so any other constant index is an
+        # `IndexError` before the sink and nothing is executed at all.
+        return True
     if method in ("partition", "rpartition"):
         if method == "partition" and index == 0:
             return separator.value in leading
@@ -949,6 +963,39 @@ def _interpolated_split_element(node, resolve = None, shadowed = None, resolve_a
     return _is_interpolated(inner.func.value, resolve, shadowed, resolve_alias)
 
 
+def _slice_keeps_interpolation(receiver: ast.AST, index: ast.Slice) -> bool:
+    """Whether a constant slice of a written-out f-string still holds its values."""
+    if not isinstance(receiver, ast.JoinedStr):
+        return False
+    if not any(isinstance(part, ast.FormattedValue) for part in receiver.values):
+        return False
+    if index.step is not None and _constant_integer(index.step) != 1:
+        return False
+    leading = trailing = 0
+    for part in receiver.values:
+        if isinstance(part, ast.Constant) and isinstance(part.value, str):
+            leading += len(part.value)
+        else:
+            break
+    for part in reversed(receiver.values):
+        if isinstance(part, ast.Constant) and isinstance(part.value, str):
+            trailing += len(part.value)
+        else:
+            break
+    lower = 0 if index.lower is None else _constant_integer(index.lower)
+    upper = 0 if index.upper is None else _constant_integer(index.upper)
+    if lower is None or upper is None:
+        return False
+    # The front cut has to stay inside the leading literal, and the back cut inside
+    # the trailing one. A positive upper bound counts from the front, which says
+    # nothing about where the values are, so it is left alone.
+    if lower < 0 or lower > leading:
+        return False
+    if index.upper is not None and not (-trailing <= upper < 0):
+        return False
+    return True
+
+
 def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
     """`exec(table[key])` where the container or the whole slice is readable."""
     # `exec([f"import {name}"][0])` and `exec({"s": f"..."}["s"])` pick the source
@@ -981,6 +1028,13 @@ def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias
             and _keeps_everything(node.slice.step, 1)
         ):
             return _is_interpolated(node.value, resolve, shadowed, resolve_alias)
+        # A partial slice of a written-out f-string can still contain the interpolated
+        # part: `f"import {name}#"[:-1]` drops the literal `#` and `f"Ximport {name}"[1:]`
+        # drops the literal `X`. Only when the cut is inside the receiver's own leading
+        # or trailing LITERAL run, which is decidable from the text; a cut that may
+        # reach into the spliced value, or a bound this cannot read, is still None.
+        if _slice_keeps_interpolation(node.value, node.slice):
+            return _is_interpolated(node.value, resolve, shadowed, resolve_alias)
         return None
     return _literal_element(node, resolve, shadowed, resolve_alias)
 
@@ -1002,6 +1056,25 @@ _REBOUND_FUNCTION_NAMES: set = set()
 
 # Helpers currently being resolved, so a recursive one cannot loop forever.
 _HELPER_STACK: set = set()
+
+# Decorators documented as handing the wrapped function's result back unchanged. Any
+# other decorator may return anything at all, and the body below it says nothing about
+# what the name ends up bound to.
+_RESULT_PRESERVING_DECORATORS = frozenset({
+    "cache", "lru_cache", "wraps", "staticmethod", "classmethod", "final",
+    "override", "no_type_check", "cached_property",
+})
+
+
+def _decorator_name(node: ast.AST) -> str:
+    """The bare name of a decorator, however it is qualified or called."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return ""
 
 
 def _returned_expressions(definition) -> list:
@@ -1920,6 +1993,15 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             # receiver; a bytes-producing one still preserves the source.
             return None
         if function.attr in _CONVERSIONS:
+            unbound = _constructor_name(function.value, shadowed, resolve_alias) is not None
+            low, high, keywords = _CONVERSION_ARITY[function.attr]
+            if unbound:
+                low, high = low + 1, high + 1
+            spelled = [keyword.arg for keyword in node.keywords]
+            if None not in spelled:
+                if set(spelled) - keywords or not low <= len(node.args) + len(spelled) <= high:
+                    # The conversion raises before the sink runs.
+                    return None
             # `str.encode(s)` is the unbound descriptor spelling of `s.encode()`.
             # There the source is the first argument and the receiver is the type,
             # so unwrapping the receiver looked at the name `str` and found nothing.
@@ -2379,6 +2461,20 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
             recorded = aliases(path)
             if recorded:
                 return recorded
+    if isinstance(function, ast.Call):
+        # `def runner(): return exec` then `runner()(f"...")` calls what the helper
+        # hands back, and that is written out in the file. Same table the source side
+        # reads, same guards: a `def` bound to nothing else, and a recursion stack.
+        helper = _visible_helper(function.func, shadowed)
+        if helper is not None and helper.name not in _HELPER_STACK:
+            _HELPER_STACK.add(helper.name)
+            try:
+                for value in _returned_expressions(helper):
+                    resolved = _sink_name(value, aliases, shadowed)
+                    if resolved is not None:
+                        return resolved
+            finally:
+                _HELPER_STACK.discard(helper.name)
     if isinstance(function, ast.Call) and isinstance(function.func, ast.Lambda):
         # `(lambda run: run)(exec)(f"...")` calls whatever the lambda hands back, which
         # is written out right here. The source side already binds arguments to
@@ -2696,6 +2792,16 @@ def _nullcontext_value(node: ast.AST, aliases = None, shadowed = None) -> ast.AS
             return None
         return node.args[0]
     return None
+
+
+def _callee_spelling(call: ast.Call) -> str:
+    """The bare name of a call's callee, for the reason string."""
+    function = call.func
+    if isinstance(function, ast.Attribute):
+        return function.attr
+    if isinstance(function, ast.Name):
+        return function.id
+    return "map"
 
 
 def _boolop_candidates(node: ast.BoolOp) -> list:
@@ -3243,6 +3349,11 @@ class _Visitor(ast.NodeVisitor):
         # when a nested body is entered, since that body runs after the whole
         # enclosing scope has. Filled in by the caller for the module level.
         self.future_taint: list[dict] = [{}]
+        # `(qualname, name) -> digest of the expression that put built source there`.
+        # A finding whose source is built one line above the sink carries it, so an
+        # edit to that line stops matching the reviewed entry even though the sink
+        # call itself is untouched.
+        self.origin_of: dict = {}
 
     def _visible_scopes(self):
         """Scope indices a name lookup here may consult, innermost first.
@@ -3666,12 +3777,13 @@ class _Visitor(ast.NodeVisitor):
                         element_reason,
                         numeric = _visibly_numeric(item),
                         literal_text = _literal_text_of(item) if element_reason is None else False,
+                        origin = item,
                     )
                     self._bind_unpacked(element, item)
                     self._shadow_assignment(element, item)
                 continue
             self.visit(target)
-            self._bind(target, reason, numeric, literal_text)
+            self._bind(target, reason, numeric, literal_text, origin = node.value)
             self._bind_unpacked(target, node.value)
             self._shadow_assignment(target, node.value)
             self._bind_container_elements(target, node.value)
@@ -3702,11 +3814,6 @@ class _Visitor(ast.NodeVisitor):
                         continue
                     pairs.append((key.value, item))
         for index, item in pairs:
-            element_reason = _is_interpolated(
-                item, self.tainted[-1].get, self._is_shadowed, self._alias,
-            )
-            if element_reason is None or isinstance(element_reason, _LiteralText):
-                continue
             path = "path>" + ast.unparse(
                 ast.Subscript(
                     value = ast.Name(id = target.id, ctx = ast.Load()),
@@ -3714,7 +3821,26 @@ class _Visitor(ast.NodeVisitor):
                     ctx = ast.Load(),
                 )
             )
-            self.tainted[-1][path] = element_reason
+            # A sink stored in the container is recorded too: `runners = [exec]` makes
+            # `runners[0](f"...")` the builtin, exactly as `table["run"] = exec` does.
+            resolved = _sink_name(item, self._alias, self._is_shadowed)
+            if resolved is not None:
+                for table in (self.sink_aliases, self.collected_aliases):
+                    table[-1][path] = resolved.rpartition(".")[2]
+            element_reason = _is_interpolated(
+                item, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
+            if element_reason is not None and not isinstance(element_reason, _LiteralText):
+                self.tainted[-1][path] = element_reason
+                continue
+            # A container INSIDE the container is addressable too:
+            # `payloads = {"run": [f"..."]}` reaches the f-string at
+            # `payloads["run"][0]`, and stopping at the outer item dropped it. The
+            # nested paths are spelled by recursing with the path built so far.
+            if isinstance(item, (ast.List, ast.Tuple, ast.Dict)):
+                self._bind_container_elements(
+                    ast.Name(id = path[len("path>"):], ctx = ast.Store()), item,
+                )
 
     def visit_AnnAssign(self, node: ast.AnnAssign):
         """Same tracking for `payload: str = f"...{x}..."`.
@@ -4660,8 +4786,15 @@ class _Visitor(ast.NodeVisitor):
 
     def _bind(
         self, target: ast.AST, reason: str | None, numeric: bool = False,
-        literal_text = False,
+        literal_text = False, origin = None,
     ) -> None:
+        if origin is not None:
+            key = target.id if isinstance(target, ast.Name) else _compound_key(target)
+            if key is not None:
+                if reason is None or isinstance(reason, _LiteralText):
+                    self.origin_of.pop((self._qualname(), key), None)
+                else:
+                    self.origin_of[(self._qualname(), key)] = _expression_digest(origin)
         if not isinstance(target, ast.Name):
             # `self.payload = f"import {name}"` then `exec(self.payload)` executes the
             # source, and dropping every non-name target lost it. The written-out path
@@ -4769,6 +4902,16 @@ class _Visitor(ast.NodeVisitor):
     def _record_local_class(self, statement) -> None:
         """`class Safe:` makes `Safe()` a receiver whose methods are not string ones."""
         if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if any(
+                _decorator_name(decorator) not in _RESULT_PRESERVING_DECORATORS
+                for decorator in statement.decorator_list
+            ):
+                # A decorator replaces what the name binds, and what it returns need
+                # not be this body at all: reading the undecorated source as the
+                # callee would answer for a function the file does not call. The few
+                # that document handing the wrapped result back unchanged are the
+                # exception, and they are the ones that appear on a helper.
+                _REBOUND_FUNCTION_NAMES.add(statement.name)
             recorded = _LOCAL_FUNCTIONS.get(statement.name)
             if recorded is not None and recorded is not statement:
                 _REBOUND_FUNCTION_NAMES.add(statement.name)
@@ -5650,6 +5793,9 @@ class _Visitor(ast.NodeVisitor):
         # normalises exactly as the inline spelling does.
         if value.attr not in (
             *_BUILDERS, *_TEMPLATE_BUILDERS, *_NORMALISERS, *_CONVERSIONS, "replace",
+            # `build = "import ".__add__` binds the operator with its left operand
+            # attached, and the call a line later concatenates exactly as `+` does.
+            "__add__", "__mod__",
         ):
             return
         receiver = value.value
@@ -6266,13 +6412,26 @@ class _Visitor(ast.NodeVisitor):
     # Consumers that take a `key` callback, and how many elements they provably feed
     # it. `sorted` computes the key for every element before it compares anything;
     # `min` and `max` compute two and then compare, which raises on None.
-    _KEY_CONSUMERS = {"sorted": None, "min": 2, "max": 2}
+    _KEY_CONSUMERS = {"sorted": None, "min": 2, "max": 2, "sort": None}
 
     def _key_sink_calls(self, node: ast.Call):
         """`sorted([f"..."], key = exec)` calls the sink on the elements it consumes."""
-        if not isinstance(node.func, ast.Name) or node.func.id not in self._KEY_CONSUMERS:
-            return
-        if self._is_shadowed(node.func.id) or len(node.args) != 1:
+        elements_from = None
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "sort"
+            and isinstance(node.func.value, (ast.List,))
+            and not node.args
+        ):
+            # `[f"..."].sort(key = exec)` is the in-place spelling of `sorted`, and it
+            # computes the key for every element exactly the same way. The receiver is
+            # a written-out list, so the elements are as visible as `sorted`'s are.
+            elements_from = node.func.value
+        elif isinstance(node.func, ast.Name) and node.func.id in self._KEY_CONSUMERS:
+            if self._is_shadowed(node.func.id) or len(node.args) != 1:
+                return
+            elements_from = node.args[0]
+        if elements_from is None:
             return
         key = None
         for keyword in node.keywords:
@@ -6286,19 +6445,37 @@ class _Visitor(ast.NodeVisitor):
         sink = _sink_name(key, self._alias, self._is_shadowed)
         if sink is None:
             return
-        elements = self._literal_elements(node.args[0]) or ()
+        elements = self._literal_elements(elements_from) or ()
         reach = len(elements)
-        counted = self._KEY_CONSUMERS[node.func.id]
+        counted = self._KEY_CONSUMERS.get(_callee_spelling(node))
         if counted is not None:
             reach = min(reach, counted)
         for element in elements[:reach]:
             yield sink, element, node
 
+    def _iterator_factory(self, function) -> str:
+        """`map` or `filter` when the callee names one, however it is qualified."""
+        if isinstance(function, ast.Name):
+            if function.id in ("map", "filter") and not self._is_shadowed(function.id):
+                return function.id
+            return ""
+        if isinstance(function, ast.Attribute) and function.attr in ("map", "filter"):
+            # `builtins.map(exec, [...])` is the same builtin spelled out, and the
+            # owner is tested the way every other qualified builtin here is.
+            if _names_module(function.value, "builtins", self._is_shadowed, self._alias):
+                return function.attr
+            if isinstance(function.value, ast.Name) and self._alias(
+                f"module:{function.value.id}"
+            ):
+                return function.attr
+        return ""
+
     def _mapped_sink_elements(self, inner, consumer: str = ""):
         """`(sink, element, call)` for a written-out `map(<sink>, [literal, ...])`."""
-        if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name)):
+        if not isinstance(inner, ast.Call):
             return
-        if inner.func.id not in ("map", "filter") or self._is_shadowed(inner.func.id):
+        factory = self._iterator_factory(inner.func)
+        if not factory:
             return
         # `map` takes no keyword arguments, so a call with one raises TypeError before
         # the callback is ever invoked. `filter` takes none either, and takes exactly
@@ -6307,7 +6484,7 @@ class _Visitor(ast.NodeVisitor):
         # does.
         if inner.keywords or len(inner.args) < 2:
             return
-        if inner.func.id == "filter" and len(inner.args) != 2:
+        if factory == "filter" and len(inner.args) != 2:
             return
         sink = _sink_name(inner.args[0], self._alias, self._is_shadowed)
         if sink is None:
@@ -6361,7 +6538,7 @@ class _Visitor(ast.NodeVisitor):
                     "path": _relative(self.path),
                     "qualname": self._qualname(),
                     "sink": mapped_sink,
-                    "reason": f"{reason} through {inner.func.id}()",
+                    "reason": f"{reason} through {_callee_spelling(inner)}()",
                     "line": inner.lineno,
                     "hash": _call_hash(inner),
                 })
@@ -6383,6 +6560,21 @@ class _Visitor(ast.NodeVisitor):
         """`[*map(exec, [...])]` consumes the map as eagerly as `list(...)` does."""
         self._report_mapped_sinks(self._mapped_sink_elements(node.value))
         self.generic_visit(node)
+
+    def _origin_of_argument(self, argument) -> str:
+        """The digest recorded for the name or path this argument reads, if any."""
+        for node in ast.walk(argument) if isinstance(argument, ast.AST) else ():
+            key = None
+            if isinstance(node, ast.Name):
+                key = node.id
+            elif isinstance(node, (ast.Attribute, ast.Subscript)):
+                key = _compound_key(node)
+            if key is None:
+                continue
+            found = self.origin_of.get((self._qualname(), key))
+            if found:
+                return found
+        return ""
 
     def _yields_a_tree(self, argument) -> bool:
         """Whether the argument is a visible `ast.parse(...)`, which is not source.
@@ -6410,7 +6602,7 @@ class _Visitor(ast.NodeVisitor):
                     "path": _relative(self.path),
                     "qualname": self._qualname(),
                     "sink": mapped_sink,
-                    "reason": f"{reason} through {inner.func.id}()",
+                    "reason": f"{reason} through {_callee_spelling(inner)}()",
                     "line": inner.lineno,
                     "hash": _call_hash(inner),
                 })
@@ -6450,17 +6642,32 @@ class _Visitor(ast.NodeVisitor):
                 argument, self.tainted[-1].get, self._is_shadowed, self._alias,
             )
             if reason is not None:
-                self.findings.append(
-                    {
-                        "path": _relative(self.path),
-                        "qualname": self._qualname(),
-                        "sink": sink,
-                        "reason": reason,
-                        "line": node.lineno,
-                        "hash": _call_hash(node),
-                    }
-                )
+                finding = {
+                    "path": _relative(self.path),
+                    "qualname": self._qualname(),
+                    "sink": sink,
+                    "reason": reason,
+                    "line": node.lineno,
+                    "hash": _call_hash(node),
+                }
+                # Where the source was BUILT, when that is a binding this walked. The
+                # call's own hash cannot see it: `payload = f"import {safe}"` becoming
+                # `payload = f"import {input()}"` leaves `exec(payload)` byte for byte
+                # the same, and the reviewed entry would still have covered it.
+                origin = self._origin_of_argument(argument)
+                if origin:
+                    finding["origin"] = origin
+                self.findings.append(finding)
         self.generic_visit(node)
+
+
+def _expression_digest(node: ast.AST) -> str:
+    """A short digest of an expression's own source, canonicalised through unparse."""
+    try:
+        text = ast.unparse(node)
+    except Exception:
+        return ""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
 
 
 def _call_hash(node: ast.Call) -> str:
@@ -7480,18 +7687,55 @@ def _annotations_deferred(tree: ast.AST) -> bool:
     return False
 
 
+def _runs_python_command(line: str) -> bool:
+    """Whether the command before a heredoc really is a Python interpreter.
+
+    A substring test called `cat > /tmp/python.py <<'PY'` Python, since the word is in
+    the destination filename. The command is tokenised instead, redirections and their
+    operands are dropped, and the remaining words are matched against the interpreter
+    pattern `_runs_python` already uses.
+    """
+    command = line.split("<<", 1)[0]
+    try:
+        tokens = shlex.split(command, comments = True)
+    except ValueError:
+        tokens = command.split()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in (">", ">>", "<", "2>", "&>", "|"):
+            # The next token is a destination, not a command.
+            index += 2
+            continue
+        if token.startswith((">", "<")):
+            index += 1
+            continue
+        name = token.rsplit("/", 1)[-1].split("\\")[-1]
+        if _PYTHON_COMMAND.fullmatch(name):
+            return True
+        index += 1
+    return False
+
+
+# An Actions expression is not Python, and a heredoc holding one does not parse until
+# the runner has substituted it. Replaced by a name so the rest of the block can be
+# read: the substituted value is whatever the workflow computes, which is exactly the
+# untrusted-value case this gate is about.
+_ACTIONS_EXPRESSION = re.compile(r"\$\{\{.*?\}\}", re.S)
+
+
 def _python_heredocs(text: str):
     """`(line number, source)` for each Python heredoc in a workflow file.
 
-    Only a heredoc whose introducing line names python: `run: |` blocks are shell, and
-    a `cat <<EOF > file` block is data. The block's common indentation is removed,
-    since YAML indents the whole `run:` scalar.
+    Only a heredoc whose introducing line really runs python: `run: |` blocks are
+    shell, and a `cat <<EOF > file` block is data. The block's common indentation is
+    removed, since YAML indents the whole `run:` scalar.
     """
     lines = text.splitlines()
     index = 0
     while index < len(lines):
         match = _HEREDOC.search(lines[index])
-        if match is None or "python" not in lines[index].lower():
+        if match is None or not _runs_python_command(lines[index]):
             index += 1
             continue
         delimiter = match.group(2)
@@ -7503,8 +7747,32 @@ def _python_heredocs(text: str):
             index += 1
         indents = [len(line) - len(line.lstrip()) for line in body if line.strip()]
         cut = min(indents) if indents else 0
-        yield start, "\n".join(line[cut:] if line.strip() else "" for line in body)
+        source = "\n".join(line[cut:] if line.strip() else "" for line in body)
+        # `name = ${{ inputs.module }}` is not Python here and IS Python on the runner,
+        # once Actions has substituted it. Skipping the block let a sink under such a
+        # line through unread, so the expression becomes a name and the block is
+        # scanned - which is the same answer the notebook reader gives a magic.
+        yield start, _ACTIONS_EXPRESSION.sub("_actions_expression", source)
         index += 1
+
+
+def _python_dash_c_commands(text: str):
+    """`(line number, program)` for each `python -c "..."` a workflow file runs.
+
+    The heredoc reader covers the multi-line spelling; this is the one-liner, which
+    executes on the runner just the same. The same extractor the notebook `%%script`
+    reader uses answers it, so there is one implementation of the option rules.
+    """
+    for number, line in enumerate(text.splitlines(), start = 1):
+        if "<<" in line or not _runs_python_command(line + " <<"):
+            continue
+        stripped = line.strip()
+        for prefix in ("run:", "- run:", "-", "|"):
+            if stripped.startswith(prefix):
+                stripped = stripped[len(prefix):].strip()
+        program = _script_command_source("%%script " + stripped)
+        if program is not None:
+            yield number, _ACTIONS_EXPRESSION.sub("_actions_expression", program)
 
 
 def _scan_workflow(path: Path) -> list[dict]:
@@ -7522,7 +7790,7 @@ def _scan_workflow(path: Path) -> list[dict]:
     visitor = _Visitor(path)
     skipped = 0
     parsed = []
-    for start, source in _python_heredocs(text):
+    for start, source in [*_python_heredocs(text), *_python_dash_c_commands(text)]:
         try:
             tree = ast.parse(source, filename = f"{path}#line{start}")
         except (SyntaxError, ValueError):
@@ -7716,8 +7984,22 @@ def key_of(finding: dict) -> str:
     return f"{finding['path']}::{finding['qualname']}::{finding['hash']}"
 
 
+def origins_by_key(findings: list[dict]) -> dict[str, str]:
+    """Every origin digest recorded against each key, in one stable string.
+
+    Two byte-identical calls under one key can be handed source built by two different
+    expressions, so the entry records both and a change to either one is a mismatch.
+    """
+    grouped: dict[str, set] = {}
+    for finding in findings:
+        if finding.get("origin"):
+            grouped.setdefault(key_of(finding), set()).add(finding["origin"])
+    return {key: "+".join(sorted(values)) for key, values in grouped.items()}
+
+
 def write_allowlist(findings: list[dict], reason: str) -> None:
     existing = load_allowlist()
+    origins = origins_by_key(findings)
     counts: dict[str, int] = {}
     for finding in findings:
         counts[key_of(finding)] = counts.get(key_of(finding), 0) + 1
@@ -7739,6 +8021,8 @@ def write_allowlist(findings: list[dict], reason: str) -> None:
             "hash": finding["hash"],
             "reason": previous.get("reason", reason),
         }
+        if origins.get(key):
+            entry["origin"] = origins[key]
         if counts[key] > 1:
             # Two byte-identical calls in one function share a key, so one entry
             # approved both - and a THIRD copy added later inherited the same
@@ -8086,6 +8370,7 @@ def main() -> int:
     # silently. When such a change alters the shape at all, it alters the reason, and
     # that is now a mismatch rather than a match. Entries written before `kind` was
     # recorded carry none, and those still match on the key alone.
+    seen_origins = origins_by_key(findings)
     seen_counts: dict[str, int] = {}
     for finding in findings:
         seen_counts[key_of(finding)] = seen_counts.get(key_of(finding), 0) + 1
@@ -8095,6 +8380,11 @@ def main() -> int:
         or allowlist[key_of(f)].get("kind", f["reason"]) != f["reason"]
         # And the number of calls sharing the key has to be the number reviewed.
         or allowlist[key_of(f)].get("count", 1) != seen_counts[key_of(f)]
+        # And the expression that BUILT the source has to be the one reviewed, when
+        # the entry records it. An entry written before this field existed carries
+        # none and still matches on the rest.
+        or allowlist[key_of(f)].get("origin", seen_origins.get(key_of(f), ""))
+        != seen_origins.get(key_of(f), "")
     ]
     pending = [
         entry

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -167,7 +167,17 @@ _IDENTITY_TRANSLATIONS = ("translate",)
 # takes its text as the first argument. Matched by name rather than by proving the
 # import, which can only ever add findings: a local helper of the same name that did
 # something else to the text would still be handing built source to a sink.
-_TEXT_PRESERVING_FUNCTIONS = ("dedent", "indent")
+# Functions that hand their argument's text straight back, and the stdlib module each
+# one lives in. `copy.copy` of a `str` returns THE SAME object - strings are immutable,
+# so there is nothing to copy - and `deepcopy` does the same, which made
+# `exec(copy.copy(f"import {name}"))` a way past the gate.
+_TEXT_PRESERVING_MODULES = {
+    "textwrap": ("dedent", "indent"),
+    "copy": ("copy", "deepcopy"),
+}
+_TEXT_PRESERVING_FUNCTIONS = tuple(
+    name for names in _TEXT_PRESERVING_MODULES.values() for name in names
+)
 _NORMALISERS = (
     "strip", "lstrip", "rstrip", "upper", "lower", "title", "capitalize",
     "casefold", "swapcase", "expandtabs", "removeprefix", "removesuffix",
@@ -216,7 +226,7 @@ _CONSTRUCTOR_SOURCE_KEYWORD = {
 # none of the tracked sets.
 _MODULE_RECEIVERS = frozenset({
     "codeop", "operator", "ast", "importlib", "functools", "textwrap", "contextlib",
-    "string",
+    "string", "copy",
 })
 
 # `operator` functions that build a string out of two values, and the operator each
@@ -245,16 +255,21 @@ _CONSUMER_NAMES = frozenset({
 def _consumed_count(consumer: str, sink: str) -> int | None:
     """How many mapped elements this consumer provably evaluates. None means every one.
 
-    What decides it is what the callback RETURNS. `exec` and `eval` return None, so
-    `sum` raises on `0 + None` and `dict` raises unpacking it, both after the first
-    element; `all` stops at the first falsy result, which None is; `any` gets None for
-    every element and runs them all. `compile` returns a code object, which reverses
-    both of those: `any` stops at the first, `all` runs them all.
+    What decides it is what the callback RETURNS. `exec` returns None, so `sum` raises
+    on `0 + None` and `dict` raises unpacking it, both after the first element; `all`
+    stops at the first falsy result, which None is; `any` gets None for every element
+    and runs them all. `compile` returns a code object, which reverses both of those:
+    `any` stops at the first, `all` runs them all.
 
-    `min` and `max` pull two elements before comparing, and None (or a code object) is
-    not orderable, so they raise having evaluated exactly two.
+    `eval` returns the value of the EXPRESSION, so its truthiness is unknown and
+    neither short circuit can be relied on: `all(map(eval, ["1", f"{name}"]))` reaches
+    the second element whenever the first is truthy. Grouping it with `exec` capped the
+    walk at one element and lost that. `sum`, `dict`, `min` and `max` are unchanged,
+    since those raise on the first values whatever they are.
     """
-    returns_none = sink.rpartition(".")[2] in ("exec", "eval")
+    returns = sink.rpartition(".")[2]
+    returns_none = returns == "exec"
+    unknown = returns == "eval"
     if consumer == "next":
         return 1
     if consumer in ("sum", "dict"):
@@ -264,7 +279,7 @@ def _consumed_count(consumer: str, sink: str) -> int | None:
     if consumer == "all":
         return 1 if returns_none else None
     if consumer == "any":
-        return None if returns_none else 1
+        return None if returns_none or unknown else 1
     return None
 
 
@@ -319,6 +334,10 @@ def _constructor_name(function: ast.AST, shadowed = None, aliases = None) -> str
             named = aliases(f"constructor:{function.id}")
             if named is not None:
                 return named
+    if isinstance(function, ast.Await):
+        # `(await choose())(f"...")` calls whatever the coroutine handed back, on the
+        # same terms as the walrus below.
+        return _sink_name(function.value, aliases, shadowed)
     if isinstance(function, ast.NamedExpr):
         # `exec((text := str)(f"..."))` converts with whatever the walrus was given,
         # right here. The sink side already unwraps a named expression callee.
@@ -460,6 +479,33 @@ def _constructor_accepts_text(node: ast.Call, name: str) -> bool:
     return True
 
 
+def _expanded_call(node: ast.Call) -> ast.Call:
+    """`f(*(a, b))` rewritten as `f(a, b)` when every expansion is written out.
+
+    `partial(*(exec, f"import {name}"))()` is a valid way to spell the same call, and
+    the first AST argument is the `Starred` node rather than the sink, so neither the
+    callee nor the bound source resolved. An opaque expansion says nothing about what
+    it supplies and the call is handed back untouched.
+    """
+    if not any(isinstance(argument, ast.Starred) for argument in node.args):
+        return node
+    arguments = []
+    for argument in node.args:
+        if not isinstance(argument, ast.Starred):
+            arguments.append(argument)
+            continue
+        inner = argument.value
+        if isinstance(inner, (ast.Tuple, ast.List)) and not any(
+            isinstance(element, ast.Starred) for element in inner.elts
+        ):
+            arguments.extend(inner.elts)
+            continue
+        return node
+    return ast.copy_location(
+        ast.Call(func = node.func, args = arguments, keywords = list(node.keywords)), node,
+    )
+
+
 def _partial_call(node: ast.AST, aliases = None, shadowed = None) -> ast.Call | None:
     """`functools.partial(...)`, a bare `partial(...)`, or a recorded alias of it.
 
@@ -483,7 +529,7 @@ def _partial_call(node: ast.AST, aliases = None, shadowed = None) -> ast.Call | 
         if shadowed is not None and shadowed(owner):
             return None
         if owner == "functools" or (aliases is not None and aliases(f"functools:{owner}")):
-            return node
+            return _expanded_call(node)
         return None
     if not isinstance(function, ast.Name):
         return None
@@ -494,7 +540,7 @@ def _partial_call(node: ast.AST, aliases = None, shadowed = None) -> ast.Call | 
     # records. Accepting the spelling unconditionally reported an application-defined
     # `def partial(...)` that never invokes what it was handed.
     if aliases is not None and aliases(f"partial:{function.id}"):
-        return node
+        return _expanded_call(node)
     return None
 
 
@@ -634,6 +680,20 @@ def _literal_selection(node: ast.Subscript) -> ast.AST | None:
     value is taken, whether it is going to be executed or is going to do the executing.
     """
     container, index = node.value, node.slice
+    if isinstance(container, (ast.ListComp, ast.SetComp)):
+        # `[f"import {name}" for _ in [0]][0]` builds a list with one element written
+        # out right here and then selects it. The element is the same expression
+        # whichever index is taken, so an index this cannot read changes nothing; what
+        # has to be certain is that the comprehension produces at least one element,
+        # which needs a visibly nonempty iterable and no filters to reject it.
+        if len(container.generators) != 1:
+            return None
+        generator = container.generators[0]
+        if generator.ifs or getattr(generator, "is_async", 0):
+            return None
+        if not _visible_length(generator.iter):
+            return None
+        return container.elt
     if isinstance(container, (ast.Tuple, ast.List)):
         position, sign = index, 1
         if isinstance(position, ast.UnaryOp) and isinstance(position.op, (ast.USub, ast.UAdd)):
@@ -658,6 +718,14 @@ def _literal_selection(node: ast.Subscript) -> ast.AST | None:
 def _literal_element(node: ast.Subscript, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
     """The reason for `<literal>[<constant>]`, or None when it is not that shape."""
     container, index = node.value, node.slice
+    if isinstance(container, (ast.ListComp, ast.SetComp)):
+        # A comprehension over a visibly nonempty iterable produces its element, and
+        # the same expression whichever index is taken. `_literal_selection` answers
+        # for the callee side; this is the source side of the same reading.
+        selected = _literal_selection(node)
+        if selected is None:
+            return None
+        return _is_interpolated(selected, resolve, shadowed, resolve_alias)
     if isinstance(container, (ast.Tuple, ast.List)):
         # A negative literal index is `UnaryOp(USub, Constant(1))`, not a `Constant`,
         # so requiring a constant rejected `[...][-1]` before the container was even
@@ -704,7 +772,10 @@ def _is_interpolated(node: ast.AST, resolve = None, shadowed = None, resolve_ali
     # each arm answers outright: nothing under an arm can match a node that
     # reached it. That is why a handler returning None and a handler not
     # matching stay indistinguishable, and why no sentinel is needed.
-    while isinstance(node, ast.NamedExpr):
+    while isinstance(node, (ast.NamedExpr, ast.Await)):
+        # `await` too: `exec(await build(name))` runs the coroutine and hands its
+        # result to the sink, so the awaited expression IS the source. It fell through
+        # every arm below, since an `Await` is none of the shapes they test.
         node = node.value
     if (
         isinstance(node, ast.Constant)
@@ -1099,8 +1170,11 @@ _HELPER_STACK: set = set()
 # what the name ends up bound to.
 _RESULT_PRESERVING_DECORATORS = frozenset({
     "cache", "lru_cache", "wraps", "staticmethod", "classmethod", "final",
-    "override", "no_type_check", "cached_property",
+    "override", "no_type_check",
 })
+# `cached_property` is NOT one of them: it hands back a descriptor, not a function, so
+# `@cached_property def build(): ...` followed by `build()` raises TypeError before any
+# sink is reached and reporting it failed the gate on a call that cannot run.
 
 
 def _decorator_name(node: ast.AST) -> str:
@@ -1119,12 +1193,20 @@ def _returned_expressions(definition) -> list:
 
     Its own: a `return` inside a nested `def` belongs to that one. A bare `return`
     hands back None and contributes nothing.
+
+    Reachable ones: collection stops at a statement that always leaves the body, so
+    `def build(): return "pass"` followed by `return f"import {name}"` hands back the
+    literal and nothing else. Reading the unreachable one reported a sink that can only
+    ever be given `pass`. Only the outermost suite is cut this way - a `return` under a
+    condition this cannot decide leaves everything below it standing.
     """
     found = []
     for statement in definition.body:
         for child in _walk_this_scope(statement):
             if isinstance(child, ast.Return) and child.value is not None:
                 found.append(child.value)
+        if _definitely_jumps(statement):
+            break
     return found
 
 
@@ -1670,8 +1752,12 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
         # The OWNER has to be `textwrap`, or a recorded alias of it. Reading the
         # attribute name alone treated `cleaner.dedent(...)` on an application object
         # as the stdlib helper and reported a call that may return anything.
-        if _names_module(function.value, "textwrap", shadowed, resolve_alias):
-            preserving = function.attr
+        for module, names in _TEXT_PRESERVING_MODULES.items():
+            if function.attr in names and _names_module(
+                function.value, module, shadowed, resolve_alias,
+            ):
+                preserving = function.attr
+                break
     if preserving not in _TEXT_PRESERVING_FUNCTIONS and isinstance(function, ast.Name):
         # `from textwrap import dedent as clean` binds the same function under a
         # different name, and matching on the spelling alone stopped before the
@@ -1741,27 +1827,11 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             return _is_interpolated(
                 ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
             )
-    if (
-        isinstance(function, ast.Attribute)
-        and function.attr == "pop"
-        # A list, not a tuple: a tuple has no `pop`, so `(f"...",).pop()` raises
-        # AttributeError before the sink is reached and reporting it failed the gate
-        # on a call that cannot execute.
-        and isinstance(function.value, ast.List)
-        and function.value.elts
-        and not any(isinstance(element, ast.Starred) for element in function.value.elts)
-        and not node.keywords
-    ):
-        # `[f"..."].pop()` returns the last element of a container written out right
-        # here, and `[a, b].pop(0)` the one it names. Only the mapping spelling was
-        # read, so the list one selected and executed source with nothing reported.
-        elements = function.value.elts
-        if not node.args:
-            return _is_interpolated(elements[-1], resolve, shadowed, resolve_alias)
-        index = _constant_integer(node.args[0]) if len(node.args) == 1 else None
-        if index is not None and -len(elements) <= index < len(elements):
-            return _is_interpolated(elements[index], resolve, shadowed, resolve_alias)
-        return None
+    if _pops_a_written_out_list(node):
+        popped = _literal_pop(node)
+        if popped is None:
+            return None
+        return _is_interpolated(popped, resolve, shadowed, resolve_alias)
     if isinstance(function, ast.Attribute):
         literal_mapping = (
             _mapping_literal(function.value, shadowed)
@@ -1771,6 +1841,25 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
         # container binding now records under its negative index. A named receiver fell
         # through the inline-display branch above and the selected source went
         # unreported.
+        if (
+            function.attr == "setdefault"
+            and len(node.args) == 2
+            and not node.keywords
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            # `{}.setdefault("x", f"import {name}")` stores the default and hands it
+            # back, so the f-string is what runs. A key the mapping already holds gives
+            # the stored value instead. Only a mapping written out right here, the same
+            # reading `get` gets.
+            mapping = _mapping_literal(function.value, shadowed)
+            if mapping is not None:
+                found = _mapping_lookup(mapping, node.args[0].value)
+                if found is None or _uncertain_lookup(mapping):
+                    found = (
+                        node.args[1] if found is None
+                        else _either_value(found, node.args[1])
+                    )
+                return _is_interpolated(found, resolve, shadowed, resolve_alias)
         selected_key = None
         if function.attr in ("get", "pop") and node.args and isinstance(
             node.args[0], ast.Constant
@@ -2544,6 +2633,40 @@ def _lambda_result(call: ast.Call):
     return None if bound is None else bound.get(body.id)
 
 
+def _pops_a_written_out_list(node: ast.AST) -> bool:
+    """Whether `node` is `[...].pop(...)` on a list written out right here.
+
+    A list, not a tuple: a tuple has no `pop`, so `(f"...",).pop()` raises
+    AttributeError before anything is reached, and reporting it failed the gate on a
+    call that cannot execute.
+    """
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "pop"
+        and isinstance(node.func.value, ast.List)
+        and bool(node.func.value.elts)
+        and not any(isinstance(element, ast.Starred) for element in node.func.value.elts)
+        and not node.keywords
+    )
+
+
+def _literal_pop(node: ast.AST):
+    """The element `[...].pop()` hands back, when the list is written out.
+
+    The LAST element with nothing named, and the one a constant index names.
+    """
+    if not _pops_a_written_out_list(node):
+        return None
+    elements = node.func.value.elts
+    if not node.args:
+        return elements[-1]
+    index = _constant_integer(node.args[0]) if len(node.args) == 1 else None
+    if index is not None and -len(elements) <= index < len(elements):
+        return elements[index]
+    return None
+
+
 def _folded_text(node: ast.AST) -> ast.AST:
     """A written-out concatenation of string literals, folded to one constant.
 
@@ -2745,6 +2868,15 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
                         return resolved
             finally:
                 _HELPER_STACK.discard(helper.name)
+    if isinstance(function, ast.Call):
+        # `[exec].pop()(f"...")` selects the callee out of a list written out right
+        # here, which the source side already reads. The callee side fell through to
+        # the `getattr` resolver and read nothing.
+        popped = _literal_pop(function)
+        if popped is not None:
+            resolved = _sink_name(popped, aliases, shadowed)
+            if resolved is not None:
+                return resolved
     if isinstance(function, ast.Call):
         # `next(iter([exec]))(f"...")` selects the callee out of a container written out
         # right here, exactly as `[exec][0](...)` does. The unwrapping was only applied
@@ -4814,26 +4946,22 @@ class _Visitor(ast.NodeVisitor):
         self._visit_suite(node.body if decided else node.orelse)
 
     def visit_AsyncWith(self, node):
-        """`async with nullcontext(...)` raises: it has no `__aenter__`.
+        """`async with` does not tell you what the target holds.
 
-        Checked on CPython: `async with contextlib.nullcontext(x)` answers
-        `TypeError: 'async with' received an object that does not implement
-        __aenter__`, so the body never runs. Aliasing this to `visit_With` inferred
-        what the target held from the synchronous constructor and reported a call in a
-        suite that cannot execute. Only that one inference is dropped; everything else
-        `visit_With` does - the unconditional rebinding, the shadowing, visiting the
-        context expressions - still applies, since an ordinary async manager does run
-        its body.
+        Aliasing this to `visit_With` inferred the target's value from the SYNCHRONOUS
+        constructor, which says nothing about what `__aenter__` hands over. Only that
+        inference is dropped; everything else `visit_With` does - the unconditional
+        rebinding, the shadowing, visiting the context expressions and the body - still
+        applies.
+
+        `nullcontext` is no longer treated as un-enterable here. It gained
+        `__aenter__`/`__aexit__` in 3.10, so `async with contextlib.nullcontext():`
+        enters normally on every interpreter this checker targets except 3.9, and
+        skipping the body hid a sink inside one. Scanning it is the conservative
+        reading across the supported range.
         """
         for item in node.items:
             self.visit(item.context_expr)
-            if _is_nullcontext_call(item.context_expr, self._alias, self._is_shadowed):
-                # A written-out `nullcontext` cannot be entered asynchronously, and
-                # items are entered LEFT TO RIGHT, so nothing after this one is even
-                # evaluated - the context expression of the next item included. Testing
-                # every item first visited those expressions and reported a sink in one
-                # of them. The body does not run either.
-                return
             if item.optional_vars is not None:
                 self.visit(item.optional_vars)
                 for child in ast.walk(item.optional_vars):
@@ -5474,7 +5602,10 @@ class _Visitor(ast.NodeVisitor):
                         continue
                     if qualified in _DIRECT_HELPERS:
                         self.collected_aliases[-1][f"stdlibfunc:{bound}"] = qualified
-                    elif statement.module == "textwrap" and alias.name in _TEXT_PRESERVING_FUNCTIONS:
+                    elif (
+                        statement.module in _TEXT_PRESERVING_MODULES
+                        and alias.name in _TEXT_PRESERVING_MODULES[statement.module]
+                    ):
                         self.collected_aliases[-1][f"text:{bound}"] = alias.name
                     elif statement.module == "functools" and alias.name == "partial":
                         self.collected_aliases[-1][f"partial:{bound}"] = "partial"
@@ -5781,9 +5912,9 @@ class _Visitor(ast.NodeVisitor):
                 self.shadowed_sinks[-1].discard(bound)
                 continue
             if (
-                node.module == "textwrap"
+                node.module in _TEXT_PRESERVING_MODULES
                 and not node.level
-                and alias.name in _TEXT_PRESERVING_FUNCTIONS
+                and alias.name in _TEXT_PRESERVING_MODULES[node.module]
             ):
                 # `from textwrap import dedent as clean` gives `clean` the same
                 # function, and matching the callee spelling alone stopped before the
@@ -6955,6 +7086,61 @@ class _Visitor(ast.NodeVisitor):
                     "hash": _call_hash(inner),
                 })
 
+    def _bind_update_elements(self, node: ast.Call) -> None:
+        """`payloads.update(run = f"...")` writes the element `payloads["run"]` holds.
+
+        A mapping populated after it is bound reaches the sink through the ordinary
+        subscript, and the binding pass only ever saw the display written at the
+        assignment - so `payloads = {}` followed by an update stored built source that
+        nothing recorded. Only visible keys: plain keywords, and a literal mapping
+        argument. A `**` of anything else supplies names this cannot read and is left
+        alone.
+        """
+        function = node.func
+        if not isinstance(function, ast.Attribute) or function.attr != "update":
+            return
+        if not isinstance(function.value, (ast.Name, ast.Attribute, ast.Subscript)):
+            return
+        pairs = []
+        for keyword in node.keywords:
+            if keyword.arg is None:
+                mapping = _mapping_literal(keyword.value, self._is_shadowed)
+                if mapping is None:
+                    return
+                for key, item in zip(mapping.keys, mapping.values):
+                    if isinstance(key, ast.Constant) and isinstance(key.value, (str, int)):
+                        pairs.append((key.value, item))
+                continue
+            pairs.append((keyword.arg, keyword.value))
+        for argument in node.args:
+            mapping = _mapping_literal(argument, self._is_shadowed)
+            if mapping is None:
+                return
+            for key, item in zip(mapping.keys, mapping.values):
+                if isinstance(key, ast.Constant) and isinstance(key.value, (str, int)):
+                    pairs.append((key.value, item))
+        for key, item in pairs:
+            path = _compound_key(
+                ast.Subscript(
+                    value = function.value,
+                    slice = ast.Constant(value = key),
+                    ctx = ast.Load(),
+                )
+            )
+            if path is None:
+                continue
+            resolved = _sink_name(item, self._alias, self._is_shadowed)
+            if resolved is not None:
+                for table in (self.sink_aliases, self.collected_aliases):
+                    table[-1][path] = resolved.rpartition(".")[2]
+            reason = _is_interpolated(
+                item, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
+            if reason is not None and not isinstance(reason, _LiteralText):
+                self.tainted[-1][path] = reason
+            else:
+                self.tainted[-1].pop(path, None)
+
     def _wrapper_sink_calls(self, node: ast.Call):
         """`(sink, argument, inner)` for `def run(source): exec(source)` called here.
 
@@ -7055,6 +7241,7 @@ class _Visitor(ast.NodeVisitor):
                     "line": inner.lineno,
                     "hash": _call_hash(inner),
                 })
+        self._bind_update_elements(node)
         for wrapped_sink, supplied, helper in self._wrapper_sink_calls(node):
             reason = _is_interpolated(
                 supplied, self.tainted[-1].get, self._is_shadowed, self._alias,
@@ -8308,6 +8495,13 @@ def _python_dash_c_commands(text: str):
         # consider the command finished.
         command, last = line, index
         while last + 1 < len(lines) and last - index < _COMMAND_LINE_LIMIT:
+            # A trailing backslash continues the command on the next line, so
+            # `python \` with `-c '...'` below it is one command. Reading the first
+            # line alone found no `-c` and the program went unread.
+            if command.rstrip().endswith("\\"):
+                last += 1
+                command = f"{command.rstrip()[:-1]}{lines[last]}"
+                continue
             try:
                 shlex.split(command, comments = True)
                 break

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -3124,16 +3124,57 @@ def _walk_this_scope(node: ast.AST):
     here. A comprehension is not pruned either: its walrus target binds in the scope
     holding it, which is this one.
     """
-    pending = [node]
-    while pending:
-        current = pending.pop()
-        yield current
-        for child in ast.iter_child_nodes(current):
-            if isinstance(child, (ast.Lambda, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-                for header in _definition_time_expressions(child):
-                    pending.append(header)
-                continue
-            pending.append(child)
+    # Memoised onto the node. The answer depends only on the subtree below it, and no
+    # pass here rewrites a tree it is walking, so the walk for a given node is the same
+    # every time it is asked for. It was asked for 7 to 8 times per node on a large
+    # file - the alias pass, the locals pass, the class pass and the taint fixpoint each
+    # rewalk the same scope - which put 40 million calls and three fifths of the total
+    # runtime in this one function. Stored on the node rather than in a dict keyed by
+    # `id()`, so it cannot outlive the tree and cannot collide with a later file that
+    # reuses an address. `_fields` is untouched, so nothing that reads the AST as data,
+    # `ast.unparse` and the finding keys included, can see the difference.
+    cached = node.__dict__.get(_SCOPE_WALK_CACHE) if hasattr(node, "__dict__") else None
+    if cached is None:
+        cached = []
+        pending = [node]
+        # The children are read off `_fields` here rather than through
+        # `ast.iter_child_nodes`, which stacks two generators - itself over
+        # `ast.iter_fields` - per node visited. Same nodes in the same order; it is the
+        # generator machinery that is gone, and this is the one walk hot enough to
+        # notice it.
+        while pending:
+            current = pending.pop()
+            cached.append(current)
+            for field in current._fields:
+                value = getattr(current, field, None)
+                if isinstance(value, ast.AST):
+                    children = (value,)
+                elif type(value) is list:
+                    children = value
+                else:
+                    continue
+                for child in children:
+                    if not isinstance(child, ast.AST):
+                        continue
+                    if isinstance(
+                        child, (ast.Lambda, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                    ):
+                        for header in _definition_time_expressions(child):
+                            pending.append(header)
+                        continue
+                    pending.append(child)
+        try:
+            setattr(node, _SCOPE_WALK_CACHE, cached)
+        except AttributeError:
+            # A node type that refuses attributes still gets the right answer.
+            pass
+    return iter(cached)
+
+
+# Where the memos live. Leading underscores and names no AST field uses, so they
+# cannot shadow a real field on any node type.
+_SCOPE_WALK_CACHE = "_lint_dynamic_exec_scope_walk"
+_DECLARED_LOCALS_CACHE = "_lint_dynamic_exec_declared_locals"
 
 
 def _definition_time_expressions(node: ast.AST):
@@ -4058,29 +4099,42 @@ class _Visitor(ast.NodeVisitor):
         the number of assignments bounds it; the cap is there so a resolver bug cannot
         spin.
         """
+        # The assignments are gathered ONCE and the rounds re-read that list. Walking
+        # every statement again per round re-tested every node in the body against three
+        # types to rediscover the same handful of assignments, eight times over.
+        # `_walk_this_scope` is the same walk the rest of the pass uses, so the answer
+        # is unchanged; only the rediscovery is gone.
+        assignments = []
+        for statement in body:
+            for child in _walk_this_scope(statement):
+                if isinstance(child, ast.Assign):
+                    targets = child.targets
+                elif isinstance(child, ast.AnnAssign) and child.value is not None:
+                    targets = [child.target]
+                elif isinstance(child, ast.AugAssign):
+                    # `payload += f"import {name}"` puts built source in the name as
+                    # plainly as `=` does, and a deferred body reads the cell after it.
+                    targets = [child.target]
+                else:
+                    continue
+                names = [t.id for t in targets if isinstance(t, ast.Name)]
+                if names:
+                    assignments.append((names, child.value))
         found: dict = {}
         for _round in range(_LATER_TAINT_ROUNDS):
             added = False
-            for statement in body:
-                for child in _walk_this_scope(statement):
-                    if isinstance(child, ast.Assign):
-                        targets = child.targets
-                    elif isinstance(child, ast.AnnAssign) and child.value is not None:
-                        targets = [child.target]
-                    elif isinstance(child, ast.AugAssign):
-                        # `payload += f"import {name}"` puts built source in the name as
-                        # plainly as `=` does, and a deferred body reads the cell after
-                        # it.
-                        targets = [child.target]
-                    else:
-                        continue
-                    reason = _is_interpolated(child.value, found.get)
-                    if reason is None or isinstance(reason, _LiteralText):
-                        continue
-                    for target in targets:
-                        if isinstance(target, ast.Name) and target.id not in found:
-                            found[target.id] = reason
-                            added = True
+            for names, value in assignments:
+                if all(name in found for name in names):
+                    # Every name it binds is already answered, and a name is never
+                    # revised once found, so re-reading the value cannot change it.
+                    continue
+                reason = _is_interpolated(value, found.get)
+                if reason is None or isinstance(reason, _LiteralText):
+                    continue
+                for name in names:
+                    if name not in found:
+                        found[name] = reason
+                        added = True
             if not added:
                 break
         return found
@@ -4093,6 +4147,12 @@ class _Visitor(ast.NodeVisitor):
         targets, imports and definitions - anything in THIS body, not in a nested one,
         since a nested scope binds in its own.
         """
+        # Memoised on the node, like the scope walk: the answer is a function of the
+        # subtree, and the same body is asked for its locals once per enclosing scope
+        # the taint pass steps through.
+        cached = node.__dict__.get(_DECLARED_LOCALS_CACHE) if hasattr(node, "__dict__") else None
+        if cached is not None:
+            return set(cached)
         names = set()
         arguments = getattr(node, "args", None)
         if isinstance(arguments, ast.arguments):
@@ -4102,6 +4162,14 @@ class _Visitor(ast.NodeVisitor):
             ):
                 if argument is not None:
                     names.add(argument.arg)
+        # A name the body declares `global` or `nonlocal` is NOT one of its locals,
+        # however many times the body assigns it: the assignment writes the enclosing
+        # cell. Counting it as local dropped the enclosing taint before the body was
+        # read, so `def f(): global payload; exec(payload); payload = "pass"` executed
+        # a payload built outside and reported nothing. Collected in the SAME pass that
+        # collects the locals, since a second pass re-walked every statement to find
+        # two statement types.
+        declared = set()
         for statement in getattr(node, "body", []) or []:
             for child in _walk_this_scope(statement):
                 if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
@@ -4117,17 +4185,13 @@ class _Visitor(ast.NodeVisitor):
                     names.add(child.name)
                 elif isinstance(child, ast.ExceptHandler) and child.name:
                     names.add(child.name)
-        # A name the body declares `global` or `nonlocal` is NOT one of its locals,
-        # however many times the body assigns it: the assignment writes the enclosing
-        # cell. Counting it as local dropped the enclosing taint before the body was
-        # read, so `def f(): global payload; exec(payload); payload = "pass"` executed
-        # a payload built outside and reported nothing.
-        declared = set()
-        for statement in getattr(node, "body", []) or []:
-            for child in _walk_this_scope(statement):
-                if isinstance(child, (ast.Global, ast.Nonlocal)):
+                elif isinstance(child, (ast.Global, ast.Nonlocal)):
                     declared.update(child.names)
         names -= declared
+        try:
+            setattr(node, _DECLARED_LOCALS_CACHE, frozenset(names))
+        except AttributeError:
+            pass
         return names
 
     def _enter(self, node):

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -1367,6 +1367,65 @@ def _interpolated_binop(node, resolve = None, shadowed = None, resolve_alias = N
     return None
 
 
+def _first_from_iterator(node: ast.AST, shadowed = None):
+    """The element `next(iter([...]))` necessarily selects, when it is written out.
+
+    The first element of a container written out right here, which is the subscript
+    spelling with the index implied. Both calls are the builtins and both are
+    shadow-tested.
+
+    A default is allowed: `next(iterator, "pass")` hands back the default only when the
+    iterator is EXHAUSTED, and this reads a container with at least one element written
+    into it, so the default is unreachable. Requiring exactly one argument skipped that
+    call and its selected source went unreported.
+    """
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "next"
+        and not (shadowed is not None and shadowed("next"))
+        and 1 <= len(node.args) <= 2
+        and not node.keywords
+        and not any(isinstance(argument, ast.Starred) for argument in node.args)
+    ):
+        return None
+    inner = node.args[0]
+    if (
+        isinstance(inner, ast.Call)
+        and isinstance(inner.func, ast.Name)
+        and inner.func.id == "iter"
+        and not (shadowed is not None and shadowed("iter"))
+        and len(inner.args) == 1
+        and not inner.keywords
+        and isinstance(inner.args[0], (ast.List, ast.Tuple))
+        and inner.args[0].elts
+        and not isinstance(inner.args[0].elts[0], ast.Starred)
+    ):
+        return inner.args[0].elts[0]
+    return None
+
+
+def _assigned_names(node: ast.AST) -> list:
+    """The names this ONE node binds, whatever the spelling.
+
+    Every binding form, not only assignment: an `import`, a `def`, a `for` target, a
+    `with ... as`, an `except ... as` and a walrus all rebind a name, and a local read
+    below must not be answered from an assignment somewhere else that shares its
+    spelling.
+    """
+    if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+        return [node.id]
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return [node.name]
+    if isinstance(node, ast.alias):
+        return [(node.asname or node.name).partition(".")[0]]
+    if isinstance(node, ast.ExceptHandler) and node.name:
+        return [node.name]
+    if isinstance(node, ast.arg):
+        return [node.arg]
+    return []
+
+
 def _helper_scope(node: ast.Call, helper, resolve, shadowed, resolve_alias):
     """A `resolve` for a visible helper's body: its parameters, then nothing local.
 
@@ -1385,13 +1444,41 @@ def _helper_scope(node: ast.Call, helper, resolve, shadowed, resolve_alias):
         if argument is not None
     }
 
+    # A local the body assigns ONCE, at the top level of its own suite, with a plain
+    # name target. `def build(name): source = f"import {name}"; return source` hands
+    # back the string it just built, and answering "local, so nothing" for `source`
+    # lost it between the assignment and the `return`. Assigned twice, assigned under a
+    # condition, or assigned by any other kind of statement and it stays unresolved -
+    # the single visible value is the whole of what is being read here.
+    stores: dict = {}
+    for statement in helper.body:
+        for child in _walk_this_scope(statement):
+            for target in _assigned_names(child):
+                stores[target] = statement if target not in stores else None
+    single_value: dict = {}
+    for name, statement in stores.items():
+        if statement is None or statement not in helper.body:
+            continue
+        if isinstance(statement, ast.Assign) and len(statement.targets) == 1:
+            single_value[name] = statement.value
+        elif isinstance(statement, ast.AnnAssign) and statement.value is not None:
+            single_value[name] = statement.value
+    resolving: set = set()
+
     def resolve_in_helper(name):
         if name in parameters:
             # `_lambda_scope` hands back the enclosing resolver when the call cannot
             # be paired up, and that resolver may be None.
             return paired(name) if callable(paired) else None
         if name in bound_here:
-            return None
+            value = single_value.get(name)
+            if value is None or name in resolving:
+                return None
+            resolving.add(name)
+            try:
+                return _is_interpolated(value, resolve_in_helper, shadowed, resolve_alias)
+            finally:
+                resolving.discard(name)
         return resolve(name) if resolve is not None else None
 
     return resolve_in_helper
@@ -1496,32 +1583,9 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             shadowed,
             resolve_alias,
         )
-    if (
-        isinstance(function, ast.Name)
-        and function.id == "next"
-        and not (shadowed is not None and shadowed("next"))
-        and len(node.args) == 1
-        and not node.keywords
-    ):
-        # `next(iter([f"import {name}"]))` selects the first element of a container
-        # written out right here, which is the subscript spelling with the index
-        # implied. Both calls are the builtins, both are shadow-tested, and only a
-        # written-out container is read.
-        inner = node.args[0]
-        if (
-            isinstance(inner, ast.Call)
-            and isinstance(inner.func, ast.Name)
-            and inner.func.id == "iter"
-            and not (shadowed is not None and shadowed("iter"))
-            and len(inner.args) == 1
-            and not inner.keywords
-            and isinstance(inner.args[0], (ast.List, ast.Tuple))
-            and inner.args[0].elts
-            and not isinstance(inner.args[0].elts[0], ast.Starred)
-        ):
-            return _is_interpolated(
-                inner.args[0].elts[0], resolve, shadowed, resolve_alias,
-            )
+    selected = _first_from_iterator(node, shadowed)
+    if selected is not None:
+        return _is_interpolated(selected, resolve, shadowed, resolve_alias)
     helper = _visible_helper(function, shadowed)
     if helper is not None and helper.name not in _HELPER_STACK:
         # `def build(): return f"import {name}"` followed by `exec(build())` executes
@@ -1622,7 +1686,10 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
     if (
         isinstance(function, ast.Attribute)
         and function.attr == "pop"
-        and isinstance(function.value, (ast.List, ast.Tuple))
+        # A list, not a tuple: a tuple has no `pop`, so `(f"...",).pop()` raises
+        # AttributeError before the sink is reached and reporting it failed the gate
+        # on a call that cannot execute.
+        and isinstance(function.value, ast.List)
         and function.value.elts
         and not any(isinstance(element, ast.Starred) for element in function.value.elts)
         and not node.keywords
@@ -1642,6 +1709,42 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             _mapping_literal(function.value, shadowed)
             if function.attr in ("get", "pop") else None
         )
+        if (
+            literal_mapping is None
+            and function.attr in ("get", "pop")
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and _compound_key(
+                ast.Subscript(
+                    value = function.value,
+                    slice = ast.Constant(value = node.args[0].value),
+                    ctx = ast.Load(),
+                )
+            ) is not None
+        ):
+            # `payloads = {"x": f"..."}` then `payloads.get("x")` reads the same element
+            # the subscript spelling reads, and the element was already recorded under
+            # its compound path when the container was bound. Only the exact accessor
+            # spelling was preserved, so the `get` and `pop` forms selected and executed
+            # stored source with nothing reported. Rewritten as the subscript and read
+            # there, which keeps one implementation of the lookup.
+            equivalent = ast.copy_location(
+                ast.Subscript(
+                    value = function.value,
+                    slice = ast.Constant(value = node.args[0].value),
+                    ctx = ast.Load(),
+                ),
+                node,
+            )
+            found = _is_interpolated(equivalent, resolve, shadowed, resolve_alias)
+            if found is not None:
+                return found
+            # Nothing recorded under that key is a MISS as far as this can tell, and a
+            # miss returns the default: `payloads.get("absent", f"...")` executes the
+            # f-string.
+            if len(node.args) > 1:
+                return _is_interpolated(node.args[1], resolve, shadowed, resolve_alias)
+            return None
         if (
             literal_mapping is not None
             and node.args
@@ -2317,28 +2420,18 @@ def _visibly_unaddable(left: ast.AST, right: ast.AST) -> bool:
     return left_kind != right_kind
 
 
-def _lambda_result(call: ast.Call):
-    """What an immediately invoked lambda hands back, when that is written out.
+def _paired_arguments(call: ast.Call, arguments: ast.arguments) -> dict | None:
+    """Parameter name to the expression the call gives it, or None when it cannot pair.
 
-    The body itself, or - when the body is one of the parameters - the argument that
-    parameter was given. Only a straightforward pairing: a `*` or `**` at the call site
-    can supply anything, and nothing is guessed there.
+    Positional arguments in order, keywords by name, and a parameter nobody supplied
+    falls back to its default. Only a straightforward pairing: a `*` or `**` at the
+    call site can supply anything, and nothing is guessed there.
     """
-    lambda_node = call.func
-    if not isinstance(lambda_node, ast.Lambda):
-        return None
-    body = lambda_node.body
-    if not isinstance(body, ast.Name):
-        return body
-    arguments = lambda_node.args
-    positional = [*arguments.posonlyargs, *arguments.args]
-    names = {argument.arg for argument in positional}
-    if body.id not in names:
-        return None
     if any(isinstance(argument, ast.Starred) for argument in call.args):
         return None
     if any(keyword.arg is None for keyword in call.keywords):
         return None
+    positional = [*arguments.posonlyargs, *arguments.args]
     bound = {}
     for index, argument in enumerate(call.args):
         if index < len(positional):
@@ -2349,7 +2442,30 @@ def _lambda_result(call: ast.Call):
     if defaults:
         for parameter, default in zip(positional[len(positional) - len(defaults):], defaults):
             bound.setdefault(parameter.arg, default)
-    return bound.get(body.id)
+    for parameter, default in zip(arguments.kwonlyargs, arguments.kw_defaults):
+        if default is not None:
+            bound.setdefault(parameter.arg, default)
+    return bound
+
+
+def _lambda_result(call: ast.Call):
+    """What an immediately invoked lambda hands back, when that is written out.
+
+    The body itself, or - when the body is one of the parameters - the argument that
+    parameter was given.
+    """
+    lambda_node = call.func
+    if not isinstance(lambda_node, ast.Lambda):
+        return None
+    body = lambda_node.body
+    if not isinstance(body, ast.Name):
+        return body
+    arguments = lambda_node.args
+    names = {argument.arg for argument in (*arguments.posonlyargs, *arguments.args)}
+    if body.id not in names:
+        return None
+    bound = _paired_arguments(call, arguments)
+    return None if bound is None else bound.get(body.id)
 
 
 def _folded_text(node: ast.AST) -> ast.AST:
@@ -2357,7 +2473,30 @@ def _folded_text(node: ast.AST) -> ast.AST:
 
     Only `+` between literals, and only when every piece is one: nothing here
     evaluates a name or calls anything. Anything else is handed back unchanged.
+
+    An f-string whose replacements are all string literals is written-out text too:
+    `f"{'exec'}"` is `"exec"` however it is spelled, so `getattr(builtins, f"{'exec'}")`
+    names the sink as plainly as the constant does and used to resolve to nothing. Only
+    a plain replacement of a string constant counts - no conversion, no format spec -
+    so the folded value is the one CPython produces rather than a guess at one.
     """
+    if isinstance(node, ast.JoinedStr):
+        pieces = []
+        for piece in node.values:
+            if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
+                pieces.append(piece.value)
+                continue
+            if (
+                isinstance(piece, ast.FormattedValue)
+                and piece.conversion in (-1, None)
+                and piece.format_spec is None
+                and isinstance(piece.value, ast.Constant)
+                and isinstance(piece.value.value, str)
+            ):
+                pieces.append(piece.value.value)
+                continue
+            return node
+        return ast.copy_location(ast.Constant(value = "".join(pieces)), node)
     if not isinstance(node, ast.BinOp) or not isinstance(node.op, ast.Add):
         return node
     left = _folded_text(node.left)
@@ -2430,6 +2569,26 @@ def _getattr_sink_name(function: ast.Call, aliases = None, shadowed = None) -> s
     return None
 
 
+def _sink_candidates(function: ast.AST, aliases = None, shadowed = None) -> list:
+    """Every sink this callee can select, most likely first.
+
+    One, for everything written out as a single callee. A conditional whose test cannot
+    be decided is the exception: both arms are reachable, they may have different
+    signatures, and answering with the first that resolved let the other one's call go
+    unreported when the first was rejected as unable to run.
+    """
+    if isinstance(function, ast.IfExp) and _constant_truth(function.test) is None:
+        found = []
+        for arm in (function.body, function.orelse):
+            resolved = _sink_name(arm, aliases, shadowed)
+            if resolved is not None and resolved not in found:
+                found.append(resolved)
+        if found:
+            return found
+    resolved = _sink_name(function, aliases, shadowed)
+    return [] if resolved is None else [resolved]
+
+
 def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None:
     """The sink this call target names, if any.
 
@@ -2467,14 +2626,32 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
         # reads, same guards: a `def` bound to nothing else, and a recursion stack.
         helper = _visible_helper(function.func, shadowed)
         if helper is not None and helper.name not in _HELPER_STACK:
+            # `def choose(run): return run` hands back whatever the CALL supplied, so
+            # `choose(builtins.exec)(f"...")` runs the builtin. Resolving the returned
+            # name against the caller's aliases read nothing, since `run` means nothing
+            # out here. The parameters are paired to the arguments exactly as an
+            # immediately invoked lambda's are.
+            bound = _paired_arguments(function, helper.args) or {}
             _HELPER_STACK.add(helper.name)
             try:
                 for value in _returned_expressions(helper):
+                    if isinstance(value, ast.Name) and value.id in bound:
+                        value = bound[value.id]
                     resolved = _sink_name(value, aliases, shadowed)
                     if resolved is not None:
                         return resolved
             finally:
                 _HELPER_STACK.discard(helper.name)
+    if isinstance(function, ast.Call):
+        # `next(iter([exec]))(f"...")` selects the callee out of a container written out
+        # right here, exactly as `[exec][0](...)` does. The unwrapping was only applied
+        # to source values, so the callee side fell through to the `getattr` resolver
+        # and read nothing.
+        picked = _first_from_iterator(function, shadowed)
+        if picked is not None:
+            resolved = _sink_name(picked, aliases, shadowed)
+            if resolved is not None:
+                return resolved
     if isinstance(function, ast.Call) and isinstance(function.func, ast.Lambda):
         # `(lambda run: run)(exec)(f"...")` calls whatever the lambda hands back, which
         # is written out right here. The source side already binds arguments to
@@ -3082,6 +3259,41 @@ def _mapping_lookup(mapping: ast.Dict, wanted: str) -> ast.AST | None:
     return None
 
 
+# How many positional arguments each sink accepts. `exec(source, globals, locals)` and
+# `eval(source, globals, locals)` take three; `compile(source, filename, mode, flags,
+# dont_inherit, optimize)` takes six.
+_SINK_ARITY = {"exec": 3, "eval": 3, "compile": 6}
+
+
+def _visibly_too_many_arguments(node: ast.Call, sink: str, skip: int = 0) -> bool:
+    """Whether the call plainly hands the sink more positional arguments than it takes.
+
+    `exec(f"import {name}", {}, {}, 1)` raises TypeError before anything is executed,
+    so reporting it failed the gate on a call that cannot reach the sink. Only when
+    every argument is visible: an opaque `*expansion` says nothing about how many
+    values it contributes, and stays unknown, which is the reporting side.
+    """
+    ceiling = _SINK_ARITY.get(sink.rpartition(".")[2])
+    if ceiling is None:
+        return False
+    positional = 0
+    for argument in node.args[skip:]:
+        if isinstance(argument, ast.Starred):
+            inner = argument.value
+            if isinstance(inner, (ast.Tuple, ast.List, ast.Set)) and not any(
+                isinstance(element, ast.Starred) for element in inner.elts
+            ):
+                positional += len(inner.elts)
+                continue
+            if isinstance(inner, ast.Dict) and not any(key is None for key in inner.keys):
+                # `*mapping` iterates its keys, so it contributes one value per key.
+                positional += len(inner.keys)
+                continue
+            return False
+        positional += 1
+    return positional > ceiling
+
+
 def _compile_call_is_complete(node: ast.Call, shadowed = None, skip: int = 0) -> bool:
     """Whether a visible `compile(...)` supplies the three arguments it requires.
 
@@ -3200,6 +3412,10 @@ def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) 
     was skipped entirely. `studio/backend/core/inference/tools.py` already resolves
     sink arguments this way.
     """
+    if _visibly_too_many_arguments(node, sink, skip):
+        # More positional arguments than the sink has parameters is a TypeError raised
+        # before any source is executed, exactly like the missing-argument case below.
+        return None
     if sink.rpartition(".")[2] == "compile" and not _compile_call_is_complete(
         node, shadowed, skip,
     ):
@@ -3676,6 +3892,19 @@ class _Visitor(ast.NodeVisitor):
         # and reporting it failed the gate on code that does nothing.
         self._visit_suite(node.body)
         self.collected_aliases.pop()
+        if isinstance(node, ast.ClassDef):
+            # The same export the taint map gets just below, for the same reason: a
+            # class body's locals become the class object's attributes.
+            # `class Runner: run = exec` leaves `Runner.run` directly callable, so
+            # `Runner.run(f"import {name}")` executes, and popping the alias map with
+            # the scope discarded the only record that the attribute names a sink.
+            exported_sinks = {
+                f"path>{node.name}.{name}": sink
+                for name, sink in self.sink_aliases[-1].items()
+                if isinstance(name, str) and not name.startswith("path>")
+            }
+        else:
+            exported_sinks = {}
         self.sink_aliases.pop()
         self.shadowed_sinks.pop()
         self.deferred_shadows.pop()
@@ -3710,6 +3939,13 @@ class _Visitor(ast.NodeVisitor):
             self.shadowed_sinks[:] = shadows
             self.sink_aliases[:] = sinks
             self.collected_aliases[:] = collected
+        # After that rollback, so a class body's exported aliases survive it. Into the
+        # deferred view as well: a class body RUNS where it is written, so a function
+        # body - which runs later, whether it is written above or below - sees the
+        # attribute. `_alias` reads the deferred map for every scope but the innermost,
+        # so recording only the executed one left the call inside `def f` unresolved.
+        self.sink_aliases[-1].update(exported_sinks)
+        self.collected_aliases[-1].update(exported_sinks)
         # The statement ends by binding its own name out here, to a function or a
         # class. Leaving the old entry in place reported
         # `payload = f"import {user}"; def payload(): pass; exec(payload)`, where the
@@ -6606,33 +6842,42 @@ class _Visitor(ast.NodeVisitor):
                     "line": inner.lineno,
                     "hash": _call_hash(inner),
                 })
-        sink = _sink_name(node.func, self._alias, self._is_shadowed)
+        candidates = _sink_candidates(node.func, self._alias, self._is_shadowed)
         # A shadowed base name applies to `b.exec(...)` as well as a bare call: with
         # `import builtins as b` visible, `def f(b, name)` supplies its own `b`.
         base = node.func
         if isinstance(base, ast.Attribute):
             base = base.value
         if isinstance(base, ast.Name) and self._is_shadowed(base.id):
-            sink = None
-        if sink is not None and _partial_sink(node.func, self._alias, self._is_shadowed):
-            # The source of `functools.partial(exec, f"...")()` was bound when the
-            # partial was built, so the outer call carries no arguments at all - but
-            # `functools.partial(exec)(f"...")` supplies it at call time instead, and
-            # asking only the inner call read that as having no source.
-            argument = _source_argument(
-                _partial_call(node.func, self._alias, self._is_shadowed),
-                sink, self._is_shadowed, skip = 1,
-            )
-            if argument is None:
-                argument = _source_argument(node, sink, self._is_shadowed)
-        else:
-            argument = _source_argument(node, sink, self._is_shadowed) if sink is not None else None
-        if (
-            argument is not None
-            and sink.rpartition(".")[2] in ("exec", "eval")
-            and self._yields_a_tree(argument)
-        ):
-            argument = None
+            candidates = []
+        sink, argument = None, None
+        # EVERY sink an undecidable choice of callee can select, not just the first
+        # that resolved: `(compile if flag else exec)(f"import {name}")` resolved to
+        # `compile`, whose single argument is then rejected as incomplete, and the
+        # `exec` the other branch really does reach was never asked about.
+        for candidate in candidates:
+            if _partial_sink(node.func, self._alias, self._is_shadowed):
+                # The source of `functools.partial(exec, f"...")()` was bound when the
+                # partial was built, so the outer call carries no arguments at all - but
+                # `functools.partial(exec)(f"...")` supplies it at call time instead, and
+                # asking only the inner call read that as having no source.
+                found = _source_argument(
+                    _partial_call(node.func, self._alias, self._is_shadowed),
+                    candidate, self._is_shadowed, skip = 1,
+                )
+                if found is None:
+                    found = _source_argument(node, candidate, self._is_shadowed)
+            else:
+                found = _source_argument(node, candidate, self._is_shadowed)
+            if (
+                found is not None
+                and candidate.rpartition(".")[2] in ("exec", "eval")
+                and self._yields_a_tree(found)
+            ):
+                found = None
+            if found is not None:
+                sink, argument = candidate, found
+                break
         if argument is not None:
             # The taint lookup has to happen wherever the unwrapping stops, not only
             # when the argument is a bare name: `payload = f"import {name}"` followed
@@ -6688,6 +6933,12 @@ NOTEBOOK_SUFFIX = ".ipynb"
 # is its own module, an unparseable one is counted rather than failing the file, since
 # a heredoc may be shell or YAML templating rather than Python.
 WORKFLOW_SUFFIXES = (".yml", ".yaml")
+
+# A committed shell script runs Python the same way a workflow step does: a heredoc fed
+# to `python -`, or a one-line `python -c`. `studio/setup.sh` and the ROCm installer both
+# do it, and a sink written inside one of those programs was covered by nothing, so the
+# hard gate stayed green over executable source the repository ships.
+SHELL_SUFFIXES = (".sh",)
 
 # `<<EOF`, `<<'PY'`, `<<-"EOF"`: the delimiter, quoted or not.
 _HEREDOC = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
@@ -7776,7 +8027,11 @@ def _python_dash_c_commands(text: str):
 
 
 def _scan_workflow(path: Path) -> list[dict]:
-    """Findings in the Python heredocs a workflow file runs.
+    """Findings in the Python heredocs a workflow file or shell script runs.
+
+    A committed `.sh` is read the same way: the whole file is shell, so the heredoc and
+    `python -c` patterns apply to it directly rather than to a `run:` block lifted out
+    of YAML.
 
     One visitor for the file, as for a notebook, and one qualname prefix per block.
     A block that will not parse is counted in NOTEBOOK_SKIPPED rather than failing the
@@ -7827,7 +8082,7 @@ def scan_file(path: Path) -> list[dict]:
     # nothing to do with dynamic execution.
     if path.suffix == NOTEBOOK_SUFFIX:
         return _scan_notebook(path)
-    if path.suffix in WORKFLOW_SUFFIXES:
+    if path.suffix in (*WORKFLOW_SUFFIXES, *SHELL_SUFFIXES):
         return _scan_workflow(path)
     try:
         # Bytes, not text. `ast.parse` applies the PEP 263 coding declaration itself,
@@ -7906,13 +8161,18 @@ def collect_paths(targets: list[str]) -> tuple[list[Path], list[str]]:
     paths, missing = [], []
     for target in targets:
         root = REPO_ROOT / target
-        if root.is_file() and root.suffix in (".py", NOTEBOOK_SUFFIX, *WORKFLOW_SUFFIXES):
+        if root.is_file() and root.suffix in (
+            ".py", NOTEBOOK_SUFFIX, *WORKFLOW_SUFFIXES, *SHELL_SUFFIXES,
+        ):
             paths.append(root)
         elif root.is_dir():
             # `is_file()` on each hit, so a directory named `foo.py` and a symlink that
             # points at one are skipped rather than read.
             before = len(paths)
-            for pattern in ("*.py", f"*{NOTEBOOK_SUFFIX}", *(f"*{x}" for x in WORKFLOW_SUFFIXES)):
+            for pattern in (
+                "*.py", f"*{NOTEBOOK_SUFFIX}",
+                *(f"*{x}" for x in (*WORKFLOW_SUFFIXES, *SHELL_SUFFIXES)),
+            ):
                 paths.extend(
                     p for p in root.rglob(pattern)
                     if p.is_file() and not _EXCLUDED_PARTS & set(_exclusion_parts(p, root))

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -174,6 +174,10 @@ _IDENTITY_TRANSLATIONS = ("translate",)
 _TEXT_PRESERVING_MODULES = {
     "textwrap": ("dedent", "indent"),
     "copy": ("copy", "deepcopy"),
+    # `ast.unparse(ast.parse(f"..."))` is a round trip: the text that comes back
+    # executes what went in, so the interpolation survives it. The outer call read as
+    # opaque and the whole round trip passed the gate.
+    "ast": ("unparse",),
 }
 _TEXT_PRESERVING_FUNCTIONS = tuple(
     name for names in _TEXT_PRESERVING_MODULES.values() for name in names
@@ -1162,6 +1166,14 @@ _REBOUND_FUNCTION_NAMES: set = set()
 # resolvers that read the tables are plain functions with no visitor to ask.
 _CURRENT_SCOPE = ""
 
+# The prefixed namespaces an alias can be recorded under. Read when a helper
+# parameter is answered from its argument: whatever the argument means, the parameter
+# means the same thing inside the body.
+_ALIAS_NAMESPACES = (
+    "module:", "constructor:", "partial:", "functools:", "text:", "stdlib:",
+    "stdlibfunc:", "builder:", "template:", "formatter:",
+)
+
 # Helpers currently being resolved, so a recursive one cannot loop forever.
 _HELPER_STACK: set = set()
 
@@ -1188,6 +1200,26 @@ def _decorator_name(node: ast.AST) -> str:
     return ""
 
 
+def _reachable_statements(body):
+    """The statements of a suite that can run, stopping at one that always leaves.
+
+    A decided `if` contributes only the branch that runs. A test this cannot decide
+    leaves both suites standing, since being generous costs at most an extra read.
+    """
+    for statement in body:
+        if isinstance(statement, ast.If):
+            decided = _constant_truth(statement.test)
+            if decided is not None:
+                branch = statement.body if decided else statement.orelse
+                yield from _reachable_statements(branch)
+                if any(_definitely_jumps(inner) for inner in branch):
+                    return
+                continue
+        yield statement
+        if _definitely_jumps(statement):
+            return
+
+
 def _returned_expressions(definition) -> list:
     """The values this function's own `return` statements hand back.
 
@@ -1201,12 +1233,10 @@ def _returned_expressions(definition) -> list:
     condition this cannot decide leaves everything below it standing.
     """
     found = []
-    for statement in definition.body:
+    for statement in _reachable_statements(definition.body):
         for child in _walk_this_scope(statement):
             if isinstance(child, ast.Return) and child.value is not None:
                 found.append(child.value)
-        if _definitely_jumps(statement):
-            break
     return found
 
 
@@ -1726,6 +1756,24 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
     selected = _first_from_iterator(node, shadowed)
     if selected is not None:
         return _is_interpolated(selected, resolve, shadowed, resolve_alias)
+    if (
+        isinstance(function, ast.Name)
+        and function.id in ("min", "max")
+        and not (shadowed is not None and shadowed(function.id))
+        and not node.keywords
+        and len(node.args) == 1
+        and not isinstance(node.args[0], ast.Starred)
+    ):
+        # `min([f"import {name}"])` has one element to choose from, so it hands that
+        # element back whichever way it compares. Only a written-out container holding
+        # exactly one element: with two, which one wins depends on the values.
+        container = node.args[0]
+        if (
+            isinstance(container, (ast.List, ast.Tuple, ast.Set))
+            and len(container.elts) == 1
+            and not isinstance(container.elts[0], ast.Starred)
+        ):
+            return _is_interpolated(container.elts[0], resolve, shadowed, resolve_alias)
     helper = _visible_helper(function, shadowed)
     if helper is not None and helper.name not in _HELPER_STACK:
         # `def build(): return f"import {name}"` followed by `exec(build())` executes
@@ -2144,6 +2192,15 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             if node.args or node.keywords:
                 return f".{function.attr}()"
             return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
+        if function.attr in _BUILDERS and _visibly_not_this_builder(
+            function.value, function.attr,
+        ):
+            # `[].format(name)` and `[].join([...])` raise AttributeError before the
+            # sink is reached: a list has neither method, and bytes has `join` but not
+            # `format`. Reporting them failed the gate on calls that cannot execute.
+            # Only a receiver written out as a literal of the wrong type; anything
+            # unknown is still read as a string method.
+            return None
         if (
             function.attr in _BUILDERS
             and _visibly_local_instance(function.value, shadowed)
@@ -2549,6 +2606,28 @@ def _literal_builtins_import(node: ast.AST, shadowed = None, aliases = None) -> 
     return False
 
 
+def _visibly_not_this_builder(receiver: ast.AST, builder: str) -> bool:
+    """Whether the receiver is written out as something without that method.
+
+    `str` has all three; `bytes` has `join` but neither formatting method; a written-out
+    list, tuple, set, dict or number has none of them. Anything not written out here -
+    a name, a call, an attribute - says nothing and is left alone, which is the
+    reporting side.
+    """
+    if isinstance(receiver, ast.JoinedStr):
+        return False
+    if isinstance(receiver, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
+        return True
+    if isinstance(receiver, ast.Constant):
+        if isinstance(receiver.value, str):
+            return False
+        if isinstance(receiver.value, bytes):
+            return builder != "join"
+        # A number, None, or True/False: none of the three exist on any of them.
+        return not isinstance(receiver.value, type(...))
+    return False
+
+
 def _visibly_unaddable(left: ast.AST, right: ast.AST) -> bool:
     """Whether adding these two written-out operands raises rather than concatenating.
 
@@ -2854,6 +2933,21 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
                 given = _sink_name(argument, aliases, shadowed)
                 if given is not None:
                     supplied[parameter] = given
+                if not isinstance(argument, ast.Name):
+                    continue
+                # And every OTHER namespace the argument is recorded in, not just the
+                # sinks: `def choose(module): return module.exec` needs `module` to
+                # answer as the builtins module, and recording only sink arguments left
+                # the returned attribute unresolved. The prefixes are the ones this
+                # file already uses, so nothing new is invented here.
+                if argument.id in ("builtins", "__builtins__"):
+                    supplied[f"module:{parameter}"] = "builtins"
+                if aliases is None:
+                    continue
+                for namespace in _ALIAS_NAMESPACES:
+                    recorded = aliases(f"{namespace}{argument.id}")
+                    if recorded:
+                        supplied[f"{namespace}{parameter}"] = recorded
 
             def inner_aliases(key):
                 if key in supplied:
@@ -7162,7 +7256,11 @@ class _Visitor(ast.NodeVisitor):
             return
         _HELPER_STACK.add(helper.name)
         try:
-            for statement in helper.body:
+            # Only the statements that can run: `def run(source): return` followed by
+            # `exec(source)` cannot reach the sink, and a walk over the whole body
+            # reported the caller's f-string for a call that never happens. Same
+            # reachability the return collector uses.
+            for statement in _reachable_statements(helper.body):
                 for child in _walk_this_scope(statement):
                     if not isinstance(child, ast.Call):
                         continue
@@ -7197,7 +7295,14 @@ class _Visitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def _origin_of_argument(self, argument) -> str:
-        """The digest recorded for the name or path this argument reads, if any."""
+        """The digests recorded for every name or path this argument reads.
+
+        EVERY one, joined and sorted, not the first found: `exec(a + b)` is built from
+        two bindings, and answering with `a`'s digest alone left a justification
+        standing when `b` changed underneath it. Sorted so the value does not depend on
+        walk order, and joined with `+` the way several findings under one key are.
+        """
+        found = set()
         for node in ast.walk(argument) if isinstance(argument, ast.AST) else ():
             key = None
             if isinstance(node, ast.Name):
@@ -7206,10 +7311,10 @@ class _Visitor(ast.NodeVisitor):
                 key = _compound_key(node)
             if key is None:
                 continue
-            found = self.origin_of.get((self._qualname(), key))
-            if found:
-                return found
-        return ""
+            recorded = self.origin_of.get((self._qualname(), key))
+            if recorded:
+                found.add(recorded)
+        return "+".join(sorted(found))
 
     def _yields_a_tree(self, argument) -> bool:
         """Whether the argument is a visible `ast.parse(...)`, which is not source.
@@ -7351,7 +7456,57 @@ WORKFLOW_SUFFIXES = (".yml", ".yaml")
 # to `python -`, or a one-line `python -c`. `studio/setup.sh` and the ROCm installer both
 # do it, and a sink written inside one of those programs was covered by nothing, so the
 # hard gate stayed green over executable source the repository ships.
-SHELL_SUFFIXES = (".sh",)
+SHELL_SUFFIXES = (".sh", ".ps1")
+
+# PowerShell launchers hold Python too, and not on the command line: the shipped
+# installers bind the program to a variable and hand that variable to `-c`, so the
+# shell reader - which follows the words of one command - saw nothing. A literal
+# assignment and a `-c` that names it are both written out, which is all this reads.
+_POWERSHELL_ASSIGNMENT = re.compile(
+    r"""^[ \t]*\$(?:\w+:)?(?P<name>[A-Za-z_]\w*)[ \t]*=[ \t]*(?P<quote>["'])(?P<body>.*?)(?P=quote)[ \t]*$""",
+    re.M,
+)
+# `@' ... '@` and `@" ... "@`, PowerShell's multi-line string.
+_POWERSHELL_HERESTRING = re.compile(
+    r"""^[ \t]*\$(?:\w+:)?(?P<name>[A-Za-z_]\w*)[ \t]*=[ \t]*@(?P<quote>["'])\r?\n(?P<body>.*?)\r?\n(?P=quote)@""",
+    re.M | re.S,
+)
+# `-c`, then either a variable or a quoted program. The comma is PowerShell's array
+# separator, and a bare space is the ordinary call spelling.
+_POWERSHELL_DASH_C = re.compile(
+    r"""["']?-c["']?[ \t]*(?:,[ \t]*)?(?:\$(?:\w+:)?(?P<name>[A-Za-z_]\w*)|(?P<quote>["'])(?P<body>.*?)(?P=quote))""",
+    re.S,
+)
+
+
+def _powershell_programs(text: str):
+    """`(line number, program)` for each Python `-c` payload a PowerShell file runs.
+
+    The payload is read where it is WRITTEN - a literal assignment or a here-string -
+    and matched to the `-c` that names it. Nothing is evaluated: a variable this cannot
+    see assigned a literal is left alone.
+    """
+    literals = {}
+    lines = {}
+    for pattern in (_POWERSHELL_HERESTRING, _POWERSHELL_ASSIGNMENT):
+        for match in pattern.finditer(text):
+            name = match.group("name")
+            if name in literals:
+                # Two literals under one name is no evidence about either.
+                literals[name] = None
+                continue
+            literals[name] = match.group("body")
+            lines[name] = text[: match.start()].count("\n") + 1
+    for match in _POWERSHELL_DASH_C.finditer(text):
+        number = text[: match.start()].count("\n") + 1
+        if match.group("name") is not None:
+            program = literals.get(match.group("name"))
+            if program:
+                yield lines.get(match.group("name"), number), program
+            continue
+        program = match.group("body")
+        if program:
+            yield number, program
 
 # `<<EOF`, `<<'PY'`, `<<-"EOF"`: the delimiter, quoted or not.
 _HEREDOC = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
@@ -7868,6 +8023,10 @@ _PYTHON_VALUE_OPTIONS = ("-c", "-m", "-W", "-X", "--check-hash-based-pycs")
 _PYTHON_COMMAND = re.compile(r"(?:python|pypy)[0-9]*(?:\.[0-9]+)?(?:\.exe)?", re.IGNORECASE)
 
 
+# `NAME=value` in front of a command, which the shell applies to that command only.
+_SHELL_ASSIGNMENT = re.compile(r"^[A-Za-z_]\w*=")
+
+
 def _names_python(argument: str) -> bool:
     """Whether a `%%script` argument names a Python interpreter at all.
 
@@ -7911,6 +8070,14 @@ def _runs_python(argument: str, body_only: bool = True) -> bool:
                 index += 2
             else:
                 index += 1
+            continue
+        if _SHELL_ASSIGNMENT.match(token):
+            # `FOO=bar python -c '...'` sets the variable for that one command and the
+            # shell runs Python all the same. Reading the assignment as the command
+            # name said the step was not Python at all, and its `-c` program went
+            # unread. The `env` wrapper below already steps over these; a bare prefix
+            # is the same thing without the wrapper.
+            index += 1
             continue
         command = token.rsplit("/", 1)[-1].split("\\")[-1]
         if command == "env":
@@ -8168,6 +8335,11 @@ def _dash_c_program(argument: str) -> str | None:
     return None
 
 
+# Cell magics that run a SHELL. The body is not Python, but a shell launches Python,
+# so the body is read for embedded programs rather than dropped.
+_SHELL_MAGICS = frozenset({"bash", "sh", "script"})
+
+
 def _foreign_cell_magic(code: str) -> str | None:
     """The `%%magic` name when it makes the whole cell stop being Python.
 
@@ -8327,6 +8499,24 @@ def _scan_notebook(path: Path) -> list[dict]:
             else:
                 code = command
         elif _foreign_cell_magic(code) is not None:
+            magic = _foreign_cell_magic(code)
+            if magic in _SHELL_MAGICS:
+                # `%%bash` is another language, but a shell cell LAUNCHES Python the
+                # same way a workflow step does - a heredoc, or `python -c '...'` - and
+                # dropping the whole cell left those programs unread. The same two
+                # readers the workflow scanner uses answer for the body.
+                body = "\n".join(code.splitlines()[1:])
+                for start, source in [
+                    *_python_heredocs(body), *_python_dash_c_commands(body),
+                ]:
+                    inner = _parse_cell(source, f"{path}#cell{index}")
+                    if inner is None:
+                        skipped += 1
+                        continue
+                    # The magic line and the lines above the program, so the finding
+                    # points where the program really sits in the cell.
+                    ast.increment_lineno(inner, start)
+                    parsed.append((index, inner))
             continue
         tree = _parse_cell(code, f"{path}#cell{index}")
         if tree is None:
@@ -8520,6 +8710,47 @@ def _python_dash_c_commands(text: str):
             )
 
 
+# `run: >` folds its lines into one command, so a `python` on one line and a `-c` on
+# the next are one shell command on the runner. `|` keeps the newlines and is left
+# alone. The indicator may carry a chomping or indentation modifier: `>-`, `>2`.
+_FOLDED_SCALAR = re.compile(r"^(?P<indent>[ \t]*)(?:-[ \t]+)?(?P<key>[\w.-]+):[ \t]*>[-+0-9]*[ \t]*$")
+
+
+def _folded_commands(text: str) -> str:
+    """`text` with every folded block scalar joined onto its introducing line.
+
+    Line for line: the joined command replaces the first line of the block and the
+    rest are blanked, so every reader below keeps reporting the line numbers the file
+    really has. A blank line inside a folded scalar is a newline in the value and ends
+    the command, exactly as YAML says.
+    """
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        match = _FOLDED_SCALAR.match(lines[index])
+        if match is None:
+            index += 1
+            continue
+        margin = len(match.group("indent"))
+        start = index + 1
+        collected = []
+        cursor = start
+        while cursor < len(lines):
+            line = lines[cursor]
+            if not line.strip():
+                break
+            if len(line) - len(line.lstrip()) <= margin:
+                break
+            collected.append(line.strip())
+            cursor += 1
+        if collected:
+            lines[index] = f"{match.group('indent')}{match.group('key')}: " + " ".join(collected)
+            for blanked in range(start, cursor):
+                lines[blanked] = ""
+        index = max(cursor, index + 1)
+    return "\n".join(lines)
+
+
 def _scan_workflow(path: Path) -> list[dict]:
     """Findings in the Python heredocs a workflow file or shell script runs.
 
@@ -8544,7 +8775,15 @@ def _scan_workflow(path: Path) -> list[dict]:
     findings = []
     skipped = 0
     parsed = []
-    for start, source in [*_python_heredocs(text), *_python_dash_c_commands(text)]:
+    if path.suffix in WORKFLOW_SUFFIXES:
+        # A folded scalar is one shell command however many lines it is written over.
+        text = _folded_commands(text)
+    embedded = [*_python_heredocs(text), *_python_dash_c_commands(text)]
+    if path.suffix == ".ps1":
+        # A PowerShell file is not shell: the heredoc and word-splitting readers above
+        # find nothing in one, and its `-c` payload is bound to a variable first.
+        embedded = list(_powershell_programs(text))
+    for start, source in embedded:
         try:
             tree = ast.parse(source, filename = f"{path}#line{start}")
         except (SyntaxError, ValueError):
@@ -8563,6 +8802,11 @@ def _scan_workflow(path: Path) -> list[dict]:
         visitor = _Visitor(path)
         visitor.qualname_prefix = f"line{start}"
         visitor._collect_aliases(tree.body)
+        # The same prepass a module and a notebook get: a nested `def` reads its
+        # closure when it is CALLED, so a heredoc that defines one above the assignment
+        # it reads really does execute the built string. Without this the identical
+        # `.py` module reported a finding and the heredoc reported nothing.
+        visitor.future_taint[0].update(visitor._later_taint(tree.body))
         try:
             visitor.visit(tree)
         except RecursionError:
@@ -8753,7 +8997,10 @@ def origins_by_key(findings: list[dict]) -> dict[str, str]:
     grouped: dict[str, set] = {}
     for finding in findings:
         if finding.get("origin"):
-            grouped.setdefault(key_of(finding), set()).add(finding["origin"])
+            # A single finding already joins the digests of every binding its source
+            # was built from, so the parts are split out again here rather than nested:
+            # two copies built the same way would otherwise repeat a digest.
+            grouped.setdefault(key_of(finding), set()).update(finding["origin"].split("+"))
     return {key: "+".join(sorted(values)) for key, values in grouped.items()}
 
 
@@ -8773,13 +9020,23 @@ def write_allowlist(findings: list[dict], reason: str) -> None:
             continue
         written.add(key)
         previous = existing.get(key, {})
+        # The justification is carried over only when every field the gate compares is
+        # unchanged. `--update` is what a reviewer is told to run after the gate fails,
+        # and copying the old reason across a changed origin, kind or count wrote the
+        # new identity next to a justification nobody had read it against - which is
+        # the whole thing the origin and count fields exist to prevent.
+        unchanged = (
+            previous.get("kind", finding["reason"]) == finding["reason"]
+            and previous.get("count", 1) == counts[key]
+            and previous.get("origin", origins.get(key, "")) == origins.get(key, "")
+        )
         entry = {
             "path": finding["path"],
             "qualname": finding["qualname"],
             "sink": finding["sink"],
             "kind": finding["reason"],
             "hash": finding["hash"],
-            "reason": previous.get("reason", reason),
+            "reason": previous.get("reason", reason) if unchanged else reason,
         }
         if origins.get(key):
             entry["origin"] = origins[key]

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -1060,7 +1060,10 @@ def _inherits_text(definition: ast.ClassDef, seen = None) -> bool:
     seen = seen if seen is not None else set()
     for base in definition.bases:
         if not isinstance(base, ast.Name):
-            continue
+            # `class Safe(Namespace.Base)` names a base this cannot resolve, and that
+            # base may itself subclass `str`. Unknown counts as textual, which is the
+            # reporting side and the same answer a base from another module gets.
+            return True
         if base.id in ("str", "bytes"):
             return True
         if base.id in seen:
@@ -1768,7 +1771,18 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             low, high = _NORMALISER_ARITY[function.attr]
             if unbound:
                 low, high = low + 1, high + 1
-            if not node.keywords and not low <= len(node.args) <= high:
+            spelled = [keyword.arg for keyword in node.keywords]
+            if None not in spelled:
+                # These parameters are positional-only, verified against CPython:
+                # every one of them raises "takes no keyword arguments" except
+                # `expandtabs`, which documents `tabsize`. So a keyword is a
+                # `TypeError` before the sink, and the call builds nothing.
+                allowed = {"tabsize"} if function.attr == "expandtabs" else set()
+                if set(spelled) - allowed:
+                    return None
+                if not low <= len(node.args) + len(spelled) <= high:
+                    return None
+            elif not node.keywords and not low <= len(node.args) <= high:
                 # The call raises before the sink runs.
                 return None
             if unbound:
@@ -2007,6 +2021,12 @@ def _replace_can_splice(node: ast.Call, template = None, offset: int = 0) -> boo
     reported on the receiver alone. Only a written-out argument answers here - a
     replacement this cannot read is assumed to splice, which is the reporting side.
     """
+    # `str.replace`'s parameters are positional-only, verified against CPython:
+    # `"X".replace(old = "X", new = name)` raises "takes no keyword arguments" before
+    # the sink. Reading those keywords as bound arguments reported a call that cannot
+    # run. A `**` this cannot read is still unknown and still splices.
+    if any(keyword.arg is not None for keyword in node.keywords):
+        return False
     # A search text that is visibly absent from a visible template replaces nothing:
     # `"pass".replace("MISSING", name)` executes the literal it started with.
     if template is None:
@@ -2457,7 +2477,12 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
         # Only the operands that can still be the value: `(print or exec)(...)` calls
         # print, since a truthy literal ends the chain, and reporting the dead operand
         # failed the gate. Same rule the source side applies.
-        for value in _reachable_operands(function):
+        #
+        # And `and` hands back its LAST operand when the earlier ones are truthy, which
+        # a builtin function always is: `(compile and exec)(f"...")` calls `exec`.
+        # Reading the first resolved name gave `compile`, whose arity test then
+        # rejected the single argument and suppressed a real call.
+        for value in _boolop_candidates(function):
             resolved = _sink_name(value, aliases, shadowed)
             if resolved is not None:
                 return resolved
@@ -2671,6 +2696,17 @@ def _nullcontext_value(node: ast.AST, aliases = None, shadowed = None) -> ast.AS
             return None
         return node.args[0]
     return None
+
+
+def _boolop_candidates(node: ast.BoolOp) -> list:
+    """The operands a boolean callee may BE, most likely first.
+
+    `or` hands back the first truthy operand, so source order is right. `and` hands
+    back the last one when the earlier ones are truthy, and every builtin function is,
+    so the last operand is read first there.
+    """
+    operands = _reachable_operands(node)
+    return list(reversed(operands)) if isinstance(node.op, ast.And) else operands
 
 
 def _reachable_operands(node: ast.BoolOp) -> list:
@@ -3330,6 +3366,10 @@ class _Visitor(ast.NodeVisitor):
                 if isinstance(child, ast.Assign):
                     targets = child.targets
                 elif isinstance(child, ast.AnnAssign) and child.value is not None:
+                    targets = [child.target]
+                elif isinstance(child, ast.AugAssign):
+                    # `payload += f"import {name}"` puts built source in the name as
+                    # plainly as `=` does, and a deferred body reads the cell after it.
                     targets = [child.target]
                 else:
                     continue
@@ -6292,6 +6332,17 @@ class _Visitor(ast.NodeVisitor):
             length = _visible_length(extra)
             if length is not None:
                 reach = min(reach, length)
+        if sink.rpartition(".")[2] == "compile" and len(inner.args) > 3:
+            # `map(compile, sources, filenames, modes)` raises on the first mode
+            # `compile` refuses, and every later source is then never reached:
+            # `map(compile, ["pass", f"..."], [...], ["bad", "exec"])` compiles the
+            # literal and raises. Only written-out constant modes decide anything.
+            modes = self._literal_elements(inner.args[3])
+            for index, mode in enumerate(modes or ()):
+                if isinstance(mode, ast.Constant) and isinstance(mode.value, str):
+                    if mode.value not in ("exec", "eval", "single"):
+                        reach = min(reach, index)
+                        break
         if consumer:
             counted = _consumed_count(consumer, sink)
             if counted is not None:
@@ -7202,6 +7253,13 @@ def _script_command_source(code: str) -> str | None:
                 continue
             if token == "-c" and position + 1 < len(tokens):
                 return tokens[position + 1]
+            if token.startswith(("-W", "-X")) and len(token) > 2:
+                # `-Wignore::DeprecationWarning` attaches the value to the option, and
+                # the letters in that value are not flags: reading the `c` in
+                # `DeprecationWarning` as a bundled `-c` extracted `ationWarning` as
+                # the program, which parses as nothing and lost the real `-c` after it.
+                position += 1
+                continue
             if (
                 token.startswith("-")
                 and not token.startswith("--")

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -176,9 +176,24 @@ _CONSTRUCTOR_SOURCE_KEYWORD = {
 # ordinary parameter, and rewriting it as `+` reported a helper that may well return a
 # fixed literal. `_binds_over_sink` never recorded the shadow because the name was in
 # none of the tracked sets.
-_MODULE_RECEIVERS = frozenset({"codeop", "operator", "ast", "importlib", "functools"})
+_MODULE_RECEIVERS = frozenset({
+    "codeop", "operator", "ast", "importlib", "functools", "textwrap", "contextlib",
+})
+
+# `operator` functions that build a string out of two values, and the operator each
+# one is. The in-place spellings return the same concatenation for a str, which has no
+# in-place add, and `mod` is `%`, which the binary form already reports as formatting.
+_OPERATOR_BUILDERS = {
+    "add": ast.Add, "concat": ast.Add, "iadd": ast.Add, "iconcat": ast.Add,
+    "mod": ast.Mod, "imod": ast.Mod,
+}
 _BUILTIN_NAMES = frozenset({
-    *SINKS, *_CONSTRUCTORS, *_MODULE_RECEIVERS, "builtins", "dict", "getattr",
+    *SINKS, *_CONSTRUCTORS, *_MODULE_RECEIVERS, *_TEXT_PRESERVING_FUNCTIONS,
+    "builtins", "dict", "getattr",
+    # The bare spelling `_nullcontext_value` accepts. A local of that name provides
+    # whatever it likes from `__enter__`, so the shadow test it already performs has
+    # to have something to find.
+    "nullcontext",
 })
 
 
@@ -328,6 +343,16 @@ def _constructor_accepts_text(node: ast.Call, name: str) -> bool:
             keyword.arg == "encoding" for keyword in node.keywords
         )
         return supplied_encoding
+    if name == "str":
+        # `str(f"import {name}", "utf-8")` is the DECODING form, and CPython answers
+        # `TypeError: decoding str is not supported` before the sink is reached.
+        # Reporting it failed the gate on a call that cannot execute. One-argument
+        # `str(text)` is unaffected, and a bytes-like source still decodes: the test
+        # above already required a VISIBLY text argument to get here.
+        supplied_encoding = len(node.args) > 1 or any(
+            keyword.arg in ("encoding", "errors") for keyword in node.keywords
+        )
+        return not supplied_encoding
     return True
 
 
@@ -663,6 +688,15 @@ def _names_module(node: ast.AST, module: str, shadowed = None, aliases = None) -
     return aliases is not None and aliases(f"stdlib:{node.id}") == module
 
 
+def _visibly_container(node: ast.AST) -> bool:
+    """Whether `node` is written out as a list, tuple or set display.
+
+    A sink handed one of these raises TypeError, so nothing it holds is ever
+    executed. Only the written-out spelling; a name is unknown and stays source.
+    """
+    return isinstance(node, (ast.List, ast.Tuple, ast.Set))
+
+
 def _positive_repetition(count: ast.AST) -> bool:
     """Whether a written-out repetition count keeps at least one copy of the string.
 
@@ -675,11 +709,13 @@ def _positive_repetition(count: ast.AST) -> bool:
     if isinstance(count, ast.UnaryOp) and isinstance(count.op, (ast.USub, ast.UAdd)):
         sign = -1 if isinstance(count.op, ast.USub) else 1
         count = count.operand
-    if (
-        isinstance(count, ast.Constant)
-        and isinstance(count.value, int)
-        and not isinstance(count.value, bool)
-    ):
+    if isinstance(count, ast.Constant) and isinstance(count.value, bool):
+        # Python takes a bool as a repetition count, so `s * False` is the empty
+        # string and `s * True` is one copy. Excluding `bool` outright made `False`
+        # fall through to the conservative default and reported a call that builds
+        # nothing.
+        return sign * int(count.value) > 0
+    if isinstance(count, ast.Constant) and isinstance(count.value, int):
         return sign * count.value > 0
     return True
 
@@ -695,6 +731,14 @@ def _interpolated_binop(node, resolve = None, shadowed = None, resolve_alias = N
         if isinstance(node.op, ast.Mod):
             return "%-format"
         if isinstance(node.op, ast.Add):
+            # `[f"import {name}"] + []` is a LIST, and a sink handed a list raises
+            # TypeError before executing anything. Reporting it forced code that is
+            # not dynamic execution at all into the allowlist, which is the same
+            # argument the visibly numeric exclusion above already makes. Both
+            # operands have to be written-out containers; anything unknown still
+            # reads as concatenation.
+            if _visibly_container(node.left) and _visibly_container(node.right):
+                return None
             return "string concatenation"
     if isinstance(node.op, ast.Mult):
         # `f"import {name}" * 0` is the empty string, and a negative count is empty
@@ -723,6 +767,13 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
         preserving = function.id
     elif isinstance(function, ast.Attribute) and isinstance(function.value, ast.Name):
         preserving = function.attr
+    if preserving not in _TEXT_PRESERVING_FUNCTIONS and isinstance(function, ast.Name):
+        # `from textwrap import dedent as clean` binds the same function under a
+        # different name, and matching on the spelling alone stopped before the
+        # argument was ever looked at. Recorded in its own namespace, so the alias
+        # resolves to the function it names and nothing else.
+        if resolve_alias is not None and not (shadowed is not None and shadowed(function.id)):
+            preserving = resolve_alias(f"text:{function.id}") or preserving
     if preserving in _TEXT_PRESERVING_FUNCTIONS and not (
         shadowed is not None and isinstance(function, ast.Name) and shadowed(function.id)
     ):
@@ -810,19 +861,22 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 function.value, "codeop", shadowed, resolve_alias,
             ):
                 return _is_interpolated(compiled, resolve, shadowed, resolve_alias)
-        if function.attr in ("add", "concat") and isinstance(function.value, ast.Name):
+        if function.attr in _OPERATOR_BUILDERS and isinstance(function.value, ast.Name):
             # `exec(operator.add("import ", name))` builds the same string the `+`
-            # operator does, and the stdlib documents `operator.concat` the same way.
-            # Rebuilt as that operator and read there, which also applies the visibly
-            # numeric exclusion, so `operator.add(1, 2)` stays quiet. Receiver written
-            # out and unshadowed, two positional arguments, the only shape these take.
+            # operator does, and the stdlib documents `concat`, the in-place `iadd`
+            # and `iconcat`, and `mod` for `%`, all the same way. Rebuilt as that
+            # operator and read there, which also applies the visibly numeric
+            # exclusion, so `operator.add(1, 2)` stays quiet. Receiver written out and
+            # unshadowed, two positional arguments, the only shape these take.
             if (
                 _names_module(function.value, "operator", shadowed, resolve_alias)
                 and len(node.args) == 2
                 and not node.keywords
             ):
                 equivalent = ast.BinOp(
-                    left = node.args[0], op = ast.Add(), right = node.args[1],
+                    left = node.args[0],
+                    op = _OPERATOR_BUILDERS[function.attr](),
+                    right = node.args[1],
                 )
                 return _is_interpolated(
                     ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
@@ -887,6 +941,14 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             if empty:
                 return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
             return None
+        if function.attr in ("removeprefix", "removesuffix") and node.args:
+            # `s.removeprefix(s)` is the empty string, so nothing survives to be
+            # executed and reporting it failed the gate on a call that builds
+            # nothing. Only when the argument is written out as the SAME expression
+            # as the receiver, which is decidable from the text; anything else still
+            # preserves the receiver through the normaliser branch below.
+            if ast.dump(function.value) == ast.dump(node.args[0]):
+                return None
         if function.attr in _NORMALISERS:
             # `str.strip(s)` is the unbound descriptor spelling of `s.strip()`, so
             # the source is the first argument and the receiver is only the type.
@@ -927,6 +989,13 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 if function.attr in ("format", "format_map"):
                     return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
                 return None
+            if function.attr == "format" and _visibly_literal_text(function.value):
+                # `"pass".format(name)` has no replacement field, so the arguments
+                # change nothing and the result is the literal. Only a written-out
+                # template is read this way; a variable receiver may well hold one.
+                template = function.value.value
+                if isinstance(template, str) and not _FORMAT_FIELD.search(template):
+                    return None
             return f".{function.attr}()"
         if function.attr == "decode" and _visibly_text(function.value):
             # Python 3 has no `str.decode`, so `f"...".decode()` raises
@@ -946,8 +1015,19 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 )
             # Unwrap the receiver: the conversion changes the type, not the syntax.
             return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
-    constructor = _constructor_name(function, shadowed, resolve_alias)
-    if constructor is not None and _constructor_accepts_text(node, constructor):
+    # Every arm a conditional callee may take, not just the first that resolves:
+    # `(memoryview if flag else str)(f"...")` answered `memoryview`, whose argument
+    # test then rejected a visible string, and the `str` arm - which does execute the
+    # source - was never looked at.
+    for constructor in _constructor_names(function, shadowed, resolve_alias):
+        if not _constructor_accepts_text(node, constructor):
+            continue
+        if constructor == "format" and _truncating_format_spec(node):
+            # `format(f"import {name}", ".0")` is the empty string on CPython, so
+            # nothing built survives to the sink. Only a written-out spec whose
+            # precision is zero; every other spec, and any spec this cannot read,
+            # still hands the source through.
+            continue
         source = _constructor_source(node, constructor, shadowed)
         if source is not None and not (constructor == "str" and _visibly_bytes(source)):
             # `str(bytes)` is the REPR of the bytes, `"b'import os'"`, which executes
@@ -1011,6 +1091,26 @@ def _always_breaks(body) -> bool:
         if isinstance(statement, (ast.Expr, ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Pass)):
             continue
         return False
+    return False
+
+
+def _definitely_jumps(statement: ast.stmt) -> bool:
+    """Whether reaching this statement always leaves the suite it is in.
+
+    A `break`, `continue`, `return` or `raise`, or an `if` whose test is decidable and
+    whose selected suite always leaves. Reachability only: a jump under a test this
+    cannot decide leaves everything below it standing.
+    """
+    if isinstance(statement, (ast.Break, ast.Continue, ast.Return, ast.Raise)):
+        return True
+    if isinstance(statement, ast.If):
+        decided = _constant_truth(statement.test)
+        if decided is None:
+            return False
+        return any(
+            _definitely_jumps(inner)
+            for inner in (statement.body if decided else statement.orelse)
+        )
     return False
 
 
@@ -1225,13 +1325,15 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
     if (
         isinstance(function, ast.Call)
         and isinstance(function.func, ast.Attribute)
-        and function.func.attr == "get"
+        and function.func.attr in ("get", "__getitem__")
         and function.args
         and isinstance(function.args[0], ast.Constant)
     ):
         # `{"run": builtins.exec}.get("run")` and `builtins.__dict__.get("exec")` pick
         # the callee out of a mapping that is written out right here, the same shape
-        # the subscript spelling already reads.
+        # the subscript spelling already reads. `__getitem__` is that subscript
+        # written as a call - `builtins.__dict__.__getitem__("exec")` - and reading
+        # only `get` left it unresolved.
         key = function.args[0].value
         # `dict(run = exec).get("run")` is the same mapping written with the
         # constructor, so it is read the same way. The source side already went
@@ -1365,6 +1467,19 @@ def _constant_truth(test: ast.AST):
     """
     if isinstance(test, ast.Constant):
         return bool(test.value)
+    if isinstance(test, (ast.List, ast.Tuple, ast.Set)):
+        # An empty display is falsy and a display of written-out elements is truthy.
+        # Reading only `ast.Constant` left `[] and (payload := "pass")` undecided, so
+        # the walrus Python skips was applied and the taint it cleared was real.
+        # A `*` element may contribute nothing, so those stay undecided.
+        if any(isinstance(element, ast.Starred) for element in test.elts):
+            return None
+        return bool(test.elts)
+    if isinstance(test, ast.Dict):
+        # `{**other}` may be empty, so only a display without one is decided.
+        if any(key is None for key in test.keys):
+            return None
+        return bool(test.keys)
     if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
         inner = _constant_truth(test.operand)
         return None if inner is None else not inner
@@ -1430,11 +1545,16 @@ def _reachable_operands(node: ast.BoolOp) -> list:
     reachable = []
     for operand in node.values:
         reachable.append(operand)
-        if not isinstance(operand, ast.Constant):
+        # `_constant_truth` rather than a bare `ast.Constant`: an empty display is
+        # statically false too, and reading only constants applied the walrus in
+        # `[] and (payload := "pass")`, which Python skips. It also folds `not` and a
+        # nested boolean operand, which the two rules below then decide on.
+        decided = _constant_truth(operand)
+        if decided is None:
             continue
-        if isinstance(node.op, ast.Or) and operand.value:
+        if isinstance(node.op, ast.Or) and decided:
             break
-        if isinstance(node.op, ast.And) and not operand.value:
+        if isinstance(node.op, ast.And) and not decided:
             break
     return reachable
 
@@ -1469,6 +1589,11 @@ def _literal_dict_call(node: ast.AST, shadowed = None) -> ast.Dict | None:
         return None
     if any(keyword.arg is None for keyword in node.keywords):
         return None
+    if len(node.args) > 1:
+        # `dict` takes at most ONE positional argument, so `dict({...}, {...})` raises
+        # TypeError before the call it feeds ever runs. Merging any number of them
+        # synthesised a mapping that cannot exist at runtime and reported the sink.
+        return None
     keys: list = []
     values: list = []
     for argument in node.args:
@@ -1489,6 +1614,45 @@ def _has_computed_key(mapping: ast.Dict) -> bool:
     return any(
         key is not None and not isinstance(key, ast.Constant) for key in mapping.keys
     )
+
+
+# A `str.format` replacement field. `{{` and `}}` are escapes for a literal brace, so
+# they are stepped over before a real field is looked for.
+_FORMAT_FIELD = re.compile(r"(?<!\{)\{(?!\{)[^{}]*\}")
+
+
+def _truncating_format_spec(node: ast.Call) -> bool:
+    """Whether a builtin `format(value, spec)` spec cuts the value to nothing.
+
+    Only `.0`, written out: `format(s, ".0")` is `""` for a string, so nothing built
+    reaches the sink. A spec this cannot read is unknown and keeps the source.
+    """
+    spec = node.args[1] if len(node.args) > 1 else None
+    if spec is None:
+        for keyword in node.keywords:
+            if keyword.arg == "format_spec":
+                spec = keyword.value
+    if not (isinstance(spec, ast.Constant) and isinstance(spec.value, str)):
+        return False
+    return bool(re.fullmatch(r"[^{}]*\.0", spec.value))
+
+
+def _constructor_names(function: ast.AST, shadowed = None, aliases = None):
+    """Every constructor a callee may resolve to, most likely first.
+
+    One name for an ordinary callee. A conditional or boolean callee that cannot be
+    decided has an arm for each side, and each has to be checked on its own: one arm
+    may refuse the argument while the other forwards it to the sink.
+    """
+    if isinstance(function, ast.IfExp) and _constant_truth(function.test) is None:
+        return [
+            name for name in (
+                _constructor_name(function.body, shadowed, aliases),
+                _constructor_name(function.orelse, shadowed, aliases),
+            ) if name is not None
+        ]
+    resolved = _constructor_name(function, shadowed, aliases)
+    return [] if resolved is None else [resolved]
 
 
 def _mapping_literal(node: ast.AST, shadowed = None) -> ast.Dict | None:
@@ -1640,6 +1804,14 @@ def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) 
                 if isinstance(inner, ast.Dict) and not inner.keys:
                     expanded = True
                     continue
+                # A written-out expansion with at least one element DOES supply the
+                # argument: `compile(*["pass"], f"<{name}>", "exec")` compiles the
+                # literal and uses the f-string as the FILENAME. Treating every
+                # expansion as possibly empty merged that filename in and reported it
+                # as executable source.
+                if isinstance(inner, (ast.Tuple, ast.List, ast.Set)) and inner.elts:
+                    candidates.append(inner.elts[0])
+                    break
                 # An opaque expansion may BE the source, `exec(*[f"..."])`, and it
                 # may also contribute nothing at runtime, in which case the next
                 # written-out argument is: `exec(*args, f"...")` with `args = ()`
@@ -2203,13 +2375,13 @@ class _Visitor(ast.NodeVisitor):
             # still runs, and an iterable this cannot read still keeps its body.
             for statement in node.body:
                 self.visit(statement)
-                if isinstance(statement, (ast.Break, ast.Continue, ast.Return, ast.Raise)):
+                if _definitely_jumps(statement):
                     # Nothing after an unconditional jump in this suite ever runs, and
                     # visiting it applied its mutations anyway: `for _ in [0]: break`
                     # followed by `payload = "pass"` cleared a binding the loop cannot
                     # reach, so a later `exec(payload)` on the built string reported
-                    # nothing. Statement level, in this suite only: a jump inside a
-                    # nested `if` is conditional and everything below it still stands.
+                    # nothing. `if True: continue` counts too, since the test folds;
+                    # a jump under a test this cannot decide does not.
                     break
         # The `else` suite also runs when the iterable was empty, in which case the
         # target was never bound and the name still means whatever it meant outside -
@@ -2293,7 +2465,10 @@ class _Visitor(ast.NodeVisitor):
         `visit_For` inferred iterations from those literals and reported a sink that
         cannot execute. The literal is still visited, since it is evaluated.
         """
-        if self._literal_elements(node.iter):
+        if self._literal_elements(node.iter) is not None:
+            # `is not None`, not truthiness: `async for _ in []` raises the same
+            # TypeError, and falling through to `visit_For` read the list as an empty
+            # ITERABLE, visited the `else` suite and reported a sink that cannot run.
             self.visit(node.iter)
             self.visit(node.target)
             return
@@ -2358,16 +2533,35 @@ class _Visitor(ast.NodeVisitor):
                 for name, captures_subject in _pattern_bindings(case.pattern)
             }
             saved_scope = self._shadow_locals(shadow if subject_sink else bound)
+            # `match [f"import {name}"]: case [payload]:` pairs element for element,
+            # exactly as an unpacking assignment does, so the capture holds the
+            # f-string and `exec(payload)` runs it. Clearing every sequence capture
+            # read that as binding nothing.
+            paired = self._sequence_pattern_pairs(node.subject, case.pattern)
             for name, captures_subject in _pattern_bindings(case.pattern):
-                self.tainted[-1][name] = f"{reason} via `{name}`" if (
-                    reason is not None and captures_subject
-                ) else None
-                if self.tainted[-1][name] is None:
+                element_reason = None
+                if reason is not None and captures_subject:
+                    element_reason = f"{reason} via `{name}`"
+                elif name in paired:
+                    inner = _is_interpolated(
+                        paired[name], self.tainted[-1].get, self._is_shadowed, self._alias,
+                    )
+                    if inner is not None:
+                        element_reason = f"{inner} via `{name}`"
+                if element_reason is None:
                     self.tainted[-1].pop(name, None)
+                else:
+                    self.tainted[-1][name] = element_reason
             if case.guard is not None:
                 self.visit(case.guard)
-            for statement in case.body:
-                self.visit(statement)
+            # A guard this can decide decides the body: `case _ if False:` never runs,
+            # and visiting it applied assignments that clear taint which survives. The
+            # guard itself is still visited above, since it is evaluated. Same literal
+            # rule `visit_If` and `visit_While` apply to their own tests.
+            if case.guard is not None and _constant_truth(case.guard) is False:
+                self._restore_locals(saved_scope)
+                continue
+            self._visit_suite(case.body)
             # An IRREFUTABLE case - a bare capture with no guard - always matches, so
             # its binding survives the statement, the same way a nonempty literal
             # loop's target does. Restoring unconditionally discarded it, and
@@ -2386,6 +2580,33 @@ class _Visitor(ast.NodeVisitor):
             if not irrefutable:
                 self._restore_locals(saved_scope)
 
+    @staticmethod
+    def _sequence_pattern_pairs(subject: ast.AST, pattern) -> dict:
+        """`{captured name: the subject element it takes}` for a literal pairing.
+
+        Both sides written out and the same length, with no star on either: that is
+        the same shape `_unpacked_pairs` already accepts for an assignment. Anything
+        less determined pairs nothing rather than guessing.
+        """
+        if not isinstance(subject, (ast.List, ast.Tuple)):
+            return {}
+        if any(isinstance(element, ast.Starred) for element in subject.elts):
+            return {}
+        if _MATCHSEQUENCE is None or not isinstance(pattern, _MATCHSEQUENCE):
+            return {}
+        patterns = list(getattr(pattern, "patterns", []))
+        if len(patterns) != len(subject.elts):
+            return {}
+        pairs = {}
+        for element, inner in zip(subject.elts, patterns):
+            if _MATCHAS is None or not isinstance(inner, _MATCHAS):
+                return {}
+            if inner.pattern is not None or inner.name is None:
+                # A nested pattern or a bare `_` binds nothing readable here.
+                continue
+            pairs[inner.name] = element
+        return pairs
+
     def visit_If(self, node: ast.If):
         """Only the suite a literal test selects is traversed.
 
@@ -2397,13 +2618,23 @@ class _Visitor(ast.NodeVisitor):
         self.visit(node.test)
         decided = _constant_truth(node.test)
         if decided is None:
-            for statement in node.body:
-                self.visit(statement)
-            for statement in node.orelse:
-                self.visit(statement)
+            self._visit_suite(node.body)
+            self._visit_suite(node.orelse)
             return
-        for statement in (node.body if decided else node.orelse):
+        self._visit_suite(node.body if decided else node.orelse)
+
+    def _visit_suite(self, body) -> None:
+        """Visit a suite, stopping at a jump that always leaves it.
+
+        Same reachability rule `visit_For` applies to a loop body: `while True: break`
+        followed by `payload = "pass"` cleared a binding the loop never reaches, so
+        the built string went to the sink unread. An `if` suite ends at a jump for the
+        same reason.
+        """
+        for statement in body:
             self.visit(statement)
+            if _definitely_jumps(statement):
+                return
 
     def visit_BoolOp(self, node: ast.BoolOp):
         """Only the operands that can still be evaluated are traversed.
@@ -2451,13 +2682,10 @@ class _Visitor(ast.NodeVisitor):
         self.visit(node.test)
         decided = _constant_truth(node.test)
         if decided is None:
-            for statement in node.body:
-                self.visit(statement)
-            for statement in node.orelse:
-                self.visit(statement)
+            self._visit_suite(node.body)
+            self._visit_suite(node.orelse)
             return
-        for statement in (node.body if decided else node.orelse):
-            self.visit(statement)
+        self._visit_suite(node.body if decided else node.orelse)
 
     def visit_TypeAlias(self, node):
         """`type run = int` rebinds the name for the rest of the scope."""
@@ -2465,6 +2693,12 @@ class _Visitor(ast.NodeVisitor):
         if isinstance(bound, ast.Name):
             self._shadow_sink(bound.id)
             self.tainted[-1].pop(bound.id, None)
+        # The value is lazy, not dead: reading `Payload.__value__` evaluates it, so
+        # `type Payload = (exec(f"import {name}") or int)` really can execute the
+        # source. Rebinding the name without visiting the value left the call unread.
+        value = getattr(node, "value", None)
+        if value is not None:
+            self.visit(value)
 
     def visit_Delete(self, node: ast.Delete):
         """`del exec` at module or class scope puts the builtin back.
@@ -2493,6 +2727,8 @@ class _Visitor(ast.NodeVisitor):
                 table[-1].pop(f"module:{target.id}", None)
                 table[-1].pop(f"constructor:{target.id}", None)
                 table[-1].pop(f"partial:{target.id}", None)
+                table[-1].pop(f"text:{target.id}", None)
+                table[-1].pop(f"stdlib:{target.id}", None)
             level = self._binding_level(target.id)
             if level != len(self.scope_kinds) - 1:
                 # `global exec; del exec` deletes the MODULE binding, so the shadow an
@@ -2505,7 +2741,17 @@ class _Visitor(ast.NodeVisitor):
                     table[level].pop(f"module:{target.id}", None)
                     table[level].pop(f"constructor:{target.id}", None)
                     table[level].pop(f"partial:{target.id}", None)
+                    table[level].pop(f"text:{target.id}", None)
+                    table[level].pop(f"stdlib:{target.id}", None)
                 self.shadowed_sinks[level].discard(target.id)
+                if target.id in self.nonlocal_names[-1]:
+                    # A deleted NONLOCAL cell is empty, and the name does not fall
+                    # back to the builtin: `nonlocal exec; del exec; exec(...)` raises
+                    # NameError. Treating it like a deleted global made the call read
+                    # as the builtin and failed the gate on code that cannot run. A
+                    # global really does fall back, which is why only this half moved.
+                    self.shadowed_sinks[-1].add(target.id)
+                    self.shadowed_sinks[level].add(target.id)
                 continue
             if self.scope_kinds[-1] == "function":
                 # But the SHADOW stays inside a function: the compiler still treats
@@ -2557,7 +2803,10 @@ class _Visitor(ast.NodeVisitor):
                 self.shadowed_sinks[-1].add(node.name)
                 for table in (self.sink_aliases, self.collected_aliases):
                     table[-1].pop(node.name, None)
-                    for prefix in ("module:", "constructor:", "partial:", "functools:"):
+                    for prefix in (
+                        "module:", "constructor:", "partial:", "functools:", "text:",
+                        "stdlib:",
+                    ):
                         table[-1].pop(f"{prefix}{node.name}", None)
         for statement in node.body:
             self.visit(statement)
@@ -2662,9 +2911,18 @@ class _Visitor(ast.NodeVisitor):
         self.generic_visit(node)
         # Resolved against the taint map for the same reason `visit_Assign` is:
         # `(alias := payload)` copies whatever `payload` holds.
+        # The numeric and literal-text markers travel with it too, exactly as they do
+        # for `visit_Assign`: without the numeric one `(payload := 1); payload += 2`
+        # read as concatenation and failed the gate on arithmetic that can only raise
+        # TypeError at the sink.
+        reason = _is_interpolated(
+            node.value, self.tainted[-1].get, self._is_shadowed, self._alias,
+        )
         self._bind(
             node.target,
-            _is_interpolated(node.value, self.tainted[-1].get, self._is_shadowed, self._alias),
+            reason,
+            numeric = _visibly_numeric(node.value),
+            literal_text = reason is None and _visibly_literal_text(node.value),
         )
         # `(exec := builtins.exec)` hands the builtin back to its own spelling exactly
         # as the statement form does, and only the taint map was being updated, so an
@@ -2695,9 +2953,17 @@ class _Visitor(ast.NodeVisitor):
             # Resolved against the taint map, as the whole-statement path is: an
             # element that is an already tainted NAME - `alias, ignored = payload,
             # None` - carries that name's reason rather than clearing the binding.
+            element_reason = _is_interpolated(
+                item, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
+            # And the markers beside the reason, for the same argument the whole
+            # statement path makes: `payload, = (1,); payload += 2` read as
+            # concatenation without the numeric one.
             self._bind(
                 element,
-                _is_interpolated(item, self.tainted[-1].get, self._is_shadowed, self._alias),
+                element_reason,
+                numeric = _visibly_numeric(item),
+                literal_text = element_reason is None and _visibly_literal_text(item),
             )
             self._bind_unpacked(element, item)
 
@@ -3190,6 +3456,18 @@ class _Visitor(ast.NodeVisitor):
                     self.collected_aliases[-1][f"constructor:{constructor}"] = constructor
                     self.shadowed_sinks[-1].discard(constructor)
                 continue
+            if (
+                node.module == "textwrap"
+                and not node.level
+                and alias.name in _TEXT_PRESERVING_FUNCTIONS
+            ):
+                # `from textwrap import dedent as clean` gives `clean` the same
+                # function, and matching the callee spelling alone stopped before the
+                # argument was read at all.
+                self.sink_aliases[-1][f"text:{bound}"] = alias.name
+                self.collected_aliases[-1][f"text:{bound}"] = alias.name
+                self.shadowed_sinks[-1].discard(bound)
+                continue
             if node.module == "functools" and not node.level and alias.name == "partial":
                 # `from functools import partial as bind` gives `bind` the real
                 # `partial`, so `bind(exec, f"...")()` binds the sink and its source
@@ -3300,6 +3578,8 @@ class _Visitor(ast.NodeVisitor):
             # inside a function makes `bind` a local for the whole body, so the outer
             # `from functools import partial as bind` must stop being visible there.
             or self._alias(f"partial:{name}") is not None
+            # And a `textwrap` function alias, for the same reason.
+            or self._alias(f"text:{name}") is not None
             # A name already recorded as shadowed still counts, so a second assignment
             # can hand it back: `run = print` then `run = builtins.exec` has to make
             # `run` an alias again, and by then the alias entry is gone.
@@ -3970,6 +4250,16 @@ class _Visitor(ast.NodeVisitor):
             )
             for generator in node.generators
         )
+        if not runs_a_pass:
+            # The same argument the lazy generator expression above makes: no pass
+            # ran, so the walrus bound nothing, and visiting the element had already
+            # cleared whatever those names held. `payload = f"import {name}";
+            # [(payload := "pass") for _ in []]; exec(payload)` executes the f-string,
+            # and suppressing only the alias EXPORT left the taint cleared.
+            for name in walrus_names:
+                self.tainted[-1].pop(name, None)
+                if name in saved:
+                    self.tainted[-1][name] = saved[name]
         for name in (walrus_names - targets) if runs_a_pass else ():
             for prefix in ("constructor:", "module:"):
                 # A walrus can bind a conversion or the builtins module as easily as a

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -456,7 +456,32 @@ _NUMERIC = object()
 # reason, because the name holds a literal and is not itself built source. Only a
 # literal binds it, so an opaque producer - `inspect.getsource(f)`, the idiom this
 # repo is built on - never does.
-_LITERAL_TEXT = object()
+class _LiteralText:
+    """Marker for a name bound to a written-out string, carrying that string.
+
+    A bare sentinel said only THAT the name holds a literal, which is enough for the
+    `.replace()` rule but not for the field-free `.format()` one: `template = "pass"`
+    and `template = "import {m}"` are different questions. The text travels with it.
+    """
+
+    __slots__ = ("text",)
+
+    def __init__(self, text):
+        self.text = text
+
+    def __repr__(self):
+        return f"_LiteralText({self.text!r})"
+
+
+# The bare marker, for the places that only ask whether a literal is held at all.
+_LITERAL_TEXT = _LiteralText("")
+
+
+def _literal_text_of(node: ast.AST):
+    """The written-out string a value is, or False when it is not one."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes)):
+        return node.value
+    return False
 
 
 def _visibly_literal_text(node: ast.AST) -> bool:
@@ -577,7 +602,7 @@ def _is_interpolated(node: ast.AST, resolve = None, shadowed = None, resolve_ali
         reason = resolve(node.id)
         # The markers are binding facts, not reasons. Returning one would put a
         # non-string into a finding.
-        return None if reason in (_NUMERIC, _LITERAL_TEXT) else reason
+        return None if reason is _NUMERIC or isinstance(reason, _LiteralText) else reason
     if isinstance(node, ast.BoolOp):
         # `exec(enabled and f"import {name}")` executes the interpolated operand
         # whenever the guard lets it through: same conditional-source shape as IfExp.
@@ -665,8 +690,15 @@ def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias
         def _keeps_everything(bound, whole):
             if bound is None:
                 return True
-            if isinstance(bound, ast.Constant) and bound.value == whole:
-                return not isinstance(bound.value, bool)
+            # `[-0::+1]` is the whole object too: a signed literal is a `UnaryOp`
+            # around the constant, not a constant, so requiring one let that spelling
+            # past the gate. Normalised the same way the repetition helper does.
+            sign = 1
+            if isinstance(bound, ast.UnaryOp) and isinstance(bound.op, (ast.USub, ast.UAdd)):
+                sign = -1 if isinstance(bound.op, ast.USub) else 1
+                bound = bound.operand
+            if isinstance(bound, ast.Constant) and not isinstance(bound.value, bool):
+                return isinstance(bound.value, int) and sign * bound.value == whole
             return False
 
         if (
@@ -677,6 +709,23 @@ def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias
             return _is_interpolated(node.value, resolve, shadowed, resolve_alias)
         return None
     return _literal_element(node, resolve, shadowed, resolve_alias)
+
+
+def _is_stable(node: ast.AST) -> bool:
+    """Whether evaluating this expression twice is guaranteed to give the same text.
+
+    The receiver and the argument of `s.removeprefix(s)` are evaluated separately, so
+    identical source does not mean identical values when either can advance something:
+    `f"{next(values)}".removeprefix(f"{next(values)}")` reads two different strings.
+    Only constants, names and f-strings built from them are treated as stable.
+    """
+    for child in ast.walk(node):
+        if isinstance(child, (ast.Call, ast.NamedExpr, ast.Await, ast.Yield, ast.YieldFrom)):
+            return False
+        if isinstance(child, (ast.Subscript, ast.Attribute)):
+            # Either can run arbitrary code through `__getitem__` or a property.
+            return False
+    return True
 
 
 def _names_module(node: ast.AST, module: str, shadowed = None, aliases = None) -> bool:
@@ -984,7 +1033,9 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             # nothing. Only when the argument is written out as the SAME expression
             # as the receiver, which is decidable from the text; anything else still
             # preserves the receiver through the normaliser branch below.
-            if ast.dump(function.value) == ast.dump(node.args[0]):
+            if _is_stable(function.value) and ast.dump(function.value) == ast.dump(
+                node.args[0]
+            ):
                 return None
         if function.attr in _NORMALISERS:
             # `str.strip(s)` is the unbound descriptor spelling of `s.strip()`, so
@@ -1026,6 +1077,18 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 if function.attr in ("format", "format_map"):
                     return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
                 return None
+            held = None
+            if isinstance(function.value, ast.Name) and resolve is not None:
+                # `template = "pass"; template.format(user)` is the literal receiver
+                # one line later, which is the same refactor the `.replace()` rule
+                # already follows. The marker carries the text, so the field scan is
+                # the same one; a template WITH a field still reports.
+                marker = resolve(function.value.id)
+                if isinstance(marker, _LiteralText):
+                    held = marker.text
+            if function.attr in ("format", "format_map") and held is not None:
+                if isinstance(held, str) and not _has_format_field(held):
+                    return None
             if function.attr in ("format", "format_map") and _visibly_literal_text(
                 function.value
             ):
@@ -1103,7 +1166,7 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             # literal receiver above. Only a name a written-out string bound: the
             # marker is set nowhere else, so `inspect.getsource(f).replace(...)`,
             # the idiom this repo is built on, still resolves to nothing here.
-            if resolve(receiver.id) is _LITERAL_TEXT:
+            if isinstance(resolve(receiver.id), _LiteralText):
                 return ".replace() on a literal"
         # `exec(f"import {model_type}".replace("-", "_"))` is the shape from the
         # original report with a normalisation step bolted on. The receiver is the
@@ -1761,6 +1824,17 @@ def _constructor_names(function: ast.AST, shadowed = None, aliases = None):
                 _constructor_name(function.orelse, shadowed, aliases),
             ) if name is not None
         ]
+    if isinstance(function, ast.BoolOp):
+        # `(memoryview and str)` really is `str`, since both objects are truthy, and
+        # collapsing to the first resolved name let `memoryview`'s argument test speak
+        # for the arm Python actually selects. Every reachable operand is returned.
+        found = []
+        for operand in _reachable_operands(function):
+            name = _constructor_name(operand, shadowed, aliases)
+            if name is not None and name not in found:
+                found.append(name)
+        if found:
+            return found
     resolved = _constructor_name(function, shadowed, aliases)
     return [] if resolved is None else [resolved]
 
@@ -2303,7 +2377,7 @@ class _Visitor(ast.NodeVisitor):
         # Visiting every target before binding any of them missed that.
         self.visit(node.value)
         numeric = _visibly_numeric(node.value)
-        literal_text = reason is None and _visibly_literal_text(node.value)
+        literal_text = _literal_text_of(node.value) if reason is None else False
         for target in node.targets:
             # An unpacking assigns each element before the NEXT target is evaluated,
             # so `payload, table[exec(payload)] = (f"import {name}", None)` executes
@@ -2323,7 +2397,7 @@ class _Visitor(ast.NodeVisitor):
                         element,
                         element_reason,
                         numeric = _visibly_numeric(item),
-                        literal_text = element_reason is None and _visibly_literal_text(item),
+                        literal_text = _literal_text_of(item) if element_reason is None else False,
                     )
                     self._bind_unpacked(element, item)
                     self._shadow_assignment(element, item)
@@ -2363,7 +2437,7 @@ class _Visitor(ast.NodeVisitor):
                 node.target,
                 reason,
                 numeric = _visibly_numeric(node.value),
-                literal_text = reason is None and _visibly_literal_text(node.value),
+                literal_text = _literal_text_of(node.value) if reason is None else False,
             )
         # An annotated assignment binds like any other one.
         if node.value is not None:
@@ -3153,7 +3227,7 @@ class _Visitor(ast.NodeVisitor):
             node.target,
             reason,
             numeric = _visibly_numeric(node.value),
-            literal_text = reason is None and _visibly_literal_text(node.value),
+            literal_text = _literal_text_of(node.value) if reason is None else False,
         )
         # `(exec := builtins.exec)` hands the builtin back to its own spelling exactly
         # as the statement form does, and only the taint map was being updated, so an
@@ -3194,7 +3268,7 @@ class _Visitor(ast.NodeVisitor):
                 element,
                 element_reason,
                 numeric = _visibly_numeric(item),
-                literal_text = element_reason is None and _visibly_literal_text(item),
+                literal_text = _literal_text_of(item) if element_reason is None else False,
             )
             self._bind_unpacked(element, item)
 
@@ -3237,15 +3311,18 @@ class _Visitor(ast.NodeVisitor):
 
     def _bind(
         self, target: ast.AST, reason: str | None, numeric: bool = False,
-        literal_text: bool = False,
+        literal_text = False,
     ) -> None:
         if not isinstance(target, ast.Name):
             return
-        if literal_text:
+        if literal_text is not False and literal_text is not None:
             # Same shape as the numeric marker: a fact about what the name holds, so a
             # later `.replace()` on it reads as a splice into a written-out template.
+            held = _LiteralText(
+                literal_text if isinstance(literal_text, (str, bytes)) else ""
+            )
             self.tainted[len(self.tainted) - 1 if self.scope_kinds[-1] != "class"
-                         else self._binding_level(target.id)][target.id] = _LITERAL_TEXT
+                         else self._binding_level(target.id)][target.id] = held
             return
         if numeric:
             # Not a reason: a marker saying the name holds a number, so a later `+=`
@@ -3423,12 +3500,37 @@ class _Visitor(ast.NodeVisitor):
                         self.collected_aliases[-1][
                             f"constructor:{alias.asname or alias.name}"
                         ] = alias.name
+            else:
+                # The recognised stdlib imports bind for the whole scope in exactly
+                # the same way, and only the builtins ones were pre-collected - so
+                # `def f(name): exec(clean(f"..."))` written above
+                # `from textwrap import dedent as clean` was scanned before `clean`
+                # meant anything and reported nothing at all. Same for the direct
+                # helpers and `functools.partial`.
+                for alias in statement.names:
+                    bound = alias.asname or alias.name
+                    qualified = f"{statement.module}.{alias.name}" if statement.module else ""
+                    if statement.level:
+                        continue
+                    if qualified in _DIRECT_HELPERS:
+                        self.collected_aliases[-1][f"stdlibfunc:{bound}"] = qualified
+                    elif statement.module == "textwrap" and alias.name in _TEXT_PRESERVING_FUNCTIONS:
+                        self.collected_aliases[-1][f"text:{bound}"] = alias.name
+                    elif statement.module == "functools" and alias.name == "partial":
+                        self.collected_aliases[-1][f"partial:{bound}"] = "partial"
         elif isinstance(statement, ast.Import):
             # The module form binds for the whole scope too, so
             # `def f(x): b.exec(f"import {x}")` above `import builtins as b` is
             # still a finding.
             for alias in statement.names:
                 bound = alias.asname or alias.name.split(".")[0]
+                if alias.name in _MODULE_RECEIVERS:
+                    # `import codeop as co` below a `def` that uses `co` binds for the
+                    # whole scope as well, and the deferred body saw nothing.
+                    self.collected_aliases[-1][f"stdlib:{bound}"] = alias.name
+                    if alias.name == "functools":
+                        self.collected_aliases[-1][f"functools:{bound}"] = "functools"
+                    continue
                 if alias.name == "builtins" and alias.asname:
                     self.collected_aliases[-1][f"module:{alias.asname}"] = "builtins"
                 else:

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -297,21 +297,33 @@ def _constructor_accepts_text(node: ast.Call, name: str) -> bool:
     return True
 
 
-def _partial_call(node: ast.AST) -> ast.Call | None:
-    """`functools.partial(...)` or a bare `partial(...)` written out here, else None."""
-    if not isinstance(node, ast.Call):
+def _partial_call(node: ast.AST, aliases = None, shadowed = None) -> ast.Call | None:
+    """`functools.partial(...)`, a bare `partial(...)`, or a recorded alias of it.
+
+    `from functools import partial as bind` makes `bind(exec, f"...")()` the same
+    call, so reading only the spelling at the call site missed it. Only a name an
+    import from `functools` bound is accepted, and only while it is not shadowed, so
+    this stays a fact stated in the file rather than a guess about what a name holds.
+    """
+    if not isinstance(node, ast.Call) or not node.args:
         return None
     function = node.func
-    name = (
-        function.attr if isinstance(function, ast.Attribute)
-        else (function.id if isinstance(function, ast.Name) else "")
-    )
-    return node if name == "partial" and node.args else None
+    if isinstance(function, ast.Attribute):
+        return node if function.attr == "partial" else None
+    if not isinstance(function, ast.Name):
+        return None
+    if shadowed is not None and shadowed(function.id):
+        return None
+    if function.id == "partial":
+        return node
+    if aliases is not None and aliases(f"partial:{function.id}"):
+        return node
+    return None
 
 
 def _partial_sink(node: ast.AST, aliases = None, shadowed = None) -> str | None:
     """The sink a visible `partial` was built around, else None."""
-    partial = _partial_call(node)
+    partial = _partial_call(node, aliases, shadowed)
     if partial is None:
         return None
     return _sink_name(partial.args[0], aliases, shadowed)
@@ -665,6 +677,40 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             return _is_interpolated(
                 ast.copy_location(inner, node), resolve, shadowed, resolve_alias,
             )
+        if function.attr == "compile_command" and isinstance(function.value, ast.Name):
+            # `exec(codeop.compile_command(f"..."))` hands back a code object compiled
+            # FROM the interpolated source, so the source survives the conversion
+            # exactly as `ast.parse` does. Checked against the stdlib:
+            # `codeop.compile_command("x = 1")` returns a `code` object. Receiver
+            # written out and unshadowed; positional or the documented `source` keyword.
+            compiled = node.args[0] if node.args else None
+            if compiled is None:
+                for keyword in reversed(node.keywords):
+                    if keyword.arg == "source":
+                        compiled = keyword.value
+                        break
+            if compiled is not None and function.value.id == "codeop" and not (
+                shadowed is not None and shadowed("codeop")
+            ):
+                return _is_interpolated(compiled, resolve, shadowed, resolve_alias)
+        if function.attr in ("add", "concat") and isinstance(function.value, ast.Name):
+            # `exec(operator.add("import ", name))` builds the same string the `+`
+            # operator does, and the stdlib documents `operator.concat` the same way.
+            # Rebuilt as that operator and read there, which also applies the visibly
+            # numeric exclusion, so `operator.add(1, 2)` stays quiet. Receiver written
+            # out and unshadowed, two positional arguments, the only shape these take.
+            if (
+                function.value.id == "operator"
+                and len(node.args) == 2
+                and not node.keywords
+                and not (shadowed is not None and shadowed("operator"))
+            ):
+                equivalent = ast.BinOp(
+                    left = node.args[0], op = ast.Add(), right = node.args[1],
+                )
+                return _is_interpolated(
+                    ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
+                )
         if function.attr == "parse" and isinstance(function.value, ast.Name):
             # `compile(ast.parse(f"..."), "<x>", "exec")` compiles the tree that
             # was parsed FROM the interpolated source, so the source survives the
@@ -965,6 +1011,12 @@ def _getattr_sink_name(function: ast.Call, aliases = None, shadowed = None) -> s
         ):
             owner, attribute = function.args[0], function.args[1]
             if isinstance(attribute, ast.Constant) and attribute.value in SINKS:
+                if _literal_builtins_import(owner, shadowed):
+                    # `getattr(__import__("builtins"), "exec")` names the module
+                    # inline, so the owner is a Call rather than a Name and the
+                    # branch below never ran. Same reasoning as the attribute
+                    # spelling: nothing is guessed at, the module is written out.
+                    return f"builtins.{attribute.value}"
                 if isinstance(owner, ast.Name):
                     module = owner.id
                     if shadowed is not None and shadowed(module):
@@ -2101,6 +2153,7 @@ class _Visitor(ast.NodeVisitor):
                 table[-1].pop(target.id, None)
                 table[-1].pop(f"module:{target.id}", None)
                 table[-1].pop(f"constructor:{target.id}", None)
+                table[-1].pop(f"partial:{target.id}", None)
             level = self._binding_level(target.id)
             if level != len(self.scope_kinds) - 1:
                 # `global exec; del exec` deletes the MODULE binding, so the shadow an
@@ -2112,6 +2165,7 @@ class _Visitor(ast.NodeVisitor):
                     table[level].pop(target.id, None)
                     table[level].pop(f"module:{target.id}", None)
                     table[level].pop(f"constructor:{target.id}", None)
+                    table[level].pop(f"partial:{target.id}", None)
                 self.shadowed_sinks[level].discard(target.id)
                 continue
             if self.scope_kinds[-1] == "function":
@@ -2756,6 +2810,15 @@ class _Visitor(ast.NodeVisitor):
                     self.collected_aliases[-1][f"constructor:{constructor}"] = constructor
                     self.shadowed_sinks[-1].discard(constructor)
                 continue
+            if node.module == "functools" and not node.level and alias.name == "partial":
+                # `from functools import partial as bind` gives `bind` the real
+                # `partial`, so `bind(exec, f"...")()` binds the sink and its source
+                # exactly as `functools.partial` does. Only the callee spelling was
+                # read, so the ordinary imported-alias form went unseen.
+                self.sink_aliases[-1][f"partial:{bound}"] = "partial"
+                self.collected_aliases[-1][f"partial:{bound}"] = "partial"
+                self.shadowed_sinks[-1].discard(bound)
+                continue
             if node.module == "builtins" and not node.level and alias.name in _CONSTRUCTORS:
                 # `from builtins import str as s` gives `s` the constructor, exactly as
                 # the sink form gives a name the builtin. Only the sinks were recorded,
@@ -2834,6 +2897,10 @@ class _Visitor(ast.NodeVisitor):
             # missed it and `text = lambda _: "pass"` left the earlier
             # `from builtins import str as text` alias standing.
             or self._alias(f"constructor:{name}") is not None
+            # And a `functools.partial` alias, for the same reason: `bind = print`
+            # inside a function makes `bind` a local for the whole body, so the outer
+            # `from functools import partial as bind` must stop being visible there.
+            or self._alias(f"partial:{name}") is not None
             # A name already recorded as shadowed still counts, so a second assignment
             # can hand it back: `run = print` then `run = builtins.exec` has to make
             # `run` an alias again, and by then the alias entry is gone.
@@ -3097,6 +3164,14 @@ class _Visitor(ast.NodeVisitor):
             return
         if not isinstance(target, ast.Name):
             return
+        # Rebinding the name takes any recorded `functools.partial` alias away:
+        # `from functools import partial as bind; bind = print` makes `bind(...)` a
+        # print, and leaving the record in place reported a call that cannot execute.
+        # Not chased any further, same as the rest of this method: `other = bind` does
+        # not re-record, which can only decline to read a call, never invent one.
+        level = self._binding_level(target.id)
+        self.sink_aliases[level].pop(f"partial:{target.id}", None)
+        self.collected_aliases[level].pop(f"partial:{target.id}", None)
         # With the shadow test: `exec = print; run = exec` makes `run` print, and
         # resolving the spelling alone recorded a sink alias that does not exist.
         partial_sink = _partial_sink(value, self._alias, self._is_shadowed)
@@ -3106,7 +3181,8 @@ class _Visitor(ast.NodeVisitor):
             # threw that argument away, so the zero-argument call had nothing to look
             # at. The reason travels onto the name instead.
             bound = _source_argument(
-                _partial_call(value), partial_sink, self._is_shadowed, skip = 1,
+                _partial_call(value, self._alias, self._is_shadowed),
+                partial_sink, self._is_shadowed, skip = 1,
             )
             reason = _is_interpolated(
                 bound, self.tainted[-1].get, self._is_shadowed, self._alias,
@@ -3182,6 +3258,8 @@ class _Visitor(ast.NodeVisitor):
         # prefixed entry kept unwrapping through a name that means something else.
         self.sink_aliases[level].pop(f"constructor:{target.id}", None)
         self.collected_aliases[level].pop(f"constructor:{target.id}", None)
+        self.sink_aliases[level].pop(f"partial:{target.id}", None)
+        self.collected_aliases[level].pop(f"partial:{target.id}", None)
 
     def _shadow_sink(self, name: str) -> None:
         """Record that `name` was bound to something that is not the builtin.
@@ -3212,6 +3290,7 @@ class _Visitor(ast.NodeVisitor):
             # `from builtins import str as text; text = lambda _: "pass"` kept
             # unwrapping through a name that no longer converts anything.
             table[-1].pop(f"constructor:{name}", None)
+            table[-1].pop(f"partial:{name}", None)
 
     def visit_Lambda(self, node: ast.Lambda):
         """A lambda parameter shadows the enclosing name for the body.
@@ -3504,7 +3583,8 @@ class _Visitor(ast.NodeVisitor):
             # `functools.partial(exec)(f"...")` supplies it at call time instead, and
             # asking only the inner call read that as having no source.
             argument = _source_argument(
-                _partial_call(node.func), sink, self._is_shadowed, skip = 1,
+                _partial_call(node.func, self._alias, self._is_shadowed),
+                sink, self._is_shadowed, skip = 1,
             )
             if argument is None:
                 argument = _source_argument(node, sink, self._is_shadowed)

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -194,11 +194,25 @@ _MODULE_RECEIVERS = frozenset({
 # `<module>.<name>`. `visit_ImportFrom` records `from ast import parse as p` against
 # these, and `_interpolated_call` rewrites such a call to the qualified spelling.
 _DIRECT_HELPERS = frozenset({
-    "ast.parse", "codeop.compile_command", "string.Template",
+    "ast.parse", "codeop.compile_command", "string.Template", "string.Formatter",
     # `from operator import add as join` binds the same builder the qualified
     # spelling names, and only the qualified one was read.
     *(f"operator.{name}" for name in ("add", "concat", "iadd", "iconcat", "mod", "imod")),
 })
+
+# Calls that consume a `map` and reach EVERY element. `next` takes one, and
+# `any`/`all` stop at the first result that decides them - a sink returns None, so
+# `any` runs them all and `all` stops at the first. Only the ones that must reach
+# every element are listed, so nothing is reported for an element that a partial
+# consumer never asks for.
+#
+# `sum` and `dict` are NOT here for the same reason: a sink returns None, so
+# `sum(map(exec, ...))` raises on `0 + None` and `dict(map(exec, ...))` raises trying
+# to unpack None, both after the FIRST element. Neither ever asks for the second.
+_CONSUMER_NAMES = frozenset({
+    "list", "tuple", "set", "frozenset", "sorted", "min", "max", "any",
+})
+
 
 _OPERATOR_BUILDERS = {
     "add": ast.Add, "concat": ast.Add, "iadd": ast.Add, "iconcat": ast.Add,
@@ -207,6 +221,10 @@ _OPERATOR_BUILDERS = {
 _BUILTIN_NAMES = frozenset({
     *SINKS, *_CONSTRUCTORS, *_MODULE_RECEIVERS, *_TEXT_PRESERVING_FUNCTIONS,
     "builtins", "dict", "getattr", "map",
+    # The consumer spellings, so a `def f(list, ...)` parameter that shadows one is
+    # honoured: the shadow test only tracks names it knows about, and a local `list`
+    # that never consumes the map was reported as if it were the builtin.
+    *_CONSUMER_NAMES, "filter", "next", "iter", "vars",
     # The bare spelling `_nullcontext_value` accepts. A local of that name provides
     # whatever it likes from `__enter__`, so the shadow test it already performs has
     # to have something to find.
@@ -428,6 +446,22 @@ def _is_builtins_mapping(node: ast.AST, aliases = None, shadowed = None) -> bool
     """
     if isinstance(node, ast.Name) and node.id == "__builtins__":
         return not (shadowed is not None and shadowed(node.id))
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "vars"
+        and not (shadowed is not None and shadowed("vars"))
+        and len(node.args) == 1
+        and not node.keywords
+        and isinstance(node.args[0], ast.Name)
+    ):
+        # `vars(builtins)` IS `builtins.__dict__`, so `vars(builtins)["exec"](...)` is
+        # the same lookup written another way. Reading only the attribute spelling
+        # missed it entirely.
+        module = node.args[0].id
+        if shadowed is not None and shadowed(module):
+            return False
+        return module == "builtins" or bool(aliases is not None and aliases(f"module:{module}"))
     if not (isinstance(node, ast.Attribute) and node.attr == "__dict__"):
         return False
     if not isinstance(node.value, ast.Name):
@@ -987,6 +1021,27 @@ def _is_template_call(node: ast.AST, shadowed = None, aliases = None) -> bool:
     return False
 
 
+def _is_formatter_call(node: ast.AST, shadowed = None, aliases = None) -> bool:
+    """Whether `node` is a written-out `string.Formatter(...)`.
+
+    The same test `string.Template` gets, for the same reason: an application class
+    called `Formatter` formats nothing in particular, while `string.Formatter().vformat`
+    is `str.format` with its arguments handed over as a tuple and a mapping.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    function = node.func
+    if isinstance(function, ast.Attribute):
+        return function.attr == "Formatter" and _names_module(
+            function.value, "string", shadowed, aliases,
+        )
+    if isinstance(function, ast.Name):
+        if shadowed is not None and shadowed(function.id):
+            return False
+        return aliases is not None and aliases(f"stdlibfunc:{function.id}") == "string.Formatter"
+    return False
+
+
 def _bound_template(node: ast.AST, shadowed = None, aliases = None):
     """The `string.Template(...)` a name was bound to, else None."""
     if not isinstance(node, ast.Name) or aliases is None:
@@ -1007,6 +1062,13 @@ def _is_stable(node: ast.AST) -> bool:
     """
     for child in ast.walk(node):
         if isinstance(child, (ast.Call, ast.NamedExpr, ast.Await, ast.Yield, ast.YieldFrom)):
+            return False
+        if isinstance(child, ast.FormattedValue):
+            # Formatting calls `__format__`, which an object supplies itself and which
+            # is under no obligation to answer the same way twice: an object whose
+            # successive calls return `"pass"` and `""` makes
+            # `f"{value}".removeprefix(f"{value}")` execute `pass`. A name is stable;
+            # what formatting it produces is not.
             return False
         if isinstance(child, (ast.Subscript, ast.Attribute)):
             # Either can run arbitrary code through `__getitem__` or a property.
@@ -1123,16 +1185,39 @@ def _lambda_scope(node: ast.Call, function: ast.Lambda, resolve, shadowed, resol
     # `*args` at the call site moves every later argument, so nothing after it pairs
     # up: those parameters stay unresolved rather than being paired with the wrong
     # value.
-    for index, argument in enumerate(node.args):
+    supplied = []
+    for argument in node.args:
         if isinstance(argument, ast.Starred):
+            # A written-out expansion says exactly which values it supplies, so
+            # `(lambda source: source)(*[f"import {name}"])` pairs up as plainly as the
+            # direct spelling does. Anything else moves every later argument and the
+            # pairing stops there.
+            inner = argument.value
+            if isinstance(inner, (ast.List, ast.Tuple)) and not any(
+                isinstance(element, ast.Starred) for element in inner.elts
+            ):
+                supplied.extend(inner.elts)
+                continue
             break
+        supplied.append(argument)
+    for index, argument in enumerate(supplied):
         if index < len(positional):
             bound[positional[index].arg] = argument
     for keyword in node.keywords:
         if keyword.arg is None:
-            # `**mapping` can supply any parameter with anything, so no parameter it
+            # A written-out mapping names its keys as plainly as a keyword does;
+            # anything else can supply any parameter with anything, so no parameter it
             # could reach is answered from the call.
-            return resolve
+            mapping = _mapping_literal(keyword.value, shadowed)
+            if mapping is None or any(
+                not (isinstance(key, ast.Constant) and isinstance(key.value, str))
+                for key in mapping.keys
+            ):
+                return resolve
+            for key, value in zip(mapping.keys, mapping.values):
+                if key.value in names:
+                    bound[key.value] = value
+            continue
         if keyword.arg in names:
             bound[keyword.arg] = keyword.value
     defaults = arguments.defaults
@@ -1172,6 +1257,32 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             shadowed,
             resolve_alias,
         )
+    if (
+        isinstance(function, ast.Name)
+        and function.id == "next"
+        and not (shadowed is not None and shadowed("next"))
+        and len(node.args) == 1
+        and not node.keywords
+    ):
+        # `next(iter([f"import {name}"]))` selects the first element of a container
+        # written out right here, which is the subscript spelling with the index
+        # implied. Both calls are the builtins, both are shadow-tested, and only a
+        # written-out container is read.
+        inner = node.args[0]
+        if (
+            isinstance(inner, ast.Call)
+            and isinstance(inner.func, ast.Name)
+            and inner.func.id == "iter"
+            and not (shadowed is not None and shadowed("iter"))
+            and len(inner.args) == 1
+            and not inner.keywords
+            and isinstance(inner.args[0], (ast.List, ast.Tuple))
+            and inner.args[0].elts
+            and not isinstance(inner.args[0].elts[0], ast.Starred)
+        ):
+            return _is_interpolated(
+                inner.args[0].elts[0], resolve, shadowed, resolve_alias,
+            )
     preserving = None
     if isinstance(function, ast.Name):
         preserving = function.id
@@ -1200,6 +1311,13 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 if keyword.arg == "text":
                     text = keyword.value
                     break
+        if preserving == "indent" and not (
+            len(node.args) > 1
+            or any(keyword.arg in ("prefix", None) for keyword in node.keywords)
+        ):
+            # `textwrap.indent(text)` has no default for `prefix`, so it raises before
+            # the sink is called. `dedent` takes the one argument and is unaffected.
+            return None
         return (
             _is_interpolated(text, resolve, shadowed, resolve_alias)
             if text is not None else None
@@ -1246,7 +1364,7 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
     if isinstance(function, ast.Attribute):
         literal_mapping = (
             _mapping_literal(function.value, shadowed)
-            if function.attr == "get" else None
+            if function.attr in ("get", "pop") else None
         )
         if (
             literal_mapping is not None
@@ -1351,6 +1469,23 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 return _is_interpolated(parsed, resolve, shadowed, resolve_alias)
         if (
             function.attr in ("__add__", "__mod__")
+            and len(node.args) == 2
+            and not node.keywords
+            and _constructor_name(function.value, shadowed, resolve_alias) in ("str", "bytes")
+        ):
+            # `str.__add__("", payload)` is the UNBOUND descriptor: the receiver is the
+            # first argument and the operand the second, so the one-argument test below
+            # skipped it and the operator it spells was never read.
+            equivalent = ast.BinOp(
+                left = node.args[0],
+                op = ast.Add() if function.attr == "__add__" else ast.Mod(),
+                right = node.args[1],
+            )
+            return _is_interpolated(
+                ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
+            )
+        if (
+            function.attr in ("__add__", "__mod__")
             and len(node.args) == 1
             and not node.keywords
         ):
@@ -1449,6 +1584,32 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             # failed the gate on code that cannot be changed to pass. Only a receiver
             # written out as a call to a class this file defines; anything unknown is
             # still read as a string method.
+            return None
+        if (
+            function.attr in ("vformat", "format_field")
+            and _is_formatter_call(function.value, shadowed, resolve_alias)
+        ):
+            # `string.Formatter().vformat("{}", (payload,), {})` is `str.format` with
+            # the arguments handed over as a tuple and a mapping, and the method was in
+            # neither builder set, so the splice was invisible. The template is the
+            # first argument here rather than the receiver.
+            template = node.args[0] if node.args else None
+            for keyword in node.keywords:
+                if keyword.arg == "format_string":
+                    template = keyword.value
+            if template is None:
+                return None
+            inner = _is_interpolated(template, resolve, shadowed, resolve_alias)
+            if inner is not None:
+                return inner
+            if len(node.args) + len(node.keywords) > 1 and (
+                not isinstance(template, ast.Constant)
+                or (
+                    isinstance(template.value, str)
+                    and _has_format_field(template.value)
+                )
+            ):
+                return f".{function.attr}()"
             return None
         if function.attr in _BUILDERS:
             # `.join([])` and `.format()` with nothing to splice in produce the
@@ -1589,7 +1750,9 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
         if _constructor_name(receiver, shadowed, resolve_alias) in ("str", "bytes"):
             if node.args:
                 template = node.args[0]
-                if isinstance(template, ast.Constant) and splices:
+                if isinstance(template, ast.Constant) and _replace_can_splice(
+                    node, template, offset = 1,
+                ):
                     if isinstance(template.value, (str, bytes)):
                         return ".replace() on a literal"
                 # The template can be built rather than literal, same as for the
@@ -1600,7 +1763,7 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
     return None
 
 
-def _replace_can_splice(node: ast.Call) -> bool:
+def _replace_can_splice(node: ast.Call, template = None, offset: int = 0) -> bool:
     """Whether a `.replace()` call can put a nonliteral value into its result.
 
     `"pass".replace("x", "y")` rewrites one literal into another and executes fixed
@@ -1608,7 +1771,26 @@ def _replace_can_splice(node: ast.Call) -> bool:
     reported on the receiver alone. Only a written-out argument answers here - a
     replacement this cannot read is assumed to splice, which is the reporting side.
     """
-    replacement = node.args[1] if len(node.args) > 1 else None
+    # A search text that is visibly absent from a visible template replaces nothing:
+    # `"pass".replace("MISSING", name)` executes the literal it started with.
+    if template is None:
+        template = node.func.value if isinstance(node.func, ast.Attribute) else None
+    # `str.replace(template, old, new)` is the unbound spelling, whose arguments all
+    # sit one place further along.
+    arguments = node.args[offset:]
+    search = arguments[0] if arguments else None
+    for keyword in node.keywords:
+        if keyword.arg == "old":
+            search = keyword.value
+    if (
+        isinstance(template, ast.Constant)
+        and isinstance(search, ast.Constant)
+        and type(template.value) is type(search.value)
+        and isinstance(template.value, (str, bytes))
+        and search.value not in template.value
+    ):
+        return False
+    replacement = arguments[1] if len(arguments) > 1 else None
     for keyword in node.keywords:
         if keyword.arg == "new":
             replacement = keyword.value
@@ -1619,7 +1801,7 @@ def _replace_can_splice(node: ast.Call) -> bool:
         replacement.value, (str, bytes)
     ):
         return False
-    count = node.args[2] if len(node.args) > 2 else None
+    count = arguments[2] if len(arguments) > 2 else None
     for keyword in node.keywords:
         if keyword.arg == "count":
             count = keyword.value
@@ -1849,6 +2031,15 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
             return function.id
         if aliases is not None and aliases(function.id):
             return aliases(function.id)
+    if isinstance(function, (ast.Attribute, ast.Subscript)) and aliases is not None:
+        # `obj.run = builtins.exec` then `obj.run(f"...")`, and the subscript spelling
+        # `table["run"]`. The path is written out and names the same place at the store
+        # and at the load, which is the same key `_bind` records taint against.
+        path = _compound_key(function)
+        if path is not None:
+            recorded = aliases(path)
+            if recorded:
+                return recorded
     if isinstance(function, ast.Call) and _partial_sink(function, aliases, shadowed):
         # `functools.partial(exec, f"...")()` binds the sink and its source and then
         # calls the result, so neither half resolved on its own. Only the visible
@@ -3042,6 +3233,12 @@ class _Visitor(ast.NodeVisitor):
         # `payload` before the subscript is evaluated, and the `exec` sees it.
         # Visiting every target before binding any of them missed that.
         self.visit(node.value)
+        # An unpacking target CONSUMES the iterator on the right: `[result] = map(exec,
+        # [f"..."])` advances the map to fill the target, so the callback runs exactly
+        # as it does under `list(...)`. Visiting the right-hand side alone reads a bare
+        # `map` as lazy, which it is until something pulls on it.
+        if any(isinstance(target, (ast.Tuple, ast.List)) for target in node.targets):
+            self._report_mapped_sinks(self._mapped_sink_elements(node.value))
         numeric = _visibly_numeric(node.value)
         literal_text = _literal_text_of(node.value) if reason is None else False
         for target in node.targets:
@@ -4090,6 +4287,14 @@ class _Visitor(ast.NodeVisitor):
     def _record_local_class(self, statement) -> None:
         """`class Safe:` makes `Safe()` a receiver whose methods are not string ones."""
         if isinstance(statement, ast.ClassDef):
+            recorded = _LOCAL_CLASSES.get(statement.name)
+            if recorded is not None and recorded is not statement:
+                # Two different classes under one name, anywhere in the file - a
+                # module-level `class Template(str)` and a `class Template` inside some
+                # function. The table is file-wide, so the second overwrote the first
+                # and a call through the name was read against whichever won. Neither
+                # earns the exemption.
+                _REBOUND_CLASS_NAMES.add(statement.name)
             _LOCAL_CLASSES[statement.name] = statement
             return
         # Any OTHER binding of that name takes the exemption away, permanently and
@@ -4437,6 +4642,15 @@ class _Visitor(ast.NodeVisitor):
                 self._collect_assignment_alias(sub_target, sub_value, rebound)
             return
         if not isinstance(target, ast.Name):
+            # A compound target names a place as plainly as a name does, so a sink
+            # stored in one is recorded under the same key `_bind` uses. Discarding
+            # every non-name target let `obj.run = builtins.exec; obj.run(f"...")`
+            # through with nothing reported.
+            path = _compound_key(target)
+            if path is not None:
+                resolved = _sink_name(value, self._alias, self._is_shadowed)
+                if resolved is not None:
+                    self.collected_aliases[-1][path] = resolved.rpartition(".")[2]
             return
         root = value
         while isinstance(root, ast.Attribute):
@@ -4947,6 +5161,17 @@ class _Visitor(ast.NodeVisitor):
                 self._shadow_assignment(sub_target, sub_value)
             return
         if not isinstance(target, ast.Name):
+            # A sink stored in a stable compound path is recorded against that path, so
+            # `obj.run = builtins.exec` makes `obj.run(f"...")` the builtin. Rebinding
+            # the same path to anything else takes the record away again.
+            path = _compound_key(target)
+            if path is not None:
+                resolved = _sink_name(value, self._alias, self._is_shadowed)
+                if resolved is not None:
+                    self.sink_aliases[-1][path] = resolved.rpartition(".")[2]
+                else:
+                    self.sink_aliases[-1].pop(path, None)
+                    self.collected_aliases[-1].pop(path, None)
             return
         # Rebinding the name takes any recorded `functools.partial` alias away:
         # `from functools import partial as bind; bind = print` makes `bind(...)` a
@@ -4959,6 +5184,18 @@ class _Visitor(ast.NodeVisitor):
         # bare name was cleared, and the stale `path>obj.payload` reason then rejected
         # a call that reads the new object.
         prefix = f"path>{target.id}"
+        # The same for a sink recorded against a path through that name: `obj.run =
+        # builtins.exec` followed by `obj = something_else` leaves `obj.run` naming
+        # whatever the new object holds, and keeping the record would report a call
+        # through it as the builtin.
+        for table in (*self.sink_aliases, *self.collected_aliases):
+            for key in [
+                key for key in table
+                if isinstance(key, str)
+                and key.startswith(prefix)
+                and (len(key) == len(prefix) or not (key[len(prefix)].isalnum() or key[len(prefix)] == "_"))
+            ]:
+                table.pop(key, None)
         for scope in self.tainted:
             for key in [
                 key for key in scope
@@ -5474,10 +5711,7 @@ class _Visitor(ast.NodeVisitor):
     # so `any` runs them all and `all` stops at the first. Only the ones that must
     # reach every element are listed, so nothing is reported for an element that a
     # partial consumer never asks for.
-    _CONSUMERS = frozenset({
-        "list", "tuple", "set", "frozenset", "dict", "sorted", "sum", "min", "max",
-        "any",
-    })
+    _CONSUMERS = _CONSUMER_NAMES
 
     def _mapped_sink_calls(self, node: ast.Call):
         """`(sink, element)` pairs for `list(map(exec, [f"..."]))`.
@@ -5498,11 +5732,16 @@ class _Visitor(ast.NodeVisitor):
         """`(sink, element, call)` for a written-out `map(<sink>, [literal, ...])`."""
         if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name)):
             return
-        if inner.func.id != "map" or self._is_shadowed("map"):
+        if inner.func.id not in ("map", "filter") or self._is_shadowed(inner.func.id):
             return
         # `map` takes no keyword arguments, so a call with one raises TypeError before
-        # the callback is ever invoked.
+        # the callback is ever invoked. `filter` takes none either, and takes exactly
+        # two arguments - it calls the same callback with each element, so
+        # `list(filter(exec, [f"..."]))` runs the sink exactly as the `map` spelling
+        # does.
         if inner.keywords or len(inner.args) < 2:
+            return
+        if inner.func.id == "filter" and len(inner.args) != 2:
             return
         sink = _sink_name(inner.args[0], self._alias, self._is_shadowed)
         if sink is None:
@@ -5513,6 +5752,10 @@ class _Visitor(ast.NodeVisitor):
         # More arguments than the sink takes raises, so those are left alone: `exec`
         # and `eval` take three, `compile` six.
         if len(inner.args) - 1 > {"exec": 3, "eval": 3}.get(sink.rpartition(".")[2], 6):
+            return
+        # And FEWER iterables than the sink requires raises too: `map(compile, [...])`
+        # calls `compile(source)`, which has no default for the filename or the mode.
+        if sink.rpartition(".")[2] == "compile" and len(inner.args) - 1 < 3:
             return
         elements = self._literal_elements(inner.args[1])
         for element in elements or ():
@@ -5529,7 +5772,7 @@ class _Visitor(ast.NodeVisitor):
                     "path": _relative(self.path),
                     "qualname": self._qualname(),
                     "sink": mapped_sink,
-                    "reason": f"{reason} through map()",
+                    "reason": f"{reason} through {inner.func.id}()",
                     "line": inner.lineno,
                     "hash": _call_hash(inner),
                 })
@@ -5538,6 +5781,21 @@ class _Visitor(ast.NodeVisitor):
         """`[*map(exec, [...])]` consumes the map as eagerly as `list(...)` does."""
         self._report_mapped_sinks(self._mapped_sink_elements(node.value))
         self.generic_visit(node)
+
+    def _yields_a_tree(self, argument) -> bool:
+        """Whether the argument is a visible `ast.parse(...)`, which is not source.
+
+        Only `compile` accepts a tree; `exec` and `eval` raise `TypeError` on one
+        before executing anything. The unwrapping that reads the parsed source through
+        `compile(ast.parse(f"..."), ...)` applied to every sink and reported calls
+        that cannot run.
+        """
+        return (
+            isinstance(argument, ast.Call)
+            and _names_module_function(
+                argument.func, "ast", "parse", self._is_shadowed, self._alias,
+            )
+        )
 
     def visit_Call(self, node: ast.Call):
         for mapped_sink, element, inner in self._mapped_sink_calls(node):
@@ -5549,7 +5807,7 @@ class _Visitor(ast.NodeVisitor):
                     "path": _relative(self.path),
                     "qualname": self._qualname(),
                     "sink": mapped_sink,
-                    "reason": f"{reason} through map()",
+                    "reason": f"{reason} through {inner.func.id}()",
                     "line": inner.lineno,
                     "hash": _call_hash(inner),
                 })
@@ -5574,6 +5832,12 @@ class _Visitor(ast.NodeVisitor):
                 argument = _source_argument(node, sink, self._is_shadowed)
         else:
             argument = _source_argument(node, sink, self._is_shadowed) if sink is not None else None
+        if (
+            argument is not None
+            and sink.rpartition(".")[2] in ("exec", "eval")
+            and self._yields_a_tree(argument)
+        ):
+            argument = None
         if argument is not None:
             # The taint lookup has to happen wherever the unwrapping stops, not only
             # when the argument is a bare name: `payload = f"import {name}"` followed

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -124,7 +124,10 @@ _MATCHSEQUENCE = _node_type("MatchSequence")
 # Conversions that hand the same source on in another type. `exec`, `eval` and
 # `compile` all accept bytes as well as str, so `exec(f"import {name}".encode())`
 # executes exactly the payload the f-string built.
-_CONVERSIONS = ("encode", "decode")
+# `.tobytes()` on a `memoryview` of built source is the same bytes back, and the
+# constructor is already read as source-preserving; without the method the chain
+# `memoryview(f"...".encode()).tobytes()` stopped one call short of the sink.
+_CONVERSIONS = ("encode", "decode", "tobytes")
 
 # The dunder spellings of the conversions above. `f"...".__str__()` returns the same
 # string and `bytes.__str__` is not a conversion at all, so only the ones whose
@@ -153,6 +156,18 @@ _NORMALISERS = (
     "casefold", "swapcase", "expandtabs", "removeprefix", "removesuffix",
     "center", "ljust", "rjust", "zfill",
 )
+
+# How many positional arguments each normaliser takes, from the CPython docs. A call
+# outside its range raises `TypeError` before the sink is reached:
+# `f"import {name}".upper(1)` is "str.upper() takes no arguments". Only checked when
+# the call has no keywords, since a keyword this cannot read may supply anything.
+_NORMALISER_ARITY = {
+    "strip": (0, 1), "lstrip": (0, 1), "rstrip": (0, 1),
+    "upper": (0, 0), "lower": (0, 0), "title": (0, 0), "capitalize": (0, 0),
+    "casefold": (0, 0), "swapcase": (0, 0), "expandtabs": (0, 1),
+    "removeprefix": (1, 1), "removesuffix": (1, 1),
+    "center": (1, 2), "ljust": (1, 2), "rjust": (1, 2), "zfill": (1, 1),
+}
 
 # Constructors that hand the same source on in another type. Same argument as
 # `_CONVERSIONS`, spelled as a call instead of a method: `bytes(s, "utf-8")` is
@@ -200,18 +215,55 @@ _DIRECT_HELPERS = frozenset({
     *(f"operator.{name}" for name in ("add", "concat", "iadd", "iconcat", "mod", "imod")),
 })
 
-# Calls that consume a `map` and reach EVERY element. `next` takes one, and
-# `any`/`all` stop at the first result that decides them - a sink returns None, so
-# `any` runs them all and `all` stops at the first. Only the ones that must reach
-# every element are listed, so nothing is reported for an element that a partial
-# consumer never asks for.
-#
-# `sum` and `dict` are NOT here for the same reason: a sink returns None, so
-# `sum(map(exec, ...))` raises on `0 + None` and `dict(map(exec, ...))` raises trying
-# to unpack None, both after the FIRST element. Neither ever asks for the second.
+# Calls that consume a `map`. How MANY elements each one provably reaches is a
+# separate question, answered by `_consumed_count` below: listing only the exhaustive
+# ones missed `next(map(exec, [f"..."]))`, which runs the callback on the first
+# element and is the whole of what it does.
 _CONSUMER_NAMES = frozenset({
-    "list", "tuple", "set", "frozenset", "sorted", "min", "max", "any",
+    "list", "tuple", "set", "frozenset", "sorted", "min", "max", "any", "all",
+    "sum", "dict", "next",
 })
+
+
+def _consumed_count(consumer: str, sink: str) -> int | None:
+    """How many mapped elements this consumer provably evaluates. None means every one.
+
+    What decides it is what the callback RETURNS. `exec` and `eval` return None, so
+    `sum` raises on `0 + None` and `dict` raises unpacking it, both after the first
+    element; `all` stops at the first falsy result, which None is; `any` gets None for
+    every element and runs them all. `compile` returns a code object, which reverses
+    both of those: `any` stops at the first, `all` runs them all.
+
+    `min` and `max` pull two elements before comparing, and None (or a code object) is
+    not orderable, so they raise having evaluated exactly two.
+    """
+    returns_none = sink.rpartition(".")[2] in ("exec", "eval")
+    if consumer == "next":
+        return 1
+    if consumer in ("sum", "dict"):
+        return 1
+    if consumer in ("min", "max"):
+        return 2
+    if consumer == "all":
+        return 1 if returns_none else None
+    if consumer == "any":
+        return None if returns_none else 1
+    return None
+
+
+def _visible_length(node: ast.AST) -> int | None:
+    """The element count of a written-out container, or None if it is not written out."""
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        if any(isinstance(element, ast.Starred) for element in node.elts):
+            return None
+        return len(node.elts)
+    if isinstance(node, ast.Dict):
+        if any(key is None for key in node.keys):
+            return None
+        return len(node.keys)
+    if isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes)):
+        return len(node.value)
+    return None
 
 
 _OPERATOR_BUILDERS = {
@@ -955,6 +1007,33 @@ def _visibly_local_instance(node: ast.AST, shadowed = None) -> bool:
     return node.func.id in _LOCAL_CLASSES
 
 
+def _inherits_text(definition: ast.ClassDef, seen = None) -> bool:
+    """Whether this local class has `str` or `bytes` anywhere above it.
+
+    Through local bases as well as direct ones: `class Base(str): pass` followed by
+    `class Template(Base): pass` inherits `str.format` just as plainly, and reading
+    only the direct bases treated the subclass as textless and exempted a real splice.
+    A base this file does not define is unknown, and unknown counts as textual - that
+    is the reporting side.
+    """
+    seen = seen if seen is not None else set()
+    for base in definition.bases:
+        if not isinstance(base, ast.Name):
+            continue
+        if base.id in ("str", "bytes"):
+            return True
+        if base.id in seen:
+            continue
+        seen.add(base.id)
+        parent = _LOCAL_CLASSES.get(base.id)
+        if parent is None:
+            # A base from somewhere else may itself be a `str` subclass.
+            return True
+        if _inherits_text(parent, seen):
+            return True
+    return False
+
+
 def _defines_own_builder(name: str, attribute: str) -> bool:
     """Whether this local class's `attribute` is its own rather than the string one.
 
@@ -965,10 +1044,7 @@ def _defines_own_builder(name: str, attribute: str) -> bool:
     definition = _LOCAL_CLASSES.get(name)
     if definition is None:
         return False
-    inherits_text = any(
-        isinstance(base, ast.Name) and base.id in ("str", "bytes")
-        for base in definition.bases
-    )
+    inherits_text = _inherits_text(definition)
     defines = any(
         isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
         and statement.name == attribute
@@ -1049,6 +1125,16 @@ def _bound_template(node: ast.AST, shadowed = None, aliases = None):
     if shadowed is not None and shadowed(node.id):
         return None
     held = aliases(f"template:{node.id}")
+    return held if isinstance(held, ast.Call) else None
+
+
+def _bound_formatter(node: ast.AST, shadowed = None, aliases = None):
+    """The `string.Formatter()` a name was bound to, else None."""
+    if not isinstance(node, ast.Name) or aliases is None:
+        return None
+    if shadowed is not None and shadowed(node.id):
+        return None
+    held = aliases(f"formatter:{node.id}")
     return held if isinstance(held, ast.Call) else None
 
 
@@ -1185,7 +1271,7 @@ def _lambda_scope(node: ast.Call, function: ast.Lambda, resolve, shadowed, resol
     # `*args` at the call site moves every later argument, so nothing after it pairs
     # up: those parameters stay unresolved rather than being paired with the wrong
     # value.
-    supplied = []
+    supplied, opaque = [], False
     for argument in node.args:
         if isinstance(argument, ast.Starred):
             # A written-out expansion says exactly which values it supplies, so
@@ -1198,8 +1284,14 @@ def _lambda_scope(node: ast.Call, function: ast.Lambda, resolve, shadowed, resol
             ):
                 supplied.extend(inner.elts)
                 continue
+            opaque = True
             break
         supplied.append(argument)
+    if arguments.vararg is None and not opaque and len(supplied) > len(positional):
+        # More positional values than the lambda takes, all of them written out:
+        # `(lambda source: source)(*["a", "b"])` raises `TypeError` before the sink
+        # runs, so nothing it appears to bind is real.
+        return resolve
     for index, argument in enumerate(supplied):
         if index < len(positional):
             bound[positional[index].arg] = argument
@@ -1361,6 +1453,24 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             return _is_interpolated(
                 ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
             )
+    if (
+        isinstance(function, ast.Attribute)
+        and function.attr == "pop"
+        and isinstance(function.value, (ast.List, ast.Tuple))
+        and function.value.elts
+        and not any(isinstance(element, ast.Starred) for element in function.value.elts)
+        and not node.keywords
+    ):
+        # `[f"..."].pop()` returns the last element of a container written out right
+        # here, and `[a, b].pop(0)` the one it names. Only the mapping spelling was
+        # read, so the list one selected and executed source with nothing reported.
+        elements = function.value.elts
+        if not node.args:
+            return _is_interpolated(elements[-1], resolve, shadowed, resolve_alias)
+        index = _constant_integer(node.args[0]) if len(node.args) == 1 else None
+        if index is not None and -len(elements) <= index < len(elements):
+            return _is_interpolated(elements[index], resolve, shadowed, resolve_alias)
+        return None
     if isinstance(function, ast.Attribute):
         literal_mapping = (
             _mapping_literal(function.value, shadowed)
@@ -1444,6 +1554,12 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 and len(node.args) == 2
                 and not node.keywords
             ):
+                if isinstance(
+                    _OPERATOR_BUILDERS[function.attr](), ast.Add
+                ) and _visibly_unaddable(node.args[0], node.args[1]):
+                    # The call raises before the sink runs. `%` is not this case: a
+                    # string and a number is an ordinary `"%d" % 1`.
+                    return None
                 equivalent = ast.BinOp(
                     left = node.args[0],
                     op = _OPERATOR_BUILDERS[function.attr](),
@@ -1484,6 +1600,17 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             return _is_interpolated(
                 ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
             )
+        if (
+            function.attr in ("__add__", "__mod__")
+            and len(node.args) == 1
+            and not node.keywords
+            and _visibly_local_instance(function.value, shadowed)
+            and _defines_own_builder(function.value.func.id, function.attr)
+        ):
+            # `class Safe: def __add__(self, value): return "pass"` followed by
+            # `Safe().__add__(name)` is not concatenation at all, exactly as the
+            # `.format()` case above is not a string builder. Same test, same reason.
+            return None
         if (
             function.attr in ("__add__", "__mod__")
             and len(node.args) == 1
@@ -1547,7 +1674,14 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             # the source is the first argument and the receiver is only the type.
             # Unwrapping the receiver looked at the name `str` and found nothing.
             # Same shape the conversions below already handle.
-            if _constructor_name(function.value, shadowed, resolve_alias) is not None:
+            unbound = _constructor_name(function.value, shadowed, resolve_alias) is not None
+            low, high = _NORMALISER_ARITY[function.attr]
+            if unbound:
+                low, high = low + 1, high + 1
+            if not node.keywords and not low <= len(node.args) <= high:
+                # The call raises before the sink runs.
+                return None
+            if unbound:
                 return (
                     _is_interpolated(node.args[0], resolve, shadowed, resolve_alias)
                     if node.args else None
@@ -1587,7 +1721,10 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             return None
         if (
             function.attr in ("vformat", "format_field")
-            and _is_formatter_call(function.value, shadowed, resolve_alias)
+            and (
+                _is_formatter_call(function.value, shadowed, resolve_alias)
+                or _bound_formatter(function.value, shadowed, resolve_alias) is not None
+            )
         ):
             # `string.Formatter().vformat("{}", (payload,), {})` is `str.format` with
             # the arguments handed over as a tuple and a mapping, and the method was in
@@ -1952,6 +2089,86 @@ def _literal_builtins_import(node: ast.AST, shadowed = None, aliases = None) -> 
     return False
 
 
+def _visibly_unaddable(left: ast.AST, right: ast.AST) -> bool:
+    """Whether adding these two written-out operands raises rather than concatenating.
+
+    `operator.add(f"import {name}", 1)` is a `TypeError`, so no source is built and
+    reporting it blocked CI on code that cannot run. Only when BOTH sides are written
+    out and one is text while the other plainly is not: anything unknown still reads
+    as a concatenation, which is the reporting side.
+    """
+    def kind(node):
+        if isinstance(node, ast.JoinedStr):
+            return "text"
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, str):
+                return "text"
+            if isinstance(node.value, bytes):
+                return "bytes"
+            return "other"
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
+            return "other"
+        return None
+
+    left_kind, right_kind = kind(left), kind(right)
+    if left_kind is None or right_kind is None:
+        return False
+    return left_kind != right_kind
+
+
+def _lambda_result(call: ast.Call):
+    """What an immediately invoked lambda hands back, when that is written out.
+
+    The body itself, or - when the body is one of the parameters - the argument that
+    parameter was given. Only a straightforward pairing: a `*` or `**` at the call site
+    can supply anything, and nothing is guessed there.
+    """
+    lambda_node = call.func
+    if not isinstance(lambda_node, ast.Lambda):
+        return None
+    body = lambda_node.body
+    if not isinstance(body, ast.Name):
+        return body
+    arguments = lambda_node.args
+    positional = [*arguments.posonlyargs, *arguments.args]
+    names = {argument.arg for argument in positional}
+    if body.id not in names:
+        return None
+    if any(isinstance(argument, ast.Starred) for argument in call.args):
+        return None
+    if any(keyword.arg is None for keyword in call.keywords):
+        return None
+    bound = {}
+    for index, argument in enumerate(call.args):
+        if index < len(positional):
+            bound[positional[index].arg] = argument
+    for keyword in call.keywords:
+        bound[keyword.arg] = keyword.value
+    defaults = arguments.defaults
+    if defaults:
+        for parameter, default in zip(positional[len(positional) - len(defaults):], defaults):
+            bound.setdefault(parameter.arg, default)
+    return bound.get(body.id)
+
+
+def _folded_text(node: ast.AST) -> ast.AST:
+    """A written-out concatenation of string literals, folded to one constant.
+
+    Only `+` between literals, and only when every piece is one: nothing here
+    evaluates a name or calls anything. Anything else is handed back unchanged.
+    """
+    if not isinstance(node, ast.BinOp) or not isinstance(node.op, ast.Add):
+        return node
+    left = _folded_text(node.left)
+    right = _folded_text(node.right)
+    if (
+        isinstance(left, ast.Constant) and isinstance(right, ast.Constant)
+        and isinstance(left.value, str) and isinstance(right.value, str)
+    ):
+        return ast.copy_location(ast.Constant(value = left.value + right.value), node)
+    return node
+
+
 def _getattr_sink_name(function: ast.Call, aliases = None, shadowed = None) -> str | None:
     """The sink `getattr(builtins, "exec")` names, or None.
 
@@ -1982,6 +2199,9 @@ def _getattr_sink_name(function: ast.Call, aliases = None, shadowed = None) -> s
             shadowed is not None and shadowed("getattr")
         ):
             owner, attribute = function.args[0], function.args[1]
+            # `"ex" + "ec"` is `"exec"` however it is written; the pieces are all
+            # literals, so folding them reads the same name CPython will.
+            attribute = _folded_text(attribute)
             if isinstance(attribute, ast.Constant) and attribute.value in SINKS:
                 if _literal_builtins_import(owner, shadowed, aliases):
                     # `getattr(__import__("builtins"), "exec")` names the module
@@ -2040,6 +2260,13 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
             recorded = aliases(path)
             if recorded:
                 return recorded
+    if isinstance(function, ast.Call) and isinstance(function.func, ast.Lambda):
+        # `(lambda run: run)(exec)(f"...")` calls whatever the lambda hands back, which
+        # is written out right here. The source side already binds arguments to
+        # parameters; the callee side stopped at the lambda and read nothing.
+        result = _lambda_result(function)
+        if result is not None:
+            return _sink_name(result, aliases, shadowed)
     if isinstance(function, ast.Call) and _partial_sink(function, aliases, shadowed):
         # `functools.partial(exec, f"...")()` binds the sink and its source and then
         # calls the result, so neither half resolved on its own. Only the visible
@@ -2487,7 +2714,8 @@ _FORMATTER = string.Formatter()
 def _truncating_format_spec(node: ast.Call) -> bool:
     """Whether a builtin `format(value, spec)` spec cuts the value to nothing.
 
-    Only `.0`, written out: `format(s, ".0")` is `""` for a string, so nothing built
+    Only `.0`, written out, with or without the `s` type that says the value is a
+    string: `format(s, ".0")` and `format(s, ".0s")` are both `""`, so nothing built
     reaches the sink. A spec this cannot read is unknown and keeps the source.
     """
     spec = node.args[1] if len(node.args) > 1 else None
@@ -2497,7 +2725,7 @@ def _truncating_format_spec(node: ast.Call) -> bool:
                 spec = keyword.value
     if not (isinstance(spec, ast.Constant) and isinstance(spec.value, str)):
         return False
-    return bool(re.fullmatch(r"[^{}]*\.0", spec.value))
+    return bool(re.fullmatch(r"[^{}]*\.0s?", spec.value))
 
 
 def _constructor_names(function: ast.AST, shadowed = None, aliases = None):
@@ -2624,7 +2852,12 @@ def _compile_call_is_complete(node: ast.Call, shadowed = None, skip: int = 0) ->
     CPython refuses it outright.
     """
     positional = 0
-    named = {keyword.arg for keyword in node.keywords if keyword.arg is not None}
+    spelled = [keyword.arg for keyword in node.keywords if keyword.arg is not None]
+    named = set(spelled)
+    if len(spelled) != len(named):
+        # `compile(source = a, source = b)` does not parse, but a mapping expansion
+        # repeating a plain keyword is the same `TypeError` and does.
+        return False
     for argument in node.args[skip:]:
         if isinstance(argument, ast.Starred):
             inner = argument.value
@@ -2653,10 +2886,16 @@ def _compile_call_is_complete(node: ast.Call, shadowed = None, skip: int = 0) ->
             key is None for key in mapping.keys
         ):
             return True
-        named |= {
+        supplied = {
             key.value for key in mapping.keys
             if isinstance(key, ast.Constant) and isinstance(key.value, str)
         }
+        if supplied & named:
+            # The same keyword twice across two visible mappings is a `TypeError`
+            # before `compile` is called: `compile(**{"source": a}, **{"source": b})`
+            # never runs, and reporting it blocked CI on code that cannot.
+            return False
+        named |= supplied
     # A keyword that repeats a positional makes the call a `TypeError` before any
     # source is compiled: `compile(f"...", "<x>", "exec", source = "pass")` never runs,
     # and reporting the f-string in it blocked CI over code CPython refuses.
@@ -2679,6 +2918,13 @@ def _compile_keyword_source(node: ast.Call, shadowed = None) -> ast.AST | None:
         if keyword.arg == "source":
             return keyword.value
         if keyword.arg is None and _mapping_literal(keyword.value) is not None:
+            # WITHOUT the shadow test, unlike `_compile_call_is_complete`. The two ask
+            # different questions: that one asks whether the call can run at all, where
+            # reading a shadowed `dict` invents an argument; this one asks what source
+            # may reach the sink, where a local `def dict(**kwargs): return kwargs`
+            # hands the interpolated value straight through. Adding the test here was
+            # measured against the corpus and turned three real findings into misses
+            # (temp/r32/dictshadow.py, temp/r48, temp/r49).
             # `compile(**{"source": f"..."})` is the same call with the same
             # argument; a literal mapping names its keys as plainly as a keyword
             # does, and `dict({...}, filename = "<x>")` is that mapping written as
@@ -3269,6 +3515,47 @@ class _Visitor(ast.NodeVisitor):
             self._bind(target, reason, numeric, literal_text)
             self._bind_unpacked(target, node.value)
             self._shadow_assignment(target, node.value)
+            self._bind_container_elements(target, node.value)
+
+    def _bind_container_elements(self, target, value) -> None:
+        """`payloads = [f"import {name}"]` records what `payloads[0]` then holds.
+
+        A container written out at the subscript is already read through; bound to a
+        name first, it was not, so `payloads = [f"..."]; exec(payloads[0])` executed
+        built source with nothing reported. Only constant-addressable elements of a
+        written-out list, tuple or mapping, recorded under the same compound key the
+        attribute form uses - the spelling at the store and at the load is the same
+        text either way.
+        """
+        if not isinstance(target, ast.Name):
+            return
+        pairs = []
+        if isinstance(value, (ast.List, ast.Tuple)):
+            if any(isinstance(element, ast.Starred) for element in value.elts):
+                return
+            pairs = list(enumerate(value.elts))
+        elif isinstance(value, ast.Dict):
+            if any(key is None for key in value.keys):
+                return
+            for key, item in zip(value.keys, value.values):
+                if isinstance(key, ast.Constant) and isinstance(key.value, (str, int)):
+                    if isinstance(key.value, bool):
+                        continue
+                    pairs.append((key.value, item))
+        for index, item in pairs:
+            element_reason = _is_interpolated(
+                item, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
+            if element_reason is None or isinstance(element_reason, _LiteralText):
+                continue
+            path = "path>" + ast.unparse(
+                ast.Subscript(
+                    value = ast.Name(id = target.id, ctx = ast.Load()),
+                    slice = ast.Constant(value = index),
+                    ctx = ast.Load(),
+                )
+            )
+            self.tainted[-1][path] = element_reason
 
     def visit_AnnAssign(self, node: ast.AnnAssign):
         """Same tracking for `payload: str = f"...{x}..."`.
@@ -3394,8 +3681,7 @@ class _Visitor(ast.NodeVisitor):
         if isinstance(node.target, ast.Name):
             self.visit(node.target)
 
-    @staticmethod
-    def _literal_elements(iterable):
+    def _literal_elements(self, iterable):
         """The elements a written-out iterable yields, or None if it is not one.
 
         Iterating a mapping yields its KEYS, so `for payload in {f"...": None}` binds
@@ -3403,6 +3689,18 @@ class _Visitor(ast.NodeVisitor):
         cleared the target and the sink in the body reported nothing. A `**` expansion
         appears as a `None` key and says nothing, so such a mapping is not read.
         """
+        # `iter([...])` and `tuple([...])` yield exactly what the container does, so
+        # `for payload in iter([f"import {name}"])` binds the interpolated element.
+        # Reading the call as opaque cleared the target and lost the sink below it.
+        if (
+            isinstance(iterable, ast.Call)
+            and isinstance(iterable.func, ast.Name)
+            and iterable.func.id in ("iter", "tuple", "list", "set", "frozenset")
+            and not self._is_shadowed(iterable.func.id)
+            and len(iterable.args) == 1
+            and not iterable.keywords
+        ):
+            return self._literal_elements(iterable.args[0])
         if isinstance(iterable, (ast.Tuple, ast.List, ast.Set)):
             return iterable.elts
         if isinstance(iterable, ast.Dict) and all(k is not None for k in iterable.keys):
@@ -3962,7 +4260,7 @@ class _Visitor(ast.NodeVisitor):
                     table[-1].pop(node.name, None)
                     for prefix in (
                         "module:", "constructor:", "partial:", "functools:", "text:",
-                        "stdlib:", "stdlibfunc:", "template:", "builder:",
+                        "stdlib:", "stdlibfunc:", "template:", "builder:", "formatter:",
                     ):
                         table[-1].pop(f"{prefix}{node.name}", None)
         for statement in node.body:
@@ -4982,7 +5280,7 @@ class _Visitor(ast.NodeVisitor):
             # `for run, ignored in [(builtins.exec, None)]` binds `run` to the builtin
             # exactly as the plain form does. Each element is paired with the target
             # the same way an unpacking assignment is.
-            elements = _Visitor._literal_elements(iterable)
+            elements = self._literal_elements(iterable)
             if elements:
                 for element in elements:
                     for sub_target, sub_value in _Visitor._unpacked_pairs(target, element):
@@ -5000,7 +5298,7 @@ class _Visitor(ast.NodeVisitor):
             return answer
         if not isinstance(target, ast.Name) or target.id not in names:
             return answer
-        elements = _Visitor._literal_elements(iterable)
+        elements = self._literal_elements(iterable)
         if not elements:
             return answer
         resolved = [
@@ -5112,6 +5410,16 @@ class _Visitor(ast.NodeVisitor):
         level = self._binding_level(target.id)
         for table in (self.sink_aliases, self.collected_aliases):
             table[level].pop(f"builder:{target.id}", None)
+        for table in (self.sink_aliases, self.collected_aliases):
+            table[level].pop(f"formatter:{target.id}", None)
+        if _is_formatter_call(value, self._is_shadowed, self._alias):
+            # `formatter = string.Formatter()` then `formatter.vformat("{}", ...)`
+            # splices exactly as the inline constructor does. Same namespace trick the
+            # template below uses, for the same reason: by the call the receiver is a
+            # bare name and the constructor is a line above.
+            for table in (self.sink_aliases, self.collected_aliases):
+                table[level][f"formatter:{target.id}"] = value
+            return
         if _is_template_call(value, self._is_shadowed, self._alias):
             # `template = string.Template("import $name")` then
             # `template.substitute(name = name)` splices exactly as the inline
@@ -5724,11 +6032,47 @@ class _Visitor(ast.NodeVisitor):
         """
         if not isinstance(node.func, ast.Name) or node.func.id not in self._CONSUMERS:
             return
-        if self._is_shadowed(node.func.id) or len(node.args) != 1 or node.keywords:
+        # `next(iterator, default)` takes a second argument and still advances the
+        # iterator once; every other consumer here takes the one.
+        allowed = 2 if node.func.id == "next" else 1
+        if self._is_shadowed(node.func.id) or not 1 <= len(node.args) <= allowed:
             return
-        yield from self._mapped_sink_elements(node.args[0])
+        if node.keywords:
+            return
+        yield from self._mapped_sink_elements(node.args[0], consumer = node.func.id)
 
-    def _mapped_sink_elements(self, inner):
+    # Consumers that take a `key` callback, and how many elements they provably feed
+    # it. `sorted` computes the key for every element before it compares anything;
+    # `min` and `max` compute two and then compare, which raises on None.
+    _KEY_CONSUMERS = {"sorted": None, "min": 2, "max": 2}
+
+    def _key_sink_calls(self, node: ast.Call):
+        """`sorted([f"..."], key = exec)` calls the sink on the elements it consumes."""
+        if not isinstance(node.func, ast.Name) or node.func.id not in self._KEY_CONSUMERS:
+            return
+        if self._is_shadowed(node.func.id) or len(node.args) != 1:
+            return
+        key = None
+        for keyword in node.keywords:
+            if keyword.arg == "key":
+                key = keyword.value
+            elif keyword.arg is None:
+                # A `**` can supply or replace the key with anything.
+                return
+        if key is None:
+            return
+        sink = _sink_name(key, self._alias, self._is_shadowed)
+        if sink is None:
+            return
+        elements = self._literal_elements(node.args[0]) or ()
+        reach = len(elements)
+        counted = self._KEY_CONSUMERS[node.func.id]
+        if counted is not None:
+            reach = min(reach, counted)
+        for element in elements[:reach]:
+            yield sink, element, node
+
+    def _mapped_sink_elements(self, inner, consumer: str = ""):
         """`(sink, element, call)` for a written-out `map(<sink>, [literal, ...])`."""
         if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name)):
             return
@@ -5758,7 +6102,19 @@ class _Visitor(ast.NodeVisitor):
         if sink.rpartition(".")[2] == "compile" and len(inner.args) - 1 < 3:
             return
         elements = self._literal_elements(inner.args[1])
-        for element in elements or ():
+        # `map` stops as soon as the SHORTEST iterable is exhausted, so a written-out
+        # second iterable caps how many elements the callback ever sees:
+        # `map(exec, [f"..."], [])` calls it not once.
+        reach = len(elements or ())
+        for extra in inner.args[2:]:
+            length = _visible_length(extra)
+            if length is not None:
+                reach = min(reach, length)
+        if consumer:
+            counted = _consumed_count(consumer, sink)
+            if counted is not None:
+                reach = min(reach, counted)
+        for element in (elements or ())[:reach]:
             yield sink, element, inner
 
     def _report_mapped_sinks(self, pairs) -> None:
@@ -5776,6 +6132,19 @@ class _Visitor(ast.NodeVisitor):
                     "line": inner.lineno,
                     "hash": _call_hash(inner),
                 })
+
+    def visit_Expr(self, node: ast.Expr):
+        """A generator expression that nobody iterates runs only its first iterable.
+
+        `(exec(f"import {name}") for _ in [0])` as a statement of its own builds a
+        generator and drops it: the element and the filters are deferred to an
+        iteration that never happens. Visiting them reported a sink that cannot run.
+        The outermost iterable IS evaluated at construction, so it is still visited.
+        """
+        if isinstance(node.value, ast.GeneratorExp) and node.value.generators:
+            self.visit(node.value.generators[0].iter)
+            return
+        self.generic_visit(node)
 
     def visit_Starred(self, node: ast.Starred):
         """`[*map(exec, [...])]` consumes the map as eagerly as `list(...)` does."""
@@ -5798,6 +6167,7 @@ class _Visitor(ast.NodeVisitor):
         )
 
     def visit_Call(self, node: ast.Call):
+        self._report_mapped_sinks(self._key_sink_calls(node))
         for mapped_sink, element, inner in self._mapped_sink_calls(node):
             reason = _is_interpolated(
                 element, self.tainted[-1].get, self._is_shadowed, self._alias,
@@ -6616,7 +6986,28 @@ def _script_command_source(code: str) -> str | None:
             tokens = _expanded_env_tokens(shlex.split(argument))
         except ValueError:
             return None
+        # Option parsing starts AFTER the interpreter and stops at the first script
+        # operand: `python --help` documents the usage as
+        # `[option] ... [-c cmd | -m mod | file | -] [arg] ...`, so in
+        # `%%script python helper.py -c "prog"` the `-c` and its string are arguments
+        # to `helper.py`, not to the interpreter, and reading them as a `-c` program
+        # reported source that nothing here runs. `_runs_python` already stops there.
+        start = 0
         for position, token in enumerate(tokens):
+            command = token.rsplit("/", 1)[-1].split("\\")[-1]
+            if _PYTHON_COMMAND.fullmatch(command):
+                start = position + 1
+                break
+        position = start
+        while position < len(tokens):
+            token = tokens[position]
+            if not token.startswith("-"):
+                # The script operand. Everything after it belongs to that script.
+                return None
+            if token in ("-W", "-X", "--check-hash-based-pycs"):
+                # These take their value in the next token, which is not an operand.
+                position += 2
+                continue
             if token == "-c" and position + 1 < len(tokens):
                 return tokens[position + 1]
             if (
@@ -6642,6 +7033,7 @@ def _script_command_source(code: str) -> str | None:
                 if rest.lstrip("-") == rest:
                     return rest
                 return tokens[position + 1] if position + 1 < len(tokens) else None
+            position += 1
         return None
     return None
 
@@ -7347,7 +7739,18 @@ def main() -> int:
         return 0
 
     allowlist = load_allowlist()
-    unreviewed = [f for f in findings if key_of(f) not in allowlist]
+    # The recorded KIND has to still match as well as the key. The key hashes the sink
+    # call itself, which is what makes editing that call force a re-review - but a
+    # finding whose source is built in the statements ABOVE it keeps the same call
+    # text, so a change to how the source is built would inherit the old approval
+    # silently. When such a change alters the shape at all, it alters the reason, and
+    # that is now a mismatch rather than a match. Entries written before `kind` was
+    # recorded carry none, and those still match on the key alone.
+    unreviewed = [
+        f for f in findings
+        if key_of(f) not in allowlist
+        or allowlist[key_of(f)].get("kind", f["reason"]) != f["reason"]
+    ]
     pending = [
         entry
         for entry in allowlist.values()

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -170,7 +170,16 @@ _CONSTRUCTOR_SOURCE_KEYWORD = {
 # `dict(...)` names the `compile` keywords and `getattr(builtins, "exec")` names a
 # sink. A local binding of either takes that reading away, so they belong here even
 # though they are not in `_CONSTRUCTORS`.
-_BUILTIN_NAMES = frozenset({*SINKS, *_CONSTRUCTORS, "builtins", "dict", "getattr"})
+# Stdlib modules this checker unwraps calls on by their written-out name, so a local
+# binding of one has to stop that unwrapping the same way a local `str` does.
+# `def f(operator, name): exec(operator.add("import ", name))` calls a method on an
+# ordinary parameter, and rewriting it as `+` reported a helper that may well return a
+# fixed literal. `_binds_over_sink` never recorded the shadow because the name was in
+# none of the tracked sets.
+_MODULE_RECEIVERS = frozenset({"codeop", "operator", "ast", "importlib", "functools"})
+_BUILTIN_NAMES = frozenset({
+    *SINKS, *_CONSTRUCTORS, *_MODULE_RECEIVERS, "builtins", "dict", "getattr",
+})
 
 
 def _constructor_name(function: ast.AST, shadowed = None, aliases = None) -> str | None:
@@ -637,6 +646,44 @@ def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias
     return _literal_element(node, resolve, shadowed, resolve_alias)
 
 
+def _names_module(node: ast.AST, module: str, shadowed = None, aliases = None) -> bool:
+    """Whether `node` is written out as the stdlib module `module`.
+
+    The module's own name, or an alias recorded under the `stdlib:` namespace by
+    `import codeop as co`. Requiring the literal name meant a conventional alias
+    turned the unwrapping off, so `exec(co.compile_command(f"import {name}"))`
+    reported nothing at all. Shadow-tested like every other written-out receiver.
+    """
+    if not isinstance(node, ast.Name):
+        return False
+    if shadowed is not None and shadowed(node.id):
+        return False
+    if node.id == module:
+        return True
+    return aliases is not None and aliases(f"stdlib:{node.id}") == module
+
+
+def _positive_repetition(count: ast.AST) -> bool:
+    """Whether a written-out repetition count keeps at least one copy of the string.
+
+    `s * 0` and `s * -1` are both the empty string, so neither builds anything. A
+    count that is not written out is unknown, and unknown keeps the source.
+    """
+    # A negative literal is `UnaryOp(USub, Constant(1))`, not a `Constant`, so
+    # requiring one read `f"..." * -1` as an unknown count.
+    sign = 1
+    if isinstance(count, ast.UnaryOp) and isinstance(count.op, (ast.USub, ast.UAdd)):
+        sign = -1 if isinstance(count.op, ast.USub) else 1
+        count = count.operand
+    if (
+        isinstance(count, ast.Constant)
+        and isinstance(count.value, int)
+        and not isinstance(count.value, bool)
+    ):
+        return sign * count.value > 0
+    return True
+
+
 def _interpolated_binop(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
     """`a % b`, `a + b` and `s * n`, minus the visibly arithmetic cases."""
     # `exec(1 + 2)` and `eval(5 % 2)` produce integers and raise TypeError at the
@@ -654,18 +701,7 @@ def _interpolated_binop(node, resolve = None, shadowed = None, resolve_alias = N
         # too, so nothing is built and reporting it failed the gate on a call that
         # cannot execute anything. Only a written-out count decides this.
         for count in (node.left, node.right):
-            # A negative literal is `UnaryOp(USub, Constant(1))`, not a `Constant`, so
-            # requiring one read `f"..." * -1` as an unknown count.
-            sign = 1
-            if isinstance(count, ast.UnaryOp) and isinstance(count.op, (ast.USub, ast.UAdd)):
-                sign = -1 if isinstance(count.op, ast.USub) else 1
-                count = count.operand
-            if (
-                isinstance(count, ast.Constant)
-                and isinstance(count.value, int)
-                and not isinstance(count.value, bool)
-                and sign * count.value <= 0
-            ):
+            if not _positive_repetition(count):
                 return None
         # `f"import {name}\n" * 2` repeats the built string; the interpolation is
         # still in every copy. Either side may be the string.
@@ -770,8 +806,8 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                     if keyword.arg == "source":
                         compiled = keyword.value
                         break
-            if compiled is not None and function.value.id == "codeop" and not (
-                shadowed is not None and shadowed("codeop")
+            if compiled is not None and _names_module(
+                function.value, "codeop", shadowed, resolve_alias,
             ):
                 return _is_interpolated(compiled, resolve, shadowed, resolve_alias)
         if function.attr in ("add", "concat") and isinstance(function.value, ast.Name):
@@ -781,10 +817,9 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             # numeric exclusion, so `operator.add(1, 2)` stays quiet. Receiver written
             # out and unshadowed, two positional arguments, the only shape these take.
             if (
-                function.value.id == "operator"
+                _names_module(function.value, "operator", shadowed, resolve_alias)
                 and len(node.args) == 2
                 and not node.keywords
-                and not (shadowed is not None and shadowed("operator"))
             ):
                 equivalent = ast.BinOp(
                     left = node.args[0], op = ast.Add(), right = node.args[1],
@@ -805,8 +840,8 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                     if keyword.arg == "source":
                         parsed = keyword.value
                         break
-            if parsed is not None and function.value.id == "ast" and not (
-                shadowed is not None and shadowed("ast")
+            if parsed is not None and _names_module(
+                function.value, "ast", shadowed, resolve_alias,
             ):
                 return _is_interpolated(parsed, resolve, shadowed, resolve_alias)
         if (
@@ -869,14 +904,18 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             # Reporting them forced literal code into the allowlist. Only a
             # visibly empty call counts; anything unknown still reports.
             spliced = list(node.args) + [k.value for k in node.keywords]
-            empty = not spliced
+            empty = no_arguments = not spliced
             if len(spliced) == 1 and isinstance(spliced[0], (ast.Tuple, ast.List, ast.Set, ast.Dict)):
                 container = spliced[0]
                 elements = container.keys if isinstance(container, ast.Dict) else container.elts
                 empty = not elements
-            if empty and function.attr == "format_map" and not node.keywords:
-                # `format_map` requires exactly one mapping argument, so the empty
-                # call raises TypeError before the sink is reached.
+            if no_arguments and function.attr == "format_map" and not node.keywords:
+                # `format_map` requires exactly one mapping argument, so the
+                # ARGUMENT-LESS call raises TypeError before the sink is reached.
+                # Keyed on `no_arguments` rather than `empty`, or
+                # `f"import {name}".format_map({})` took this branch as well: the
+                # required argument is there, it is just empty, so the call returns
+                # the already-built receiver and `exec` runs it.
                 return None
             if empty:
                 # Nothing was spliced in, but the RECEIVER can already be built
@@ -1173,7 +1212,15 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
                 # ordinary parameter, not the module. The owner needs the same shadow
                 # test the bare-name branch above already applies to the callee.
                 return None
-            if module == "builtins" or (aliases is not None and aliases(f"module:{module}")):
+            # `__builtins__` as well as `builtins`: CPython binds it to the builtins
+            # MODULE in `__main__`, so `__builtins__.exec(f"import {name}")` runs in
+            # exactly the script that gets executed directly. It was already read as
+            # the namespace MAPPING by `_is_builtins_mapping`; the attribute spelling
+            # went unread and the call reported nothing.
+            if (
+                module in ("builtins", "__builtins__")
+                or (aliases is not None and aliases(f"module:{module}"))
+            ):
                 return f"builtins.{function.attr}"
     if (
         isinstance(function, ast.Call)
@@ -1327,14 +1374,23 @@ def _constant_truth(test: ast.AST):
         # Short-circuit rules: `and` is False as soon as one operand is, and True only
         # when every one is; `or` mirrors it. An undecidable operand before a deciding
         # one leaves the whole thing undecided, which is the safe answer.
+        # An unknown operand does NOT make the whole expression unknown, because the
+        # deciding operand may be further along: `flag and False` is falsy whichever
+        # way `flag` goes, since a falsy `flag` is returned as-is and a truthy one
+        # returns `False`. `flag or True` mirrors it. Returning at the first unknown
+        # read `while flag and False:` as an ordinary loop and applied the shadow its
+        # body could never install. So the scan continues, and only a run that reaches
+        # the end without a deciding constant is undecided.
         decisive = isinstance(test.op, ast.Or)
+        unknown = False
         for operand in test.values:
             decided = _constant_truth(operand)
             if decided is None:
-                return None
+                unknown = True
+                continue
             if decided is decisive:
                 return decisive
-        return not decisive
+        return None if unknown else not decisive
     return None
 
 
@@ -1519,6 +1575,35 @@ def _mapping_lookup(mapping: ast.Dict, wanted: str) -> ast.AST | None:
     return None
 
 
+def _compile_keyword_source(node: ast.Call, shadowed = None) -> ast.AST | None:
+    """The `source=` argument of a `compile` call, however the keyword is spelled."""
+    for keyword in node.keywords:
+        if keyword.arg == "source":
+            return keyword.value
+        if keyword.arg is None and _mapping_literal(keyword.value) is not None:
+            # `compile(**{"source": f"..."})` is the same call with the same
+            # argument; a literal mapping names its keys as plainly as a keyword
+            # does, and `dict({...}, filename = "<x>")` is that mapping written as
+            # a call. A `**` of anything else is opaque and stays ignored.
+            found = _mapping_lookup(_mapping_literal(keyword.value), "source")
+            if found is not None:
+                return found
+        if keyword.arg is None and isinstance(keyword.value, ast.Call):
+            # `compile(**dict(source = f"..."))` is the same call spelled with the
+            # constructor. Only a bare `dict(...)` with plain keywords, which names
+            # its keys as plainly as a literal mapping does.
+            call = keyword.value
+            if (
+                isinstance(call.func, ast.Name)
+                and call.func.id == "dict"
+                and not (shadowed is not None and shadowed("dict"))
+            ):
+                for inner in reversed(call.keywords):
+                    if inner.arg == "source":
+                        return inner.value
+    return None
+
+
 def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) -> ast.AST | None:
     """The source argument of a sink call, whether positional or by keyword.
 
@@ -1572,6 +1657,17 @@ def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) 
             answer = candidates[0]
             for other in candidates[1:]:
                 answer = _either_value(answer, other)
+            # An opaque expansion may contribute NOTHING, and then a `source=`
+            # keyword is what `compile` receives: `compile(*args, source = f"...")`
+            # with `args = ()` compiles the f-string. Returning the unresolvable
+            # `*args` on its own reported nothing at all, so the keyword is merged
+            # in as the other value this argument may take.
+            if sink.rpartition(".")[2] == "compile" and any(
+                isinstance(candidate, ast.Starred) for candidate in candidates
+            ):
+                by_keyword = _compile_keyword_source(node, shadowed)
+                if by_keyword is not None:
+                    answer = _either_value(answer, by_keyword)
             return answer
         # Every positional argument was a visibly empty expansion, so nothing was
         # passed positionally at all and the keyword form below still applies:
@@ -1580,30 +1676,7 @@ def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) 
         if sink.rpartition(".")[2] != "compile":
             return None
     if sink.rpartition(".")[2] == "compile":
-        for keyword in node.keywords:
-            if keyword.arg == "source":
-                return keyword.value
-            if keyword.arg is None and _mapping_literal(keyword.value) is not None:
-                # `compile(**{"source": f"..."})` is the same call with the same
-                # argument; a literal mapping names its keys as plainly as a keyword
-                # does, and `dict({...}, filename = "<x>")` is that mapping written as
-                # a call. A `**` of anything else is opaque and stays ignored.
-                found = _mapping_lookup(_mapping_literal(keyword.value), "source")
-                if found is not None:
-                    return found
-            if keyword.arg is None and isinstance(keyword.value, ast.Call):
-                # `compile(**dict(source = f"..."))` is the same call spelled with the
-                # constructor. Only a bare `dict(...)` with plain keywords, which names
-                # its keys as plainly as a literal mapping does.
-                call = keyword.value
-                if (
-                    isinstance(call.func, ast.Name)
-                    and call.func.id == "dict"
-                    and not (shadowed is not None and shadowed("dict"))
-                ):
-                    for inner in reversed(call.keywords):
-                        if inner.arg == "source":
-                            return inner.value
+        return _compile_keyword_source(node, shadowed)
     return None
 
 
@@ -1952,7 +2025,16 @@ class _Visitor(ast.NodeVisitor):
             # The numeric marker travels with an annotated assignment too, or
             # `payload: int = 1; payload += 2` read as concatenation and failed the
             # gate on arithmetic that can only ever raise TypeError at the sink.
-            self._bind(node.target, reason, numeric = _visibly_numeric(node.value))
+            # The literal-text marker travels with it too, for the same reason the
+            # numeric one does: without it `template: str = "import MODULE"` followed
+            # by `exec(template.replace("MODULE", name))` went unreported while the
+            # unannotated spelling was caught, so an annotation disabled the check.
+            self._bind(
+                node.target,
+                reason,
+                numeric = _visibly_numeric(node.value),
+                literal_text = reason is None and _visibly_literal_text(node.value),
+            )
         # An annotated assignment binds like any other one.
         if node.value is not None:
             self._shadow_assignment(node.target, node.value)
@@ -1994,6 +2076,17 @@ class _Visitor(ast.NodeVisitor):
             reason = _is_interpolated(node.value) or (
                 None if _visibly_numeric(node.value) else "string repetition"
             )
+            # The RECEIVER may be what holds the built source: `payload =
+            # f"import {name}"; payload *= 2` leaves `payload` the f-string twice
+            # over. Deriving the reason from the multiplier alone got `None` and
+            # cleared the target, so the repeated source reached the sink unread.
+            # A visibly non-positive count still clears it, since `s * 0` and
+            # `s * -1` are both the empty string; that is the one case the
+            # existing `f"..." * 0` rule already decides in `_interpolated_binop`.
+            if reason is None and _visibly_numeric(node.value):
+                held = _is_interpolated(node.target, self.tainted[-1].get, self._is_shadowed, self._alias)
+                if held is not None and _positive_repetition(node.value):
+                    reason = held
             self._bind(node.target, f"{reason} repeated" if reason else None)
             self.visit(node.target)
             return
@@ -2110,6 +2203,14 @@ class _Visitor(ast.NodeVisitor):
             # still runs, and an iterable this cannot read still keeps its body.
             for statement in node.body:
                 self.visit(statement)
+                if isinstance(statement, (ast.Break, ast.Continue, ast.Return, ast.Raise)):
+                    # Nothing after an unconditional jump in this suite ever runs, and
+                    # visiting it applied its mutations anyway: `for _ in [0]: break`
+                    # followed by `payload = "pass"` cleared a binding the loop cannot
+                    # reach, so a later `exec(payload)` on the built string reported
+                    # nothing. Statement level, in this suite only: a jump inside a
+                    # nested `if` is conditional and everything below it still stands.
+                    break
         # The `else` suite also runs when the iterable was empty, in which case the
         # target was never bound and the name still means whatever it meant outside -
         # `for exec in []: pass` leaves `exec` as the builtin.
@@ -2490,6 +2591,16 @@ class _Visitor(ast.NodeVisitor):
                 # made `run` a shadow and the call went unread. Only that one
                 # constructor, written out and unshadowed.
                 handed = _nullcontext_value(item.context_expr, self._alias, self._is_shadowed)
+                # A tuple target pairs with nothing when the value is opaque, and
+                # `_bind` ignores a non-name target, so `with ctx() as (payload, _):`
+                # kept a stale reason on `payload` even though reaching the suite
+                # guarantees it was rebound. Every Store name is cleared FIRST: doing it
+                # after the binds below deleted the very reason `nullcontext` had just
+                # handed over, so `with nullcontext(f"import {name}") as payload:`
+                # reached `exec(payload)` with nothing recorded.
+                for child in ast.walk(item.optional_vars):
+                    if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                        self.tainted[-1].pop(child.id, None)
                 self._bind_unpacked(item.optional_vars, handed)
                 self._bind(
                     item.optional_vars,
@@ -2497,13 +2608,6 @@ class _Visitor(ast.NodeVisitor):
                         handed, self.tainted[-1].get, self._is_shadowed, self._alias,
                     ) if handed is not None else None,
                 )
-                # A tuple target pairs with nothing when the value is opaque, and
-                # `_bind` ignores a non-name target, so `with ctx() as (payload, _):`
-                # kept a stale reason on `payload` even though reaching the suite
-                # guarantees it was rebound. Every Store name is cleared.
-                for child in ast.walk(item.optional_vars):
-                    if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
-                        self.tainted[-1].pop(child.id, None)
                 # Applied HERE, before the NEXT context expression is visited. Items are
                 # entered left to right and each `as` target is bound before the one
                 # after it runs, so delaying every shadow to the end read
@@ -3134,6 +3238,16 @@ class _Visitor(ast.NodeVisitor):
                 self.sink_aliases[-1][f"functools:{bound}"] = "functools"
                 self.collected_aliases[-1][f"functools:{bound}"] = "functools"
                 continue
+            if alias.name in _MODULE_RECEIVERS:
+                # `import codeop as co` makes `co.compile_command` the real one, so
+                # `exec(co.compile_command(f"import {name}"))` compiles and runs the
+                # interpolated source. Requiring the literal receiver name `codeop`
+                # meant a conventional alias turned the check off. Own namespace,
+                # keyed by the module it names, so `co.exec` still resolves to
+                # nothing: only the module's own helpers are unwrapped.
+                self.sink_aliases[-1][f"stdlib:{bound}"] = alias.name
+                self.collected_aliases[-1][f"stdlib:{bound}"] = alias.name
+                continue
             if alias.name == "builtins":
                 # Read BEFORE `_shadow_sink` clears both tables, since that clearing is
                 # what the check below would otherwise be looking at.
@@ -3501,6 +3615,15 @@ class _Visitor(ast.NodeVisitor):
             # `b = builtins` makes `b.exec` the builtin, the same way
             # `import builtins as b` does. Only the import form was recorded.
             level = self._binding_level(target.id)
+            # The name can only hold ONE thing, so an earlier sink or constructor
+            # entry for it has to go first: `run = builtins.exec; run = builtins`
+            # leaves `run` the MODULE, and the surviving `run -> exec` entry made the
+            # following `run(f"...")` read as the builtin, failing the gate on a call
+            # that can only raise TypeError. The reverse direction already cleared,
+            # so this makes the two symmetric.
+            for table in (self.sink_aliases, self.collected_aliases):
+                table[level].pop(target.id, None)
+                table[level].pop(f"constructor:{target.id}", None)
             self.sink_aliases[level][f"module:{target.id}"] = "builtins"
             self.collected_aliases[level][f"module:{target.id}"] = "builtins"
             self.shadowed_sinks[level].discard(target.id)

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -193,7 +193,12 @@ _MODULE_RECEIVERS = frozenset({
 # Stdlib helpers that hand their source through and can be imported directly, as
 # `<module>.<name>`. `visit_ImportFrom` records `from ast import parse as p` against
 # these, and `_interpolated_call` rewrites such a call to the qualified spelling.
-_DIRECT_HELPERS = frozenset({"ast.parse", "codeop.compile_command", "string.Template"})
+_DIRECT_HELPERS = frozenset({
+    "ast.parse", "codeop.compile_command", "string.Template",
+    # `from operator import add as join` binds the same builder the qualified
+    # spelling names, and only the qualified one was read.
+    *(f"operator.{name}" for name in ("add", "concat", "iadd", "iconcat", "mod", "imod")),
+})
 
 _OPERATOR_BUILDERS = {
     "add": ast.Add, "concat": ast.Add, "iadd": ast.Add, "iconcat": ast.Add,
@@ -608,6 +613,11 @@ def _is_interpolated(node: ast.AST, resolve = None, shadowed = None, resolve_ali
     if stored is not None:
         return stored
     if isinstance(node, ast.Subscript):
+        # A piece of a split string still holds the interpolation, and the element
+        # lookup below cannot read a call result, so it answered nothing.
+        piece = _interpolated_split_element(node, resolve, shadowed, resolve_alias)
+        if piece is not None:
+            return piece
         return _interpolated_subscript(node, resolve, shadowed, resolve_alias)
     if isinstance(node, ast.Name):
         if resolve is None:
@@ -732,6 +742,23 @@ def _interpolated_starred(node, resolve = None, shadowed = None, resolve_alias =
         # only when it is written out rather than coming from a `**` expansion.
         return _is_interpolated(inner.keys[0], resolve, shadowed, resolve_alias)
     return None
+
+
+# Methods that cut a string into pieces. Selecting one of those pieces still carries
+# the interpolation: `f"import {name}".partition("#")[0]` is `import <name>`.
+_SPLITTERS = ("split", "rsplit", "partition", "rpartition", "splitlines")
+
+
+def _interpolated_split_element(node, resolve = None, shadowed = None, resolve_alias = None):
+    """The source a `s.split(...)[i]` selection still carries, if any."""
+    if not isinstance(node, ast.Subscript):
+        return None
+    inner = node.value
+    if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)):
+        return None
+    if inner.func.attr not in _SPLITTERS:
+        return None
+    return _is_interpolated(inner.func.value, resolve, shadowed, resolve_alias)
 
 
 def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
@@ -918,6 +945,13 @@ def _interpolated_binop(node, resolve = None, shadowed = None, resolve_alias = N
 def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
     """Every call shape that hands its argument through as source."""
     function = node.func
+    if isinstance(function, ast.Lambda):
+        # `(lambda: f"import {name}")()` returns exactly what its body evaluates to,
+        # and that body is written out right here. The callee is a `Lambda` rather
+        # than a name, so none of the branches below saw it. Parameters are not
+        # resolved: a body reading one is unknown, and `resolve` answers for the
+        # enclosing scope, so `_is_interpolated` reads it as an ordinary name.
+        return _is_interpolated(function.body, resolve, shadowed, resolve_alias)
     preserving = None
     if isinstance(function, ast.Name):
         preserving = function.id
@@ -2401,6 +2435,40 @@ class _Visitor(ast.NodeVisitor):
                 parts.append(node.returns)
         return parts
 
+    @staticmethod
+    def _declared_locals(node) -> set:
+        """Names a function body binds itself, so its closure never reads the outer one.
+
+        Parameters, assignment and walrus targets, `for`/`with`/`except`/`match`
+        targets, imports and definitions - anything in THIS body, not in a nested one,
+        since a nested scope binds in its own.
+        """
+        names = set()
+        arguments = getattr(node, "args", None)
+        if isinstance(arguments, ast.arguments):
+            for argument in (
+                *arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs,
+                arguments.vararg, arguments.kwarg,
+            ):
+                if argument is not None:
+                    names.add(argument.arg)
+        for statement in getattr(node, "body", []) or []:
+            for child in _walk_this_scope(statement):
+                if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                    names.add(child.id)
+                elif isinstance(child, ast.arg):
+                    names.add(child.arg)
+                elif isinstance(child, (ast.Import, ast.ImportFrom)):
+                    for alias in child.names:
+                        names.add(alias.asname or alias.name.split(".")[0])
+                elif isinstance(child, (
+                    ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef,
+                )):
+                    names.add(child.name)
+                elif isinstance(child, ast.ExceptHandler) and child.name:
+                    names.add(child.name)
+        return names
+
     def _enter(self, node):
         # Evaluated in the scope we are still in, before the new one exists.
         for part in self._outer_parts(node):
@@ -2453,8 +2521,20 @@ class _Visitor(ast.NodeVisitor):
         # but a class namespace is NOT a lexical scope, so a class nested directly in
         # another sees the enclosing FUNCTION or module, never the outer class's
         # locals. `class A: payload = f"..."; class B: exec(payload)` raises NameError.
+        # A nested function CLOSES OVER the enclosing locals, so
+        # `payload = f"import {name}"; def inner(): exec(payload)` really does execute
+        # the built string. Starting every body with an empty map dropped that. The
+        # names the nested body binds itself are left out, since those are its own
+        # locals for the whole body and the closure never sees the outer one.
+        inherited = {}
+        if not isinstance(node, ast.ClassDef) and self.scope_kinds[-1] == "function":
+            bound_here = self._declared_locals(node)
+            inherited = {
+                name: reason for name, reason in self.tainted[-1].items()
+                if isinstance(name, str) and name not in bound_here
+            }
         self.tainted.append(
-            self._implicit_base_taint() if isinstance(node, ast.ClassDef) else {}
+            self._implicit_base_taint() if isinstance(node, ast.ClassDef) else inherited
         )
         # Aliases are lexical too: a `from builtins import exec as run` inside one
         # function said nothing about a `run` parameter in the next one. Parameters
@@ -4687,6 +4767,26 @@ class _Visitor(ast.NodeVisitor):
         # left those local bindings behind, which reported a clean outer name.
         self.tainted[-1] = saved
 
+    def _generator_yields(self, generator) -> bool:
+        """Whether a comprehension clause can produce a pass at all.
+
+        A written-out empty iterable produces none, and an `async for` over a
+        written-out synchronous container raises while acquiring its async iterator -
+        the same fact `visit_AsyncFor` records for the statement form. Anything this
+        cannot read is assumed to yield, which is the reporting direction.
+        """
+        if self._literal_elements(generator.iter) == []:
+            return False
+        if (
+            isinstance(generator.iter, ast.Constant)
+            and isinstance(generator.iter.value, (str, bytes))
+            and not generator.iter.value
+        ):
+            return False
+        if getattr(generator, "is_async", False):
+            return self._literal_elements(generator.iter) is None
+        return True
+
     def _visit_comprehension(self, node):
         """A comprehension target is local to the comprehension.
 
@@ -4786,13 +4886,32 @@ class _Visitor(ast.NodeVisitor):
                             aggregated.setdefault(key, value)
                     self.tainted[-1] = before
                 self.tainted[-1].update(aggregated)
-            for condition in generator.ifs:
-                self.visit(condition)
+            # A filter only runs if this generator yields something: `[None for _ in
+            # [] if exec(f"...")]` evaluates neither, and reporting the sink failed
+            # the gate on code that cannot execute. Same test the element below uses,
+            # applied to this generator on its own.
+            if self._generator_yields(generator):
+                for condition in generator.ifs:
+                    self.visit(condition)
 
-        for field in ("elt", "key", "value"):
-            child = getattr(node, field, None)
-            if child is not None:
-                self.visit(child)
+        # The element only runs if some pass reaches it. `[None for _ in [] if
+        # exec(f"...")]` never evaluates either, and reporting the sink failed the
+        # gate on code that cannot execute; an `async for` over a written-out
+        # synchronous list raises while acquiring its async iterator, before the
+        # element too. Anything undecidable still visits the element, which is where
+        # the reporting direction belongs.
+        reaches_element = all(
+            self._generator_yields(generator)
+            and not any(
+                _constant_truth(condition) is False for condition in generator.ifs
+            )
+            for generator in node.generators
+        )
+        if reaches_element:
+            for field in ("elt", "key", "value"):
+                child = getattr(node, field, None)
+                if child is not None:
+                    self.visit(child)
 
         # A generator expression is LAZY. Nothing in it has run when the statement
         # ends, so a walrus inside one has not bound anything yet and carrying its
@@ -4845,8 +4964,13 @@ class _Visitor(ast.NodeVisitor):
                 and isinstance(generator.iter.value, (str, bytes))
                 and not generator.iter.value
             )
-            and not any(
-                _constant_truth(condition) is False for condition in generator.ifs
+            and all(
+                # A filter this cannot decide may reject every item, and then the
+                # comprehension binds nothing: `[(run := print) for _ in [0] if flag]`
+                # leaves `run` whatever it was when `flag` is false. Treating an
+                # undecidable filter as true exported a shadow that may not exist and
+                # hid a call to the builtin. Only a filter PROVED true keeps the pass.
+                _constant_truth(condition) is True for condition in generator.ifs
             )
             for generator in node.generators
         )

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -309,7 +309,19 @@ def _partial_call(node: ast.AST, aliases = None, shadowed = None) -> ast.Call | 
         return None
     function = node.func
     if isinstance(function, ast.Attribute):
-        return node if function.attr == "partial" else None
+        # The owner has to BE functools. Accepting any attribute called `partial`
+        # reported `runner.partial(exec, f"...")()` on an application object whose
+        # method never invokes the builtin, which fails the gate on valid code that
+        # cannot be changed to pass. A recorded module alias of functools counts,
+        # since that states the same thing outright.
+        if function.attr != "partial" or not isinstance(function.value, ast.Name):
+            return None
+        owner = function.value.id
+        if shadowed is not None and shadowed(owner):
+            return None
+        if owner == "functools" or (aliases is not None and aliases(f"functools:{owner}")):
+            return node
+        return None
     if not isinstance(function, ast.Name):
         return None
     if shadowed is not None and shadowed(function.id):
@@ -371,6 +383,18 @@ def _constructor_source(node: ast.Call, name: str, shadowed = None) -> ast.AST |
 # The map otherwise holds reasons, which are strings, so a sentinel object cannot be
 # mistaken for one.
 _NUMERIC = object()
+# The same idea for a name that holds a written-out string: `template = "import
+# MODULE"` makes `template.replace("MODULE", name)` the same splice as doing it on the
+# literal, which one line of refactoring otherwise hid. Kept as a marker rather than a
+# reason, because the name holds a literal and is not itself built source. Only a
+# literal binds it, so an opaque producer - `inspect.getsource(f)`, the idiom this
+# repo is built on - never does.
+_LITERAL_TEXT = object()
+
+
+def _visibly_literal_text(node: ast.AST) -> bool:
+    """Whether the value is a written-out string or bytes, so a name holding it is one."""
+    return isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes))
 
 
 def _visibly_numeric(node: ast.AST) -> bool:
@@ -484,9 +508,9 @@ def _is_interpolated(node: ast.AST, resolve = None, shadowed = None, resolve_ali
         if resolve is None:
             return None
         reason = resolve(node.id)
-        # The numeric marker is a binding fact, not a reason. Returning it would put a
+        # The markers are binding facts, not reasons. Returning one would put a
         # non-string into a finding.
-        return None if reason is _NUMERIC else reason
+        return None if reason in (_NUMERIC, _LITERAL_TEXT) else reason
     if isinstance(node, ast.BoolOp):
         # `exec(enabled and f"import {name}")` executes the interpolated operand
         # whenever the guard lets it through: same conditional-source shape as IfExp.
@@ -843,6 +867,14 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
         if isinstance(receiver, ast.Constant):
             if isinstance(receiver.value, (str, bytes)):
                 return ".replace() on a literal"
+        if isinstance(receiver, ast.Name) and resolve is not None:
+            # `template = "import MODULE"; template.replace("MODULE", name)` is the
+            # same splice one line later, which is a two-line refactor away from the
+            # literal receiver above. Only a name a written-out string bound: the
+            # marker is set nowhere else, so `inspect.getsource(f).replace(...)`,
+            # the idiom this repo is built on, still resolves to nothing here.
+            if resolve(receiver.id) is _LITERAL_TEXT:
+                return ".replace() on a literal"
         # `exec(f"import {model_type}".replace("-", "_"))` is the shape from the
         # original report with a normalisation step bolted on. The receiver is the
         # f-string itself, so recursing into it keeps that visible. This does not
@@ -1094,12 +1126,16 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
         # the callee out of a mapping that is written out right here, the same shape
         # the subscript spelling already reads.
         key = function.args[0].value
-        if isinstance(function.func.value, ast.Dict):
-            found = _mapping_lookup(function.func.value, key)
+        # `dict(run = exec).get("run")` is the same mapping written with the
+        # constructor, so it is read the same way. The source side already went
+        # through `_mapping_literal`; the callee side still required a display.
+        literal_mapping = _mapping_literal(function.func.value, shadowed)
+        if literal_mapping is not None:
+            found = _mapping_lookup(literal_mapping, key)
             fallback = function.args[1] if len(function.args) > 1 else None
             if found is None:
                 found = fallback
-            elif fallback is not None and _uncertain_lookup(function.func.value):
+            elif fallback is not None and _uncertain_lookup(literal_mapping):
                 # A computed key means the hit is not certain, so the default is a
                 # possible callee too: `{key: print}.get("run", exec)(...)` calls the
                 # builtin whenever `key != "run"`.
@@ -1225,6 +1261,31 @@ def _constant_truth(test: ast.AST):
     if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
         inner = _constant_truth(test.operand)
         return None if inner is None else not inner
+    return None
+
+
+def _nullcontext_value(node: ast.AST, aliases = None, shadowed = None) -> ast.AST | None:
+    """The single argument a written-out `contextlib.nullcontext(...)` hands over.
+
+    The stdlib documents `nullcontext(enter_result)` as returning `enter_result` from
+    `__enter__`, so `with nullcontext(builtins.exec) as run:` makes `run` the builtin
+    as plainly as an assignment would. Only the visible spelling: an unshadowed
+    `contextlib.nullcontext` or a bare `nullcontext`, with exactly one argument.
+    """
+    if not isinstance(node, ast.Call) or len(node.args) != 1 or node.keywords:
+        return None
+    function = node.func
+    if isinstance(function, ast.Attribute):
+        if function.attr != "nullcontext" or not isinstance(function.value, ast.Name):
+            return None
+        owner = function.value.id
+        if owner != "contextlib" or (shadowed is not None and shadowed(owner)):
+            return None
+        return node.args[0]
+    if isinstance(function, ast.Name) and function.id == "nullcontext":
+        if shadowed is not None and shadowed(function.id):
+            return None
+        return node.args[0]
     return None
 
 
@@ -1788,9 +1849,10 @@ class _Visitor(ast.NodeVisitor):
         # Visiting every target before binding any of them missed that.
         self.visit(node.value)
         numeric = _visibly_numeric(node.value)
+        literal_text = reason is None and _visibly_literal_text(node.value)
         for target in node.targets:
             self.visit(target)
-            self._bind(target, reason, numeric)
+            self._bind(target, reason, numeric, literal_text)
             self._bind_unpacked(target, node.value)
             self._shadow_assignment(target, node.value)
 
@@ -1988,7 +2050,13 @@ class _Visitor(ast.NodeVisitor):
         # keep insertion order, so its keys are read like a list.
         ordered = literal and not isinstance(node.iter, ast.Set)
         breaks = _can_break(node.body)
-        if ordered and not breaks:
+        if ordered and not breaks and not self._rebinds(node.body, node.target):
+            # Skipped when the BODY assigns the target: the last thing that ran in the
+            # final iteration is that assignment, not the element. Rebinding from
+            # `literal[-1]` regardless overwrote it both ways - it hid
+            # `for payload in ["pass"]: payload = f"..."` and it invented a finding for
+            # the opposite body - so the body's own binding, already applied above,
+            # stands instead.
             last = literal[-1]
             self._bind(node.target, _is_interpolated(last))
             self._bind_unpacked(node.target, last)
@@ -2037,6 +2105,30 @@ class _Visitor(ast.NodeVisitor):
                 self.visit(statement)
 
     visit_AsyncFor = visit_For
+
+    @staticmethod
+    def _rebinds(body, target) -> bool:
+        """Whether this loop body assigns any name the loop target binds.
+
+        Only THIS body: a nested `def`/`class`/`lambda` binds in its own scope and
+        does not change what the target holds out here.
+        """
+        names = {
+            child.id for child in ast.walk(target)
+            if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+        }
+        if not names:
+            return False
+        for statement in body:
+            for node in _walk_this_scope(statement):
+                for child in ast.walk(node) if isinstance(node, ast.AST) else ():
+                    if (
+                        isinstance(child, ast.Name)
+                        and isinstance(child.ctx, ast.Store)
+                        and child.id in names
+                    ):
+                        return True
+        return False
 
     def visit_Match(self, node: _MATCH):
         """`match f"import {name}": case payload: exec(payload)` binds the subject.
@@ -2119,6 +2211,41 @@ class _Visitor(ast.NodeVisitor):
             return
         for statement in (node.body if decided else node.orelse):
             self.visit(statement)
+
+    def visit_BoolOp(self, node: ast.BoolOp):
+        """Only the operands that can still be evaluated are traversed.
+
+        `False and (payload := "pass")` never runs the walrus, so applying its binding
+        cleared a taint that survives in real execution and the sink went unreported.
+        The same short-circuit rule the source reader already uses, applied to the
+        traversal: only a written-out constant decides anything, a name decides nothing.
+        """
+        for operand in _reachable_operands(node):
+            self.visit(operand)
+
+    def visit_IfExp(self, node: ast.IfExp):
+        """A literal condition picks one arm; the other never runs.
+
+        Same reasoning as `visit_If` for the statement form, and as `_is_interpolated`
+        already applies when reading the value of a conditional expression.
+        """
+        self.visit(node.test)
+        decided = _constant_truth(node.test)
+        if decided is None:
+            self.visit(node.body)
+            self.visit(node.orelse)
+            return
+        self.visit(node.body if decided else node.orelse)
+
+    def visit_Assert(self, node: ast.Assert):
+        """The message is only evaluated when the test FAILS.
+
+        `assert True, (payload := "pass")` never builds the message, so a binding in it
+        does not happen. A literal truthy test is the only case decided here.
+        """
+        self.visit(node.test)
+        if node.msg is not None and _constant_truth(node.test) is not True:
+            self.visit(node.msg)
 
     def visit_TypeAlias(self, node):
         """`type run = int` rebinds the name for the rest of the scope."""
@@ -2239,8 +2366,19 @@ class _Visitor(ast.NodeVisitor):
             self.visit(item.context_expr)
             if item.optional_vars is not None:
                 self.visit(item.optional_vars)
-                self._bind_unpacked(item.optional_vars, None)
-                self._bind(item.optional_vars, None)
+                # `with contextlib.nullcontext(builtins.exec) as run:` states outright
+                # what the target gets: `nullcontext` is documented as returning its
+                # argument from `__enter__`. Treating every context result as opaque
+                # made `run` a shadow and the call went unread. Only that one
+                # constructor, written out and unshadowed.
+                handed = _nullcontext_value(item.context_expr, self._alias, self._is_shadowed)
+                self._bind_unpacked(item.optional_vars, handed)
+                self._bind(
+                    item.optional_vars,
+                    _is_interpolated(
+                        handed, self.tainted[-1].get, self._is_shadowed, self._alias,
+                    ) if handed is not None else None,
+                )
                 # A tuple target pairs with nothing when the value is opaque, and
                 # `_bind` ignores a non-name target, so `with ctx() as (payload, _):`
                 # kept a stale reason on `payload` even though reaching the suite
@@ -2264,6 +2402,10 @@ class _Visitor(ast.NodeVisitor):
             child.id
             for item in node.items
             if item.optional_vars is not None
+            # A visible `nullcontext` states what it hands over, so its target is not
+            # opaque and must not be shadowed: it is bound by `_shadow_assignment`
+            # below, exactly as the equivalent plain assignment would be.
+            and _nullcontext_value(item.context_expr, self._alias, self._is_shadowed) is None
             for child in ast.walk(item.optional_vars)
             # Store context only: in `with ctx() as table[exec]` the `exec` is a
             # subscript key that is merely READ, so treating it as bound shadowed a
@@ -2275,6 +2417,13 @@ class _Visitor(ast.NodeVisitor):
         # ends, so `with ctx() as exec: pass` then `exec(f"import {name}")` calls
         # whatever the context manager handed over, not the builtin.
         self._shadow_locals(names)
+        for item in node.items:
+            handed = _nullcontext_value(item.context_expr, self._alias, self._is_shadowed)
+            if handed is not None and item.optional_vars is not None:
+                # `contextlib.nullcontext(builtins.exec)` hands its argument straight
+                # through, so the target is whatever that argument resolves to - a
+                # sink, a constructor, or nothing - rather than an opaque shadow.
+                self._shadow_assignment(item.optional_vars, handed)
         for statement in node.body:
             self.visit(statement)
 
@@ -2367,8 +2516,17 @@ class _Visitor(ast.NodeVisitor):
             pairs = list(zip(target.elts, value.elts))
         return pairs
 
-    def _bind(self, target: ast.AST, reason: str | None, numeric: bool = False) -> None:
+    def _bind(
+        self, target: ast.AST, reason: str | None, numeric: bool = False,
+        literal_text: bool = False,
+    ) -> None:
         if not isinstance(target, ast.Name):
+            return
+        if literal_text:
+            # Same shape as the numeric marker: a fact about what the name holds, so a
+            # later `.replace()` on it reads as a splice into a written-out template.
+            self.tainted[len(self.tainted) - 1 if self.scope_kinds[-1] != "class"
+                         else self._binding_level(target.id)][target.id] = _LITERAL_TEXT
             return
         if numeric:
             # Not a reason: a marker saying the name holds a number, so a later `+=`
@@ -2849,6 +3007,15 @@ class _Visitor(ast.NodeVisitor):
         for alias in node.names:
             bound = alias.asname or alias.name.split(".")[0]
             self.tainted[-1].pop(bound, None)
+            if alias.name == "functools":
+                # `import functools as ft` makes `ft.partial` the real one, exactly as
+                # `import builtins as b` makes `b.exec` the real builtin. Kept in its
+                # own key rather than the `module:` one, which means the BUILTINS
+                # module: putting functools there would have made `ft.exec` resolve as
+                # a sink, which it is not.
+                self.sink_aliases[-1][f"functools:{bound}"] = "functools"
+                self.collected_aliases[-1][f"functools:{bound}"] = "functools"
+                continue
             if alias.name == "builtins":
                 # Read BEFORE `_shadow_sink` clears both tables, since that clearing is
                 # what the check below would otherwise be looking at.
@@ -4329,12 +4496,16 @@ def _script_command_source(code: str) -> str | None:
                 token.startswith("-")
                 and not token.startswith("--")
                 and len(token) > 2
-                and token.endswith("c")
-                and "c" not in token[1:-1]
+                and "c" in token[1:]
             ):
-                # A bundle ending in `c`, `python -uc "prog"`: the program is the next
-                # token, because `-c` consumes the rest of the ARGUMENT and there was
-                # nothing left of it.
+                # A bundle containing `c`. `-c` consumes the REST of the argument, so
+                # `python -uc"prog"` puts the program right there and `python -uc
+                # "prog"` puts it in the next token. Only a bundle ENDING in `c` was
+                # read, so the attached form returned nothing and the cell was passed
+                # over. Split at the first `c` and take whatever follows it.
+                attached = token[token.index("c", 1) + 1:]
+                if attached:
+                    return attached
                 return tokens[position + 1] if position + 1 < len(tokens) else None
             if token.startswith("-c") and len(token) > 2 and not token.startswith("--"):
                 # `python -cPROGRAM` attaches the program to the option, which is what

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -3418,8 +3418,10 @@ class _Visitor(ast.NodeVisitor):
                     self.sink_aliases[-1].pop(argument.arg, None)
                     self.sink_aliases[-1].pop(f"module:{argument.arg}", None)
         self._collect_aliases(node.body)
-        for statement in node.body:
-            self.visit(statement)
+        # The body ends at an unconditional jump, exactly as a loop or an `if` suite
+        # does: `def f(name): return; exec(f"import {name}")` cannot reach the sink,
+        # and reporting it failed the gate on code that does nothing.
+        self._visit_suite(node.body)
         self.collected_aliases.pop()
         self.sink_aliases.pop()
         self.shadowed_sinks.pop()

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -273,6 +273,28 @@ def _visibly_text(node: ast.AST) -> bool:
     return False
 
 
+def _visibly_bytes(node: ast.AST) -> bool:
+    """Whether the value is written out as bytes, so `str()` of it is a repr.
+
+    `str(f"import {name}".encode())` is `"b'import os'"`, a quoted bytes literal, and
+    executing that expression imports nothing: the interpolation is escaped rather
+    than spliced into syntax. Reporting it failed the gate on a call that cannot do
+    what the finding claims. Narrow on purpose: a bytes literal, a `.encode()` on
+    anything, or a `bytes`/`bytearray` construction, all written out here.
+    """
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, bytes)
+    if isinstance(node, ast.Call):
+        function = node.func
+        if isinstance(function, ast.Attribute) and function.attr == "encode":
+            return True
+        name = function.id if isinstance(function, ast.Name) else (
+            function.attr if isinstance(function, ast.Attribute) else ""
+        )
+        return name in ("bytes", "bytearray")
+    return False
+
+
 def _constructor_accepts_text(node: ast.Call, name: str) -> bool:
     """Whether this constructor call can reach the sink with what it was handed.
 
@@ -560,6 +582,21 @@ def _interpolated_starred(node, resolve = None, shadowed = None, resolve_alias =
         return _is_interpolated(inner.elts[0], resolve, shadowed, resolve_alias)
     if isinstance(inner, (ast.Tuple, ast.List)) and inner.elts:
         return _is_interpolated(inner.elts[0], resolve, shadowed, resolve_alias)
+    if isinstance(inner, ast.Dict):
+        # A `**{}` contributes no runtime key, so the first key the mapping actually
+        # yields may sit behind one. Reading `keys[0]` regardless saw a `None` and gave
+        # up, and `exec(*{**{}, f"import {name}": None})` went unreported.
+        for position, key in enumerate(inner.keys):
+            if key is None:
+                expansion = inner.values[position]
+                if isinstance(expansion, ast.Dict) and not expansion.keys:
+                    continue
+                if _literal_dict_call(expansion, shadowed) is not None and not (
+                    _literal_dict_call(expansion, shadowed).keys
+                ):
+                    continue
+                break
+            return _is_interpolated(key, resolve, shadowed, resolve_alias)
     if isinstance(inner, ast.Dict) and inner.keys and inner.keys[0] is not None:
         # Spreading a mapping iterates its KEYS, so `exec(*{f"import {name}": None})`
         # hands the interpolated key straight to the sink. Only the first key, and
@@ -610,6 +647,23 @@ def _interpolated_binop(node, resolve = None, shadowed = None, resolve_alias = N
         if isinstance(node.op, ast.Add):
             return "string concatenation"
     if isinstance(node.op, ast.Mult):
+        # `f"import {name}" * 0` is the empty string, and a negative count is empty
+        # too, so nothing is built and reporting it failed the gate on a call that
+        # cannot execute anything. Only a written-out count decides this.
+        for count in (node.left, node.right):
+            # A negative literal is `UnaryOp(USub, Constant(1))`, not a `Constant`, so
+            # requiring one read `f"..." * -1` as an unknown count.
+            sign = 1
+            if isinstance(count, ast.UnaryOp) and isinstance(count.op, (ast.USub, ast.UAdd)):
+                sign = -1 if isinstance(count.op, ast.USub) else 1
+                count = count.operand
+            if (
+                isinstance(count, ast.Constant)
+                and isinstance(count.value, int)
+                and not isinstance(count.value, bool)
+                and sign * count.value <= 0
+            ):
+                return None
         # `f"import {name}\n" * 2` repeats the built string; the interpolation is
         # still in every copy. Either side may be the string.
         return (
@@ -853,7 +907,10 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
     constructor = _constructor_name(function, shadowed, resolve_alias)
     if constructor is not None and _constructor_accepts_text(node, constructor):
         source = _constructor_source(node, constructor, shadowed)
-        if source is not None:
+        if source is not None and not (constructor == "str" and _visibly_bytes(source)):
+            # `str(bytes)` is the REPR of the bytes, `"b'import os'"`, which executes
+            # as a string expression and imports nothing. Every other constructor here
+            # hands the text through unchanged.
             return _is_interpolated(source, resolve, shadowed, resolve_alias)
     # `exec("import MODULE".replace("MODULE", name))` splices a value into a
     # template that is right there in the file, which is the `.format()` shape
@@ -4227,6 +4284,25 @@ def _neutralised(source: str) -> str:
                     continue
         if stripped.startswith(("%", "!")):
             indent = line[: len(line) - len(stripped)]
+            if stripped.startswith("!"):
+                # `!python -c 'prog'` runs `prog` as Python, exactly as
+                # `%%script python -c 'prog'` does. Replacing the whole escape with
+                # `pass` threw that program away, so a sink inside it was never read.
+                # The same extractor answers both, asked here about the one line.
+                program = _script_command_source("%%script " + stripped[1:].strip())
+                if program is not None:
+                    try:
+                        ast.parse(program)
+                    except (SyntaxError, ValueError):
+                        pass
+                    else:
+                        # The program takes the escape's place rather than being
+                        # added after it, so a one-line `-c` program keeps the line
+                        # count exactly and a sink further down the cell is still
+                        # reported at its own line.
+                        out.extend(indent + piece for piece in program.splitlines())
+                        continuing = False
+                        continue
             # A line magic that takes code keeps its argument; the magic itself is not
             # Python but what follows it is, and dropping the line hid the sink.
             if stripped.startswith("%") and not stripped.startswith("%%"):

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -66,7 +66,14 @@ ALLOWLIST_PATH = Path(__file__).resolve().parent / "dynamic_exec_allowlist.json"
 # from those copies. Excluding the whole tree as "generated" therefore left real
 # source unscanned. Scanning all of it costs about three seconds and no allowlist
 # entries, which is cheaper than tracking which files are the exceptions.
-DEFAULT_TARGETS = ("unsloth_zoo", "scripts")
+DEFAULT_TARGETS = (
+    "unsloth_zoo",
+    "scripts",
+    # Workflow `run:` steps execute Python heredocs on the CI runner, with the
+    # runner's token in the environment, so a sink written inside one is as
+    # executable as anything else here and was covered by nothing.
+    ".github/workflows",
+)
 
 
 class ScanError(Exception):
@@ -987,6 +994,40 @@ _LOCAL_CLASSES: dict = {}
 # a name that is a class in one place and a lambda in another is no evidence at all.
 _REBOUND_CLASS_NAMES: set = set()
 
+# Functions the file defines, and the names it binds to more than one thing. Same
+# shape as the class tables above and read the same way: a name that means two things
+# somewhere in the file is no evidence anywhere in it.
+_LOCAL_FUNCTIONS: dict = {}
+_REBOUND_FUNCTION_NAMES: set = set()
+
+# Helpers currently being resolved, so a recursive one cannot loop forever.
+_HELPER_STACK: set = set()
+
+
+def _returned_expressions(definition) -> list:
+    """The values this function's own `return` statements hand back.
+
+    Its own: a `return` inside a nested `def` belongs to that one. A bare `return`
+    hands back None and contributes nothing.
+    """
+    found = []
+    for statement in definition.body:
+        for child in _walk_this_scope(statement):
+            if isinstance(child, ast.Return) and child.value is not None:
+                found.append(child.value)
+    return found
+
+
+def _visible_helper(function: ast.AST, shadowed = None):
+    """The local `def` a callee names, when that is a fact stated in the file."""
+    if not isinstance(function, ast.Name):
+        return None
+    if shadowed is not None and shadowed(function.id):
+        return None
+    if function.id in _REBOUND_FUNCTION_NAMES:
+        return None
+    return _LOCAL_FUNCTIONS.get(function.id)
+
 
 def _visibly_local_instance(node: ast.AST, shadowed = None) -> bool:
     """Whether `node` is written out as an instance of a class defined in this file.
@@ -1250,6 +1291,36 @@ def _interpolated_binop(node, resolve = None, shadowed = None, resolve_alias = N
     return None
 
 
+def _helper_scope(node: ast.Call, helper, resolve, shadowed, resolve_alias):
+    """A `resolve` for a visible helper's body: its parameters, then nothing local.
+
+    The parameters come from the call, the same pairing `_lambda_scope` performs. A
+    name the body BINDS is its own local and resolves to nothing; anything else falls
+    through to the enclosing scope, which is where a module-level constant lives.
+    """
+    paired = _lambda_scope(node, helper, resolve, shadowed, resolve_alias)
+    bound_here = _Visitor._declared_locals(helper)
+    parameters = {
+        argument.arg
+        for argument in (
+            *helper.args.posonlyargs, *helper.args.args, *helper.args.kwonlyargs,
+            helper.args.vararg, helper.args.kwarg,
+        )
+        if argument is not None
+    }
+
+    def resolve_in_helper(name):
+        if name in parameters:
+            # `_lambda_scope` hands back the enclosing resolver when the call cannot
+            # be paired up, and that resolver may be None.
+            return paired(name) if callable(paired) else None
+        if name in bound_here:
+            return None
+        return resolve(name) if resolve is not None else None
+
+    return resolve_in_helper
+
+
 def _lambda_scope(node: ast.Call, function: ast.Lambda, resolve, shadowed, resolve_alias):
     """A `resolve` that answers for an immediately invoked lambda's parameters.
 
@@ -1375,6 +1446,25 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             return _is_interpolated(
                 inner.args[0].elts[0], resolve, shadowed, resolve_alias,
             )
+    helper = _visible_helper(function, shadowed)
+    if helper is not None and helper.name not in _HELPER_STACK:
+        # `def build(): return f"import {name}"` followed by `exec(build())` executes
+        # what the helper hands back, and that is written out one screen away. Only a
+        # `def` this file states outright and binds to nothing else, with its
+        # parameters paired to the arguments exactly as an immediately invoked lambda
+        # is; a name the body binds itself resolves to nothing rather than to the
+        # caller's value of the same spelling.
+        returned = _returned_expressions(helper)
+        if returned:
+            inner_resolve = _helper_scope(node, helper, resolve, shadowed, resolve_alias)
+            _HELPER_STACK.add(helper.name)
+            try:
+                for value in returned:
+                    reason = _is_interpolated(value, inner_resolve, shadowed, resolve_alias)
+                    if reason is not None and not isinstance(reason, _LiteralText):
+                        return reason
+            finally:
+                _HELPER_STACK.discard(helper.name)
     preserving = None
     if isinstance(function, ast.Name):
         preserving = function.id
@@ -1759,6 +1849,15 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 container = spliced[0]
                 elements = container.keys if isinstance(container, ast.Dict) else container.elts
                 empty = not elements
+            if function.attr in ("join", "format_map") and not any(
+                keyword.arg is None for keyword in node.keywords
+            ):
+                # Both take exactly one positional argument and no keywords, so
+                # `",".join([x], [])` and `t.format_map(m, m2)` raise before the sink.
+                # A `**` this cannot read may still supply the one, so it is left
+                # alone.
+                if len(node.args) > 1 or node.keywords:
+                    return None
             if no_arguments and function.attr == "format_map" and not node.keywords:
                 # `format_map` requires exactly one mapping argument, so the
                 # ARGUMENT-LESS call raises TypeError before the sink is reached.
@@ -3054,8 +3153,11 @@ class _Visitor(ast.NodeVisitor):
         # Reset per file, so a class name from the previous one cannot silence a
         # receiver here. Populated by `_collect_aliases` as it walks each scope.
         global _LOCAL_CLASSES, _REBOUND_CLASS_NAMES
+        global _LOCAL_FUNCTIONS, _REBOUND_FUNCTION_NAMES
         _LOCAL_CLASSES = {}
         _REBOUND_CLASS_NAMES = set()
+        _LOCAL_FUNCTIONS = {}
+        _REBOUND_FUNCTION_NAMES = set()
         # Set for a notebook cell, so two cells defining the same function name are
         # separate allowlist entries rather than colliding on one key.
         self.qualname_prefix = ""
@@ -3430,7 +3532,22 @@ class _Visitor(ast.NodeVisitor):
         self.global_names.pop()
         self.nonlocal_names.pop()
         self.future_taint.pop()
+        if isinstance(node, ast.ClassDef):
+            # A class body's locals become the class object's attributes, and they
+            # outlive the body: `class C: payload = f"import {name}"` followed by
+            # `exec(C.payload)` executes the built string. Popping the map discarded
+            # them, so they are exported to the compound path the attribute access
+            # spells first. Rebinding `C` takes them away again, through the same
+            # root-rebinding cleanup every other path gets.
+            exported = {
+                f"path>{node.name}.{name}": reason
+                for name, reason in self.tainted[-1].items()
+                if isinstance(name, str) and not name.startswith("path>")
+            }
+        else:
+            exported = {}
         self.tainted.pop()
+        self.tainted[-1].update(exported)
         self.scope.pop()
         self.scope_kinds.pop()
         saved_deferred = self.deferred_state.pop()
@@ -3703,6 +3820,31 @@ class _Visitor(ast.NodeVisitor):
             and not iterable.keywords
         ):
             return self._literal_elements(iterable.args[0])
+        # `enumerate([...])` yields `(index, element)` pairs, and the pairs are as
+        # visible as the container is: `for _, payload in enumerate([f"import
+        # {name}"])` binds the interpolated element. Read as opaque, it cleared the
+        # target and the sink in the body went unreported. The pairs are built here so
+        # the ordinary unpacking machinery does the rest.
+        if (
+            isinstance(iterable, ast.Call)
+            and isinstance(iterable.func, ast.Name)
+            and iterable.func.id == "enumerate"
+            and not self._is_shadowed("enumerate")
+            and len(iterable.args) in (1, 2)
+        ):
+            inner = self._literal_elements(iterable.args[0])
+            if inner is None:
+                return None
+            return [
+                ast.copy_location(
+                    ast.Tuple(
+                        elts = [ast.Constant(value = index), element],
+                        ctx = ast.Load(),
+                    ),
+                    element,
+                )
+                for index, element in enumerate(inner)
+            ]
         if isinstance(iterable, (ast.Tuple, ast.List, ast.Set)):
             return iterable.elts
         if isinstance(iterable, ast.Dict) and all(k is not None for k in iterable.keys):
@@ -4586,6 +4728,20 @@ class _Visitor(ast.NodeVisitor):
 
     def _record_local_class(self, statement) -> None:
         """`class Safe:` makes `Safe()` a receiver whose methods are not string ones."""
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            recorded = _LOCAL_FUNCTIONS.get(statement.name)
+            if recorded is not None and recorded is not statement:
+                _REBOUND_FUNCTION_NAMES.add(statement.name)
+            _LOCAL_FUNCTIONS[statement.name] = statement
+        elif isinstance(statement, ast.ClassDef):
+            _REBOUND_FUNCTION_NAMES.add(statement.name)
+        else:
+            for child in _walk_this_scope(statement):
+                if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                    _REBOUND_FUNCTION_NAMES.add(child.id)
+                elif isinstance(child, (ast.Import, ast.ImportFrom)):
+                    for alias in child.names:
+                        _REBOUND_FUNCTION_NAMES.add(alias.asname or alias.name.split(".")[0])
         if isinstance(statement, ast.ClassDef):
             recorded = _LOCAL_CLASSES.get(statement.name)
             if recorded is not None and recorded is not statement:
@@ -5432,14 +5588,38 @@ class _Visitor(ast.NodeVisitor):
             return
         for table in (self.sink_aliases, self.collected_aliases):
             table[level].pop(f"template:{target.id}", None)
+        for table in (self.sink_aliases, self.collected_aliases):
+            table[level].pop(f"stdlibfunc:{target.id}", None)
         if not isinstance(value, ast.Attribute):
             return
-        if value.attr not in (*_BUILDERS, *_TEMPLATE_BUILDERS):
+        # `build = operator.add` binds the same helper `from operator import add`
+        # does, and only the import spelling was recorded, so the later bare call was
+        # read as an ordinary function of unknown behaviour.
+        if isinstance(value.value, ast.Name):
+            for module in _MODULE_RECEIVERS:
+                if not _names_module(value.value, module, self._is_shadowed, self._alias):
+                    continue
+                qualified = f"{module}.{value.attr}"
+                if qualified in _DIRECT_HELPERS:
+                    for table in (self.sink_aliases, self.collected_aliases):
+                        table[level][f"stdlibfunc:{target.id}"] = qualified
+                    return
+        # Every method that hands text on, not only the formatting ones:
+        # `replace = "import MODULE".replace` and `normalize = payload.strip` bind the
+        # method with its receiver attached, and the call a line later splices or
+        # normalises exactly as the inline spelling does.
+        if value.attr not in (
+            *_BUILDERS, *_TEMPLATE_BUILDERS, *_NORMALISERS, *_CONVERSIONS, "replace",
+        ):
             return
         receiver = value.value
         if not (
             _visibly_literal_text(receiver)
             or _is_template_call(receiver, self._is_shadowed, self._alias)
+            # A plain name is recorded too: the replay resolves it at the CALL site,
+            # against the taint map as it stands there, so nothing is assumed about
+            # what it holds when the method is bound.
+            or isinstance(receiver, ast.Name)
         ):
             return
         replay = ast.Call(func = value, args = [], keywords = [])
@@ -6243,6 +6423,16 @@ def _call_hash(node: ast.Call) -> str:
 
 
 NOTEBOOK_SUFFIX = ".ipynb"
+
+# Workflow files hold Python too: a `python - <<'PY' ... PY` block in a `run:` step is
+# a program the CI runner executes, with the runner's token in the environment, and a
+# sink written inside one was covered by nothing. Scanned like a notebook - each block
+# is its own module, an unparseable one is counted rather than failing the file, since
+# a heredoc may be shell or YAML templating rather than Python.
+WORKFLOW_SUFFIXES = (".yml", ".yaml")
+
+# `<<EOF`, `<<'PY'`, `<<-"EOF"`: the delimiter, quoted or not.
+_HEREDOC = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
 
 
 def _notebook_code_cells(path: Path) -> list[tuple[int, str]]:
@@ -7232,6 +7422,78 @@ def _annotations_deferred(tree: ast.AST) -> bool:
     return False
 
 
+def _python_heredocs(text: str):
+    """`(line number, source)` for each Python heredoc in a workflow file.
+
+    Only a heredoc whose introducing line names python: `run: |` blocks are shell, and
+    a `cat <<EOF > file` block is data. The block's common indentation is removed,
+    since YAML indents the whole `run:` scalar.
+    """
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        match = _HEREDOC.search(lines[index])
+        if match is None or "python" not in lines[index].lower():
+            index += 1
+            continue
+        delimiter = match.group(2)
+        start = index + 1
+        body = []
+        index = start
+        while index < len(lines) and lines[index].strip() != delimiter:
+            body.append(lines[index])
+            index += 1
+        indents = [len(line) - len(line.lstrip()) for line in body if line.strip()]
+        cut = min(indents) if indents else 0
+        yield start, "\n".join(line[cut:] if line.strip() else "" for line in body)
+        index += 1
+
+
+def _scan_workflow(path: Path) -> list[dict]:
+    """Findings in the Python heredocs a workflow file runs.
+
+    One visitor for the file, as for a notebook, and one qualname prefix per block.
+    A block that will not parse is counted in NOTEBOOK_SKIPPED rather than failing the
+    file: `python -` is also spelled with templating and `${{ }}` inside, which is not
+    Python at all.
+    """
+    try:
+        text = path.read_text(encoding = "utf-8", errors = "replace")
+    except OSError as error:
+        raise ScanError(f"{_relative(path)}: {error.strerror or error}") from None
+    visitor = _Visitor(path)
+    skipped = 0
+    parsed = []
+    for start, source in _python_heredocs(text):
+        try:
+            tree = ast.parse(source, filename = f"{path}#line{start}")
+        except (SyntaxError, ValueError):
+            skipped += 1
+            continue
+        except (MemoryError, RecursionError) as error:
+            raise ScanError(
+                f"{_relative(path)}#line{start}: hit a parser limit "
+                f"({error.__class__.__name__}), so the block was not checked"
+            ) from None
+        # The block's own line numbers start at 1; the findings should point into the
+        # workflow file, so every node is shifted to where the block really sits.
+        ast.increment_lineno(tree, start)
+        parsed.append((start, tree))
+    for _start, tree in parsed:
+        visitor._collect_aliases(tree.body)
+    for start, tree in parsed:
+        visitor.qualname_prefix = f"line{start}"
+        try:
+            visitor.visit(tree)
+        except RecursionError:
+            raise ScanError(
+                f"{_relative(path)}#line{start}: too deeply nested to walk"
+            ) from None
+    if skipped:
+        NOTEBOOK_SKIPPED.append((_relative(path), skipped))
+    return visitor.findings
+
+
 def scan_file(path: Path) -> list[dict]:
     # A hard CI gate must not fall over on something that is not a readable file. A
     # dangling symlink, a directory named `*.py`, or a symlink to one all reach here
@@ -7239,6 +7501,8 @@ def scan_file(path: Path) -> list[dict]:
     # nothing to do with dynamic execution.
     if path.suffix == NOTEBOOK_SUFFIX:
         return _scan_notebook(path)
+    if path.suffix in WORKFLOW_SUFFIXES:
+        return _scan_workflow(path)
     try:
         # Bytes, not text. `ast.parse` applies the PEP 263 coding declaration itself,
         # while decoding here as UTF-8 with errors = "replace" corrupted any file that
@@ -7316,13 +7580,13 @@ def collect_paths(targets: list[str]) -> tuple[list[Path], list[str]]:
     paths, missing = [], []
     for target in targets:
         root = REPO_ROOT / target
-        if root.is_file() and root.suffix in (".py", NOTEBOOK_SUFFIX):
+        if root.is_file() and root.suffix in (".py", NOTEBOOK_SUFFIX, *WORKFLOW_SUFFIXES):
             paths.append(root)
         elif root.is_dir():
             # `is_file()` on each hit, so a directory named `foo.py` and a symlink that
             # points at one are skipped rather than read.
             before = len(paths)
-            for pattern in ("*.py", f"*{NOTEBOOK_SUFFIX}"):
+            for pattern in ("*.py", f"*{NOTEBOOK_SUFFIX}", *(f"*{x}" for x in WORKFLOW_SUFFIXES)):
                 paths.extend(
                     p for p in root.rglob(pattern)
                     if p.is_file() and not _EXCLUDED_PARTS & set(_exclusion_parts(p, root))
@@ -7396,19 +7660,35 @@ def key_of(finding: dict) -> str:
 
 def write_allowlist(findings: list[dict], reason: str) -> None:
     existing = load_allowlist()
-    allowed = []
+    counts: dict[str, int] = {}
     for finding in findings:
-        previous = existing.get(key_of(finding), {})
-        allowed.append(
-            {
-                "path": finding["path"],
-                "qualname": finding["qualname"],
-                "sink": finding["sink"],
-                "kind": finding["reason"],
-                "hash": finding["hash"],
-                "reason": previous.get("reason", reason),
-            }
-        )
+        counts[key_of(finding)] = counts.get(key_of(finding), 0) + 1
+    allowed = []
+    written = set()
+    for finding in findings:
+        key = key_of(finding)
+        if key in written:
+            # One entry per key: the copies are indistinguishable by it, and the count
+            # below is what says how many were reviewed.
+            continue
+        written.add(key)
+        previous = existing.get(key, {})
+        entry = {
+            "path": finding["path"],
+            "qualname": finding["qualname"],
+            "sink": finding["sink"],
+            "kind": finding["reason"],
+            "hash": finding["hash"],
+            "reason": previous.get("reason", reason),
+        }
+        if counts[key] > 1:
+            # Two byte-identical calls in one function share a key, so one entry
+            # approved both - and a THIRD copy added later inherited the same
+            # approval. The count is what the reviewer signed off: adding a copy
+            # changes it and the call has to be reviewed again. It does not move when
+            # unrelated lines do, which a line number would.
+            entry["count"] = counts[key]
+        allowed.append(entry)
     allowed.sort(key = lambda e: (e["path"], e["qualname"], e["hash"]))
     ALLOWLIST_PATH.write_text(
         json.dumps(
@@ -7748,10 +8028,15 @@ def main() -> int:
     # silently. When such a change alters the shape at all, it alters the reason, and
     # that is now a mismatch rather than a match. Entries written before `kind` was
     # recorded carry none, and those still match on the key alone.
+    seen_counts: dict[str, int] = {}
+    for finding in findings:
+        seen_counts[key_of(finding)] = seen_counts.get(key_of(finding), 0) + 1
     unreviewed = [
         f for f in findings
         if key_of(f) not in allowlist
         or allowlist[key_of(f)].get("kind", f["reason"]) != f["reason"]
+        # And the number of calls sharing the key has to be the number reviewed.
+        or allowlist[key_of(f)].get("count", 1) != seen_counts[key_of(f)]
     ]
     pending = [
         entry

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -35,6 +35,7 @@ import ast
 import hashlib
 import json
 import re
+import string
 import shlex
 import sys
 import warnings
@@ -183,6 +184,11 @@ _MODULE_RECEIVERS = frozenset({
 # `operator` functions that build a string out of two values, and the operator each
 # one is. The in-place spellings return the same concatenation for a str, which has no
 # in-place add, and `mod` is `%`, which the binary form already reports as formatting.
+# Stdlib helpers that hand their source through and can be imported directly, as
+# `<module>.<name>`. `visit_ImportFrom` records `from ast import parse as p` against
+# these, and `_interpolated_call` rewrites such a call to the qualified spelling.
+_DIRECT_HELPERS = frozenset({"ast.parse", "codeop.compile_command"})
+
 _OPERATOR_BUILDERS = {
     "add": ast.Add, "concat": ast.Add, "iadd": ast.Add, "iconcat": ast.Add,
     "mod": ast.Mod, "imod": ast.Mod,
@@ -385,8 +391,10 @@ def _partial_call(node: ast.AST, aliases = None, shadowed = None) -> ast.Call | 
         return None
     if shadowed is not None and shadowed(function.id):
         return None
-    if function.id == "partial":
-        return node
+    # A bare `partial` has no builtin meaning: it only means `functools.partial` if
+    # this file imported it, and that import is exactly what the `partial:` alias
+    # records. Accepting the spelling unconditionally reported an application-defined
+    # `def partial(...)` that never invokes what it was handed.
     if aliases is not None and aliases(f"partial:{function.id}"):
         return node
     return None
@@ -766,7 +774,11 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
     if isinstance(function, ast.Name):
         preserving = function.id
     elif isinstance(function, ast.Attribute) and isinstance(function.value, ast.Name):
-        preserving = function.attr
+        # The OWNER has to be `textwrap`, or a recorded alias of it. Reading the
+        # attribute name alone treated `cleaner.dedent(...)` on an application object
+        # as the stdlib helper and reported a call that may return anything.
+        if _names_module(function.value, "textwrap", shadowed, resolve_alias):
+            preserving = function.attr
     if preserving not in _TEXT_PRESERVING_FUNCTIONS and isinstance(function, ast.Name):
         # `from textwrap import dedent as clean` binds the same function under a
         # different name, and matching on the spelling alone stopped before the
@@ -790,6 +802,28 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             _is_interpolated(text, resolve, shadowed, resolve_alias)
             if text is not None else None
         )
+    if isinstance(function, ast.Name) and resolve_alias is not None and not (
+        shadowed is not None and shadowed(function.id)
+    ):
+        # `from ast import parse` binds the helper directly, with no module attribute
+        # to match on, so the source-preserving branches below never saw it. Rewritten
+        # as the qualified spelling and read there, which keeps one implementation of
+        # each rule rather than a second copy for the direct-import form.
+        named = resolve_alias(f"stdlibfunc:{function.id}")
+        if named in _DIRECT_HELPERS:
+            module, _, attribute = named.partition(".")
+            equivalent = ast.Call(
+                func = ast.Attribute(
+                    value = ast.Name(id = module, ctx = ast.Load()),
+                    attr = attribute,
+                    ctx = ast.Load(),
+                ),
+                args = list(node.args),
+                keywords = list(node.keywords),
+            )
+            return _is_interpolated(
+                ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
+            )
     if isinstance(function, ast.Attribute):
         literal_mapping = (
             _mapping_literal(function.value, shadowed)
@@ -845,7 +879,9 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             return _is_interpolated(
                 ast.copy_location(inner, node), resolve, shadowed, resolve_alias,
             )
-        if function.attr == "compile_command" and isinstance(function.value, ast.Name):
+        if _names_module_function(
+            function, "codeop", "compile_command", shadowed, resolve_alias,
+        ):
             # `exec(codeop.compile_command(f"..."))` hands back a code object compiled
             # FROM the interpolated source, so the source survives the conversion
             # exactly as `ast.parse` does. Checked against the stdlib:
@@ -857,9 +893,7 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                     if keyword.arg == "source":
                         compiled = keyword.value
                         break
-            if compiled is not None and _names_module(
-                function.value, "codeop", shadowed, resolve_alias,
-            ):
+            if compiled is not None:
                 return _is_interpolated(compiled, resolve, shadowed, resolve_alias)
         if function.attr in _OPERATOR_BUILDERS and isinstance(function.value, ast.Name):
             # `exec(operator.add("import ", name))` builds the same string the `+`
@@ -881,7 +915,7 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 return _is_interpolated(
                     ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
                 )
-        if function.attr == "parse" and isinstance(function.value, ast.Name):
+        if _names_module_function(function, "ast", "parse", shadowed, resolve_alias):
             # `compile(ast.parse(f"..."), "<x>", "exec")` compiles the tree that
             # was parsed FROM the interpolated source, so the source survives the
             # conversion exactly as `str()` and `.encode()` do. The receiver is
@@ -894,9 +928,7 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                     if keyword.arg == "source":
                         parsed = keyword.value
                         break
-            if parsed is not None and _names_module(
-                function.value, "ast", shadowed, resolve_alias,
-            ):
+            if parsed is not None:
                 return _is_interpolated(parsed, resolve, shadowed, resolve_alias)
         if (
             function.attr in ("__add__", "__mod__")
@@ -938,6 +970,11 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             ) or (
                 isinstance(argument, ast.Constant) and argument.value in ("", b"")
             )
+            # A table that maps every code point it names to ITSELF changes nothing,
+            # so the receiver comes through unaltered: `f"...".translate({0: 0})` is
+            # the f-string. Reading only an EMPTY table dropped the source there.
+            if not empty and _identity_translation(argument):
+                empty = True
             if empty:
                 return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
             return None
@@ -989,12 +1026,16 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                 if function.attr in ("format", "format_map"):
                     return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
                 return None
-            if function.attr == "format" and _visibly_literal_text(function.value):
+            if function.attr in ("format", "format_map") and _visibly_literal_text(
+                function.value
+            ):
                 # `"pass".format(name)` has no replacement field, so the arguments
                 # change nothing and the result is the literal. Only a written-out
                 # template is read this way; a variable receiver may well hold one.
+                # `format_map` never consults its mapping for such a template either,
+                # so both spellings take the same answer.
                 template = function.value.value
-                if isinstance(template, str) and not _FORMAT_FIELD.search(template):
+                if isinstance(template, str) and not _has_format_field(template):
                     return None
             return f".{function.attr}()"
         if function.attr == "decode" and _visibly_text(function.value):
@@ -1192,7 +1233,7 @@ def _pattern_bindings(pattern: ast.AST, captures_subject: bool = True):
                 yield child.rest, False
 
 
-def _literal_builtins_import(node: ast.AST, shadowed = None) -> bool:
+def _literal_builtins_import(node: ast.AST, shadowed = None, aliases = None) -> bool:
     """Whether `node` is written out as `__import__("builtins")`.
 
     The module is named inline rather than bound to a name, so nothing is guessed at:
@@ -1214,9 +1255,13 @@ def _literal_builtins_import(node: ast.AST, shadowed = None) -> bool:
         owner = function.value.id
         if shadowed is not None and shadowed(owner):
             return False
-        return (
-            (function.attr == "__import__" and owner == "builtins") or
-            (function.attr == "import_module" and owner == "importlib")
+        if function.attr == "__import__" and owner == "builtins":
+            return True
+        # `import importlib as il` records a `stdlib:` alias, and requiring the
+        # literal spelling meant `il.import_module("builtins").exec(...)` resolved to
+        # nothing at all.
+        return function.attr == "import_module" and _names_module(
+            function.value, "importlib", shadowed, aliases,
         )
     return False
 
@@ -1252,7 +1297,7 @@ def _getattr_sink_name(function: ast.Call, aliases = None, shadowed = None) -> s
         ):
             owner, attribute = function.args[0], function.args[1]
             if isinstance(attribute, ast.Constant) and attribute.value in SINKS:
-                if _literal_builtins_import(owner, shadowed):
+                if _literal_builtins_import(owner, shadowed, aliases):
                     # `getattr(__import__("builtins"), "exec")` names the module
                     # inline, so the owner is a Call rather than a Name and the
                     # branch below never ran. Same reasoning as the attribute
@@ -1267,7 +1312,11 @@ def _getattr_sink_name(function: ast.Call, aliases = None, shadowed = None) -> s
                         # reporting it failed the gate on code that cannot be
                         # changed to pass.
                         return None
-                    if module == "builtins" or (
+                    # `__builtins__` too: CPython binds it to the builtins MODULE in
+                    # `__main__`, so `getattr(__builtins__, "exec")(...)` runs in a
+                    # script that is executed directly. The attribute spelling already
+                    # read it; this owner check did not.
+                    if module in ("builtins", "__builtins__") or (
                         aliases is not None and aliases(f"module:{module}")
                     ):
                         return f"builtins.{attribute.value}"
@@ -1311,7 +1360,7 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
         # what `exec(source)` does; the attribute is written out, so nothing is guessed.
         return _sink_name(function.value, aliases, shadowed)
     if isinstance(function, ast.Attribute) and function.attr in SINKS:
-        if _literal_builtins_import(function.value, shadowed):
+        if _literal_builtins_import(function.value, shadowed, aliases):
             # `__import__("builtins").exec(f"...")` names the module inline, so the
             # owner is a Call rather than a Name and the branch below never ran.
             return f"builtins.{function.attr}"
@@ -1533,8 +1582,9 @@ def _nullcontext_value(node: ast.AST, aliases = None, shadowed = None) -> ast.AS
     if isinstance(function, ast.Attribute):
         if function.attr != "nullcontext" or not isinstance(function.value, ast.Name):
             return None
-        owner = function.value.id
-        if owner != "contextlib" or (shadowed is not None and shadowed(owner)):
+        if not _names_module(function.value, "contextlib", shadowed, aliases):
+            # `import contextlib as ctx` records a `stdlib:` alias, and requiring the
+            # literal spelling read `ctx.nullcontext(...)` as an opaque manager.
             return None
         return node.args[0]
     if isinstance(function, ast.Name) and function.id == "nullcontext":
@@ -1626,9 +1676,59 @@ def _has_computed_key(mapping: ast.Dict) -> bool:
     )
 
 
-# A `str.format` replacement field. `{{` and `}}` are escapes for a literal brace, so
-# they are stepped over before a real field is looked for.
-_FORMAT_FIELD = re.compile(r"(?<!\{)\{(?!\{)[^{}]*\}")
+def _names_module_function(
+    function: ast.AST, module: str, name: str, shadowed = None, aliases = None,
+) -> bool:
+    """Whether a callee is `<module>.<name>`, however it was imported.
+
+    `ast.parse(...)`, `alias.parse(...)` through a recorded module alias, and the
+    direct `from ast import parse [as p]` form, which `visit_ImportFrom` records under
+    `stdlibfunc:`. Reading only the attribute spelling let the direct import through.
+    """
+    if isinstance(function, ast.Attribute):
+        return function.attr == name and _names_module(
+            function.value, module, shadowed, aliases,
+        )
+    if isinstance(function, ast.Name):
+        if shadowed is not None and shadowed(function.id):
+            return False
+        return aliases is not None and aliases(f"stdlibfunc:{function.id}") == f"{module}.{name}"
+    return False
+
+
+def _identity_translation(table: ast.AST) -> bool:
+    """Whether a written-out `translate` table maps every key to itself.
+
+    Both sides written out as the same integer, for every entry. Anything else - a
+    computed key, a name, a `**` - is unknown and the table may well remove the text.
+    """
+    if not isinstance(table, ast.Dict) or not table.keys:
+        return False
+    for key, value in zip(table.keys, table.values):
+        if not (isinstance(key, ast.Constant) and isinstance(key.value, int)):
+            return False
+        if not (isinstance(value, ast.Constant) and isinstance(value.value, int)):
+            return False
+        if key.value != value.value:
+            return False
+    return True
+
+
+def _has_format_field(template: str) -> bool:
+    """Whether a `str.format` template has a replacement field to splice into.
+
+    `string.Formatter().parse` is what `str.format` itself uses, so `{{` and `}}` are
+    escapes and `{{{x}}}` really does have the field `x` between two literal braces.
+    A brace-adjacency regex read that template as field-free and let the splice
+    through. A template `format` itself rejects is unknown, so it keeps the source.
+    """
+    try:
+        return any(field is not None for _, field, _, _ in _FORMATTER.parse(template))
+    except ValueError:
+        return True
+
+
+_FORMATTER = string.Formatter()
 
 
 def _truncating_format_spec(node: ast.Call) -> bool:
@@ -1749,6 +1849,25 @@ def _mapping_lookup(mapping: ast.Dict, wanted: str) -> ast.AST | None:
     return None
 
 
+def _compile_call_is_complete(node: ast.Call, skip: int = 0) -> bool:
+    """Whether a visible `compile(...)` supplies the three arguments it requires.
+
+    `compile(source, filename, mode)` has no defaults for any of them. A `*` or `**`
+    in the call may supply what is missing, so those are unknown and count as
+    complete: this only ever declines to report a call CPython refuses outright.
+    """
+    if any(isinstance(argument, ast.Starred) for argument in node.args):
+        return True
+    if any(keyword.arg is None for keyword in node.keywords):
+        return True
+    positional = len(node.args) - skip
+    named = {keyword.arg for keyword in node.keywords}
+    return all(
+        positional > index or wanted in named
+        for index, wanted in enumerate(("source", "filename", "mode"))
+    )
+
+
 def _compile_keyword_source(node: ast.Call, shadowed = None) -> ast.AST | None:
     """The `source=` argument of a `compile` call, however the keyword is spelled."""
     for keyword in node.keywords:
@@ -1789,6 +1908,12 @@ def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) 
     was skipped entirely. `studio/backend/core/inference/tools.py` already resolves
     sink arguments this way.
     """
+    if sink.rpartition(".")[2] == "compile" and not _compile_call_is_complete(node, skip):
+        # `compile(f"import {name}")` raises TypeError for the missing `filename` and
+        # `mode` before it compiles anything, so reporting it failed the gate on a
+        # call that cannot execute. Only a call whose arguments are all visible is
+        # judged this way; an opaque expansion may supply the rest.
+        return None
     if node.args[skip:]:
         # `exec(*[], *[f"..."])` is valid, and the first AST argument contributes no
         # values. Statically visible empty expansions are stepped over so the real
@@ -2180,6 +2305,29 @@ class _Visitor(ast.NodeVisitor):
         numeric = _visibly_numeric(node.value)
         literal_text = reason is None and _visibly_literal_text(node.value)
         for target in node.targets:
+            # An unpacking assigns each element before the NEXT target is evaluated,
+            # so `payload, table[exec(payload)] = (f"import {name}", None)` executes
+            # the f-string it has just bound. Visiting the whole tuple first read that
+            # subscript while `payload` still looked clean. Only a pairing this can
+            # read is walked element by element; anything else keeps the old order.
+            paired = self._unpacked_pairs(target, node.value) if isinstance(
+                target, (ast.Tuple, ast.List)
+            ) else []
+            if paired and len(paired) == len(target.elts):
+                for element, item in paired:
+                    self.visit(element)
+                    element_reason = _is_interpolated(
+                        item, self.tainted[-1].get, self._is_shadowed, self._alias,
+                    )
+                    self._bind(
+                        element,
+                        element_reason,
+                        numeric = _visibly_numeric(item),
+                        literal_text = element_reason is None and _visibly_literal_text(item),
+                    )
+                    self._bind_unpacked(element, item)
+                    self._shadow_assignment(element, item)
+                continue
             self.visit(target)
             self._bind(target, reason, numeric, literal_text)
             self._bind_unpacked(target, node.value)
@@ -2248,6 +2396,12 @@ class _Visitor(ast.NodeVisitor):
         statements. The remaining augmented operators do not build source out of a
         value, so they are left alone.
         """
+        # The TARGET is evaluated first for a subscript or an attribute: Python reads
+        # the object and the index, then the right-hand side. Visiting the value first
+        # let a walrus in it clear taint that the index had already executed.
+        # A bare Name target loads nothing, so it stays where it was, after the value.
+        if not isinstance(node.target, ast.Name):
+            self.visit(node.target)
         self.visit(node.value)
         if isinstance(node.op, ast.Mult) and not (
             _visibly_numeric(node.value) and _visibly_numeric_name(node.target, self.tainted[-1])
@@ -2270,7 +2424,8 @@ class _Visitor(ast.NodeVisitor):
                 if held is not None and _positive_repetition(node.value):
                     reason = held
             self._bind(node.target, f"{reason} repeated" if reason else None)
-            self.visit(node.target)
+            if isinstance(node.target, ast.Name):
+                self.visit(node.target)
             return
         if isinstance(node.op, (ast.Add, ast.Mod)):
             if isinstance(node.op, ast.Mod):
@@ -2299,7 +2454,8 @@ class _Visitor(ast.NodeVisitor):
                 self._bind(node.target, None, numeric = True)
             else:
                 self._bind(node.target, f"{reason} {verb}")
-        self.visit(node.target)
+        if isinstance(node.target, ast.Name):
+            self.visit(node.target)
 
     @staticmethod
     def _literal_elements(iterable):
@@ -2538,16 +2694,30 @@ class _Visitor(ast.NodeVisitor):
             # whole-subject capture, where the value is the subject itself.
             # The sink NAME, so a FRESH capture such as `case check:` is registered as
             # an alias for it. Marking it "not shadowed" left it resolving to nothing.
+            paired = self._sequence_pattern_pairs(node.subject, case.pattern)
+            # A paired element can BE a sink or a constructor: `match [builtins.exec]:
+            # case [run]:` leaves `run` the builtin as plainly as the whole-subject
+            # capture does. Marking every sequence capture an opaque shadow hid the
+            # call in the body.
+            element_callables = {}
+            for name, element in paired.items():
+                resolved = _sink_name(element, self._alias, self._is_shadowed)
+                element_callables[name] = resolved.rpartition(".")[2] if resolved else (
+                    _prefixed_constructor(
+                        _constructor_name(element, self._is_shadowed, self._alias)
+                    )
+                )
             shadow = {
-                name: subject_sink if captures_subject else None
+                name: subject_sink if captures_subject else element_callables.get(name)
                 for name, captures_subject in _pattern_bindings(case.pattern)
             }
-            saved_scope = self._shadow_locals(shadow if subject_sink else bound)
+            saved_scope = self._shadow_locals(
+                shadow if subject_sink or any(element_callables.values()) else bound
+            )
             # `match [f"import {name}"]: case [payload]:` pairs element for element,
             # exactly as an unpacking assignment does, so the capture holds the
             # f-string and `exec(payload)` runs it. Clearing every sequence capture
             # read that as binding nothing.
-            paired = self._sequence_pattern_pairs(node.subject, case.pattern)
             for name, captures_subject in _pattern_bindings(case.pattern):
                 element_reason = None
                 if reason is not None and captures_subject:
@@ -2773,6 +2943,7 @@ class _Visitor(ast.NodeVisitor):
                 table[-1].pop(f"partial:{target.id}", None)
                 table[-1].pop(f"text:{target.id}", None)
                 table[-1].pop(f"stdlib:{target.id}", None)
+                table[-1].pop(f"stdlibfunc:{target.id}", None)
             level = self._binding_level(target.id)
             if level != len(self.scope_kinds) - 1:
                 # `global exec; del exec` deletes the MODULE binding, so the shadow an
@@ -2787,6 +2958,7 @@ class _Visitor(ast.NodeVisitor):
                     table[level].pop(f"partial:{target.id}", None)
                     table[level].pop(f"text:{target.id}", None)
                     table[level].pop(f"stdlib:{target.id}", None)
+                    table[level].pop(f"stdlibfunc:{target.id}", None)
                 self.shadowed_sinks[level].discard(target.id)
                 if target.id in self.nonlocal_names[-1]:
                     # A deleted NONLOCAL cell is empty, and the name does not fall
@@ -2849,7 +3021,7 @@ class _Visitor(ast.NodeVisitor):
                     table[-1].pop(node.name, None)
                     for prefix in (
                         "module:", "constructor:", "partial:", "functools:", "text:",
-                        "stdlib:",
+                        "stdlib:", "stdlibfunc:",
                     ):
                         table[-1].pop(f"{prefix}{node.name}", None)
         for statement in node.body:
@@ -2945,6 +3117,19 @@ class _Visitor(ast.NodeVisitor):
     # `visit_AsyncWith` is defined on its own above: `async with` cannot enter a
     # synchronous context manager, so the `nullcontext` inference here does not apply
     # to it.
+
+    def visit_Dict(self, node: ast.Dict):
+        """Each key is evaluated immediately before its own value.
+
+        `NodeVisitor` walks every key and then every value, so
+        `{0: (payload := f"import {name}"), exec(payload): None}` had the second key
+        read before the first value had bound anything. Runtime order is pairwise,
+        left to right; a `**` entry has a `None` key and only its value runs.
+        """
+        for key, value in zip(node.keys, node.values):
+            if key is not None:
+                self.visit(key)
+            self.visit(value)
 
     def visit_NamedExpr(self, node: ast.NamedExpr):
         """`(payload := f"import {name}")` as a statement, then `exec(payload)`.
@@ -3380,6 +3565,16 @@ class _Visitor(ast.NodeVisitor):
                 # exists at all. Nested scopes still see the binding, because they
                 # are deferred - that is `_collect_aliases` on their own body plus
                 # the outward walk, not this shadow.
+                #
+                # A later rebinding here is NOT applied to deferred bodies either,
+                # though a `def exec` written below one is. Tried and reverted: five
+                # corpus cases re-establish the builtin AFTER such an assignment -
+                # `global exec; exec = builtins.exec` inside the function, a module
+                # `for exec in [builtins.exec]`, a class body's `global exec; from
+                # builtins import exec`, and `global exec; del exec` - and a deferred
+                # shadow is consulted ahead of the alias table and never cleared, so
+                # it turned all five real findings into misses. The `def` form does
+                # not have that problem: a name given a `def` is not handed back.
                 return
             for target in targets:
                 for child in ast.walk(target):
@@ -3501,6 +3696,18 @@ class _Visitor(ast.NodeVisitor):
                     self.sink_aliases[-1][f"constructor:{constructor}"] = constructor
                     self.collected_aliases[-1][f"constructor:{constructor}"] = constructor
                     self.shadowed_sinks[-1].discard(constructor)
+                continue
+            if (
+                node.module is not None
+                and not node.level
+                and f"{node.module}.{alias.name}" in _DIRECT_HELPERS
+            ):
+                # `from ast import parse as p` binds the helper itself, and matching
+                # on a module attribute alone meant `compile(p(f"..."), ...)` read
+                # nothing at all.
+                self.sink_aliases[-1][f"stdlibfunc:{bound}"] = f"{node.module}.{alias.name}"
+                self.collected_aliases[-1][f"stdlibfunc:{bound}"] = f"{node.module}.{alias.name}"
+                self.shadowed_sinks[-1].discard(bound)
                 continue
             if (
                 node.module == "textwrap"
@@ -3626,6 +3833,7 @@ class _Visitor(ast.NodeVisitor):
             or self._alias(f"partial:{name}") is not None
             # And a `textwrap` function alias, for the same reason.
             or self._alias(f"text:{name}") is not None
+            or self._alias(f"stdlibfunc:{name}") is not None
             # A name already recorded as shadowed still counts, so a second assignment
             # can hand it back: `run = print` then `run = builtins.exec` has to make
             # `run` an alias again, and by then the alias entry is gone.
@@ -4118,6 +4326,14 @@ class _Visitor(ast.NodeVisitor):
             self.sink_aliases[-1][f"constructor:{name}"] = constructor
             self.collected_aliases[-1][f"constructor:{name}"] = constructor
             self.shadowed_sinks[-1].discard(name)
+        # And the ordinary parameter shadows, in the lambda's OWN scope as well.
+        # `_shadow_locals` above put them in the scope the lambda is WRITTEN in, and
+        # when that is a class body `_visible_scopes` skips it once this function
+        # level is on top - so `class C: f = lambda exec, name: exec(...)` read the
+        # parameter as the builtin. Same argument the default aliases just made.
+        for name in shadowed:
+            if name not in default_sinks and name not in default_constructors:
+                self.shadowed_sinks[-1].add(name)
         self.visit(node.body)
         self.scope_kinds.pop()
         self.collected_aliases.pop()

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -34,7 +34,10 @@ import argparse
 import ast
 import hashlib
 import json
+import re
+import shlex
 import sys
+import warnings
 from pathlib import Path
 
 
@@ -45,7 +48,28 @@ ALLOWLIST_PATH = Path(__file__).resolve().parent / "dynamic_exec_allowlist.json"
 
 # Directories scanned by default. Tests are excluded: they legitimately keep the
 # removed exec/eval around as an oracle to prove the replacement matches it.
-DEFAULT_TARGETS = ("unsloth_zoo", "unsloth", "studio", "scripts")
+# The maintained source in this repo: the scripts dir plus the three top-level
+# generators. `nb/`, `python_scripts/`, `kaggle/` and `molab/` are generated from
+# `original_template/` and are deliberately out of scope.
+# `original_template/` is the source of truth CODEOWNERS names: `nb/`, `kaggle/`,
+# `python_scripts/` and `molab/` are generated from it. Scanning only the scripts left
+# the repository's main executable content unchecked, so an interpolated exec added to
+# a notebook cell passed this gate. The generated trees stay out of scope because a
+# finding there is a finding here, reported twice.
+# `Template_Notebook.ipynb` sits at the root rather than under `original_template/`.
+# README tells contributors to copy it when starting a notebook and CODEOWNERS treats
+# it as maintained source, so an interpolated exec added there propagates into every
+# notebook made from it afterwards.
+# `nb/` is mostly generated from `original_template/`, but not entirely: some
+# notebooks live only there, and `update_all_notebooks.py` sources AMD counterparts
+# from those copies. Excluding the whole tree as "generated" therefore left real
+# source unscanned. Scanning all of it costs about three seconds and no allowlist
+# entries, which is cheaper than tracking which files are the exceptions.
+DEFAULT_TARGETS = ("unsloth_zoo", "scripts")
+
+
+class ScanError(Exception):
+    """A file the checker could not finish reading. The gate fails rather than guess."""
 
 
 def _relative(path: Path) -> str:
@@ -60,40 +84,1255 @@ def _relative(path: Path) -> str:
         return path.as_posix()
 
 
-def _is_interpolated(node: ast.AST) -> str | None:
-    """Returns why `node` is a built string, or None if it is not one."""
+# Methods that build a string out of values. `format_map` is `format` with the
+# fields taken from a mapping instead of keyword arguments - same interpolation,
+# same shape, so leaving it out let `exec("import {m}".format_map(cfg))` through.
+_BUILDERS = ("format", "format_map", "join")
+
+
+class _AbsentNode(ast.AST):
+    """Stand-in for an AST node type this interpreter does not have.
+
+    `_MATCH` and the pattern nodes arrived in 3.10, and both packages declare
+    `requires-python = ">=3.9"`. Naming them directly made every `isinstance` tuple
+    holding one raise `AttributeError` on 3.9, so the documented `python
+    scripts/lint_dynamic_exec.py` command could not scan anything at all there. No
+    node is ever an instance of this, so a check against it is simply false - which is
+    the right answer on an interpreter whose parser cannot produce that syntax.
+    """
+
+
+def _node_type(name: str):
+    return getattr(ast, name, _AbsentNode)
+
+
+_TYPEALIAS = _node_type("TypeAlias")
+_MATCH = _node_type("Match")
+_MATCHAS = _node_type("MatchAs")
+_MATCHSTAR = _node_type("MatchStar")
+_MATCHCLASS = _node_type("MatchClass")
+_MATCHMAPPING = _node_type("MatchMapping")
+_MATCHOR = _node_type("MatchOr")
+_MATCHSEQUENCE = _node_type("MatchSequence")
+
+# Conversions that hand the same source on in another type. `exec`, `eval` and
+# `compile` all accept bytes as well as str, so `exec(f"import {name}".encode())`
+# executes exactly the payload the f-string built.
+_CONVERSIONS = ("encode", "decode")
+
+# The dunder spellings of the conversions above. `f"...".__str__()` returns the same
+# string and `bytes.__str__` is not a conversion at all, so only the ones whose
+# receiver is the text itself are listed here.
+_IDENTITY_METHODS = ("__str__",)
+
+# Methods that hand back the same text, possibly trimmed or recased. The interpolated
+# content survives all of them, so `exec(f" import {name}".strip())` executes exactly
+# what the f-string built and the outer call must not read as clean.
+# `str.translate` with an empty literal mapping returns the string unchanged, so it
+# preserves the source. With anything else it may not, and this does not evaluate
+# translation tables, so only the visibly empty form counts.
+_IDENTITY_TRANSLATIONS = ("translate",)
+
+# Functions that hand the same text back with only whitespace changed, so the
+# interpolated content survives them exactly as it survives `.strip()`.
+# `exec(textwrap.dedent(f"..."))` is the ordinary way to write an indented block of
+# generated source, and stopping at the call read it as clean. Both spellings are
+# matched, `textwrap.dedent(...)` and the directly imported `dedent(...)`, and each
+# takes its text as the first argument. Matched by name rather than by proving the
+# import, which can only ever add findings: a local helper of the same name that did
+# something else to the text would still be handing built source to a sink.
+_TEXT_PRESERVING_FUNCTIONS = ("dedent", "indent")
+_NORMALISERS = (
+    "strip", "lstrip", "rstrip", "upper", "lower", "title", "capitalize",
+    "casefold", "swapcase", "expandtabs", "removeprefix", "removesuffix",
+    "center", "ljust", "rjust", "zfill",
+)
+
+# Constructors that hand the same source on in another type. Same argument as
+# `_CONVERSIONS`, spelled as a call instead of a method: `bytes(s, "utf-8")` is
+# documented as `s.encode("utf-8")`, `str(s)` on a str is the str, and `exec`
+# compiles any of them. Verified on CPython 3.13: `exec(bytes(f"import {name}",
+# "utf-8"))`, `exec(bytearray(...))` and `exec(memoryview(...))` all import.
+_CONSTRUCTORS = ("bytes", "bytearray", "str", "memoryview", "format")
+
+# Each constructor also takes its source by keyword, verified on CPython 3.13:
+# `bytes(source = ..., encoding = ...)` and `str(object = ...)` both build the same
+# value a positional call would, so reading only `args[0]` missed them.
+_CONSTRUCTOR_SOURCE_KEYWORD = {
+    "bytes": "source", "bytearray": "source",
+    "str": "object", "memoryview": "object",
+}
+
+
+# Every builtin name whose ordinary meaning this checker depends on. A local binding
+# of any of them takes that meaning away.
+# `dict` and `getattr` are not conversions, but the resolver reads them: a literal
+# `dict(...)` names the `compile` keywords and `getattr(builtins, "exec")` names a
+# sink. A local binding of either takes that reading away, so they belong here even
+# though they are not in `_CONSTRUCTORS`.
+_BUILTIN_NAMES = frozenset({*SINKS, *_CONSTRUCTORS, "builtins", "dict", "getattr"})
+
+
+def _constructor_name(function: ast.AST, shadowed = None, aliases = None) -> str | None:
+    """`bytes` for both `bytes(...)` and `builtins.bytes(...)`, else None."""
+    if isinstance(function, ast.Name):
+        if function.id in _CONSTRUCTORS:
+            # `def f(str, name): exec(str(f"import {name}"))` supplies its own `str`,
+            # which may return anything at all, so unwrapping to the f-string was a
+            # false positive. Same test the sinks themselves get.
+            return None if shadowed is not None and shadowed(function.id) else function.id
+        # A fresh name given the constructor, `s = builtins.str`, resolves the same way
+        # an imported sink alias does - unless something nearer took the name away:
+        # `from builtins import str as text` then `def f(): text = print` calls print,
+        # and the enclosing alias was still being found.
+        if shadowed is not None and shadowed(function.id):
+            return None
+        if aliases is not None:
+            named = aliases(f"constructor:{function.id}")
+            if named is not None:
+                return named
+    if isinstance(function, ast.NamedExpr):
+        # `exec((text := str)(f"..."))` converts with whatever the walrus was given,
+        # right here. The sink side already unwraps a named expression callee.
+        return _constructor_name(function.value, shadowed, aliases)
+    if isinstance(function, ast.Attribute) and function.attr == "__call__":
+        # `str.__call__(f"...")` converts exactly as `str(f"...")` does, the same way
+        # `exec.__call__` executes exactly as `exec` does on the sink side.
+        return _constructor_name(function.value, shadowed, aliases)
+    if isinstance(function, ast.IfExp):
+        # `(str if flag else format)(f"...")` preserves the source whichever arm runs,
+        # the same reasoning the sink resolver applies to a conditional callee.
+        if isinstance(function.test, ast.Constant):
+            taken = function.body if function.test.value else function.orelse
+            return _constructor_name(taken, shadowed, aliases)
+        return (
+            _constructor_name(function.body, shadowed, aliases)
+            or _constructor_name(function.orelse, shadowed, aliases)
+        )
+    if isinstance(function, ast.BoolOp):
+        for value in _reachable_operands(function):
+            resolved = _constructor_name(value, shadowed, aliases)
+            if resolved is not None:
+                return resolved
+    if isinstance(function, ast.Subscript):
+        if (
+            isinstance(function.slice, ast.Constant)
+            and function.slice.value in _CONSTRUCTORS
+            and _is_builtins_mapping(function.value, aliases, shadowed)
+        ):
+            # `builtins.__dict__["str"](f"...")` names the conversion through the
+            # module's own namespace, which the sink resolver already reads.
+            return function.slice.value
+        # `[builtins.str][0](...)` selects the constructor from a literal written
+        # right here, the same shape the sink resolver already reads for a callee.
+        selected = _literal_selection(function)
+        if selected is not None:
+            return _constructor_name(selected, shadowed, aliases)
+    if isinstance(function, ast.Call) and isinstance(function.func, ast.Name):
+        # `getattr(builtins, "str")(f"...")` names the conversion as plainly as
+        # `builtins.str` does, which the sink side already reads for `exec`. Same
+        # bounds: a literal attribute, an unshadowed `getattr`, an unshadowed owner,
+        # and the two- or three-argument form, since the attribute exists either way.
+        if function.func.id == "getattr" and len(function.args) in (2, 3) and not (
+            shadowed is not None and shadowed("getattr")
+        ):
+            owner, attribute = function.args[0], function.args[1]
+            if (
+                isinstance(attribute, ast.Constant)
+                and attribute.value in _CONSTRUCTORS
+                and isinstance(owner, ast.Name)
+                and not (shadowed is not None and shadowed(owner.id))
+                and (
+                    owner.id == "builtins"
+                    or (aliases is not None and aliases(f"module:{owner.id}"))
+                )
+            ):
+                return attribute.value
+    if isinstance(function, ast.Attribute) and function.attr in _CONSTRUCTORS:
+        if isinstance(function.value, ast.Name):
+            module = function.value.id
+            # `import builtins as b` makes `b.str` the constructor exactly as it makes
+            # `b.exec` the sink. `_sink_name` consulted the recorded `module:` alias and
+            # this did not, so `b.exec(b.str(f"..."))` was never unwrapped.
+            if module != "builtins" and not (aliases is not None and aliases(f"module:{module}")):
+                return None
+            if shadowed is not None and shadowed(module):
+                return None
+            return function.attr
+    return None
+
+
+def _visibly_text(node: ast.AST) -> bool:
+    """Whether an expression is visibly a `str` rather than something bytes-like."""
+    if isinstance(node, ast.JoinedStr):
+        return True
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, str)
+    if isinstance(node, ast.BinOp):
+        return _visibly_text(node.left) or _visibly_text(node.right)
+    return False
+
+
+def _constructor_accepts_text(node: ast.Call, name: str) -> bool:
+    """Whether this constructor call can reach the sink with what it was handed.
+
+    Verified on CPython 3.13: `bytes("x")` and `bytearray("x")` raise
+    `TypeError: string argument without an encoding`, and `memoryview("x")` raises
+    outright, so reporting those calls was a false failure on code that cannot be made
+    to pass. Everything else is read on - `bytes(f"...".encode())` really does hand the
+    interpolated bytes to `exec`, and suppressing every one-argument call turned that
+    into a bypass. The test is on the ARGUMENT, not on how many there are: an
+    `errors = "ignore"` keyword does not make `bytes(source = "x")` legal.
+    """
+    source = _constructor_source(node, name)
+    if source is None or not _visibly_text(source):
+        return True
+    if name == "memoryview":
+        return False
+    if name in ("bytes", "bytearray"):
+        supplied_encoding = len(node.args) > 1 or any(
+            keyword.arg == "encoding" for keyword in node.keywords
+        )
+        return supplied_encoding
+    return True
+
+
+def _partial_call(node: ast.AST) -> ast.Call | None:
+    """`functools.partial(...)` or a bare `partial(...)` written out here, else None."""
+    if not isinstance(node, ast.Call):
+        return None
+    function = node.func
+    name = (
+        function.attr if isinstance(function, ast.Attribute)
+        else (function.id if isinstance(function, ast.Name) else "")
+    )
+    return node if name == "partial" and node.args else None
+
+
+def _partial_sink(node: ast.AST, aliases = None, shadowed = None) -> str | None:
+    """The sink a visible `partial` was built around, else None."""
+    partial = _partial_call(node)
+    if partial is None:
+        return None
+    return _sink_name(partial.args[0], aliases, shadowed)
+
+
+def _is_builtins_mapping(node: ast.AST, aliases = None, shadowed = None) -> bool:
+    """Whether `node` is written out as the builtins module's namespace mapping.
+
+    `builtins.__dict__` and any recorded module alias of it, plus the implicit
+    `__builtins__` global, which CPython binds to that dictionary in an imported
+    module. Both are shadow-tested like every other owner here.
+    """
+    if isinstance(node, ast.Name) and node.id == "__builtins__":
+        return not (shadowed is not None and shadowed(node.id))
+    if not (isinstance(node, ast.Attribute) and node.attr == "__dict__"):
+        return False
+    if not isinstance(node.value, ast.Name):
+        return False
+    module = node.value.id
+    if shadowed is not None and shadowed(module):
+        return False
+    return module == "builtins" or bool(aliases is not None and aliases(f"module:{module}"))
+
+
+def _constructor_source(node: ast.Call, name: str, shadowed = None) -> ast.AST | None:
+    """The value a constructor is converting, positional or by keyword."""
+    if node.args:
+        return node.args[0]
+    wanted = _CONSTRUCTOR_SOURCE_KEYWORD.get(name)
+    if wanted is None:
+        return None
+    for keyword in reversed(node.keywords):
+        if keyword.arg == wanted:
+            return keyword.value
+        if keyword.arg is None and _mapping_literal(keyword.value, shadowed) is not None:
+            # `str(**{"object": f"..."})` names its key as plainly as the keyword form,
+            # and `dict(object = f"...")` is the same mapping written as a call.
+            found = _mapping_lookup(_mapping_literal(keyword.value, shadowed), wanted)
+            if found is not None:
+                return found
+    return None
+
+
+# Marker kept in the taint map for a name whose value is written out as a number.
+# The map otherwise holds reasons, which are strings, so a sentinel object cannot be
+# mistaken for one.
+_NUMERIC = object()
+
+
+def _visibly_numeric(node: ast.AST) -> bool:
+    """Whether an expression is written out as a number, so it cannot be source.
+
+    Deliberately narrow: a literal, a unary sign on one, or arithmetic between two of
+    those. A name says nothing, and `"a" * 3` is a string, so neither qualifies.
+    """
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, (int, float, complex)) and not isinstance(node.value, bool)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.USub, ast.UAdd)):
+        return _visibly_numeric(node.operand)
+    if isinstance(node, ast.BinOp):
+        return _visibly_numeric(node.left) and _visibly_numeric(node.right)
+    return False
+
+
+def _visibly_numeric_name(target: ast.AST, numeric_names) -> bool:
+    """Whether an augmented-assignment target is known to hold a number.
+
+    Only a plain name recorded as numeric by an earlier visibly numeric assignment in
+    the same scope. Anything else says nothing and keeps the conservative reading.
+    """
+    return isinstance(target, ast.Name) and numeric_names.get(target.id) == _NUMERIC
+
+
+def _literal_selection(node: ast.Subscript) -> ast.AST | None:
+    """The element a `<literal>[<constant>]` subscript selects, or None.
+
+    Shared by the source reader and the callee resolver: the same shape says which
+    value is taken, whether it is going to be executed or is going to do the executing.
+    """
+    container, index = node.value, node.slice
+    if isinstance(container, (ast.Tuple, ast.List)):
+        position, sign = index, 1
+        if isinstance(position, ast.UnaryOp) and isinstance(position.op, (ast.USub, ast.UAdd)):
+            sign = -1 if isinstance(position.op, ast.USub) else 1
+            position = position.operand
+        if not isinstance(position, ast.Constant):
+            return None
+        # `True` and `False` index as 1 and 0. Excluding them left
+        # `exec(["pass", f"..."][True])` unread, which is a bypass rather than a
+        # nicety; `int()` normalises both spellings.
+        if not isinstance(position.value, int):
+            return None
+        try:
+            return container.elts[sign * int(position.value)]
+        except IndexError:
+            return None
+    if isinstance(container, ast.Dict) and isinstance(index, ast.Constant):
+        return _mapping_lookup(container, index.value)
+    return None
+
+
+def _literal_element(node: ast.Subscript, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
+    """The reason for `<literal>[<constant>]`, or None when it is not that shape."""
+    container, index = node.value, node.slice
+    if isinstance(container, (ast.Tuple, ast.List)):
+        # A negative literal index is `UnaryOp(USub, Constant(1))`, not a `Constant`,
+        # so requiring a constant rejected `[...][-1]` before the container was even
+        # looked at and the last element - the one that runs - went unread.
+        position = index
+        sign = 1
+        if isinstance(position, ast.UnaryOp) and isinstance(position.op, (ast.USub, ast.UAdd)):
+            sign = -1 if isinstance(position.op, ast.USub) else 1
+            position = position.operand
+        if not isinstance(position, ast.Constant):
+            return None
+        if not isinstance(position.value, int):
+            return None
+        try:
+            return _is_interpolated(
+                container.elts[sign * int(position.value)], resolve, shadowed, resolve_alias,
+            )
+        except IndexError:
+            return None
+    if not isinstance(index, ast.Constant):
+        return None
+    mapping = _mapping_literal(container, shadowed)
+    if mapping is not None:
+        # Last one wins, as it does at runtime, and a nested `**{...}` overrides
+        # everything written before it, so the same resolver the `compile(**{...})`
+        # path uses is used here. `dict(source = f"...")["source"]` is the same
+        # mapping written out with the constructor, so it is read the same way.
+        found = _mapping_lookup(mapping, index.value)
+        if found is not None:
+            return _is_interpolated(found, resolve, shadowed, resolve_alias)
+    return None
+
+
+def _is_interpolated(node: ast.AST, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
+    """Returns why `node` is a built string, or None if it is not one.
+
+    `resolve` maps a bare name to the reason it is tainted, or None. It is passed
+    at a sink and not while binding, so this stays one level of indirection: a
+    name is resolved where it is executed, never chained into another binding.
+    """
+    # `exec(payload := f"import {name}")` executes the f-string; the walrus is an
+    # `ast.NamedExpr` wrapper around it, not a different value.
+    # The shapes below are disjoint AST classes and the tail is `return None`, so
+    # each arm answers outright: nothing under an arm can match a node that
+    # reached it. That is why a handler returning None and a handler not
+    # matching stay indistinguishable, and why no sentinel is needed.
+    while isinstance(node, ast.NamedExpr):
+        node = node.value
+    if isinstance(node, ast.Starred):
+        return _interpolated_starred(node, resolve, shadowed, resolve_alias)
+    if isinstance(node, ast.Subscript):
+        return _interpolated_subscript(node, resolve, shadowed, resolve_alias)
+    if isinstance(node, ast.Name):
+        if resolve is None:
+            return None
+        reason = resolve(node.id)
+        # The numeric marker is a binding fact, not a reason. Returning it would put a
+        # non-string into a finding.
+        return None if reason is _NUMERIC else reason
+    if isinstance(node, ast.BoolOp):
+        # `exec(enabled and f"import {name}")` executes the interpolated operand
+        # whenever the guard lets it through: same conditional-source shape as IfExp.
+        for operand in _reachable_operands(node):
+            reason = _is_interpolated(operand, resolve, shadowed, resolve_alias)
+            if reason is not None:
+                return reason
+        return None
+    if isinstance(node, ast.IfExp):
+        # `exec(f"import {name}" if flag else "import os")` executes whichever branch
+        # is taken, so either one being built is enough.
+        decided = _constant_truth(node.test)
+        if decided is not None:
+            # A literal test decides the expression outright: `exec("pass" if True else
+            # f"...")` can only ever run the literal, and reporting the unreachable arm
+            # failed the gate on code that cannot be changed to pass. `not` applied to
+            # a constant decides it just as completely; anything else keeps both arms.
+            taken = node.body if decided else node.orelse
+            return _is_interpolated(taken, resolve, shadowed, resolve_alias)
+        return _is_interpolated(node.body, resolve, shadowed, resolve_alias) or _is_interpolated(node.orelse, resolve, shadowed, resolve_alias)
     if isinstance(node, ast.JoinedStr):
         # An f-string with no placeholders is just a literal.
         if any(isinstance(v, ast.FormattedValue) for v in node.values):
             return "f-string"
         return None
     if isinstance(node, ast.BinOp):
+        return _interpolated_binop(node, resolve, shadowed, resolve_alias)
+    if isinstance(node, ast.Call):
+        return _interpolated_call(node, resolve, shadowed, resolve_alias)
+    return None
+
+
+def _interpolated_starred(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
+    """`exec(*container)` where the container is written out right here."""
+    # `exec(*(f"import {name}",))` spreads a literal container, so the source is
+    # right there. The source is always the FIRST element, because that is the
+    # position it occupies in a normal call, so a longer container is read the same
+    # way: `exec(*(f"import {name}", globals()))` and
+    # `compile(*(f"x = {name}", "<x>", "exec"))` are ordinary calls that happen to
+    # pass their later arguments through the same star. Requiring exactly one
+    # element dropped both. A starred NAME is still left alone: nothing here knows
+    # what it holds, and flagging every `exec(*args)` would be noise.
+    inner = node.value
+    if isinstance(inner, ast.Set) and len(inner.elts) == 1:
+        # A set has no order, so only a one-element literal says which value is
+        # spread; `exec(*{f"import {name}"})` is that.
+        return _is_interpolated(inner.elts[0], resolve, shadowed, resolve_alias)
+    if isinstance(inner, (ast.Tuple, ast.List)) and inner.elts:
+        return _is_interpolated(inner.elts[0], resolve, shadowed, resolve_alias)
+    if isinstance(inner, ast.Dict) and inner.keys and inner.keys[0] is not None:
+        # Spreading a mapping iterates its KEYS, so `exec(*{f"import {name}": None})`
+        # hands the interpolated key straight to the sink. Only the first key, and
+        # only when it is written out rather than coming from a `**` expansion.
+        return _is_interpolated(inner.keys[0], resolve, shadowed, resolve_alias)
+    return None
+
+
+def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
+    """`exec(table[key])` where the container or the whole slice is readable."""
+    # `exec([f"import {name}"][0])` and `exec({"s": f"..."}["s"])` pick the source
+    # out of a literal that is right there, so the container is no more opaque
+    # than the string itself. Only a constant index into a literal container is
+    # read; a computed index or a name says nothing and is left alone.
+    if isinstance(node.slice, ast.Slice):
+        # A whole-object slice is the same string. `[:]`, and also the spellings
+        # that say the same thing outright: a `0` lower bound, an omitted upper
+        # bound and a step of `1` each drop nothing. A bound this cannot read is
+        # left alone, since a partial slice may cut the interpolation out and
+        # nothing here evaluates bounds.
+        def _keeps_everything(bound, whole):
+            if bound is None:
+                return True
+            if isinstance(bound, ast.Constant) and bound.value == whole:
+                return not isinstance(bound.value, bool)
+            return False
+
+        if (
+            _keeps_everything(node.slice.lower, 0)
+            and node.slice.upper is None
+            and _keeps_everything(node.slice.step, 1)
+        ):
+            return _is_interpolated(node.value, resolve, shadowed, resolve_alias)
+        return None
+    return _literal_element(node, resolve, shadowed, resolve_alias)
+
+
+def _interpolated_binop(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
+    """`a % b`, `a + b` and `s * n`, minus the visibly arithmetic cases."""
+    # `exec(1 + 2)` and `eval(5 % 2)` produce integers and raise TypeError at the
+    # sink. Reporting them forced harmless non-dynamic code into the allowlist,
+    # which is the worst kind of entry: a justification for something that is not
+    # dynamic execution at all. Only a VISIBLY numeric operand rules it out;
+    # anything unknown is still treated as built source.
+    if not _visibly_numeric(node):
         if isinstance(node.op, ast.Mod):
             return "%-format"
         if isinstance(node.op, ast.Add):
             return "string concatenation"
-    if isinstance(node, ast.Call):
-        function = node.func
-        if isinstance(function, ast.Attribute) and function.attr in ("format", "join"):
-            return f".{function.attr}()"
+    if isinstance(node.op, ast.Mult):
+        # `f"import {name}\n" * 2` repeats the built string; the interpolation is
+        # still in every copy. Either side may be the string.
+        return (
+            _is_interpolated(node.left, resolve, shadowed, resolve_alias)
+            or _is_interpolated(node.right, resolve, shadowed, resolve_alias)
+        )
+    # A visibly numeric operand, or an operator that is none of the three above,
+    # fell through every remaining arm in the original: a BinOp is not a Call, so
+    # control reached the closing `return None`. Spelled out here.
     return None
 
 
-def _sink_name(function: ast.AST) -> str | None:
+def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
+    """Every call shape that hands its argument through as source."""
+    function = node.func
+    preserving = None
+    if isinstance(function, ast.Name):
+        preserving = function.id
+    elif isinstance(function, ast.Attribute) and isinstance(function.value, ast.Name):
+        preserving = function.attr
+    if preserving in _TEXT_PRESERVING_FUNCTIONS and not (
+        shadowed is not None and isinstance(function, ast.Name) and shadowed(function.id)
+    ):
+        # `textwrap.dedent(text = f"...")` is the documented keyword spelling and
+        # hands over exactly the same string, so requiring a positional argument
+        # let it through.
+        text = node.args[0] if node.args else None
+        if text is None:
+            for keyword in reversed(node.keywords):
+                if keyword.arg == "text":
+                    text = keyword.value
+                    break
+        return (
+            _is_interpolated(text, resolve, shadowed, resolve_alias)
+            if text is not None else None
+        )
+    if isinstance(function, ast.Attribute):
+        literal_mapping = (
+            _mapping_literal(function.value, shadowed)
+            if function.attr == "get" else None
+        )
+        if (
+            literal_mapping is not None
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            # `{"s": f"..."}.get("s")` picks the value out of a literal written
+            # right here, exactly as the subscript spelling does, so the same
+            # lookup answers it. A missing key gives the default, which is the
+            # second argument when there is one and `None` otherwise - neither is
+            # source, so nothing is read for it.
+            found = _mapping_lookup(literal_mapping, node.args[0].value)
+            fallback = node.args[1] if len(node.args) > 1 else None
+            if found is None:
+                # A miss returns the DEFAULT, which is the second argument when
+                # there is one: `{}.get("s", f"...")` executes the f-string. It
+                # was being read as "nothing found" and reported clean.
+                return (
+                    _is_interpolated(fallback, resolve, shadowed, resolve_alias)
+                    if fallback is not None else None
+                )
+            if fallback is not None and _uncertain_lookup(literal_mapping):
+                # A computed key makes the hit itself uncertain, so the default is
+                # a possible result too.
+                found = _either_value(found, fallback)
+            return _is_interpolated(found, resolve, shadowed, resolve_alias)
+        if (
+            function.attr == "__getitem__"
+            and len(node.args) == 1
+            and not node.keywords
+        ):
+            # `{"s": f"..."}.__getitem__("s")` is the subscript spelling written as
+            # a call and selects exactly the same element, so it is handed to the
+            # same reader. Only the one-argument form, which is the only one the
+            # method takes.
+            equivalent = ast.Subscript(
+                value = function.value, slice = node.args[0], ctx = ast.Load(),
+            )
+            return _literal_element(
+                ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
+            )
+        if function.attr == "__call__" and isinstance(function.value, ast.Attribute):
+            # `f"...".encode.__call__()` calls the bound method, so the attribute
+            # this branch sees is `__call__` rather than the conversion. Unwrapped
+            # the same way the sink and constructor resolvers already unwrap it.
+            inner = ast.Call(
+                func = function.value, args = list(node.args), keywords = list(node.keywords),
+            )
+            return _is_interpolated(
+                ast.copy_location(inner, node), resolve, shadowed, resolve_alias,
+            )
+        if function.attr == "parse" and isinstance(function.value, ast.Name):
+            # `compile(ast.parse(f"..."), "<x>", "exec")` compiles the tree that
+            # was parsed FROM the interpolated source, so the source survives the
+            # conversion exactly as `str()` and `.encode()` do. The receiver is
+            # written out, so nothing is guessed at.
+            # `ast.parse(source = f"...")` is the documented keyword spelling of
+            # the same call; requiring a positional argument skipped it entirely.
+            parsed = node.args[0] if node.args else None
+            if parsed is None:
+                for keyword in reversed(node.keywords):
+                    if keyword.arg == "source":
+                        parsed = keyword.value
+                        break
+            if parsed is not None and function.value.id == "ast" and not (
+                shadowed is not None and shadowed("ast")
+            ):
+                return _is_interpolated(parsed, resolve, shadowed, resolve_alias)
+        if (
+            function.attr in ("__add__", "__mod__")
+            and len(node.args) == 1
+            and not node.keywords
+        ):
+            # `"print(".__add__(name)` is `+` written as a call and
+            # `"print(%r)".__mod__(name)` is `%`; the receiver is the template and
+            # the argument is the value, which is exactly the operator spelling
+            # `_is_interpolated` reports above. So it is rebuilt as that operator
+            # and read there, which also applies the visibly numeric exclusion:
+            # `(1).__add__(2)` returns the integer 3 and no source was ever built,
+            # and reporting it forced arithmetic into the allowlist. Only the
+            # one-argument form, which is the only one these methods take.
+            equivalent = ast.BinOp(
+                left = function.value,
+                op = ast.Add() if function.attr == "__add__" else ast.Mod(),
+                right = node.args[0],
+            )
+            return _is_interpolated(
+                ast.copy_location(equivalent, node), resolve, shadowed, resolve_alias,
+            )
+        if function.attr in _IDENTITY_METHODS and node.args and _constructor_name(
+            function.value, shadowed, resolve_alias
+        ) is not None:
+            # `str.__str__(f"...")` is the unbound descriptor spelling of
+            # `f"...".__str__()`: the receiver names the type and the source is the
+            # first argument, the same shape the conversions below already handle.
+            return _is_interpolated(node.args[0], resolve, shadowed, resolve_alias)
+        if function.attr in _IDENTITY_METHODS and not node.args and not node.keywords:
+            # `exec(f"import {name}".__str__())` hands back the same string, so
+            # the receiver is the source. Only the no-argument spelling, which is
+            # the only one that means this.
+            return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
+        if function.attr in _IDENTITY_TRANSLATIONS:
+            argument = node.args[0] if node.args else None
+            empty = (
+                isinstance(argument, ast.Dict) and not argument.keys
+            ) or (
+                isinstance(argument, ast.Constant) and argument.value in ("", b"")
+            )
+            if empty:
+                return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
+            return None
+        if function.attr in _NORMALISERS:
+            # `str.strip(s)` is the unbound descriptor spelling of `s.strip()`, so
+            # the source is the first argument and the receiver is only the type.
+            # Unwrapping the receiver looked at the name `str` and found nothing.
+            # Same shape the conversions below already handle.
+            if _constructor_name(function.value, shadowed, resolve_alias) is not None:
+                return (
+                    _is_interpolated(node.args[0], resolve, shadowed, resolve_alias)
+                    if node.args else None
+                )
+            return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
+        if function.attr in _BUILDERS:
+            # `.join([])` and `.format()` with nothing to splice in produce the
+            # receiver, or the empty string, and nothing was interpolated at all.
+            # Reporting them forced literal code into the allowlist. Only a
+            # visibly empty call counts; anything unknown still reports.
+            spliced = list(node.args) + [k.value for k in node.keywords]
+            empty = not spliced
+            if len(spliced) == 1 and isinstance(spliced[0], (ast.Tuple, ast.List, ast.Set, ast.Dict)):
+                container = spliced[0]
+                elements = container.keys if isinstance(container, ast.Dict) else container.elts
+                empty = not elements
+            if empty and function.attr == "format_map" and not node.keywords:
+                # `format_map` requires exactly one mapping argument, so the empty
+                # call raises TypeError before the sink is reached.
+                return None
+            if empty:
+                # Nothing was spliced in, but the RECEIVER can already be built
+                # source: `f"import {name}".format()` has no placeholders left and
+                # returns the f-string unchanged. Returning None here dropped it,
+                # which turned "this call splices nothing" into a bypass. `.join`
+                # on an empty sequence really is the empty string, so only the
+                # formatting spellings keep their receiver.
+                if function.attr in ("format", "format_map"):
+                    return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
+                return None
+            return f".{function.attr}()"
+        if function.attr == "decode" and _visibly_text(function.value):
+            # Python 3 has no `str.decode`, so `f"...".decode()` raises
+            # AttributeError before the sink is reached. Only a VISIBLY string
+            # receiver; a bytes-producing one still preserves the source.
+            return None
+        if function.attr in _CONVERSIONS:
+            # `str.encode(s)` is the unbound descriptor spelling of `s.encode()`.
+            # There the source is the first argument and the receiver is the type,
+            # so unwrapping the receiver looked at the name `str` and found nothing.
+            # `str.encode(s)` and `builtins.str.encode(s)` alike: the receiver
+            # names the type, so the source is the first argument.
+            if _constructor_name(function.value, shadowed, resolve_alias) is not None:
+                return (
+                    _is_interpolated(node.args[0], resolve, shadowed, resolve_alias)
+                    if node.args else None
+                )
+            # Unwrap the receiver: the conversion changes the type, not the syntax.
+            return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
+    constructor = _constructor_name(function, shadowed, resolve_alias)
+    if constructor is not None and _constructor_accepts_text(node, constructor):
+        source = _constructor_source(node, constructor, shadowed)
+        if source is not None:
+            return _is_interpolated(source, resolve, shadowed, resolve_alias)
+    # `exec("import MODULE".replace("MODULE", name))` splices a value into a
+    # template that is right there in the file, which is the `.format()` shape
+    # spelled differently. Restricted to a literal receiver on purpose: the
+    # `exec(inspect.getsource(f).replace(...))` idiom this repo is built on has a
+    # variable receiver and is not this shape. Verified: adding plain "replace"
+    # to _BUILDERS instead raises 5 findings here and 5 in unsloth, all of them
+    # that idiom; this branch raises none.
+    if isinstance(function, ast.Attribute) and function.attr == "replace":
+        receiver = function.value
+        if isinstance(receiver, ast.Constant):
+            if isinstance(receiver.value, (str, bytes)):
+                return ".replace() on a literal"
+        # `exec(f"import {model_type}".replace("-", "_"))` is the shape from the
+        # original report with a normalisation step bolted on. The receiver is the
+        # f-string itself, so recursing into it keeps that visible. This does not
+        # catch the `exec(inspect.getsource(f).replace(...))` idiom, whose receiver
+        # is a call that is not interpolated and yields None here.
+        inner = _is_interpolated(receiver, resolve, shadowed, resolve_alias)
+        if inner is not None:
+            return inner
+        # `str.replace(template, old, new)` is the unbound spelling; the template
+        # is the first argument rather than the receiver.
+        if _constructor_name(receiver, shadowed, resolve_alias) in ("str", "bytes"):
+            if node.args:
+                template = node.args[0]
+                if isinstance(template, ast.Constant):
+                    if isinstance(template.value, (str, bytes)):
+                        return ".replace() on a literal"
+                # The template can be built rather than literal, same as for the
+                # bound spelling handled just above.
+                return _is_interpolated(template, resolve, shadowed, resolve_alias)
+    # An unrecognised call shape fell through to the closing `return None` in the
+    # original, because a Call is none of the disjoint shapes above it. Spelled out.
+    return None
+
+
+def _always_breaks(body) -> bool:
+    """Whether this loop body reaches a `break` of its own on every path.
+
+    Only the straight-line case: a `break` written at the top level of the body with
+    nothing conditional in front of it. A `break` inside an `if` may not be taken, and
+    one inside a nested loop belongs to that loop.
+    """
+    for statement in body:
+        if isinstance(statement, ast.Break):
+            return True
+        if isinstance(statement, (ast.Expr, ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Pass)):
+            continue
+        return False
+    return False
+
+
+def _can_break(body) -> bool:
+    """Whether a loop body can reach a `break` belonging to that loop.
+
+    A `break` inside a NESTED loop belongs to the nested one, and a `def` or `class`
+    body is a different scope, so both are stepped over.
+    """
+    for statement in body:
+        if isinstance(statement, ast.Break):
+            return True
+        if isinstance(statement, (
+            ast.For, ast.AsyncFor, ast.While,
+            ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef,
+        )):
+            # `orelse` of a nested loop is outside it, so a `break` there is ours.
+            if isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+                if _can_break(statement.orelse):
+                    return True
+            continue
+        for field in ("body", "orelse", "finalbody"):
+            if _can_break(getattr(statement, field, []) or []):
+                return True
+        for handler in getattr(statement, "handlers", []) or []:
+            if _can_break(handler.body):
+                return True
+        for case in getattr(statement, "cases", []) or []:
+            if _can_break(case.body):
+                return True
+    return False
+
+
+def _pattern_bindings(pattern: ast.AST, captures_subject: bool = True):
+    """`(name, captures_subject)` for each name a match pattern binds.
+
+    `captures_subject` says whether the name receives the subject itself, which is the
+    only case where the subject's reason carries over. A sequence element binds a PART
+    of the subject, so it is reported as a binding that does not carry the reason,
+    which clears any stale value instead of inventing one.
+    """
+    if isinstance(pattern, _MATCHAS):
+        if pattern.name is not None:
+            # `case _ as payload` and `case str() as payload` both bind the whole value
+            # the pattern matched, which at the top level IS the subject. Requiring the
+            # subpattern to be absent treated those as binding something else.
+            yield pattern.name, captures_subject
+        if pattern.pattern is not None:
+            yield from _pattern_bindings(pattern.pattern, False)
+    elif isinstance(pattern, _MATCHSTAR):
+        if pattern.name is not None:
+            yield pattern.name, False
+    elif isinstance(pattern, _MATCHOR):
+        for alternative in pattern.patterns:
+            yield from _pattern_bindings(alternative, captures_subject)
+    elif isinstance(pattern, _MATCHSEQUENCE):
+        for element in pattern.patterns:
+            yield from _pattern_bindings(element, False)
+    elif isinstance(pattern, (_MATCHCLASS, _MATCHMAPPING)):
+        for child in ast.walk(pattern):
+            if isinstance(child, _MATCHAS) and child.name is not None:
+                yield child.name, False
+            elif isinstance(child, _MATCHSTAR) and child.name is not None:
+                yield child.name, False
+            elif isinstance(child, _MATCHMAPPING) and child.rest is not None:
+                # `rest` is a plain string field rather than a child node, so
+                # `ast.walk` never reaches it. Checking only the top-level pattern
+                # missed `case C({**payload})`, where `payload` really is rebound.
+                yield child.rest, False
+
+
+def _literal_builtins_import(node: ast.AST, shadowed = None) -> bool:
+    """Whether `node` is written out as `__import__("builtins")`.
+
+    The module is named inline rather than bound to a name, so nothing is guessed at:
+    the argument is a literal and the callee is the unshadowed builtin. `importlib`'s
+    spelling, `import_module("builtins")`, reads the same way when it is reached
+    through the module it lives in.
+    """
+    if not isinstance(node, ast.Call) or not node.args:
+        return False
+    first = node.args[0]
+    if not (isinstance(first, ast.Constant) and first.value == "builtins"):
+        return False
+    function = node.func
+    if isinstance(function, ast.Name):
+        return function.id == "__import__" and not (
+            shadowed is not None and shadowed("__import__")
+        )
+    if isinstance(function, ast.Attribute) and isinstance(function.value, ast.Name):
+        owner = function.value.id
+        if shadowed is not None and shadowed(owner):
+            return False
+        return (
+            (function.attr == "__import__" and owner == "builtins") or
+            (function.attr == "import_module" and owner == "importlib")
+        )
+    return False
+
+
+def _getattr_sink_name(function: ast.Call, aliases = None, shadowed = None) -> str | None:
+    """The sink `getattr(builtins, "exec")` names, or None.
+
+    Split out of `_sink_name` because it is the only five-level-nested block there.
+    Nothing else changed: it is the third and last of that resolver's `ast.Call`
+    arms, so returning None from here means the same as falling off its end did.
+    """
+    # `getattr(builtins, "exec")` names the sink as plainly as `builtins.exec`
+    # does: the attribute is a literal and the object is the builtins module. Both
+    # spellings have to be visible, and no name lookup is being guessed at.
+    qualified = function.func
+    if isinstance(qualified, ast.Attribute) and qualified.attr == "getattr":
+        # `builtins.getattr(builtins, "exec")` states both halves outright, so the
+        # qualified spelling resolves like the bare one.
+        if isinstance(qualified.value, ast.Name) and not (
+            shadowed is not None and shadowed(qualified.value.id)
+        ) and (
+            qualified.value.id == "builtins"
+            or (aliases is not None and aliases(f"module:{qualified.value.id}"))
+        ):
+            qualified = ast.Name(id = "getattr", ctx = ast.Load())
+    if isinstance(qualified, ast.Name) and qualified.id == "getattr":
+        # Two or three arguments: the third is the default, and since `exec`,
+        # `eval` and `compile` are all attributes the builtins module really has,
+        # `getattr(builtins, "exec", print)` returns the builtin and never the
+        # default. Requiring exactly two let that spelling through the gate.
+        if len(function.args) in (2, 3) and not (
+            shadowed is not None and shadowed("getattr")
+        ):
+            owner, attribute = function.args[0], function.args[1]
+            if isinstance(attribute, ast.Constant) and attribute.value in SINKS:
+                if isinstance(owner, ast.Name):
+                    module = owner.id
+                    if shadowed is not None and shadowed(module):
+                        # Only the `getattr` name was tested for shadowing, not the
+                        # object it reads. `def f(builtins, name): getattr(builtins,
+                        # "exec")(...)` is an ordinary method on a parameter, and
+                        # reporting it failed the gate on code that cannot be
+                        # changed to pass.
+                        return None
+                    if module == "builtins" or (
+                        aliases is not None and aliases(f"module:{module}")
+                    ):
+                        return f"builtins.{attribute.value}"
+    return None
+
+
+def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None:
     """The sink this call target names, if any.
 
     Both `exec(...)` and `builtins.exec(...)` execute. Matching only `ast.Name` meant
     the second form passed the lint with zero findings.
+
+    `aliases` resolves a local name to the sink it was imported as, innermost scope
+    first, or returns None. `from builtins import
+    exec as run` gives `run` the same builtin, so reading only the spelling at the call
+    site missed it. Only names bound by an import from `builtins` are recorded, which
+    keeps this to a fact stated in the file rather than a guess about what a name holds.
     """
-    if isinstance(function, ast.Name) and function.id in SINKS:
-        return function.id
+    if isinstance(function, ast.Name):
+        if shadowed is not None and shadowed(function.id):
+            # `exec = print; (exec or print)(...)` calls print. `visit_Call` applies
+            # the shadow only to the OUTER callee, so a rebound name reached through a
+            # composite one was still read as the builtin.
+            return None
+        if function.id in SINKS:
+            return function.id
+        if aliases is not None and aliases(function.id):
+            return aliases(function.id)
+    if isinstance(function, ast.Call) and _partial_sink(function, aliases, shadowed):
+        # `functools.partial(exec, f"...")()` binds the sink and its source and then
+        # calls the result, so neither half resolved on its own. Only the visible
+        # spelling: a `partial` whose first argument is a sink written out right here.
+        return _partial_sink(function, aliases, shadowed)
+    if isinstance(function, ast.NamedExpr):
+        # `(run := builtins.exec)(f"...")` calls whatever the walrus was given, right
+        # here, before the name it binds means anything. The source side already
+        # unwraps a named expression; the callee side stopped at it and read nothing.
+        return _sink_name(function.value, aliases, shadowed)
+    if isinstance(function, ast.Attribute) and function.attr == "__call__":
+        # `exec.__call__(source)` and `builtins.exec.__call__(source)` execute exactly
+        # what `exec(source)` does; the attribute is written out, so nothing is guessed.
+        return _sink_name(function.value, aliases, shadowed)
     if isinstance(function, ast.Attribute) and function.attr in SINKS:
-        if isinstance(function.value, ast.Name) and function.value.id == "builtins":
+        if _literal_builtins_import(function.value, shadowed):
+            # `__import__("builtins").exec(f"...")` names the module inline, so the
+            # owner is a Call rather than a Name and the branch below never ran.
             return f"builtins.{function.attr}"
+        if isinstance(function.value, ast.Name):
+            module = function.value.id
+            if shadowed is not None and shadowed(module):
+                # `def f(builtins, name): builtins.exec(...)` calls a method on an
+                # ordinary parameter, not the module. The owner needs the same shadow
+                # test the bare-name branch above already applies to the callee.
+                return None
+            if module == "builtins" or (aliases is not None and aliases(f"module:{module}")):
+                return f"builtins.{function.attr}"
+    if (
+        isinstance(function, ast.Call)
+        and isinstance(function.func, ast.Attribute)
+        and function.func.attr == "get"
+        and function.args
+        and isinstance(function.args[0], ast.Constant)
+    ):
+        # `{"run": builtins.exec}.get("run")` and `builtins.__dict__.get("exec")` pick
+        # the callee out of a mapping that is written out right here, the same shape
+        # the subscript spelling already reads.
+        key = function.args[0].value
+        if isinstance(function.func.value, ast.Dict):
+            found = _mapping_lookup(function.func.value, key)
+            fallback = function.args[1] if len(function.args) > 1 else None
+            if found is None:
+                found = fallback
+            elif fallback is not None and _uncertain_lookup(function.func.value):
+                # A computed key means the hit is not certain, so the default is a
+                # possible callee too: `{key: print}.get("run", exec)(...)` calls the
+                # builtin whenever `key != "run"`.
+                found = _either_value(found, fallback)
+            if found is not None:
+                return _sink_name(found, aliases, shadowed)
+        elif key in SINKS and _is_builtins_mapping(function.func.value, aliases, shadowed):
+            return f"builtins.{key}"
+    if isinstance(function, ast.Call):
+        # The third and last `ast.Call` arm, tried after the `partial` and mapping
+        # `.get` arms above and reached only when neither of them resolved.
+        return _getattr_sink_name(function, aliases, shadowed)
+    if isinstance(function, ast.Subscript):
+        # `builtins.__dict__["exec"](...)` is the module's own namespace, spelled out:
+        # a literal key on `<builtins>.__dict__` names the sink as plainly as the
+        # attribute form does. Both the `builtins` spelling and a recorded module alias
+        # count, and the owner is shadow-tested like every other owner here.
+        if isinstance(function.slice, ast.Constant) and function.slice.value in SINKS:
+            if _is_builtins_mapping(function.value, aliases, shadowed):
+                return f"builtins.{function.slice.value}"
+        # `[builtins.exec][0](...)` selects the callee from a literal written right
+        # here, which is the same shape `_literal_element` already reads for a source.
+        selected = _literal_selection(function)
+        if selected is not None:
+            return _sink_name(selected, aliases, shadowed)
+    if isinstance(function, ast.BoolOp):
+        # `(enabled and builtins.exec)(...)` calls the builtin whenever the guard holds,
+        # and `(builtins.exec or print)(...)` always does. Same argument as the
+        # conditional below: the whole callee is written out at the call site.
+        # Only the operands that can still be the value: `(print or exec)(...)` calls
+        # print, since a truthy literal ends the chain, and reporting the dead operand
+        # failed the gate. Same rule the source side applies.
+        for value in _reachable_operands(function):
+            resolved = _sink_name(value, aliases, shadowed)
+            if resolved is not None:
+                return resolved
+    if isinstance(function, ast.IfExp):
+        # `(builtins.exec if enabled else print)(...)` executes whenever the condition
+        # holds. The whole callee is written out right here, so reading either branch
+        # stays at the same level of indirection as the rest of this resolver - it is
+        # not an inference about what a name holds.
+        decided = _constant_truth(function.test)
+        if decided is not None:
+            # A literal test decides the callee outright: `(print if True else exec)(...)`
+            # calls print, and reporting the unreachable arm failed the gate on code
+            # that cannot be changed to pass. `not` applied to a constant decides it
+            # too, which is the rule the source side already applies.
+            taken = function.body if decided else function.orelse
+            return _sink_name(taken, aliases, shadowed)
+        return (
+            _sink_name(function.body, aliases, shadowed)
+            or _sink_name(function.orelse, aliases, shadowed)
+        )
     return None
 
 
-def _source_argument(node: ast.Call, sink: str) -> ast.AST | None:
+# A test that is deliberately NOT a constant, so the branch-selecting rule below leaves
+# both arms of a synthetic choice standing.
+_UNDECIDED = "__lint_undecided__"
+
+
+def _walk_this_scope(node: ast.AST):
+    """Every node of `node` that belongs to the scope holding it.
+
+    `ast.walk` with a `continue` on a nested scope does NOT stop: the walk has already
+    queued that lambda's children, so a lambda-local walrus was still read as binding
+    in the enclosing function. This descends by hand and stops at a nested scope, with
+    one exception - a nested definition's decorators, defaults and annotations are
+    evaluated where the definition is WRITTEN, so a walrus in one really does bind
+    here. A comprehension is not pruned either: its walrus target binds in the scope
+    holding it, which is this one.
+    """
+    pending = [node]
+    while pending:
+        current = pending.pop()
+        yield current
+        for child in ast.iter_child_nodes(current):
+            if isinstance(child, (ast.Lambda, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                for header in _definition_time_expressions(child):
+                    pending.append(header)
+                continue
+            pending.append(child)
+
+
+def _definition_time_expressions(node: ast.AST):
+    """The parts of a definition that are evaluated where the definition is written."""
+    for decorator in getattr(node, "decorator_list", []) or []:
+        yield decorator
+    arguments = getattr(node, "args", None)
+    if isinstance(arguments, ast.arguments):
+        for default in arguments.defaults:
+            yield default
+        for default in arguments.kw_defaults:
+            if default is not None:
+                yield default
+        for argument in (
+            *arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs,
+            arguments.vararg, arguments.kwarg,
+        ):
+            if argument is not None and argument.annotation is not None:
+                yield argument.annotation
+    if getattr(node, "returns", None) is not None:
+        yield node.returns
+    for base in getattr(node, "bases", []) or []:
+        yield base
+    for keyword in getattr(node, "keywords", []) or []:
+        yield keyword.value
+
+
+def _prefixed_constructor(constructor: str | None) -> str | None:
+    """A resolved constructor under the `constructor:` key the alias table uses."""
+    return None if constructor is None else f"constructor:{constructor}"
+
+
+def _constant_truth(test: ast.AST):
+    """True/False for a statically decidable condition, else None.
+
+    A written-out constant, or `not` applied to one. Anything else decides nothing,
+    because this checker does not evaluate names.
+    """
+    if isinstance(test, ast.Constant):
+        return bool(test.value)
+    if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+        inner = _constant_truth(test.operand)
+        return None if inner is None else not inner
+    return None
+
+
+def _reachable_operands(node: ast.BoolOp) -> list:
+    """The operands of an `and`/`or` that can still be the value of the expression.
+
+    `"pass" or f"..."` never evaluates the f-string: the first operand is truthy and
+    is the result. `None and f"..."` is the same in the other direction. Reporting the
+    dead operand failed the gate on code that cannot be changed to pass. Only a
+    written-out constant short-circuits here; a name decides nothing.
+    """
+    reachable = []
+    for operand in node.values:
+        reachable.append(operand)
+        if not isinstance(operand, ast.Constant):
+            continue
+        if isinstance(node.op, ast.Or) and operand.value:
+            break
+        if isinstance(node.op, ast.And) and not operand.value:
+            break
+    return reachable
+
+
+def _either_value(first: ast.AST | None, second: ast.AST | None) -> ast.AST | None:
+    """Both outcomes of a choice this checker cannot decide, as one expression.
+
+    Written as an `ast.IfExp` because every resolver here already reads both arms of
+    one. The test is a bare name rather than a constant so that the constant-condition
+    rule does not then pick an arm and undo the merge.
+    """
+    if first is None:
+        return second
+    if second is None:
+        return first
+    choice = ast.IfExp(
+        test = ast.Name(id = _UNDECIDED, ctx = ast.Load()), body = first, orelse = second,
+    )
+    return ast.copy_location(choice, first)
+
+
+def _literal_dict_call(node: ast.AST, shadowed = None) -> ast.Dict | None:
+    """`dict(a = 1)` as the mapping literal it is, when every key is written out."""
+    if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+        return None
+    if node.func.id != "dict":
+        return None
+    if shadowed is not None and shadowed("dict"):
+        # A local `def dict(...)` may return anything, so reading its keyword
+        # arguments as the mapping it builds was a false failure on code that never
+        # passes them on. `dict` is in `_BUILTIN_NAMES` for exactly this reason.
+        return None
+    if any(keyword.arg is None for keyword in node.keywords):
+        return None
+    keys: list = []
+    values: list = []
+    for argument in node.args:
+        # `dict({"source": f"..."}, filename = "<x>")` merges a positional mapping
+        # with the keywords, and reading only the keywords lost the whole first half.
+        positional = argument if isinstance(argument, ast.Dict) else _literal_dict_call(argument)
+        if positional is None:
+            return None
+        keys.extend(positional.keys)
+        values.extend(positional.values)
+    keys.extend(ast.Constant(value = keyword.arg) for keyword in node.keywords)
+    values.extend(keyword.value for keyword in node.keywords)
+    return ast.Dict(keys = keys, values = values)
+
+
+def _has_computed_key(mapping: ast.Dict) -> bool:
+    """Whether any key of a literal mapping is not written out as a constant."""
+    return any(
+        key is not None and not isinstance(key, ast.Constant) for key in mapping.keys
+    )
+
+
+def _mapping_literal(node: ast.AST, shadowed = None) -> ast.Dict | None:
+    """A mapping written out here, whether as a display or as a `dict(...)` call."""
+    if isinstance(node, ast.Dict):
+        return node
+    return _literal_dict_call(node, shadowed)
+
+
+def _uncertain_lookup(mapping: ast.Dict) -> bool:
+    """Whether a lookup in this mapping may miss even when a key appears to match.
+
+    A computed key nested under `**` makes the outer lookup as uncertain as a computed
+    key written at the top level, and checking only the outer keys treated
+    `{**{key: "pass"}}.get("s", f"...")` as a definite hit that drops the default.
+    """
+    if _has_computed_key(mapping):
+        return True
+    for key, value in zip(mapping.keys, mapping.values):
+        if key is not None:
+            continue
+        nested = value if isinstance(value, ast.Dict) else _literal_dict_call(value)
+        if nested is None or _uncertain_lookup(nested):
+            return True
+    return False
+
+
+def _mapping_lookup(mapping: ast.Dict, wanted: str) -> ast.AST | None:
+    """The value a literal mapping gives `wanted`, scanning right to left.
+
+    Last one wins, as it does at runtime. A nested `**{...}` appears as a `None` key
+    and overrides everything written before it, so it is looked into rather than
+    skipped: `{"source": "pass", **{"source": f"..."}}` compiles the second one.
+    A `**` of anything that is not a literal mapping is opaque, and hitting one means
+    the answer cannot be read at all - returning an earlier key there would be worse
+    than returning nothing.
+    """
+    for position, (key, value) in enumerate(
+        zip(reversed(mapping.keys), reversed(mapping.values))
+    ):
+        if key is not None and not isinstance(key, ast.Constant):
+            # A computed key may BE the one we are looking for, and it sits later than
+            # anything before it, so it can override an earlier literal. Its own value
+            # is the answer when it matches; when it does not, the answer is whatever
+            # was written EARLIER under `wanted`. Returning only its own value read
+            # `{"s": f"...", key: "pass"}["s"]` as the clean literal and reported
+            # nothing, and returning only the earlier one missed the override, so
+            # both outcomes are handed back together.
+            cut = len(mapping.keys) - position - 1
+            earlier = _mapping_lookup(
+                ast.Dict(keys = mapping.keys[:cut], values = mapping.values[:cut]), wanted
+            )
+            return _either_value(value, earlier)
+        if key is None:
+            if isinstance(value, ast.Call) and _literal_dict_call(value) is not None:
+                # `**dict(other = "pass")` is a literal mapping written as a call, so
+                # it can be read rather than treated as opaque.
+                value = _literal_dict_call(value)
+            if not isinstance(value, ast.Dict):
+                # An opaque expansion MAY override the wanted key and may not, so the
+                # earlier entry under it still stands: `{"s": f"...", **dict(...)}["s"]`
+                # was reported clean because hitting one abandoned the scan entirely.
+                cut = len(mapping.keys) - position - 1
+                return _mapping_lookup(
+                    ast.Dict(keys = mapping.keys[:cut], values = mapping.values[:cut]), wanted
+                )
+            found = _mapping_lookup(value, wanted)
+            if found is not None:
+                if _has_computed_key(value):
+                    # The nested answer came from a computed key, so it MAY not be
+                    # this entry at all: `{"s": f"...", **{key: "pass"}}["s"]` runs the
+                    # outer f-string whenever `key != "s"`. Taking the nested value
+                    # alone discarded the outer one, so both stand.
+                    cut = len(mapping.keys) - position - 1
+                    earlier = _mapping_lookup(
+                        ast.Dict(keys = mapping.keys[:cut], values = mapping.values[:cut]),
+                        wanted,
+                    )
+                    return _either_value(found, earlier)
+                return found
+            continue
+        if isinstance(key, ast.Constant) and key.value == wanted:
+            return value
+    return None
+
+
+def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) -> ast.AST | None:
     """The source argument of a sink call, whether positional or by keyword.
 
     `exec` and `eval` take their source positional-only, so for those it is always
@@ -104,34 +1343,371 @@ def _source_argument(node: ast.Call, sink: str) -> ast.AST | None:
     was skipped entirely. `studio/backend/core/inference/tools.py` already resolves
     sink arguments this way.
     """
-    if node.args:
-        return node.args[0]
+    if node.args[skip:]:
+        # `exec(*[], *[f"..."])` is valid, and the first AST argument contributes no
+        # values. Statically visible empty expansions are stepped over so the real
+        # first positional value is found; anything opaque stops the search, since
+        # nothing here knows how many values it contributes.
+        candidates = []
+        # Later positional arguments only become candidates BEHIND an expansion that
+        # may contribute nothing. Without one, `compile(src, f"<{name}>", "exec")`
+        # passes the f-string as the FILENAME, which is not executed, and merging it
+        # in reported two real call sites that compile a fixed source under a
+        # generated filename.
+        expanded = False
+        # `skip` steps over arguments that are not candidates at all: in
+        # `partial(exec, f"...")` the first one IS the sink.
+        for argument in node.args[skip:]:
+            if isinstance(argument, ast.Starred):
+                inner = argument.value
+                if isinstance(inner, (ast.Tuple, ast.List, ast.Set)) and not inner.elts:
+                    expanded = True
+                    continue
+                # `*{}` iterates the mapping's KEYS, so an empty one contributes
+                # nothing either. Stopping at it read the real argument as absent.
+                if isinstance(inner, ast.Dict) and not inner.keys:
+                    expanded = True
+                    continue
+                # An opaque expansion may BE the source, `exec(*[f"..."])`, and it
+                # may also contribute nothing at runtime, in which case the next
+                # written-out argument is: `exec(*args, f"...")` with `args = ()`
+                # executes the f-string. Both stand, so it is kept as a candidate and
+                # the scan continues rather than stopping here.
+                candidates.append(argument)
+                expanded = True
+                continue
+            candidates.append(argument)
+            if not expanded:
+                # Nothing skippable in front of it, so this IS the first positional
+                # argument and the rest are the sink's other parameters.
+                break
+        if candidates:
+            answer = candidates[0]
+            for other in candidates[1:]:
+                answer = _either_value(answer, other)
+            return answer
+        # Every positional argument was a visibly empty expansion, so nothing was
+        # passed positionally at all and the keyword form below still applies:
+        # `compile(*[], source = f"...")` compiles the keyword. Returning here read it
+        # as "no source" and reported nothing.
+        if sink.rpartition(".")[2] != "compile":
+            return None
     if sink.rpartition(".")[2] == "compile":
         for keyword in node.keywords:
             if keyword.arg == "source":
                 return keyword.value
+            if keyword.arg is None and _mapping_literal(keyword.value) is not None:
+                # `compile(**{"source": f"..."})` is the same call with the same
+                # argument; a literal mapping names its keys as plainly as a keyword
+                # does, and `dict({...}, filename = "<x>")` is that mapping written as
+                # a call. A `**` of anything else is opaque and stays ignored.
+                found = _mapping_lookup(_mapping_literal(keyword.value), "source")
+                if found is not None:
+                    return found
+            if keyword.arg is None and isinstance(keyword.value, ast.Call):
+                # `compile(**dict(source = f"..."))` is the same call spelled with the
+                # constructor. Only a bare `dict(...)` with plain keywords, which names
+                # its keys as plainly as a literal mapping does.
+                call = keyword.value
+                if (
+                    isinstance(call.func, ast.Name)
+                    and call.func.id == "dict"
+                    and not (shadowed is not None and shadowed("dict"))
+                ):
+                    for inner in reversed(call.keywords):
+                        if inner.arg == "source":
+                            return inner.value
     return None
 
 
 class _Visitor(ast.NodeVisitor):
     def __init__(self, path: Path):
         self.path = path
+        # Set for a notebook cell, so two cells defining the same function name are
+        # separate allowlist entries rather than colliding on one key.
+        self.qualname_prefix = ""
+        # An annotation only runs at module or class scope, and only when the module
+        # has not deferred annotations. Set by the caller from the parsed tree.
+        self.annotations_deferred = False
+        # Kind of each enclosing scope, innermost last. What decides whether an
+        # annotation runs is the scope it sits in directly, not whether a function
+        # appears anywhere above it.
+        self.scope_kinds: list[str] = ["module"]
         self.scope: list[str] = []
         self.findings: list[dict] = []
         # name -> reason, for locals bound to a built string in the current scope.
         self.tainted: list[dict[str, str]] = [{}]
+        # Local name -> the sink it names, for `from builtins import exec as run` and
+        # `import builtins as b`. One flat map: an import binds for the whole module.
+        # `collected` is everything this scope's own imports bind, gathered before the
+        # walk so a definition above the import still sees it - a nested body runs
+        # later, when the import has executed. `sink_aliases` is what has actually
+        # executed in the current scope, because code BEFORE a local import cannot see
+        # it: `def f(n): run(...); from builtins import exec as run` can only raise
+        # UnboundLocalError, and reporting it was a false positive.
+        self.collected_aliases: list[dict[str, str]] = [{}]
+        self.sink_aliases: list[dict[str, str]] = [{}]
+        # Sink names this file rebound to something else, e.g. `from re import compile`.
+        self.shadowed_sinks: list[set[str]] = [set()]
+        # One entry per scope pushed by `_enter`: the enclosing binding state to
+        # restore when a deferred function body is finished with, or None for a class
+        # body, which runs in place and keeps what it writes.
+        self.deferred_state: list = []
+        # Names a scope rebinds LATER, as seen from a body that is deferred past the
+        # whole scope. `shadowed_sinks` is what the scope's own statements see, and at
+        # module or class scope those statements have already run when a later
+        # `def exec` is created, so the two views differ and cannot share one table.
+        self.deferred_shadows: list = [set()]
+        # Sinks a `from builtins import *` puts back for the whole scope. A nested
+        # body is DEFERRED, so it runs after that import even when it is written above
+        # it, and an earlier `exec = print` at this level no longer applies to it.
+        self.star_restored: list[set[str]] = [set()]
+        # Names this scope declared `global`, so a rebinding of one updates the module
+        # rather than a fresh function-level entry that the outer state then outvotes.
+        self.global_names: list[set[str]] = [set()]
+        # Names declared `nonlocal`, which rebind in the nearest enclosing FUNCTION
+        # scope rather than at module level.
+        self.nonlocal_names: list[set[str]] = [set()]
+
+    def _visible_scopes(self):
+        """Scope indices a name lookup here may consult, innermost first.
+
+        A class body is not a lexical scope for the functions defined inside it: a
+        method does not close over class locals, so `class C: from re import compile`
+        does not make a bare `compile` inside `C.f` anything other than the builtin.
+        Treating every enclosing scope alike let a class-body import suppress a real
+        finding in a method. The innermost scope is always visible, which is what keeps
+        code written directly in the class body working.
+        """
+        for index in range(len(self.sink_aliases) - 1, -1, -1):
+            if index != len(self.sink_aliases) - 1 and self.scope_kinds[index] == "class":
+                continue
+            yield index
+
+    def _implicit_base_taint(self) -> dict:
+        """What a lambda or comprehension written in this scope can see.
+
+        An implicit scope closes over the same scopes a nested `def` does, so a class
+        body between it and the names it reads is skipped. Starting it EMPTY was wrong
+        in the other direction: a comprehension inside a class body inside a function
+        still sees the function's locals, and blanking the map made an interpolated
+        value assigned there look clean at the sink.
+        """
+        for index in range(len(self.tainted) - 1, -1, -1):
+            if self.scope_kinds[index] != "class":
+                return dict(self.tainted[index])
+        return {}
+
+    def _alias(self, name: str) -> str | None:
+        """The sink `name` resolves to through an import, innermost scope first."""
+        for index in self._visible_scopes():
+            table = self.sink_aliases if index == len(self.sink_aliases) - 1 else self.collected_aliases
+            if name in table[index]:
+                return table[index][name]
+        return None
+
+    def _is_shadowed(self, name: str) -> bool:
+        """Whether `name` was rebound away from the builtin, innermost scope first.
+
+        Innermost wins in both directions, so a function parameter or local import
+        that shadows an outer `from builtins import exec as run` is honoured rather
+        than inheriting it. Shadowing is checked before the alias at each level,
+        because a comprehension target or parameter that reuses an alias name in the
+        same scope supersedes it.
+        """
+        innermost = len(self.shadowed_sinks) - 1
+        for index in self._visible_scopes():
+            if index != innermost and name in self.star_restored[index]:
+                # This scope's own statements may still be shadowed, but a nested body
+                # runs after the whole scope has executed, so the star import has
+                # happened by then.
+                return False
+            if index != innermost and name in self.deferred_shadows[index]:
+                # A `def exec` written further down an eager scope applies to a body
+                # deferred past it, though not to the statements above it.
+                return True
+            if name in self.shadowed_sinks[index]:
+                return True
+            table = self.sink_aliases if index == len(self.sink_aliases) - 1 else self.collected_aliases
+            if name in table[index]:
+                return False
+        return False
 
     def _qualname(self) -> str:
-        return ".".join(self.scope) if self.scope else "<module>"
+        inner = ".".join(self.scope) if self.scope else "<module>"
+        return f"{self.qualname_prefix}::{inner}" if self.qualname_prefix else inner
+
+    def _outer_parts(self, node):
+        """The pieces of a `def`/`class` that run in the *enclosing* scope.
+
+        A definition statement is not one atomic thing. Decorators, default values,
+        base classes and (unless deferred) parameter and return annotations are all
+        evaluated where the `def` or `class` appears, before the new scope exists.
+        Only the body runs later, in the new scope. Visiting the whole node inside the
+        fresh taint map therefore lost real findings: `payload = f"import {user}"`
+        followed by `def f(x = exec(payload)): ...` executes the built string at
+        definition time, in the scope that built it.
+
+        This is scope *accuracy*, not the taint-inheritance-into-nested-scopes idea
+        that stays rejected: nothing here lets a name bound in one scope be trusted or
+        distrusted in another. It only puts each expression in the scope that actually
+        evaluates it.
+        """
+        parts = list(node.decorator_list)
+        if isinstance(node, ast.ClassDef):
+            parts.extend(node.bases)
+            parts.extend(node.keywords)
+            return parts
+        args = node.args
+        parts.extend(d for d in args.defaults)
+        parts.extend(d for d in args.kw_defaults if d is not None)
+        if not self.annotations_deferred:
+            for arg in (
+                *args.posonlyargs, *args.args, *args.kwonlyargs,
+                args.vararg, args.kwarg,
+            ):
+                if arg is not None and arg.annotation is not None:
+                    parts.append(arg.annotation)
+            if node.returns is not None:
+                parts.append(node.returns)
+        return parts
 
     def _enter(self, node):
+        # Evaluated in the scope we are still in, before the new one exists.
+        for part in self._outer_parts(node):
+            self.visit(part)
+
+        # A function body is DEFERRED: it may never run, so what it binds through
+        # `global` or `nonlocal` must not be recorded in the enclosing scopes while the
+        # definition is merely being scanned. `def configure(): global exec; exec = print`
+        # left a module-level shadow that suppressed a real call at module level.
+        # Class bodies are the opposite - they run in place - so they keep their writes.
+        if not isinstance(node, ast.ClassDef):
+            self.deferred_state.append((
+                [set(level) for level in self.shadowed_sinks],
+                [dict(level) for level in self.sink_aliases],
+                [dict(level) for level in self.collected_aliases],
+            ))
+        else:
+            self.deferred_state.append(None)
+
+        # Defaults are evaluated out here, in the scope the `def` is written in, so
+        # they have to be classified before the new scope is pushed. Doing it after
+        # meant `_visible_scopes` was already skipping the class level, and
+        # `class C: from re import compile` followed by `def f(self, compile=compile)`
+        # read the default as the builtin when it is `re.compile`.
+        outer_defaults = (
+            {} if isinstance(node, ast.ClassDef) else self._sink_defaults(node.args)
+        )
+        # A default is also a VALUE the parameter carries when the caller omits it, so
+        # `def f(payload = f"import {name}"): exec(payload)` executes an interpolated
+        # string on `f()`. Read out here, where the default is evaluated.
+        outer_default_taint = (
+            {} if isinstance(node, ast.ClassDef) else self._default_taint(node.args)
+        )
+        default_sinks = (
+            {} if isinstance(node, ast.ClassDef) else self._default_sink_names(node.args)
+        )
+        default_constructors = (
+            {} if isinstance(node, ast.ClassDef) else self._default_constructor_names(node.args)
+        )
+
         self.scope.append(node.name)
+        self.scope_kinds.append(
+            "class" if isinstance(node, ast.ClassDef) else "function"
+        )
         # A fresh scope: a name built in one function says nothing about the same name
-        # in another.
-        self.tainted.append({})
-        self.generic_visit(node)
+        # in another. A class body is the exception - it runs immediately, in place,
+        # so `payload = f"import {name}"` above `class C: exec(payload)` really is
+        # executed and the map carries over.
+        # A class body runs immediately, in place, so it inherits what encloses it -
+        # but a class namespace is NOT a lexical scope, so a class nested directly in
+        # another sees the enclosing FUNCTION or module, never the outer class's
+        # locals. `class A: payload = f"..."; class B: exec(payload)` raises NameError.
+        self.tainted.append(
+            self._implicit_base_taint() if isinstance(node, ast.ClassDef) else {}
+        )
+        # Aliases are lexical too: a `from builtins import exec as run` inside one
+        # function said nothing about a `run` parameter in the next one. Parameters
+        # shadow, so they are recorded as rebindings for this scope.
+        self.collected_aliases.append({})
+        self.sink_aliases.append({})
+        self.shadowed_sinks.append(set())
+        self.deferred_shadows.append(set())
+        self.star_restored.append(set())
+        self.global_names.append(set())
+        self.nonlocal_names.append(set())
+        if not isinstance(node, ast.ClassDef):
+            arguments = node.args
+            defaults = outer_defaults
+            for argument in (
+                *arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs,
+                arguments.vararg, arguments.kwarg,
+            ):
+                if argument is None:
+                    continue
+                # A parameter shadows whatever the name meant outside, so it has to
+                # cover an alias as well as the literal spelling: with
+                # `from builtins import exec as run` at module level, `def f(run, x)`
+                # supplies its own `run`.
+                reason = outer_default_taint.get(argument.arg)
+                if reason is not None:
+                    self.tainted[-1][argument.arg] = reason
+                constructor = default_constructors.get(argument.arg)
+                if constructor is not None:
+                    # `def f(name, text = builtins.str)` supplies the conversion unless
+                    # the caller overrides it, so `exec(text(f"..."))` in the body is a
+                    # sink call on built source.
+                    self.sink_aliases[-1][f"constructor:{argument.arg}"] = constructor
+                    self.collected_aliases[-1][f"constructor:{argument.arg}"] = constructor
+                    continue
+                if defaults.get(argument.arg):
+                    # `def f(name, exec = exec)` supplies the builtin itself unless the
+                    # caller overrides it, so the body really can reach the sink. A
+                    # fresh name needs the alias recorded, not just the shadow skipped.
+                    sink = default_sinks.get(argument.arg)
+                    if sink is not None:
+                        self.sink_aliases[-1][argument.arg] = sink
+                        self.collected_aliases[-1][argument.arg] = sink
+                    continue
+                if self._binds_over_sink(argument.arg):
+                    self.shadowed_sinks[-1].add(argument.arg)
+                    self.sink_aliases[-1].pop(argument.arg, None)
+                    self.sink_aliases[-1].pop(f"module:{argument.arg}", None)
+        self._collect_aliases(node.body)
+        for statement in node.body:
+            self.visit(statement)
+        self.collected_aliases.pop()
+        self.sink_aliases.pop()
+        self.shadowed_sinks.pop()
+        self.deferred_shadows.pop()
+        self.star_restored.pop()
+        self.global_names.pop()
+        self.nonlocal_names.pop()
         self.tainted.pop()
         self.scope.pop()
+        self.scope_kinds.pop()
+        saved_deferred = self.deferred_state.pop()
+        if saved_deferred is not None:
+            # Roll the enclosing scopes back to what they were before the definition
+            # was scanned. Binding the `def`'s own name, just below, is the only thing
+            # the statement really does out here.
+            shadows, sinks, collected = saved_deferred
+            self.shadowed_sinks[:] = shadows
+            self.sink_aliases[:] = sinks
+            self.collected_aliases[:] = collected
+        # The statement ends by binding its own name out here, to a function or a
+        # class. Leaving the old entry in place reported
+        # `payload = f"import {user}"; def payload(): pass; exec(payload)`, where the
+        # sink can only ever be handed a function object. Unlike a conditional rebind
+        # this one is unconditional: reaching the end of the statement means the name
+        # was assigned.
+        self.tainted[-1].pop(node.name, None)
+        # `def exec(x): ...` makes a later bare `exec(...)` that function.
+        if self._binds_over_sink(node.name):
+            self.shadowed_sinks[-1].add(node.name)
+            self.sink_aliases[-1].pop(node.name, None)
+            self.collected_aliases[-1].pop(node.name, None)
 
     visit_FunctionDef = _enter
     visit_AsyncFunctionDef = _enter
@@ -146,22 +1722,1802 @@ class _Visitor(ast.NodeVisitor):
         to something that is not a built string clears it, so this does not accumulate
         false positives.
         """
-        reason = _is_interpolated(node.value)
+        # Resolved against the taint map, so a name that already holds a built string
+        # carries it: `payload = f"..."; alias = payload; exec(alias)` executes the
+        # interpolation, and reading the right-hand side by shape alone missed it.
+        reason = _is_interpolated(
+            node.value, self.tainted[-1].get, self._is_shadowed, self._alias,
+        )
+        # Runtime order, not source order. The right hand side is evaluated first,
+        # then the targets are assigned left to right, and a target that is not a
+        # plain name has expressions of its own that run at its turn. So in
+        # `payload = table[exec(payload)] = f"import {name}"` the f-string reaches
+        # `payload` before the subscript is evaluated, and the `exec` sees it.
+        # Visiting every target before binding any of them missed that.
+        self.visit(node.value)
+        numeric = _visibly_numeric(node.value)
         for target in node.targets:
-            if not isinstance(target, ast.Name): continue
-            if reason is None:
-                self.tainted[-1].pop(target.id, None)
+            self.visit(target)
+            self._bind(target, reason, numeric)
+            self._bind_unpacked(target, node.value)
+            self._shadow_assignment(target, node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign):
+        """Same tracking for `payload: str = f"...{x}..."`.
+
+        An annotated assignment is an `ast.AnnAssign`, a sibling of `ast.Assign`, and
+        `NodeVisitor` dispatches on the exact class name - so `visit_Assign` never saw
+        it and adding a type hint was enough to hide the binding. `node.value` is
+        optional: a bare `payload: str` declares nothing and must leave taint alone
+        rather than clear it.
+        """
+        # Resolved against the taint map, exactly as `visit_Assign` does: an
+        # annotated alias of a name that already holds a built string carries it, and
+        # reading the right-hand side by shape alone read `alias: str = payload` as a
+        # plain name and CLEARED the binding instead.
+        reason = (
+            _is_interpolated(node.value, self.tainted[-1].get, self._is_shadowed, self._alias)
+            if node.value is not None else None
+        )
+        if node.value is not None:
+            self.visit(node.value)
+            # The numeric marker travels with an annotated assignment too, or
+            # `payload: int = 1; payload += 2` read as concatenation and failed the
+            # gate on arithmetic that can only ever raise TypeError at the sink.
+            self._bind(node.target, reason, numeric = _visibly_numeric(node.value))
+        # An annotated assignment binds like any other one.
+        if node.value is not None:
+            self._shadow_assignment(node.target, node.value)
+        # The annotation is evaluated AFTER the store, so a runtime annotation
+        # observes the new binding: `payload: exec(payload) = f"import {name}"`
+        # executes the value that was just assigned. Confirmed on CPython 3.13.
+        #
+        # But only where the annotation runs at all. A function-local annotation is
+        # never evaluated, and neither is a module or class one under
+        # `from __future__ import annotations`. Visiting those unconditionally
+        # reported code that cannot execute, which is a false CI failure rather than
+        # a missed detection - verified both cases against the interpreter.
+        if self._annotation_executes():
+            self.visit(node.annotation)
+        self.visit(node.target)
+
+    def visit_AugAssign(self, node: ast.AugAssign):
+        """`payload += anything` builds a string the same way `a + b` does.
+
+        `_is_interpolated` reports a plain `a + b` as concatenation without caring what
+        the operands are, so `payload += model_type` has to be treated the same way.
+        Requiring the right hand side to be interpolated made
+        `payload = "import "; payload += model_type; exec(payload)` pass while the
+        one-line `exec("import " + model_type)` was caught, which is the same code.
+
+        `%=` is the same argument in the other spelling: `_is_interpolated` already
+        reports a binary `"import %s" % name` as `%-format`, and
+        `payload = "import %s"; payload %= name` is that expression written as two
+        statements. The remaining augmented operators do not build source out of a
+        value, so they are left alone.
+        """
+        self.visit(node.value)
+        if isinstance(node.op, ast.Mult) and not (
+            _visibly_numeric(node.value) and _visibly_numeric_name(node.target, self.tainted[-1])
+        ):
+            # `payload = 1; payload *= f"..."` leaves `payload` the repeated STRING,
+            # so the numeric marker had to go and the reason of the operand stands.
+            # Two visibly numeric sides are still arithmetic.
+            reason = _is_interpolated(node.value) or (
+                None if _visibly_numeric(node.value) else "string repetition"
+            )
+            self._bind(node.target, f"{reason} repeated" if reason else None)
+            self.visit(node.target)
+            return
+        if isinstance(node.op, (ast.Add, ast.Mod)):
+            if isinstance(node.op, ast.Mod):
+                if _visibly_numeric(node.value) and _visibly_numeric_name(
+                    node.target, self.tainted[-1]
+                ):
+                    # `total = 5; total %= 2` is arithmetic, exactly as `+=` on two
+                    # numbers is. Only when BOTH sides are visibly numeric; anything
+                    # unknown is still read as formatting.
+                    reason, verb = None, "applied"
+                else:
+                    reason, verb = "%-format", "applied"
             else:
-                self.tainted[-1][target.id] = f"{reason} via `{target.id}`"
+                if _visibly_numeric(node.value) and _visibly_numeric_name(
+                    node.target, self.tainted[-1]
+                ):
+                    # `total = 1; total += 2` is arithmetic. Treating every `+=` as
+                    # concatenation reported integers as built source and forced them
+                    # into the allowlist.
+                    reason, verb = None, "appended"
+                else:
+                    reason, verb = _is_interpolated(node.value) or "string concatenation", "appended"
+            if reason is None:
+                # Still a number after the operation, so a later `+=` on it is also
+                # arithmetic rather than concatenation.
+                self._bind(node.target, None, numeric = True)
+            else:
+                self._bind(node.target, f"{reason} {verb}")
+        self.visit(node.target)
+
+    @staticmethod
+    def _literal_elements(iterable):
+        """The elements a written-out iterable yields, or None if it is not one.
+
+        Iterating a mapping yields its KEYS, so `for payload in {f"...": None}` binds
+        the interpolated key. Only tuples, lists and sets were read, so that loop
+        cleared the target and the sink in the body reported nothing. A `**` expansion
+        appears as a `None` key and says nothing, so such a mapping is not read.
+        """
+        if isinstance(iterable, (ast.Tuple, ast.List, ast.Set)):
+            return iterable.elts
+        if isinstance(iterable, ast.Dict) and all(k is not None for k in iterable.keys):
+            return iterable.keys
+        return None
+
+    def visit_For(self, node: ast.For):
+        """`for payload in (f"import {name}",): exec(payload)` binds the same way.
+
+        A loop target is a binding form like the assignments already tracked, and this
+        one stays at the same level of indirection: only a literal tuple or list is
+        looked into, so `for payload in build(): ...` reports nothing because nothing
+        here knows what `build()` yields.
+
+        A literal iterable also REBINDS: every element is statically visible, so if
+        none of them is built then the target is clean afterwards no matter what it
+        held before. Binding only on the interpolated elements left a stale reason on
+        `payload = f"import {name}"; for payload in ("pass",): exec(payload)`, which
+        executes the literal and nothing else. An empty literal never runs its body and
+        never rebinds, so it clears nothing.
+        """
+        self.visit(node.iter)
+        # Reaching the body means the target was rebound from the iterable, whatever
+        # that is, so a reason carried in from before the loop is stale there:
+        # `payload = f"..."; for payload in values: exec(payload)` executes what
+        # `values` yielded. Cleared for the body; the pre-loop state is put back after
+        # it, since an empty iterable never rebinds at all.
+        before_loop = dict(self.tainted[-1])
+        self._bind(node.target, None)
+        self._bind_unpacked(node.target, None)
+        for child in ast.walk(node.target):
+            if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                self.tainted[-1].pop(child.id, None)
+        iterated = self._literal_elements(node.iter)
+        if iterated:
+            reasons = [_is_interpolated(element) for element in iterated]
+            self._bind(node.target, next((r for r in reasons if r is not None), None))
+            # A tuple target takes each element APART, so the whole-element reason
+            # says nothing about it. Aggregated across elements, first reason wins,
+            # because the loop runs over all of them.
+            aggregated: dict[str, str] = {}
+            for element in iterated:
+                before = dict(self.tainted[-1])
+                self._bind_unpacked(node.target, element)
+                for key, value in self.tainted[-1].items():
+                    if before.get(key) != value:
+                        aggregated.setdefault(key, value)
+                self.tainted[-1] = before
+            self.tainted[-1].update(aggregated)
+        self.visit(node.target)
+        # `for exec in callbacks:` calls the callback in the body, not the builtin.
+        # Store context only: in `for table[exec] in ...` the `exec` is a subscript key
+        # that is merely READ, so treating it as bound shadowed the sink for the body.
+        names = {
+            child.id for child in ast.walk(node.target)
+            if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+        }
+        saved_scope = self._shadow_locals(self._sink_valued(names, node.target, node.iter))
+        empty = self._literal_elements(node.iter) == [] or (
+            isinstance(node.iter, ast.Constant)
+            and isinstance(node.iter.value, (str, bytes))
+            and not node.iter.value
+        )
+        if not empty:
+            # `for _ in []: exec(f"...")` never runs its body, and reporting the sink
+            # in it failed the gate on code that cannot execute. The `else` suite below
+            # still runs, and an iterable this cannot read still keeps its body.
+            for statement in node.body:
+                self.visit(statement)
+        # The `else` suite also runs when the iterable was empty, in which case the
+        # target was never bound and the name still means whatever it meant outside -
+        # `for exec in []: pass` leaves `exec` as the builtin.
+        #
+        # The target holds the LAST element once the loop is over, whatever the body
+        # saw while it ran. `for payload in [f"import {name}", "pass"]: pass` then
+        # `exec(payload)` executes the literal and nothing else, so keeping the
+        # aggregated reason past the loop was a false positive on correct code.
+        #
+        # Unless the body can leave early. A `break` stops the loop on any element, so
+        # `for payload in [f"...", "pass"]: break` really does leave the FIRST one
+        # bound, and taking the last would have reported that file clean. The
+        # aggregate, which covers every element, is kept in that case.
+        literal = self._literal_elements(node.iter)
+        # A SET has no order, so "the last element" is a property of the source text
+        # and not of the iteration. Any of them may be the one left bound, so the
+        # aggregate stands, exactly as it does when the body can break. A mapping does
+        # keep insertion order, so its keys are read like a list.
+        ordered = literal and not isinstance(node.iter, ast.Set)
+        breaks = _can_break(node.body)
+        if ordered and not breaks:
+            last = literal[-1]
+            self._bind(node.target, _is_interpolated(last))
+            self._bind_unpacked(node.target, last)
+        if not literal:
+            # Nothing is known about what the target holds afterwards, and an empty
+            # iterable leaves whatever it held before, so the pre-loop state stands.
+            for child in ast.walk(node.target):
+                if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                    self.tainted[-1].pop(child.id, None)
+                    if child.id in before_loop:
+                        self.tainted[-1][child.id] = before_loop[child.id]
+        # A visibly nonempty literal is the opposite: the loop necessarily ran, so the
+        # target keeps whatever the last element gave it. `exec = print` then
+        # `for exec in [builtins.exec]: pass` leaves `exec` as the builtin, and
+        # restoring the pre-loop shadow suppressed the call that follows. Only this
+        # shape, where every element is written out in the source.
+        if not literal:
+            self._restore_locals(saved_scope)
+        elif breaks:
+            # A `break` means the loop stopped on SOME element, and every one of them
+            # was already assigned to the target to get there. The aggregate covers all
+            # of them and is what the taint half keeps in this case, so restoring the
+            # pre-loop state here contradicted it: `run = print;
+            # for run in [builtins.exec]: break` leaves `run` as the builtin, and the
+            # restored `print` shadow hid the call that follows.
+            pass
+        elif not ordered:
+            # A set has no last element, so any of them may be the one left bound.
+            # The aggregate - which treats the target as a sink if ANY element is -
+            # is the conservative answer and is already installed.
+            pass
+        elif len(literal) > 1:
+            # The loop ran to the end, so the target holds the LAST element. The body
+            # had to treat a mixed literal as a sink on its first pass, but afterwards
+            # `for run in [builtins.exec, print]` leaves `run` as `print`, and keeping
+            # the sink alias failed the gate on a call that cannot reach the builtin.
+            self._restore_locals(saved_scope)
+            self._shadow_locals(self._sink_valued(
+                names, node.target, ast.Tuple(elts = [literal[-1]], ctx = ast.Load()),
+            ))
+        if not (literal and _always_breaks(node.body)):
+            # A nonempty literal loop whose body unconditionally breaks on the first
+            # iteration can never run its `else`, and visiting it reported a sink that
+            # cannot execute. Only that shape is decided; every other loop keeps it.
+            for statement in node.orelse:
+                self.visit(statement)
+
+    visit_AsyncFor = visit_For
+
+    def visit_Match(self, node: _MATCH):
+        """`match f"import {name}": case payload: exec(payload)` binds the subject.
+
+        An irrefutable capture pattern is a binding form like the assignments and loop
+        targets already tracked, and it sits at the same one level of indirection: the
+        subject is visible right there. Only capture patterns and the elements of a
+        sequence pattern are read, both of which name what they bind outright. A class
+        or mapping pattern binds from somewhere this does not model, so its names are
+        cleared rather than guessed at.
+        """
+        self.visit(node.subject)
+        reason = _is_interpolated(node.subject, self.tainted[-1].get)
+        subject_sink = _sink_name(node.subject, self._alias, self._is_shadowed)
+        subject_sink = subject_sink.rpartition(".")[2] if subject_sink else None
+        if subject_sink is None:
+            # `match builtins.str: case s: exec(s(f"..."))` binds the conversion as
+            # plainly as the sink form binds the builtin, and only sinks were read, so
+            # the capture was treated as an ordinary shadow. Kept under the prefixed
+            # key `_shadow_locals` already understands.
+            subject_sink = _prefixed_constructor(
+                _constructor_name(node.subject, self._is_shadowed, self._alias)
+            )
+        for case in node.cases:
+            bound = [name for name, _ in _pattern_bindings(case.pattern)]
+            # `match builtins.exec: case exec:` binds the builtin back to its own
+            # spelling, the same way `for exec in [builtins.exec]` does, so shadowing
+            # the captured name unconditionally hid the call in the body. Only a
+            # whole-subject capture, where the value is the subject itself.
+            # The sink NAME, so a FRESH capture such as `case check:` is registered as
+            # an alias for it. Marking it "not shadowed" left it resolving to nothing.
+            shadow = {
+                name: subject_sink if captures_subject else None
+                for name, captures_subject in _pattern_bindings(case.pattern)
+            }
+            saved_scope = self._shadow_locals(shadow if subject_sink else bound)
+            for name, captures_subject in _pattern_bindings(case.pattern):
+                self.tainted[-1][name] = f"{reason} via `{name}`" if (
+                    reason is not None and captures_subject
+                ) else None
+                if self.tainted[-1][name] is None:
+                    self.tainted[-1].pop(name, None)
+            if case.guard is not None:
+                self.visit(case.guard)
+            for statement in case.body:
+                self.visit(statement)
+            # An IRREFUTABLE case - a bare capture with no guard - always matches, so
+            # its binding survives the statement, the same way a nonempty literal
+            # loop's target does. Restoring unconditionally discarded it, and
+            # `match builtins.exec: case run: pass` then `run(...)` really does call
+            # the builtin. Every other case is conditional and is restored.
+            # `case _ as run:` is a MatchAs whose inner pattern is a wildcard, which
+            # is itself irrefutable, so the whole thing always matches and `run` stays
+            # bound afterwards. Reading only `pattern is None` missed that spelling.
+            inner = getattr(case.pattern, "pattern", None)
+            irrefutable = case.guard is None and isinstance(
+                case.pattern, (_MATCHAS, _MATCHSTAR),
+            ) and (
+                inner is None
+                or (isinstance(inner, _MATCHAS) and inner.pattern is None)
+            )
+            if not irrefutable:
+                self._restore_locals(saved_scope)
+
+    def visit_If(self, node: ast.If):
+        """Only the suite a literal test selects is traversed.
+
+        `if True: from re import compile as c` / `else: from builtins import compile as c`
+        binds the regex compiler and nothing else, and visiting both suites recorded a
+        builtin alias that never exists. The pre-pass applies the same rule. Anything
+        the test does still runs, and an undecidable test keeps both suites.
+        """
+        self.visit(node.test)
+        decided = _constant_truth(node.test)
+        if decided is None:
+            for statement in node.body:
+                self.visit(statement)
+            for statement in node.orelse:
+                self.visit(statement)
+            return
+        for statement in (node.body if decided else node.orelse):
+            self.visit(statement)
+
+    def visit_TypeAlias(self, node):
+        """`type run = int` rebinds the name for the rest of the scope."""
+        bound = getattr(node, "name", None)
+        if isinstance(bound, ast.Name):
+            self._shadow_sink(bound.id)
+            self.tainted[-1].pop(bound.id, None)
+
+    def visit_Delete(self, node: ast.Delete):
+        """`del exec` at module or class scope puts the builtin back.
+
+        A shadow recorded by an earlier `exec = print` outlived the `del`, so the
+        following bare call read as shadowed when Python would resolve it through
+        builtins again. Only module and class scope: deleting a function local leaves
+        the compiler treating that spelling as a local for the whole function, so the
+        name does not fall back to the builtin there.
+        """
+        for target in node.targets:
+            self.visit(target)
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                continue
+            self.tainted[-1].pop(target.id, None)
+            # The alias goes in both cases: the name is unbound either way, so
+            # `from builtins import exec as run; del run; run(...)` raises rather than
+            # executing, and keeping the entry reported a call that cannot happen.
+            for table in (self.sink_aliases, self.collected_aliases):
+                # The prefixed entries go with it: after `import builtins as b; del b`
+                # the name is unbound, so `b.exec(...)` raises NameError and keeping
+                # `module:b` reported a call that cannot happen. Same for a
+                # `constructor:` entry.
+                table[-1].pop(target.id, None)
+                table[-1].pop(f"module:{target.id}", None)
+                table[-1].pop(f"constructor:{target.id}", None)
+            level = self._binding_level(target.id)
+            if level != len(self.scope_kinds) - 1:
+                # `global exec; del exec` deletes the MODULE binding, so the shadow an
+                # earlier `exec = print` left there has to go and the following call
+                # reaches the builtin. Treating it as a function-local delete kept that
+                # shadow and reported the call as nothing. Same for `nonlocal`.
+                self.tainted[level].pop(target.id, None)
+                for table in (self.sink_aliases, self.collected_aliases):
+                    table[level].pop(target.id, None)
+                    table[level].pop(f"module:{target.id}", None)
+                    table[level].pop(f"constructor:{target.id}", None)
+                self.shadowed_sinks[level].discard(target.id)
+                continue
+            if self.scope_kinds[-1] == "function":
+                # But the SHADOW stays inside a function: the compiler still treats
+                # that spelling as a local for the whole body, so it does not fall back
+                # to the builtin or to an outer alias.
+                self.shadowed_sinks[-1].add(target.id)
+            else:
+                # At module or class scope the bare spelling resolves through builtins
+                # again, so a shadow recorded by an earlier `exec = print` has to go.
+                self.shadowed_sinks[-1].discard(target.id)
+
+    def visit_Global(self, node: ast.Global):
+        """`global exec` sends later rebindings in this function to module scope."""
+        self.global_names[-1].update(node.names)
         self.generic_visit(node)
 
+    def visit_Nonlocal(self, node: ast.Nonlocal):
+        """`nonlocal exec` sends later rebindings to the nearest enclosing function.
+
+        Same problem `global` had: the update went into this scope's fresh bookkeeping
+        while the enclosing entry, which is the one that actually applies, stayed
+        stale and outvoted it.
+        """
+        self.nonlocal_names[-1].update(node.names)
+        self.generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler):
+        """`except Exception as payload:` rebinds, and then deletes, the name.
+
+        Inside the handler `payload` is necessarily the exception object, so a reason
+        carried in from before the `try` was stale. Python also unbinds the name when
+        the handler exits, so it is cleared on the way out as well rather than
+        restored.
+        """
+        if node.type is not None:
+            self.visit(node.type)
+        if node.name is not None:
+            self.tainted[-1].pop(node.name, None)
+            # Every recognised builtin name, not just the sinks: `except E as str:`
+            # binds the exception object, so unwrapping `str(...)` as a conversion was
+            # a false failure on code that cannot be made to pass. Same set the
+            # parameters, imports and other binding forms already use.
+            if node.name in _BUILTIN_NAMES or self._alias(node.name):
+                self.shadowed_sinks[-1].add(node.name)
+                self.sink_aliases[-1].pop(node.name, None)
+                self.sink_aliases[-1].pop(f"module:{node.name}", None)
+        for statement in node.body:
+            self.visit(statement)
+        if node.name is not None:
+            self.tainted[-1].pop(node.name, None)
+            # Python unbinds the name when the handler exits, so at module or class
+            # scope the bare spelling resolves through builtins again. Inside a
+            # function it does not: the compiler still treats it as a local, and a
+            # later reference raises UnboundLocalError rather than calling the
+            # builtin, so the shadow has to stay - same distinction `visit_Delete`
+            # already draws.
+            if self.scope_kinds[-1] != "function":
+                self.shadowed_sinks[-1].discard(node.name)
+
+    def visit_With(self, node: ast.With):
+        """`with ... as payload:` rebinds unconditionally before the body runs.
+
+        Reaching the body means every `as` target was assigned, so
+        `payload = f"import {user}"` followed by
+        `with nullcontext("import os") as payload: exec(payload)` executes the literal.
+        Same statement-level rebinding already accepted for `def`, `class` and `import`.
+        The context expression is visited first, since it is evaluated first.
+        """
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self.visit(item.optional_vars)
+                self._bind_unpacked(item.optional_vars, None)
+                self._bind(item.optional_vars, None)
+                # A tuple target pairs with nothing when the value is opaque, and
+                # `_bind` ignores a non-name target, so `with ctx() as (payload, _):`
+                # kept a stale reason on `payload` even though reaching the suite
+                # guarantees it was rebound. Every Store name is cleared.
+                for child in ast.walk(item.optional_vars):
+                    if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                        self.tainted[-1].pop(child.id, None)
+                # Applied HERE, before the NEXT context expression is visited. Items are
+                # entered left to right and each `as` target is bound before the one
+                # after it runs, so delaying every shadow to the end read
+                # `with ctx(print) as exec, ctx(exec(...))` as a call to the builtin
+                # when it is the object the first item handed over. Statement-level
+                # binding between items, which is the level this checker works at.
+                self._shadow_locals({
+                    child.id: None
+                    for child in ast.walk(item.optional_vars)
+                    if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+                })
+        # `with ctx() as exec:` calls whatever the context manager handed over.
+        names = {
+            child.id
+            for item in node.items
+            if item.optional_vars is not None
+            for child in ast.walk(item.optional_vars)
+            # Store context only: in `with ctx() as table[exec]` the `exec` is a
+            # subscript key that is merely READ, so treating it as bound shadowed a
+            # sink the code goes on to call. Same rule the loop targets follow.
+            if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+        }
+        # Not restored afterwards. Unlike a comprehension target, an `as` target is an
+        # ordinary assignment in the enclosing scope and is still bound once the suite
+        # ends, so `with ctx() as exec: pass` then `exec(f"import {name}")` calls
+        # whatever the context manager handed over, not the builtin.
+        self._shadow_locals(names)
+        for statement in node.body:
+            self.visit(statement)
+
+    visit_AsyncWith = visit_With
+
+    def visit_NamedExpr(self, node: ast.NamedExpr):
+        """`(payload := f"import {name}")` as a statement, then `exec(payload)`.
+
+        Unwrapping the walrus at the sink only helps when the named expression is
+        handed straight to it. Standing on its own it is exactly the one level of
+        local indirection already tracked for `payload = f"..."`, and it is a
+        parenthesis away from that spelling, so it has to bind the same way.
+        """
+        self.generic_visit(node)
+        # Resolved against the taint map for the same reason `visit_Assign` is:
+        # `(alias := payload)` copies whatever `payload` holds.
+        self._bind(
+            node.target,
+            _is_interpolated(node.value, self.tainted[-1].get, self._is_shadowed, self._alias),
+        )
+        # `(exec := builtins.exec)` hands the builtin back to its own spelling exactly
+        # as the statement form does, and only the taint map was being updated, so an
+        # earlier `exec = print` shadow survived and suppressed the real call.
+        self._shadow_assignment(node.target, node.value)
+
+    def _annotation_executes(self) -> bool:
+        """Whether an annotation in the current scope is evaluated at runtime.
+
+        A module or class body executes its annotations; a function body does not.
+        What matters is the scope the annotation sits in DIRECTLY: a class nested
+        inside a function still runs its body, so its annotations are evaluated even
+        though a function encloses it. Counting function depth instead treated those
+        as inert and missed them.
+        """
+        return not self.annotations_deferred and self.scope_kinds[-1] != "function"
+
+    def _bind_unpacked(self, target: ast.AST, value: ast.AST) -> None:
+        """`payload, ignored = f"import {name}", None` binds each element separately.
+
+        `_is_interpolated` looks at the tuple as a whole and reports nothing, and
+        `_bind` ignores a target that is not a Name, so unpacking hid the same one
+        level of local indirection the tracking exists to cover. Only the shapes that
+        line up element for element are paired; a starred target or a mismatched
+        length is left alone rather than guessed at.
+        """
+        for element, item in self._unpacked_pairs(target, value):
+            # Resolved against the taint map, as the whole-statement path is: an
+            # element that is an already tainted NAME - `alias, ignored = payload,
+            # None` - carries that name's reason rather than clearing the binding.
+            self._bind(
+                element,
+                _is_interpolated(item, self.tainted[-1].get, self._is_shadowed, self._alias),
+            )
+            self._bind_unpacked(element, item)
+
+    @staticmethod
+    def _unpacked_pairs(target: ast.AST, value: ast.AST) -> list:
+        """`[(sub_target, sub_value)]` for an unpacking whose pairing is readable.
+
+        A single starred target still pins the rest: the fixed targets before the star
+        take from the front and the fixed ones after take from the back. Anything less
+        determined - a starred VALUE, two stars, or a literal too short to fill both
+        ends - yields nothing rather than a guess.
+        """
+        if not isinstance(target, (ast.Tuple, ast.List)):
+            return []
+        if not isinstance(value, (ast.Tuple, ast.List)):
+            return []
+        if any(isinstance(e, ast.Starred) for e in value.elts):
+            return []
+        starred = [i for i, e in enumerate(target.elts) if isinstance(e, ast.Starred)]
+        if starred:
+            # `payload, *rest = [f"import {name}"]` still says exactly what reaches
+            # `payload`: the fixed targets before the star take from the front and the
+            # fixed ones after it take from the back. Only when the value has enough
+            # elements to fill them, and only one star, which is all Python allows.
+            if len(starred) > 1:
+                return []
+            cut = starred[0]
+            head = target.elts[:cut]
+            tail = target.elts[cut + 1:]
+            if len(value.elts) < len(head) + len(tail):
+                return []
+            pairs = list(zip(head, value.elts[:len(head)]))
+            if tail:
+                pairs += list(zip(tail, value.elts[len(value.elts) - len(tail):]))
+        else:
+            if len(target.elts) != len(value.elts):
+                return []
+            pairs = list(zip(target.elts, value.elts))
+        return pairs
+
+    def _bind(self, target: ast.AST, reason: str | None, numeric: bool = False) -> None:
+        if not isinstance(target, ast.Name):
+            return
+        if numeric:
+            # Not a reason: a marker saying the name holds a number, so a later `+=`
+            # on it is arithmetic rather than concatenation. `_is_interpolated` only
+            # ever reads string reasons out of this map, and the sentinel is not one.
+            self.tainted[len(self.tainted) - 1 if self.scope_kinds[-1] != "class"
+                         else self._binding_level(target.id)][target.id] = _NUMERIC
+            return
+        level = len(self.tainted) - 1
+        if self.scope_kinds[-1] == "class":
+            # A class body runs immediately, so a `global`/`nonlocal` assignment in one
+            # really does update the outer name. Writing it into the class map lost it
+            # when the class exited. Function bodies keep the isolation on purpose -
+            # they are deferred and may never run.
+            level = self._binding_level(target.id)
+        if reason is None:
+            self.tainted[level].pop(target.id, None)
+        else:
+            self.tainted[level][target.id] = f"{reason} via `{target.id}`"
+
+    @staticmethod
+    def _declared_outer(body) -> set:
+        """Names this statement list declares `global` or `nonlocal`, for the pre-pass.
+
+        Neither is a local binding, so an assignment to one must not be recorded as a
+        shadow of this scope; it is handled where the name actually lives.
+        """
+        names = set()
+        for statement in body:
+            if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            if isinstance(statement, (ast.Global, ast.Nonlocal)):
+                names.update(statement.names)
+                continue
+            # A declaration applies to the whole function wherever it is written, so a
+            # same-scope `if` or `try` around it has to be looked into.
+            for field in ("body", "orelse", "finalbody", "handlers"):
+                for child in getattr(statement, field, []) or []:
+                    if isinstance(child, ast.ExceptHandler):
+                        names |= _Visitor._declared_outer(child.body)
+                    elif isinstance(child, ast.stmt):
+                        names |= _Visitor._declared_outer([child])
+            for case in getattr(statement, "cases", []) or []:
+                names |= _Visitor._declared_outer(case.body)
+        return names
+
+    def _collect_aliases(self, body, declared = None) -> None:
+        """Record the sink aliases a scope's own imports bind, before walking it.
+
+        An import binds for the whole scope, not from its line downwards, so
+        `def use(name): run(f"import {name}")` followed at module level by
+        `from builtins import exec as run` really does execute interpolated source.
+        Resolving in traversal order missed it. Only the statements directly in this
+        scope are read; nested scopes collect their own.
+        """
+        if declared is None:
+            # Computed ONCE for the scope. `_declared_outer` walks the whole body, and
+            # asking it per assignment target made this quadratic: a generated function
+            # with 2,000 plain assignments took seconds, which is a lint job that times
+            # out on a large enough file. The set belongs to the scope, not to the
+            # statement, so it is passed down into the same-scope suites below.
+            declared = self._declared_outer(body)
+        # Spellings this scope has already given a meaning of its own, in source order.
+        # `from re import compile` above `run = compile` means `run` is the regex
+        # compiler, and the pre-pass runs before any of these statements have been
+        # traversed, so `_is_shadowed` cannot answer for them yet.
+        rebound: set = set()
+        for statement in body:
+            # Six independent passes over the same statement, in the order the blocks
+            # they came from were written. `rebound` is one set mutated in place by
+            # more than one of them, so this order is the definition of what each pass
+            # sees, not a formatting choice.
+            if self._alias_pass_definition(statement, declared, rebound):
+                continue
+            self._alias_pass_rebound_names(statement, rebound)
+            self._alias_pass_builtins_imports(statement)
+            self._alias_pass_block_targets(statement, declared)
+            self._alias_pass_walrus_locals(statement, declared)
+            self._alias_pass_bindings(statement, declared, rebound)
+
+    def _alias_pass_definition(self, statement, declared, rebound) -> None:
+        """A `def` or `class` binds its own name in THIS scope.
+
+        Returns True when it handled the statement, which is every time its guard
+        holds: the original `continue`d out of the iteration at both exits."""
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            # Its body is its own scope and collects for itself, but the statement
+            # still BINDS its name here, so a sibling defined above it closes over
+            # this function rather than an outer alias of the same name.
+            for header in _definition_time_expressions(statement):
+                # A default, decorator or annotation is evaluated where the
+                # definition is WRITTEN, so `def g(value = (run := builtins.exec))`
+                # binds `run` in this scope. The pre-pass skipped the whole
+                # statement and never saw it.
+                for child in _walk_this_scope(header):
+                    if isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name):
+                        self._collect_assignment_alias(child.target, child.value, rebound)
+                        if self.scope_kinds[-1] == "function" and child.target.id not in declared:
+                            if self._binds_over_sink(child.target.id):
+                                self.shadowed_sinks[-1].add(child.target.id)
+            if self.scope_kinds[-1] != "function":
+                if statement.name not in declared and (
+                    statement.name in _BUILTIN_NAMES
+                    or self._alias(statement.name)
+                    or self._alias(f"module:{statement.name}")
+                ):
+                    # Recorded for DEFERRED bodies only: a sibling `def f` written
+                    # above `def exec` really does call that function when it runs.
+                    self.deferred_shadows[-1].add(statement.name)
+                # At module or class scope the statements above a `def` have
+                # ALREADY run when it is created, so a later `def exec` does not
+                # apply to them: `exec(f"...")` written above one really does call
+                # the builtin. Pre-shadowing there hid the call entirely. Inside a
+                # function the name is local for the whole body, which is why this
+                # exists; a nested body still sees the binding through its own
+                # collection pass and the outward walk.
+                return True
+            if statement.name not in declared:
+                # `_BUILTIN_NAMES` too, not only an imported alias: `def exec(...)`
+                # below a sibling `def f` really does make `f` call that function,
+                # and reporting it failed the gate on code that cannot be changed
+                # to pass. Same set every other binding form here uses.
+                if (
+                    statement.name in _BUILTIN_NAMES
+                    or self._alias(statement.name)
+                    or self._alias(f"module:{statement.name}")
+                ):
+                    self.shadowed_sinks[-1].add(statement.name)
+            return True
+        return False
+
+    def _alias_pass_rebound_names(self, statement, rebound) -> None:
+        """Records spellings an import in this scope has already given a meaning to."""
+        if isinstance(statement, (ast.Import, ast.ImportFrom)) and not (
+            getattr(statement, "module", None) == "builtins"
+            and not getattr(statement, "level", 0)
+        ):
+            for alias in statement.names:
+                if isinstance(statement, ast.ImportFrom):
+                    rebound.add(alias.asname or alias.name)
+                elif alias.name.split(".")[0] != "builtins":
+                    # `import builtins` and `import builtins as b` bind the real
+                    # module, so the name they bind still means the builtins module
+                    # and an assignment reading it is a genuine sink alias.
+                    rebound.add(alias.asname or alias.name.split(".")[0])
+
+    def _alias_pass_builtins_imports(self, statement) -> None:
+        """`from builtins import exec as run` and `import builtins as b`."""
+        if isinstance(statement, ast.ImportFrom):
+            if statement.module == "builtins" and not statement.level:
+                for alias in statement.names:
+                    if alias.name == "*":
+                        # A star import binds every sink for the whole scope, so a
+                        # `def` written above it sees them. The runtime visitor
+                        # already installed all three and the pre-pass ignored the
+                        # `*` entirely.
+                        for sink in SINKS:
+                            self.collected_aliases[-1][sink] = sink
+                            self.star_restored[-1].add(sink)
+                        for constructor in _CONSTRUCTORS:
+                            # The star hands back the conversions as well as the
+                            # sinks, so `str = print` above one stops applying and
+                            # `exec(str(f"..."))` reaches the real `str`.
+                            self.collected_aliases[-1][f"constructor:{constructor}"] = constructor
+                            self.star_restored[-1].add(constructor)
+                        continue
+                    if alias.name in SINKS:
+                        self.collected_aliases[-1][alias.asname or alias.name] = alias.name
+                    elif alias.name in _CONSTRUCTORS:
+                        # `from builtins import str as s` binds for the whole scope
+                        # too, so `def f(name): exec(s(f"import {name}"))` written
+                        # above it still reaches the sink. Only the sink imports
+                        # were pre-collected, so the conversion was never unwrapped
+                        # in a body defined earlier in the file.
+                        self.collected_aliases[-1][
+                            f"constructor:{alias.asname or alias.name}"
+                        ] = alias.name
+        elif isinstance(statement, ast.Import):
+            # The module form binds for the whole scope too, so
+            # `def f(x): b.exec(f"import {x}")` above `import builtins as b` is
+            # still a finding.
+            for alias in statement.names:
+                bound = alias.asname or alias.name.split(".")[0]
+                if alias.name == "builtins" and alias.asname:
+                    self.collected_aliases[-1][f"module:{alias.asname}"] = "builtins"
+                else:
+                    # `import builtins as b` then `import re as b` leaves `b` as
+                    # `re` for the whole scope, so a nested body must not keep the
+                    # earlier entry. The pre-pass recorded only the first one.
+                    self.collected_aliases[-1].pop(f"module:{bound}", None)
+                    self.collected_aliases[-1].pop(bound, None)
+
+    def _alias_pass_block_targets(self, statement, declared) -> None:
+        """Loop, `with`, `except` and `case` targets are locals for the whole function."""
+        if self.scope_kinds[-1] == "function" and isinstance(
+            statement, (ast.For, ast.AsyncFor, ast.With, ast.AsyncWith, ast.Try, _MATCH)
+        ):
+            # A loop, `with`, `except` or `match` target is a local for the whole
+            # function exactly as an assignment is, so a nested `def` written above
+            # one cannot fall through to an outer alias of that name. Recording
+            # only assignments reported such a body as calling the builtin when it
+            # can only ever see the local. The suites themselves are walked by the
+            # generic branch further down.
+            bound = set()
+            for item in getattr(statement, "items", []) or []:
+                if item.optional_vars is not None:
+                    bound |= {
+                        child.id for child in ast.walk(item.optional_vars)
+                        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+                    }
+            if isinstance(statement, (ast.For, ast.AsyncFor)):
+                bound |= {
+                    child.id for child in ast.walk(statement.target)
+                    if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+                }
+            for handler in getattr(statement, "handlers", []) or []:
+                if handler.name is not None:
+                    bound.add(handler.name)
+            for case in getattr(statement, "cases", []) or []:
+                bound |= {name for name, _ in _pattern_bindings(case.pattern)}
+            for name in bound:
+                if name in declared:
+                    continue
+                if self._binds_over_sink(name):
+                    self.shadowed_sinks[-1].add(name)
+
+    def _alias_pass_walrus_locals(self, statement, declared) -> None:
+        """A walrus target is a local for the whole function, wherever it is written."""
+        if self.scope_kinds[-1] == "function" and not isinstance(
+            statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            # A walrus binds its target in the ENCLOSING scope, so one anywhere in
+            # a function body - including inside an expression that never runs -
+            # makes that name a local for the whole function. `exec(...)` above
+            # `False and (exec := print)` raises UnboundLocalError, and reporting
+            # it failed the gate on code that cannot be made to pass. Nested
+            # scopes are skipped: a walrus in a lambda is lambda-local, and one in
+            # a comprehension binds in the scope holding the comprehension.
+            for child in _walk_this_scope(statement):
+                if isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name):
+                    name = child.target.id
+                    if name in declared:
+                        continue
+                    if self._binds_over_sink(name):
+                        self.shadowed_sinks[-1].add(name)
+
+    def _alias_pass_bindings(self, statement, declared, rebound) -> None:
+        """Imports, `del`, type aliases and assignments, plus the recursion into suites."""
+        if isinstance(statement, (ast.Import, ast.ImportFrom)) and self.scope_kinds[-1] == "function":
+            # Inside a function, an import TARGET is a local for the whole scope
+            # even though its value is not bound until the import runs. So
+            # `def f(name): compile(...); from re import compile` cannot reach the
+            # builtin - it raises UnboundLocalError - and reporting it was a false
+            # failure on code that cannot be made to pass. The alias itself is
+            # still only installed when the statement is reached; this records the
+            # shadow. Module and class scope are excluded for the same reason
+            # ordinary assignments are: there a later import does not make an
+            # earlier reference local.
+            for alias in statement.names:
+                if isinstance(statement, ast.ImportFrom):
+                    bound = alias.asname or alias.name
+                else:
+                    bound = alias.asname or alias.name.split(".")[0]
+                if bound in declared:
+                    continue
+                if self._binds_over_sink(bound):
+                    self.shadowed_sinks[-1].add(bound)
+        elif isinstance(statement, ast.Delete) and self.scope_kinds[-1] == "function":
+            # `del exec` makes that spelling a local for the WHOLE function, so
+            # `def f(name): exec(f"..."); del exec` raises UnboundLocalError and
+            # reporting it failed the gate on code that cannot be changed to pass.
+            # A `global`/`nonlocal` name is not a local binding and is left alone,
+            # exactly as an assignment to one is.
+            for target in statement.targets:
+                if not isinstance(target, ast.Name) or target.id in declared:
+                    continue
+                if self._binds_over_sink(target.id):
+                    self.shadowed_sinks[-1].add(target.id)
+        elif isinstance(statement, _TYPEALIAS):
+            # `type run = int` binds `run` to a TypeAliasType on 3.12+, exactly as
+            # an assignment binds it, so a call through that name cannot reach the
+            # builtin and reporting it failed the gate on code that cannot pass.
+            bound = getattr(statement, "name", None)
+            if isinstance(bound, ast.Name) and bound.id not in declared:
+                if self._binds_over_sink(bound.id):
+                    self.shadowed_sinks[-1].add(bound.id)
+        elif isinstance(statement, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            # An ordinary local binding of an outer alias also applies for the
+            # whole scope, so a nested function defined above it must not fall
+            # through to that alias: `run = print` below `def inner` still makes
+            # `run` print inside `inner`. Recorded as a shadow rather than a value,
+            # since what it becomes is not this checker's business.
+            targets = (
+                statement.targets if isinstance(statement, ast.Assign)
+                else [statement.target]
+            )
+            # An assignment binds for the whole scope as far as a DEFERRED body is
+            # concerned: `def f(name): run(f"...")` written above `run = builtins.exec`
+            # calls the builtin whenever `f` runs after that line. The import forms
+            # were pre-collected here and the assignment form was not, so the body
+            # was scanned before `run` meant anything and reported clean. Only a
+            # plain name given a visibly sink-, constructor- or builtins-valued
+            # right-hand side is recorded; nothing is inferred about any other value.
+            if not isinstance(statement, ast.AugAssign):
+                for target in targets:
+                    self._collect_assignment_alias(target, statement.value, rebound)
+                for target in targets:
+                    for child in ast.walk(target):
+                        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                            rebound.add(child.id)
+            if self.scope_kinds[-1] != "function":
+                # At module or class scope a later assignment does NOT make an
+                # earlier reference local: `exec(f"import {name}"); exec = print`
+                # calls the builtin and only then rebinds it. Pre-shadowing there
+                # hid the call entirely. Inside a function the compiler really does
+                # make the name local for the whole body, which is why this pass
+                # exists at all. Nested scopes still see the binding, because they
+                # are deferred - that is `_collect_aliases` on their own body plus
+                # the outward walk, not this shadow.
+                return
+            for target in targets:
+                for child in ast.walk(target):
+                    if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                        # A `global` name is not a local binding at all, so it must
+                        # not be recorded as shadowing this scope - the assignment
+                        # updates the module and is handled there.
+                        if child.id in declared:
+                            continue
+                        if (
+                            child.id in _BUILTIN_NAMES
+                            or self._alias(child.id)
+                            or self._alias(f"module:{child.id}")
+                        ):
+                            # `exec = print` below a nested `def` still applies to
+                            # it, and the builtin spellings need this as much as an
+                            # imported alias does.
+                            self.shadowed_sinks[-1].add(child.id)
+        elif isinstance(statement, ast.If) and _constant_truth(statement.test) is not None:
+            # A literal test decides which suite exists: with
+            # `if True: from re import compile as c` / `else: from builtins import
+            # compile as c`, only the first one ever binds, and collecting both
+            # reported a builtin call that cannot happen.
+            taken = statement.body if _constant_truth(statement.test) else statement.orelse
+            self._collect_aliases(taken, declared)
+        else:
+            # An import can sit inside an `if`, `try` or loop in the same scope and
+            # still bind for the whole of it, so those suites are walked too.
+            for field in ("body", "orelse", "finalbody", "handlers"):
+                for child in getattr(statement, field, []) or []:
+                    if isinstance(child, ast.stmt):
+                        self._collect_aliases([child], declared)
+                    elif isinstance(child, ast.ExceptHandler):
+                        self._collect_aliases(child.body, declared)
+            # `_MATCH` keeps its suites under `cases`, which is none of the
+            # fields above, so an import inside a `case` was invisible.
+            for case in getattr(statement, "cases", []) or []:
+                self._collect_aliases(case.body, declared)
+
+    def _collect_assignment_alias(self, target: ast.AST, value: ast.AST, rebound = ()) -> None:
+        """Pre-record `run = builtins.exec` for bodies deferred past it.
+
+        The mirror of `_shadow_assignment`, restricted to what a nested body can see:
+        it writes only `collected_aliases`, never the executed table, so a statement in
+        this scope still resolves by what has actually run above it. Entries are only
+        added. A later rebinding to something else does not remove one, because a
+        deferred body can be called between the two lines and the reporting direction
+        is the safe one.
+        """
+        if value is None:
+            return
+        if isinstance(target, (ast.Tuple, ast.List)):
+            for sub_target, sub_value in self._unpacked_pairs(target, value):
+                self._collect_assignment_alias(sub_target, sub_value, rebound)
+            return
+        if not isinstance(target, ast.Name):
+            return
+        root = value
+        while isinstance(root, ast.Attribute):
+            root = root.value
+        if isinstance(root, ast.Name) and root.id in rebound:
+            # The spelling was given a meaning by an earlier statement in this scope,
+            # so it is not the builtin: `from re import compile; run = compile` binds
+            # the regex compiler and pre-collecting a sink alias for `run` failed the
+            # gate on an ordinary call.
+            return
+        if isinstance(value, ast.Name) and (
+            value.id == "builtins" or self._alias(f"module:{value.id}")
+        ):
+            self.collected_aliases[-1][f"module:{target.id}"] = "builtins"
+            return
+        # With the shadow test: `from re import compile; run = compile` gives `run`
+        # the regex compiler, and resolving the spelling alone pre-collected a builtin
+        # alias that does not exist, failing the gate on an ordinary call.
+        resolved = _sink_name(value, self._alias, self._is_shadowed)
+        if resolved is not None:
+            self.collected_aliases[-1][target.id] = resolved.rpartition(".")[2]
+            return
+        constructor = _constructor_name(value, self._is_shadowed, self._alias)
+        if constructor is not None:
+            self.collected_aliases[-1][f"constructor:{target.id}"] = constructor
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        """`from builtins import exec as run` makes `run` the same builtin."""
+        for alias in node.names:
+            bound = alias.asname or alias.name
+            if self.scope_kinds[-1] == "class" and bound in self.global_names[-1]:
+                # A class body runs in place, so `global exec` inside one sends the
+                # import's binding to module scope - where the earlier `exec = print`
+                # shadow lives - rather than making a class attribute.
+                level = self._binding_level(bound)
+                if node.module == "builtins" and not node.level and alias.name in SINKS:
+                    self.sink_aliases[level][bound] = alias.name
+                    self.collected_aliases[level][bound] = alias.name
+                    self.shadowed_sinks[level].discard(bound)
+                    continue
+                if node.module == "builtins" and not node.level and alias.name in _CONSTRUCTORS:
+                    # The conversions go out to module scope under a class-body
+                    # `global` exactly as the sinks do, so `class C: global str;
+                    # from builtins import str` puts the real `str` back where an
+                    # earlier `str = print` shadow lives. Only the sinks were routed,
+                    # so that shadow survived and the conversion stopped unwrapping.
+                    self.sink_aliases[level][f"constructor:{bound}"] = alias.name
+                    self.collected_aliases[level][f"constructor:{bound}"] = alias.name
+                    self.shadowed_sinks[level].discard(bound)
+                    continue
+            if node.module == "builtins" and not node.level and alias.name == "*":
+                # A star import binds every sink under its own spelling, so it hands
+                # them back after an earlier `exec = print` took one away.
+                for sink in SINKS:
+                    self.sink_aliases[-1][sink] = sink
+                    self.collected_aliases[-1][sink] = sink
+                    self.shadowed_sinks[-1].discard(sink)
+                for constructor in _CONSTRUCTORS:
+                    # And the conversions with them: `str = print; from builtins import *`
+                    # leaves `str` the builtin again, so `exec(str(f"..."))` is a sink
+                    # call on built source. Only the sinks were restored, so the earlier
+                    # shadow stood and the call read as nothing.
+                    self.sink_aliases[-1][f"constructor:{constructor}"] = constructor
+                    self.collected_aliases[-1][f"constructor:{constructor}"] = constructor
+                    self.shadowed_sinks[-1].discard(constructor)
+                continue
+            if node.module == "builtins" and not node.level and alias.name in _CONSTRUCTORS:
+                # `from builtins import str as s` gives `s` the constructor, exactly as
+                # the sink form gives a name the builtin. Only the sinks were recorded,
+                # so `exec(s(f"..."))` was never unwrapped.
+                self.sink_aliases[-1][f"constructor:{bound}"] = alias.name
+                self.collected_aliases[-1][f"constructor:{bound}"] = alias.name
+                self.shadowed_sinks[-1].discard(bound)
+                continue
+            if node.module == "builtins" and not node.level and alias.name in SINKS:
+                self.sink_aliases[-1][bound] = alias.name
+                self.collected_aliases[-1][bound] = alias.name
+                self.shadowed_sinks[-1].discard(bound)
+            else:
+                self.tainted[-1].pop(bound, None)
+                # `from helper import str` binds the application's object, not the
+                # constructor, so the name stops being one of ours.
+                self._shadow_sink(bound)
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import):
+        """`import builtins as b` makes `b.exec` the same builtin.
+
+        An import also BINDS, unconditionally: `import json as payload` after
+        `payload = f"import {user}"` means the sink can only ever be handed a module,
+        because an import that fails raises instead of falling through. Same argument
+        as the `def`/`class` rebinding, so it gets the same treatment.
+        """
+        for alias in node.names:
+            bound = alias.asname or alias.name.split(".")[0]
+            self.tainted[-1].pop(bound, None)
+            if alias.name == "builtins":
+                # Read BEFORE `_shadow_sink` clears both tables, since that clearing is
+                # what the check below would otherwise be looking at.
+                collected_for_nested = f"module:{bound}" in self.collected_aliases[-1]
+                # This import IS the builtins binding, so it must register rather than
+                # shadow; clearing first and registering after wiped it out.
+                self._shadow_sink(bound)
+                # Both tables, since `_shadow_sink` clears both and a nested scope
+                # reads `collected_aliases`. `bound` is `builtins` itself for the
+                # plain `import builtins`, which must register here rather than fall
+                # through to the shadow branch now that `builtins` is a name the
+                # checker recognises.
+                self.sink_aliases[-1][f"module:{bound}"] = "builtins"
+                # `collected_aliases` is what NESTED scopes see, and the pre-pass has
+                # already walked the whole scope: if it left no entry here, a later
+                # import rebinds this name, and a deferred body runs after that. Only
+                # `sink_aliases`, which governs this scope's own statements from here
+                # on, is written unconditionally.
+                if collected_for_nested:
+                    self.collected_aliases[-1][f"module:{bound}"] = "builtins"
+                # `builtins` is itself one of the names the checker recognises, so the
+                # clearing above now records a shadow for it. This import is the real
+                # binding, so that shadow has to come straight back off.
+                self.shadowed_sinks[-1].discard(bound)
+            else:
+                self._shadow_sink(bound)
+        self.generic_visit(node)
+
+    def _binds_over_sink(self, name: str) -> bool:
+        """Whether binding `name` here takes it away from a sink.
+
+        Covers all three spellings a name can carry: the builtin itself, an imported
+        alias of it, and a `builtins` module alias, which is stored under a `module:`
+        key and so was invisible to a plain lookup.
+
+        The set is every builtin name this checker relies on, not just the sinks: it
+        unwraps `str(...)` and `bytes(...)` as conversions, so `def f(str, name)`
+        supplying its own `str` has to stop that unwrapping too, and a local
+        `builtins` has to stop `builtins.exec` resolving.
+        """
+        return (
+            name in _BUILTIN_NAMES
+            or self._alias(name) is not None
+            or self._alias(f"module:{name}") is not None
+            # A constructor alias lives under its own prefixed key, so a plain lookup
+            # missed it and `text = lambda _: "pass"` left the earlier
+            # `from builtins import str as text` alias standing.
+            or self._alias(f"constructor:{name}") is not None
+            # A name already recorded as shadowed still counts, so a second assignment
+            # can hand it back: `run = print` then `run = builtins.exec` has to make
+            # `run` an alias again, and by then the alias entry is gone.
+            or self._is_shadowed(name)
+        )
+
+    def _default_taint(self, arguments) -> dict:
+        """`{parameter: why its default is a built string}`, for defaults that are.
+
+        The default is evaluated in the enclosing scope, so it is read there, and it
+        reaches the body whenever the caller omits the argument.
+        """
+        answer: dict = {}
+        positional = [*arguments.posonlyargs, *arguments.args]
+        for argument, default in zip(positional[len(positional) - len(arguments.defaults):],
+                                     arguments.defaults):
+            reason = _is_interpolated(
+                default, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
+            if reason is not None:
+                answer[argument.arg] = f"{reason} via default `{argument.arg}`"
+        for argument, default in zip(arguments.kwonlyargs, arguments.kw_defaults):
+            if default is None:
+                continue
+            reason = _is_interpolated(
+                default, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
+            if reason is not None:
+                answer[argument.arg] = f"{reason} via default `{argument.arg}`"
+        return answer
+
+    def _default_sink_names(self, arguments) -> dict:
+        """`{parameter: the sink its default names}`, for defaults that name one.
+
+        Not shadowing the parameter was only half of it: `def f(name, run = builtins.exec)`
+        binds a FRESH name to the builtin, and with no alias entry the call in the body
+        resolved to nothing at all.
+        """
+        answer: dict = {}
+        positional = [*arguments.posonlyargs, *arguments.args]
+        pairs = list(zip(positional[len(positional) - len(arguments.defaults):],
+                         arguments.defaults))
+        pairs += [(a, d) for a, d in zip(arguments.kwonlyargs, arguments.kw_defaults)
+                  if d is not None]
+        for argument, default in pairs:
+            if not self._default_is_sink(default):
+                continue
+            resolved = _sink_name(default, self._alias, self._is_shadowed)
+            if resolved is not None:
+                answer[argument.arg] = resolved.rpartition(".")[2]
+        return answer
+
+    def _default_constructor_names(self, arguments) -> dict:
+        """`{parameter: the constructor its default names}`, for defaults that name one.
+
+        `def f(name, text = builtins.str)` gives a fresh parameter the conversion, so
+        `exec(text(f"..."))` in the body is the same sink call `exec(str(f"..."))` is.
+        Only sink-valued defaults were recorded, so the conversion was never unwrapped
+        and the call read as nothing at all. Same shadow test as the sink form: a
+        default is evaluated where the `def` is written.
+        """
+        answer: dict = {}
+        positional = [*arguments.posonlyargs, *arguments.args]
+        pairs = list(zip(positional[len(positional) - len(arguments.defaults):],
+                         arguments.defaults))
+        pairs += [(a, d) for a, d in zip(arguments.kwonlyargs, arguments.kw_defaults)
+                  if d is not None]
+        for argument, default in pairs:
+            constructor = _constructor_name(default, self._is_shadowed, self._alias)
+            if constructor is None:
+                continue
+            root = default
+            while isinstance(root, ast.Attribute):
+                root = root.value
+            if isinstance(root, ast.Name) and self._is_shadowed(root.id):
+                continue
+            answer[argument.arg] = constructor
+        return answer
+
+    def _default_is_sink(self, default) -> bool:
+        """Whether a parameter default is visibly the builtin, in the scope it runs in.
+
+        Spelling alone is not the test. A default is evaluated where the `def` is
+        written, so `class C: from re import compile` above
+        `def f(self, compile = compile)` supplies `re.compile`, and reading the name as
+        the builtin left the parameter unshadowed - then method lookup correctly
+        skipped the class namespace and the body was reported as calling the builtin.
+        """
+        # The shadow predicate goes INTO the resolver, not just onto the root
+        # afterwards: `def f(name, run = [compile][0])` resolves through a subscript,
+        # so the root is not a name at all and the later test could not correct it.
+        if _sink_name(default, self._alias, self._is_shadowed) is None:
+            return False
+        root = default
+        while isinstance(root, ast.Attribute):
+            root = root.value
+        if isinstance(root, ast.Name) and self._is_shadowed(root.id):
+            return False
+        return True
+
+    def _sink_defaults(self, arguments) -> dict:
+        """`{parameter: whether its default is visibly a sink}`.
+
+        Defaults line up with the TAIL of the positional parameters, and keyword-only
+        defaults are positional against `kwonlyargs` with `None` for "no default".
+        """
+        answer: dict = {}
+        positional = [*arguments.posonlyargs, *arguments.args]
+        for argument, default in zip(positional[len(positional) - len(arguments.defaults):],
+                                     arguments.defaults):
+            answer[argument.arg] = self._default_is_sink(default)
+        for argument, default in zip(arguments.kwonlyargs, arguments.kw_defaults):
+            if default is not None:
+                answer[argument.arg] = self._default_is_sink(default)
+        return answer
+
+    def _sink_valued(self, names, target, iterable) -> dict:
+        """`{name: whether the literal iterable visibly binds it to a sink}`.
+
+        Only a plain name target over a literal container, and only when EVERY element
+        resolves to a sink - one element that does not means the body may see something
+        else, and suppressing resolution is the safe answer there.
+        """
+        answer: dict = {name: None for name in names}
+        if isinstance(target, (ast.Tuple, ast.List)):
+            # `for run, ignored in [(builtins.exec, None)]` binds `run` to the builtin
+            # exactly as the plain form does. Each element is paired with the target
+            # the same way an unpacking assignment is.
+            elements = _Visitor._literal_elements(iterable)
+            if elements:
+                for element in elements:
+                    for sub_target, sub_value in _Visitor._unpacked_pairs(target, element):
+                        if not isinstance(sub_target, ast.Name):
+                            continue
+                        if answer.get(sub_target.id) is not None:
+                            continue
+                        resolved = _sink_name(
+                            sub_value, self._alias, self._is_shadowed,
+                        ) or _prefixed_constructor(
+                            _constructor_name(sub_value, self._is_shadowed, self._alias)
+                        )
+                        if resolved is not None:
+                            answer[sub_target.id] = resolved.rpartition(".")[2]
+            return answer
+        if not isinstance(target, ast.Name) or target.id not in names:
+            return answer
+        elements = _Visitor._literal_elements(iterable)
+        if not elements:
+            return answer
+        resolved = [
+            # Shadow-tested for the same reason the assignment form is:
+            # `from re import compile; for run in [compile]` binds the regex compiler.
+            _sink_name(element, self._alias, self._is_shadowed)
+            # `for s in [builtins.str]: exec(s(f"..."))` states what `s` holds as
+            # plainly as the sink form does, and only sinks were resolved, so the
+            # conversion was read as an ordinary shadow and never unwrapped. Kept
+            # under the same prefix the alias table already uses for constructors.
+            or _prefixed_constructor(_constructor_name(element, self._is_shadowed, self._alias))
+            for element in elements
+        ]
+        # ANY element, not all of them. `for run in [builtins.exec, print]` really does
+        # call the builtin on the first pass, and requiring every element to be a sink
+        # turned a mixed literal into a shadow that hid it. The sink NAME, not just
+        # "yes": a fresh name like `run` has to be registered as an alias for what it
+        # holds, or the call in the body resolves to nothing at all.
+        found = next((sink for sink in resolved if sink is not None), None)
+        if found is not None:
+            answer[target.id] = found.rpartition(".")[2]
+        return answer
+
+    def _shadow_locals(self, names):
+        """Make `names` stop resolving to a sink for a nested binding construct.
+
+        `names` may be a mapping from name to "this binding is visibly a sink", which
+        a loop or comprehension over a literal can answer: `for exec in [builtins.exec]`
+        binds the builtin back to its own spelling and must keep resolving.
+
+        Returns what to hand back to `_restore_locals`. Both the shadow set and the
+        alias table are snapshotted: adding to `shadowed_sinks` alone was not enough
+        when an alias of the same name lived in the same scope, and subtracting the
+        names afterwards wiped out shadowing that was already there for another reason.
+        """
+        saved_shadow = set(self.shadowed_sinks[-1])
+        saved_alias = dict(self.sink_aliases[-1])
+        saved_collected = dict(self.collected_aliases[-1])
+        for name in names:
+            sink = names.get(name) if isinstance(names, dict) else None
+            if sink:
+                # The binding is visibly the builtin itself, so it is not shadowed:
+                # `for exec in [builtins.exec]` really does call `exec` in the body.
+                # Actively undone rather than merely skipped, because an earlier
+                # `exec = print` in this scope had already recorded a shadow and
+                # lookup would have found that one instead.
+                self.shadowed_sinks[-1].discard(name)
+                # And the name is registered as an alias for the sink it now holds.
+                # Not shadowing it was only half the job: `for run in [builtins.exec]`
+                # binds a FRESH name, which resolved to nothing at all, so the call in
+                # the body reported neither the builtin nor anything else.
+                if isinstance(sink, str):
+                    if sink.startswith("constructor:"):
+                        # A constructor binding is kept under the prefixed key the
+                        # alias table already uses for one, so `s` in
+                        # `for s in [builtins.str]` unwraps rather than resolving as a
+                        # sink named `str`.
+                        self.sink_aliases[-1][f"constructor:{name}"] = sink.partition(":")[2]
+                        self.collected_aliases[-1][f"constructor:{name}"] = sink.partition(":")[2]
+                        continue
+                    self.sink_aliases[-1][name] = sink
+                    self.collected_aliases[-1][name] = sink
+                continue
+            if self._binds_over_sink(name):
+                self.shadowed_sinks[-1].add(name)
+                self.sink_aliases[-1].pop(name, None)
+                self.sink_aliases[-1].pop(f"module:{name}", None)
+        return saved_shadow, saved_alias, saved_collected
+
+    def _restore_locals(self, saved) -> None:
+        saved_shadow, saved_alias, saved_collected = saved
+        self.shadowed_sinks[-1] = saved_shadow
+        self.sink_aliases[-1] = saved_alias
+        self.collected_aliases[-1] = saved_collected
+
+    def _binding_level(self, name: str) -> int:
+        """Which scope a rebinding of `name` here updates.
+
+        `global` goes to module scope; `nonlocal` to the nearest enclosing function,
+        skipping class bodies, which a `nonlocal` cannot name; everything else stays
+        local.
+        """
+        if name in self.global_names[-1]:
+            return 0
+        if name in self.nonlocal_names[-1]:
+            for index in range(len(self.scope_kinds) - 2, 0, -1):
+                if self.scope_kinds[index] == "function":
+                    return index
+            return 0
+        return len(self.scope_kinds) - 1
+
+    def _shadow_assignment(self, target: ast.AST, value: ast.AST) -> None:
+        """Record `compile = re.compile`, which makes the bare name not the builtin.
+
+        Only a plain name target, and only when the value is not itself a reference to
+        the same builtin, so `exec = exec` and `exec = builtins.exec` keep resolving to
+        the sink. An imported alias counts as well: `from builtins import exec as run`
+        followed by `run = print` makes `run` print, so the spelling alone is not the
+        test.
+
+        Applied AFTER the right hand side has been visited, because that is when Python
+        binds it. Doing it first meant `exec = exec(f"import {name}")` suppressed the
+        very call it was assigning from. Deliberately not chased any further than that: this checker does not
+        follow value flow, and something like `exec = getattr(builtins, "exec")` is
+        obfuscation rather than the good-faith code this gate exists to protect.
+        """
+        if isinstance(target, (ast.Tuple, ast.List)):
+            # `run, ignored = exec, None` binds `run` to the builtin just as the plain
+            # form does, and `*ignored, run = [print, builtins.exec]` still says
+            # exactly which value `run` gets. The pairing is the one `_bind_unpacked`
+            # already works out for taint, so it is asked for it rather than repeated.
+            for sub_target, sub_value in self._unpacked_pairs(target, value):
+                self._shadow_assignment(sub_target, sub_value)
+            return
+        if not isinstance(target, ast.Name):
+            return
+        # With the shadow test: `exec = print; run = exec` makes `run` print, and
+        # resolving the spelling alone recorded a sink alias that does not exist.
+        partial_sink = _partial_sink(value, self._alias, self._is_shadowed)
+        if partial_sink is not None:
+            # `run = functools.partial(exec, f"..."); run()` executes the source bound
+            # when the partial was built, and collapsing it to a plain `exec` alias
+            # threw that argument away, so the zero-argument call had nothing to look
+            # at. The reason travels onto the name instead.
+            bound = _source_argument(
+                _partial_call(value), partial_sink, self._is_shadowed, skip = 1,
+            )
+            reason = _is_interpolated(
+                bound, self.tainted[-1].get, self._is_shadowed, self._alias,
+            ) if bound is not None else None
+            if reason is not None:
+                # Reported HERE rather than at the later call: this is where the built
+                # source meets the sink, and the call that runs it carries no arguments
+                # of its own to look at. The key is the partial construction, so
+                # editing what is bound re-opens the review.
+                self.findings.append(
+                    {
+                        "path": _relative(self.path),
+                        "qualname": self._qualname(),
+                        "sink": partial_sink,
+                        "reason": f"{reason} bound into a partial",
+                        "line": value.lineno,
+                        "hash": _call_hash(value),
+                    }
+                )
+        resolved = _sink_name(value, self._alias, self._is_shadowed)
+        if isinstance(value, ast.Name) and (
+            value.id == "builtins" or self._alias(f"module:{value.id}")
+        ) and not self._is_shadowed(value.id):
+            # `b = builtins` makes `b.exec` the builtin, the same way
+            # `import builtins as b` does. Only the import form was recorded.
+            level = self._binding_level(target.id)
+            self.sink_aliases[level][f"module:{target.id}"] = "builtins"
+            self.collected_aliases[level][f"module:{target.id}"] = "builtins"
+            self.shadowed_sinks[level].discard(target.id)
+            return
+        constructor = _constructor_name(value, self._is_shadowed, self._alias)
+        if resolved is None and constructor is not None:
+            # `str = builtins.str` hands the constructor back to its own spelling, the
+            # same way `exec = builtins.exec` does for a sink, and `s = builtins.str`
+            # gives a FRESH name the constructor. Only the sinks were resolved here, so
+            # both read as shadows and `exec(s(f"..."))` stopped being unwrapped.
+            level = self._binding_level(target.id)
+            self.shadowed_sinks[level].discard(target.id)
+            # Stored under a prefixed key in the alias table `_alias` already walks,
+            # the same way the `builtins` module alias is kept under `module:`.
+            self.sink_aliases[level][f"constructor:{target.id}"] = constructor
+            self.collected_aliases[level][f"constructor:{target.id}"] = constructor
+            return
+        if resolved is None and not self._binds_over_sink(target.id):
+            # A name that means nothing here and is not being given a sink cannot make
+            # anything resolve differently. But a name being GIVEN a sink has to be
+            # recorded whether or not it meant anything before: `run = builtins.exec`
+            # makes a fresh `run` the builtin.
+            return
+        if resolved is not None:
+            # `exec = builtins.exec` under `global exec` puts the builtin back at
+            # module level, where the earlier `exec = print` shadow lives.
+            level = self._binding_level(target.id)
+            self.shadowed_sinks[level].discard(target.id)
+            # `run = print` then `run = builtins.exec` has to make `run` an alias
+            # again; dropping the shadow alone left it resolving to nothing, because
+            # the first assignment had already removed the alias entry.
+            #
+            # Recorded for the builtin spellings too. Dropping the shadow only clears
+            # THIS level, and lookup walks outward, so `exec = print` at module level
+            # followed by `(exec := builtins.exec)` inside a function still found the
+            # module shadow. An entry at the binding level makes the inner one win.
+            sink = resolved.rpartition(".")[2]
+            self.sink_aliases[level][target.id] = sink
+            self.collected_aliases[level][target.id] = sink
+            return
+        level = self._binding_level(target.id)
+        self.shadowed_sinks[level].add(target.id)
+        self.sink_aliases[level].pop(target.id, None)
+        self.collected_aliases[level].pop(target.id, None)
+        # The conversion alias goes with it: `from builtins import str as text` then
+        # `text = lambda _: "pass"` no longer converts anything, and leaving the
+        # prefixed entry kept unwrapping through a name that means something else.
+        self.sink_aliases[level].pop(f"constructor:{target.id}", None)
+        self.collected_aliases[level].pop(f"constructor:{target.id}", None)
+
+    def _shadow_sink(self, name: str) -> None:
+        """Record that `name` was bound to something that is not the builtin.
+
+        `from re import compile` then `compile(f"^{name}$")` is a regular expression,
+        not dynamic execution, and failing a hard gate on it is the worst kind of false
+        positive: correct code that cannot be made to pass. Only bindings this file
+        states are honoured, and `builtins.compile(...)` is unaffected because it names
+        the builtin explicitly rather than through the shadowed name.
+        """
+        if name in _BUILTIN_NAMES:
+            # Every name this checker relies on, not just the three sinks. It unwraps
+            # `str(...)` and `bytes(...)` as conversions and resolves `builtins.exec`
+            # through the module name, so `from helper import str` and
+            # `import helper as builtins` have to take those away too - otherwise the
+            # gate fails on code that never touches a builtin at all.
+            self.shadowed_sinks[-1].add(name)
+        # Both tables: `sink_aliases` is what the current scope has executed, and
+        # `collected_aliases` is what a nested scope sees, so leaving the name in the
+        # second one meant `def f(): b.compile(...)` still reached the builtin after
+        # `import re as b` had taken `b` away at module level.
+        for table in (self.sink_aliases, self.collected_aliases):
+            table[-1].pop(name, None)
+            # `import builtins as b` is stored under `module:b`, so dropping only the
+            # plain spelling left `import re as b` still resolving `b.compile`.
+            table[-1].pop(f"module:{name}", None)
+            # And a conversion alias lives under `constructor:`, so
+            # `from builtins import str as text; text = lambda _: "pass"` kept
+            # unwrapping through a name that no longer converts anything.
+            table[-1].pop(f"constructor:{name}", None)
+
+    def visit_Lambda(self, node: ast.Lambda):
+        """A lambda parameter shadows the enclosing name for the body.
+
+        `payload = f"import {name}"` followed by `run = lambda payload: exec(payload)`
+        was reported although the sink can only ever see the argument the caller
+        passes. The parameters are the part that is certainly shadowed, so only they
+        are removed, and only for the body.
+
+        Note what is deliberately NOT done here: the body still reads the enclosing map
+        otherwise, because `lambda: exec(payload)` really does close over the outer
+        `payload` and that is a true finding. Clearing the whole scope, as a `def`
+        does, would trade this false positive for a false negative. The asymmetry with
+        `_enter` is the existing documented limit on cross-scope taint, not something
+        introduced here.
+
+        Whatever the body binds is discarded afterwards, because a lambda is a
+        function scope: a walrus inside it binds locally, so letting those bindings
+        survive reported outer names the lambda never touched.
+        """
+        args = node.args
+        for default in (*args.defaults, *(d for d in args.kw_defaults if d is not None)):
+            self.visit(default)
+        defaults = self._sink_defaults(args)
+        # Read out here, in the scope the lambda is written in, which is where a
+        # default is evaluated. Only sink-valued defaults were being looked at, so
+        # `lambda payload = f"import {name}": exec(payload)` had its parameter shadowed
+        # and the interpolation thrown away. Same treatment `_enter` gives a `def`.
+        default_taint = self._default_taint(args)
+        default_sinks = self._default_sink_names(args)
+        default_constructors = self._default_constructor_names(args)
+        shadowed = {
+            arg.arg
+            for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs,
+                        args.vararg, args.kwarg)
+            if arg is not None and not defaults.get(arg.arg)
+        }
+        saved = dict(self.tainted[-1])
+        for name in shadowed:
+            self.tainted[-1].pop(name, None)
+        if self.scope_kinds[-1] == "class":
+            # A lambda in a class body does not close over the class namespace, so
+            # `class C: payload = f"..."; fn = lambda: exec(payload)` reads a global
+            # `payload`, not the class attribute. `_visible_scopes` already hides
+            # class-local ALIASES from these implicit scopes; taint follows the same
+            # rule - dropped for the class level, kept for whatever encloses it.
+            self.tainted[-1] = self._implicit_base_taint()
+        saved_scope = self._shadow_locals(shadowed)
+        for name, reason in default_taint.items():
+            self.tainted[-1][name] = reason
+        # A lambda defined in a class body does not close over the class namespace
+        # either, so its body needs a real function level for `_visible_scopes` to
+        # skip that class.
+        self.scope_kinds.append("function")
+        self.collected_aliases.append({})
+        self.sink_aliases.append({})
+        self.shadowed_sinks.append(set())
+        self.deferred_shadows.append(set())
+        # Its own declaration sets. Reusing the enclosing ones routed a lambda-local
+        # walrus to module scope under an enclosing `global exec`, which is not where
+        # it binds: a walrus inside a lambda is lambda-local, unlike one inside a
+        # comprehension. Same push the comprehension handler already does.
+        self.star_restored.append(set())
+        self.global_names.append(set())
+        self.nonlocal_names.append(set())
+        # The default aliases go in the lambda's OWN scope. Written to the enclosing
+        # one they were invisible from the body whenever that scope was a class body,
+        # because `_visible_scopes` skips class levels once a function level is on top.
+        for name, sink in default_sinks.items():
+            self.sink_aliases[-1][name] = sink
+            self.collected_aliases[-1][name] = sink
+            self.shadowed_sinks[-1].discard(name)
+        for name, constructor in default_constructors.items():
+            # `lambda name, s = builtins.str: exec(s(f"..."))` supplies the conversion
+            # unless the caller overrides it, exactly as the `def` form does. Only
+            # sink-valued defaults were installed, so `s` read as an ordinary shadow.
+            self.sink_aliases[-1][f"constructor:{name}"] = constructor
+            self.collected_aliases[-1][f"constructor:{name}"] = constructor
+            self.shadowed_sinks[-1].discard(name)
+        self.visit(node.body)
+        self.scope_kinds.pop()
+        self.collected_aliases.pop()
+        self.sink_aliases.pop()
+        self.shadowed_sinks.pop()
+        self.deferred_shadows.pop()
+        self.star_restored.pop()
+        self.global_names.pop()
+        self.nonlocal_names.pop()
+        self._restore_locals(saved_scope)
+        # A lambda IS a function scope, so a walrus in its body binds locally and
+        # nothing it does reaches the enclosing map. Restoring the parameters alone
+        # left those local bindings behind, which reported a clean outer name.
+        self.tainted[-1] = saved
+
+    def _visit_comprehension(self, node):
+        """A comprehension target is local to the comprehension.
+
+        `payload = f"import {name}"` followed by
+        `[exec(payload) for payload in ["import os"]]` executes only the literal, but
+        the sink was read against the enclosing map and the outer reason was still
+        there. The outermost iterable really is evaluated in the enclosing scope, so it
+        is visited first, and the target names are then lifted for the rest.
+
+        Generators are entered ONE AT A TIME, in execution order: each iterable is
+        evaluated, then its target comes into scope, then its conditions run. Removing
+        every target up front hid a sink in a later iterable that reads an enclosing
+        name of the same spelling, and binding every target up front let a later
+        generator's clean literal erase an earlier one's reason before the earlier
+        condition was even read.
+
+        A walrus inside a comprehension binds in the ENCLOSING scope, unlike one inside
+        a lambda, so the map is not snapshotted wholesale here: only the target names
+        are removed and only they are put back.
+        """
+        generators = node.generators
+        targets = {
+            child.id
+            for generator in generators
+            for child in ast.walk(generator.target)
+            if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+        }
+        saved = dict(self.tainted[-1])
+        # Visited BEFORE the class map is swapped out. The outermost iterable is
+        # evaluated in the class body itself, so `class C: payload = f"..."; [.. for _
+        # in [exec(payload)]]` really does read the class local, and blanking the map
+        # first hid it. Only the rest of the comprehension cannot see class locals.
+        if generators:
+            self.visit(generators[0].iter)
+        if self.scope_kinds[-1] == "class":
+            # Same as the lambda: a comprehension in a class body cannot see class
+            # locals - but it does see whatever encloses the class.
+            self.tainted[-1] = self._implicit_base_taint()
+        # A comprehension runs in an implicit scope of its own, so a class body around
+        # it is no more visible to it than it is to a method.
+        self.scope_kinds.append("function")
+        self.collected_aliases.append({})
+        self.sink_aliases.append({})
+        self.shadowed_sinks.append(set())
+        self.deferred_shadows.append(set())
+        self.star_restored.append(set())
+        self.global_names.append(set())
+        self.nonlocal_names.append(set())
+        # Shadows are installed AFTER the push, so they land in the comprehension's own
+        # scope. Recording them in the enclosing one was invisible from the body when
+        # that scope was a class body, because `_visible_scopes` skips class levels
+        # when looking outward. Popping the scope drops them, so there is nothing to
+        # hand back.
+        #
+        # And one generator at a time, after its own iterable has been visited. The
+        # outermost iterable is evaluated before ANY target is bound, so shadowing
+        # every target up front made `[None for exec in [exec(f"import {name}")]]`
+        # report nothing even though the call in the iterable really is the builtin.
+        for index, generator in enumerate(generators):
+            if index:
+                # Every later iterable is evaluated inside the comprehension scope,
+                # before its own target is bound but after the earlier targets are.
+                # The outermost one was already visited above, out in the enclosing
+                # scope, which is where it really runs.
+                self.visit(generator.iter)
+            names = {
+                child.id
+                for child in ast.walk(generator.target)
+                if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+            }
+            # Computed HERE, for this generator only. Precomputing every generator up
+            # front let a later `for exec in [print]` overwrite an earlier
+            # `for exec in [builtins.exec]`, so a real call in the earlier filter was
+            # suppressed by a binding that had not happened yet.
+            self._shadow_locals(self._sink_valued(names, generator.target, generator.iter))
+            for name in names:
+                self.tainted[-1].pop(name, None)
+            generated = self._literal_elements(generator.iter)
+            if generated:
+                reasons = [_is_interpolated(element) for element in generated]
+                self._bind(generator.target, next((r for r in reasons if r is not None), None))
+                # A tuple target takes each element APART, so the whole-element reason
+                # above says nothing about it. Reasons are aggregated across elements
+                # rather than overwritten, because the loop runs over all of them and
+                # an interpolated first element is executed whatever the last one is.
+                aggregated: dict[str, str] = {}
+                for element in generated:
+                    before = dict(self.tainted[-1])
+                    self._bind_unpacked(generator.target, element)
+                    for key, value in self.tainted[-1].items():
+                        if before.get(key) != value:
+                            aggregated.setdefault(key, value)
+                    self.tainted[-1] = before
+                self.tainted[-1].update(aggregated)
+            for condition in generator.ifs:
+                self.visit(condition)
+
+        for field in ("elt", "key", "value"):
+            child = getattr(node, field, None)
+            if child is not None:
+                self.visit(child)
+
+        # A generator expression is LAZY. Nothing in it has run when the statement
+        # ends, so a walrus inside one has not bound anything yet and carrying its
+        # state out reported a name that is still unbound. The other comprehensions
+        # are eager and do bind.
+        walrus_names = {
+            child.target.id
+            for child in ast.walk(node)
+            if isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name)
+        }
+        if isinstance(node, ast.GeneratorExp):
+            # A generator expression is LAZY: nothing in it has run when the statement
+            # ends, so its walrus has bound nothing. Suppressing the alias EXPORT was
+            # only half of it - visiting the body had already cleared the taint those
+            # names carried before, so `payload = f"..."; g = ((payload := "pass") for
+            # _ in [0]); exec(payload)` read as clean. The pre-expression taint is put
+            # back for exactly those names.
+            for name in walrus_names:
+                self.tainted[-1].pop(name, None)
+                if name in saved:
+                    self.tainted[-1][name] = saved[name]
+            walrus_names = set()
+        self.scope_kinds.pop()
+        inner_aliases = {**self.collected_aliases.pop(), **self.sink_aliases.pop()}
+        inner_shadows = self.shadowed_sinks.pop()
+        self.deferred_shadows.pop()
+        self.star_restored.pop()
+        self.global_names.pop()
+        self.nonlocal_names.pop()
+        # Only the target names are put back. Restoring the whole map discarded any
+        # walrus made inside the comprehension, which binds in the ENCLOSING scope and
+        # outlives it: `[... for x in y if (payload := f"import {name}")]` then
+        # `exec(payload)` executes it.
+        for name in targets:
+            self.tainted[-1].pop(name, None)
+            if name in saved:
+                self.tainted[-1][name] = saved[name]
+        # Same argument for the alias and shadow half, which was still being discarded
+        # with the scope: `[(run := builtins.exec) for _ in [0]]` really does leave
+        # `run` bound to the builtin. Only the walrus names - the targets ARE
+        # comprehension-local and went with the popped scope.
+        # ...and only when the comprehension can actually run a pass. A visibly empty
+        # iterable, or a filter that is a false constant, binds nothing at all:
+        # `run = builtins.exec; [(run := print) for _ in []]` leaves `run` the builtin,
+        # and exporting the shadow hid the call after it.
+        runs_a_pass = all(
+            self._literal_elements(generator.iter) != []
+            and not (
+                isinstance(generator.iter, ast.Constant)
+                and isinstance(generator.iter.value, (str, bytes))
+                and not generator.iter.value
+            )
+            and not any(
+                _constant_truth(condition) is False for condition in generator.ifs
+            )
+            for generator in node.generators
+        )
+        for name in (walrus_names - targets) if runs_a_pass else ():
+            for prefix in ("constructor:", "module:"):
+                # A walrus can bind a conversion or the builtins module as easily as a
+                # sink, and those live under a prefixed key, so checking the bare name
+                # alone dropped them: `[(text := str) for _ in [0]]` then
+                # `exec(text(f"..."))` lost the conversion.
+                prefixed = f"{prefix}{name}"
+                if prefixed in inner_aliases:
+                    self.sink_aliases[-1][prefixed] = inner_aliases[prefixed]
+                    self.collected_aliases[-1][prefixed] = inner_aliases[prefixed]
+                    self.shadowed_sinks[-1].discard(name)
+            if name in inner_aliases:
+                self.sink_aliases[-1][name] = inner_aliases[name]
+                self.collected_aliases[-1][name] = inner_aliases[name]
+                self.shadowed_sinks[-1].discard(name)
+            elif name in inner_shadows:
+                self.shadowed_sinks[-1].add(name)
+                self.sink_aliases[-1].pop(name, None)
+                self.collected_aliases[-1].pop(name, None)
+
+    visit_ListComp = _visit_comprehension
+    visit_SetComp = _visit_comprehension
+    visit_DictComp = _visit_comprehension
+    visit_GeneratorExp = _visit_comprehension
+
     def visit_Call(self, node: ast.Call):
-        sink = _sink_name(node.func)
-        argument = _source_argument(node, sink) if sink is not None else None
+        sink = _sink_name(node.func, self._alias, self._is_shadowed)
+        # A shadowed base name applies to `b.exec(...)` as well as a bare call: with
+        # `import builtins as b` visible, `def f(b, name)` supplies its own `b`.
+        base = node.func
+        if isinstance(base, ast.Attribute):
+            base = base.value
+        if isinstance(base, ast.Name) and self._is_shadowed(base.id):
+            sink = None
+        if sink is not None and _partial_sink(node.func, self._alias, self._is_shadowed):
+            # The source of `functools.partial(exec, f"...")()` was bound when the
+            # partial was built, so the outer call carries no arguments at all - but
+            # `functools.partial(exec)(f"...")` supplies it at call time instead, and
+            # asking only the inner call read that as having no source.
+            argument = _source_argument(
+                _partial_call(node.func), sink, self._is_shadowed, skip = 1,
+            )
+            if argument is None:
+                argument = _source_argument(node, sink, self._is_shadowed)
+        else:
+            argument = _source_argument(node, sink, self._is_shadowed) if sink is not None else None
         if argument is not None:
-            reason = _is_interpolated(argument)
-            if reason is None and isinstance(argument, ast.Name):
-                reason = self.tainted[-1].get(argument.id)
+            # The taint lookup has to happen wherever the unwrapping stops, not only
+            # when the argument is a bare name: `payload = f"import {name}"` followed
+            # by `exec(payload.encode())` executes the same bytes and used to unwrap
+            # to an `ast.Name` that nothing then looked up.
+            reason = _is_interpolated(
+                argument, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
             if reason is not None:
                 self.findings.append(
                     {
@@ -186,59 +3542,1006 @@ def _call_hash(node: ast.Call) -> str:
     return hashlib.sha256(ast.unparse(node).encode("utf-8")).hexdigest()[:16]
 
 
+NOTEBOOK_SUFFIX = ".ipynb"
+
+
+def _notebook_code_cells(path: Path) -> list[tuple[int, str]]:
+    """(index, raw source) for each code cell, exactly as written."""
+    try:
+        raw = path.read_bytes()
+    except OSError as error:
+        # `.py` files return [] here, but a notebook named on the command line has been
+        # asked for explicitly, and silently skipping it is the reduced coverage the
+        # rest of this file exists to report.
+        raise ScanError(
+            f"{_relative(path)}: could not be read ({error.__class__.__name__}), so "
+            f"its code cells were not checked"
+        ) from None
+    try:
+        document = json.loads(raw.decode("utf-8", errors = "replace"))
+    except (ValueError, UnicodeError, RecursionError, MemoryError) as error:
+        # RecursionError and MemoryError cover the decoder's own limits: about ten
+        # thousand nested arrays exhausts it, and letting that escape aborted the whole
+        # command before any other file was scanned.
+        raise ScanError(
+            f"{_relative(path)}: could not be read as a notebook "
+            f"({error.__class__.__name__}), so its code cells were not checked"
+        ) from None
+    # `cells` has to be THERE. Defaulting it to an empty list let `{}` - a valid JSON
+    # document that is not a notebook - pass validation and be reported clean after
+    # nothing at all was scanned, which is the opposite of how every other malformed
+    # shape here is treated.
+    if not isinstance(document, dict) or not isinstance(document.get("cells"), list):
+        raise ScanError(
+            f"{_relative(path)}: is not a notebook document, so its code cells were "
+            f"not checked"
+        )
+    cells = []
+    for index, cell in enumerate(document["cells"]):
+        if not isinstance(cell, dict):
+            # A valid non-code cell is skipped below; a cell that is not an object at
+            # all is malformed, and skipping it would let an invalid notebook report
+            # clean - the opposite of how every other malformed shape is treated here.
+            raise ScanError(
+                f"{_relative(path)}#cell{index}: is {type(cell).__name__}, not a cell "
+                f"object, so it was not checked"
+            )
+        if cell.get("cell_type") != "code":
+            continue
+        if "source" not in cell:
+            # `source` is required on a code cell. Defaulting it made a malformed
+            # notebook look like a successfully scanned empty one, which is the same
+            # bypass as the missing `cells` member above.
+            raise ScanError(
+                f"{_relative(path)}#cell{index}: a code cell with no `source`, so it "
+                f"was not checked"
+            )
+        source = cell["source"]
+        if isinstance(source, list):
+            if not all(isinstance(piece, str) for piece in source):
+                raise ScanError(
+                    f"{_relative(path)}#cell{index}: `source` is a list of something "
+                    f"other than strings, so the cell was not checked"
+                )
+            source = "".join(source)
+        if not isinstance(source, str):
+            # A cell whose `source` is a number or an object is not something this can
+            # read. Failing closed puts it in the unscannable count instead of raising
+            # AttributeError out of the walk and taking every remaining file with it.
+            raise ScanError(
+                f"{_relative(path)}#cell{index}: `source` is "
+                f"{type(source).__name__}, not text, so the cell was not checked"
+            )
+        cells.append((index, source))
+    return cells
+
+
+# Line magics whose argument is ordinary Python, so replacing the whole line would
+# throw away real code: `%time exec(payload)` executes exactly what it says.
+_CODE_MAGICS = ("time", "timeit", "prun", "debug", "capture")
+
+
+def _first_shell_token(text: str):
+    """The first shell-quoted token of `text` and what follows it.
+
+    Splitting on the first space cut `-s "exec(f'import {name}')"` in half, because
+    the setup value has spaces inside its quotes. A quoted value runs to its matching
+    quote; an unquoted one to the next space.
+    """
+    stripped = text.lstrip()
+    if stripped[:1] in ("'", '"'):
+        quote = stripped[0]
+        end = stripped.find(quote, 1)
+        if end != -1:
+            return stripped[:end + 1], stripped[end + 1:]
+    head, _, tail = stripped.partition(" ")
+    return head, tail
+
+
+def _magic_setups(rest: str) -> list:
+    """The `-s/--setup` snippets of a line magic, unquoted.
+
+    `%timeit -s "exec(f'...')" pass` RUNS its setup value as Python before timing the
+    statement, so it is not an inert option value. The statement being timed is what
+    `_magic_argument` returns; these are scanned as statements of their own.
+    """
+    found: list = []
+    _magic_argument(rest, found)
+    unquoted: list = []
+    for value in found:
+        try:
+            pieces = shlex.split(value)
+        except ValueError:
+            continue
+        unquoted.extend(piece for piece in pieces if piece.strip())
+    return unquoted
+
+
+def _magic_argument(rest: str, setups = None) -> str:
+    """The Python part of a line magic's argument, with its options removed.
+
+    `%timeit -n 1 exec(payload)` carries options before the code, and keeping the whole
+    remainder left `-n 1 exec(...)`, which does not parse - so the cell was skipped and
+    the sink went unread. Leading option tokens are dropped one at a time until what is
+    left parses. Dropping only from the front, and only while the remainder still fails,
+    means a genuine argument is never truncated.
+    """
+    candidate = rest.strip()
+    after_option = False
+    if setups is None:
+        setups = []
+    while candidate:
+        try:
+            ast.parse(candidate)
+            return candidate
+        except SyntaxError:
+            pieces = candidate.split(maxsplit = 1)
+            head = pieces[0] if pieces else ""
+            tail = pieces[1] if len(pieces) > 1 else ""
+            if len(pieces) < 2:
+                break
+            if head.rstrip("=") in ("-s", "--setup") or head.startswith(("-s", "--setup=")):
+                # `%timeit -s "exec(...)"` runs its value as SETUP code, so it is not
+                # an inert option value like `-n 1`. The statement being timed is what
+                # this function returns, so the setup is collected separately and
+                # scanned as a statement of its own.
+                value, remainder = _first_shell_token(tail)
+                setups.append(value)
+                candidate = remainder.strip()
+                after_option = False
+                continue
+            if head.startswith("-"):
+                # An option may carry a value of any shape: `%timeit -s "x=1" exec(...)`
+                # leaves a quoted string at the front, which is not option-looking and
+                # is not numeric, so the loop used to stop there and the whole cell was
+                # skipped. One value per option is consumed, and only immediately after
+                # the option that introduced it, so a genuine argument is still never
+                # truncated.
+                after_option = True
+            elif after_option or head.lstrip("-").isdigit():
+                after_option = False
+            else:
+                break
+            candidate = tail.strip()
+    return rest
+
+
+# `out = !ls`, `files, err = !ls`, `t = %timeit -o f()`, `outputs["run-log"] = !ls`.
+# IPython's capture syntax is an assignment whose right hand side is a magic or a shell
+# escape, so the `!` or `%` is not at the start of the line and the plain check below
+# never fires. Neither the raw text nor the neutralised text parses, so the whole cell -
+# including any sink after it - is skipped.
+#
+# The left hand side is validated by the parser rather than by a character class. Two
+# rounds of widening that class (quotes, then punctuation inside quoted keys) showed it
+# was the wrong tool: a subscript key is an arbitrary Python string. `_capture_target`
+# asks CPython whether the text is a valid assignment target, which is exactly the
+# question, and `(?!=)` keeps `x = y != z` out.
+
+
+def _capture_target(line: str):
+    """`(indent, target, operator, rest, targets)` for a capture assignment, or None.
+
+    Every `=` that is followed by `!` or `%` is tried in turn, shortest first, and the
+    first one whose left hand side parses as an assignment target wins. A single
+    non-greedy match stopped at the `=` inside a key like `outputs["=!log"]` and gave
+    up on a line that is perfectly valid IPython.
+    """
+    for match in re.finditer(r"=\s*([!%])(?!=)", line):
+        head, operator = line[: match.start()], match.group(1)
+        indent = head[: len(head) - len(head.lstrip())]
+        target = head.strip()
+        if not target:
+            continue
+        try:
+            tree = ast.parse(f"{target} = None")
+        except (SyntaxError, ValueError):
+            continue
+        if len(tree.body) != 1 or not isinstance(tree.body[0], ast.Assign):
+            continue
+        return indent, target, operator, line[match.end():], tree.body[0].targets
+    return None
+
+
+def _string_open_lines(source: str) -> frozenset:
+    """Indices of physical lines that begin inside an unterminated string literal.
+
+    Text inside a triple-quoted string is data, not code, and a line of it may well
+    begin with `%` or `!`. Rewriting such a line to `pass` can delete the string's own
+    closing delimiter, which turns a parseable cell into a skipped one and loses every
+    sink below it. Scanning for the quote state first keeps the rewrite to real code.
+
+    This is a scanner, not a tokenizer, because the input is by definition not valid
+    Python - it is a cell with magics in it, which is why it reached this function at
+    all. It handles escapes, comments and both quote characters; it is not asked to do
+    more than decide, per line, "are we inside a triple-quoted string here".
+    """
+    inside = set()
+    delimiter = ""
+    index, line_number = 0, 0
+    while index < len(source):
+        character = source[index]
+        if character == "\n":
+            line_number += 1
+            if delimiter:
+                inside.add(line_number)
+            index += 1
+            continue
+        if delimiter:
+            if character == "\\":
+                index += 2
+                continue
+            if source.startswith(delimiter, index):
+                index += len(delimiter)
+                delimiter = ""
+                continue
+            index += 1
+            continue
+        if character == "#":
+            index = source.find("\n", index)
+            if index == -1:
+                break
+            continue
+        if character in "\"'":
+            triple = source[index : index + 3]
+            if triple in ('"""', "'''"):
+                delimiter = triple
+                index += 3
+            else:
+                # A single-quoted string cannot span lines except by continuation, and
+                # a line inside one still is not a magic, so it is enough to skip it.
+                delimiter = character
+                index += 1
+            continue
+        index += 1
+    return frozenset(inside)
+
+
+def _neutralised(source: str) -> str:
+    """The cell with IPython magics and shell escapes replaced by `pass`.
+
+    A `%magic` becomes `pass` at the same indentation rather than a blank line, so a
+    magic alone in an `if:` body does not leave an empty block. A `!cmd \\` continues
+    onto the following physical lines, and those are blanked too - otherwise ordinary
+    Python further down the same cell was thrown away with the shell command.
+    """
+    out, continuing, skip = [], False, 0
+    in_string = _string_open_lines(source)
+    lines = source.splitlines()
+    for number, line in enumerate(lines):
+        if skip:
+            skip -= 1
+            continue
+        if number in in_string:
+            out.append(line)
+            continuing = False
+            continue
+        capture = _capture_target(line)
+        if capture:
+            indent, target, operator, rest, _targets = capture
+            pieces = rest.split(maxsplit = 1)
+            magic = pieces[0] if operator == "%" and pieces else ""
+            tail = pieces[1] if len(pieces) > 1 else ""
+            if magic in _CODE_MAGICS and (tail.strip() or line.rstrip().endswith("\\")):
+                # `t = %timeit -o exec(payload)` captures a result, but IPython still
+                # runs the Python argument. Replacing the whole line dropped the sink,
+                # which is the same mistake the bare `%time exec(...)` handling already
+                # fixed once.
+                #
+                # A backslash continuation puts that argument on the following physical
+                # lines. Joining was added for the bare-magic branch below but not
+                # here, so the sink was blanked by the generic continuation handling.
+                joined, consumed = [tail.rstrip().removesuffix("\\")], 1
+                while line.rstrip().endswith("\\") and number + consumed < len(lines):
+                    piece = lines[number + consumed].rstrip()
+                    joined.append(piece.removesuffix("\\"))
+                    consumed += 1
+                    if not piece.endswith("\\"):
+                        break
+                argument = _magic_argument(" ".join(joined).strip())
+                # `-s` setup code RUNS before the timed statement, so it is emitted as
+                # a statement of its own rather than dropped with the other options.
+                for setup in _magic_setups(" ".join(joined).strip()):
+                    out.append(indent + setup)
+                # The argument is emitted as its own expression and the target gets an
+                # opaque value: `%timeit -o` binds a timing result object, not the
+                # value of the code it timed, so binding the argument to the target
+                # reported `payload = %timeit -o f"..."` as if `payload` were the
+                # f-string.
+                if magic == "time" and _is_expression(argument):
+                    # `%time` RETURNS the value of the expression it timed, so
+                    # `payload = %time f"import {name}"` really does bind the
+                    # f-string and a following `exec(payload)` executes it. Emitting
+                    # the argument and then binding None cleared it. `%timeit -o`
+                    # binds a timing result object instead, which is why the opaque
+                    # rewrite stays for every other magic here, and a `%time` of a
+                    # STATEMENT returns None, so only an expression is bound.
+                    out.append(f"{indent}{target} = {argument}")
+                else:
+                    out.append(f"{indent}{argument}")
+                    out.append(f"{indent}{target} = None")
+                out.extend([""] * (consumed - 2 if consumed > 1 else 0))
+                skip = consumed - 1
+                continuing = False
+                continue
+            else:
+                # The shell or magic result is opaque, so binding None both keeps the
+                # statement parseable and correctly clears the target.
+                #
+                # Every bound NAME is spelled out as its own target rather than
+                # reusing the original text. `payload, ignored = None` parses but is
+                # one scalar against a tuple, which nothing can pair up, so a
+                # `payload` built before the capture kept its stale reason. Chained
+                # targets bind each name to None and say exactly what happened.
+                #
+                # Store context only. `outputs[payload] = !cmd` READS `payload` to
+                # index with; it does not rebind it, and clearing it there turned this
+                # cleanup into a bypass.
+                names = sorted({
+                    child.id
+                    for node in _targets
+                    for child in ast.walk(node)
+                    if isinstance(child, ast.Name)
+                    and isinstance(child.ctx, ast.Store)
+                })
+                # A target that is not a plain name is KEPT rather than dropped:
+                # `result = outputs[exec(payload)] = !cmd` still evaluates the
+                # subscript, so replacing the whole chain with `result = None` threw
+                # the sink away. Each such target is spliced back into the chain.
+                # Original order, because assignment is left to right and the
+                # targets have effects: in `payload = table[exec(payload)] = !cmd`
+                # the magic result clears `payload` before the subscript is
+                # evaluated, so moving the subscript first reported the `exec`
+                # against a value it can no longer see.
+                pieces = [
+                    child.id if isinstance(child, ast.Name) else ast.unparse(child)
+                    for child in _targets
+                ]
+                left = " = ".join(pieces) if pieces else target
+                # The names are cleared in trailing statements on the SAME physical
+                # line, so the targets keep their order and their effects, every bound
+                # name still loses any stale reason, and the cell's line numbering is
+                # unchanged - findings below have to keep pointing at the right line.
+                clears = "".join(f"; {name} = None" for name in names)
+                out.append(f"{indent}{left} = None{clears}")
+            continuing = line.rstrip().endswith("\\")
+            continue
+        if continuing:
+            out.append("")
+            continuing = line.rstrip().endswith("\\")
+            continue
+        stripped = line.lstrip()
+        automagic = stripped.split(maxsplit = 1)[0] if stripped else ""
+        remainder = stripped.split(maxsplit = 1)
+        if (
+            automagic in _CODE_MAGICS
+            and len(remainder) > 1
+            and not stripped.startswith(("%", "!"))
+        ):
+            # IPython's automagic lets `timeit exec(payload)` run the sink without a
+            # leading `%`. The raw cell does not parse and nothing here rewrote the
+            # line, so the cell was skipped along with the sink. Only rewritten when
+            # the remainder is Python, so an ordinary `capture = 1` is untouched, and
+            # only when there IS a remainder: a line holding nothing but `timeit` is a
+            # bare name expression, and reaching for a second token raised IndexError
+            # out of `_neutralised`, which aborted the whole run rather than skipping
+            # one cell.
+            indent = line[: len(line) - len(stripped)]
+            # A backslash continuation puts the rest on the following physical lines,
+            # exactly as for the percent-prefixed spelling.
+            joined, consumed = [remainder[1].rstrip().removesuffix("\\")], 1
+            while line.rstrip().endswith("\\") and number + consumed < len(lines):
+                piece = lines[number + consumed].rstrip()
+                joined.append(piece.removesuffix("\\"))
+                consumed += 1
+                if not piece.endswith("\\"):
+                    break
+            argument = _magic_argument(" ".join(joined).strip())
+            # `-s` setup code RUNS before the timed statement, so it is emitted as
+            # a statement of its own rather than dropped with the other options.
+            for setup in _magic_setups(" ".join(joined).strip()):
+                out.append(indent + setup)
+            try:
+                ast.parse(argument)
+            except (SyntaxError, ValueError):
+                pass
+            else:
+                out.append(indent + argument)
+                out.extend([""] * (consumed - 2 if consumed > 1 else 0))
+                skip = consumed - 1
+                continuing = False
+                continue
+        if stripped.lstrip().startswith("?") and not stripped.startswith("#"):
+            # IPython accepts `?len` and `??len` as well as the suffix spellings, and
+            # neither parses, so the whole cell was counted as skipped and the sink
+            # below it never read. Blanked rather than parsed, exactly as the suffix
+            # form is: it is help syntax, not Python.
+            out.append("")
+            continuing = False
+            continue
+        if stripped.rstrip().endswith(("?", "??")) and not stripped.startswith("#"):
+            # `len?` and `obj??` are IPython help syntax, not Python. Leaving the line
+            # alone meant both parse attempts failed and the WHOLE cell was counted as
+            # skipped, so ordinary code below it - including a sink - was never read.
+            # Only when the line is not otherwise valid Python, so a genuine
+            # `x = a if b else c ?` style syntax error is not quietly swallowed and a
+            # conditional expression ending in `?` inside a string is untouched.
+            candidate = stripped.rstrip().rstrip("?")
+            try:
+                ast.parse(stripped)
+            except (SyntaxError, ValueError):
+                try:
+                    ast.parse(candidate)
+                except (SyntaxError, ValueError):
+                    pass
+                else:
+                    out.append(line[: len(line) - len(stripped)] + "pass")
+                    continuing = False
+                    continue
+        if stripped.startswith(("%", "!")):
+            indent = line[: len(line) - len(stripped)]
+            # A line magic that takes code keeps its argument; the magic itself is not
+            # Python but what follows it is, and dropping the line hid the sink.
+            if stripped.startswith("%") and not stripped.startswith("%%"):
+                head = stripped[1:].split(maxsplit = 1)
+                magic = head[0] if head else ""
+                rest = head[1] if len(head) > 1 else ""
+                if magic in _CODE_MAGICS and line.rstrip().endswith("\\"):
+                    # `%timeit \` puts the Python on the following physical lines.
+                    # Emitting the backslash and blanking what followed threw the sink
+                    # away, so the continuation is joined here and read as the
+                    # argument. The lines it consumed become blanks to keep the
+                    # numbering.
+                    joined, consumed = [], 0
+                    while number + consumed < len(lines):
+                        piece = lines[number + consumed].rstrip()
+                        joined.append(piece.removesuffix("\\"))
+                        consumed += 1
+                        if not piece.endswith("\\"):
+                            break
+                    argument = _magic_argument(" ".join(joined).lstrip()[len(magic) + 1:])
+                    # `-s` setup code RUNS before the timed statement, so it is emitted as
+                    # a statement of its own rather than dropped with the other options.
+                    for setup in _magic_setups(" ".join(joined).lstrip()[len(magic) + 1:]):
+                        out.append(indent + setup)
+                    out.append(indent + argument)
+                    out.extend([""] * (consumed - 1))
+                    skip = consumed - 1
+                    continuing = False
+                    continue
+                if magic in _CODE_MAGICS and rest.strip():
+                    for setup in _magic_setups(rest):
+                        out.append(indent + setup)
+                    out.append(indent + _magic_argument(rest))
+                    continuing = line.rstrip().endswith("\\")
+                    continue
+            out.append(indent + "pass")
+            continuing = line.rstrip().endswith("\\")
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+# `%%script` options that take their value in the following token.
+_SCRIPT_VALUE_OPTIONS = ("--out", "--err", "--proc")
+
+# `env` options that take their value in the following token.
+_ENV_VALUE_OPTIONS = ("-u", "--unset", "-C", "--chdir", "-S", "--split-string")
+
+# Real interpreter names: `python`, `python3`, `python3.13`, `pypy3`, and the Windows
+# `.exe` spellings. Not `python3-config`, `python3-dbg` or anything else that merely
+# starts with the same letters and does not execute the cell body.
+# Interpreter options that take a value in the next token, so it must not be mistaken
+# for the script name.
+_PYTHON_VALUE_OPTIONS = ("-c", "-m", "-W", "-X", "--check-hash-based-pycs")
+_PYTHON_COMMAND = re.compile(r"(?:python|pypy)[0-9]*(?:\.[0-9]+)?(?:\.exe)?", re.IGNORECASE)
+
+
+def _names_python(argument: str) -> bool:
+    """Whether a `%%script` argument names a Python interpreter at all.
+
+    Separate from `_runs_python`, which additionally asks whether that interpreter
+    reads the CELL BODY. With `-c` it does not, but it is still Python being run.
+    """
+    return _runs_python(argument, body_only = False)
+
+
+# `python --help` documents each of these as printing and exiting, so the interpreter
+# never reaches stdin and a `%%script python --help` body is data, not code.
+_PYTHON_EXIT_ONLY_OPTIONS = frozenset({
+    "-h", "-?", "--help", "-V", "--version",
+    "--help-env", "--help-xoptions", "--help-all",
+})
+
+
+def _runs_python(argument: str, body_only: bool = True) -> bool:
+    """Whether a `%%script` argument names a Python interpreter.
+
+    Options are skipped and the command is read off the front, so
+    `%%script --no-raise-error python3` is recognised. Only the executable name is
+    considered, which keeps `/usr/bin/python3.13` and a bare `python` on the same
+    footing.
+    """
+    try:
+        # `%%script --out "my captured" python` quotes like a shell, so a plain split
+        # made `"my` the option value and `captured"` the command.
+        tokens = shlex.split(argument)
+    except ValueError:
+        tokens = argument.split()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.startswith("-"):
+            # IPython documents `--out OUT`, `--err ERR` and `--proc PROC` for
+            # `%%script`, so the value sits in its own token. Skipping only the option
+            # left `captured` looking like the executable, and
+            # `%%script --out captured python` was classified as another language.
+            if token.split("=", 1)[0] in _SCRIPT_VALUE_OPTIONS and "=" not in token:
+                index += 2
+            else:
+                index += 1
+            continue
+        command = token.rsplit("/", 1)[-1].split("\\")[-1]
+        if command == "env":
+            # `%%script /usr/bin/env python` reaches Python through a wrapper. Its own
+            # options and any `NAME=value` assignments come first, so they are stepped
+            # over before the real command is read.
+            index += 1
+            while index < len(tokens):
+                token = tokens[index]
+                if "=" in token and not token.startswith("-"):
+                    index += 1
+                    continue
+                if not token.startswith("-"):
+                    break
+                # `env -u FOO python`: `-u/--unset` and `-C/--chdir` take a mandatory
+                # argument, so skipping only the option left `FOO` looking like the
+                # command and the Python cell was classified as foreign.
+                name = token.split("=", 1)[0]
+                if token.startswith("-S") and len(token) > 2 and "=" not in token:
+                    # GNU `env` accepts the value attached to the short form, and
+                    # `env -Spython` really does launch Python. Splitting on `=` left
+                    # `-Spython`, which matched neither the option nor a command.
+                    return _runs_python(token[2:], body_only)
+                if name in ("-S", "--split-string"):
+                    # `env -S "python -u"` puts the whole command in one argument, so
+                    # the wrapped command is inside that value rather than after it.
+                    value = token.split("=", 1)[1] if "=" in token else (
+                        tokens[index + 1] if index + 1 < len(tokens) else ""
+                    )
+                    return _runs_python(value, body_only)
+                if name in _ENV_VALUE_OPTIONS and "=" not in token:
+                    index += 2
+                else:
+                    index += 1
+            continue
+        # `python3-config` and friends take options; they do not run the cell body.
+        if not _PYTHON_COMMAND.fullmatch(command):
+            return False
+        # The interpreter only reads the cell body when it is reading stdin. With a
+        # script name, a `-c` command or a `-m` module it runs that instead and the
+        # body is just data piped at it, so scanning it reported findings in text that
+        # is never executed as Python here.
+        if not body_only:
+            return True
+        rest = tokens[index + 1:]
+        position = 0
+        # `-i` forces a prompt, so the body is read AFTER whatever else runs. It is
+        # recorded rather than returned on the spot: an exit-only option written after
+        # it wins, and `python -i --help` prints the help and exits without reading
+        # stdin at all.
+        interactive = False
+        while position < len(rest):
+            token = rest[position]
+            if token == "-":
+                return True
+            if token in _PYTHON_EXIT_ONLY_OPTIONS or (
+                token.startswith("-")
+                and not token.startswith("--")
+                and any(letter in token[1:] for letter in "hV?")
+            ):
+                # `python --help` documents `-h/-?/--help` as "print this help message
+                # and exit" and `-V/--version` as "print the Python version number and
+                # exit". Checked against the local CPython CLI: piping a program at
+                # `python --help`, `-h`, `-V`, `--version`, `-uh` or even `-i --help`
+                # exits without reading stdin at all. So the cell body is inert data,
+                # and scanning it failed the gate on an `exec(f"...")` nothing runs.
+                # This is checked BEFORE `-i`, because the help wins over it.
+                return False
+            if token.startswith("-") and not token.startswith("--") and "i" in token[1:]:
+                # `python --help` documents `-i` as "inspect interactively after
+                # running script; forces a prompt even if stdin does not appear to be
+                # a terminal". So `python -i helper.py` runs the script and THEN reads
+                # the cell body as Python, and `-ic`/`-im` do the same after the
+                # command or module. The body is Python either way.
+                interactive = True
+                position += 1
+                continue
+            if not token.startswith("-"):
+                return interactive
+            if token in ("-c", "-m"):
+                return interactive
+            if token.split("=", 1)[0] in _PYTHON_VALUE_OPTIONS and "=" not in token:
+                position += 2
+                continue
+            # Bundled short flags: `-uc` is `-u -c`.
+            if len(token) > 1 and token[1] != "-" and ("c" in token or "m" in token):
+                return interactive
+            position += 1
+        return True
+    return False
+
+
+def _expanded_env_tokens(tokens: list) -> list:
+    """`env -S "python -c '...'"` with its split-string opened out.
+
+    GNU `env` documents `-S/--split-string` as splitting its value into separate
+    arguments, and `_runs_python` already follows it to decide whether the cell runs
+    Python. This is the other half: the `-c` program lives INSIDE that value, so
+    scanning the outer tokens alone found nothing and the cell was passed over as
+    another language. Both spellings, `-S value` and the attached `-Svalue`.
+    """
+    expanded = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        value = None
+        if token.split("=", 1)[0] in ("-S", "--split-string"):
+            if "=" in token:
+                value = token.split("=", 1)[1]
+                index += 1
+            elif index + 1 < len(tokens):
+                value = tokens[index + 1]
+                index += 2
+            else:
+                index += 1
+        elif token.startswith("-S") and len(token) > 2 and not token.startswith("--"):
+            value = token[2:]
+            index += 1
+        else:
+            expanded.append(token)
+            index += 1
+            continue
+        if value is not None:
+            try:
+                expanded.extend(_expanded_env_tokens(shlex.split(value)))
+            except ValueError:
+                return expanded
+    return expanded
+
+
+def _is_expression(text: str) -> bool:
+    """Whether `text` is a single expression, so its value can be bound to a name."""
+    try:
+        ast.parse(text, mode = "eval")
+    except SyntaxError:
+        return False
+    return True
+
+
+def _script_command_source(code: str) -> str | None:
+    """The program a `%%script python -c "..."` cell hands to the interpreter.
+
+    `python --help` documents `-c cmd` as "program passed in as string", so that
+    string is the Python that runs and the cell body is stdin data the program may
+    never read. Only `%%script`, only when the command really is a Python interpreter,
+    and only when the argument is quoted plainly enough for `shlex` to read it.
+    """
+    for line in code.splitlines():
+        if not line.strip():
+            continue
+        if not line.startswith("%%"):
+            return None
+        pieces = line[2:].split(maxsplit = 1)
+        if not pieces or pieces[0] != "script":
+            return None
+        argument = pieces[1] if len(pieces) > 1 else ""
+        if not _names_python(argument):
+            return None
+        try:
+            tokens = _expanded_env_tokens(shlex.split(argument))
+        except ValueError:
+            return None
+        for position, token in enumerate(tokens):
+            if token == "-c" and position + 1 < len(tokens):
+                return tokens[position + 1]
+            if (
+                token.startswith("-")
+                and not token.startswith("--")
+                and len(token) > 2
+                and token.endswith("c")
+                and "c" not in token[1:-1]
+            ):
+                # A bundle ending in `c`, `python -uc "prog"`: the program is the next
+                # token, because `-c` consumes the rest of the ARGUMENT and there was
+                # nothing left of it.
+                return tokens[position + 1] if position + 1 < len(tokens) else None
+            if token.startswith("-c") and len(token) > 2 and not token.startswith("--"):
+                # `python -cPROGRAM` attaches the program to the option, which is what
+                # `-c` consuming the rest of the argument means. `-uc "prog"` is the
+                # other shape: bundled flags with the program in the next token.
+                rest = token[2:]
+                if rest.lstrip("-") == rest:
+                    return rest
+                return tokens[position + 1] if position + 1 < len(tokens) else None
+        return None
+    return None
+
+
+def _foreign_cell_magic(code: str) -> str | None:
+    """The `%%magic` name when it makes the whole cell stop being Python.
+
+    `%%bash`, `%%sh`, `%%html`, `%%writefile` and friends mean every line below is
+    another language, so failing to parse such a cell is the expected outcome rather
+    than a gap in coverage - reporting it as "did not parse" only trained readers to
+    ignore the notice. `%%time`, `%%capture` and the rest of `_CODE_MAGICS` are the
+    opposite: the body is ordinary Python and must still be checked, so they are not
+    foreign and only their first line is dropped.
+    """
+    for line in code.splitlines():
+        if not line.strip():
+            continue
+        if not line.startswith("%%"):
+            return None
+        if not line[2:].strip():
+            return None
+        pieces = line[2:].split(maxsplit = 1)
+        magic = pieces[0] if pieces else ""
+        argument = pieces[1] if len(pieces) > 1 else ""
+        if magic in _CODE_MAGICS or magic in ("python", "python3"):
+            return None
+        if magic == "script" and _runs_python(argument):
+            # `%%script python` hands the body to a Python interpreter, so it is
+            # Python and has to be scanned. Reading only the magic name classified it
+            # as foreign and skipped the cell entirely.
+            #
+            # `%%script` only. `%%bash` runs bash whatever its argument says, so
+            # letting `%%bash python` through here reported shell text that happened
+            # to parse as Python.
+            return None
+        return magic
+    return None
+
+
+def _parse_cell(code: str, filename: str):
+    """The cell's AST, trying it verbatim before neutralising anything.
+
+    Parsing the raw text first matters: a line may begin with `%` and be an ordinary
+    continuation of a modulo expression rather than a magic, and rewriting that to
+    `pass` corrupted a cell that was valid Python to begin with. Only a cell that
+    genuinely will not parse is put through `_neutralised`.
+    """
+    # Notebook prose regularly contains things like `\\(` in a regex written without a
+    # raw string. That is the notebook author's business, not this gate's, and letting
+    # the warning through buries the findings in noise.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SyntaxWarning)
+        for candidate in (code, _neutralised(code)):
+            try:
+                return ast.parse(candidate, filename = filename)
+            except (SyntaxError, ValueError):
+                continue
+            except (MemoryError, RecursionError) as error:
+                # A parser resource limit is not "this cell is not Python". Counting it
+                # as a skipped cell let a valid cell with a huge expression in front of
+                # a sink pass with no finding at all, so it fails the file instead.
+                raise ScanError(
+                    f"{filename}: hit a parser limit ({error.__class__.__name__}), so "
+                    f"the cell was not checked"
+                ) from None
+    return None
+
+
+def _scan_notebook(path: Path) -> list[dict]:
+    """Findings across a notebook's code cells, which share one namespace.
+
+    A single visitor spans the cells, because a notebook's cells run in order against
+    the same globals: a payload built in one cell and executed in a later one is the
+    natural way to write it, and a fresh visitor per cell threw that away. Only the
+    qualname prefix changes per cell, so findings stay attributable.
+
+    A cell that will not parse either way is SKIPPED, which is the opposite of what a
+    `.py` file gets, and the difference is deliberate. A `.py` file claims to be a
+    Python module, so failing to parse it means the gate did not check something it was
+    supposed to. A notebook cell routinely is not Python at all. The count is printed
+    so the gap stays visible rather than silent.
+    """
+    visitor = _Visitor(path)
+    skipped = 0
+    parsed = []
+    for index, code in _notebook_code_cells(path):
+        # `%%script python -c "<program>"` runs the STRING, not the cell body, so the
+        # body is data and the program is what executes. Scanning the body was wrong
+        # and skipping the cell missed the program entirely; the `-c` argument becomes
+        # the cell's source instead.
+        command = _script_command_source(code)
+        if command is not None:
+            code = command
+        elif _foreign_cell_magic(code) is not None:
+            continue
+        tree = _parse_cell(code, f"{path}#cell{index}")
+        if tree is None:
+            skipped += 1
+            continue
+        parsed.append((index, tree))
+    # Every cell first, then the walk. Cells share one namespace and a function defined
+    # in cell 0 is called after cell 1 has run, so an alias imported later is visible
+    # to it - collecting per cell analysed that function before the import existed.
+    for _index, tree in parsed:
+        visitor._collect_aliases(tree.body)
+    for index, tree in parsed:
+        if _annotations_deferred(tree):
+            visitor.annotations_deferred = True
+        visitor.qualname_prefix = f"cell{index}"
+        try:
+            visitor.visit(tree)
+        except RecursionError:
+            raise ScanError(
+                f"{_relative(path)}#cell{index}: too deeply nested to walk"
+            ) from None
+    if skipped:
+        NOTEBOOK_SKIPPED.append((_relative(path), skipped))
+    return visitor.findings
+
+
+NOTEBOOK_SKIPPED: list[tuple[str, int]] = []
+
+
+def _annotations_deferred(tree: ast.AST) -> bool:
+    """True when the module carries `from __future__ import annotations`."""
+    for node in getattr(tree, "body", []):
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            if any(alias.name == "annotations" for alias in node.names):
+                return True
+    return False
+
+
 def scan_file(path: Path) -> list[dict]:
     # A hard CI gate must not fall over on something that is not a readable file. A
     # dangling symlink, a directory named `*.py`, or a symlink to one all reach here
     # through rglob and raise out of read_text, failing the build for a reason that has
     # nothing to do with dynamic execution.
+    if path.suffix == NOTEBOOK_SUFFIX:
+        return _scan_notebook(path)
     try:
-        source = path.read_text(encoding = "utf-8", errors = "replace")
-    except OSError:
-        return []
+        # Bytes, not text. `ast.parse` applies the PEP 263 coding declaration itself,
+        # while decoding here as UTF-8 with errors = "replace" corrupted any file that
+        # declares another encoding. That was harmless while an unparseable file was
+        # reported clean, but now that it fails the gate it turned a valid module into
+        # a build failure: a latin-1 file with a non-ASCII identifier decoded to U+FFFD
+        # and raised `invalid character`, even though py_compile accepts it.
+        source = path.read_bytes()
+    except OSError as error:
+        # Not clean: it has not been checked. `collect_paths` already filters
+        # directories and dangling symlinks, so reaching here means a file that exists
+        # and could not be read - a permission problem, say - and reporting zero
+        # findings for it is the same bypass as swallowing a parse error.
+        raise ScanError(
+            f"{_relative(path)}: could not be read ({error.__class__.__name__}), so it "
+            f"was not checked"
+        ) from None
     try:
         tree = ast.parse(source, filename = str(path))
-    except (SyntaxError, ValueError):
-        # compileall in the same lint job is what reports unparseable files. ValueError
-        # covers a source containing a NUL byte, which ast.parse rejects separately.
-        return []
+    except (SyntaxError, ValueError, MemoryError, RecursionError) as error:
+        # A file that cannot be parsed has not been checked, and reporting it as clean
+        # is the same bypass as swallowing a RecursionError. The comment here used to
+        # defer to compileall in the same job, but both syntax-reporting steps in
+        # lint-ci.yml are `continue-on-error: true`, so nothing else fails the build.
+        # ValueError covers a source containing a NUL byte, which ast.parse rejects
+        # separately from a syntax error. MemoryError and RecursionError cover the
+        # parser's own limits: about ten thousand nested unary operators raises
+        # `MemoryError: Parser stack overflowed`, which is a resource limit rather than
+        # a real memory problem. Letting it escape aborted the whole run before any
+        # other file was scanned or reported, which is the one-bad-file-hides-every-
+        # finding failure mode this file has now hit three times.
+        raise ScanError(
+            f"{_relative(path)}: could not be parsed ({error.__class__.__name__}), so "
+            f"it was not checked for interpolated dynamic execution"
+        ) from None
     visitor = _Visitor(path)
+    visitor.annotations_deferred = _annotations_deferred(tree)
+    visitor._collect_aliases(tree.body)
     try:
         visitor.visit(tree)
     except RecursionError:
-        # A deeply nested literal can exhaust the stack during the walk, after parse
-        # succeeded. Report nothing rather than taking the gate down; compileall still
-        # sees the file.
-        return []
+        # A deeply nested expression can exhaust the stack during the walk, after parse
+        # succeeded. Returning [] here reported the file as clean, which is a bypass:
+        # 500 nested `not` in front of an interpolated exec compiled fine and the gate
+        # passed with zero findings. An unfinishable walk is an unknown, and a security
+        # gate reports an unknown as a failure, not as a pass.
+        raise ScanError(
+            f"{_relative(path)}: too deeply nested to walk, so this file could not be "
+            f"checked for interpolated dynamic execution"
+        ) from None
     return visitor.findings
 
 
-def scan(paths: list[Path]) -> list[dict]:
-    findings = []
+def scan(paths: list[Path]) -> tuple[list[dict], list[str]]:
+    """Findings, plus the files the checker could not finish. Both fail the gate."""
+    findings, errors = [], []
     for path in sorted(paths):
-        findings.extend(scan_file(path))
-    return findings
+        try:
+            findings.extend(scan_file(path))
+        except ScanError as error:
+            errors.append(str(error))
+    return findings, errors
 
 
-def collect_paths(targets: list[str]) -> list[Path]:
-    paths = []
+def collect_paths(targets: list[str]) -> tuple[list[Path], list[str]]:
+    """Files to scan, plus the targets that resolved to nothing.
+
+    A target that is neither a Python file nor a directory used to be dropped in
+    silence, so renaming a file in `DEFAULT_TARGETS` or mistyping a `--paths`
+    argument left the gate passing over less code than it claims to cover. Reduced
+    coverage that still exits 0 is the failure this whole checker exists to avoid,
+    so an unresolvable target is reported rather than skipped.
+    """
+    paths, missing = [], []
     for target in targets:
         root = REPO_ROOT / target
-        if root.is_file() and root.suffix == ".py":
+        if root.is_file() and root.suffix in (".py", NOTEBOOK_SUFFIX):
             paths.append(root)
         elif root.is_dir():
             # `is_file()` on each hit, so a directory named `foo.py` and a symlink that
             # points at one are skipped rather than read.
-            paths.extend(
-                p for p in root.rglob("*.py")
-                if p.is_file() and "tests" not in p.relative_to(REPO_ROOT).parts
+            before = len(paths)
+            for pattern in ("*.py", f"*{NOTEBOOK_SUFFIX}"):
+                paths.extend(
+                    p for p in root.rglob(pattern)
+                    if p.is_file() and not _EXCLUDED_PARTS & set(_exclusion_parts(p, root))
+                )
+            if len(paths) == before:
+                # An existing but empty directory resolved "successfully" while
+                # contributing nothing, which is the same reduced coverage a missing
+                # target gives and was the one way left to exit 0 having checked
+                # nothing.
+                missing.append(
+                    f"{target}: scan target contains no Python files or notebooks, "
+                    f"so nothing under it was checked"
+                )
+        else:
+            missing.append(
+                f"{target}: requested scan target does not exist, so nothing under it "
+                f"was checked"
             )
-    return paths
+    return paths, missing
+
+
+# Directory names a recursive scan never descends into. `tests` is excluded because a
+# test legitimately keeps the removed `exec`/`eval` around as an oracle. The rest are
+# not part of any commit: a checkout that has run a frontend install or a plugin build
+# carries third-party and generated Python that this gate has no business failing on,
+# and `--update` would otherwise write allowlist entries for files a clean CI checkout
+# does not even have.
+_EXCLUDED_PARTS = frozenset({
+    "tests", "node_modules", "build", "dist", ".venv", "venv", "site-packages",
+    ".git", ".tox", ".mypy_cache", ".pytest_cache", "__pycache__", ".ipynb_checkpoints",
+    ".eggs",
+})
+
+
+def _exclusion_parts(path: Path, root: Path) -> tuple[str, ...]:
+    """Path components the directory exclusions are matched against.
+
+    Repo-relative when the file is in the repo, so the default scan keeps excluding
+    `<target>/tests/...` exactly as before. A directory passed through `--paths` may
+    sit outside the checkout - a pytest tmp_path, a vendored tree - and
+    `relative_to(REPO_ROOT)` raises `ValueError` for every file under it, which took
+    the whole run down with a traceback before any finding was printed. External
+    single files already worked, so this only makes directories agree with them.
+    """
+    for base in (REPO_ROOT, root):
+        try:
+            return path.relative_to(base).parts
+        except ValueError:
+            continue
+    return path.parts
 
 
 def load_allowlist() -> dict[str, dict]:
     if not ALLOWLIST_PATH.exists():
         return {}
-    data = json.loads(ALLOWLIST_PATH.read_text())
+    data = json.loads(ALLOWLIST_PATH.read_text(encoding = "utf-8"))
     return {key_of(entry): entry for entry in data.get("allowed", [])}
 
 
@@ -297,6 +4600,54 @@ def f(model_type):
     compile("x = %s" % value, "<x>", "exec")
     exec("a.{}.b".format(name))
     compile(source = f"y = {value}", filename = "<x>", mode = "exec")
+    exec("import {module}".format_map(values))
+    exec(f"import {name}".encode())
+    annotated: str = f"import {name}"
+    exec(annotated)
+    exec(bytes(f"import {name}", "utf-8"))
+    exec(payload := f"import {name}")
+    exec("import MODULE".replace("MODULE", name))
+
+def g(name):
+    payload = f"import {name}"
+    exec(payload.encode())
+
+def h(name):
+    payload = f"import {name}"
+    payload: object = exec(payload)
+
+def i(name):
+    payload = f"import {name}"
+    payload = exec(payload)
+
+def j(name):
+    (payload := f"import {name}")
+    exec(payload)
+
+def n(name, enabled):
+    exec(enabled and f"import {name}")
+    payload, ignored = f"import {name}", None
+    exec(payload)
+    exec(builtins.str.encode(f"import {name}"))
+
+class Outer:
+    inner_annotation: exec(f"import {NAME}") = 1
+
+def m(model_type):
+    payload = "import "
+    payload += model_type
+    exec(payload)
+
+def k(name):
+    table = {}
+    payload = table[exec(payload)] = f"import {name}"
+
+def l(name):
+    exec(bytes(source = f"import {name}", encoding = "utf-8"))
+    exec(str(object = f"import {name}"))
+    exec(str.encode(f"import {name}"))
+
+annotated_at_module: exec(annotated_at_module) = f"import {NAME}"
 """
 
 _GOOD = """
@@ -309,6 +4660,8 @@ def f(cls):
     exec(f"plain f-string with no placeholders")
     module.exec(f"{name}")          # not the builtin
     exec()                          # no arguments
+    exec(source.replace("def a", "def b"), globals())   # variable receiver
+    exec(str(source))               # str() of a name is not interpolation
 """
 
 
@@ -321,9 +4674,39 @@ def self_test() -> int:
         bad.write_text(_BAD)
         findings = scan_file(bad)
         kinds = sorted(f["reason"] for f in findings)
-        if kinds != ["%-format", ".format()", "f-string", "f-string", "string concatenation"]:
-            failures.append(f"expected all four shapes plus the keyword call, got {kinds}")
-        if any(f["qualname"] != "f" for f in findings):
+        expected = [
+            "%-format",
+            ".format()",
+            ".format_map()",
+            ".replace() on a literal",
+            "f-string",
+            "f-string",
+            "f-string",
+            "f-string",
+            "f-string",
+            "f-string",
+            "f-string",
+            "f-string",
+            "f-string",
+            "f-string",
+            "f-string",
+            "f-string via `annotated_at_module`",
+            "f-string via `annotated`",
+            "f-string via `payload`",
+            "f-string via `payload`",
+            "f-string via `payload`",
+            "f-string via `payload`",
+            "f-string via `payload`",
+            "f-string via `payload`",
+            "string concatenation",
+            "string concatenation appended via `payload`",
+        ]
+        if kinds != expected:
+            failures.append(f"expected {expected}, got {kinds}")
+        if any(
+            f["qualname"] not in ("f", "g", "h", "i", "j", "k", "l", "m", "n", "Outer", "<module>")
+            for f in findings
+        ):
             failures.append(f"qualname wrong: {[f['qualname'] for f in findings]}")
 
         good = Path(directory) / "good.py"
@@ -346,6 +4729,122 @@ def self_test() -> int:
             failures.append("reformatting changed the hash")
         if h1 == h3:
             failures.append("changing the interpolation did not change the hash")
+
+        # An AST too deep to walk must fail the gate, not report the file clean.
+        deep = Path(directory) / "deep.py"
+        deep.write_text(
+            "def f(user):\n"
+            "    x = " + "not " * 500 + "True\n"
+            '    exec(f"import {user}")\n'
+        )
+        try:
+            scan_file(deep)
+            failures.append("a file too deep to walk was reported clean")
+        except ScanError:
+            pass
+        _, errors = scan([deep])
+        if len(errors) != 1:
+            failures.append(f"scan() should surface the unscannable file, got {errors}")
+
+        # A directory outside the repo must scan rather than crash on relative_to.
+        external = Path(directory) / "external"
+        external.mkdir()
+        (external / "x.py").write_text('def f(m):\n    exec(f"import {m}")\n')
+        collected, missing = collect_paths([str(external)])
+        found, errors = scan(collected)
+        errors += missing
+        if len(found) != 1 or errors:
+            failures.append(f"external directory not scanned: {found}, {errors}")
+
+        # A file that cannot be parsed has not been checked, so it must not read as
+        # clean. Both syntax-reporting steps in lint-ci.yml are continue-on-error, so
+        # nothing else in the job would fail the build for it.
+        broken = Path(directory) / "broken.py"
+        broken.write_text("def f(:\n")
+        try:
+            scan_file(broken)
+            failures.append("a file that does not parse was reported clean")
+        except ScanError:
+            pass
+
+        # A file declaring a non-UTF-8 encoding is valid Python and must not fail the
+        # gate. Decoding it as UTF-8 with errors = "replace" turned a latin-1
+        # identifier into U+FFFD and made a good module unscannable.
+        latin1 = Path(directory) / "latin1.py"
+        latin1.write_bytes("# -*- coding: latin-1 -*-\ncaf\xe9 = 1\n".encode("latin-1"))
+        try:
+            if scan_file(latin1) != []:
+                failures.append("the latin-1 file produced findings it should not have")
+        except ScanError:
+            failures.append("a valid latin-1 module was reported unscannable")
+
+        # ast.parse rejects a NUL byte with ValueError rather than SyntaxError.
+        nul = Path(directory) / "nul.py"
+        nul.write_bytes(b"x = 1\x00\n")
+        try:
+            scan_file(nul)
+            failures.append("a file containing a NUL byte was reported clean")
+        except ScanError:
+            pass
+
+        # An annotation that cannot execute must not be reported. A function-local
+        # annotation is never evaluated, and neither is a module one under
+        # `from __future__ import annotations`.
+        for name, body in (
+            ("inert_local.py", 'def f(name):\n    x: exec(f"import {name}") = 1\n'),
+            (
+                "inert_future.py",
+                "from __future__ import annotations\n"
+                'name = "os"\ny: exec(f"import {name}") = 1\n',
+            ),
+        ):
+            inert = Path(directory) / name
+            inert.write_text(body)
+            if scan_file(inert):
+                failures.append(f"{name}: reported an annotation that never runs")
+        # ... while the module-scope one that does run is still reported.
+        live = Path(directory) / "live_annotation.py"
+        live.write_text('name = "os"\npayload: exec(payload) = f"import {name}"\n')
+        if not scan_file(live):
+            failures.append("a module-scope runtime annotation was not reported")
+
+        # A notebook's cells share one namespace, and a `%`-leading continuation of a
+        # modulo expression is not a magic.
+        import json as _json
+        def _nb(cells):
+            return _json.dumps({
+                "cells": [{"cell_type": "code", "source": c} for c in cells],
+                "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+            })
+        for name, cells in (
+            # payload built in one cell, executed in the next
+            ("cross.ipynb", [['name = "os"\n', 'payload = f"import {name}"\n'],
+                             ["exec(payload)\n"]]),
+            # a continuation line starting with `%` is modulo, not a magic
+            ("modulo.ipynb", [['name = "os"\n', 'exec("import %s"\n', "     % name)\n"]]),
+            # ordinary Python after a multi-line shell command must still be read
+            ("mixed.ipynb", [["!pip install x \\\n", "  --quiet\n",
+                              'name = "os"\n', 'exec(f"import {name}")\n']]),
+        ):
+            notebook = Path(directory) / name
+            notebook.write_text(_nb(cells))
+            if not scan_file(notebook):
+                failures.append(f"{name}: notebook payload was not reported")
+
+        # An existing but empty directory is reduced coverage, not a clean run.
+        hollow = Path(directory) / "hollow"
+        hollow.mkdir()
+        _, nothing = collect_paths([str(hollow)])
+        if len(nothing) != 1:
+            failures.append(f"an empty scan directory was accepted: {nothing}")
+
+        # A target that resolves to nothing means reduced coverage, not a clean run.
+        _, absent = collect_paths(["no_such_target_xyz.py"])
+        if len(absent) != 1:
+            failures.append(f"a missing scan target was skipped in silence: {absent}")
+        _, present = collect_paths([str(external)])
+        if present:
+            failures.append(f"an existing target was reported missing: {present}")
 
     for failure in failures:
         print(f"self-test: {failure}", file = sys.stderr)
@@ -374,9 +4873,32 @@ def main() -> int:
         return self_test()
 
     targets = args.paths if args.paths else list(DEFAULT_TARGETS)
-    findings = scan(collect_paths(targets))
+    collected, missing = collect_paths(targets)
+    findings, errors = scan(collected)
+    # A target that resolved to nothing is reported with the unscannable files: in
+    # both cases the gate looked at less code than it was asked to.
+    errors += missing
 
     if args.update:
+        # `--update` REPLACES the file, so it may only ever run over the full tree.
+        # With `--paths` it wrote just that subset and silently dropped every reviewed
+        # entry outside it - updating one temporary offender replaced a 37 entry
+        # allowlist with a one entry file, and the justifications were only
+        # recoverable from git.
+        if args.paths:
+            print(
+                "FAIL: --update rewrites the whole allowlist and cannot be combined "
+                "with --paths, which would drop every entry outside the subset.\n"
+                "Run --update with no --paths to rewrite from the full tree.",
+                file = sys.stderr,
+            )
+            return 1
+        # An allowlist written from an incomplete scan would bake in the gap.
+        if errors:
+            for error in errors:
+                print(f"scan error: {error}", file = sys.stderr)
+            print("\nFAIL: refusing to rewrite the allowlist from an incomplete scan.", file = sys.stderr)
+            return 1
         write_allowlist(findings, reason = "REVIEW ME")
         print(f"wrote {len(findings)} entries to {ALLOWLIST_PATH.name}")
         return 0
@@ -411,11 +4933,19 @@ def main() -> int:
             f"{entry['qualname']} no longer matches any call - re-run --update",
             file = sys.stderr,
         )
+    for error in errors:
+        print(f"scan error: {error}", file = sys.stderr)
+    for notebook, count in NOTEBOOK_SKIPPED:
+        print(
+            f"note: {notebook}: {count} code cell(s) did not parse and were not "
+            f"checked (shell or partial cells)",
+            file = sys.stderr,
+        )
 
-    if unreviewed or pending or stale:
+    if unreviewed or pending or stale or errors:
         print(
             f"\nFAIL: {len(unreviewed)} unreviewed, {len(pending)} unjustified, "
-            f"{len(stale)} stale.\n"
+            f"{len(stale)} stale, {len(errors)} unscannable.\n"
             f"Fix the call, or run --update and write down why the interpolated value "
             f"cannot be attacker controlled.",
             file = sys.stderr,

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -766,6 +766,82 @@ def _interpolated_starred(node, resolve = None, shadowed = None, resolve_alias =
 _SPLITTERS = ("split", "rsplit", "partition", "rpartition", "splitlines")
 
 
+def _constant_integer(node) -> int | None:
+    """A written-out `int`, including the `-1` spelling that is a `UnaryOp`."""
+    sign = 1
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.USub, ast.UAdd)):
+        sign = -1 if isinstance(node.op, ast.USub) else 1
+        node = node.operand
+    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+        if isinstance(node.value, bool):
+            return None
+        return sign * node.value
+    return None
+
+
+def _split_piece_is_literal(inner: ast.Call, index_node) -> bool:
+    """Whether the selected piece of a split receiver is fixed text whatever is spliced.
+
+    `f"PREFIX{name}".partition("PREFIX")[0]` is the empty string however `name` is
+    spelled: the separator sits in the receiver's own leading literal, so the first
+    split point falls inside that literal and everything before it is literal too. The
+    mirror holds for the LAST piece of `rpartition` and `rsplit` against the trailing
+    literal.
+
+    Only that case. `f"{name}#pass".partition("#")[2]` looks fixed and is not: a `name`
+    containing `#` moves the first separator into the spliced value and the piece after
+    it carries the rest of that value.
+    """
+    receiver = inner.func.value
+    if not isinstance(receiver, ast.JoinedStr):
+        return False
+    separator = inner.args[0] if inner.args else None
+    for keyword in inner.keywords:
+        if keyword.arg == "sep":
+            separator = keyword.value
+    if not (
+        isinstance(separator, ast.Constant)
+        and isinstance(separator.value, str)
+        and separator.value
+    ):
+        return False
+    index = _constant_integer(index_node)
+    if index is None:
+        return False
+    leading, trailing = "", ""
+    for value in receiver.values:
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            leading += value.value
+        else:
+            break
+    for value in reversed(receiver.values):
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            trailing = value.value + trailing
+        else:
+            break
+    method = inner.func.attr
+    if method in ("partition", "rpartition"):
+        if method == "partition" and index == 0:
+            return separator.value in leading
+        if method == "rpartition" and index == 2:
+            return separator.value in trailing
+        return False
+    # `split` and `rsplit` take a maxsplit, and a maxsplit of zero performs no split
+    # at all: the single piece is the WHOLE receiver, interpolation included. A
+    # maxsplit this cannot read is treated the same way.
+    maxsplit = inner.args[1] if len(inner.args) > 1 else None
+    for keyword in inner.keywords:
+        if keyword.arg == "maxsplit":
+            maxsplit = keyword.value
+    if maxsplit is not None and _constant_integer(maxsplit) == 0:
+        return False
+    if method == "split" and index == 0:
+        return separator.value in leading
+    if method == "rsplit" and index == -1:
+        return separator.value in trailing
+    return False
+
+
 def _interpolated_split_element(node, resolve = None, shadowed = None, resolve_alias = None):
     """The source a `s.split(...)[i]` selection still carries, if any."""
     if not isinstance(node, ast.Subscript):
@@ -774,6 +850,8 @@ def _interpolated_split_element(node, resolve = None, shadowed = None, resolve_a
     if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)):
         return None
     if inner.func.attr not in _SPLITTERS:
+        return None
+    if _split_piece_is_literal(inner, node.slice):
         return None
     return _is_interpolated(inner.func.value, resolve, shadowed, resolve_alias)
 
@@ -819,6 +897,10 @@ def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias
 # one file is scanned at a time, and `_Visitor` sets it before it walks anything.
 _LOCAL_CLASSES: dict = {}
 
+# Class names the file also binds to something else. Read alongside the table above:
+# a name that is a class in one place and a lambda in another is no evidence at all.
+_REBOUND_CLASS_NAMES: set = set()
+
 
 def _visibly_local_instance(node: ast.AST, shadowed = None) -> bool:
     """Whether `node` is written out as an instance of a class defined in this file.
@@ -829,6 +911,8 @@ def _visibly_local_instance(node: ast.AST, shadowed = None) -> bool:
     if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
         return False
     if shadowed is not None and shadowed(node.func.id):
+        return False
+    if node.func.id in _REBOUND_CLASS_NAMES:
         return False
     # A class that SUBCLASSES `str` or `bytes` inherits the real builder unless it
     # overrides it, so `class Template(str): pass` followed by
@@ -1018,16 +1102,76 @@ def _interpolated_binop(node, resolve = None, shadowed = None, resolve_alias = N
     return None
 
 
+def _lambda_scope(node: ast.Call, function: ast.Lambda, resolve, shadowed, resolve_alias):
+    """A `resolve` that answers for an immediately invoked lambda's parameters.
+
+    Positional arguments pair with the parameters in order, keywords by name, and a
+    parameter nobody supplied falls back to its default. A parameter is answered from
+    the CALL, never from the enclosing scope, since it shadows whatever that name
+    meant outside. Every other name is passed straight through.
+    """
+    arguments = function.args
+    positional = [*arguments.posonlyargs, *arguments.args]
+    names = {
+        argument.arg
+        for argument in (
+            *positional, *arguments.kwonlyargs, arguments.vararg, arguments.kwarg,
+        )
+        if argument is not None
+    }
+    bound: dict = {}
+    # `*args` at the call site moves every later argument, so nothing after it pairs
+    # up: those parameters stay unresolved rather than being paired with the wrong
+    # value.
+    for index, argument in enumerate(node.args):
+        if isinstance(argument, ast.Starred):
+            break
+        if index < len(positional):
+            bound[positional[index].arg] = argument
+    for keyword in node.keywords:
+        if keyword.arg is None:
+            # `**mapping` can supply any parameter with anything, so no parameter it
+            # could reach is answered from the call.
+            return resolve
+        if keyword.arg in names:
+            bound[keyword.arg] = keyword.value
+    defaults = arguments.defaults
+    if defaults:
+        for parameter, default in zip(positional[len(positional) - len(defaults):], defaults):
+            bound.setdefault(parameter.arg, default)
+    for parameter, default in zip(arguments.kwonlyargs, arguments.kw_defaults):
+        if default is not None:
+            bound.setdefault(parameter.arg, default)
+
+    def resolve_in_lambda(name):
+        if name in bound:
+            return _is_interpolated(bound[name], resolve, shadowed, resolve_alias)
+        if name in names:
+            return None
+        return resolve(name) if resolve is not None else None
+
+    return resolve_in_lambda
+
+
 def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
     """Every call shape that hands its argument through as source."""
     function = node.func
     if isinstance(function, ast.Lambda):
         # `(lambda: f"import {name}")()` returns exactly what its body evaluates to,
         # and that body is written out right here. The callee is a `Lambda` rather
-        # than a name, so none of the branches below saw it. Parameters are not
-        # resolved: a body reading one is unknown, and `resolve` answers for the
-        # enclosing scope, so `_is_interpolated` reads it as an ordinary name.
-        return _is_interpolated(function.body, resolve, shadowed, resolve_alias)
+        # than a name, so none of the branches below saw it.
+        #
+        # The arguments are matched to the parameters first. A body that returns one
+        # of them, `(lambda source: source)(f"import {name}")`, returns the argument,
+        # and resolving the body against the ENCLOSING scope alone left `source`
+        # unresolved and the call silent. A parameter with no visible argument
+        # resolves to nothing rather than to the enclosing name it shadows.
+        return _is_interpolated(
+            function.body,
+            _lambda_scope(node, function, resolve, shadowed, resolve_alias),
+            shadowed,
+            resolve_alias,
+        )
     preserving = None
     if isinstance(function, ast.Name):
         preserving = function.id
@@ -1414,11 +1558,17 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
     # to _BUILDERS instead raises 5 findings here and 5 in unsloth, all of them
     # that idiom; this branch raises none.
     if isinstance(function, ast.Attribute) and function.attr == "replace":
+        # The receiver's OWN interpolation is read whatever the arguments are; only
+        # the "literal template plus a spliced replacement" reading below depends on
+        # them. Gating the whole branch on the arguments dropped the taint a built
+        # receiver carries, which is the shape this repo's `inspect.getsource`
+        # rewriting has.
+        splices = _replace_can_splice(node)
         receiver = function.value
-        if isinstance(receiver, ast.Constant):
+        if isinstance(receiver, ast.Constant) and splices:
             if isinstance(receiver.value, (str, bytes)):
                 return ".replace() on a literal"
-        if isinstance(receiver, ast.Name) and resolve is not None:
+        if isinstance(receiver, ast.Name) and resolve is not None and splices:
             # `template = "import MODULE"; template.replace("MODULE", name)` is the
             # same splice one line later, which is a two-line refactor away from the
             # literal receiver above. Only a name a written-out string bound: the
@@ -1439,7 +1589,7 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
         if _constructor_name(receiver, shadowed, resolve_alias) in ("str", "bytes"):
             if node.args:
                 template = node.args[0]
-                if isinstance(template, ast.Constant):
+                if isinstance(template, ast.Constant) and splices:
                     if isinstance(template.value, (str, bytes)):
                         return ".replace() on a literal"
                 # The template can be built rather than literal, same as for the
@@ -1448,6 +1598,39 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
     # An unrecognised call shape fell through to the closing `return None` in the
     # original, because a Call is none of the disjoint shapes above it. Spelled out.
     return None
+
+
+def _replace_can_splice(node: ast.Call) -> bool:
+    """Whether a `.replace()` call can put a nonliteral value into its result.
+
+    `"pass".replace("x", "y")` rewrites one literal into another and executes fixed
+    source; `"pass".replace("x", name, 0)` performs no replacement at all. Both were
+    reported on the receiver alone. Only a written-out argument answers here - a
+    replacement this cannot read is assumed to splice, which is the reporting side.
+    """
+    replacement = node.args[1] if len(node.args) > 1 else None
+    for keyword in node.keywords:
+        if keyword.arg == "new":
+            replacement = keyword.value
+        elif keyword.arg is None:
+            # `**mapping` can supply anything, including the replacement.
+            return True
+    if isinstance(replacement, ast.Constant) and isinstance(
+        replacement.value, (str, bytes)
+    ):
+        return False
+    count = node.args[2] if len(node.args) > 2 else None
+    for keyword in node.keywords:
+        if keyword.arg == "count":
+            count = keyword.value
+    if (
+        isinstance(count, ast.Constant)
+        and isinstance(count.value, int)
+        and not isinstance(count.value, bool)
+        and count.value == 0
+    ):
+        return False
+    return True
 
 
 def _always_breaks(body) -> bool:
@@ -2245,6 +2428,9 @@ def _compile_call_is_complete(node: ast.Call, shadowed = None, skip: int = 0) ->
     `compile(source, filename, mode)` has no defaults for any of them. A `*` or `**`
     in the call may supply what is missing, so those are unknown and count as
     complete: this only ever declines to report a call CPython refuses outright.
+
+    False also for a call that binds one parameter twice, which is the other way
+    CPython refuses it outright.
     """
     positional = 0
     named = {keyword.arg for keyword in node.keywords if keyword.arg is not None}
@@ -2280,6 +2466,16 @@ def _compile_call_is_complete(node: ast.Call, shadowed = None, skip: int = 0) ->
             key.value for key in mapping.keys
             if isinstance(key, ast.Constant) and isinstance(key.value, str)
         }
+    # A keyword that repeats a positional makes the call a `TypeError` before any
+    # source is compiled: `compile(f"...", "<x>", "exec", source = "pass")` never runs,
+    # and reporting the f-string in it blocked CI over code CPython refuses.
+    if any(
+        positional > index and wanted in named
+        for index, wanted in enumerate(
+            ("source", "filename", "mode", "flags", "dont_inherit", "optimize")
+        )
+    ):
+        return False
     return all(
         positional > index or wanted in named
         for index, wanted in enumerate(("source", "filename", "mode"))
@@ -2365,7 +2561,15 @@ def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) 
                 # expansion as possibly empty merged that filename in and reported it
                 # as executable source.
                 if isinstance(inner, (ast.Tuple, ast.List, ast.Set)) and inner.elts:
-                    candidates.append(inner.elts[0])
+                    # A set has no order: `compile(*{"exec", "<x>", f"import {name}"})`
+                    # yields its three elements in hash order, so ANY of them can be
+                    # the source argument. Reading the one written first said the
+                    # f-string was the mode and reported nothing. A list or tuple does
+                    # state the order, and keeps it.
+                    if isinstance(inner, ast.Set):
+                        candidates.extend(inner.elts)
+                    else:
+                        candidates.append(inner.elts[0])
                     break
                 # An opaque expansion may BE the source, `exec(*[f"..."])`, and it
                 # may also contribute nothing at runtime, in which case the next
@@ -2412,8 +2616,9 @@ class _Visitor(ast.NodeVisitor):
         self.path = path
         # Reset per file, so a class name from the previous one cannot silence a
         # receiver here. Populated by `_collect_aliases` as it walks each scope.
-        global _LOCAL_CLASSES
+        global _LOCAL_CLASSES, _REBOUND_CLASS_NAMES
         _LOCAL_CLASSES = {}
+        _REBOUND_CLASS_NAMES = set()
         # Set for a notebook cell, so two cells defining the same function name are
         # separate allowlist entries rather than colliding on one key.
         self.qualname_prefix = ""
@@ -2459,6 +2664,10 @@ class _Visitor(ast.NodeVisitor):
         # Names declared `nonlocal`, which rebind in the nearest enclosing FUNCTION
         # scope rather than at module level.
         self.nonlocal_names: list[set[str]] = [set()]
+        # Per scope, the names it binds to built source anywhere in its body. Read
+        # when a nested body is entered, since that body runs after the whole
+        # enclosing scope has. Filled in by the caller for the module level.
+        self.future_taint: list[dict] = [{}]
 
     def _visible_scopes(self):
         """Scope indices a name lookup here may consult, innermost first.
@@ -2564,6 +2773,36 @@ class _Visitor(ast.NodeVisitor):
         return parts
 
     @staticmethod
+    def _later_taint(body) -> dict:
+        """Names this scope binds to built source ANYWHERE in it, in one pass.
+
+        A nested function reads its closure when it is CALLED, not where it is
+        written, so `payload = "pass"; def inner(): exec(payload); payload = f"..."`
+        really does execute the f-string. Inheriting only the taint present at the
+        `def` froze the cell at the wrong moment and reported nothing.
+
+        Written-out assignments only, resolved against nothing: this answers "does the
+        scope ever put built source in that name", which does not depend on where the
+        reader sits. Order-sensitive reasoning stays where it belongs, in the walk.
+        """
+        found: dict = {}
+        for statement in body:
+            for child in _walk_this_scope(statement):
+                if isinstance(child, ast.Assign):
+                    targets = child.targets
+                elif isinstance(child, ast.AnnAssign) and child.value is not None:
+                    targets = [child.target]
+                else:
+                    continue
+                reason = _is_interpolated(child.value)
+                if reason is None or isinstance(reason, _LiteralText):
+                    continue
+                for target in targets:
+                    if isinstance(target, ast.Name):
+                        found.setdefault(target.id, reason)
+        return found
+
+    @staticmethod
     def _declared_locals(node) -> set:
         """Names a function body binds itself, so its closure never reads the outer one.
 
@@ -2595,6 +2834,17 @@ class _Visitor(ast.NodeVisitor):
                     names.add(child.name)
                 elif isinstance(child, ast.ExceptHandler) and child.name:
                     names.add(child.name)
+        # A name the body declares `global` or `nonlocal` is NOT one of its locals,
+        # however many times the body assigns it: the assignment writes the enclosing
+        # cell. Counting it as local dropped the enclosing taint before the body was
+        # read, so `def f(): global payload; exec(payload); payload = "pass"` executed
+        # a payload built outside and reported nothing.
+        declared = set()
+        for statement in getattr(node, "body", []) or []:
+            for child in _walk_this_scope(statement):
+                if isinstance(child, (ast.Global, ast.Nonlocal)):
+                    declared.update(child.names)
+        names -= declared
         return names
 
     def _enter(self, node):
@@ -2655,12 +2905,26 @@ class _Visitor(ast.NodeVisitor):
         # names the nested body binds itself are left out, since those are its own
         # locals for the whole body and the closure never sees the outer one.
         inherited = {}
-        if not isinstance(node, ast.ClassDef) and self.scope_kinds[-1] == "function":
+        if not isinstance(node, ast.ClassDef):
             bound_here = self._declared_locals(node)
-            inherited = {
-                name: reason for name, reason in self.tainted[-1].items()
-                if isinstance(name, str) and name not in bound_here
-            }
+            if self.scope_kinds[-1] == "function":
+                inherited = {
+                    name: reason for name, reason in self.tainted[-1].items()
+                    if isinstance(name, str) and name not in bound_here
+                }
+            # And what the enclosing scope binds LATER. The body is deferred, so a
+            # write BELOW the `def` has already happened by the time it runs:
+            # `payload = "pass"; def inner(): exec(payload); payload = f"..."` executes
+            # the f-string. Reading the enclosing map alone froze the cell at the
+            # `def`. This holds whatever encloses the body, module scope included,
+            # which is why it sits outside the test above.
+            # These OVERRIDE what the enclosing map holds now, which is the state at
+            # the `def` and not the state at the call: in the example above the map
+            # says `payload` is the literal `"pass"` at that line, and keeping it left
+            # the body reading a value that has been replaced by the time it runs.
+            for name, reason in self.future_taint[-1].items():
+                if name not in bound_here:
+                    inherited[name] = reason
         self.tainted.append(
             self._implicit_base_taint() if isinstance(node, ast.ClassDef) else inherited
         )
@@ -2674,6 +2938,11 @@ class _Visitor(ast.NodeVisitor):
         self.star_restored.append(set())
         self.global_names.append(set())
         self.nonlocal_names.append(set())
+        # A class body is not a lexical scope, so a function nested in one closes over
+        # whatever encloses the CLASS; it has no later bindings of its own to offer.
+        self.future_taint.append(
+            {} if isinstance(node, ast.ClassDef) else self._later_taint(node.body)
+        )
         if not isinstance(node, ast.ClassDef):
             arguments = node.args
             defaults = outer_defaults
@@ -2721,6 +2990,7 @@ class _Visitor(ast.NodeVisitor):
         self.star_restored.pop()
         self.global_names.pop()
         self.nonlocal_names.pop()
+        self.future_taint.pop()
         self.tainted.pop()
         self.scope.pop()
         self.scope_kinds.pop()
@@ -3821,6 +4091,21 @@ class _Visitor(ast.NodeVisitor):
         """`class Safe:` makes `Safe()` a receiver whose methods are not string ones."""
         if isinstance(statement, ast.ClassDef):
             _LOCAL_CLASSES[statement.name] = statement
+            return
+        # Any OTHER binding of that name takes the exemption away, permanently and
+        # file-wide. `class Safe: ...` followed by `Safe = lambda: "import {}"` leaves
+        # `Safe()` a plain string builder, and reading the class definition through the
+        # new value made `exec(Safe().format(name))` silent. The table is a file-wide
+        # fact, so the withdrawal is one too: a name that means two things somewhere in
+        # the file earns no exemption anywhere in it.
+        for child in _walk_this_scope(statement):
+            if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                _REBOUND_CLASS_NAMES.add(child.id)
+            elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                _REBOUND_CLASS_NAMES.add(child.name)
+            elif isinstance(child, (ast.Import, ast.ImportFrom)):
+                for alias in child.names:
+                    _REBOUND_CLASS_NAMES.add(alias.asname or alias.name.split(".")[0])
 
     def _alias_pass_definition(self, statement, declared, rebound) -> None:
         """A `def` or `class` binds its own name in THIS scope.
@@ -4885,6 +5170,9 @@ class _Visitor(ast.NodeVisitor):
         self.star_restored.append(set())
         self.global_names.append(set())
         self.nonlocal_names.append(set())
+        # A lambda body and a comprehension bind nothing later that a nested body
+        # could read, so the parallel stack stays level with an empty frame.
+        self.future_taint.append({})
         # The default aliases go in the lambda's OWN scope. Written to the enclosing
         # one they were invisible from the body whenever that scope was a class body,
         # because `_visible_scopes` skips class levels once a function level is on top.
@@ -4916,6 +5204,7 @@ class _Visitor(ast.NodeVisitor):
         self.star_restored.pop()
         self.global_names.pop()
         self.nonlocal_names.pop()
+        self.future_taint.pop()
         self._restore_locals(saved_scope)
         # A lambda IS a function scope, so a walrus in its body binds locally and
         # nothing it does reaches the enclosing map. Restoring the parameters alone
@@ -4990,6 +5279,9 @@ class _Visitor(ast.NodeVisitor):
         self.star_restored.append(set())
         self.global_names.append(set())
         self.nonlocal_names.append(set())
+        # A lambda body and a comprehension bind nothing later that a nested body
+        # could read, so the parallel stack stays level with an empty frame.
+        self.future_taint.append({})
         # Shadows are installed AFTER the push, so they land in the comprehension's own
         # scope. Recording them in the enclosing one was invisible from the body when
         # that scope was a class body, because `_visible_scopes` skips class levels
@@ -5012,6 +5304,18 @@ class _Visitor(ast.NodeVisitor):
                 for child in ast.walk(generator.target)
                 if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
             }
+            # A target that is not a plain name is EVALUATED on every iteration:
+            # `[None for table[exec(f"import {name}")] in [1]]` calls the builtin to
+            # work out where to store. Only stored names were extracted here, so the
+            # subscript and its index were never read. Visited under the same test the
+            # filters use, since a generator that yields nothing never binds.
+            if self._generator_yields(generator):
+                for child in ast.walk(generator.target):
+                    if isinstance(child, ast.Subscript):
+                        self.visit(child.value)
+                        self.visit(child.slice)
+                    elif isinstance(child, ast.Attribute):
+                        self.visit(child.value)
             # Computed HERE, for this generator only. Precomputing every generator up
             # front let a later `for exec in [print]` overwrite an earlier
             # `for exec in [builtins.exec]`, so a real call in the earlier filter was
@@ -5096,6 +5400,7 @@ class _Visitor(ast.NodeVisitor):
         self.star_restored.pop()
         self.global_names.pop()
         self.nonlocal_names.pop()
+        self.future_taint.pop()
         # Only the target names are put back. Restoring the whole map discarded any
         # walrus made inside the comprehension, which binds in the ENCLOSING scope and
         # outlives it: `[... for x in y if (payload := f"import {name}")]` then
@@ -6112,6 +6417,49 @@ def _foreign_cell_magic(code: str) -> str | None:
     return None
 
 
+# How many lines one cell may lose to recovery before it is given up on. A cell that
+# needs more than this is not Python with a magic in it, it is something else.
+_RECOVERY_LIMIT = 20
+
+
+def _blanked_unparseable(source: str) -> str | None:
+    """`source` with the individual lines that will not parse blanked out.
+
+    IPython's automagic runs `pip install requests` as `%pip install requests`, and
+    there is no list of every alias a running kernel might have: `_neutralised` can
+    only rewrite the spellings it knows. A line it does not know left the whole cell
+    unparseable, and the whole cell was then skipped - including any sink written
+    below the magic, which is the part that matters.
+
+    So the unrecognised line is dropped instead of the cell. Strictly more code is
+    read than before: a cell that recovers here was contributing nothing at all.
+    """
+    lines = source.splitlines()
+    removed = 0
+    while removed < _RECOVERY_LIMIT:
+        try:
+            ast.parse("\n".join(lines))
+        except (SyntaxError, ValueError) as error:
+            number = getattr(error, "lineno", None)
+            if not isinstance(number, int) or not 1 <= number <= len(lines):
+                return None
+            if not lines[number - 1].strip():
+                # Blanking it again would loop: the reported line is already empty, so
+                # the error is about the structure around it and no line can be blamed.
+                return None
+            indent = lines[number - 1][: len(lines[number - 1]) - len(lines[number - 1].lstrip())]
+            # `pass` at the same indentation rather than a blank line, so a magic alone
+            # in an `if:` body does not leave an empty block - the same reason
+            # `_neutralised` writes `pass` there.
+            lines[number - 1] = indent + "pass"
+            removed += 1
+            continue
+        except (MemoryError, RecursionError):
+            return None
+        return "\n".join(lines) if removed else None
+    return None
+
+
 def _parse_cell(code: str, filename: str):
     """The cell's AST, trying it verbatim before neutralising anything.
 
@@ -6138,6 +6486,14 @@ def _parse_cell(code: str, filename: str):
                     f"{filename}: hit a parser limit ({error.__class__.__name__}), so "
                     f"the cell was not checked"
                 ) from None
+        # Last resort: drop the individual lines that will not parse rather than the
+        # cell they are in.
+        recovered = _blanked_unparseable(_neutralised(code))
+        if recovered is not None:
+            try:
+                return ast.parse(recovered, filename = filename)
+            except (SyntaxError, ValueError, MemoryError, RecursionError):
+                return None
     return None
 
 
@@ -6189,6 +6545,7 @@ def _scan_notebook(path: Path) -> list[dict]:
     # in cell 0 is called after cell 1 has run, so an alias imported later is visible
     # to it - collecting per cell analysed that function before the import existed.
     for _index, tree in parsed:
+        visitor.future_taint[0].update(visitor._later_taint(tree.body))
         visitor._collect_aliases(tree.body)
     for index, tree in parsed:
         if _annotations_deferred(tree):
@@ -6261,6 +6618,7 @@ def scan_file(path: Path) -> list[dict]:
         ) from None
     visitor = _Visitor(path)
     visitor.annotations_deferred = _annotations_deferred(tree)
+    visitor.future_taint[0].update(visitor._later_taint(tree.body))
     visitor._collect_aliases(tree.body)
     try:
         visitor.visit(tree)

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -72,7 +72,7 @@ DEFAULT_TARGETS = (
     # Workflow `run:` steps execute Python heredocs on the CI runner, with the
     # runner's token in the environment, so a sink written inside one is as
     # executable as anything else here and was covered by nothing.
-    ".github/workflows",
+    ".github/workflows", ".github/actions",
 )
 
 
@@ -706,6 +706,17 @@ def _is_interpolated(node: ast.AST, resolve = None, shadowed = None, resolve_ali
     # matching stay indistinguishable, and why no sentinel is needed.
     while isinstance(node, ast.NamedExpr):
         node = node.value
+    if (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and _ACTIONS_SUBSTITUTION in node.value
+    ):
+        # The runner splices an Actions expression into the program text before Python
+        # ever sees it, so `exec("${{ github.event.pull_request.title }}")` really is a
+        # built string - and one built from a value a pull request supplies. Reading
+        # the substituted name as ordinary text passed it. Only the marker this file
+        # writes in place of `${{ ... }}` counts, so nothing else is guessed at.
+        return "Actions expression"
     if isinstance(node, ast.Starred):
         return _interpolated_starred(node, resolve, shadowed, resolve_alias)
     # A written-out attribute or subscript path can hold built source:
@@ -963,11 +974,22 @@ def _interpolated_split_element(node, resolve = None, shadowed = None, resolve_a
     return _is_interpolated(inner.func.value, resolve, shadowed, resolve_alias)
 
 
-def _slice_keeps_interpolation(receiver: ast.AST, index: ast.Slice) -> bool:
-    """Whether a constant slice of a written-out f-string still holds its values."""
+def _slice_removes_interpolation(receiver: ast.AST, index: ast.Slice) -> bool:
+    """Whether a constant slice provably cuts every interpolated value away.
+
+    The question this asks was inverted. It used to be "does the slice provably KEEP
+    the values", and anything undecidable read as clean - so `f"{input()}"[:1000]`
+    passed the gate while executing any injected program shorter than a thousand
+    characters. Uncertainty about a slice has to leave the source tainted, exactly as
+    uncertainty everywhere else here does, so only the two cases that are decidable
+    from the text answer True.
+
+    Both need a written-out f-string: a name says nothing about where its values sit.
+    """
     if not isinstance(receiver, ast.JoinedStr):
         return False
     if not any(isinstance(part, ast.FormattedValue) for part in receiver.values):
+        # No values to remove, so the caller's ordinary reading of the receiver holds.
         return False
     if index.step is not None and _constant_integer(index.step) != 1:
         return False
@@ -983,17 +1005,22 @@ def _slice_keeps_interpolation(receiver: ast.AST, index: ast.Slice) -> bool:
         else:
             break
     lower = 0 if index.lower is None else _constant_integer(index.lower)
-    upper = 0 if index.upper is None else _constant_integer(index.upper)
-    if lower is None or upper is None:
+    if lower is None:
         return False
-    # The front cut has to stay inside the leading literal, and the back cut inside
-    # the trailing one. A positive upper bound counts from the front, which says
-    # nothing about where the values are, so it is left alone.
-    if lower < 0 or lower > leading:
-        return False
-    if index.upper is not None and not (-trailing <= upper < 0):
-        return False
-    return True
+    # Everything the slice keeps lies inside the LEADING literal run: the front cut
+    # starts at or after 0 and the back cut ends inside it. `f"import {name}"[:3]`
+    # cannot reach the value however long the value turns out to be.
+    if lower >= 0 and index.upper is not None:
+        upper = _constant_integer(index.upper)
+        if upper is not None and 0 <= upper <= leading and lower <= upper:
+            return True
+    # Or inside the TRAILING literal run, counted from the end: `f"import {name}#!"[-2:]`
+    # is the `#!`, whatever the value is.
+    if lower < 0 and -lower <= trailing:
+        upper = None if index.upper is None else _constant_integer(index.upper)
+        if index.upper is None or (upper is not None and lower <= upper < 0):
+            return True
+    return False
 
 
 def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
@@ -1028,14 +1055,16 @@ def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias
             and _keeps_everything(node.slice.step, 1)
         ):
             return _is_interpolated(node.value, resolve, shadowed, resolve_alias)
-        # A partial slice of a written-out f-string can still contain the interpolated
-        # part: `f"import {name}#"[:-1]` drops the literal `#` and `f"Ximport {name}"[1:]`
-        # drops the literal `X`. Only when the cut is inside the receiver's own leading
-        # or trailing LITERAL run, which is decidable from the text; a cut that may
-        # reach into the spliced value, or a bound this cannot read, is still None.
-        if _slice_keeps_interpolation(node.value, node.slice):
-            return _is_interpolated(node.value, resolve, shadowed, resolve_alias)
-        return None
+        # A partial slice keeps the source tainted unless it provably cuts every
+        # interpolated value away. `f"import {name}#"[:-1]` drops the literal `#` and
+        # `f"Ximport {name}"[1:]` drops the literal `X`, and both still execute the
+        # value; `f"{input()}"[:1000]` executes any injected program under a thousand
+        # characters. Only a slice whose whole extent lies inside the receiver's own
+        # leading or trailing LITERAL run reads as clean, which is decidable from the
+        # text - everything else is uncertain, and uncertainty reports.
+        if _slice_removes_interpolation(node.value, node.slice):
+            return None
+        return _is_interpolated(node.value, resolve, shadowed, resolve_alias)
     return _literal_element(node, resolve, shadowed, resolve_alias)
 
 
@@ -1048,11 +1077,19 @@ _LOCAL_CLASSES: dict = {}
 # a name that is a class in one place and a lambda in another is no evidence at all.
 _REBOUND_CLASS_NAMES: set = set()
 
-# Functions the file defines, and the names it binds to more than one thing. Same
-# shape as the class tables above and read the same way: a name that means two things
-# somewhere in the file is no evidence anywhere in it.
+# Functions the file defines, keyed by the scope that defines them, and the (scope,
+# name) pairs it binds to more than one thing. Keyed by SCOPE rather than by the bare
+# name: two helpers called `build` in two unrelated functions are two different
+# functions, and treating them as one rebound name suppressed a real finding in the
+# second. A call still falls outward through the enclosing scopes, which is how Python
+# resolves the name.
 _LOCAL_FUNCTIONS: dict = {}
 _REBOUND_FUNCTION_NAMES: set = set()
+
+# The scope the walk is currently in, as `_qualname` spells it. A module-level value
+# like the tables above, for the same reason: one file is scanned at a time, and the
+# resolvers that read the tables are plain functions with no visitor to ask.
+_CURRENT_SCOPE = ""
 
 # Helpers currently being resolved, so a recursive one cannot loop forever.
 _HELPER_STACK: set = set()
@@ -1091,15 +1128,36 @@ def _returned_expressions(definition) -> list:
     return found
 
 
+def _enclosing_scopes(scope: str):
+    """`scope` and then every scope around it, out to the module.
+
+    The qualname spelling `_qualname` produces: an optional `prefix::` for a notebook
+    cell or a workflow block, then dotted scope names, or `<module>`.
+    """
+    prefix, separator, inner = scope.rpartition("::")
+    head = prefix + separator
+    parts = inner.split(".") if inner and inner != "<module>" else []
+    while parts:
+        yield head + ".".join(parts)
+        parts.pop()
+    yield head + "<module>"
+
+
 def _visible_helper(function: ast.AST, shadowed = None):
     """The local `def` a callee names, when that is a fact stated in the file."""
     if not isinstance(function, ast.Name):
         return None
     if shadowed is not None and shadowed(function.id):
         return None
-    if function.id in _REBOUND_FUNCTION_NAMES:
-        return None
-    return _LOCAL_FUNCTIONS.get(function.id)
+    for scope in _enclosing_scopes(_CURRENT_SCOPE):
+        # A name that means two things in ONE scope is no evidence in that scope; an
+        # unrelated `build` in a sibling function says nothing about this one.
+        if (scope, function.id) in _REBOUND_FUNCTION_NAMES:
+            return None
+        found = _LOCAL_FUNCTIONS.get((scope, function.id))
+        if found is not None:
+            return found
+    return None
 
 
 def _visibly_local_instance(node: ast.AST, shadowed = None) -> bool:
@@ -1709,15 +1767,24 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             _mapping_literal(function.value, shadowed)
             if function.attr in ("get", "pop") else None
         )
+        # `payloads.pop()` with nothing named returns the LAST element, which the
+        # container binding now records under its negative index. A named receiver fell
+        # through the inline-display branch above and the selected source went
+        # unreported.
+        selected_key = None
+        if function.attr in ("get", "pop") and node.args and isinstance(
+            node.args[0], ast.Constant
+        ):
+            selected_key = node.args[0].value
+        elif function.attr == "pop" and not node.args and not node.keywords:
+            selected_key = -1
         if (
             literal_mapping is None
-            and function.attr in ("get", "pop")
-            and node.args
-            and isinstance(node.args[0], ast.Constant)
+            and selected_key is not None
             and _compound_key(
                 ast.Subscript(
                     value = function.value,
-                    slice = ast.Constant(value = node.args[0].value),
+                    slice = ast.Constant(value = selected_key),
                     ctx = ast.Load(),
                 )
             ) is not None
@@ -1731,7 +1798,7 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             equivalent = ast.copy_location(
                 ast.Subscript(
                     value = function.value,
-                    slice = ast.Constant(value = node.args[0].value),
+                    slice = ast.Constant(value = selected_key),
                     ctx = ast.Load(),
                 ),
                 node,
@@ -2420,7 +2487,9 @@ def _visibly_unaddable(left: ast.AST, right: ast.AST) -> bool:
     return left_kind != right_kind
 
 
-def _paired_arguments(call: ast.Call, arguments: ast.arguments) -> dict | None:
+def _paired_arguments(
+    call: ast.Call, arguments: ast.arguments, defaults: bool = True,
+) -> dict | None:
     """Parameter name to the expression the call gives it, or None when it cannot pair.
 
     Positional arguments in order, keywords by name, and a parameter nobody supplied
@@ -2438,9 +2507,16 @@ def _paired_arguments(call: ast.Call, arguments: ast.arguments) -> dict | None:
             bound[positional[index].arg] = argument
     for keyword in call.keywords:
         bound[keyword.arg] = keyword.value
-    defaults = arguments.defaults
-    if defaults:
-        for parameter, default in zip(positional[len(positional) - len(defaults):], defaults):
+    if not defaults:
+        # The caller wants only what THIS call supplies. A default is already read
+        # where the definition is written, so counting it here reported the same
+        # execution twice.
+        return bound
+    positional_defaults = arguments.defaults
+    if positional_defaults:
+        for parameter, default in zip(
+            positional[len(positional) - len(positional_defaults):], positional_defaults
+        ):
             bound.setdefault(parameter.arg, default)
     for parameter, default in zip(arguments.kwonlyargs, arguments.kw_defaults):
         if default is not None:
@@ -2611,6 +2687,20 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
             return function.id
         if aliases is not None and aliases(function.id):
             return aliases(function.id)
+    if (
+        isinstance(function, ast.Attribute)
+        and aliases is not None
+        and _visibly_local_instance(function.value, shadowed)
+    ):
+        # `class Runner: run = builtins.exec` then `Runner().run(f"...")`. A plain
+        # function stored on a class does not bind as a method when it is a BUILTIN, so
+        # the instance hands back the sink itself. `_compound_key` refuses a path with
+        # a call in it, which is right for taint - a call can return anything - but the
+        # class here is written out in this file and its attribute was already exported
+        # under the class path, so the same record answers for the instance.
+        recorded = aliases(f"path>{function.value.func.id}.{function.attr}")
+        if recorded:
+            return recorded
     if isinstance(function, (ast.Attribute, ast.Subscript)) and aliases is not None:
         # `obj.run = builtins.exec` then `obj.run(f"...")`, and the subscript spelling
         # `table["run"]`. The path is written out and names the same place at the store
@@ -2631,13 +2721,26 @@ def _sink_name(function: ast.AST, aliases = None, shadowed = None) -> str | None
             # name against the caller's aliases read nothing, since `run` means nothing
             # out here. The parameters are paired to the arguments exactly as an
             # immediately invoked lambda's are.
+            # Through the ALIASES, not by substituting a top-level name: a returned
+            # `run if flag else print` never was an `ast.Name`, so the substitution
+            # missed it and `run` resolved to nothing. Answering for the parameter
+            # wherever it is written resolves every shape this resolver already knows.
             bound = _paired_arguments(function, helper.args) or {}
+            supplied = {}
+            for parameter, argument in bound.items():
+                given = _sink_name(argument, aliases, shadowed)
+                if given is not None:
+                    supplied[parameter] = given
+
+            def inner_aliases(key):
+                if key in supplied:
+                    return supplied[key]
+                return aliases(key) if aliases is not None else None
+
             _HELPER_STACK.add(helper.name)
             try:
                 for value in _returned_expressions(helper):
-                    if isinstance(value, ast.Name) and value.id in bound:
-                        value = bound[value.id]
-                    resolved = _sink_name(value, aliases, shadowed)
+                    resolved = _sink_name(value, inner_aliases, shadowed)
                     if resolved is not None:
                         return resolved
             finally:
@@ -3265,6 +3368,37 @@ def _mapping_lookup(mapping: ast.Dict, wanted: str) -> ast.AST | None:
 _SINK_ARITY = {"exec": 3, "eval": 3, "compile": 6}
 
 
+# Keyword names each sink accepts, as a UNION across supported Pythons: `exec` and
+# `eval` take no keyword arguments at all before 3.11 and take these after, so a file
+# using one may be right or wrong depending on the interpreter, and only a name outside
+# the union is refused by every version.
+_SINK_KEYWORDS = {
+    "exec": frozenset({"globals", "locals", "closure"}),
+    "eval": frozenset({"globals", "locals"}),
+    "compile": frozenset({
+        "source", "filename", "mode", "flags", "dont_inherit", "optimize",
+        "_feature_version",
+    }),
+}
+
+
+def _visibly_invalid_keyword(node: ast.Call, sink: str) -> bool:
+    """Whether the call names a keyword the sink does not have.
+
+    `exec(f"import {name}", spam = 1)` is a TypeError raised before anything runs, so
+    reporting it failed the gate on a call that cannot reach the sink. A `**` expansion
+    says nothing about which names it supplies and leaves the call unknown, which is
+    the reporting side.
+    """
+    allowed = _SINK_KEYWORDS.get(sink.rpartition(".")[2])
+    if allowed is None:
+        return False
+    for keyword in node.keywords:
+        if keyword.arg is None:
+            return False
+    return any(keyword.arg not in allowed for keyword in node.keywords)
+
+
 def _visibly_too_many_arguments(node: ast.Call, sink: str, skip: int = 0) -> bool:
     """Whether the call plainly hands the sink more positional arguments than it takes.
 
@@ -3412,6 +3546,8 @@ def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) 
     was skipped entirely. `studio/backend/core/inference/tools.py` already resolves
     sink arguments this way.
     """
+    if _visibly_invalid_keyword(node, sink):
+        return None
     if _visibly_too_many_arguments(node, sink, skip):
         # More positional arguments than the sink has parameters is a TypeError raised
         # before any source is executed, exactly like the missing-argument case below.
@@ -3527,6 +3663,8 @@ class _Visitor(ast.NodeVisitor):
         # appears anywhere above it.
         self.scope_kinds: list[str] = ["module"]
         self.scope: list[str] = []
+        global _CURRENT_SCOPE
+        _CURRENT_SCOPE = self._qualname()
         self.findings: list[dict] = []
         # name -> reason, for locals bound to a built string in the current scope.
         self.tainted: list[dict[str, str]] = [{}]
@@ -3683,29 +3821,42 @@ class _Visitor(ast.NodeVisitor):
         really does execute the f-string. Inheriting only the taint present at the
         `def` froze the cell at the wrong moment and reported nothing.
 
-        Written-out assignments only, resolved against nothing: this answers "does the
-        scope ever put built source in that name", which does not depend on where the
-        reader sits. Order-sensitive reasoning stays where it belongs, in the walk.
+        Written-out assignments only: this answers "does the scope ever put built
+        source in that name", which does not depend on where the reader sits.
+        Order-sensitive reasoning stays where it belongs, in the walk.
+
+        Repeated until nothing new is found, since one of those assignments may be
+        another name: `payload = f"import {name}"` then `alias = payload` puts the same
+        built string in `alias`, and a single pass that resolved against nothing left
+        the deferred body reading `alias` as clean. Each round can only add names, so
+        the number of assignments bounds it; the cap is there so a resolver bug cannot
+        spin.
         """
         found: dict = {}
-        for statement in body:
-            for child in _walk_this_scope(statement):
-                if isinstance(child, ast.Assign):
-                    targets = child.targets
-                elif isinstance(child, ast.AnnAssign) and child.value is not None:
-                    targets = [child.target]
-                elif isinstance(child, ast.AugAssign):
-                    # `payload += f"import {name}"` puts built source in the name as
-                    # plainly as `=` does, and a deferred body reads the cell after it.
-                    targets = [child.target]
-                else:
-                    continue
-                reason = _is_interpolated(child.value)
-                if reason is None or isinstance(reason, _LiteralText):
-                    continue
-                for target in targets:
-                    if isinstance(target, ast.Name):
-                        found.setdefault(target.id, reason)
+        for _round in range(_LATER_TAINT_ROUNDS):
+            added = False
+            for statement in body:
+                for child in _walk_this_scope(statement):
+                    if isinstance(child, ast.Assign):
+                        targets = child.targets
+                    elif isinstance(child, ast.AnnAssign) and child.value is not None:
+                        targets = [child.target]
+                    elif isinstance(child, ast.AugAssign):
+                        # `payload += f"import {name}"` puts built source in the name as
+                        # plainly as `=` does, and a deferred body reads the cell after
+                        # it.
+                        targets = [child.target]
+                    else:
+                        continue
+                    reason = _is_interpolated(child.value, found.get)
+                    if reason is None or isinstance(reason, _LiteralText):
+                        continue
+                    for target in targets:
+                        if isinstance(target, ast.Name) and target.id not in found:
+                            found[target.id] = reason
+                            added = True
+            if not added:
+                break
         return found
 
     @staticmethod
@@ -3794,6 +3945,8 @@ class _Visitor(ast.NodeVisitor):
         )
 
         self.scope.append(node.name)
+        global _CURRENT_SCOPE
+        _CURRENT_SCOPE = self._qualname()
         self.scope_kinds.append(
             "class" if isinstance(node, ast.ClassDef) else "function"
         )
@@ -3929,6 +4082,7 @@ class _Visitor(ast.NodeVisitor):
         self.tainted.pop()
         self.tainted[-1].update(exported)
         self.scope.pop()
+        _CURRENT_SCOPE = self._qualname()
         self.scope_kinds.pop()
         saved_deferred = self.deferred_state.pop()
         if saved_deferred is not None:
@@ -4041,6 +4195,13 @@ class _Visitor(ast.NodeVisitor):
             if any(isinstance(element, ast.Starred) for element in value.elts):
                 return
             pairs = list(enumerate(value.elts))
+            # And under the index counted from the END, which is the same element:
+            # `payloads[-1]` names it, and so does `payloads.pop()`, which returns the
+            # last one. Recording only the forward index left both unresolved.
+            pairs += [
+                (index - len(value.elts), element)
+                for index, element in enumerate(value.elts)
+            ]
         elif isinstance(value, ast.Dict):
             if any(key is None for key in value.keys):
                 return
@@ -5030,7 +5191,16 @@ class _Visitor(ast.NodeVisitor):
                 if reason is None or isinstance(reason, _LiteralText):
                     self.origin_of.pop((self._qualname(), key), None)
                 else:
-                    self.origin_of[(self._qualname(), key)] = _expression_digest(origin)
+                    # Through an ALIAS, when there is one. `alias = payload` records
+                    # the digest of `payload`, which is the same three characters
+                    # however the f-string above it changes, so an allowlist entry
+                    # written for a safe source still covered an attacker-controlled
+                    # one. The origin carried forward is the expression that BUILT the
+                    # value, wherever the chain of names started.
+                    inherited = self._origin_of_argument(origin)
+                    self.origin_of[(self._qualname(), key)] = (
+                        inherited or _expression_digest(origin)
+                    )
         if not isinstance(target, ast.Name):
             # `self.payload = f"import {name}"` then `exec(self.payload)` executes the
             # source, and dropping every non-name target lost it. The written-out path
@@ -5137,6 +5307,10 @@ class _Visitor(ast.NodeVisitor):
 
     def _record_local_class(self, statement) -> None:
         """`class Safe:` makes `Safe()` a receiver whose methods are not string ones."""
+        # The scope this statement binds in. A `def build` inside one function and
+        # another inside a sibling are two different names, and recording them under
+        # one spelling made each look like the other's rebind.
+        scope = self._qualname()
         if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
             if any(
                 _decorator_name(decorator) not in _RESULT_PRESERVING_DECORATORS
@@ -5147,20 +5321,22 @@ class _Visitor(ast.NodeVisitor):
                 # callee would answer for a function the file does not call. The few
                 # that document handing the wrapped result back unchanged are the
                 # exception, and they are the ones that appear on a helper.
-                _REBOUND_FUNCTION_NAMES.add(statement.name)
-            recorded = _LOCAL_FUNCTIONS.get(statement.name)
+                _REBOUND_FUNCTION_NAMES.add((scope, statement.name))
+            recorded = _LOCAL_FUNCTIONS.get((scope, statement.name))
             if recorded is not None and recorded is not statement:
-                _REBOUND_FUNCTION_NAMES.add(statement.name)
-            _LOCAL_FUNCTIONS[statement.name] = statement
+                _REBOUND_FUNCTION_NAMES.add((scope, statement.name))
+            _LOCAL_FUNCTIONS[(scope, statement.name)] = statement
         elif isinstance(statement, ast.ClassDef):
-            _REBOUND_FUNCTION_NAMES.add(statement.name)
+            _REBOUND_FUNCTION_NAMES.add((scope, statement.name))
         else:
             for child in _walk_this_scope(statement):
                 if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
-                    _REBOUND_FUNCTION_NAMES.add(child.id)
+                    _REBOUND_FUNCTION_NAMES.add((scope, child.id))
                 elif isinstance(child, (ast.Import, ast.ImportFrom)):
                     for alias in child.names:
-                        _REBOUND_FUNCTION_NAMES.add(alias.asname or alias.name.split(".")[0])
+                        _REBOUND_FUNCTION_NAMES.add(
+                            (scope, alias.asname or alias.name.split(".")[0])
+                        )
         if isinstance(statement, ast.ClassDef):
             recorded = _LOCAL_CLASSES.get(statement.name)
             if recorded is not None and recorded is not statement:
@@ -6779,6 +6955,43 @@ class _Visitor(ast.NodeVisitor):
                     "hash": _call_hash(inner),
                 })
 
+    def _wrapper_sink_calls(self, node: ast.Call):
+        """`(sink, argument, inner)` for `def run(source): exec(source)` called here.
+
+        A one-line wrapper around a sink is an ordinary way to write this, and the
+        source it executes is built at the CALL: the helper body only ever sees a
+        parameter, which carries no taint of its own, and the call itself is not a sink,
+        so `run(f"import {name}")` was reported by neither half.
+
+        Only a `def` this file states outright and binds to nothing else, with its
+        parameters paired to the arguments exactly as the source-side helper resolution
+        pairs them, and only a sink call inside it whose source argument IS one of those
+        parameters. A recursion stack, since a wrapper may call itself.
+        """
+        helper = _visible_helper(node.func, self._is_shadowed)
+        if helper is None or helper.name in _HELPER_STACK:
+            return
+        bound = _paired_arguments(node, helper.args, defaults = False)
+        if not bound:
+            return
+        _HELPER_STACK.add(helper.name)
+        try:
+            for statement in helper.body:
+                for child in _walk_this_scope(statement):
+                    if not isinstance(child, ast.Call):
+                        continue
+                    sink = _sink_name(child.func, self._alias, self._is_shadowed)
+                    if sink is None:
+                        continue
+                    inner_argument = _source_argument(child, sink, self._is_shadowed)
+                    if not isinstance(inner_argument, ast.Name):
+                        continue
+                    supplied = bound.get(inner_argument.id)
+                    if supplied is not None:
+                        yield sink, supplied, helper
+        finally:
+            _HELPER_STACK.discard(helper.name)
+
     def visit_Expr(self, node: ast.Expr):
         """A generator expression that nobody iterates runs only its first iterable.
 
@@ -6841,6 +7054,19 @@ class _Visitor(ast.NodeVisitor):
                     "reason": f"{reason} through {_callee_spelling(inner)}()",
                     "line": inner.lineno,
                     "hash": _call_hash(inner),
+                })
+        for wrapped_sink, supplied, helper in self._wrapper_sink_calls(node):
+            reason = _is_interpolated(
+                supplied, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
+            if reason is not None and not isinstance(reason, _LiteralText):
+                self.findings.append({
+                    "path": _relative(self.path),
+                    "qualname": self._qualname(),
+                    "sink": wrapped_sink,
+                    "reason": f"{reason} through {helper.name}()",
+                    "line": node.lineno,
+                    "hash": _call_hash(node),
                 })
         candidates = _sink_candidates(node.func, self._alias, self._is_shadowed)
         # A shadowed base name applies to `b.exec(...)` as well as a bare call: with
@@ -7680,69 +7906,78 @@ def _script_command_source(code: str) -> str | None:
         pieces = line[2:].split(maxsplit = 1)
         if not pieces or pieces[0] != "script":
             return None
-        argument = pieces[1] if len(pieces) > 1 else ""
-        if not _names_python(argument):
-            return None
-        try:
-            tokens = _expanded_env_tokens(shlex.split(argument))
-        except ValueError:
-            return None
-        # Option parsing starts AFTER the interpreter and stops at the first script
-        # operand: `python --help` documents the usage as
-        # `[option] ... [-c cmd | -m mod | file | -] [arg] ...`, so in
-        # `%%script python helper.py -c "prog"` the `-c` and its string are arguments
-        # to `helper.py`, not to the interpreter, and reading them as a `-c` program
-        # reported source that nothing here runs. `_runs_python` already stops there.
-        start = 0
-        for position, token in enumerate(tokens):
-            command = token.rsplit("/", 1)[-1].split("\\")[-1]
-            if _PYTHON_COMMAND.fullmatch(command):
-                start = position + 1
-                break
-        position = start
-        while position < len(tokens):
-            token = tokens[position]
-            if not token.startswith("-"):
-                # The script operand. Everything after it belongs to that script.
-                return None
-            if token in ("-W", "-X", "--check-hash-based-pycs"):
-                # These take their value in the next token, which is not an operand.
-                position += 2
-                continue
-            if token == "-c" and position + 1 < len(tokens):
-                return tokens[position + 1]
-            if token.startswith(("-W", "-X")) and len(token) > 2:
-                # `-Wignore::DeprecationWarning` attaches the value to the option, and
-                # the letters in that value are not flags: reading the `c` in
-                # `DeprecationWarning` as a bundled `-c` extracted `ationWarning` as
-                # the program, which parses as nothing and lost the real `-c` after it.
-                position += 1
-                continue
-            if (
-                token.startswith("-")
-                and not token.startswith("--")
-                and len(token) > 2
-                and "c" in token[1:]
-            ):
-                # A bundle containing `c`. `-c` consumes the REST of the argument, so
-                # `python -uc"prog"` puts the program right there and `python -uc
-                # "prog"` puts it in the next token. Only a bundle ENDING in `c` was
-                # read, so the attached form returned nothing and the cell was passed
-                # over. Split at the first `c` and take whatever follows it.
-                attached = token[token.index("c", 1) + 1:]
-                if attached:
-                    return attached
-                return tokens[position + 1] if position + 1 < len(tokens) else None
-            if token.startswith("-c") and len(token) > 2 and not token.startswith("--"):
-                # `python -cPROGRAM` attaches the program to the option, which is what
-                # `-c` consuming the rest of the argument means. `-uc "prog"` is the
-                # other shape: bundled flags with the program in the next token.
-                rest = token[2:]
-                if rest.lstrip("-") == rest:
-                    return rest
-                return tokens[position + 1] if position + 1 < len(tokens) else None
-            position += 1
+        return _dash_c_program(pieces[1] if len(pieces) > 1 else "")
+    return None
+
+
+def _dash_c_program(argument: str) -> str | None:
+    """The `-c` program a shell command hands to a Python interpreter, or None.
+
+    Split out of the cell reader so a workflow command can use it directly. That
+    reader looks at the magic LINE, so a quoted program spanning several lines -
+    an active workflow shape - returned nothing and went unread.
+    """
+    if not _names_python(argument):
         return None
+    try:
+        tokens = _expanded_env_tokens(shlex.split(argument))
+    except ValueError:
+        return None
+    # Option parsing starts AFTER the interpreter and stops at the first script
+    # operand: `python --help` documents the usage as
+    # `[option] ... [-c cmd | -m mod | file | -] [arg] ...`, so in
+    # `%%script python helper.py -c "prog"` the `-c` and its string are arguments
+    # to `helper.py`, not to the interpreter, and reading them as a `-c` program
+    # reported source that nothing here runs. `_runs_python` already stops there.
+    start = 0
+    for position, token in enumerate(tokens):
+        command = token.rsplit("/", 1)[-1].split("\\")[-1]
+        if _PYTHON_COMMAND.fullmatch(command):
+            start = position + 1
+            break
+    position = start
+    while position < len(tokens):
+        token = tokens[position]
+        if not token.startswith("-"):
+            # The script operand. Everything after it belongs to that script.
+            return None
+        if token in ("-W", "-X", "--check-hash-based-pycs"):
+            # These take their value in the next token, which is not an operand.
+            position += 2
+            continue
+        if token == "-c" and position + 1 < len(tokens):
+            return tokens[position + 1]
+        if token.startswith(("-W", "-X")) and len(token) > 2:
+            # `-Wignore::DeprecationWarning` attaches the value to the option, and
+            # the letters in that value are not flags: reading the `c` in
+            # `DeprecationWarning` as a bundled `-c` extracted `ationWarning` as
+            # the program, which parses as nothing and lost the real `-c` after it.
+            position += 1
+            continue
+        if (
+            token.startswith("-")
+            and not token.startswith("--")
+            and len(token) > 2
+            and "c" in token[1:]
+        ):
+            # A bundle containing `c`. `-c` consumes the REST of the argument, so
+            # `python -uc"prog"` puts the program right there and `python -uc
+            # "prog"` puts it in the next token. Only a bundle ENDING in `c` was
+            # read, so the attached form returned nothing and the cell was passed
+            # over. Split at the first `c` and take whatever follows it.
+            attached = token[token.index("c", 1) + 1:]
+            if attached:
+                return attached
+            return tokens[position + 1] if position + 1 < len(tokens) else None
+        if token.startswith("-c") and len(token) > 2 and not token.startswith("--"):
+            # `python -cPROGRAM` attaches the program to the option, which is what
+            # `-c` consuming the rest of the argument means. `-uc "prog"` is the
+            # other shape: bundled flags with the program in the next token.
+            rest = token[2:]
+            if rest.lstrip("-") == rest:
+                return rest
+            return tokens[position + 1] if position + 1 < len(tokens) else None
+        position += 1
     return None
 
 
@@ -7779,6 +8014,12 @@ def _foreign_cell_magic(code: str) -> str | None:
             return None
         return magic
     return None
+
+
+# How many times the deferred-taint prepass reruns before it stops. Each round can
+# only add names, so a chain of aliases this long is already past anything written by
+# hand; the cap is a stop, not a rule about the code.
+_LATER_TAINT_ROUNDS = 8
 
 
 # How many lines one cell may lose to recovery before it is given up on. A cell that
@@ -7946,7 +8187,12 @@ def _runs_python_command(line: str) -> bool:
     operands are dropped, and the remaining words are matched against the interpreter
     pattern `_runs_python` already uses.
     """
-    command = line.split("<<", 1)[0]
+    # The heredoc introducer is removed rather than everything after it: the interpreter
+    # may sit on the far side of a PIPE, `cat <<'PY' | python`, and cutting the line at
+    # `<<` threw that away, so the block was read as data and a sink inside it passed
+    # the gate. The delimiter word goes with the introducer, so it cannot be mistaken
+    # for a command.
+    command = _HEREDOC.sub(" ", line)
     try:
         tokens = shlex.split(command, comments = True)
     except ValueError:
@@ -7954,7 +8200,12 @@ def _runs_python_command(line: str) -> bool:
     index = 0
     while index < len(tokens):
         token = tokens[index]
-        if token in (">", ">>", "<", "2>", "&>", "|"):
+        if token in ("|", "|&", ";", "&&", "||", "&"):
+            # A separator: what follows is the next COMMAND, not an operand, and
+            # stepping over it hid the interpreter a heredoc was piped into.
+            index += 1
+            continue
+        if token in (">", ">>", "<", "2>", "&>"):
             # The next token is a destination, not a command.
             index += 2
             continue
@@ -7973,6 +8224,11 @@ def _runs_python_command(line: str) -> bool:
 # read: the substituted value is whatever the workflow computes, which is exactly the
 # untrusted-value case this gate is about.
 _ACTIONS_EXPRESSION = re.compile(r"\$\{\{.*?\}\}", re.S)
+
+# What replaces it. A name, so the block still parses wherever the expression stood,
+# and a distinctive one, so a string that CONTAINS it is recognised as spliced text
+# rather than read as the fixed characters of an ordinary literal.
+_ACTIONS_SUBSTITUTION = "_actions_expression"
 
 
 def _python_heredocs(text: str):
@@ -8003,8 +8259,31 @@ def _python_heredocs(text: str):
         # once Actions has substituted it. Skipping the block let a sink under such a
         # line through unread, so the expression becomes a name and the block is
         # scanned - which is the same answer the notebook reader gives a magic.
-        yield start, _ACTIONS_EXPRESSION.sub("_actions_expression", source)
+        yield start, _ACTIONS_EXPRESSION.sub(_ACTIONS_SUBSTITUTION, source)
         index += 1
+
+
+# How many lines a single command may span before this stops looking for its closing
+# quote. A workflow step is not a program: an unbalanced quote that never closes would
+# otherwise drag the rest of the file into one command.
+_COMMAND_LINE_LIMIT = 200
+
+
+def _dedented_program(program: str) -> str:
+    """A `-c` program with the workflow's own indentation removed.
+
+    The block scalar keeps its indentation in the raw text, so every line after the
+    opening quote carries it and the program will not parse. The first line is left
+    alone: it is whatever followed `-c "` on that line, usually nothing.
+    """
+    lines = program.splitlines()
+    if len(lines) < 2:
+        return program
+    indents = [len(line) - len(line.lstrip()) for line in lines[1:] if line.strip()]
+    cut = min(indents) if indents else 0
+    return "\n".join(
+        [lines[0]] + [line[cut:] if line.strip() else "" for line in lines[1:]]
+    )
 
 
 def _python_dash_c_commands(text: str):
@@ -8014,16 +8293,37 @@ def _python_dash_c_commands(text: str):
     executes on the runner just the same. The same extractor the notebook `%%script`
     reader uses answers it, so there is one implementation of the option rules.
     """
-    for number, line in enumerate(text.splitlines(), start = 1):
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        number = index + 1
         if "<<" in line or not _runs_python_command(line + " <<"):
+            index += 1
             continue
-        stripped = line.strip()
+        # A quoted program may span lines - `python -c "` then the program then the
+        # closing quote is an active workflow shape - and reading one physical line
+        # left the command unparseable, so the whole program went unread. Lines are
+        # joined until the quoting balances, which is exactly when the shell would
+        # consider the command finished.
+        command, last = line, index
+        while last + 1 < len(lines) and last - index < _COMMAND_LINE_LIMIT:
+            try:
+                shlex.split(command, comments = True)
+                break
+            except ValueError:
+                last += 1
+                command = f"{command}\n{lines[last]}"
+        stripped = command.strip()
         for prefix in ("run:", "- run:", "-", "|"):
             if stripped.startswith(prefix):
                 stripped = stripped[len(prefix):].strip()
-        program = _script_command_source("%%script " + stripped)
+        program = _dash_c_program(stripped)
+        index = last + 1
         if program is not None:
-            yield number, _ACTIONS_EXPRESSION.sub("_actions_expression", program)
+            yield number, _ACTIONS_EXPRESSION.sub(
+                "_actions_expression", _dedented_program(program),
+            )
 
 
 def _scan_workflow(path: Path) -> list[dict]:
@@ -8033,7 +8333,12 @@ def _scan_workflow(path: Path) -> list[dict]:
     `python -c` patterns apply to it directly rather than to a `run:` block lifted out
     of YAML.
 
-    One visitor for the file, as for a notebook, and one qualname prefix per block.
+    One visitor PER BLOCK, unlike a notebook: the cells of a notebook share one
+    namespace, while each heredoc and each `-c` command starts its own interpreter. A
+    single visitor let a name bound in one program answer for the next, so
+    `exec = print` in one step made a later step's `exec(...)` read as harmless when
+    that process starts with the builtin.
+
     A block that will not parse is counted in NOTEBOOK_SKIPPED rather than failing the
     file: `python -` is also spelled with templating and `${{ }}` inside, which is not
     Python at all.
@@ -8042,7 +8347,7 @@ def _scan_workflow(path: Path) -> list[dict]:
         text = path.read_text(encoding = "utf-8", errors = "replace")
     except OSError as error:
         raise ScanError(f"{_relative(path)}: {error.strerror or error}") from None
-    visitor = _Visitor(path)
+    findings = []
     skipped = 0
     parsed = []
     for start, source in [*_python_heredocs(text), *_python_dash_c_commands(text)]:
@@ -8060,19 +8365,20 @@ def _scan_workflow(path: Path) -> list[dict]:
         # workflow file, so every node is shifted to where the block really sits.
         ast.increment_lineno(tree, start)
         parsed.append((start, tree))
-    for _start, tree in parsed:
-        visitor._collect_aliases(tree.body)
     for start, tree in parsed:
+        visitor = _Visitor(path)
         visitor.qualname_prefix = f"line{start}"
+        visitor._collect_aliases(tree.body)
         try:
             visitor.visit(tree)
         except RecursionError:
             raise ScanError(
                 f"{_relative(path)}#line{start}: too deeply nested to walk"
             ) from None
+        findings.extend(visitor.findings)
     if skipped:
         NOTEBOOK_SKIPPED.append((_relative(path), skipped))
-    return visitor.findings
+    return findings
 
 
 def scan_file(path: Path) -> list[dict]:

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -202,9 +202,12 @@ def _constructor_name(function: ast.AST, shadowed = None, aliases = None) -> str
     if isinstance(function, ast.IfExp):
         # `(str if flag else format)(f"...")` preserves the source whichever arm runs,
         # the same reasoning the sink resolver applies to a conditional callee.
-        if isinstance(function.test, ast.Constant):
-            taken = function.body if function.test.value else function.orelse
-            return _constructor_name(taken, shadowed, aliases)
+        decided = _constant_truth(function.test)
+        if decided is not None:
+            # `_constant_truth` rather than a bare `ast.Constant`, which is what
+            # `_sink_name` already uses: `not True` and `True and False` are decidable
+            # too, and requiring a plain constant reported the arm that cannot run.
+            return _constructor_name(function.body if decided else function.orelse, shadowed, aliases)
         return (
             _constructor_name(function.body, shadowed, aliases)
             or _constructor_name(function.orelse, shadowed, aliases)
@@ -1318,6 +1321,20 @@ def _constant_truth(test: ast.AST):
     if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
         inner = _constant_truth(test.operand)
         return None if inner is None else not inner
+    if isinstance(test, ast.BoolOp):
+        # `True and False` is decidable, and reading it as unknown left a walrus in a
+        # comprehension filter that never runs looking like it had bound its target.
+        # Short-circuit rules: `and` is False as soon as one operand is, and True only
+        # when every one is; `or` mirrors it. An undecidable operand before a deciding
+        # one leaves the whole thing undecided, which is the safe answer.
+        decisive = isinstance(test.op, ast.Or)
+        for operand in test.values:
+            decided = _constant_truth(operand)
+            if decided is None:
+                return None
+            if decided is decisive:
+                return decisive
+        return not decisive
     return None
 
 
@@ -2053,7 +2070,13 @@ class _Visitor(ast.NodeVisitor):
                 self.tainted[-1].pop(child.id, None)
         iterated = self._literal_elements(node.iter)
         if iterated:
-            reasons = [_is_interpolated(element) for element in iterated]
+            # Resolved against the taint map, as the assignment path is: an element
+            # that is an already tainted NAME - `for source in [payload]` - carries
+            # that name's reason instead of binding the target as clean.
+            reasons = [
+                _is_interpolated(element, self.tainted[-1].get, self._is_shadowed, self._alias)
+                for element in iterated
+            ]
             self._bind(node.target, next((r for r in reasons if r is not None), None))
             # A tuple target takes each element APART, so the whole-element reason
             # says nothing about it. Aggregated across elements, first reason wins,
@@ -2115,7 +2138,7 @@ class _Visitor(ast.NodeVisitor):
             # the opposite body - so the body's own binding, already applied above,
             # stands instead.
             last = literal[-1]
-            self._bind(node.target, _is_interpolated(last))
+            self._bind(node.target, _is_interpolated(last, self.tainted[-1].get, self._is_shadowed, self._alias))
             self._bind_unpacked(node.target, last)
         if not literal:
             # Nothing is known about what the target holds afterwards, and an empty
@@ -2161,7 +2184,19 @@ class _Visitor(ast.NodeVisitor):
             for statement in node.orelse:
                 self.visit(statement)
 
-    visit_AsyncFor = visit_For
+    def visit_AsyncFor(self, node):
+        """`async for` over a written-out list, tuple, set or dict never runs.
+
+        Checked against CPython: it raises `TypeError: 'async for' requires an object
+        with __aiter__ method, got list` before entering the body. Aliasing this to
+        `visit_For` inferred iterations from those literals and reported a sink that
+        cannot execute. The literal is still visited, since it is evaluated.
+        """
+        if self._literal_elements(node.iter):
+            self.visit(node.iter)
+            self.visit(node.target)
+            return
+        self.visit_For(node)
 
     @staticmethod
     def _rebinds(body, target) -> bool:
@@ -2304,6 +2339,25 @@ class _Visitor(ast.NodeVisitor):
         if node.msg is not None and _constant_truth(node.test) is not True:
             self.visit(node.msg)
 
+    def visit_While(self, node: ast.While):
+        """A literal test decides the suite, as `visit_If` already does for `if`.
+
+        `while False: run = print` never runs, so recording that shadow suppressed a
+        call to the builtin that really does happen. Its `else` runs instead, and a
+        truthy literal keeps the body and skips the `else`, which cannot run without a
+        `break`. An undecidable test keeps both, unchanged.
+        """
+        self.visit(node.test)
+        decided = _constant_truth(node.test)
+        if decided is None:
+            for statement in node.body:
+                self.visit(statement)
+            for statement in node.orelse:
+                self.visit(statement)
+            return
+        for statement in (node.body if decided else node.orelse):
+            self.visit(statement)
+
     def visit_TypeAlias(self, node):
         """`type run = int` rebinds the name for the rest of the scope."""
         bound = getattr(node, "name", None)
@@ -2393,10 +2447,17 @@ class _Visitor(ast.NodeVisitor):
             # binds the exception object, so unwrapping `str(...)` as a conversion was
             # a false failure on code that cannot be made to pass. Same set the
             # parameters, imports and other binding forms already use.
-            if node.name in _BUILTIN_NAMES or self._alias(node.name):
+            # `self._binds_over_sink` rather than a bare-name lookup: a constructor
+            # or a `functools.partial` alias lives under a prefixed key, so
+            # `from builtins import str as text; except E as text:` left the
+            # `constructor:text` entry standing and the handler body was reported for
+            # a call that raises before it reaches the sink.
+            if self._binds_over_sink(node.name):
                 self.shadowed_sinks[-1].add(node.name)
-                self.sink_aliases[-1].pop(node.name, None)
-                self.sink_aliases[-1].pop(f"module:{node.name}", None)
+                for table in (self.sink_aliases, self.collected_aliases):
+                    table[-1].pop(node.name, None)
+                    for prefix in ("module:", "constructor:", "partial:", "functools:"):
+                        table[-1].pop(f"{prefix}{node.name}", None)
         for statement in node.body:
             self.visit(statement)
         if node.name is not None:
@@ -3290,7 +3351,14 @@ class _Visitor(ast.NodeVisitor):
         # turned a mixed literal into a shadow that hid it. The sink NAME, not just
         # "yes": a fresh name like `run` has to be registered as an alias for what it
         # holds, or the call in the body resolves to nothing at all.
-        found = next((sink for sink in resolved if sink is not None), None)
+        # A SINK first, and a constructor only when no element is one. Taking the
+        # first non-None hid `for run in [builtins.str, builtins.exec]`: the second
+        # iteration necessarily calls the builtin, but `run` was recorded as the
+        # conversion and the call in the body resolved to nothing.
+        found = next(
+            (sink for sink in resolved if sink is not None and not sink.startswith("constructor:")),
+            None,
+        ) or next((sink for sink in resolved if sink is not None), None)
         if found is not None:
             answer[target.id] = found.rpartition(".")[2]
         return answer
@@ -3445,6 +3513,13 @@ class _Visitor(ast.NodeVisitor):
             # both read as shadows and `exec(s(f"..."))` stopped being unwrapped.
             level = self._binding_level(target.id)
             self.shadowed_sinks[level].discard(target.id)
+            # The name can only hold ONE thing, so an earlier sink or module entry for
+            # it has to go: `run = builtins.exec; run = builtins.str` leaves `run` the
+            # conversion, and the surviving sink entry made the next call read as the
+            # builtin and fail the gate on code that only builds a string.
+            for table in (self.sink_aliases, self.collected_aliases):
+                table[level].pop(target.id, None)
+                table[level].pop(f"module:{target.id}", None)
             # Stored under a prefixed key in the alias table `_alias` already walks,
             # the same way the `builtins` module alias is kept under `module:`.
             self.sink_aliases[level][f"constructor:{target.id}"] = constructor
@@ -3688,7 +3763,12 @@ class _Visitor(ast.NodeVisitor):
                 self.tainted[-1].pop(name, None)
             generated = self._literal_elements(generator.iter)
             if generated:
-                reasons = [_is_interpolated(element) for element in generated]
+                # Same resolution the loop form uses: a tainted name among the
+                # elements carries its reason into the comprehension target.
+                reasons = [
+                    _is_interpolated(element, self.tainted[-1].get, self._is_shadowed, self._alias)
+                    for element in generated
+                ]
                 self._bind(generator.target, next((r for r in reasons if r is not None), None))
                 # A tuple target takes each element APART, so the whole-element reason
                 # above says nothing about it. Reasons are aggregated across elements

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -206,7 +206,7 @@ _OPERATOR_BUILDERS = {
 }
 _BUILTIN_NAMES = frozenset({
     *SINKS, *_CONSTRUCTORS, *_MODULE_RECEIVERS, *_TEXT_PRESERVING_FUNCTIONS,
-    "builtins", "dict", "getattr",
+    "builtins", "dict", "getattr", "map",
     # The bare spelling `_nullcontext_value` accepts. A local of that name provides
     # whatever it likes from `__enter__`, so the shadow test it already performs has
     # to have something to find.
@@ -629,6 +629,23 @@ def _is_interpolated(node: ast.AST, resolve = None, shadowed = None, resolve_ali
     if isinstance(node, ast.BoolOp):
         # `exec(enabled and f"import {name}")` executes the interpolated operand
         # whenever the guard lets it through: same conditional-source shape as IfExp.
+        #
+        # Operands are evaluated left to right, and a walrus in one binds before the
+        # next is read: `exec((payload := "pass") and payload)` executes the literal,
+        # and resolving every operand against the state from before the expression
+        # reported the f-string that name used to hold.
+        walrus = {}
+        for earlier in node.values:
+            for child in ast.walk(earlier):
+                if isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name):
+                    walrus[child.target.id] = _is_interpolated(
+                        child.value, resolve, shadowed, resolve_alias,
+                    )
+        if walrus and resolve is not None:
+            outer = resolve
+
+            def resolve(name, _outer = outer, _walrus = walrus):
+                return _walrus[name] if name in _walrus else _outer(name)
         for operand in _reachable_operands(node):
             reason = _is_interpolated(operand, resolve, shadowed, resolve_alias)
             if reason is not None:
@@ -800,7 +817,7 @@ def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias
 # Classes the file being scanned defines. Set once per parse, read by the receiver
 # test below. A module-level set rather than another parameter on every resolver:
 # one file is scanned at a time, and `_Visitor` sets it before it walks anything.
-_LOCAL_CLASSES: set = set()
+_LOCAL_CLASSES: dict = {}
 
 
 def _visibly_local_instance(node: ast.AST, shadowed = None) -> bool:
@@ -813,7 +830,56 @@ def _visibly_local_instance(node: ast.AST, shadowed = None) -> bool:
         return False
     if shadowed is not None and shadowed(node.func.id):
         return False
+    # A class that SUBCLASSES `str` or `bytes` inherits the real builder unless it
+    # overrides it, so `class Template(str): pass` followed by
+    # `Template("import {}").format(name)` really does splice. Only a class that
+    # cannot inherit one is treated as not a string builder.
     return node.func.id in _LOCAL_CLASSES
+
+
+def _defines_own_builder(name: str, attribute: str) -> bool:
+    """Whether this local class's `attribute` is its own rather than the string one.
+
+    True when the class writes the method itself, and true when it cannot have
+    inherited one - it subclasses nothing textual. False for `class T(str): pass`,
+    which inherits the real `str.format` and really does splice.
+    """
+    definition = _LOCAL_CLASSES.get(name)
+    if definition is None:
+        return False
+    inherits_text = any(
+        isinstance(base, ast.Name) and base.id in ("str", "bytes")
+        for base in definition.bases
+    )
+    defines = any(
+        isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and statement.name == attribute
+        for statement in definition.body
+    )
+    return defines or not inherits_text
+
+
+def _has_template_placeholder(template: str) -> bool:
+    """Whether a `string.Template` body has a placeholder to substitute into.
+
+    Read with `string.Template.pattern` itself, so `$$` is the escaped dollar it
+    really is and `$$name` renders as the literal `$name` with nothing substituted.
+    A hand-written regex got that one wrong.
+    """
+    return any(
+        match.group("named") or match.group("braced")
+        for match in string.Template.pattern.finditer(template)
+    )
+
+
+def _template_text(node: ast.AST):
+    """The written-out template a `string.Template(...)` was built from, else None."""
+    if not isinstance(node, ast.Call) or not node.args:
+        return None
+    first = node.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    return None
 
 
 def _is_template_call(node: ast.AST, shadowed = None, aliases = None) -> bool:
@@ -835,6 +901,16 @@ def _is_template_call(node: ast.AST, shadowed = None, aliases = None) -> bool:
             return False
         return aliases is not None and aliases(f"stdlibfunc:{function.id}") == "string.Template"
     return False
+
+
+def _bound_template(node: ast.AST, shadowed = None, aliases = None):
+    """The `string.Template(...)` a name was bound to, else None."""
+    if not isinstance(node, ast.Name) or aliases is None:
+        return None
+    if shadowed is not None and shadowed(node.id):
+        return None
+    held = aliases(f"template:{node.id}")
+    return held if isinstance(held, ast.Call) else None
 
 
 def _is_stable(node: ast.AST) -> bool:
@@ -1198,17 +1274,32 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                     if node.args else None
                 )
             return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
+        template_receiver = function.value
+        if function.attr in _TEMPLATE_BUILDERS:
+            bound = _bound_template(function.value, shadowed, resolve_alias)
+            if bound is not None:
+                template_receiver = bound
         if function.attr in _TEMPLATE_BUILDERS and _is_template_call(
-            function.value, shadowed, resolve_alias,
+            template_receiver, shadowed, resolve_alias,
         ):
             # A `string.Template` substitution builds source out of the values it is
             # handed, exactly as `.format` does. The receiver has to be a written-out
             # `Template(...)`, so nothing is guessed about what an arbitrary object's
             # `substitute` returns.
+            template = _template_text(template_receiver)
+            if template is not None and not _has_template_placeholder(template):
+                # `string.Template("pass").substitute(x = name)` has no placeholder,
+                # so the mapping is never consulted and the result is the literal.
+                # Same rule the field-free `.format()` case applies.
+                return None
             if node.args or node.keywords:
                 return f".{function.attr}()"
             return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
-        if function.attr in _BUILDERS and _visibly_local_instance(function.value, shadowed):
+        if (
+            function.attr in _BUILDERS
+            and _visibly_local_instance(function.value, shadowed)
+            and _defines_own_builder(function.value.func.id, function.attr)
+        ):
             # `class Safe: def format(self, v): return "pass"` followed by
             # `Safe().format(name)` is not a string builder at all, and reporting it
             # failed the gate on code that cannot be changed to pass. Only a receiver
@@ -1772,6 +1863,43 @@ def _constant_truth(test: ast.AST):
     if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
         inner = _constant_truth(test.operand)
         return None if inner is None else not inner
+    if isinstance(test, ast.Compare):
+        # `if 1 == 2:` is decidable, and reading it as unknown traversed a suite that
+        # cannot run and applied its assignments. Only written-out constants on every
+        # side, and only the comparisons whose result depends on nothing else; `is`
+        # and `in` are left alone, since identity and membership of equal literals are
+        # not decided by their values.
+        operands = [test.left, *test.comparators]
+        if all(
+            isinstance(operand, ast.Constant) and not isinstance(operand.value, bool)
+            for operand in operands
+        ) and all(
+            isinstance(operator, (ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE))
+            for operator in test.ops
+        ):
+            # Compared here rather than by evaluating the expression: this file is
+            # itself scanned by this gate, and building a `compile`/`eval` pair to
+            # fold a constant would be exactly the shape it exists to report.
+            comparisons = {
+                ast.Eq: lambda a, b: a == b,
+                ast.NotEq: lambda a, b: a != b,
+                ast.Lt: lambda a, b: a < b,
+                ast.LtE: lambda a, b: a <= b,
+                ast.Gt: lambda a, b: a > b,
+                ast.GtE: lambda a, b: a >= b,
+            }
+            try:
+                for index, operator in enumerate(test.ops):
+                    left = operands[index].value
+                    right = operands[index + 1].value
+                    if not comparisons[type(operator)](left, right):
+                        return False
+            except TypeError:
+                # `1 < "a"` raises at runtime, so the condition decides nothing and
+                # the statement does not complete either.
+                return None
+            return True
+        return None
     if isinstance(test, ast.BoolOp):
         # `True and False` is decidable, and reading it as unknown left a walrus in a
         # comprehension filter that never runs looking like it had bound its target.
@@ -2285,7 +2413,7 @@ class _Visitor(ast.NodeVisitor):
         # Reset per file, so a class name from the previous one cannot silence a
         # receiver here. Populated by `_collect_aliases` as it walks each scope.
         global _LOCAL_CLASSES
-        _LOCAL_CLASSES = set()
+        _LOCAL_CLASSES = {}
         # Set for a notebook cell, so two cells defining the same function name are
         # separate allowlist entries rather than colliding on one key.
         self.qualname_prefix = ""
@@ -2863,6 +2991,10 @@ class _Visitor(ast.NodeVisitor):
                         aggregated.setdefault(key, value)
                 self.tainted[-1] = before
             self.tainted[-1].update(aggregated)
+        # `for _ in map(exec, [f"..."]): pass` advances the map, so the callback runs
+        # on every element. The iterable is a call to `map` rather than to the sink,
+        # so nothing had associated the two.
+        self._report_mapped_sinks(self._mapped_sink_elements(node.iter))
         self.visit(node.target)
         # `for exec in callbacks:` calls the callback in the body, not the builtin.
         # Store context only: in `for table[exec] in ...` the `exec` is a subscript key
@@ -3363,7 +3495,7 @@ class _Visitor(ast.NodeVisitor):
                     table[-1].pop(node.name, None)
                     for prefix in (
                         "module:", "constructor:", "partial:", "functools:", "text:",
-                        "stdlib:", "stdlibfunc:",
+                        "stdlib:", "stdlibfunc:", "template:", "builder:",
                     ):
                         table[-1].pop(f"{prefix}{node.name}", None)
         for statement in node.body:
@@ -3688,7 +3820,7 @@ class _Visitor(ast.NodeVisitor):
     def _record_local_class(self, statement) -> None:
         """`class Safe:` makes `Safe()` a receiver whose methods are not string ones."""
         if isinstance(statement, ast.ClassDef):
-            _LOCAL_CLASSES.add(statement.name)
+            _LOCAL_CLASSES[statement.name] = statement
 
     def _alias_pass_definition(self, statement, declared, rebound) -> None:
         """A `def` or `class` binds its own name in THIS scope.
@@ -4481,6 +4613,16 @@ class _Visitor(ast.NodeVisitor):
         level = self._binding_level(target.id)
         for table in (self.sink_aliases, self.collected_aliases):
             table[level].pop(f"builder:{target.id}", None)
+        if _is_template_call(value, self._is_shadowed, self._alias):
+            # `template = string.Template("import $name")` then
+            # `template.substitute(name = name)` splices exactly as the inline
+            # spelling does, and the receiver is a bare name by then. The constructor
+            # call is stored, so the substitution reads the same template text.
+            for table in (self.sink_aliases, self.collected_aliases):
+                table[level][f"template:{target.id}"] = value
+            return
+        for table in (self.sink_aliases, self.collected_aliases):
+            table[level].pop(f"template:{target.id}", None)
         if not isinstance(value, ast.Attribute):
             return
         if value.attr not in (*_BUILDERS, *_TEMPLATE_BUILDERS):
@@ -4527,6 +4669,19 @@ class _Visitor(ast.NodeVisitor):
         # Not chased any further, same as the rest of this method: `other = bind` does
         # not re-record, which can only decline to read a call, never invent one.
         self._record_builder_alias(target, value)
+        # `obj.payload = f"..."` then `obj = something_else` replaces the object, so
+        # the path recorded against the old one no longer describes anything. Only the
+        # bare name was cleared, and the stale `path>obj.payload` reason then rejected
+        # a call that reads the new object.
+        prefix = f"path>{target.id}"
+        for scope in self.tainted:
+            for key in [
+                key for key in scope
+                if isinstance(key, str)
+                and key.startswith(prefix)
+                and (len(key) == len(prefix) or not (key[len(prefix)].isalnum() or key[len(prefix)] == "_"))
+            ]:
+                scope.pop(key, None)
         level = self._binding_level(target.id)
         self.sink_aliases[level].pop(f"partial:{target.id}", None)
         self.collected_aliases[level].pop(f"partial:{target.id}", None)
@@ -5009,10 +5164,14 @@ class _Visitor(ast.NodeVisitor):
     visit_DictComp = _visit_comprehension
     visit_GeneratorExp = _visit_comprehension
 
-    # Calls that consume a `map` eagerly, so the callback really does run.
+    # Calls that consume a `map` and reach EVERY element. `next` takes one, and
+    # `any`/`all` stop at the first result that decides them - a sink returns None,
+    # so `any` runs them all and `all` stops at the first. Only the ones that must
+    # reach every element are listed, so nothing is reported for an element that a
+    # partial consumer never asks for.
     _CONSUMERS = frozenset({
-        "list", "tuple", "set", "frozenset", "dict", "sorted", "sum", "any", "all",
-        "min", "max", "next",
+        "list", "tuple", "set", "frozenset", "dict", "sorted", "sum", "min", "max",
+        "any",
     })
 
     def _mapped_sink_calls(self, node: ast.Call):
@@ -5028,17 +5187,52 @@ class _Visitor(ast.NodeVisitor):
             return
         if self._is_shadowed(node.func.id) or len(node.args) != 1 or node.keywords:
             return
-        inner = node.args[0]
+        yield from self._mapped_sink_elements(node.args[0])
+
+    def _mapped_sink_elements(self, inner):
+        """`(sink, element, call)` for a written-out `map(<sink>, [literal, ...])`."""
         if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name)):
             return
-        if inner.func.id != "map" or self._is_shadowed("map") or len(inner.args) != 2:
+        if inner.func.id != "map" or self._is_shadowed("map"):
+            return
+        # `map` takes no keyword arguments, so a call with one raises TypeError before
+        # the callback is ever invoked.
+        if inner.keywords or len(inner.args) < 2:
             return
         sink = _sink_name(inner.args[0], self._alias, self._is_shadowed)
         if sink is None:
             return
+        # `map(exec, sources, scopes)` calls `exec(source, scope)`, which executes just
+        # the same; the FIRST iterable supplies the source and the rest are the sink's
+        # other parameters. Requiring exactly two iterables let that spelling past.
+        # More arguments than the sink takes raises, so those are left alone: `exec`
+        # and `eval` take three, `compile` six.
+        if len(inner.args) - 1 > {"exec": 3, "eval": 3}.get(sink.rpartition(".")[2], 6):
+            return
         elements = self._literal_elements(inner.args[1])
         for element in elements or ():
             yield sink, element, inner
+
+    def _report_mapped_sinks(self, pairs) -> None:
+        """Report a sink invoked as a `map` callback over written-out elements."""
+        for mapped_sink, element, inner in pairs:
+            reason = _is_interpolated(
+                element, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
+            if reason is not None:
+                self.findings.append({
+                    "path": _relative(self.path),
+                    "qualname": self._qualname(),
+                    "sink": mapped_sink,
+                    "reason": f"{reason} through map()",
+                    "line": inner.lineno,
+                    "hash": _call_hash(inner),
+                })
+
+    def visit_Starred(self, node: ast.Starred):
+        """`[*map(exec, [...])]` consumes the map as eagerly as `list(...)` does."""
+        self._report_mapped_sinks(self._mapped_sink_elements(node.value))
+        self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call):
         for mapped_sink, element, inner in self._mapped_sink_calls(node):
@@ -5803,6 +5997,33 @@ def _is_expression(text: str) -> bool:
     return True
 
 
+def _interactive_script_command(code: str) -> bool:
+    """Whether a `%%script python ...` escape also reads the cell body interactively.
+
+    `python --help` documents `-i` as forcing a prompt even when stdin is not a
+    terminal, so `python -i -c "..."` runs the command and THEN reads what follows.
+    Only the `-i` spellings, and only where an exit-only option does not win.
+    """
+    for line in code.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(("%%script", "%%bash", "!", "%")):
+            continue
+        tokens = stripped.lstrip("%!").split()
+        for token in tokens:
+            if token in _PYTHON_EXIT_ONLY_OPTIONS:
+                return False
+            if (
+                token.startswith("-")
+                and not token.startswith("--")
+                and any(letter in token[1:] for letter in "hV?")
+            ):
+                return False
+        for token in tokens:
+            if token.startswith("-") and not token.startswith("--") and "i" in token[1:]:
+                return True
+    return False
+
+
 def _script_command_source(code: str) -> str | None:
     """The program a `%%script python -c "..."` cell hands to the interpreter.
 
@@ -5944,7 +6165,19 @@ def _scan_notebook(path: Path) -> list[dict]:
         # the cell's source instead.
         command = _script_command_source(code)
         if command is not None:
-            code = command
+            # `-i` with `-c` runs BOTH: the command first, then interactive mode reads
+            # the cell body from stdin as Python. Replacing the cell with the command
+            # alone discarded the body, so a sink written under the escape went
+            # unread. The escape lines are blanked rather than removed, so the body
+            # keeps the line numbers it had.
+            if _interactive_script_command(code):
+                body = "\n".join(
+                    "" if line.lstrip().startswith(("%", "!")) else line
+                    for line in code.splitlines()
+                )
+                code = command + "\n" + body
+            else:
+                code = command
         elif _foreign_cell_magic(code) is not None:
             continue
         tree = _parse_cell(code, f"{path}#cell{index}")

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -90,6 +90,11 @@ def _relative(path: Path) -> str:
 # same shape, so leaving it out let `exec("import {m}".format_map(cfg))` through.
 _BUILDERS = ("format", "format_map", "join")
 
+# `string.Template("import $m").substitute(m = name)` splices exactly as `.format`
+# does, and the receiver is the template object rather than a string, so it went
+# through none of the builder branches.
+_TEMPLATE_BUILDERS = ("substitute", "safe_substitute")
+
 
 class _AbsentNode(ast.AST):
     """Stand-in for an AST node type this interpreter does not have.
@@ -179,6 +184,7 @@ _CONSTRUCTOR_SOURCE_KEYWORD = {
 # none of the tracked sets.
 _MODULE_RECEIVERS = frozenset({
     "codeop", "operator", "ast", "importlib", "functools", "textwrap", "contextlib",
+    "string",
 })
 
 # `operator` functions that build a string out of two values, and the operator each
@@ -187,7 +193,7 @@ _MODULE_RECEIVERS = frozenset({
 # Stdlib helpers that hand their source through and can be imported directly, as
 # `<module>.<name>`. `visit_ImportFrom` records `from ast import parse as p` against
 # these, and `_interpolated_call` rewrites such a call to the qualified spelling.
-_DIRECT_HELPERS = frozenset({"ast.parse", "codeop.compile_command"})
+_DIRECT_HELPERS = frozenset({"ast.parse", "codeop.compile_command", "string.Template"})
 
 _OPERATOR_BUILDERS = {
     "add": ast.Add, "concat": ast.Add, "iadd": ast.Add, "iconcat": ast.Add,
@@ -594,6 +600,13 @@ def _is_interpolated(node: ast.AST, resolve = None, shadowed = None, resolve_ali
         node = node.value
     if isinstance(node, ast.Starred):
         return _interpolated_starred(node, resolve, shadowed, resolve_alias)
+    # A written-out attribute or subscript path can hold built source:
+    # `self.payload = f"import {name}"` then `exec(self.payload)`. Asked before the
+    # shape handlers below, since a subscript is one of them and its element reading
+    # answers a different question.
+    stored = _interpolated_compound(node, resolve, shadowed, resolve_alias)
+    if stored is not None:
+        return stored
     if isinstance(node, ast.Subscript):
         return _interpolated_subscript(node, resolve, shadowed, resolve_alias)
     if isinstance(node, ast.Name):
@@ -633,6 +646,52 @@ def _is_interpolated(node: ast.AST, resolve = None, shadowed = None, resolve_ali
     if isinstance(node, ast.Call):
         return _interpolated_call(node, resolve, shadowed, resolve_alias)
     return None
+
+
+def _compound_key(node: ast.AST) -> str | None:
+    """A stable text key for an attribute or subscript path, or None.
+
+    `self.payload` and `payloads["run"]` are written out and cannot run code of their
+    own, so the same spelling names the same place at the store and at the load. A
+    computed index, a call anywhere in the path, or anything else unreadable gives
+    None and the value is not tracked at all.
+    """
+    walk = node
+    while True:
+        if isinstance(walk, ast.Attribute):
+            walk = walk.value
+            continue
+        if isinstance(walk, ast.Subscript):
+            index = walk.slice
+            if not (isinstance(index, ast.Constant) and isinstance(index.value, (str, int))):
+                return None
+            if isinstance(index.value, bool):
+                return None
+            walk = walk.value
+            continue
+        if isinstance(walk, ast.Name):
+            break
+        return None
+    if node is walk:
+        # A bare name is handled by the ordinary binding, not here.
+        return None
+    try:
+        # A prefix no identifier can carry, so a path key can never collide with a
+        # plain name in the same map.
+        return "path>" + ast.unparse(node)
+    except Exception:
+        return None
+
+
+def _interpolated_compound(node, resolve = None, shadowed = None, resolve_alias = None):
+    """The reason recorded for a written-out attribute or subscript path, if any."""
+    if resolve is None or not isinstance(node, (ast.Attribute, ast.Subscript)):
+        return None
+    path = _compound_key(node)
+    if path is None:
+        return None
+    held = resolve(path)
+    return held if isinstance(held, str) else None
 
 
 def _interpolated_starred(node, resolve = None, shadowed = None, resolve_alias = None) -> str | None:
@@ -709,6 +768,46 @@ def _interpolated_subscript(node, resolve = None, shadowed = None, resolve_alias
             return _is_interpolated(node.value, resolve, shadowed, resolve_alias)
         return None
     return _literal_element(node, resolve, shadowed, resolve_alias)
+
+
+# Classes the file being scanned defines. Set once per parse, read by the receiver
+# test below. A module-level set rather than another parameter on every resolver:
+# one file is scanned at a time, and `_Visitor` sets it before it walks anything.
+_LOCAL_CLASSES: set = set()
+
+
+def _visibly_local_instance(node: ast.AST, shadowed = None) -> bool:
+    """Whether `node` is written out as an instance of a class defined in this file.
+
+    `Safe()` where a `class Safe` is visible, and `Safe` has not been rebound to
+    something else. A fact stated in the file rather than a guess about a name.
+    """
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+        return False
+    if shadowed is not None and shadowed(node.func.id):
+        return False
+    return node.func.id in _LOCAL_CLASSES
+
+
+def _is_template_call(node: ast.AST, shadowed = None, aliases = None) -> bool:
+    """Whether `node` is a written-out `string.Template(...)`.
+
+    Qualified through the module or a recorded alias of it, or the bare name when
+    `from string import Template` bound it here. Nothing else: an application class
+    called `Template` may substitute nothing at all.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    function = node.func
+    if isinstance(function, ast.Attribute):
+        return function.attr == "Template" and _names_module(
+            function.value, "string", shadowed, aliases,
+        )
+    if isinstance(function, ast.Name):
+        if shadowed is not None and shadowed(function.id):
+            return False
+        return aliases is not None and aliases(f"stdlibfunc:{function.id}") == "string.Template"
+    return False
 
 
 def _is_stable(node: ast.AST) -> bool:
@@ -854,6 +953,23 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
     if isinstance(function, ast.Name) and resolve_alias is not None and not (
         shadowed is not None and shadowed(function.id)
     ):
+        # `formatter = "import {}".format` binds the METHOD, template and all, so
+        # `formatter(name)` splices exactly as `"import {}".format(name)` does. The
+        # callee is a bare name by then, so none of the attribute branches saw it.
+        # `builder:` holds the receiver the method was taken from.
+        bound_template = resolve_alias(f"builder:{function.id}")
+        if isinstance(bound_template, ast.Call):
+            return _is_interpolated(
+                ast.copy_location(
+                    ast.Call(
+                        func = bound_template.func,
+                        args = list(node.args),
+                        keywords = list(node.keywords),
+                    ),
+                    node,
+                ),
+                resolve, shadowed, resolve_alias,
+            )
         # `from ast import parse` binds the helper directly, with no module attribute
         # to match on, so the source-preserving branches below never saw it. Rewritten
         # as the qualified spelling and read there, which keeps one implementation of
@@ -1048,6 +1164,23 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
                     if node.args else None
                 )
             return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
+        if function.attr in _TEMPLATE_BUILDERS and _is_template_call(
+            function.value, shadowed, resolve_alias,
+        ):
+            # A `string.Template` substitution builds source out of the values it is
+            # handed, exactly as `.format` does. The receiver has to be a written-out
+            # `Template(...)`, so nothing is guessed about what an arbitrary object's
+            # `substitute` returns.
+            if node.args or node.keywords:
+                return f".{function.attr}()"
+            return _is_interpolated(function.value, resolve, shadowed, resolve_alias)
+        if function.attr in _BUILDERS and _visibly_local_instance(function.value, shadowed):
+            # `class Safe: def format(self, v): return "pass"` followed by
+            # `Safe().format(name)` is not a string builder at all, and reporting it
+            # failed the gate on code that cannot be changed to pass. Only a receiver
+            # written out as a call to a class this file defines; anything unknown is
+            # still read as a string method.
+            return None
         if function.attr in _BUILDERS:
             # `.join([])` and `.format()` with nothing to splice in produce the
             # receiver, or the empty string, and nothing was interpolated at all.
@@ -1631,6 +1764,27 @@ def _constant_truth(test: ast.AST):
     return None
 
 
+def _is_nullcontext_call(node: ast.AST, aliases = None, shadowed = None) -> bool:
+    """Whether `node` is a written-out `contextlib.nullcontext(...)`, argument or not.
+
+    `_nullcontext_value` answers what it HANDS OVER and so needs exactly one argument.
+    `async with` only needs to know that this manager has no `__aenter__`, and
+    `nullcontext()` with no argument has none either.
+    """
+    if not isinstance(node, ast.Call) or len(node.args) > 1 or node.keywords:
+        return False
+    function = node.func
+    if isinstance(function, ast.Attribute):
+        return function.attr == "nullcontext" and _names_module(
+            function.value, "contextlib", shadowed, aliases,
+        )
+    return (
+        isinstance(function, ast.Name)
+        and function.id == "nullcontext"
+        and not (shadowed is not None and shadowed(function.id))
+    )
+
+
 def _nullcontext_value(node: ast.AST, aliases = None, shadowed = None) -> ast.AST | None:
     """The single argument a written-out `contextlib.nullcontext(...)` hands over.
 
@@ -1923,19 +2077,47 @@ def _mapping_lookup(mapping: ast.Dict, wanted: str) -> ast.AST | None:
     return None
 
 
-def _compile_call_is_complete(node: ast.Call, skip: int = 0) -> bool:
+def _compile_call_is_complete(node: ast.Call, shadowed = None, skip: int = 0) -> bool:
     """Whether a visible `compile(...)` supplies the three arguments it requires.
 
     `compile(source, filename, mode)` has no defaults for any of them. A `*` or `**`
     in the call may supply what is missing, so those are unknown and count as
     complete: this only ever declines to report a call CPython refuses outright.
     """
-    if any(isinstance(argument, ast.Starred) for argument in node.args):
-        return True
-    if any(keyword.arg is None for keyword in node.keywords):
-        return True
-    positional = len(node.args) - skip
-    named = {keyword.arg for keyword in node.keywords}
+    positional = 0
+    named = {keyword.arg for keyword in node.keywords if keyword.arg is not None}
+    for argument in node.args[skip:]:
+        if isinstance(argument, ast.Starred):
+            inner = argument.value
+            # A written-out expansion says exactly how many values it supplies:
+            # `compile(*[f"..."])` supplies one and still raises for the missing
+            # filename and mode. Treating any `*` as "may supply the rest" reported
+            # that call. An opaque one really may, and stays unknown.
+            if isinstance(inner, (ast.Tuple, ast.List, ast.Set)) and not any(
+                isinstance(element, ast.Starred) for element in inner.elts
+            ):
+                positional += len(inner.elts)
+                continue
+            if isinstance(inner, ast.Dict) and not any(key is None for key in inner.keys):
+                positional += len(inner.keys)
+                continue
+            return True
+        positional += 1
+    for keyword in node.keywords:
+        if keyword.arg is not None:
+            continue
+        # WITH the shadow test: a local `def dict(...)` may return anything, so the
+        # keys it appears to name are not the keys `compile` receives, and reading
+        # them made a call that really does reach the sink look incomplete.
+        mapping = _mapping_literal(keyword.value, shadowed)
+        if mapping is None or _has_computed_key(mapping) or any(
+            key is None for key in mapping.keys
+        ):
+            return True
+        named |= {
+            key.value for key in mapping.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
     return all(
         positional > index or wanted in named
         for index, wanted in enumerate(("source", "filename", "mode"))
@@ -1982,7 +2164,9 @@ def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) 
     was skipped entirely. `studio/backend/core/inference/tools.py` already resolves
     sink arguments this way.
     """
-    if sink.rpartition(".")[2] == "compile" and not _compile_call_is_complete(node, skip):
+    if sink.rpartition(".")[2] == "compile" and not _compile_call_is_complete(
+        node, shadowed, skip,
+    ):
         # `compile(f"import {name}")` raises TypeError for the missing `filename` and
         # `mode` before it compiles anything, so reporting it failed the gate on a
         # call that cannot execute. Only a call whose arguments are all visible is
@@ -2064,6 +2248,10 @@ def _source_argument(node: ast.Call, sink: str, shadowed = None, skip: int = 0) 
 class _Visitor(ast.NodeVisitor):
     def __init__(self, path: Path):
         self.path = path
+        # Reset per file, so a class name from the previous one cannot silence a
+        # receiver here. Populated by `_collect_aliases` as it walks each scope.
+        global _LOCAL_CLASSES
+        _LOCAL_CLASSES = set()
         # Set for a notebook cell, so two cells defining the same function name are
         # separate allowlist entries rather than colliding on one key.
         self.qualname_prefix = ""
@@ -2955,6 +3143,13 @@ class _Visitor(ast.NodeVisitor):
         """
         for item in node.items:
             self.visit(item.context_expr)
+            if _is_nullcontext_call(item.context_expr, self._alias, self._is_shadowed):
+                # A written-out `nullcontext` cannot be entered asynchronously, and
+                # items are entered LEFT TO RIGHT, so nothing after this one is even
+                # evaluated - the context expression of the next item included. Testing
+                # every item first visited those expressions and reported a sink in one
+                # of them. The body does not run either.
+                return
             if item.optional_vars is not None:
                 self.visit(item.optional_vars)
                 for child in ast.walk(item.optional_vars):
@@ -2965,13 +3160,6 @@ class _Visitor(ast.NodeVisitor):
                     for child in ast.walk(item.optional_vars)
                     if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
                 })
-        if any(
-            _nullcontext_value(item.context_expr, self._alias, self._is_shadowed) is not None
-            for item in node.items
-        ):
-            # A written-out `nullcontext` cannot be entered asynchronously, so nothing
-            # below it runs at all.
-            return
         for statement in node.body:
             self.visit(statement)
 
@@ -3314,6 +3502,17 @@ class _Visitor(ast.NodeVisitor):
         literal_text = False,
     ) -> None:
         if not isinstance(target, ast.Name):
+            # `self.payload = f"import {name}"` then `exec(self.payload)` executes the
+            # source, and dropping every non-name target lost it. The written-out path
+            # is the key: only an attribute or subscript chain of names, attributes and
+            # literal indices, which cannot run code of its own and names the same
+            # place at the store and at the load. Anything else is still dropped.
+            path = _compound_key(target)
+            if path is not None:
+                if reason is None:
+                    self.tainted[-1].pop(path, None)
+                else:
+                    self.tainted[-1][path] = reason
             return
         if literal_text is not False and literal_text is not None:
             # Same shape as the numeric marker: a fact about what the name holds, so a
@@ -3395,6 +3594,9 @@ class _Visitor(ast.NodeVisitor):
             # they came from were written. `rebound` is one set mutated in place by
             # more than one of them, so this order is the definition of what each pass
             # sees, not a formatting choice.
+            # First: `_alias_pass_definition` reports a `class` as handled and the
+            # loop moves on, so anything below it never sees one.
+            self._record_local_class(statement)
             if self._alias_pass_definition(statement, declared, rebound):
                 continue
             self._alias_pass_rebound_names(statement, rebound)
@@ -3402,6 +3604,11 @@ class _Visitor(ast.NodeVisitor):
             self._alias_pass_block_targets(statement, declared)
             self._alias_pass_walrus_locals(statement, declared)
             self._alias_pass_bindings(statement, declared, rebound)
+
+    def _record_local_class(self, statement) -> None:
+        """`class Safe:` makes `Safe()` a receiver whose methods are not string ones."""
+        if isinstance(statement, ast.ClassDef):
+            _LOCAL_CLASSES.add(statement.name)
 
     def _alias_pass_definition(self, statement, declared, rebound) -> None:
         """A `def` or `class` binds its own name in THIS scope.
@@ -4181,6 +4388,34 @@ class _Visitor(ast.NodeVisitor):
             return 0
         return len(self.scope_kinds) - 1
 
+    def _record_builder_alias(self, target: ast.AST, value: ast.AST) -> None:
+        """`formatter = "import {}".format` keeps the template that method belongs to.
+
+        Only a written-out string or a `string.Template(...)` receiver, and only the
+        builder method names, so nothing is recorded about an arbitrary object's
+        attribute. The stored value is a synthetic call node the resolver replays with
+        the arguments of the later invocation.
+        """
+        if not isinstance(target, ast.Name):
+            return
+        level = self._binding_level(target.id)
+        for table in (self.sink_aliases, self.collected_aliases):
+            table[level].pop(f"builder:{target.id}", None)
+        if not isinstance(value, ast.Attribute):
+            return
+        if value.attr not in (*_BUILDERS, *_TEMPLATE_BUILDERS):
+            return
+        receiver = value.value
+        if not (
+            _visibly_literal_text(receiver)
+            or _is_template_call(receiver, self._is_shadowed, self._alias)
+        ):
+            return
+        replay = ast.Call(func = value, args = [], keywords = [])
+        ast.copy_location(replay, value)
+        for table in (self.sink_aliases, self.collected_aliases):
+            table[level][f"builder:{target.id}"] = replay
+
     def _shadow_assignment(self, target: ast.AST, value: ast.AST) -> None:
         """Record `compile = re.compile`, which makes the bare name not the builtin.
 
@@ -4211,6 +4446,7 @@ class _Visitor(ast.NodeVisitor):
         # print, and leaving the record in place reported a call that cannot execute.
         # Not chased any further, same as the rest of this method: `other = bind` does
         # not re-record, which can only decline to read a call, never invent one.
+        self._record_builder_alias(target, value)
         level = self._binding_level(target.id)
         self.sink_aliases[level].pop(f"partial:{target.id}", None)
         self.collected_aliases[level].pop(f"partial:{target.id}", None)
@@ -4649,7 +4885,51 @@ class _Visitor(ast.NodeVisitor):
     visit_DictComp = _visit_comprehension
     visit_GeneratorExp = _visit_comprehension
 
+    # Calls that consume a `map` eagerly, so the callback really does run.
+    _CONSUMERS = frozenset({
+        "list", "tuple", "set", "frozenset", "dict", "sorted", "sum", "any", "all",
+        "min", "max", "next",
+    })
+
+    def _mapped_sink_calls(self, node: ast.Call):
+        """`(sink, element)` pairs for `list(map(exec, [f"..."]))`.
+
+        A sink handed to `map` as a CALLBACK is called with each element, and the
+        callee of the call node is `map`, so nothing associated the two. Only a
+        written-out `map` inside a written-out consumer - `map` on its own is lazy and
+        runs nothing - with a written-out iterable, so this stays a fact stated in the
+        file.
+        """
+        if not isinstance(node.func, ast.Name) or node.func.id not in self._CONSUMERS:
+            return
+        if self._is_shadowed(node.func.id) or len(node.args) != 1 or node.keywords:
+            return
+        inner = node.args[0]
+        if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name)):
+            return
+        if inner.func.id != "map" or self._is_shadowed("map") or len(inner.args) != 2:
+            return
+        sink = _sink_name(inner.args[0], self._alias, self._is_shadowed)
+        if sink is None:
+            return
+        elements = self._literal_elements(inner.args[1])
+        for element in elements or ():
+            yield sink, element, inner
+
     def visit_Call(self, node: ast.Call):
+        for mapped_sink, element, inner in self._mapped_sink_calls(node):
+            reason = _is_interpolated(
+                element, self.tainted[-1].get, self._is_shadowed, self._alias,
+            )
+            if reason is not None:
+                self.findings.append({
+                    "path": _relative(self.path),
+                    "qualname": self._qualname(),
+                    "sink": mapped_sink,
+                    "reason": f"{reason} through map()",
+                    "line": inner.lineno,
+                    "hash": _call_hash(inner),
+                })
         sink = _sink_name(node.func, self._alias, self._is_shadowed)
         # A shadowed base name applies to `b.exec(...)` as well as a bare call: with
         # `import builtins as b` visible, `def f(b, name)` supplies its own `b`.

--- a/scripts/lint_dynamic_exec.py
+++ b/scripts/lint_dynamic_exec.py
@@ -1029,7 +1029,17 @@ def _interpolated_call(node, resolve = None, shadowed = None, resolve_alias = No
             # still hands the source through.
             continue
         source = _constructor_source(node, constructor, shadowed)
-        if source is not None and not (constructor == "str" and _visibly_bytes(source)):
+        # `str(b"...")` is the REPR of the bytes and executes nothing. `str(b"...",
+        # "utf-8")` is the DECODING form and hands the text straight back, so limiting
+        # the exemption to the one-argument spelling was the difference between a
+        # quoted repr and the source itself.
+        decodes = constructor == "str" and (
+            len(node.args) > 1
+            or any(keyword.arg in ("encoding", "errors") for keyword in node.keywords)
+        )
+        if source is not None and not (
+            constructor == "str" and _visibly_bytes(source) and not decodes
+        ):
             # `str(bytes)` is the REPR of the bytes, `"b'import os'"`, which executes
             # as a string expression and imports nothing. Every other constructor here
             # hands the text through unchanged.
@@ -2687,6 +2697,40 @@ class _Visitor(ast.NodeVisitor):
             return
         self._visit_suite(node.body if decided else node.orelse)
 
+    def visit_AsyncWith(self, node):
+        """`async with nullcontext(...)` raises: it has no `__aenter__`.
+
+        Checked on CPython: `async with contextlib.nullcontext(x)` answers
+        `TypeError: 'async with' received an object that does not implement
+        __aenter__`, so the body never runs. Aliasing this to `visit_With` inferred
+        what the target held from the synchronous constructor and reported a call in a
+        suite that cannot execute. Only that one inference is dropped; everything else
+        `visit_With` does - the unconditional rebinding, the shadowing, visiting the
+        context expressions - still applies, since an ordinary async manager does run
+        its body.
+        """
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self.visit(item.optional_vars)
+                for child in ast.walk(item.optional_vars):
+                    if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store):
+                        self.tainted[-1].pop(child.id, None)
+                self._shadow_locals({
+                    child.id: None
+                    for child in ast.walk(item.optional_vars)
+                    if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+                })
+        if any(
+            _nullcontext_value(item.context_expr, self._alias, self._is_shadowed) is not None
+            for item in node.items
+        ):
+            # A written-out `nullcontext` cannot be entered asynchronously, so nothing
+            # below it runs at all.
+            return
+        for statement in node.body:
+            self.visit(statement)
+
     def visit_TypeAlias(self, node):
         """`type run = int` rebinds the name for the rest of the scope."""
         bound = getattr(node, "name", None)
@@ -2898,7 +2942,9 @@ class _Visitor(ast.NodeVisitor):
         for statement in node.body:
             self.visit(statement)
 
-    visit_AsyncWith = visit_With
+    # `visit_AsyncWith` is defined on its own above: `async with` cannot enter a
+    # synchronous context manager, so the `nullcontext` inference here does not apply
+    # to it.
 
     def visit_NamedExpr(self, node: ast.NamedExpr):
         """`(payload := f"import {name}")` as a statement, then `exec(payload)`.

--- a/tests/security/test_incremental_save_quotes_its_arguments.py
+++ b/tests/security/test_incremental_save_quotes_its_arguments.py
@@ -2,17 +2,18 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """`incremental_save_pretrained` writes `repo_id` and `revision` into generated Python.
 
 That source is handed to the `exec` in `merge_and_dequantize_lora`, so both values have

--- a/tests/security/test_incremental_save_quotes_its_arguments.py
+++ b/tests/security/test_incremental_save_quotes_its_arguments.py
@@ -1,0 +1,99 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""`incremental_save_pretrained` writes `repo_id` and `revision` into generated Python.
+
+That source is handed to the `exec` in `merge_and_dequantize_lora`, so both values have
+to arrive as string LITERALS. `revision` was interpolated bare, which made an ordinary
+`revision = "main"` a name lookup and a revision spelled as an expression executable;
+`repo_id` was wrapped in single quotes, which one apostrophe ends.
+"""
+
+import ast
+import textwrap
+
+import pytest
+
+from unsloth_zoo.saving_utils import incremental_save_pretrained
+
+
+# The two shapes `incremental_save_pretrained` rewrites, and nothing else.
+_SAVE_PRETRAINED = textwrap.dedent(
+    """
+    def save_pretrained(self, save_directory):
+        os.makedirs(save_directory, exist_ok = True)
+        for shard_file, tensors in filename_to_tensors:
+            shard = {}
+            pass
+        return None
+    """
+)
+
+
+def _generated(repo_id, revision):
+    return incremental_save_pretrained(
+        _SAVE_PRETRAINED,
+        low_disk_space_usage = True,
+        use_temp_file = True,
+        repo_id = repo_id,
+        revision = revision,
+    )
+
+
+@pytest.mark.parametrize(
+    "repo_id, revision",
+    [
+        ("me/model", "main"),
+        # An apostrophe ends the single-quoted spelling the generator used to write.
+        ("me/it's", "main"),
+        ("me/model", None),
+        # A revision that is Python rather than a name. It must land as a string.
+        ("me/model", "__import__('os').getcwd()"),
+        ('me/"quoted"', 'rev"quoted"'),
+    ],
+)
+def test_the_generated_source_carries_both_values_as_literals(repo_id, revision):
+    generated = _generated(repo_id, revision)
+    tree = ast.parse(generated)
+
+    found = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg in ("repo_id", "revision"):
+                found[keyword.arg] = keyword.value
+
+    assert set(found) == {"repo_id", "revision"}, generated
+    for name, expected in (("repo_id", repo_id), ("revision", revision)):
+        node = found[name]
+        assert isinstance(node, ast.Constant), f"{name} is not a literal:\n{generated}"
+        assert node.value == expected
+
+
+def test_the_generated_assignment_carries_the_repo_id_as_a_literal():
+    # The `repo_id = ...` statement written into the temp-file branch is the second
+    # site, and it was quoted the same fragile way.
+    generated = _generated("me/it's", "main")
+    tree = ast.parse(generated)
+    assignments = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(getattr(t, "id", None) == "repo_id" for t in node.targets)
+    ]
+    assert assignments, generated
+    for node in assignments:
+        assert isinstance(node.value, ast.Constant)
+        assert node.value.value == "me/it's"

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,7 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a sink above the return still runs': 'def f(name):\n    exec(f"import {name}")\n    return\n',
     'next runs the callback on the first mapped element': 'def f(name):\n    next(map(exec, [f"import {name}"]))\n',
     'a lambda hands the sink itself back': 'def f(name):\n    (lambda run: run)(exec)(f"import {name}")\n',
     'a key callback runs on every element sorted consumes': 'def f(name):\n    sorted([f"import {name}"], key = exec)\n',
@@ -417,6 +418,8 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a function body ends at an unconditional return': 'def f(name):\n    return\n    exec(f"import {name}")\n',
+    'a function body ends at an unconditional raise': 'def f(name):\n    raise SystemExit\n    exec(f"import {name}")\n',
     'a discarded generator never evaluates its element': 'def f(name):\n    (exec(f"import {name}") for _ in [0])\n',
     'min compares two results and raises before the third': 'def f(name):\n    min(map(exec, ["pass", "pass", f"import {name}"]))\n',
     'an empty second iterable stops the map before it starts': 'def f(name):\n    list(map(exec, [f"import {name}"], []))\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,9 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a mixed literal loop keeps the sink over the constructor': 'import builtins\ndef f(name):\n    for run in [builtins.str, builtins.exec]:\n        run(f"import {name}")\n',
+    'a statically false while never takes the builtin away': 'import builtins\ndef f(name, condition):\n    run = builtins.exec\n    while False:\n        run = print\n    run(f"import {name}")\n',
+    'a decidable boolean filter binds no comprehension walrus': 'import builtins\ndef f(name):\n    run = builtins.exec\n    [(run := print) for _ in [0] if True and False]\n    run(f"import {name}")\n',
     'a dict constructor literal answers get on the callee side': 'def f(name):\n    dict(run = exec).get("run")(f"import {name}")\n',
     'functools under a module alias still binds the sink': 'import functools as ft\ndef f(name):\n    ft.partial(exec, f"import {name}")()\n',
     'nullcontext hands its argument to the with target': 'import contextlib, builtins\ndef f(name):\n    with contextlib.nullcontext(builtins.exec) as run:\n        run(f"import {name}")\n',
@@ -303,6 +306,7 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'a literal loop element carries the taint it holds': 'def f(name):\n    payload = f"import {name}"\n    for source in [payload]:\n        exec(source)\n',
     'a short-circuited walrus never clears the taint': 'def f(name):\n    payload = f"import {name}"\n    False and (payload := "pass")\n    exec(payload)\n',
     'the final loop body wins over the last element': 'def f(name):\n    for payload in ["pass"]:\n        payload = f"import {name}"\n    exec(payload)\n',
     'a walrus alias carries the taint': 'def f(name):\n    payload = f"import {name}"\n    (alias := payload)\n    exec(alias)\n',
@@ -322,6 +326,10 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a folded unary condition drops the constructor arm': 'def f(name):\n    exec((str if not True else print)(f"import {name}"))\n',
+    'an except target takes a prefixed alias away': 'from builtins import str as text\ndef f(name):\n    try:\n        pass\n    except Exception as text:\n        exec(text(f"import {name}"))\n',
+    'async for cannot iterate a synchronous literal': 'async def f(name):\n    async for payload in [f"import {name}"]:\n        exec(payload)\n',
+    'a constructor assignment clears the earlier sink': 'import builtins\ndef f(name):\n    run = builtins.exec\n    run = builtins.str\n    run(f"import {name}")\n',
     'str of visibly bytes is a repr, not the text': 'def f(name):\n    exec(str(f"import {name}".encode()))\n',
     'a zero repetition builds an empty string': 'def f(name):\n    exec(f"import {name}" * 0)\n',
     'a negative repetition builds an empty string': 'def f(name):\n    exec(f"import {name}" * -1)\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,8 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a sink popped from a written-out list is still the builtin': 'def f(name):\n    [exec].pop()(f"import {name}")\n',
+    'a partial built from a written-out expansion still binds the sink': 'from functools import partial\ndef f(name):\n    partial(*(exec, f"import {name}"))()\n',
     'a helper hands back a choice between the sink and something else': 'import builtins\ndef choose(run, flag):\n    return run if flag else print\ndef f(name):\n    choose(builtins.exec, True)(f"import {name}")\n',
     'a sink on a class is the builtin through an instance too': 'import builtins\nclass Runner:\n    run = builtins.exec\ndef f(name):\n    Runner().run(f"import {name}")\n',
     'a constant f-string names the same builtin': 'import builtins\ndef f(name):\n    getattr(builtins, f"{\'exec\'}")(f"import {name}")\n',
@@ -313,6 +315,11 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a comprehension over a nonempty iterable produces its element': 'def f(name):\n    exec([f"import {name}" for _ in [0]][0])\n',
+    'setdefault stores the default and hands it back': 'def f(name):\n    exec({}.setdefault("x", f"import {name}"))\n',
+    'copy of a string is the same string': 'import copy\ndef f(name):\n    exec(copy.copy(f"import {name}"))\n',
+    'await hands back what the coroutine built': 'async def build(name):\n    return f"import {name}"\nasync def f(name):\n    exec(await build(name))\n',
+    'all reaches past an eval whose value it cannot know': 'def f(name):\n    all(map(eval, ["1", f"{name}"]))\n',
     'a slice that may keep the spliced value still executes it': 'def f():\n    exec(f"{input()}"[:1000])\n',
     'a wrapper executes what its caller built': 'def run(source):\n    exec(source)\ndef f(name):\n    run(f"import {name}")\n',
     'a default cannot be reached past a written-out element': 'def f(name):\n    exec(next(iter([f"import {name}"]), "pass"))\n',
@@ -403,6 +410,9 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'a second context expression runs once the first is entered': 'import contextlib\nasync def f(name, manager):\n    async with contextlib.nullcontext(), manager(exec(f"import {name}")):\n        pass\n',
+    'update writes the element the subscript then reads': 'def f(name):\n    payloads = {}\n    payloads.update(run = f"import {name}")\n    exec(payloads["run"])\n',
+    'an async with that enters still runs its body': 'import contextlib\nasync def f(name):\n    async with contextlib.nullcontext():\n        exec(f"import {name}")\n',
     'pop with nothing named takes the last element': 'def f(name):\n    payloads = [f"import {name}"]\n    exec(payloads.pop())\n',
     'a closure reads an alias bound after the def': 'def f(name):\n    payload = f"import {name}"\n    def inner():\n        exec(alias)\n    alias = payload\n    inner()\n',
     'a helper in one function is not the helper in another': 'def harmless():\n    def build():\n        return "pass"\n    return exec(build())\ndef vulnerable(name):\n    def build():\n        return f"import {name}"\n    exec(build())\n',
@@ -451,6 +461,8 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a cached_property is a descriptor, not a callable': 'from functools import cached_property\n@cached_property\ndef build(name):\n    return f"import {name}"\ndef f(name):\n    exec(build())\n',
+    'a return below an unconditional return never runs': 'def build(name):\n    return "pass"\n    return f"import {name}"\ndef f(name):\n    exec(build(name))\n',
     'exec has no such keyword': 'def f(name):\n    exec(f"import {name}", spam = 1)\n',
     'eval has no such keyword either': 'def f(name):\n    eval(f"1 + {name}", spam = 1)\n',
     'compile has no such keyword either': 'def f(name):\n    compile(f"import {name}", "<x>", "exec", spam = 1)\n',
@@ -503,7 +515,6 @@ _NOTHING_REACHES_THE_SINK = {
     'a format method on a locally defined class is not a builder': 'class Safe:\n    def format(self, value):\n        return "pass"\ndef f(name):\n    exec(Safe().format(name))\n',
     'a written-out expansion says how many arguments it supplies': 'def f(name):\n    compile(*[f"import {name}"])\n',
     'a written-out mapping expansion names the keys it supplies': 'def f(name):\n    compile(**{"source": f"import {name}"})\n',
-    'an async with stops at the context it cannot enter': 'import contextlib\nasync def f(name, manager):\n    async with contextlib.nullcontext(), manager(exec(f"import {name}")):\n        pass\n',
     'a field-free template held by a name ignores its arguments': 'def f(user):\n    template = "pass"\n    exec(template.format(user))\n',
     'a field-free format_map template ignores its mapping': 'def f(name):\n    exec("pass".format_map({"x": name}))\n',
     'compile without a filename and a mode raises first': 'def f(name):\n    compile(f"import {name}")\n',
@@ -940,3 +951,23 @@ def test_composite_actions_are_scanned_where_they_exist():
     assert '".github/actions"' in source, (
         "this repository ships composite actions, so they belong in DEFAULT_TARGETS"
     )
+
+
+_WORKFLOW_CONTINUES_A_LINE = """name: demo
+on: [push]
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          python \\
+            -c 'exec(f"import {name}")'
+"""
+
+
+def test_a_continued_shell_command_is_joined(tmp_path):
+    """A trailing backslash continues the command, so the `-c` is on the next line."""
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_CONTINUES_A_LINE)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,8 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a helper hands back a choice between the sink and something else': 'import builtins\ndef choose(run, flag):\n    return run if flag else print\ndef f(name):\n    choose(builtins.exec, True)(f"import {name}")\n',
+    'a sink on a class is the builtin through an instance too': 'import builtins\nclass Runner:\n    run = builtins.exec\ndef f(name):\n    Runner().run(f"import {name}")\n',
     'a constant f-string names the same builtin': 'import builtins\ndef f(name):\n    getattr(builtins, f"{\'exec\'}")(f"import {name}")\n',
     'a sink selected from a written-out iterator is still the builtin': 'def f(name):\n    next(iter([exec]))(f"import {name}")\n',
     'a helper hands back the sink it was given': 'import builtins\ndef choose(run):\n    return run\ndef f(name):\n    choose(builtins.exec)(f"import {name}")\n',
@@ -311,6 +313,8 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a slice that may keep the spliced value still executes it': 'def f():\n    exec(f"{input()}"[:1000])\n',
+    'a wrapper executes what its caller built': 'def run(source):\n    exec(source)\ndef f(name):\n    run(f"import {name}")\n',
     'a default cannot be reached past a written-out element': 'def f(name):\n    exec(next(iter([f"import {name}"]), "pass"))\n',
     'a nested container element is still addressable': 'def f(name):\n    payloads = {"run": [f"import {name}"]}\n    exec(payloads["run"][0])\n',
     'a slice that cuts only the literal tail keeps the value': 'def f(name):\n    exec(f"import {name}#"[:-1])\n',
@@ -399,6 +403,9 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'pop with nothing named takes the last element': 'def f(name):\n    payloads = [f"import {name}"]\n    exec(payloads.pop())\n',
+    'a closure reads an alias bound after the def': 'def f(name):\n    payload = f"import {name}"\n    def inner():\n        exec(alias)\n    alias = payload\n    inner()\n',
+    'a helper in one function is not the helper in another': 'def harmless():\n    def build():\n        return "pass"\n    return exec(build())\ndef vulnerable(name):\n    def build():\n        return f"import {name}"\n    exec(build())\n',
     'a helper local carries the string to the return': 'def build(name):\n    source = f"import {name}"\n    return source\ndef f(name):\n    exec(build(name))\n',
     'get reads the same element the subscript reads': 'def f(name):\n    payloads = {"x": f"import {name}"}\n    exec(payloads.get("x"))\n',
     'pop reads it too': 'def f(name):\n    payloads = {"x": f"import {name}"}\n    exec(payloads.pop("x"))\n',
@@ -444,6 +451,9 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'exec has no such keyword': 'def f(name):\n    exec(f"import {name}", spam = 1)\n',
+    'eval has no such keyword either': 'def f(name):\n    eval(f"1 + {name}", spam = 1)\n',
+    'compile has no such keyword either': 'def f(name):\n    compile(f"import {name}", "<x>", "exec", spam = 1)\n',
     'a tuple has no pop to select with': 'def f(name):\n    exec((f"import {name}",).pop())\n',
     'exec given more arguments than it takes raises first': 'def f(name):\n    exec(f"import {name}", {}, {}, 1)\n',
     'compile given a seventh argument raises first': 'def f(name):\n    compile(f"import {name}", "<x>", "exec", 0, False, -1, 1)\n',
@@ -831,3 +841,102 @@ def test_a_shell_script_under_a_directory_target_is_collected(tmp_path):
     (tmp_path / "nested" / "setup.sh").write_text(_SHELL_RUNS_PYTHON)
     proc = _run("--paths", str(tmp_path))
     assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+_WORKFLOW_MULTILINE_COMMAND = """name: demo
+on: [push]
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          python -c "
+          name = 'x'
+          exec(f'import {name}')
+          "
+"""
+
+_WORKFLOW_PIPES_A_HEREDOC = """name: demo
+on: [push]
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          cat <<'PY' | python
+          name = 'x'
+          exec(f'import {name}')
+          PY
+"""
+
+_WORKFLOW_TWO_PROGRAMS = """name: demo
+on: [push]
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          python - <<'PY'
+          exec = print
+          PY
+      - run: |
+          python - <<'PY'
+          exec(f"import {input()}")
+          PY
+"""
+
+_WORKFLOW_SPLICES_AN_EXPRESSION = """name: demo
+on: [push]
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          python - <<'PY'
+          exec("${{ github.event.pull_request.title }}")
+          PY
+"""
+
+
+def test_a_multiline_python_command_is_parsed(tmp_path):
+    """`python -c "` with the program on the lines below is an active workflow shape."""
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_MULTILINE_COMMAND)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_a_heredoc_piped_into_python_is_scanned(tmp_path):
+    """`cat <<'PY' | python` runs the block; the interpreter is past the pipe."""
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_PIPES_A_HEREDOC)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_each_workflow_program_starts_with_its_own_builtins(tmp_path):
+    """Two heredocs are two processes, so a name bound in one is gone in the next."""
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_TWO_PROGRAMS)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_an_actions_expression_is_interpolated_source(tmp_path):
+    """The runner splices it into the program text before Python sees it."""
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_SPLICES_AN_EXPRESSION)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+    assert "Actions expression" in proc.stderr, proc.stderr
+
+
+def test_composite_actions_are_scanned_where_they_exist():
+    """`.github/actions` holds `run:` blocks the runner executes, like a workflow."""
+    source = SCRIPT.read_text(encoding = "utf-8")
+    repo = SCRIPT.parent.parent
+    if not (repo / ".github" / "actions").is_dir():
+        return
+    assert '".github/actions"' in source, (
+        "this repository ships composite actions, so they belong in DEFAULT_TARGETS"
+    )

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -237,6 +237,7 @@ def test_a_sink_reached_through_another_spelling_is_reported(description, tmp_pa
 
 # `str`, `bytes` and friends reached indirectly still pass the source through.
 _CONSTRUCTOR_IS_STILL_RESOLVED = {
+    'the decoding form of str hands the text back': 'def f(name):\n    exec(str(f"import {name}".encode(), "utf-8"))\n',
     'an undecidable constructor choice checks both arms': 'def f(name, flag):\n    exec((memoryview if flag else str)(f"import {name}"))\n',
     'a builtins star import hands back the conversions too': "def f(name):\n    str = print\n    from builtins import *\n    exec(str(f'import {name}'))\n",
     'a byte constructor over already encoded source reaches the sink': 'def f(name):\n    exec(bytes(f"import {name}".encode()))\n    exec(bytearray(f"import {name}".encode()))\n    exec(memoryview(f"import {name}".encode()))\n',
@@ -269,6 +270,7 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'an ordinary async context manager still runs its body': 'async def f(name, manager):\n    async with manager as payload:\n        exec(f"import {name}")\n',
     'format_map with an empty mapping returns the receiver': 'def f(name):\n    exec(f"import {name}".format_map({}))\n',
     'an opaque expansion leaves compile its source keyword': 'def f(name, args = ()):\n    exec(compile(*args, source = f"import {name}", filename = "<x>", mode = "exec"))\n',
     'nullcontext hands its argument to the as target': 'import contextlib\ndef f(name):\n    with contextlib.nullcontext(f"import {name}") as payload:\n        exec(payload)\n',
@@ -347,6 +349,7 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'async with cannot enter a synchronous nullcontext': 'import builtins, contextlib\nasync def f(name):\n    async with contextlib.nullcontext(builtins.exec) as run:\n        run(f"import {name}")\n',
     'False is a zero repetition count': 'def f(name):\n    exec(f"import {name}" * False)\n',
     'two written-out containers add to a list, not to source': 'def f(name):\n    exec([f"import {name}"] + [])\n',
     'an async loop over a synchronous literal never reaches its else': 'async def f(name):\n    async for _ in []:\n        pass\n    else:\n        exec(f"import {name}")\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -1071,3 +1071,116 @@ def test_a_shell_magic_cell_still_launches_python(tmp_path):
     }))
     proc = _run("--paths", str(sample))
     assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def _loaded():
+    """The checker imported by path, so its internals can be called directly."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("lint_dynamic_exec_memo", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_MEMO_SAMPLE = '''
+import os
+
+
+def outer(name):
+    payload = f"import {name}"
+
+    def deferred(argument = os.getenv("X")):
+        exec(payload)
+
+    class Inner:
+        attribute = payload
+
+    for item in [1, 2]:
+        with open(item) as handle:
+            try:
+                del payload
+            except OSError as error:
+                global missing
+    return deferred
+'''
+
+
+def test_the_scope_walk_memo_answers_what_an_uncached_walk_answers():
+    """The memo is an optimisation, so it must be invisible in the result.
+
+    An uncached reference walk is written out here rather than reusing the checker's,
+    so a change to the real one cannot silently redefine what "correct" means.
+    """
+    import ast
+
+    module = _loaded()
+    tree = ast.parse(_MEMO_SAMPLE)
+
+    def reference(node):
+        walked, pending = [], [node]
+        while pending:
+            current = pending.pop()
+            walked.append(current)
+            for child in ast.iter_child_nodes(current):
+                if isinstance(
+                    child, (ast.Lambda, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                ):
+                    pending.extend(module._definition_time_expressions(child))
+                    continue
+                pending.append(child)
+        return walked
+
+    for node in ast.walk(tree):
+        expected = reference(node)
+        first = list(module._walk_this_scope(node))
+        second = list(module._walk_this_scope(node))
+        assert [id(n) for n in first] == [id(n) for n in expected], ast.dump(node)[:80]
+        assert [id(n) for n in second] == [id(n) for n in expected], "second call differs"
+
+
+def test_the_memo_does_not_carry_between_two_trees_of_the_same_source():
+    """Two parses are two trees. A memo keyed on identity must not answer for both."""
+    import ast
+
+    module = _loaded()
+    one, two = ast.parse(_MEMO_SAMPLE), ast.parse(_MEMO_SAMPLE)
+    walked_one = list(module._walk_this_scope(one))
+    walked_two = list(module._walk_this_scope(two))
+    assert len(walked_one) == len(walked_two)
+    assert not {id(n) for n in walked_one} & {id(n) for n in walked_two}, (
+        "the second tree was answered with nodes from the first"
+    )
+
+
+def test_the_declared_locals_memo_survives_a_caller_mutating_the_answer():
+    """It hands back a set; a caller is free to mutate it without poisoning the memo."""
+    import ast
+
+    module = _loaded()
+    tree = ast.parse(_MEMO_SAMPLE)
+    function = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "outer"
+    )
+    first = module._Visitor._declared_locals(function)
+    assert first, "the sample binds names, so this would be vacuous"
+    baseline = set(first)
+    first.add("injected-by-the-caller")
+    first.discard(next(iter(baseline)))
+    assert module._Visitor._declared_locals(function) == baseline
+
+
+def test_the_memo_is_not_visible_to_anything_that_reads_the_tree_as_data():
+    """The finding key is a digest of `ast.unparse`, so a stray field would rekey it."""
+    import ast
+
+    module = _loaded()
+    tree = ast.parse(_MEMO_SAMPLE)
+    before = ast.unparse(tree)
+    for node in ast.walk(tree):
+        list(module._walk_this_scope(node))
+    assert ast.unparse(tree) == before
+    assert all(
+        module._SCOPE_WALK_CACHE not in node._fields for node in ast.walk(tree)
+    ), "the memo must not appear as an AST field"

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,12 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'map with a second iterable still calls the sink': 'def f(name):\n    list(map(exec, [f"import {name}"], [{}]))\n',
+    'a for loop over a map consumes it': 'def f(name):\n    for _ in map(exec, [f"import {name}"]):\n        pass\n',
+    'a starred display of a map consumes it': 'def f(name):\n    [*map(exec, [f"import {name}"])]\n',
+    'a template held by a name still substitutes': 'import string\ndef f(name):\n    template = string.Template("import $name")\n    exec(template.substitute(name = name))\n',
+    'a decidable comparison leaves the live binding alone': 'def f(name):\n    payload = f"import {name}"\n    if 1 == 2:\n        payload = "pass"\n    exec(payload)\n',
+    'a local class that subclasses str inherits the builder': 'class Template(str):\n    pass\ndef f(name):\n    exec(Template("import {}").format(name))\n',
     'a directly imported operator builder still concatenates': 'from operator import add as join\ndef f(name):\n    exec(join("import ", name))\n',
     'an undecidable comprehension filter binds no walrus': 'import builtins\ndef f(name, flag):\n    run = builtins.exec\n    [(run := print) for _ in [0] if flag]\n    run(f"import {name}")\n',
     'a string.Template substitution splices like format': 'import string\ndef f(name):\n    exec(string.Template("import $module").substitute(module = name))\n',
@@ -374,6 +380,12 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a local map is not the builtin': 'def f(map, name):\n    list(map(exec, [f"import {name}"]))\n',
+    'map takes no keyword arguments': 'def f(name):\n    list(map(exec, [f"import {name}"], nope = True))\n',
+    'a partial consumer never reaches the later element': 'def f(name):\n    next(map(exec, ["pass", f"import {name}"]))\n',
+    'a walrus binds before the next boolean operand is read': 'def f(name):\n    payload = f"import {name}"\n    exec((payload := "pass") and payload)\n',
+    'rebinding the root clears the path recorded against it': 'import types\ndef f(obj, name):\n    obj.payload = f"import {name}"\n    obj = types.SimpleNamespace(payload = "pass")\n    exec(obj.payload)\n',
+    'a template with no placeholder ignores its arguments': 'import string\ndef f(name):\n    exec(string.Template("pass").substitute(x = name))\n',
     'a nested function that rebinds the name sees its own': 'def f(name):\n    payload = f"import {name}"\n    def inner():\n        payload = "pass"\n        exec(payload)\n    inner()\n',
     'a filter over an empty iterable never runs': 'def f(name):\n    [None for _ in [] if exec(f"import {name}")]\n',
     'an async comprehension over a synchronous literal raises first': 'async def f(name):\n    return [exec(payload) async for payload in [f"import {name}"]]\n',
@@ -460,6 +472,7 @@ def test_code_that_cannot_execute_a_built_string_is_quiet(description, tmp_path)
 
 # A magic or interpreter invocation that really does execute the cell body.
 _NOTEBOOK_RUNS_PYTHON = {
+    'an interactive command still reads the cell body': '{"cells": [{"cell_type": "code", "metadata": {}, "source": ["%%script python -i -c \\"pass\\"\\n", "exec(f\\"import {name}\\")\\n"], "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'a shell escape running python -c carries a program': '{"cells": [{"cell_type": "code", "source": "!python -c \'name=input(); exec(f\\"import {name}\\")\'\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'a bundled short option carries its attached program': '{"cells": [{"cell_type": "code", "source": "%%script python -uc\'name=\\"x\\";exec(f\\"import {name}\\")\'\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'an assignment-form %time binds the value it timed': '{"cells": [{"cell_type": "code", "source": "name = input()\\npayload = %time f\\"import {name}\\"\\nexec(payload)\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,8 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'an imported alias of functools.partial binds the sink': 'from functools import partial as bind\ndef f(name):\n    bind(exec, f"import {name}")()\n',
+    'an inline builtins import is a getattr owner': 'def f(name):\n    getattr(__import__("builtins"), "exec")(f"import {name}")\n',
     'a builtins-qualified getattr names the sink': 'import builtins\ndef f(name):\n    builtins.getattr(builtins, "exec")(f"import {name}")\n',
     'a computed key keeps the get default reachable as a callee': 'def f(name, key):\n    {key: print}.get("run", exec)(f"import {name}")\n',
     'a later module-level def does not apply to earlier calls': 'name = "ok"\nexec(f"import {name}")\ndef exec(source):\n    pass\n',
@@ -253,6 +255,9 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'codeop compiles the source it was handed': 'import codeop\ndef f(name):\n    exec(codeop.compile_command(f"import {name}"))\n',
+    'operator.add is concatenation under another name': 'import operator\ndef f(name):\n    exec(operator.add("import ", name))\n',
+    'operator.concat is the same concatenation': 'import operator\ndef f(name):\n    exec(operator.concat("import ", name))\n',
     '__add__ is concatenation written as a call': 'def f(name):\n    exec("print(".__add__(name).__add__(")"))\n',
     '__mod__ is the percent operator written as a call': 'def f(name):\n    exec("print(%r)".__mod__(name))\n',
     '__str__ hands back the same string': 'def f(name):\n    exec(f"import {name}".__str__())\n',
@@ -310,6 +315,8 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a rebound partial alias is no longer partial': 'from functools import partial as bind\ndef f(name):\n    bind = print\n    bind(exec, f"import {name}")()\n',
+    'operator.add on numbers builds no source': 'import operator\ndef f():\n    exec(operator.add(1, 2))\n',
     'a composite default resolving to a shadowed name is not the builtin': 'from re import compile\ndef f(name, run = [compile][0]):\n    run(f"^{name}$")\n',
     'a constant short-circuits a boolean callee': "def f(name):\n    (None and exec)(f'import {name}')\n",
     'a literal condition decides a conditional expression': "def f(name):\n    exec('pass' if True else f'import {name}')\n",

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,7 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'an and hands back its last operand': 'def f(name):\n    (compile and exec)(f"import {name}")\n',
     'a sink above the return still runs': 'def f(name):\n    exec(f"import {name}")\n    return\n',
     'next runs the callback on the first mapped element': 'def f(name):\n    next(map(exec, [f"import {name}"]))\n',
     'a lambda hands the sink itself back': 'def f(name):\n    (lambda run: run)(exec)(f"import {name}")\n',
@@ -301,6 +302,7 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a base this file cannot resolve may still be textual': 'class Namespace:\n    class Base(str):\n        pass\nclass Safe(Namespace.Base):\n    pass\ndef f(name):\n    exec(Safe("import {}").format(name))\n',
     'a visible local helper hands back what it built': 'def build(name):\n    return f"import {name}"\ndef f(name):\n    exec(build(name))\n',
     'a class attribute outlives the class body': 'class C:\n    payload = None\ndef f(name):\n    C.payload = f"import {name}"\n    exec(C.payload)\n',
     'a bound replace keeps its template': 'def f(name):\n    replace = "import MODULE".replace\n    exec(replace("MODULE", name))\n',
@@ -382,6 +384,7 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'an augmented write below the def is read by the closure': 'def f(name):\n    payload = "pass\\n"\n    def inner():\n        exec(payload)\n    payload += f"import {name}"\n    inner()\n',
     'enumerate over a written-out list still pairs its elements': 'def f(name):\n    for _, payload in enumerate([f"import {name}"]):\n        exec(payload)\n',
     'an iter around a written-out list still yields its elements': 'def f(name):\n    for payload in iter([f"import {name}"]):\n        exec(payload)\n',
     'a global declaration leaves the name in the enclosing scope': 'payload = f"import {name}"\ndef f():\n    global payload\n    exec(payload)\n    payload = "pass"\nf()\n',
@@ -423,6 +426,9 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a normaliser given a keyword it does not take raises first': 'def f(name):\n    exec(f"import {name}".upper(foo = 1))\n',
+    'replace takes its arguments positionally only': 'def f(name):\n    exec("X".replace(old = "X", new = name))\n',
+    'a visibly invalid compile mode stops the map there': 'def f(name):\n    list(map(compile, ["pass", f"import {name}"], ["<x>", "<x>"], ["bad", "exec"]))\n',
     'join takes one iterable and raises on two': 'def f(name):\n    exec(",".join([f"import {name}"], []))\n',
     'format_map takes one mapping and raises on two': 'def f(name):\n    exec("import {name}".format_map({"name": name}, {}))\n',
     'a function body ends at an unconditional return': 'def f(name):\n    return\n    exec(f"import {name}")\n',
@@ -542,6 +548,7 @@ def test_code_that_cannot_execute_a_built_string_is_quiet(description, tmp_path)
 
 # A magic or interpreter invocation that really does execute the cell body.
 _NOTEBOOK_RUNS_PYTHON = {
+    'an attached warning option is not a bundled -c': '{"cells": [{"cell_type": "code", "metadata": {}, "outputs": [], "execution_count": null, "source": "%%script python -Wignore::DeprecationWarning -c \\"name=input(); exec(f\'import {name}\')\\"\\n"}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'an unrecognised automagic does not hide the rest of the cell': '{"cells": [{"cell_type": "code", "metadata": {}, "source": "pip install requests\\nname = input()\\nexec(f\\"import {name}\\")\\n", "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'an interactive command still reads the cell body': '{"cells": [{"cell_type": "code", "metadata": {}, "source": ["%%script python -i -c \\"pass\\"\\n", "exec(f\\"import {name}\\")\\n"], "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'a shell escape running python -c carries a program': '{"cells": [{"cell_type": "code", "source": "!python -c \'name=input(); exec(f\\"import {name}\\")\'\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,7 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a helper resolves the module it was handed': 'import builtins\ndef choose(module):\n    return module.exec\ndef f(name):\n    choose(builtins)(f"import {name}")\n',
     'a sink popped from a written-out list is still the builtin': 'def f(name):\n    [exec].pop()(f"import {name}")\n',
     'a partial built from a written-out expansion still binds the sink': 'from functools import partial\ndef f(name):\n    partial(*(exec, f"import {name}"))()\n',
     'a helper hands back a choice between the sink and something else': 'import builtins\ndef choose(run, flag):\n    return run if flag else print\ndef f(name):\n    choose(builtins.exec, True)(f"import {name}")\n',
@@ -315,6 +316,8 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'one element is what min has to choose': 'def f(name):\n    exec(min([f"import {name}"]))\n',
+    'unparse hands back what parse was given': 'import ast\ndef f(name):\n    exec(ast.unparse(ast.parse(f"import {name}")))\n',
     'a comprehension over a nonempty iterable produces its element': 'def f(name):\n    exec([f"import {name}" for _ in [0]][0])\n',
     'setdefault stores the default and hands it back': 'def f(name):\n    exec({}.setdefault("x", f"import {name}"))\n',
     'copy of a string is the same string': 'import copy\ndef f(name):\n    exec(copy.copy(f"import {name}"))\n',
@@ -461,6 +464,9 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a list has no format method': 'def f(name):\n    exec([].format(name))\n',
+    'a list has no join method either': 'def f(name):\n    exec([].join([f"{name}"]))\n',
+    'a wrapper that returns first never reaches its sink': 'def run(source):\n    return\n    exec(source)\ndef f(name):\n    run(f"import {name}")\n',
     'a cached_property is a descriptor, not a callable': 'from functools import cached_property\n@cached_property\ndef build(name):\n    return f"import {name}"\ndef f(name):\n    exec(build())\n',
     'a return below an unconditional return never runs': 'def build(name):\n    return "pass"\n    return f"import {name}"\ndef f(name):\n    exec(build(name))\n',
     'exec has no such keyword': 'def f(name):\n    exec(f"import {name}", spam = 1)\n',
@@ -969,5 +975,99 @@ def test_a_continued_shell_command_is_joined(tmp_path):
     """A trailing backslash continues the command, so the `-c` is on the next line."""
     sample = tmp_path / "demo.yml"
     sample.write_text(_WORKFLOW_CONTINUES_A_LINE)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+_WORKFLOW_ASSIGNS_FIRST = """name: demo
+on: [push]
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - run: FOO=bar python -c 'name = input(); exec(f"import {name}")'
+"""
+
+_WORKFLOW_FOLDS_ITS_COMMAND = """name: demo
+on: [push]
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - run: >
+          python
+          -c 'name = input(); exec(f"import {name}")'
+"""
+
+_WORKFLOW_DEFERS_INSIDE_A_HEREDOC = """name: demo
+on: [push]
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          python - <<'PY'
+          def inner():
+              exec(payload)
+          payload = f"import {input()}"
+          inner()
+          PY
+"""
+
+
+def test_an_assignment_prefix_does_not_hide_the_interpreter(tmp_path):
+    """`FOO=bar python -c ...` runs Python with a variable set for that command."""
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_ASSIGNS_FIRST)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_a_folded_scalar_is_one_command(tmp_path):
+    """`run: >` folds its lines, so the interpreter and the `-c` are one command."""
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_FOLDS_ITS_COMMAND)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_a_heredoc_gets_the_deferred_taint_prepass(tmp_path):
+    """A closure in a heredoc reads its cell when it is CALLED, as in a module."""
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_DEFERS_INSIDE_A_HEREDOC)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_a_powershell_launcher_program_is_scanned(tmp_path):
+    """The shipped installers bind the program to a variable and hand it to `-c`."""
+    sample = tmp_path / "install.ps1"
+    sample.write_text(
+        '$script:Trampoline = "import sys; exec(f\'import {sys.argv[1]}\')"\n'
+        '$pythonArgs = @("-X", "utf8", "-c", $script:Trampoline)\n'
+        "& $Python @pythonArgs\n"
+    )
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_a_shell_magic_cell_still_launches_python(tmp_path):
+    """`%%bash` is another language, and it runs Python the same way a step does."""
+    sample = tmp_path / "demo.ipynb"
+    sample.write_text(json.dumps({
+        "cells": [{
+            "cell_type": "code",
+            "metadata": {},
+            "execution_count": None,
+            "outputs": [],
+            "source": [
+                "%%bash\n",
+                "python -c 'name = input(); exec(f\"import {name}\")'\n",
+            ],
+        }],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }))
     proc = _run("--paths", str(sample))
     assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,9 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a dict constructor literal answers get on the callee side': 'def f(name):\n    dict(run = exec).get("run")(f"import {name}")\n',
+    'functools under a module alias still binds the sink': 'import functools as ft\ndef f(name):\n    ft.partial(exec, f"import {name}")()\n',
+    'nullcontext hands its argument to the with target': 'import contextlib, builtins\ndef f(name):\n    with contextlib.nullcontext(builtins.exec) as run:\n        run(f"import {name}")\n',
     'an imported alias of functools.partial binds the sink': 'from functools import partial as bind\ndef f(name):\n    bind(exec, f"import {name}")()\n',
     'an inline builtins import is a getattr owner': 'def f(name):\n    getattr(__import__("builtins"), "exec")(f"import {name}")\n',
     'a builtins-qualified getattr names the sink': 'import builtins\ndef f(name):\n    builtins.getattr(builtins, "exec")(f"import {name}")\n',
@@ -255,6 +258,7 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a literal template reached through a name is still a template': 'def f(name):\n    template = "import MODULE"\n    exec(template.replace("MODULE", name))\n',
     'codeop compiles the source it was handed': 'import codeop\ndef f(name):\n    exec(codeop.compile_command(f"import {name}"))\n',
     'operator.add is concatenation under another name': 'import operator\ndef f(name):\n    exec(operator.add("import ", name))\n',
     'operator.concat is the same concatenation': 'import operator\ndef f(name):\n    exec(operator.concat("import ", name))\n',
@@ -298,6 +302,8 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'a short-circuited walrus never clears the taint': 'def f(name):\n    payload = f"import {name}"\n    False and (payload := "pass")\n    exec(payload)\n',
+    'the final loop body wins over the last element': 'def f(name):\n    for payload in ["pass"]:\n        payload = f"import {name}"\n    exec(payload)\n',
     'a walrus alias carries the taint': 'def f(name):\n    payload = f"import {name}"\n    (alias := payload)\n    exec(alias)\n',
     'an annotated alias carries the taint': 'def f(name):\n    payload = f"import {name}"\n    alias: str = payload\n    exec(alias)\n',
     'an unpacked alias carries the taint': 'def f(name):\n    payload = f"import {name}"\n    alias, ignored = payload, None\n    exec(alias)\n',
@@ -315,6 +321,9 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a partial method on some other object is not functools': 'class R:\n    def partial(self, *a):\n        return lambda: None\ndef f(name, runner):\n    runner.partial(exec, f"import {name}")()\n',
+    'the last element wins when the body does not rebind': 'def f(name):\n    for payload in [f"import {name}"]:\n        payload = "pass"\n    exec(payload)\n',
+    'an opaque receiver is not a literal template': 'import inspect\ndef f(name, target):\n    exec(inspect.getsource(target).replace("MODULE", name))\n',
     'a rebound partial alias is no longer partial': 'from functools import partial as bind\ndef f(name):\n    bind = print\n    bind(exec, f"import {name}")()\n',
     'operator.add on numbers builds no source': 'import operator\ndef f():\n    exec(operator.add(1, 2))\n',
     'a composite default resolving to a shadowed name is not the builtin': 'from re import compile\ndef f(name, run = [compile][0]):\n    run(f"^{name}$")\n',
@@ -360,6 +369,7 @@ def test_code_that_cannot_execute_a_built_string_is_quiet(description, tmp_path)
 
 # A magic or interpreter invocation that really does execute the cell body.
 _NOTEBOOK_RUNS_PYTHON = {
+    'a bundled short option carries its attached program': '{"cells": [{"cell_type": "code", "source": "%%script python -uc\'name=\\"x\\";exec(f\\"import {name}\\")\'\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'an assignment-form %time binds the value it timed': '{"cells": [{"cell_type": "code", "source": "name = input()\\npayload = %time f\\"import {name}\\"\\nexec(payload)\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'env -S carries the interpreter command inside its value': '{"cells": [{"cell_type": "code", "source": "%%script env -S \\"python -c \'name=input(); exec(f\\\\\\"import {name}\\\\\\")\'\\"\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'prefix help syntax does not hide the rest of the cell': '{"cells": [{"cell_type": "code", "source": "?len\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,12 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a field between escaped braces is still a field': 'def f(name):\n    exec("{{{x}}}".format(x = name))\n',
+    'a directly imported ast.parse still preserves its source': 'from ast import parse\ndef f(name):\n    compile(parse(f"import {name}"), "<x>", "exec")\n',
+    'getattr reads the implicit builtins module too': 'def f(name):\n    getattr(__builtins__, "exec")(f"import {name}")\n',
+    'an aliased importlib still names the builtins module': 'import importlib as il\ndef f(name):\n    il.import_module("builtins").exec(f"import {name}")\n',
+    'an aliased contextlib still hands its argument over': 'import builtins\nimport contextlib as ctx\ndef f(name):\n    with ctx.nullcontext(builtins.exec) as run:\n        run(f"import {name}")\n',
+    'a literal sequence subject hands a sink to its capture': 'import builtins\ndef f(name):\n    match [builtins.exec]:\n        case [run]:\n            run(f"import {name}")\n',
     'an aliased textwrap wrapper still hands the source through': 'from textwrap import dedent as clean\ndef f(name):\n    exec(clean(f"import {name}"))\n',
     'operator.mod is percent formatting written as a call': 'import operator\ndef f(name):\n    exec(operator.mod("import %s", name))\n',
     'the in-place operator spellings concatenate too': 'import operator\ndef f(name):\n    exec(operator.iadd("import ", name))\n',
@@ -270,6 +276,7 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'an identity translation table changes nothing': 'def f(name):\n    exec(f"import {name}".translate({0: 0}))\n',
     'an ordinary async context manager still runs its body': 'async def f(name, manager):\n    async with manager as payload:\n        exec(f"import {name}")\n',
     'format_map with an empty mapping returns the receiver': 'def f(name):\n    exec(f"import {name}".format_map({}))\n',
     'an opaque expansion leaves compile its source keyword': 'def f(name, args = ()):\n    exec(compile(*args, source = f"import {name}", filename = "<x>", mode = "exec"))\n',
@@ -319,6 +326,9 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'an unpacking binds each element before the next target runs': 'def f(name, table):\n    payload, table[exec(payload)] = (f"import {name}", None)\n',
+    'an augmented subscript evaluates its target first': 'def f(name, table):\n    payload = f"import {name}"\n    table[exec(payload)] += (payload := "pass")\n',
+    'a dict evaluates each key beside its own value': 'def f(name):\n    {0: (payload := f"import {name}"), exec(payload): None}\n',
     'a while suite ends at an unconditional break': 'def f(name):\n    payload = f"import {name}"\n    while True:\n        break\n        payload = "pass"\n    exec(payload)\n',
     'a jump under a decidable test ends the suite as well': 'def f(name):\n    payload = f"import {name}"\n    for _ in [0]:\n        if True:\n            continue\n        payload = "pass"\n    exec(payload)\n',
     'a statically false case guard runs no body': 'def f(name, value):\n    payload = f"import {name}"\n    match value:\n        case _ if False:\n            payload = "pass"\n    exec(payload)\n',
@@ -349,6 +359,11 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a field-free format_map template ignores its mapping': 'def f(name):\n    exec("pass".format_map({"x": name}))\n',
+    'compile without a filename and a mode raises first': 'def f(name):\n    compile(f"import {name}")\n',
+    'a bare partial is only functools.partial when imported': 'def partial(callback, source):\n    return lambda: None\ndef f(name):\n    partial(exec, f"import {name}")()\n',
+    'a dedent on something other than textwrap is not the helper': 'def f(cleaner, name):\n    exec(cleaner.dedent(f"import {name}"))\n',
+    'a class-body lambda parameter shadows the builtin': 'class C:\n    f = lambda exec, name: exec(f"import {name}")\n',
     'async with cannot enter a synchronous nullcontext': 'import builtins, contextlib\nasync def f(name):\n    async with contextlib.nullcontext(builtins.exec) as run:\n        run(f"import {name}")\n',
     'False is a zero repetition count': 'def f(name):\n    exec(f"import {name}" * False)\n',
     'two written-out containers add to a list, not to source': 'def f(name):\n    exec([f"import {name}"] + [])\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,11 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a sink stored on an attribute is still the builtin': 'import builtins, types\ndef f(name):\n    obj = types.SimpleNamespace()\n    obj.run = builtins.exec\n    obj.run(f"import {name}")\n',
+    'a sink stored under a literal key is still the builtin': 'import builtins\ndef f(name):\n    table = {}\n    table["run"] = builtins.exec\n    table["run"](f"import {name}")\n',
+    'vars of the builtins module is the same namespace mapping': 'import builtins\ndef f(name):\n    vars(builtins)["exec"](f"import {name}")\n',
+    'filter calls its callback with each element too': 'def f(name):\n    list(filter(exec, [f"import {name}"]))\n',
+    'an unpacking target consumes the map that fills it': 'def f(name):\n    [result] = map(exec, [f"import {name}"])\n',
     'map with a second iterable still calls the sink': 'def f(name):\n    list(map(exec, [f"import {name}"], [{}]))\n',
     'a for loop over a map consumes it': 'def f(name):\n    for _ in map(exec, [f"import {name}"]):\n        pass\n',
     'a starred display of a map consumes it': 'def f(name):\n    [*map(exec, [f"import {name}"])]\n',
@@ -291,6 +296,18 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'an f-string removed from an equal f-string is two evaluations': 'def f(name):\n    exec(f"import {name}".removeprefix(f"import {name}"))\n',
+    'a string Formatter vformat is the format method spelled apart': 'import string\ndef f(name):\n    payload = f"import {name}"\n    exec(string.Formatter().vformat("{}", (payload,), {}))\n',
+    'an unbound string add takes its receiver as an argument': 'def f(name):\n    payload = f"import {name}"\n    exec(str.__add__("", payload))\n',
+    'an unbound string modulo splices the same way': 'def f(name):\n    exec(str.__mod__("%s", name))\n',
+    'a literal mapping pop selects the value a get would': 'def f(name):\n    exec({"source": f"import {name}"}.pop("source"))\n',
+    'next over a written-out iterator selects the first element': 'def f(name):\n    exec(next(iter([f"import {name}"])))\n',
+    'two classes under one name earn no exemption': 'class Template(str):\n    pass\ndef unused():\n    class Template:\n        def format(self, value):\n            return "pass"\ndef f(name):\n    exec(Template("import {}").format(name))\n',
+    'a written-out expansion pairs with the lambda parameters': 'def f(name):\n    exec((lambda source: source)(*[f"import {name}"]))\n',
+    'a written-out mapping names the lambda parameter it fills': 'def f(name):\n    exec((lambda source: source)(**{"source": f"import {name}"}))\n',
+    'a formatted value is not stable across two evaluations': 'def f(value):\n    exec(f"{value}".removeprefix(f"{value}"))\n',
+    'a parsed tree is still source for compile': 'import ast\ndef f(name):\n    compile(ast.parse(f"import {name}"), "<x>", "exec")\n',
+    'an unbound replace still splices into its template': 'def f(name):\n    exec(str.replace("import MODULE", "MODULE", name))\n',
     'a class name rebound elsewhere is no longer that class': 'class Safe:\n    def format(self, value):\n        return "pass"\nSafe = lambda: "import {}"\ndef f(name):\n    exec(Safe().format(name))\n',
     'a set expanded into compile can yield any element first': 'def f(name):\n    compile(*{"exec", "<x>", f"import {name}"})\n',
     'an invoked lambda hands its argument to its body': 'def f(name):\n    exec((lambda source: source)(f"import {name}"))\n',
@@ -389,6 +406,14 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'textwrap indent without its prefix raises first': 'import textwrap\ndef f(name):\n    exec(textwrap.indent(f"import {name}"))\n',
+    'a search text absent from the literal replaces nothing': 'def f(name):\n    exec("pass".replace("MISSING", name))\n',
+    'an unbound replace with an absent search text changes nothing': 'def f(name):\n    exec(str.replace("pass", "MISSING", name))\n',
+    'a parsed tree is not source for exec': 'import ast\ndef f(name):\n    exec(ast.parse(f"import {name}"))\n',
+    'a compile callback needs three iterables': 'def f(name):\n    list(map(compile, [f"import {name}"]))\n',
+    'sum raises on the first mapped result': 'def f(name):\n    sum(map(exec, ["pass", f"import {name}"]))\n',
+    'dict raises on the first mapped result': 'def f(name):\n    dict(map(exec, ["pass", f"import {name}"]))\n',
+    'a local consumer is not the builtin one': 'def f(list, name):\n    list(map(exec, [f"import {name}"]))\n',
     'a replace between two literals splices nothing': 'def f():\n    exec("pass".replace("x", "y"))\n',
     'a replace with a zero count performs no replacement': 'def f(name):\n    exec("pass".replace("x", name, 0))\n',
     'a leading literal separator leaves the first piece empty': 'def f(name):\n    exec(f"PREFIX{name}".partition("PREFIX")[0])\n',
@@ -419,7 +444,7 @@ _NOTHING_REACHES_THE_SINK = {
     'an async loop over a synchronous literal never reaches its else': 'async def f(name):\n    async for _ in []:\n        pass\n    else:\n        exec(f"import {name}")\n',
     'a deleted nonlocal cell is empty, not the builtin': 'def outer(name):\n    exec = print\n    def inner():\n        nonlocal exec\n        del exec\n        exec(f"import {name}")\n    return inner\n',
     'a zero precision format spec keeps nothing': 'def f(name):\n    exec(format(f"import {name}", ".0"))\n',
-    'removing the receiver as its own prefix leaves nothing': 'def f(name):\n    exec(f"import {name}".removeprefix(f"import {name}"))\n',
+    'removing a name as its own prefix leaves nothing': 'def f(name):\n    payload = f"import {name}"\n    exec(payload.removeprefix(payload))\n',
     'a written-out expansion supplies the source itself': 'def f(name):\n    exec(compile(*["pass"], f"<{name}>", "exec"))\n',
     'an unpacked number stays a number': 'def f(name):\n    payload, = (1,)\n    payload += 2\n    exec(payload)\n',
     'a walrus number stays a number': 'def f(name):\n    (payload := 1)\n    payload += 2\n    exec(payload)\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,10 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'next runs the callback on the first mapped element': 'def f(name):\n    next(map(exec, [f"import {name}"]))\n',
+    'a lambda hands the sink itself back': 'def f(name):\n    (lambda run: run)(exec)(f"import {name}")\n',
+    'a key callback runs on every element sorted consumes': 'def f(name):\n    sorted([f"import {name}"], key = exec)\n',
+    'a folded constant names the same builtin': 'import builtins\ndef f(name):\n    getattr(builtins, "ex" + "ec")(f"import {name}")\n',
     'a sink stored on an attribute is still the builtin': 'import builtins, types\ndef f(name):\n    obj = types.SimpleNamespace()\n    obj.run = builtins.exec\n    obj.run(f"import {name}")\n',
     'a sink stored under a literal key is still the builtin': 'import builtins\ndef f(name):\n    table = {}\n    table["run"] = builtins.exec\n    table["run"](f"import {name}")\n',
     'vars of the builtins module is the same namespace mapping': 'import builtins\ndef f(name):\n    vars(builtins)["exec"](f"import {name}")\n',
@@ -296,6 +300,12 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a memoryview handed back as bytes is the same source': 'def f(name):\n    exec(memoryview(f"import {name}".encode()).tobytes())\n',
+    'a text subclass one level down still inherits the builder': 'class Base(str):\n    pass\nclass Template(Base):\n    pass\ndef f(name):\n    exec(Template("import {}").format(name))\n',
+    'a Formatter bound to a name still formats': 'import string\ndef f(name):\n    payload = f"import {name}"\n    formatter = string.Formatter()\n    exec(formatter.vformat("{}", (payload,), {}))\n',
+    'a written-out list hands back the element popped from it': 'def f(name):\n    exec([f"import {name}"].pop())\n',
+    'a container bound to a name keeps its elements': 'def f(name):\n    payloads = [f"import {name}"]\n    exec(payloads[0])\n',
+    'a mapping bound to a name keeps its values': 'def f(name):\n    payloads = {"run": f"import {name}"}\n    exec(payloads["run"])\n',
     'an f-string removed from an equal f-string is two evaluations': 'def f(name):\n    exec(f"import {name}".removeprefix(f"import {name}"))\n',
     'a string Formatter vformat is the format method spelled apart': 'import string\ndef f(name):\n    payload = f"import {name}"\n    exec(string.Formatter().vformat("{}", (payload,), {}))\n',
     'an unbound string add takes its receiver as an argument': 'def f(name):\n    payload = f"import {name}"\n    exec(str.__add__("", payload))\n',
@@ -367,6 +377,7 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'an iter around a written-out list still yields its elements': 'def f(name):\n    for payload in iter([f"import {name}"]):\n        exec(payload)\n',
     'a global declaration leaves the name in the enclosing scope': 'payload = f"import {name}"\ndef f():\n    global payload\n    exec(payload)\n    payload = "pass"\nf()\n',
     'a nonlocal declaration leaves the name in the enclosing scope': 'def outer(name):\n    payload = f"import {name}"\n    def f():\n        nonlocal payload\n        exec(payload)\n        payload = "pass"\n    f()\n',
     'a closure reads what its scope binds after the def': 'def f(name):\n    payload = "pass"\n    def inner():\n        exec(payload)\n    payload = f"import {name}"\n    inner()\n',
@@ -406,6 +417,16 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a discarded generator never evaluates its element': 'def f(name):\n    (exec(f"import {name}") for _ in [0])\n',
+    'min compares two results and raises before the third': 'def f(name):\n    min(map(exec, ["pass", "pass", f"import {name}"]))\n',
+    'an empty second iterable stops the map before it starts': 'def f(name):\n    list(map(exec, [f"import {name}"], []))\n',
+    'a shorter second iterable stops the map early': 'def f(name):\n    list(map(exec, ["pass", f"import {name}"], [{}]))\n',
+    'a lambda given more values than it takes raises first': 'def f(name):\n    exec((lambda source: source)(*[f"import {name}", "extra"]))\n',
+    'a local class with its own add is not concatenation': 'class Safe:\n    def __add__(self, value):\n        return "pass"\ndef f(name):\n    exec(Safe().__add__(f"{name}"))\n',
+    'the same keyword from two expansions raises first': 'def f(name):\n    compile(**{"source": f"import {name}"}, **{"source": "pass"}, filename = "<x>", mode = "exec")\n',
+    'a normaliser given an argument it does not take raises first': 'def f(name):\n    exec(f"import {name}".upper(1))\n',
+    'adding a visible number to visible text raises first': 'import operator\ndef f(name):\n    exec(operator.add(f"import {name}", 1))\n',
+    'a zero precision with the string type truncates too': 'def f(name):\n    exec(format(f"import {name}", ".0s"))\n',
     'textwrap indent without its prefix raises first': 'import textwrap\ndef f(name):\n    exec(textwrap.indent(f"import {name}"))\n',
     'a search text absent from the literal replaces nothing': 'def f(name):\n    exec("pass".replace("MISSING", name))\n',
     'an unbound replace with an absent search text changes nothing': 'def f(name):\n    exec(str.replace("pass", "MISSING", name))\n',
@@ -533,6 +554,7 @@ def test_a_notebook_cell_that_runs_python_is_reported(description, tmp_path):
 
 # The cell body is data: no interpreter reads it.
 _NOTEBOOK_IS_INERT = {
+    'an option after the script operand belongs to the script': '{"cells": [{"cell_type": "code", "metadata": {}, "outputs": [], "execution_count": null, "source": "%%script python helper.py -c \\"exec(f\'import {name}\')\\"\\nprint(1)\\n"}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'a bundled help flag never reads the cell body': '{"cells": [{"cell_type": "code", "source": "%%script python -uh\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'help wins over interactive mode': '{"cells": [{"cell_type": "code", "source": "%%script python -i --help\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'python --help never reads the cell body': '{"cells": [{"cell_type": "code", "source": "%%script python --help\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,8 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'the implicit __builtins__ names the sink as an attribute': 'def f(name):\n    __builtins__.exec(f"import {name}")\n',
+    'an aliased codeop still compiles the source it was given': 'import codeop as co\ndef f(name):\n    exec(co.compile_command(f"import {name}"))\n',
     'a mixed literal loop keeps the sink over the constructor': 'import builtins\ndef f(name):\n    for run in [builtins.str, builtins.exec]:\n        run(f"import {name}")\n',
     'a statically false while never takes the builtin away': 'import builtins\ndef f(name, condition):\n    run = builtins.exec\n    while False:\n        run = print\n    run(f"import {name}")\n',
     'a decidable boolean filter binds no comprehension walrus': 'import builtins\ndef f(name):\n    run = builtins.exec\n    [(run := print) for _ in [0] if True and False]\n    run(f"import {name}")\n',
@@ -261,6 +263,9 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'format_map with an empty mapping returns the receiver': 'def f(name):\n    exec(f"import {name}".format_map({}))\n',
+    'an opaque expansion leaves compile its source keyword': 'def f(name, args = ()):\n    exec(compile(*args, source = f"import {name}", filename = "<x>", mode = "exec"))\n',
+    'nullcontext hands its argument to the as target': 'import contextlib\ndef f(name):\n    with contextlib.nullcontext(f"import {name}") as payload:\n        exec(payload)\n',
     'an empty expansion does not hide the first spread key': 'def f(name):\n    exec(*{**{}, f"import {name}": None})\n',
     'a literal template reached through a name is still a template': 'def f(name):\n    template = "import MODULE"\n    exec(template.replace("MODULE", name))\n',
     'codeop compiles the source it was handed': 'import codeop\ndef f(name):\n    exec(codeop.compile_command(f"import {name}"))\n',
@@ -306,6 +311,10 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'an annotated literal is still a template for replace': 'def f(name):\n    template: str = "import MODULE"\n    exec(template.replace("MODULE", name))\n',
+    'a positive augmented repetition keeps the built source': 'def f(name):\n    payload = f"import {name}"\n    payload *= 2\n    exec(payload)\n',
+    'an assignment below an unconditional break never runs': 'def f(name):\n    payload = f"import {name}"\n    for _ in [0]:\n        break\n        payload = "pass"\n    exec(payload)\n',
+    'an unknown operand before a decisive constant still decides': 'import builtins\ndef f(name, flag):\n    run = builtins.exec\n    while flag and False:\n        run = print\n    run(f"import {name}")\n',
     'a literal loop element carries the taint it holds': 'def f(name):\n    payload = f"import {name}"\n    for source in [payload]:\n        exec(source)\n',
     'a short-circuited walrus never clears the taint': 'def f(name):\n    payload = f"import {name}"\n    False and (payload := "pass")\n    exec(payload)\n',
     'the final loop body wins over the last element': 'def f(name):\n    for payload in ["pass"]:\n        payload = f"import {name}"\n    exec(payload)\n',
@@ -326,6 +335,9 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a local operator is not the stdlib module': 'def f(operator, name):\n    exec(operator.add("import ", name))\n',
+    'assigning the builtins module drops the earlier sink alias': 'import builtins\ndef f(name):\n    run = builtins.exec\n    run = builtins\n    run(f"import {name}")\n',
+    'an augmented repetition by zero builds nothing': 'def f(name):\n    payload = f"import {name}"\n    payload *= 0\n    exec(payload)\n',
     'a folded unary condition drops the constructor arm': 'def f(name):\n    exec((str if not True else print)(f"import {name}"))\n',
     'an except target takes a prefixed alias away': 'from builtins import str as text\ndef f(name):\n    try:\n        pass\n    except Exception as text:\n        exec(text(f"import {name}"))\n',
     'async for cannot iterate a synchronous literal': 'async def f(name):\n    async for payload in [f"import {name}"]:\n        exec(payload)\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,8 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a directly imported operator builder still concatenates': 'from operator import add as join\ndef f(name):\n    exec(join("import ", name))\n',
+    'an undecidable comprehension filter binds no walrus': 'import builtins\ndef f(name, flag):\n    run = builtins.exec\n    [(run := print) for _ in [0] if flag]\n    run(f"import {name}")\n',
     'a string.Template substitution splices like format': 'import string\ndef f(name):\n    exec(string.Template("import $module").substitute(module = name))\n',
     'a bound builder method keeps its template': 'def f(name):\n    formatter = "import {}".format\n    exec(formatter(name))\n',
     'a sink handed to a consumed map is still called': 'def f(name):\n    list(map(exec, [f"import {name}"]))\n',
@@ -283,6 +285,8 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a piece of a split string still holds the interpolation': 'def f(name):\n    exec(f"import {name}".partition("#")[0])\n',
+    'an immediately invoked lambda returns what its body builds': 'def f(name):\n    exec((lambda: f"import {name}")())\n',
     'two calls that read the same source are not the same value': 'def f(values, scope):\n    exec(f"{next(values)}".removeprefix(f"{next(values)}"), scope)\n',
     'an identity translation table changes nothing': 'def f(name):\n    exec(f"import {name}".translate({0: 0}))\n',
     'an ordinary async context manager still runs its body': 'async def f(name, manager):\n    async with manager as payload:\n        exec(f"import {name}")\n',
@@ -334,6 +338,7 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'a nested function closes over the enclosing source': 'def f(name):\n    payload = f"import {name}"\n    def inner():\n        exec(payload)\n    inner()\n',
     'an attribute holds the source it was given': 'def f(self, name):\n    self.payload = f"import {name}"\n    exec(self.payload)\n',
     'a literal subscript holds the source it was given': 'def f(name, payloads):\n    payloads["run"] = f"import {name}"\n    exec(payloads["run"])\n',
     'an unpacking binds each element before the next target runs': 'def f(name, table):\n    payload, table[exec(payload)] = (f"import {name}", None)\n',
@@ -369,6 +374,9 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a nested function that rebinds the name sees its own': 'def f(name):\n    payload = f"import {name}"\n    def inner():\n        payload = "pass"\n        exec(payload)\n    inner()\n',
+    'a filter over an empty iterable never runs': 'def f(name):\n    [None for _ in [] if exec(f"import {name}")]\n',
+    'an async comprehension over a synchronous literal raises first': 'async def f(name):\n    return [exec(payload) async for payload in [f"import {name}"]]\n',
     'a format method on a locally defined class is not a builder': 'class Safe:\n    def format(self, value):\n        return "pass"\ndef f(name):\n    exec(Safe().format(name))\n',
     'a written-out expansion says how many arguments it supplies': 'def f(name):\n    compile(*[f"import {name}"])\n',
     'a written-out mapping expansion names the keys it supplies': 'def f(name):\n    compile(**{"source": f"import {name}"})\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -301,6 +301,10 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a visible local helper hands back what it built': 'def build(name):\n    return f"import {name}"\ndef f(name):\n    exec(build(name))\n',
+    'a class attribute outlives the class body': 'class C:\n    payload = None\ndef f(name):\n    C.payload = f"import {name}"\n    exec(C.payload)\n',
+    'a bound replace keeps its template': 'def f(name):\n    replace = "import MODULE".replace\n    exec(replace("MODULE", name))\n',
+    'a bound normaliser keeps its receiver': 'def f(name):\n    payload = f"import {name}"\n    normalize = payload.strip\n    exec(normalize())\n',
     'a memoryview handed back as bytes is the same source': 'def f(name):\n    exec(memoryview(f"import {name}".encode()).tobytes())\n',
     'a text subclass one level down still inherits the builder': 'class Base(str):\n    pass\nclass Template(Base):\n    pass\ndef f(name):\n    exec(Template("import {}").format(name))\n',
     'a Formatter bound to a name still formats': 'import string\ndef f(name):\n    payload = f"import {name}"\n    formatter = string.Formatter()\n    exec(formatter.vformat("{}", (payload,), {}))\n',
@@ -378,6 +382,7 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'enumerate over a written-out list still pairs its elements': 'def f(name):\n    for _, payload in enumerate([f"import {name}"]):\n        exec(payload)\n',
     'an iter around a written-out list still yields its elements': 'def f(name):\n    for payload in iter([f"import {name}"]):\n        exec(payload)\n',
     'a global declaration leaves the name in the enclosing scope': 'payload = f"import {name}"\ndef f():\n    global payload\n    exec(payload)\n    payload = "pass"\nf()\n',
     'a nonlocal declaration leaves the name in the enclosing scope': 'def outer(name):\n    payload = f"import {name}"\n    def f():\n        nonlocal payload\n        exec(payload)\n        payload = "pass"\n    f()\n',
@@ -418,6 +423,8 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'join takes one iterable and raises on two': 'def f(name):\n    exec(",".join([f"import {name}"], []))\n',
+    'format_map takes one mapping and raises on two': 'def f(name):\n    exec("import {name}".format_map({"name": name}, {}))\n',
     'a function body ends at an unconditional return': 'def f(name):\n    return\n    exec(f"import {name}")\n',
     'a function body ends at an unconditional raise': 'def f(name):\n    raise SystemExit\n    exec(f"import {name}")\n',
     'a discarded generator never evaluates its element': 'def f(name):\n    (exec(f"import {name}") for _ in [0])\n',
@@ -599,3 +606,58 @@ def test_the_scanner_runs_without_the_match_node_types():
         for name, value in saved.items():
             setattr(ast, name, value)
     assert isinstance(findings, list)
+
+
+# A workflow `run:` step executes its Python heredoc on the CI runner.
+_WORKFLOW_RUNS_PYTHON = """name: demo
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: run it
+        run: |
+          python3 - <<'PY'
+          import os
+          name = os.environ["M"]
+          exec(f"import {name}")
+          PY
+"""
+
+# The same text in a heredoc nothing runs as Python.
+_WORKFLOW_IS_DATA = """name: demo
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: write a file
+        run: |
+          cat <<'EOF' > note.txt
+          exec(f"import {name}")
+          EOF
+"""
+
+
+def test_a_python_heredoc_in_a_workflow_is_scanned(tmp_path):
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_RUNS_PYTHON)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+    assert "exec()" in proc.stderr, proc.stderr
+
+
+def test_a_heredoc_that_is_not_python_is_left_alone(tmp_path):
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_IS_DATA)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_the_workflow_directory_is_a_default_target():
+    """A capability nothing points at is not a gate."""
+    source = SCRIPT.read_text(encoding = "utf-8")
+    assert '".github/workflows"' in source, (
+        "the default targets no longer name .github/workflows, so the heredocs in "
+        "workflow run steps are scanned by nothing"
+    )

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -291,6 +291,12 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a class name rebound elsewhere is no longer that class': 'class Safe:\n    def format(self, value):\n        return "pass"\nSafe = lambda: "import {}"\ndef f(name):\n    exec(Safe().format(name))\n',
+    'a set expanded into compile can yield any element first': 'def f(name):\n    compile(*{"exec", "<x>", f"import {name}"})\n',
+    'an invoked lambda hands its argument to its body': 'def f(name):\n    exec((lambda source: source)(f"import {name}"))\n',
+    'a computed comprehension target is evaluated on every pass': 'def f(name, table):\n    [None for table[exec(f"import {name}")] in [1]]\n',
+    'a piece after the first separator can carry the spliced value': 'def f(name):\n    exec(f"{name}#pass".partition("#")[2])\n',
+    'a zero maxsplit hands back the whole receiver': 'def f(name):\n    exec(f"PREFIX{name}".split("PREFIX", 0)[0])\n',
     'a piece of a split string still holds the interpolation': 'def f(name):\n    exec(f"import {name}".partition("#")[0])\n',
     'an immediately invoked lambda returns what its body builds': 'def f(name):\n    exec((lambda: f"import {name}")())\n',
     'two calls that read the same source are not the same value': 'def f(values, scope):\n    exec(f"{next(values)}".removeprefix(f"{next(values)}"), scope)\n',
@@ -344,6 +350,9 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'a global declaration leaves the name in the enclosing scope': 'payload = f"import {name}"\ndef f():\n    global payload\n    exec(payload)\n    payload = "pass"\nf()\n',
+    'a nonlocal declaration leaves the name in the enclosing scope': 'def outer(name):\n    payload = f"import {name}"\n    def f():\n        nonlocal payload\n        exec(payload)\n        payload = "pass"\n    f()\n',
+    'a closure reads what its scope binds after the def': 'def f(name):\n    payload = "pass"\n    def inner():\n        exec(payload)\n    payload = f"import {name}"\n    inner()\n',
     'a nested function closes over the enclosing source': 'def f(name):\n    payload = f"import {name}"\n    def inner():\n        exec(payload)\n    inner()\n',
     'an attribute holds the source it was given': 'def f(self, name):\n    self.payload = f"import {name}"\n    exec(self.payload)\n',
     'a literal subscript holds the source it was given': 'def f(name, payloads):\n    payloads["run"] = f"import {name}"\n    exec(payloads["run"])\n',
@@ -380,6 +389,11 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a replace between two literals splices nothing': 'def f():\n    exec("pass".replace("x", "y"))\n',
+    'a replace with a zero count performs no replacement': 'def f(name):\n    exec("pass".replace("x", name, 0))\n',
+    'a leading literal separator leaves the first piece empty': 'def f(name):\n    exec(f"PREFIX{name}".partition("PREFIX")[0])\n',
+    'a trailing literal separator leaves the last piece fixed': 'def f(name):\n    exec(f"{name}#pass".rpartition("#")[2])\n',
+    'a compile that binds one parameter twice raises first': 'def f(name):\n    compile(f"import {name}", "<x>", "exec", source = "pass")\n',
     'a local map is not the builtin': 'def f(map, name):\n    list(map(exec, [f"import {name}"]))\n',
     'map takes no keyword arguments': 'def f(name):\n    list(map(exec, [f"import {name}"], nope = True))\n',
     'a partial consumer never reaches the later element': 'def f(name):\n    next(map(exec, ["pass", f"import {name}"]))\n',
@@ -472,6 +486,7 @@ def test_code_that_cannot_execute_a_built_string_is_quiet(description, tmp_path)
 
 # A magic or interpreter invocation that really does execute the cell body.
 _NOTEBOOK_RUNS_PYTHON = {
+    'an unrecognised automagic does not hide the rest of the cell': '{"cells": [{"cell_type": "code", "metadata": {}, "source": "pip install requests\\nname = input()\\nexec(f\\"import {name}\\")\\n", "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'an interactive command still reads the cell body': '{"cells": [{"cell_type": "code", "metadata": {}, "source": ["%%script python -i -c \\"pass\\"\\n", "exec(f\\"import {name}\\")\\n"], "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'a shell escape running python -c carries a program': '{"cells": [{"cell_type": "code", "source": "!python -c \'name=input(); exec(f\\"import {name}\\")\'\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'a bundled short option carries its attached program': '{"cells": [{"cell_type": "code", "source": "%%script python -uc\'name=\\"x\\";exec(f\\"import {name}\\")\'\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,10 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a helper that returns the sink is still the builtin': 'def runner():\n    return exec\ndef f(name):\n    runner()(f"import {name}")\n',
+    'a sink stored in a written-out list is still the builtin': 'def f(name):\n    runners = [exec]\n    runners[0](f"import {name}")\n',
+    'a builtins-qualified map still consumes its callback': 'import builtins\ndef f(name):\n    list(builtins.map(exec, [f"import {name}"]))\n',
+    'sort takes the same key callback sorted does': 'def f(name):\n    [f"import {name}"].sort(key = exec)\n',
     'an and hands back its last operand': 'def f(name):\n    (compile and exec)(f"import {name}")\n',
     'a sink above the return still runs': 'def f(name):\n    exec(f"import {name}")\n    return\n',
     'next runs the callback on the first mapped element': 'def f(name):\n    next(map(exec, [f"import {name}"]))\n',
@@ -302,6 +306,11 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a nested container element is still addressable': 'def f(name):\n    payloads = {"run": [f"import {name}"]}\n    exec(payloads["run"][0])\n',
+    'a slice that cuts only the literal tail keeps the value': 'def f(name):\n    exec(f"import {name}#"[:-1])\n',
+    'a slice that cuts only the literal head keeps the value': 'def f(name):\n    exec(f"Ximport {name}"[1:])\n',
+    'a result-preserving decorator still hands the body back': 'import functools\n@functools.cache\ndef build(value):\n    return f"import {value}"\ndef f(name):\n    exec(build(name))\n',
+    'a bound dunder builder keeps its left operand': 'def f(name):\n    build = "import ".__add__\n    exec(build(name))\n',
     'a base this file cannot resolve may still be textual': 'class Namespace:\n    class Base(str):\n        pass\nclass Safe(Namespace.Base):\n    pass\ndef f(name):\n    exec(Safe("import {}").format(name))\n',
     'a visible local helper hands back what it built': 'def build(name):\n    return f"import {name}"\ndef f(name):\n    exec(build(name))\n',
     'a class attribute outlives the class body': 'class C:\n    payload = None\ndef f(name):\n    C.payload = f"import {name}"\n    exec(C.payload)\n',
@@ -426,6 +435,10 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a conversion given more arguments than it takes raises first': 'def f(name):\n    exec(f"import {name}".encode("utf-8", "strict", "extra"))\n',
+    'a partition index outside its three elements raises first': 'def f(name):\n    exec(f"import {name}".partition("#")[3])\n',
+    'a slice that cuts into the spliced value says nothing': 'def f(name):\n    exec(f"import {name}"[:3])\n',
+    'a decorator that replaces the function is not read': 'def swap(func):\n    return lambda value: "pass"\n@swap\ndef build(value):\n    return f"import {value}"\ndef f(name):\n    exec(build(name))\n',
     'a normaliser given a keyword it does not take raises first': 'def f(name):\n    exec(f"import {name}".upper(foo = 1))\n',
     'replace takes its arguments positionally only': 'def f(name):\n    exec("X".replace(old = "X", new = name))\n',
     'a visibly invalid compile mode stops the map there': 'def f(name):\n    list(map(compile, ["pass", f"import {name}"], ["<x>", "<x>"], ["bad", "exec"]))\n',
@@ -667,4 +680,96 @@ def test_the_workflow_directory_is_a_default_target():
     assert '".github/workflows"' in source, (
         "the default targets no longer name .github/workflows, so the heredocs in "
         "workflow run steps are scanned by nothing"
+    )
+
+
+# A workflow step that runs Python without a heredoc.
+_WORKFLOW_DASH_C = """name: demo
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: python -c 'name=input(); exec(f"import {name}")'
+"""
+
+# A heredoc written to a file whose NAME contains python, and run by nothing.
+_WORKFLOW_WRITES_A_FILE = """name: demo
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          cat > /tmp/python.py <<'PY'
+          exec(f"import {name}")
+          PY
+"""
+
+# A heredoc holding an Actions expression: not Python here, Python on the runner.
+_WORKFLOW_IS_TEMPLATED = """name: demo
+on: [workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          python3 - <<'PY'
+          name = ${{ toJSON(inputs.module) }}
+          exec(f"import {name}")
+          PY
+"""
+
+
+def test_a_one_line_python_command_in_a_workflow_is_scanned(tmp_path):
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_DASH_C)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_a_heredoc_written_to_a_file_named_python_is_not_scanned(tmp_path):
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_WRITES_A_FILE)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_a_templated_heredoc_is_read_rather_than_skipped(tmp_path):
+    sample = tmp_path / "demo.yml"
+    sample.write_text(_WORKFLOW_IS_TEMPLATED)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+    assert "skipped" not in proc.stdout.lower(), proc.stdout
+
+
+def test_the_origin_of_a_built_source_is_recorded(tmp_path):
+    """Editing the line that BUILDS the source invalidates the reviewed entry.
+
+    The key hashes the sink call, which is byte for byte the same in both files here;
+    only the assignment above it differs, and that is what the origin records. The
+    module is loaded by path rather than run as a subprocess, since the digest is a
+    field of the finding and the command line prints a summary.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("lint_dynamic_exec_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    digests = []
+    for index, source in enumerate((
+        'def f(safe):\n    payload = f"import {safe}"\n    exec(payload)\n',
+        'def f():\n    payload = f"import {input()}"\n    exec(payload)\n',
+    )):
+        sample = tmp_path / f"sample{index}.py"
+        sample.write_text(source)
+        findings = module.scan_file(sample)
+        assert len(findings) == 1, findings
+        digests.append(findings[0].get("origin"))
+
+    assert all(digests), digests
+    assert digests[0] != digests[1], (
+        "two different source-building expressions produced the same origin, so an "
+        "edit to the line above an allowlisted sink would inherit its review"
     )

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,11 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a constant f-string names the same builtin': 'import builtins\ndef f(name):\n    getattr(builtins, f"{\'exec\'}")(f"import {name}")\n',
+    'a sink selected from a written-out iterator is still the builtin': 'def f(name):\n    next(iter([exec]))(f"import {name}")\n',
+    'a helper hands back the sink it was given': 'import builtins\ndef choose(run):\n    return run\ndef f(name):\n    choose(builtins.exec)(f"import {name}")\n',
+    'a sink stored on a class is still the builtin': 'class Runner:\n    run = exec\ndef f(name):\n    Runner.run(f"import {name}")\n',
+    'an undecided choice of callee reports the arm that can run': 'def f(name, flag):\n    (compile if flag else exec)(f"import {name}")\n',
     'a helper that returns the sink is still the builtin': 'def runner():\n    return exec\ndef f(name):\n    runner()(f"import {name}")\n',
     'a sink stored in a written-out list is still the builtin': 'def f(name):\n    runners = [exec]\n    runners[0](f"import {name}")\n',
     'a builtins-qualified map still consumes its callback': 'import builtins\ndef f(name):\n    list(builtins.map(exec, [f"import {name}"]))\n',
@@ -306,6 +311,7 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'a default cannot be reached past a written-out element': 'def f(name):\n    exec(next(iter([f"import {name}"]), "pass"))\n',
     'a nested container element is still addressable': 'def f(name):\n    payloads = {"run": [f"import {name}"]}\n    exec(payloads["run"][0])\n',
     'a slice that cuts only the literal tail keeps the value': 'def f(name):\n    exec(f"import {name}#"[:-1])\n',
     'a slice that cuts only the literal head keeps the value': 'def f(name):\n    exec(f"Ximport {name}"[1:])\n',
@@ -393,6 +399,9 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'a helper local carries the string to the return': 'def build(name):\n    source = f"import {name}"\n    return source\ndef f(name):\n    exec(build(name))\n',
+    'get reads the same element the subscript reads': 'def f(name):\n    payloads = {"x": f"import {name}"}\n    exec(payloads.get("x"))\n',
+    'pop reads it too': 'def f(name):\n    payloads = {"x": f"import {name}"}\n    exec(payloads.pop("x"))\n',
     'an augmented write below the def is read by the closure': 'def f(name):\n    payload = "pass\\n"\n    def inner():\n        exec(payload)\n    payload += f"import {name}"\n    inner()\n',
     'enumerate over a written-out list still pairs its elements': 'def f(name):\n    for _, payload in enumerate([f"import {name}"]):\n        exec(payload)\n',
     'an iter around a written-out list still yields its elements': 'def f(name):\n    for payload in iter([f"import {name}"]):\n        exec(payload)\n',
@@ -435,6 +444,9 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a tuple has no pop to select with': 'def f(name):\n    exec((f"import {name}",).pop())\n',
+    'exec given more arguments than it takes raises first': 'def f(name):\n    exec(f"import {name}", {}, {}, 1)\n',
+    'compile given a seventh argument raises first': 'def f(name):\n    compile(f"import {name}", "<x>", "exec", 0, False, -1, 1)\n',
     'a conversion given more arguments than it takes raises first': 'def f(name):\n    exec(f"import {name}".encode("utf-8", "strict", "extra"))\n',
     'a partition index outside its three elements raises first': 'def f(name):\n    exec(f"import {name}".partition("#")[3])\n',
     'a slice that cuts into the spliced value says nothing': 'def f(name):\n    exec(f"import {name}"[:3])\n',
@@ -773,3 +785,49 @@ def test_the_origin_of_a_built_source_is_recorded(tmp_path):
         "two different source-building expressions produced the same origin, so an "
         "edit to the line above an allowlisted sink would inherit its review"
     )
+
+
+_SHELL_RUNS_PYTHON = """#!/usr/bin/env bash
+set -euo pipefail
+name="$1"
+python - <<'PY'
+exec(f"import {name}")
+PY
+"""
+
+_SHELL_IS_DATA = """#!/usr/bin/env bash
+cat <<'EOF' > note.txt
+exec(f"import {name}")
+EOF
+"""
+
+
+def test_a_python_heredoc_in_a_shell_script_is_scanned(tmp_path):
+    """A committed `.sh` runs Python the same way a workflow step does."""
+    sample = tmp_path / "setup.sh"
+    sample.write_text(_SHELL_RUNS_PYTHON)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+    assert "exec()" in proc.stderr, proc.stderr
+
+
+def test_a_shell_heredoc_that_is_not_python_is_left_alone(tmp_path):
+    sample = tmp_path / "setup.sh"
+    sample.write_text(_SHELL_IS_DATA)
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_a_one_line_python_command_in_a_shell_script_is_scanned(tmp_path):
+    sample = tmp_path / "setup.sh"
+    sample.write_text('#!/bin/sh\npython3 -c \'exec(f"import {name}")\'\n')
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_a_shell_script_under_a_directory_target_is_collected(tmp_path):
+    """The capability has to be reached by the sweep, not only by an explicit path."""
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "setup.sh").write_text(_SHELL_RUNS_PYTHON)
+    proc = _run("--paths", str(tmp_path))
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,9 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a string.Template substitution splices like format': 'import string\ndef f(name):\n    exec(string.Template("import $module").substitute(module = name))\n',
+    'a bound builder method keeps its template': 'def f(name):\n    formatter = "import {}".format\n    exec(formatter(name))\n',
+    'a sink handed to a consumed map is still called': 'def f(name):\n    list(map(exec, [f"import {name}"]))\n',
     'a stdlib alias imported below a function still binds for it': 'def f(name):\n    exec(clean(f"result = {name}"))\nfrom textwrap import dedent as clean\nf("42")\n',
     'a signed zero and a signed step still slice the whole string': 'def f(name, scope):\n    exec(f"result = {name}"[-0::+1], scope)\n',
     'a template held by a name still splices its field': 'def f(user):\n    template = "import {m}"\n    exec(template.format(m = user))\n',
@@ -331,6 +334,8 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'an attribute holds the source it was given': 'def f(self, name):\n    self.payload = f"import {name}"\n    exec(self.payload)\n',
+    'a literal subscript holds the source it was given': 'def f(name, payloads):\n    payloads["run"] = f"import {name}"\n    exec(payloads["run"])\n',
     'an unpacking binds each element before the next target runs': 'def f(name, table):\n    payload, table[exec(payload)] = (f"import {name}", None)\n',
     'an augmented subscript evaluates its target first': 'def f(name, table):\n    payload = f"import {name}"\n    table[exec(payload)] += (payload := "pass")\n',
     'a dict evaluates each key beside its own value': 'def f(name):\n    {0: (payload := f"import {name}"), exec(payload): None}\n',
@@ -364,6 +369,10 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a format method on a locally defined class is not a builder': 'class Safe:\n    def format(self, value):\n        return "pass"\ndef f(name):\n    exec(Safe().format(name))\n',
+    'a written-out expansion says how many arguments it supplies': 'def f(name):\n    compile(*[f"import {name}"])\n',
+    'a written-out mapping expansion names the keys it supplies': 'def f(name):\n    compile(**{"source": f"import {name}"})\n',
+    'an async with stops at the context it cannot enter': 'import contextlib\nasync def f(name, manager):\n    async with contextlib.nullcontext(), manager(exec(f"import {name}")):\n        pass\n',
     'a field-free template held by a name ignores its arguments': 'def f(user):\n    template = "pass"\n    exec(template.format(user))\n',
     'a field-free format_map template ignores its mapping': 'def f(name):\n    exec("pass".format_map({"x": name}))\n',
     'compile without a filename and a mode raises first': 'def f(name):\n    compile(f"import {name}")\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -258,6 +258,7 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'an empty expansion does not hide the first spread key': 'def f(name):\n    exec(*{**{}, f"import {name}": None})\n',
     'a literal template reached through a name is still a template': 'def f(name):\n    template = "import MODULE"\n    exec(template.replace("MODULE", name))\n',
     'codeop compiles the source it was handed': 'import codeop\ndef f(name):\n    exec(codeop.compile_command(f"import {name}"))\n',
     'operator.add is concatenation under another name': 'import operator\ndef f(name):\n    exec(operator.add("import ", name))\n',
@@ -321,6 +322,9 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'str of visibly bytes is a repr, not the text': 'def f(name):\n    exec(str(f"import {name}".encode()))\n',
+    'a zero repetition builds an empty string': 'def f(name):\n    exec(f"import {name}" * 0)\n',
+    'a negative repetition builds an empty string': 'def f(name):\n    exec(f"import {name}" * -1)\n',
     'a partial method on some other object is not functools': 'class R:\n    def partial(self, *a):\n        return lambda: None\ndef f(name, runner):\n    runner.partial(exec, f"import {name}")()\n',
     'the last element wins when the body does not rebind': 'def f(name):\n    for payload in [f"import {name}"]:\n        payload = "pass"\n    exec(payload)\n',
     'an opaque receiver is not a literal template': 'import inspect\ndef f(name, target):\n    exec(inspect.getsource(target).replace("MODULE", name))\n',
@@ -369,6 +373,7 @@ def test_code_that_cannot_execute_a_built_string_is_quiet(description, tmp_path)
 
 # A magic or interpreter invocation that really does execute the cell body.
 _NOTEBOOK_RUNS_PYTHON = {
+    'a shell escape running python -c carries a program': '{"cells": [{"cell_type": "code", "source": "!python -c \'name=input(); exec(f\\"import {name}\\")\'\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'a bundled short option carries its attached program': '{"cells": [{"cell_type": "code", "source": "%%script python -uc\'name=\\"x\\";exec(f\\"import {name}\\")\'\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'an assignment-form %time binds the value it timed': '{"cells": [{"cell_type": "code", "source": "name = input()\\npayload = %time f\\"import {name}\\"\\nexec(payload)\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
     'env -S carries the interpreter command inside its value': '{"cells": [{"cell_type": "code", "source": "%%script env -S \\"python -c \'name=input(); exec(f\\\\\\"import {name}\\\\\\")\'\\"\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,11 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'an aliased textwrap wrapper still hands the source through': 'from textwrap import dedent as clean\ndef f(name):\n    exec(clean(f"import {name}"))\n',
+    'operator.mod is percent formatting written as a call': 'import operator\ndef f(name):\n    exec(operator.mod("import %s", name))\n',
+    'the in-place operator spellings concatenate too': 'import operator\ndef f(name):\n    exec(operator.iadd("import ", name))\n',
+    '__getitem__ is the mapping subscript written as a call': 'import builtins\ndef f(name):\n    builtins.__dict__.__getitem__("exec")(f"import {name}")\n',
+    'a lazy type alias value is evaluated when the alias is read': 'type Payload = (exec(f"import {NAME}") or int)\n',
     'the implicit __builtins__ names the sink as an attribute': 'def f(name):\n    __builtins__.exec(f"import {name}")\n',
     'an aliased codeop still compiles the source it was given': 'import codeop as co\ndef f(name):\n    exec(co.compile_command(f"import {name}"))\n',
     'a mixed literal loop keeps the sink over the constructor': 'import builtins\ndef f(name):\n    for run in [builtins.str, builtins.exec]:\n        run(f"import {name}")\n',
@@ -232,6 +237,7 @@ def test_a_sink_reached_through_another_spelling_is_reported(description, tmp_pa
 
 # `str`, `bytes` and friends reached indirectly still pass the source through.
 _CONSTRUCTOR_IS_STILL_RESOLVED = {
+    'an undecidable constructor choice checks both arms': 'def f(name, flag):\n    exec((memoryview if flag else str)(f"import {name}"))\n',
     'a builtins star import hands back the conversions too': "def f(name):\n    str = print\n    from builtins import *\n    exec(str(f'import {name}'))\n",
     'a byte constructor over already encoded source reaches the sink': 'def f(name):\n    exec(bytes(f"import {name}".encode()))\n    exec(bytearray(f"import {name}".encode()))\n    exec(memoryview(f"import {name}".encode()))\n',
     'a class-body global import restores the constructor globally': 'str = print\nclass C:\n    global str\n    from builtins import str\ndef f(name):\n    exec(str(f"import {name}"))\n',
@@ -311,6 +317,12 @@ def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
 
 # One level of local indirection: an alias of a name that holds a built string.
 _TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'a while suite ends at an unconditional break': 'def f(name):\n    payload = f"import {name}"\n    while True:\n        break\n        payload = "pass"\n    exec(payload)\n',
+    'a jump under a decidable test ends the suite as well': 'def f(name):\n    payload = f"import {name}"\n    for _ in [0]:\n        if True:\n            continue\n        payload = "pass"\n    exec(payload)\n',
+    'a statically false case guard runs no body': 'def f(name, value):\n    payload = f"import {name}"\n    match value:\n        case _ if False:\n            payload = "pass"\n    exec(payload)\n',
+    'a comprehension that runs no pass binds no walrus': 'def f(name):\n    payload = f"import {name}"\n    [(payload := "pass") for _ in []]\n    exec(payload)\n',
+    'an empty display is a false condition': 'def f(name):\n    payload = f"import {name}"\n    [] and (payload := "pass")\n    exec(payload)\n',
+    'a literal sequence subject pairs with its capture': 'def f(name):\n    match [f"import {name}"]:\n        case [payload]:\n            exec(payload)\n',
     'an annotated literal is still a template for replace': 'def f(name):\n    template: str = "import MODULE"\n    exec(template.replace("MODULE", name))\n',
     'a positive augmented repetition keeps the built source': 'def f(name):\n    payload = f"import {name}"\n    payload *= 2\n    exec(payload)\n',
     'an assignment below an unconditional break never runs': 'def f(name):\n    payload = f"import {name}"\n    for _ in [0]:\n        break\n        payload = "pass"\n    exec(payload)\n',
@@ -335,6 +347,20 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'False is a zero repetition count': 'def f(name):\n    exec(f"import {name}" * False)\n',
+    'two written-out containers add to a list, not to source': 'def f(name):\n    exec([f"import {name}"] + [])\n',
+    'an async loop over a synchronous literal never reaches its else': 'async def f(name):\n    async for _ in []:\n        pass\n    else:\n        exec(f"import {name}")\n',
+    'a deleted nonlocal cell is empty, not the builtin': 'def outer(name):\n    exec = print\n    def inner():\n        nonlocal exec\n        del exec\n        exec(f"import {name}")\n    return inner\n',
+    'a zero precision format spec keeps nothing': 'def f(name):\n    exec(format(f"import {name}", ".0"))\n',
+    'removing the receiver as its own prefix leaves nothing': 'def f(name):\n    exec(f"import {name}".removeprefix(f"import {name}"))\n',
+    'a written-out expansion supplies the source itself': 'def f(name):\n    exec(compile(*["pass"], f"<{name}>", "exec"))\n',
+    'an unpacked number stays a number': 'def f(name):\n    payload, = (1,)\n    payload += 2\n    exec(payload)\n',
+    'a walrus number stays a number': 'def f(name):\n    (payload := 1)\n    payload += 2\n    exec(payload)\n',
+    'dict takes at most one positional argument': 'def f(name):\n    compile(**dict({"source": f"import {name}"}, {"filename": "<x>", "mode": "exec"}))\n',
+    'the decoding form of str rejects text': 'def f(name):\n    exec(str(f"import {name}", "utf-8"))\n',
+    'a local contextlib is not the stdlib module': 'def f(contextlib, name):\n    with contextlib.nullcontext(f"import {name}") as payload:\n        exec(payload)\n',
+    'a literal template with no field ignores its arguments': 'def f(name):\n    exec("pass".format(name))\n',
+    'a local codeop is not the stdlib module': 'def f(codeop, name):\n    exec(codeop.compile_command(f"import {name}"))\n',
     'a local operator is not the stdlib module': 'def f(operator, name):\n    exec(operator.add("import ", name))\n',
     'assigning the builtins module drops the earlier sink alias': 'import builtins\ndef f(name):\n    run = builtins.exec\n    run = builtins\n    run(f"import {name}")\n',
     'an augmented repetition by zero builds nothing': 'def f(name):\n    payload = f"import {name}"\n    payload *= 0\n    exec(payload)\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -194,6 +194,9 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
 
 # The callee is written some other way and still resolves to the builtin.
 _SINK_IS_STILL_RESOLVED = {
+    'a stdlib alias imported below a function still binds for it': 'def f(name):\n    exec(clean(f"result = {name}"))\nfrom textwrap import dedent as clean\nf("42")\n',
+    'a signed zero and a signed step still slice the whole string': 'def f(name, scope):\n    exec(f"result = {name}"[-0::+1], scope)\n',
+    'a template held by a name still splices its field': 'def f(user):\n    template = "import {m}"\n    exec(template.format(m = user))\n',
     'a field between escaped braces is still a field': 'def f(name):\n    exec("{{{x}}}".format(x = name))\n',
     'a directly imported ast.parse still preserves its source': 'from ast import parse\ndef f(name):\n    compile(parse(f"import {name}"), "<x>", "exec")\n',
     'getattr reads the implicit builtins module too': 'def f(name):\n    getattr(__builtins__, "exec")(f"import {name}")\n',
@@ -243,6 +246,7 @@ def test_a_sink_reached_through_another_spelling_is_reported(description, tmp_pa
 
 # `str`, `bytes` and friends reached indirectly still pass the source through.
 _CONSTRUCTOR_IS_STILL_RESOLVED = {
+    'a boolean callee names every constructor it can select': 'def f(name):\n    exec((memoryview and str)(f"result = {name}"))\n',
     'the decoding form of str hands the text back': 'def f(name):\n    exec(str(f"import {name}".encode(), "utf-8"))\n',
     'an undecidable constructor choice checks both arms': 'def f(name, flag):\n    exec((memoryview if flag else str)(f"import {name}"))\n',
     'a builtins star import hands back the conversions too': "def f(name):\n    str = print\n    from builtins import *\n    exec(str(f'import {name}'))\n",
@@ -276,6 +280,7 @@ def test_a_text_constructor_reached_through_another_spelling_is_reported(descrip
 
 # The built string survives a lookup, an operator, a wrapper or a spread.
 _SOURCE_SURVIVES_THE_SHAPE = {
+    'two calls that read the same source are not the same value': 'def f(values, scope):\n    exec(f"{next(values)}".removeprefix(f"{next(values)}"), scope)\n',
     'an identity translation table changes nothing': 'def f(name):\n    exec(f"import {name}".translate({0: 0}))\n',
     'an ordinary async context manager still runs its body': 'async def f(name, manager):\n    async with manager as payload:\n        exec(f"import {name}")\n',
     'format_map with an empty mapping returns the receiver': 'def f(name):\n    exec(f"import {name}".format_map({}))\n',
@@ -359,6 +364,7 @@ def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
 
 # Shadowed, unreachable, unbound or unable to build a string at all.
 _NOTHING_REACHES_THE_SINK = {
+    'a field-free template held by a name ignores its arguments': 'def f(user):\n    template = "pass"\n    exec(template.format(user))\n',
     'a field-free format_map template ignores its mapping': 'def f(name):\n    exec("pass".format_map({"x": name}))\n',
     'compile without a filename and a mode raises first': 'def f(name):\n    compile(f"import {name}")\n',
     'a bare partial is only functools.partial when imported': 'def partial(callback, source):\n    return lambda: None\ndef f(name):\n    partial(exec, f"import {name}")()\n',

--- a/tests/security/test_lint_dynamic_exec.py
+++ b/tests/security/test_lint_dynamic_exec.py
@@ -58,6 +58,12 @@ def test_live_tree_passes():
     ('eval("torch." + x)', "concatenation"),
     ('compile("y = %s" % x, "<x>", "exec")', "%-format"),
     ('exec("a.{}".format(x))', ".format()"),
+    # `compile`'s source is not positional-only, so an interpolated payload can
+    # reach it with `node.args` empty.
+    ('compile(source = f"y = {x}", filename = "<x>", mode = "exec")',
+     "compile source= keyword"),
+    ('builtins.compile(source = f"y = {x}", filename = "<x>", mode = "exec")',
+     "builtins.compile source= keyword"),
 ])
 def test_a_new_interpolated_call_fails(body, description, tmp_path):
     offender = tmp_path / "offender.py"
@@ -72,11 +78,16 @@ def test_a_new_interpolated_call_fails(body, description, tmp_path):
     "eval(name)",
     'exec("literal source")',
     'module.exec(f"{x}")',
+    # Keyword resolution must not invent findings: a literal source, and a
+    # sink call carrying no source at all, both stay quiet.
+    'compile(source = "literal", filename = "<x>", mode = "exec")',
+    'compile(filename = "<x>", mode = "exec")',
+    "exec(**kwargs)",
 ])
 def test_non_interpolated_calls_are_not_flagged(body, tmp_path):
     """Bare exec of generated source is the normal case here and must stay quiet."""
     clean = tmp_path / "clean.py"
-    clean.write_text(f"def f(source, name, x, module):\n    {body}\n")
+    clean.write_text(f"def f(source, name, x, module, **kwargs):\n    {body}\n")
     proc = _run("--paths", str(clean))
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
 
@@ -86,7 +97,7 @@ def test_non_interpolated_calls_are_not_flagged(body, tmp_path):
 def test_every_allowlist_entry_has_a_justification():
     # An empty allowlist is a legitimate state: it means no interpolated dynamic
     # execution is left in this repo at all.
-    entries = json.loads(ALLOWLIST.read_text())["allowed"]
+    entries = json.loads(ALLOWLIST.read_text(encoding = "utf-8"))["allowed"]
     unjustified = [
         e for e in entries
         if e.get("reason", "").strip().upper() in ("", "REVIEW ME")
@@ -96,7 +107,7 @@ def test_every_allowlist_entry_has_a_justification():
 
 def test_allowlist_entries_are_keyed_on_content_not_lines():
     """Line numbers drift; a justification keyed on one would silently detach."""
-    entries = json.loads(ALLOWLIST.read_text())["allowed"]
+    entries = json.loads(ALLOWLIST.read_text(encoding = "utf-8"))["allowed"]
     assert all("hash" in e for e in entries)
     assert all("line" not in e for e in entries)
 
@@ -124,7 +135,7 @@ def test_editing_an_allowlisted_call_revokes_its_justification(tmp_path):
 def _isolated_lint(tmp_path, allowlist):
     """A copy of the lint whose allowlist is `allowlist` (it reads the one beside it)."""
     script = tmp_path / "lint_dynamic_exec.py"
-    script.write_text(SCRIPT.read_text())
+    script.write_text(SCRIPT.read_text(encoding = "utf-8"))
     (tmp_path / "dynamic_exec_allowlist.json").write_text(json.dumps(allowlist))
     return script
 
@@ -175,3 +186,229 @@ def test_an_unjustified_allowlist_entry_fails(tmp_path):
     )
     assert proc.returncode == 1
     assert "no justification" in proc.stderr
+
+
+# Grouped by what each case proves, not by the review round that found it.
+# Every description is unique across the whole file, so a new case that
+# duplicates an existing one is a merge conflict rather than a silent overwrite.
+
+# The callee is written some other way and still resolves to the builtin.
+_SINK_IS_STILL_RESOLVED = {
+    'a builtins-qualified getattr names the sink': 'import builtins\ndef f(name):\n    builtins.getattr(builtins, "exec")(f"import {name}")\n',
+    'a computed key keeps the get default reachable as a callee': 'def f(name, key):\n    {key: print}.get("run", exec)(f"import {name}")\n',
+    'a later module-level def does not apply to earlier calls': 'name = "ok"\nexec(f"import {name}")\ndef exec(source):\n    pass\n',
+    'a literal key on the builtins dict names the sink': 'import builtins\ndef f(name):\n    builtins.__dict__["exec"](f"import {name}")\n',
+    'a partial assigned to a name keeps the source bound into it': 'import functools\ndef f(name):\n    run = functools.partial(exec, f"import {name}")\n    run()\n',
+    'a partial that binds only the sink takes its source at call time': 'import functools\ndef f(name):\n    functools.partial(exec)(f"import {name}")\n',
+    'a sink assigned below the function still binds for it': "import builtins\ndef f(name):\n    run(f'import {name}')\nrun = builtins.exec\n",
+    'a walrus callee is called before the name it binds means anything': "import builtins\ndef f(name):\n    (run := builtins.exec)(f'import {name}')\n",
+    'a walrus inside a lambda is local to the lambda': "def f(name):\n    exec(f'import {name}')\n    g = lambda: (exec := print)\n",
+    'an inline builtins import names the sink': 'def f(name):\n    __import__("builtins").exec(f"import {name}")\n',
+    'deleting a global shadow puts the builtin back': "exec = print\ndef f(name):\n    global exec\n    del exec\n    exec(f'import {name}')\n",
+    'functools.partial binds the sink and its source': 'import functools\ndef f(name):\n    functools.partial(exec, f"import {name}")()\n',
+    'get on a literal mapping selects the callee': 'import builtins\ndef f(name):\n    {\'run\': builtins.exec}.get(\'run\')(f"import {name}")\n',
+    'get on the builtins mapping returns the sink': 'import builtins\ndef f(name):\n    builtins.__dict__.get("exec")(f"import {name}")\n',
+    'the implicit builtins mapping holds the sink': 'def f(name):\n    __builtins__[\'exec\'](f"import {name}")\n',
+}
+
+
+@pytest.mark.parametrize("description", sorted(_SINK_IS_STILL_RESOLVED))
+def test_a_sink_reached_through_another_spelling_is_reported(description, tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text(_SINK_IS_STILL_RESOLVED[description])
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{description}:\n{proc.stdout}\n{proc.stderr}"
+
+
+# `str`, `bytes` and friends reached indirectly still pass the source through.
+_CONSTRUCTOR_IS_STILL_RESOLVED = {
+    'a builtins star import hands back the conversions too': "def f(name):\n    str = print\n    from builtins import *\n    exec(str(f'import {name}'))\n",
+    'a byte constructor over already encoded source reaches the sink': 'def f(name):\n    exec(bytes(f"import {name}".encode()))\n    exec(bytearray(f"import {name}".encode()))\n    exec(memoryview(f"import {name}".encode()))\n',
+    'a class-body global import restores the constructor globally': 'str = print\nclass C:\n    global str\n    from builtins import str\ndef f(name):\n    exec(str(f"import {name}"))\n',
+    'a constructor imported below the function still binds for it': "def f(name):\n    exec(s(f'import {name}'))\nfrom builtins import str as s\n",
+    'a constructor reached through __call__ still converts': 'def f(name):\n    exec(str.__call__(f"import {name}"))\n',
+    'a constructor selected from the builtins mapping still converts': 'import builtins\ndef f(name):\n    exec(builtins.__dict__[\'str\'](f"import {name}"))\n',
+    'a conversion called through __call__ still converts': 'def f(name):\n    exec(f"import {name}".encode.__call__())\n',
+    'a lambda default names a constructor': 'import builtins\ng = lambda name, text = builtins.str: exec(text(f"import {name}"))\n',
+    'a lambda parameter defaulting to a constructor carries it': "import builtins\nf = (lambda name, s = builtins.str: exec(s(f'import {name}')))\n",
+    'a literal loop states the constructor it binds': "import builtins\ndef f(name):\n    for s in [builtins.str]:\n        exec(s(f'import {name}'))\n",
+    'a parameter defaulting to a constructor carries the conversion': "import builtins\ndef f(name, text = builtins.str):\n    exec(text(f'import {name}'))\n",
+    'a walrus constructor callee converts right there': "def f(name):\n    exec((text := str)(f'import {name}'))\n",
+    'an eager comprehension walrus keeps a prefixed alias': 'def f(name):\n    [(text := str) for _ in [0]]\n    exec(text(f"import {name}"))\n',
+    'an irrefutable match capture binds the constructor it matched': "import builtins\ndef f(name):\n    match builtins.str:\n        case s:\n            exec(s(f'import {name}'))\n",
+    'both arms of a conditional constructor preserve the source': 'def f(name, flag):\n    exec((str if flag else format)(f"import {name}"))\n',
+    'getattr names a constructor as plainly as an attribute': 'import builtins\ndef f(name):\n    exec(getattr(builtins, "str")(f"import {name}"))\n',
+    'getattr with a default still returns the attribute that exists': "import builtins\ndef f(name):\n    getattr(builtins, 'exec', print)(f'import {name}')\n",
+    'memoryview over bytes reaches the sink': 'def f(name):\n    exec(memoryview(bytes(f"import {name}", "utf-8")))\n',
+}
+
+
+@pytest.mark.parametrize("description", sorted(_CONSTRUCTOR_IS_STILL_RESOLVED))
+def test_a_text_constructor_reached_through_another_spelling_is_reported(description, tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text(_CONSTRUCTOR_IS_STILL_RESOLVED[description])
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{description}:\n{proc.stdout}\n{proc.stderr}"
+
+
+# The built string survives a lookup, an operator, a wrapper or a spread.
+_SOURCE_SURVIVES_THE_SHAPE = {
+    '__add__ is concatenation written as a call': 'def f(name):\n    exec("print(".__add__(name).__add__(")"))\n',
+    '__mod__ is the percent operator written as a call': 'def f(name):\n    exec("print(%r)".__mod__(name))\n',
+    '__str__ hands back the same string': 'def f(name):\n    exec(f"import {name}".__str__())\n',
+    'a computed key does not erase an earlier matching entry': "def f(name, key):\n    exec({'source': f'import {name}', key: 'pass'}['source'])\n",
+    'a computed key nested under a double star keeps the get default reachable': 'def f(name, key):\n    exec({**{key: \'pass\'}}.get(\'source\', f"import {name}"))\n',
+    'a computed key that cannot match still leaves the earlier value': "def f(name):\n    key = 'other'\n    exec({'s': f'import {name}', key: 'pass'}['s'])\n",
+    'a computed key under a double star does not erase the outer value': "def f(name, key):\n    exec({'s': f'import {name}', **{key: 'pass'}}['s'])\n",
+    'a dict constructor literal answers get': 'def f(name):\n    exec(dict(source = f"import {name}").get("source"))\n',
+    'a lazy generator walrus binds nothing': 'def f(name):\n    payload = f"import {name}"\n    generator = ((payload := "pass") for _ in [0])\n    exec(payload)\n',
+    'a literal get returns its default when the key is absent': 'def f(name):\n    exec({}.get("source", f"import {name}"))\n',
+    'a literal loop that can break leaves some element bound': "import builtins\ndef f(name):\n    run = print\n    for run in [builtins.exec]:\n        break\n    run(f'import {name}')\n",
+    'a text-preserving wrapper takes its text by keyword': 'import textwrap\ndef f(name):\n    exec(textwrap.dedent(text = f"import {name}"))\n',
+    'a walrus in a definition header binds where it is written': 'import builtins\ndef f(name):\n    run(f"import {name}")\ndef g(value = (run := builtins.exec)):\n    pass\n',
+    'a written out getitem selects the source': 'def f(name):\n    exec({"source": f"import {name}"}.__getitem__("source"))\n',
+    'an empty comprehension binds no walrus at all': 'import builtins\ndef f(name):\n    run = builtins.exec\n    [(run := print) for _ in []]\n    run(f"import {name}")\n',
+    'an opaque double-star expansion does not erase an earlier entry': 'def f(name):\n    exec({\'source\': f"import {name}", **dict(other = \'pass\')}[\'source\'])\n',
+    'an opaque star expansion may contribute nothing': 'def f(name, args = ()):\n    exec(*args, f"import {name}")\n',
+    'ast.parse keeps the source it parsed': 'import ast\ndef f(name):\n    compile(ast.parse(f"print({name!r})"), "<x>", "exec")\n',
+    'ast.parse takes its source as a keyword': 'import ast\ndef f(name):\n    compile(ast.parse(source = f"import {name}"), "<x>", "exec")\n',
+    'augmented multiplication can build a string': 'def f(name):\n    payload = 1\n    payload *= f"import {name}"\n    exec(payload)\n',
+    'dict merges a positional mapping with its keywords': 'def f(name):\n    compile(**dict({\'source\': f"import {name}"}, filename = \'<x>\', mode = \'exec\'))\n',
+    'format with nothing to splice still returns the receiver': "def f(name):\n    exec(f'import {name}'.format())\n",
+    'get on a literal mapping reads the same value a subscript would': "def f(name):\n    exec({'s': f'import {name}'}.get('s'))\n",
+    'iterating a literal mapping yields its keys': 'def f(name):\n    for payload in {f"import {name}": None}:\n        exec(payload)\n',
+    'spreading a literal mapping passes its first key': "def f(name):\n    exec(*{f'import {name}': None})\n",
+    'textwrap.dedent keeps what the f-string built': "import textwrap\ndef f(name):\n    exec(textwrap.dedent(f'import {name}'))\n",
+    'the unbound descriptor spelling of __str__ preserves the source': 'def f(name):\n    exec(str.__str__(f"import {name}"))\n',
+}
+
+
+@pytest.mark.parametrize("description", sorted(_SOURCE_SURVIVES_THE_SHAPE))
+def test_a_source_that_survives_its_wrapper_is_reported(description, tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text(_SOURCE_SURVIVES_THE_SHAPE[description])
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{description}:\n{proc.stdout}\n{proc.stderr}"
+
+
+# One level of local indirection: an alias of a name that holds a built string.
+_TAINT_TRAVELS_THROUGH_A_BINDING = {
+    'a walrus alias carries the taint': 'def f(name):\n    payload = f"import {name}"\n    (alias := payload)\n    exec(alias)\n',
+    'an annotated alias carries the taint': 'def f(name):\n    payload = f"import {name}"\n    alias: str = payload\n    exec(alias)\n',
+    'an unpacked alias carries the taint': 'def f(name):\n    payload = f"import {name}"\n    alias, ignored = payload, None\n    exec(alias)\n',
+    'taint travels through a plain alias assignment': 'def f(name):\n    payload = f"import {name}"\n    alias = payload\n    exec(alias)\n',
+}
+
+
+@pytest.mark.parametrize("description", sorted(_TAINT_TRAVELS_THROUGH_A_BINDING))
+def test_taint_carried_through_a_binding_is_reported(description, tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text(_TAINT_TRAVELS_THROUGH_A_BINDING[description])
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{description}:\n{proc.stdout}\n{proc.stderr}"
+
+
+# Shadowed, unreachable, unbound or unable to build a string at all.
+_NOTHING_REACHES_THE_SINK = {
+    'a composite default resolving to a shadowed name is not the builtin': 'from re import compile\ndef f(name, run = [compile][0]):\n    run(f"^{name}$")\n',
+    'a constant short-circuits a boolean callee': "def f(name):\n    (None and exec)(f'import {name}')\n",
+    'a literal condition decides a conditional expression': "def f(name):\n    exec('pass' if True else f'import {name}')\n",
+    'a literal false condition decides a conditional callee': 'import builtins\ndef f(name):\n    (builtins.exec if False else print)(f"hello {name}")\n',
+    'a literal loop over a shadowed spelling is not the builtin': 'from re import compile\ndef f(name):\n    for run in [compile]:\n        run(f"^{name}$")\n',
+    'a literal true condition decides a conditional callee': "def f(name):\n    (print if True else exec)(f'import {name}')\n",
+    'a local dict is not the mapping constructor': 'def dict(**kwargs):\n    return {"object": "pass"}\ndef f(name):\n    exec(str(**dict(object = f"import {name}")))\n',
+    'a local rebinding hides an enclosing constructor alias': 'from builtins import str as text\ndef f(name):\n    text = print\n    exec(text(f"import {name}"))\n',
+    'a loop whose body always breaks cannot run its else': 'def f(name):\n    for payload in [f"import {name}"]:\n        break\n    else:\n        exec(payload)\n',
+    'a match subject that is shadowed is not the builtin': 'from re import compile\ndef f(name):\n    match compile:\n        case run:\n            run(f"^{name}$")\n',
+    'a truthy literal short-circuits the rest of an or': "def f(name):\n    exec('pass' or f'import {name}')\n",
+    'a type alias rebinds its name': 'from builtins import exec as run\ndef f(name):\n    type run = int\n    run(f"import {name}")\n',
+    'a visibly empty loop never runs its body': 'def f(name):\n    for _ in []:\n        exec(f"import {name}")\n',
+    'an alias bound only in a dead branch is not the builtin': 'if True:\n    from re import compile as comp\nelse:\n    from builtins import compile as comp\ndef f(name):\n    comp(f"{name}")\n',
+    'an annotated numeric assignment stays numeric': 'def f():\n    payload: int = 1\n    payload += 2\n    exec(payload)\n',
+    'an assignment copying a shadowed spelling is not the builtin': 'from re import compile\nrun = compile\ndef f(name):\n    run(f"^{name}$")\n',
+    'an attribute call on a parameter named builtins is not the module': 'def f(builtins, name):\n    builtins.exec(f"import {name}")\n',
+    'byte constructors without an encoding never reach the sink': 'def f(name):\n    exec(bytes(f"import {name}"))\n    exec(memoryview(f"import {name}"))\n',
+    'bytes without an encoding keyword cannot reach the sink': 'def f(name):\n    exec(bytes(source = f"import {name}", errors = "ignore"))\n',
+    'decode on a visibly string receiver raises before the sink': 'def f(name):\n    exec(f"import {name}".decode())\n',
+    'deleting a module alias unbinds it': 'import builtins as b\ndel b\ndef f(name):\n    b.exec(f"import {name}")\n',
+    'deleting a name makes it local for the whole function': "def f(name):\n    exec(f'import {name}')\n    del exec\n",
+    'explicit integer addition builds no source': 'def f():\n    exec((1).__add__(2))\n',
+    'explicit integer modulo builds no source': 'def f():\n    exec((7).__mod__(2))\n',
+    'format_map without a mapping raises before the sink': 'def f(name):\n    exec(f"import {name}".format_map())\n',
+    'getattr on a parameter named builtins is not the module': 'def f(builtins, name):\n    getattr(builtins, "exec")(f"import {name}")\n',
+    'modulo between two numbers is arithmetic': 'def f():\n    payload = 5\n    payload %= 2\n    exec(payload)\n',
+    'not applied to a constant decides a conditional': 'def f(name):\n    exec("pass" if not False else f"import {name}")\n',
+    'not applied to a constant decides a conditional callee': 'def f(name):\n    (exec if not True else print)(f"import {name}")\n',
+    'rebinding a constructor alias stops the unwrapping': 'from builtins import str as text\ntext = lambda _: "pass"\ndef f(name):\n    exec(text(f"import {name}"))\n',
+}
+
+
+@pytest.mark.parametrize("description", sorted(_NOTHING_REACHES_THE_SINK))
+def test_code_that_cannot_execute_a_built_string_is_quiet(description, tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text(_NOTHING_REACHES_THE_SINK[description])
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 0, f"{description}:\n{proc.stdout}\n{proc.stderr}"
+
+
+# A magic or interpreter invocation that really does execute the cell body.
+_NOTEBOOK_RUNS_PYTHON = {
+    'an assignment-form %time binds the value it timed': '{"cells": [{"cell_type": "code", "source": "name = input()\\npayload = %time f\\"import {name}\\"\\nexec(payload)\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+    'env -S carries the interpreter command inside its value': '{"cells": [{"cell_type": "code", "source": "%%script env -S \\"python -c \'name=input(); exec(f\\\\\\"import {name}\\\\\\")\'\\"\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+    'prefix help syntax does not hide the rest of the cell': '{"cells": [{"cell_type": "code", "source": "?len\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+    'python -i reads the cell body from stdin': '{"cells": [{"cell_type": "code", "source": "%%script python -i helper.py\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+    'timeit setup code runs before the timed statement': '{"cells": [{"cell_type": "code", "source": "name = input()\\n%timeit -n 1 -s \\"exec(f\'import {name}\')\\" pass\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+}
+
+
+@pytest.mark.parametrize("description", sorted(_NOTEBOOK_RUNS_PYTHON))
+def test_a_notebook_cell_that_runs_python_is_reported(description, tmp_path):
+    sample = tmp_path / "sample.ipynb"
+    sample.write_text(_NOTEBOOK_RUNS_PYTHON[description])
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 1, f"{description}:\n{proc.stdout}\n{proc.stderr}"
+
+
+# The cell body is data: no interpreter reads it.
+_NOTEBOOK_IS_INERT = {
+    'a bundled help flag never reads the cell body': '{"cells": [{"cell_type": "code", "source": "%%script python -uh\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+    'help wins over interactive mode': '{"cells": [{"cell_type": "code", "source": "%%script python -i --help\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+    'python --help never reads the cell body': '{"cells": [{"cell_type": "code", "source": "%%script python --help\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+    'python -V never reads the cell body': '{"cells": [{"cell_type": "code", "source": "%%script python -V\\nname = input()\\nexec(f\\"import {name}\\")\\n", "metadata": {}, "outputs": [], "execution_count": null}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+}
+
+
+@pytest.mark.parametrize("description", sorted(_NOTEBOOK_IS_INERT))
+def test_a_notebook_cell_that_never_runs_is_quiet(description, tmp_path):
+    sample = tmp_path / "sample.ipynb"
+    sample.write_text(_NOTEBOOK_IS_INERT[description])
+    proc = _run("--paths", str(sample))
+    assert proc.returncode == 0, f"{description}:\n{proc.stdout}\n{proc.stderr}"
+
+
+def test_the_scanner_runs_without_the_match_node_types():
+    """`ast.Match` arrived in 3.10 and both packages declare `requires-python >= 3.9`.
+
+    Naming it directly made every isinstance tuple holding one raise AttributeError
+    there, so the documented command could not scan anything at all. The 3.9 surface is
+    simulated by hiding those attributes rather than by needing a 3.9 interpreter.
+    """
+    import ast
+    import importlib.util
+
+    hidden = [
+        "Match", "MatchAs", "MatchStar", "MatchClass",
+        "MatchMapping", "MatchOr", "MatchSequence", "match_case",
+    ]
+    saved = {name: getattr(ast, name) for name in hidden if hasattr(ast, name)}
+    for name in saved:
+        delattr(ast, name)
+    try:
+        spec = importlib.util.spec_from_file_location("lint_dynamic_exec_39", str(SCRIPT))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        findings = module.scan_file(SCRIPT)
+    finally:
+        for name, value in saved.items():
+            setattr(ast, name, value)
+    assert isinstance(findings, list)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3860,7 +3860,7 @@ _PUSHING_CODE = \
 PushToHubMixin._upload_modified_files(
     PushToHubMixin,
     working_dir = save_directory,
-    repo_id = '{repo_id}',
+    repo_id = {repo_id},
     files_timestamps = files_timestamps,
     commit_message = "Upload Unsloth finetuned model",
     token = token,
@@ -3920,8 +3920,10 @@ def incremental_save_pretrained(
             " "*spaces + \
             re.sub(r"[ ]{8,}", "",
                    _PUSHING_CODE.format(
-                       repo_id = repo_id,
-                       revision = revision,
+                       # `repr` so a repo id or revision carrying a quote is a string
+                       # literal in the generated source rather than more source.
+                       repo_id = repr(repo_id),
+                       revision = repr(revision),
                        use_temp_file = use_temp_file,
                     ).rstrip()
             ).replace("\n", "\n" + " "*spaces)
@@ -3946,7 +3948,7 @@ def incremental_save_pretrained(
             " "*(spaces) + \
             "save_directory = temp_file.name\n" + \
             " "*(spaces) + \
-            f"repo_id = '{repo_id}'\n"
+            f"repo_id = {repo_id!r}\n"
     pass
     save_pretrained = save_pretrained.replace(for_loop, new_for_loop)
 


### PR DESCRIPTION
### Summary

Follow-up to #1108, which merged before these were found. Reviewing the identical checker in `unslothai/unsloth#9777` and `unslothai/notebooks#365` turned up further bypasses and false positives that apply here too, so this carries the same fixes over and keeps the three copies from drifting.

Split out of #1111, which is now just the CPU-fallback fix. Lint only: no runtime code changes.

### Detections added

| Shape | Why it was missed |
|---|---|
| `exec("import {m}".format_map(cfg))` | `format_map` was not next to `format` and `join`, though it is the same replacement-field machinery |
| `payload: str = f"import {name}"` | `ast.AnnAssign` is a sibling of `ast.Assign`, so `visit_Assign` never saw it and a type hint alone hid the binding |
| `exec(f"import {name}".encode())` | `exec` accepts bytes; `_Py_SourceAsString` has an explicit bytes branch |
| `__import__("builtins").exec(...)` | the owner is a `Call`, not a `Name`, so the builtins branch never ran |
| `ast.parse(source = ...)` | the branch required a positional argument |
| `dict(source = ...).get(...)`, `{...}.__getitem__(k)` | only the display and subscript spellings were read |
| `alias: str = payload`, `(alias := payload)`, `alias, _ = payload, None` | these bindings resolved by shape and cleared the taint instead of carrying it |

### False positives removed

- `exec((1).__add__(2))` was reported as string concatenation. It returns the integer 3; no source is built. Both `__add__` and `__mod__` now go through the operator path, which applies the same visibly-numeric exclusion.
- `%%script python --help` cell bodies were scanned as executed Python. Checked against the CLI: piping a program at `--help`, `-h`, `-V`, `--version`, `-uh` or even `-i --help` exits without reading stdin at all.

### Failing closed

A pathological nesting depth used to make `scan_file` return no findings, which is the wrong lever for a gate that reads incoming PR contents. It now raises a `ScanError` naming the file, counted as `unscannable` in the FAIL line, and `--update` refuses to rewrite the allowlist from an incomplete scan.

### Restructured, with no behaviour change

`_is_interpolated` goes from 339 lines to 56 and `_collect_aliases` from 278 to 33, by naming the parts they were already made of. Two dead symbols are gone: a `_Visitor._can_break` with no callers that shadowed the live module-level function of the same name, and a `_CAPTURE` regex nothing read. The tests are grouped by what each case proves rather than by the review round that found it: 726 lines to 414, all 103 fixtures carried over verbatim.

### Verification

Allowlist count is unchanged at **60**, so no new detection matches anything already in tree and no existing justification needed revisiting. A 325-file regression corpus gives identical per-file findings before and after the restructure, across all three copies, and the three copies stay byte-identical apart from `DEFAULT_TARGETS`. `--self-test` and the full scan are green on Python 3.9 and 3.13. `tests/security/test_lint_dynamic_exec.py`: 126 passed.
