### PR TITLE
Close two mxfp4 detector holes, and fix the corruption they hid on transformers 5.0.0

### DIFF
--- a/tests/test_mxfp4_load_path_layout.py
+++ b/tests/test_mxfp4_load_path_layout.py
@@ -21,9 +21,9 @@ Zoo's `convert_moe_packed_tensors` replacement returns the UN-transposed
 [E, G*B*2, D]:
 
   * 4.x             -> module level `mxfp4.dequantize`, called by quantizer_mxfp4
-  * 5.1.0 and newer -> `Mxfp4Dequantize` (a ConversionOps) -> `dequantize_convertops`
+  * 5.0.0 and newer -> `Mxfp4Dequantize` (a ConversionOps) -> `dequantize_convertops`
 
-Zoo only ever patched `dequantize`, so from 5.1.0 the transpose was dropped and
+Zoo only ever patched `dequantize`, so from 5.0.0 the transpose was dropped and
 GPT-OSS loaded with dims 1 and 2 swapped; 5.16.0 deleting the function is what
 finally turned the drift detector red. The existing mxfp4 tests missed it because
 they only exercise the SAVE path, which stayed self-consistent. So assert the
@@ -45,6 +45,7 @@ import pytest
 # against the installed transformers rather than a hardcoded, version-gated shape.
 _PROBE = textwrap.dedent(
     """
+    import inspect
     import torch
     import transformers
     import transformers.integrations.mxfp4 as m
@@ -53,17 +54,33 @@ _PROBE = textwrap.dedent(
         print("SKIP no dequantize_convertops (pre-5.0 ConversionOps path)")
         raise SystemExit(0)
 
+    # Arity-agnostic. transformers 5.0.0 declares
+    # (blocks, scales, target_device); 5.1.0 and newer declare (blocks, scales).
+    # Hardcoding two positionals made this probe die on 5.0.0 with "missing 1
+    # required positional argument: 'target_device'" while capturing the golden,
+    # i.e. it went red before it could measure the corruption it exists to detect.
+    # Mirror Mxfp4Dequantize.convert, which passes the blocks' own device.
+    _N_POS = len([
+        p for p in inspect.signature(m.dequantize_convertops).parameters.values()
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    ])
+
+    def _call(fn, blocks, scales):
+        if _N_POS >= 3:
+            return fn(blocks, scales, blocks.device)
+        return fn(blocks, scales)
+
     E, D, G, B = 2, 4, 3, 16
     torch.manual_seed(0)
     blocks = torch.randint(0, 255, (E, D, G, B), dtype=torch.uint8)
     scales = torch.full((E, D, G), 127, dtype=torch.uint8)
 
-    golden = m.dequantize_convertops(blocks.clone(), scales.clone()).clone()
+    golden = _call(m.dequantize_convertops, blocks.clone(), scales.clone()).clone()
 
     from unsloth_zoo.temporary_patches.mxfp4 import patch_convert_moe_packed_tensors
     patch_convert_moe_packed_tensors()
 
-    after = m.dequantize_convertops(blocks.clone(), scales.clone())
+    after = _call(m.dequantize_convertops, blocks.clone(), scales.clone())
 
     # .cpu(): zoo's convert_moe_packed_tensors moves inputs to the accelerator when
     # one is present, which is intended and irrelevant to the layout being checked.

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -1355,8 +1355,12 @@ def test_mxfp4_dequantize_signature():
 # with the replacement defined in temporary_patches/mxfp4.py: patch_function refuses
 # a replacement whose parameters do not match the original exactly, so a shape that
 # is not listed here is a shape zoo cannot patch.
+# 5.0.0 alone takes target_device; 5.1.0 and newer leave placement to the caller.
+# If the 5.0.0 arm in mxfp4.py is ever dropped, drop the 3-tuple here too, or this
+# test will pass on a version zoo can no longer patch.
 _CONVERTOPS_HANDLED_SIGNATURES = (
     ("blocks", "scales"),
+    ("blocks", "scales", "target_device"),
 )
 
 

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -41,6 +41,13 @@ _TX_IS_5X = Version(_TX_VERSION) >= Version("5.0.0")
 # mxfp4.dequantize and reduced tensor_parallel.shard_and_distribute_module to a
 # tombstone that still imports but raises RuntimeError when called.
 _TX_GE_5_16 = Version(_TX_VERSION) >= Version("5.16.0")
+# transformers 5.10.0 was published from a stale branch, yanked on PyPI ~14 minutes
+# later ("We pushed from a week old main branch ... missing a bunch of fixes") and
+# superseded by 5.10.1. Its tree carries an in-progress refactor in which
+# integrations/tensor_parallel.py had been moved to distributed/tensor_parallel.py
+# and shard_and_distribute_module did not exist anywhere; 5.10.1 restored the
+# integrations layout. It is a retracted artifact, not an upstream API decision.
+_TX_IS_YANKED_5_10_0 = Version(_TX_VERSION) == Version("5.10.0")
 
 
 def _skip_if_transformers_5x(reason: str) -> None:
@@ -1344,14 +1351,31 @@ def test_mxfp4_dequantize_signature():
         )
 
 
+# Every upstream shape zoo's mxfp4.py knows how to replace. MUST be kept in sync
+# with the replacement defined in temporary_patches/mxfp4.py: patch_function refuses
+# a replacement whose parameters do not match the original exactly, so a shape that
+# is not listed here is a shape zoo cannot patch.
+_CONVERTOPS_HANDLED_SIGNATURES = (
+    ("blocks", "scales"),
+)
+
+
 def test_mxfp4_dequantize_convertops_signature():
-    """mxfp4.py patches ``mxfp4.dequantize_convertops`` (blocks, scales) on
-    transformers 5.x.
+    """mxfp4.py patches ``mxfp4.dequantize_convertops`` on transformers 5.x.
 
     The 5.x replacement for module-level ``dequantize``: ``Mxfp4Dequantize.convert``
     is its only caller, and zoo rebinds it to re-apply the ``transpose(1, 2)`` its
     own un-transposed ``convert_moe_packed_tensors`` leaves off. Absent on 4.x, where
-    the legacy ``dequantize`` hook carries the transpose instead."""
+    the legacy ``dequantize`` hook carries the transpose instead.
+
+    EXACT parameter tuple, not a superset. ``can_safely_patch`` refuses any arity
+    the replacement does not match exactly, so a superset check is the wrong
+    predicate here: 5.0.0's 3-arg ``(blocks, scales, target_device)`` IS a superset
+    of ``["blocks", "scales"]`` and sailed through this test while the patch it was
+    meant to police was being rejected at runtime with "Parameter count mismatch:
+    3 vs 2", leaving GPT-OSS loading with dims 1 and 2 swapped. Assert instead that
+    the installed signature is one zoo actually dispatches on; anything else is
+    drift, because anything else is a patch that will not apply."""
     try:
         mod = importlib.import_module("transformers.integrations.mxfp4")
     except Exception as exc:
@@ -1372,12 +1396,18 @@ def test_mxfp4_dequantize_convertops_signature():
             "keeps zoo's un-transposed [E, D, G*B*2] layout and GPT-OSS loads "
             "with dims 1 and 2 swapped."
         )
-    _assert_params_superset(
-        fn,
-        required=["blocks", "scales"],
-        zoo_file="mxfp4.py",
-        label="dequantize_convertops",
-    )
+    got = tuple(_param_names(fn))
+    if got not in _CONVERTOPS_HANDLED_SIGNATURES:
+        pytest.fail(
+            f"DRIFT DETECTED: zoo temporary_patches/mxfp4.py replaces "
+            f"transformers.integrations.mxfp4.dequantize_convertops and has arms "
+            f"for {list(_CONVERTOPS_HANDLED_SIGNATURES)}, but transformers "
+            f"{_TX_VERSION} declares {inspect.signature(fn)}. patch_function will "
+            f"refuse a replacement whose parameters do not match exactly, so the "
+            f"transpose(1, 2) that zoo's un-transposed convert_moe_packed_tensors "
+            f"leaves off would never be restored and GPT-OSS would load with dims "
+            f"1 and 2 swapped."
+        )
     # The class and its call site must both still exist for the patch to reach
     # the loader.
     cls = getattr(mod, "Mxfp4Dequantize", None)
@@ -1493,12 +1523,37 @@ def test_mxfp4_shard_and_distribute_module_present():
     5.16.0 replaced the function with a ``(*args, **kwargs)`` tombstone that raises
     RuntimeError, so there is nothing left to pin above that version and zoo gates
     both call sites off instead. It is a genuine upstream stub, NOT a decorator
-    wrapper: no ``__wrapped__``, so ``follow_wrapped`` recovers nothing."""
+    wrapper: no ``__wrapped__``, so ``follow_wrapped`` recovers nothing.
+
+    An unimportable module is a hard failure on every release EXCEPT the yanked
+    5.10.0, where it is xfail. Not a skip: the consequence is real. gpt_oss.py's
+    import sits under a ``< 5.16.0`` gate inside ``patch_gpt_oss``, so on 5.10.0 it
+    raises and ``return raise_error(...)`` abandons the remainder of that function,
+    losing both ``load_and_swizzle_mxfp4`` and ``replace_with_mxfp4_linear`` --
+    silently, because ``raise_error`` only speaks under UNSLOTH_ENABLE_LOGGING.
+    (Reached only when triton_kernels is installed; without it ``patch_gpt_oss``
+    returns earlier and 5.10.0 costs nothing extra.) xfail keeps that written down
+    and reported, and turns into XPASS if the module ever comes back, whereas a
+    skip would read as "not applicable" and a hard fail would redden a lane no
+    change to zoo can ever green: 5.10.0 is yanked, so the fix is 5.10.1.
+
+    Note that widening the gate to match gpt_oss.py's ``< 5.16.0`` would NOT help:
+    5.10.0 is inside that range, so the test would still fail."""
     try:
         mod = importlib.import_module("transformers.integrations.tensor_parallel")
     except Exception as exc:
+        if _TX_IS_YANKED_5_10_0:
+            pytest.xfail(
+                "transformers 5.10.0 is YANKED upstream (published from a stale "
+                "branch, replaced by 5.10.1 minutes later). It moved "
+                "integrations/tensor_parallel.py to distributed/tensor_parallel.py "
+                "and shipped no shard_and_distribute_module at all, so "
+                "patch_gpt_oss aborts at its gated import and silently drops "
+                "load_and_swizzle_mxfp4 and replace_with_mxfp4_linear on installs "
+                f"that have triton_kernels. Upgrade to 5.10.1 or newer. ({exc})"
+            )
         pytest.fail(
-            "DRIFT DETECTED: zoo temporary_patches/mxfp4.py imports "
+            "DRIFT DETECTED: zoo temporary_patches/mxfp4.py and gpt_oss.py import "
             f"transformers.integrations.tensor_parallel but it is missing: {exc}"
         )
     fn = getattr(mod, "shard_and_distribute_module", None)

--- a/unsloth_zoo/temporary_patches/mxfp4.py
+++ b/unsloth_zoo/temporary_patches/mxfp4.py
@@ -161,20 +161,49 @@ def patch_convert_moe_packed_tensors():
     # that convention), so the live loader hook must restore GPT-OSS's [E, G*B*2, D].
     # Which hook is live:
     #   4.x             -> module level mxfp4.dequantize, called by quantizer_mxfp4
-    #   5.1.0 and newer -> Mxfp4Dequantize (a ConversionOps) -> dequantize_convertops
-    # (5.0.0's dequantize_convertops is 3-arg and excluded by pyproject.) mxfp4.dequantize
-    # survives unreferenced until 5.16.0 (upstream PR #47579, the DTensor TP rewrite)
-    # deletes it, so patching only dequantize dropped the transpose from 5.1.0 on and
-    # loaded GPT-OSS with dims 1 and 2 silently swapped.
+    #   5.0.0 and newer -> Mxfp4Dequantize (a ConversionOps) -> dequantize_convertops
+    # mxfp4.dequantize survives unreferenced from 5.0.0 until 5.16.0 (upstream PR
+    # #47579, the DTensor TP rewrite) deletes it, so patching only dequantize dropped
+    # the transpose from 5.0.0 on and loaded GPT-OSS with dims 1 and 2 silently
+    # swapped.
+    #
+    # 5.0.0 alone declares dequantize_convertops(blocks, scales, target_device); every
+    # release from 5.1.0 on declares (blocks, scales). A 2-arg replacement against the
+    # 3-arg original is refused by can_safely_patch ("Parameter count mismatch: 3 vs
+    # 2"), which left 5.0.0 with the un-transposed convert_moe_packed_tensors above and
+    # nothing restoring the transpose. So pick the arm that matches what is actually
+    # installed.
+    #
+    # Dispatch on the observed parameter names rather than on transformers_version:
+    # arity is the exact property can_safely_patch enforces, so reading it directly
+    # cannot disagree with it, whereas a version gate is a proxy that a backport or a
+    # fork can falsify. An unrecognised signature falls through to the 2-arg arm and is
+    # rejected loudly by can_safely_patch, which is the correct failure mode.
+    _convertops = getattr(transformers.integrations.mxfp4, "dequantize_convertops", None)
+    if _convertops is not None:
+        # 5.x path, called only by Mxfp4Dequantize.convert. Both arms close over the
+        # local un-transposed convert_moe_packed_tensors rather than re-reading the
+        # module attribute, so the transpose stays correct even if patch_function above
+        # did not take and upstream's self-transposing version is still installed.
+        try:
+            _convertops_params = tuple(inspect.signature(_convertops).parameters)
+        except (TypeError, ValueError):
+            _convertops_params = ()
 
-    if hasattr(transformers.integrations.mxfp4, "dequantize_convertops"):
-        # 5.x path, called only by Mxfp4Dequantize.convert. Closes over the local
-        # un-transposed convert_moe_packed_tensors rather than re-reading the module
-        # attribute, so the transpose stays correct even if patch_function above did
-        # not take and upstream's self-transposing version is still installed.
-        def dequantize_convertops(blocks, scales):
-            dequantized = convert_moe_packed_tensors(blocks, scales)
-            return torch.nn.Parameter(dequantized.transpose(1, 2).contiguous())
+        if _convertops_params == ("blocks", "scales", "target_device"):
+            # 5.0.0. Mirrors upstream's own body (empty_cache before the move, and the
+            # result placed on target_device) with the transpose added back.
+            def dequantize_convertops(blocks, scales, target_device):
+                dequantized = convert_moe_packed_tensors(blocks, scales)
+                dequantized = dequantized.transpose(1, 2).contiguous()
+                if target_device == "cpu" and torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+                return torch.nn.Parameter(dequantized.to(target_device))
+        else:
+            # 5.1.0 and newer. Upstream leaves placement to its caller here.
+            def dequantize_convertops(blocks, scales):
+                dequantized = convert_moe_packed_tensors(blocks, scales)
+                return torch.nn.Parameter(dequantized.transpose(1, 2).contiguous())
         patch_function(transformers.integrations.mxfp4, "dequantize_convertops", dequantize_convertops)
 
     if transformers_version < Version("5.0.0"):


### PR DESCRIPTION
Two commits, deliberately separable. `403df55b` is the detector work and is pin-independent; `2796ba13` is the 5.0.0 code fix. Dropping the second leaves a coherent tree.

## The detector holes (the part that matters most)

Both would let the **next** upstream arity change through silently, on versions squarely inside the supported set.

**1. The signature detector could not fail.** `test_mxfp4_dequantize_convertops_signature` used `_assert_params_superset(fn, required=["blocks", "scales"])`. A 3-arg upstream **is** a superset of a 2-arg requirement, so the exact property `can_safely_patch` enforces sailed straight through the test meant to police it. Demonstrated against real 5.0.0, not a synthetic: old assertion GREEN where the patch is in fact being refused.

**2. The layout probe crashed instead of measuring.** It hardcoded a 2-positional call, so on 5.0.0 it died capturing the golden with `TypeError: dequantize_convertops() missing 1 required positional argument`. Right colour, wrong reason, and it told you nothing about the layout. It now passes `len(inspect.signature(fn).parameters)` positionals:

```
old probe + old zoo -> TypeError (crashes before measuring)
new probe + old zoo -> FAIL: loader got (2, 4, 96), stock gives (2, 96, 4)
new probe + new zoo -> pass
```

**3. `test_mxfp4_shard_and_distribute_module_present` on transformers 5.10.0.** The test called `pytest.fail` unconditionally while the code it guards is version-gated, reddening a lane no change to zoo could ever green. That is how hole 1 survived. It is now `xfail` on exactly 5.10.0 and a hard failure everywhere else.

Not a skip, and not a widened gate. Aligning the gate with `gpt_oss.py`'s `< 5.16.0` does not work, because 5.10.0 sits inside that range. And this is not drift: upstream moved the module to `transformers/distributed/tensor_parallel.py`, deleted `shard_and_distribute_module` at that tag, then restored the `integrations` layout in 5.10.1 fourteen minutes later, and PyPI has yanked 5.10.0. A drift detector firing on a retracted artifact is a false positive. `xfail` keeps it in the report and flips to XPASS if the module returns; a skip would read "not applicable," which is false.

## The corruption on 5.0.0

The existing comment said 5.0.0's 3-arg `dequantize_convertops` was "excluded by pyproject." That reads as safe, and it is not. `hasattr` is true, so zoo attempts the 2-arg patch, `can_safely_patch` refuses it (`Parameter count mismatch: 3 vs 2`, logged only under `UNSLOTH_ENABLE_LOGGING`), and `convert_moe_packed_tensors` has already been swapped for the un-transposed version. Nothing restores `transpose(1, 2)`, so GPT-OSS loads with dims 1 and 2 swapped. The pin never protected the code path; it only stops a default resolve.

The fix dispatches on the **observed parameter names**, not on `transformers_version`. Arity is the exact property `can_safely_patch` enforces, so reading it directly cannot disagree with it, whereas a version gate is a proxy a backport or fork can falsify. An unrecognised signature falls through to the 2-arg arm and is rejected loudly.

The 5.0.0 arm mirrors upstream's own body (verified against the `v5.0.0` tag: `empty_cache` when `target_device == "cpu"`, result placed on `target_device`) with the transpose added back before placement.

## Measured, nine versions

Layout tuples from an arity-agnostic probe, golden captured pre-patch in-process on the same input.

| transformers | arity | stock | before | after | drift file (after) |
|---|---|---|---|---|---|
| 4.57.6 | absent | n/a | n/a | n/a | 101 passed, 18 skipped |
| **5.0.0** | **3** | (2, 96, 4) | **(2, 4, 96)** | **(2, 96, 4)** | 97 passed, 22 skipped |
| 5.1.0 | 2 | (2, 96, 4) | (2, 96, 4) | (2, 96, 4) | 97 passed, 22 skipped |
| 5.5.0 | 2 | (2, 96, 4) | (2, 96, 4) | (2, 96, 4) | 106 passed, 13 skipped |
| 5.9.0 | 2 | (2, 96, 4) | (2, 96, 4) | (2, 96, 4) | 106 passed, 13 skipped |
| 5.10.0 | 2 | (2, 96, 4) | (2, 96, 4) | (2, 96, 4) | 105 passed, 13 skipped, 1 xfailed |
| 5.10.1 | 2 | (2, 96, 4) | (2, 96, 4) | (2, 96, 4) | 106 passed, 13 skipped |
| 5.16.0 | 2 | (2, 96, 4) | (2, 96, 4) | (2, 96, 4) | 103 passed, 16 skipped |
| 5.16.1 | 2 | (2, 96, 4) | (2, 96, 4) | (2, 96, 4) | 103 passed, 16 skipped |

Signature census: 5.0.0 alone at 3 params, the other seven at 2. No collateral failures on any version.

**Mutation-verified.** The first commit alone is the mutation: detectors without the code fix, swept over all nine versions, green everywhere and on 5.0.0 both fire against genuine upstream (`arity=3 golden=(2, 96, 4) after=(2, 4, 96) dqc_patched=False verdict=CORRUPT_SHAPE` plus `FAILED test_mxfp4_dequantize_convertops_signature`). The tightened signature assertion also goes red if upstream renames the third parameter or grows a fourth, and stays green on both real signatures.

## One correction to an earlier claim

I previously described the 5.10.0 problem as test-only. It is not, though it is conditional. `return raise_error(...)` sits at line 466 **inside** `patch_gpt_oss` (114-577), so it abandons the rest of that function and loses two patches, `load_and_swizzle_mxfp4` and `replace_with_mxfp4_linear`. But `patch_gpt_oss` returns unconditionally at line 156 when `triton_kernels` is absent (traced: `last_line_executed=156`, `reached_tp_import=False`), so the loss only materialises on real GPT-OSS MXFP4 GPU setups.

That mid-function `return raise_error(...)` pattern, where one failed optional import silently abandons every later patch, is worth its own issue. It is not specific to mxfp4 and fixing it changes behaviour on many versions, so it is out of scope here.

## Pins

Unchanged, deliberately. Recording the verification only: `!=5.1.0` is unnecessary (5.1.0 measured clean), the `<=5.5.0` cap is stale across these nine (5.9.0 through 5.16.1 all clean), and `!=5.10.0` is not needed since the PyPI yank already stops resolvers. Note the constraint string is duplicated at `pyproject.toml` lines 55 and 100.