### PR TITLE
Stop the PEFT ParamWrapper canary going vacuous on PEFT 0.20.0

### DIFF
--- a/tests/test_peft_paramwrapper_layout_drift.py
+++ b/tests/test_peft_paramwrapper_layout_drift.py
@@ -36,7 +36,7 @@ PER_EXPERT_R   = 4
 TOTAL_RANK     = NUM_EXPERTS * PER_EXPERT_R
 
 
-class _ToyMoE(nn.Module):
+class _ToyExperts(nn.Module):
     num_experts = NUM_EXPERTS
 
     def __init__(self):
@@ -45,6 +45,25 @@ class _ToyMoE(nn.Module):
 
     def forward(self, x):
         return torch.einsum("bh,eih->bei", x, self.gate_up_proj)
+
+
+class _ToyMoE(nn.Module):
+    """Nests the fused parameter one level, as real GPT-OSS does.
+
+    PEFT 0.20.0 refuses to target an nn.Parameter on the top-level module
+    (tuners_utils.py, create_and_replace_param). Held flat, this canary raised
+    there and the wrap-failure skip below swallowed it, so it went permanently
+    vacuous on the newest supported PEFT. Real GPT-OSS has the parameter at
+    ...mlp.experts.gate_up_proj, so nesting is also the more faithful fixture.
+    """
+    num_experts = NUM_EXPERTS
+
+    def __init__(self):
+        super().__init__()
+        self.experts = _ToyExperts()
+
+    def forward(self, x):
+        return self.experts(x)
 
 
 def _peft_supports_target_parameters() -> bool:
@@ -65,14 +84,14 @@ def test_paramwrapper_lora_shape_is_one_of_two_known_layouts():
 
     cfg_kwargs = dict(r=PER_EXPERT_R, lora_alpha=PER_EXPERT_R * 2, lora_dropout=0.0, bias="none")
     try:
-        cfg = LoraConfig(target_parameters=["gate_up_proj"], **cfg_kwargs)
+        cfg = LoraConfig(target_parameters=["experts.gate_up_proj"], **cfg_kwargs)
     except TypeError:
         pytest.skip("Installed PEFT does not accept target_parameters yet")
 
-    try:
-        peft_model = get_peft_model(base, cfg)
-    except Exception as e:
-        pytest.skip(f"PEFT failed to wrap fused 3D param on this build: {e}")
+    # Not a skip. PEFT has already said it supports target_parameters, so failing
+    # to wrap a correctly nested GPT-OSS-shaped parameter is the drift this test
+    # is for. Skipping here is how it stayed silently dead on PEFT 0.20.0.
+    peft_model = get_peft_model(base, cfg)
 
     lora_A = lora_B = None
     for name, p in peft_model.named_parameters():


### PR DESCRIPTION
A sweep of PEFT 0.18.0 through 0.20.0 found this canary has been **silently dead on the newest supported PEFT**.

PEFT 0.20.0 added a guard (`peft/tuners/tuners_utils.py`, `create_and_replace_param`) that refuses to target an `nn.Parameter` on the top-level module:

```
ValueError: Targeting an nn.Parameter on the top-level module is not supported (parameter 'gate_up_proj').
```

`_ToyMoE` held `gate_up_proj` flat, so `get_peft_model` raised and the broad `except Exception: pytest.skip(...)` swallowed it. The test reported a skip and nobody looked again.

## The fix

Nest the fused parameter one level. That is also the more faithful fixture: real GPT-OSS has it at `...mlp.experts.gate_up_proj`, not on the model root.

The wrap failure is no longer a skip. Once PEFT has accepted `target_parameters`, failing to wrap a correctly nested parameter **is** the drift this test exists to catch, and converting that into a skip is exactly how it went dead. The narrow `TypeError` skip for PEFT builds that predate `target_parameters` stays.

## Measured, all five versions in the supported range

| peft | before | after |
|---|---|---|
| 0.18.0 | 2 passed | 2 passed |
| 0.19.0 | 2 passed | 2 passed |
| 0.19.1 | 2 passed | 2 passed |
| 0.20.0 | **1 passed, 1 SKIPPED** | **2 passed** |

(0.18.1 also 2 passed after; it behaves identically to 0.18.0 here.)

## Why this matters beyond the skip

The same sweep found **PEFT flipped its ParamWrapper LoRA layout between 0.19.0 and 0.19.1**, inside the supported range:

```
peft 0.18.0  nested -> swapped
peft 0.18.1  nested -> swapped
peft 0.19.0  nested -> swapped
peft 0.19.1  nested -> standard
peft 0.20.0  nested -> standard
```

`_detect_moe_lora_layout` handles both, so zoo is correct across the whole range and nothing is broken today. But a canary that skips on the newest PEFT cannot warn about the next flip, and this one demonstrably flips.

## One thing I am not claiming

Both arms above also emit `1 error` from the `conftest.py` sys.modules teardown check on the second test. It is present identically before and after, so it is not from this change; it is an artifact of the ad-hoc `PYTHONPATH` harness used to load five unpacked PEFT wheels without building five venvs. Tests only.