### PR TITLE
Drop stale line numbers from the find_spec("unsloth") guard comments

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -131,7 +131,7 @@ jobs:
           }
 
           # CPU index avoids the multi-GB CUDA wheel set. `--no-deps unsloth`
-          # satisfies the find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
+          # satisfies the find_spec("unsloth") guard in unsloth_zoo/__init__.py.
           lane() {
             version="$1"; interpreter="$2"
             venv=".lanes/venv-$version"
@@ -234,7 +234,7 @@ jobs:
             pyproject.toml
 
       - name: Install runtime + test deps
-        # --no-deps unsloth satisfies the find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
+        # --no-deps unsloth satisfies the find_spec("unsloth") guard in unsloth_zoo/__init__.py.
         run: |
           python -m pip install --upgrade pip
           pip install --index-url https://download.pytorch.org/whl/cpu \
@@ -566,7 +566,7 @@ jobs:
       # Pure-Python protobuf parser; transformers' bundled *_pb2.py is rejected by C++ protobuf 4+/5+.
       PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
       UNSLOTH_COMPILE_DISABLE: '1'
-      # Secondary handshake after find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
+      # Secondary handshake after the find_spec("unsloth") guard in unsloth_zoo/__init__.py.
       UNSLOTH_IS_PRESENT: '1'
     steps:
       - name: Harden runner (audit)

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -97,7 +97,7 @@ jobs:
           PY
 
       - name: Import smoke (clean venv)
-        # unsloth_zoo/__init__.py:128 raises ImportError when parent `unsloth` is
+        # unsloth_zoo/__init__.py raises ImportError when parent `unsloth` is
         # absent (deliberate guardrail). A bare `import unsloth_zoo` in a wheel-only
         # venv will fail by design, so the smoke pivots to reading the version
         # string from dist-info METADATA via importlib.metadata.


### PR DESCRIPTION
Four CI comments point at `unsloth_zoo/__init__.py:128` as the `find_spec("unsloth")` guard that a `--no-deps unsloth` install exists to satisfy.

The guard is at line **250**. Line 128 is unrelated: `UNSLOTH_ENABLE_LOGGING` / Triton env setup. The citations predate #1112 and #1114 and are wrong in all four places.

Rather than renumber them, this cites the file and drops the line number, so the comment cannot rot the next time the module shifts.

Comment-only. No workflow logic changes; both files still parse as YAML.

Sites fixed:
- `.github/workflows/consolidated-tests-ci.yml` (3 places: the drift lane installer, the repo-tests installer, and the `UNSLOTH_IS_PRESENT` handshake note)
- `.github/workflows/wheel-smoke.yml` (1 place: the import-smoke pivot note)