### PR TITLE
feat(mlx): support Qwen3.8-Flash-Next and GLM-5.3-Flash — differentiable MoE routing, structural patch selection, and text-path loading

### DIFF
--- a/tests/mlx_simulation/mlx_stub.py
+++ b/tests/mlx_simulation/mlx_stub.py
@@ -71,7 +71,13 @@ class _PermissiveModule(types.ModuleType):
     def __getattr__(self, name):
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
-        return _Noop(f"{self.__name__}.{name}")
+        # Cached, so a module attribute has stable identity the way a real
+        # module's does. Without this, `getattr(mx, n) is getattr(mx, n)` is
+        # False for anything unimplemented, and code that saves an attribute and
+        # later asserts it was restored can never pass under the shim.
+        value = _Noop(f"{self.__name__}.{name}")
+        setattr(self, name, value)
+        return value
 
 
 class _Noop:
@@ -165,10 +171,18 @@ def __getattr__(name):
 
     This is what makes `mx.some_op_we_havent_implemented_yet` not crash
     at import time but raise with a clear name when actually called.
+
+    The sentinel is cached into the module so repeated lookups return the SAME
+    object, the way a real module's attributes do. Production code that wraps an
+    `mx.*` op and later restores it compares identity to prove the restore
+    happened; with a fresh sentinel per lookup that comparison can never hold and
+    the shim fails such a test no matter how correct the code is.
     """
     if name.startswith("__") and name.endswith("__"):
         raise AttributeError(name)
-    return _Noop(f"mlx.core.{name}")
+    value = _Noop(f"mlx.core.{name}")
+    globals()[name] = value
+    return value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -40,6 +40,8 @@ if not _HAS_REAL_MLX:
 
 import mlx.core as mx  # noqa: E402  (real, or the torch shim on CI)
 
+from unsloth_zoo.mlx.loader import (  # noqa: E402
+    _disable_fused_input_projections, _disable_fused_mrope)
 from unsloth_zoo.mlx.utils import (  # noqa: E402
     _MLX_INDEX_OP_NAMES, acquire_mlx_training_patches, mlx_training_patches_active,
     pause_mlx_training_patches, release_mlx_training_patches,
@@ -570,3 +572,62 @@ def test_qwen35_attention_detection_follows_the_mro():
     subclass = type("Qwen4ExpAttention", (base,), {})
     assert model_has_qwen35_attention_layers(_FakeModel(subclass()))
     assert not model_has_qwen35_attention_layers(_FakeModel(object()))
+
+
+@pytest.mark.parametrize("disable, flag, extra", [
+    (_disable_fused_input_projections, "fuse_in", {"_fused_ready": True}),
+    (_disable_fused_mrope, "fused_apply", {}),
+])
+def test_disabling_a_fusion_targets_only_fused_modules(disable, flag, extra):
+    """The returned modules are what the trainer re-fuses once training is over."""
+    fused = types.SimpleNamespace(**{flag: True}, **extra)
+    plain = types.SimpleNamespace()
+    assert disable(_FakeModel(fused, plain)) == [fused]
+    assert getattr(fused, flag) is False
+    assert not hasattr(plain, flag)
+    # The projection fusion also drops the concatenation it cached.
+    assert not extra or fused._fused_ready is False
+    assert disable(_FakeModel(fused, plain)) == []
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("mlx_vlm.models.glm5_next") is None
+    or not _HAS_REAL_MLX,
+    reason="needs mlx-vlm with glm5_next on real MLX",
+)
+def test_unfused_projection_matches_the_fused_one():
+    if sys.modules.get("mlx.core") is not mx:
+        pytest.skip("another suite installed the MLX shim")
+    from mlx_vlm.models.glm5_next.config import TextConfig
+    from mlx_vlm.models.glm5_next.language import Glm5NextLinearAttention
+
+    config = TextConfig(
+        model_type="glm5_next_text", vocab_size=64, hidden_size=64, intermediate_size=128,
+        moe_intermediate_size=64, num_hidden_layers=1, num_attention_heads=4,
+        num_key_value_heads=4, n_shared_experts=1, n_routed_experts=4, index_topk=8,
+        routed_scaling_factor=1.0, kv_lora_rank=16, q_lora_rank=32, qk_rope_head_dim=0,
+        v_head_dim=32, qk_nope_head_dim=32, num_experts_per_tok=2, index_n_heads=2,
+        first_k_dense_replace=0, max_position_embeddings=256, rms_norm_eps=1e-5,
+        index_head_dim=32, layer_types=["linear_attention"], mlp_layer_types=["dense"],
+        linear_attn_config={"num_heads": 2, "head_dim": 32,
+                            "short_conv_kernel_size": 4, "gate_lower_bound": -5.0},
+    )
+    module = Glm5NextLinearAttention(config)
+    mx.eval(module.parameters())
+    x = mx.random.normal((1, 16, config.hidden_size))
+
+    fused = module(x)
+    mx.eval(fused)
+
+    # A zero-initialized adapter leaves the output unchanged, but the fusion
+    # reads `.weight` off the projection and LoRALinear has none.
+    from mlx_lm.tuner.lora import LoRALinear
+    module.update_modules({"q_proj": LoRALinear.from_base(module.q_proj, r=4)})
+    module._fused_ready = False
+    with pytest.raises(AttributeError):
+        module(x)
+
+    assert _disable_fused_input_projections(_FakeModel(module)) == [module]
+    unfused = module(x)
+    mx.eval(unfused)
+    assert mx.allclose(fused, unfused, atol=1e-5, rtol=1e-5).item()

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -494,6 +494,26 @@ def test_one_trainers_evaluation_leaves_another_threads_flag_alone():
     assert not mlx_training_patches_active()
 
 
+def test_resume_keeps_its_reference_when_another_run_acquired_mid_pause():
+    """A pauses as the sole holder, B acquires during the pause, A resumes. If the
+    resume assigns the depth instead of incrementing it, A's reference is lost and
+    B's release unpatches mlx.core while A is still differentiating."""
+    acquire_mlx_training_patches()                      # A trains
+    try:
+        paused = pause_mlx_training_patches()           # A evaluates, sole holder
+        assert paused is True
+        acquire_mlx_training_patches()                  # B trains during A's eval
+        try:
+            resume_mlx_training_patches(paused)         # A back to training
+        finally:
+            release_mlx_training_patches()              # B finishes first
+        assert mx.take_along_axis._unsloth_index_stop_gradient, (
+            "B's release unpatched mlx.core while A was still training")
+    finally:
+        release_mlx_training_patches()
+    assert not hasattr(mx.take_along_axis, "_unsloth_index_stop_gradient")
+
+
 def test_detaching_preserves_container_types():
     """`mx.checkpoint` hands the layer its own arguments back, so rebuilding a
     NamedTuple as a plain tuple turns `payload.ids` into an AttributeError."""

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -44,9 +44,9 @@ import mlx.nn as nn  # noqa: E402
 from unsloth_zoo.mlx.loader import (  # noqa: E402
     _disable_fused_input_projections, _disable_fused_mrope)
 from unsloth_zoo.mlx.utils import (  # noqa: E402
-    _MLX_INDEX_OP_NAMES, acquire_mlx_training_patches, mlx_training_patches_active,
-    pause_mlx_training_patches, release_mlx_training_patches,
-    resume_mlx_training_patches)
+    _MLX_INDEX_OP_NAMES, _detach_integer_arrays, acquire_mlx_training_patches,
+    mlx_training_patches_active, pause_mlx_training_patches,
+    release_mlx_training_patches, resume_mlx_training_patches)
 
 _HAS_METAL = _HAS_REAL_MLX and mx.metal.is_available()
 requires_metal = pytest.mark.skipif(
@@ -416,9 +416,14 @@ def test_window_depth_accounting():
     assert not mlx_training_patches_active()
     acquire_mlx_training_patches()
     acquire_mlx_training_patches()
-    # The outer run still needs the window, so this pause must be refused.
+    # The outer run still needs the patches, so removing them is refused -- but
+    # the evaluation doing the pausing must still stop reading as training,
+    # otherwise nesting silently routes it down the training paths.
     assert pause_mlx_training_patches() is False
-    assert mlx_training_patches_active() and mx.take_along_axis._unsloth_index_stop_gradient
+    assert not mlx_training_patches_active()
+    assert mx.take_along_axis._unsloth_index_stop_gradient
+    resume_mlx_training_patches(False)
+    assert mlx_training_patches_active()
     release_mlx_training_patches()
     assert pause_mlx_training_patches() is True
     assert not mlx_training_patches_active()
@@ -431,6 +436,65 @@ def test_window_depth_accounting():
     # Outside a run there is nothing to close, and nothing to reopen.
     resume_mlx_training_patches(pause_mlx_training_patches())
     assert not mlx_training_patches_active()
+
+
+def test_pause_stops_evaluation_reading_as_training_at_any_depth():
+    """`_is_training_call` consults the window, so an evaluation that cannot
+    remove the process-wide patches must still stop being counted as training."""
+    for depth in (1, 2, 3):
+        for _ in range(depth):
+            acquire_mlx_training_patches()
+        assert mlx_training_patches_active()
+        paused = pause_mlx_training_patches()
+        assert paused is (depth == 1), "only a lone run may unpatch mlx.core"
+        assert not mlx_training_patches_active(), (
+            f"evaluation still reads as training at depth {depth}")
+        resume_mlx_training_patches(paused)
+        assert mlx_training_patches_active()
+        for _ in range(depth):
+            release_mlx_training_patches()
+        assert not mlx_training_patches_active()
+
+
+def test_detaching_preserves_container_types():
+    """`mx.checkpoint` hands the layer its own arguments back, so rebuilding a
+    NamedTuple as a plain tuple turns `payload.ids` into an AttributeError."""
+    import collections
+
+    Payload = collections.namedtuple("Payload", "ids hidden")
+    ids = mx.array([1, 2, 3])
+    payload = Payload(ids=ids, hidden=mx.zeros((2, 2)))
+
+    out = _detach_integer_arrays(payload)
+    assert isinstance(out, Payload) and out.ids.tolist() == [1, 2, 3]
+
+    nested = _detach_integer_arrays({"mask": [payload], "axis": 1})
+    assert isinstance(nested, dict) and isinstance(nested["mask"][0], Payload)
+    assert nested["axis"] == 1
+
+    plain = _detach_integer_arrays((ids, [ids]))
+    assert type(plain) is tuple and isinstance(plain[1], list)
+    assert plain[0].tolist() == plain[1][0].tolist() == [1, 2, 3]
+
+
+def test_patch_gated_delta_survives_an_mlx_lm_without_the_module(monkeypatch):
+    """Layers are matched structurally now, so an mlx-vlm-defined gated-delta
+    mixer routes here even where mlx_lm ships no `models/gated_delta`."""
+    from unsloth_zoo import gated_delta_vjp
+
+    class _Block:
+        def find_spec(self, name, path=None, target=None):
+            if name == "mlx_lm.models.gated_delta":
+                raise ModuleNotFoundError(f"No module named '{name}'", name=name)
+            return None
+
+    monkeypatch.delitem(sys.modules, "mlx_lm.models.gated_delta", raising=False)
+    monkeypatch.setattr(sys, "meta_path", [_Block()] + sys.meta_path)
+    mlx_lm_models = sys.modules.get("mlx_lm.models")
+    if mlx_lm_models is not None:
+        monkeypatch.delattr(mlx_lm_models, "gated_delta", raising=False)
+
+    gated_delta_vjp.patch_gated_delta()          # must not raise
 
 
 @requires_real_mlx

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -21,6 +21,8 @@
 #     B >= 2 (mx `.at[:, t].add` corrupted rows past the first on mlx 0.31,
 #     fixed by ml-explore/mlx#3483). Metal-only.
 #   * kernel routing: training calls must reach the fused-kernel VJP.
+#   * the training window that turns those patches on, the index detachment it
+#     installs, and the fusions it must disable.
 
 from __future__ import annotations
 
@@ -38,10 +40,16 @@ if not _HAS_REAL_MLX:
 
 import mlx.core as mx  # noqa: E402  (real, or the torch shim on CI)
 
+from unsloth_zoo.mlx.utils import (  # noqa: E402
+    _MLX_INDEX_OP_NAMES, acquire_mlx_training_patches, mlx_training_patches_active,
+    pause_mlx_training_patches, release_mlx_training_patches,
+    resume_mlx_training_patches)
+
 _HAS_METAL = _HAS_REAL_MLX and mx.metal.is_available()
 requires_metal = pytest.mark.skipif(
     not _HAS_METAL, reason="needs Apple Silicon Metal GPU"
 )
+requires_real_mlx = pytest.mark.skipif(not _HAS_REAL_MLX, reason="needs real MLX")
 
 # Snapshot the REAL mlx/mlx_lm modules now, before sibling test files install
 # the mlx_simulation torch-stub into sys.modules, so the code under test
@@ -349,3 +357,97 @@ def test_kernel_dispatch_guards_partial_threadgroup_rows():
     bad_v = mx.zeros((1, 8, 2, 30))
     assert gv.gated_delta_kernel_supported(q, g, None, ok_v)
     assert not gv.gated_delta_kernel_supported(q, g, None, bad_v)
+
+
+# -- training window and index detachment -------------------------------------
+
+@pytest.fixture
+def index_stop():
+    acquire_mlx_training_patches()
+    try:
+        yield
+    finally:
+        release_mlx_training_patches()
+
+
+def test_window_depth_accounting():
+    """Trainer runs overlap and the patches are global: an inner window must not
+    unpatch an outer one, and a pause must refuse while anyone else holds it."""
+    originals = {name: getattr(mx, name) for name in _MLX_INDEX_OP_NAMES}
+    assert not mlx_training_patches_active()
+    acquire_mlx_training_patches()
+    acquire_mlx_training_patches()
+    # The outer run still needs the window, so this pause must be refused.
+    assert pause_mlx_training_patches() is False
+    assert mlx_training_patches_active() and mx.take_along_axis._unsloth_index_stop_gradient
+    release_mlx_training_patches()
+    assert pause_mlx_training_patches() is True
+    assert not mlx_training_patches_active()
+    assert not hasattr(mx.take_along_axis, "_unsloth_index_stop_gradient")
+    resume_mlx_training_patches(True)
+    assert all(getattr(mx, n)._unsloth_index_stop_gradient for n in _MLX_INDEX_OP_NAMES)
+    release_mlx_training_patches()
+    assert not mlx_training_patches_active()
+    assert all(getattr(mx, n) is originals[n] for n in _MLX_INDEX_OP_NAMES)
+    # Outside a run there is nothing to close, and nothing to reopen.
+    resume_mlx_training_patches(pause_mlx_training_patches())
+    assert not mlx_training_patches_active()
+
+
+@requires_real_mlx
+def test_router_gradient_matches_detached_reference(index_stop):
+    """Top-k routing in the shape every MoE block uses. An all-zero grad would
+    mean the score path was severed with the index path, leaving it untrained."""
+    x, w = mx.random.normal((4, 8)), mx.random.normal((8, 6))
+    raw = mx.argpartition._unsloth_index_original
+
+    def router(w, argpartition=mx.argpartition, detach=lambda i: i):
+        gates = mx.softmax(x @ w, axis=-1)
+        inds = detach(argpartition(gates, kth=-2, axis=-1)[..., -2:])
+        return mx.take_along_axis(gates, inds, axis=-1).sum()
+
+    grad = mx.grad(router)(w)
+    expected = mx.grad(lambda w: router(w, raw, mx.stop_gradient))(w)
+    mx.eval(grad, expected)
+    assert mx.allclose(grad, expected, atol=1e-6).item()
+    assert mx.abs(grad).sum().item() > 0
+
+
+def _gather_sort_loss(w):
+    """SwitchGLU's `x[argsort(indices)]` produces the index inside __getitem__."""
+    h = mx.random.normal((8, 4)) @ w
+    return h[mx.argsort(h[:, 0])].sum()
+
+
+def _sparse_mask_loss(w):
+    """GLM-5.x's mask index never passes through an arg* op at all."""
+    h = mx.random.normal((2, 6)) @ w
+    safe = mx.where(h[:, :2] > 0, mx.array([[0, 2], [1, 3]]), 3)
+    scattered = mx.put_along_axis(mx.zeros_like(h), safe, mx.array(1.0), axis=-1)
+    return (h * scattered).sum()
+
+
+@requires_real_mlx
+@pytest.mark.parametrize("loss, shape",
+                         [(_gather_sort_loss, (4, 4)), (_sparse_mask_loss, (6, 4))])
+def test_index_derived_graphs_stay_differentiable(loss, shape, index_stop):
+    grad = mx.grad(loss)(mx.random.normal(shape))
+    mx.eval(grad)
+    assert mx.abs(grad).sum().item() > 0
+
+
+@requires_real_mlx
+def test_only_the_index_argument_is_detached(index_stop):
+    """MLX differentiates integer arrays; detaching every one would drop a real gradient."""
+    data = mx.array([[10, 20], [30, 40]])
+    grad = mx.grad(
+        lambda d: mx.take_along_axis(d * 2, mx.array([[0], [1]]), axis=-1).sum()
+    )(data)
+    mx.eval(grad)
+    assert grad.tolist() == [[2, 0], [0, 2]]
+
+    # SwitchGLU's quantized path passes lhs_indices=None, which must not detach.
+    a, b = mx.random.normal((4, 3, 5)), mx.random.normal((4, 5, 2))
+    rhs = mx.array([0, 2, 1, 3], dtype=mx.uint32)
+    assert mx.gather_mm(a, b, None, rhs).shape == (4, 3, 2)
+    assert mx.gather_mm(a, b, lhs_indices=None, rhs_indices=rhs).shape == (4, 3, 2)

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -456,6 +456,44 @@ def test_pause_stops_evaluation_reading_as_training_at_any_depth():
         assert not mlx_training_patches_active()
 
 
+def test_one_trainers_evaluation_leaves_another_threads_flag_alone():
+    """The flag is what routes a backward pass, so clearing it globally is a crash,
+    not a slowdown: a call site like GLM-5.x's passes no `use_kernel`, and reading
+    as inference sends its backward to the fused kernel, which has no VJP."""
+    import threading
+
+    b_holds, a_paused = threading.Event(), threading.Event()
+    seen = {}
+
+    def second_trainer():
+        acquire_mlx_training_patches()
+        try:
+            b_holds.set()
+            a_paused.wait(10)
+            seen["active"] = mlx_training_patches_active()
+        finally:
+            release_mlx_training_patches()
+
+    acquire_mlx_training_patches()
+    thread = threading.Thread(target=second_trainer)
+    thread.start()
+    try:
+        assert b_holds.wait(10)
+        paused = pause_mlx_training_patches()
+        assert paused is False, "the other trainer still needs mlx.core patched"
+        assert not mlx_training_patches_active(), "our own evaluation reads as training"
+    finally:
+        a_paused.set()
+        thread.join(30)
+        resume_mlx_training_patches(False)
+        release_mlx_training_patches()
+
+    assert seen["active"] is True, (
+        "one trainer's evaluation cleared the training flag out from under another "
+        "thread that was still differentiating")
+    assert not mlx_training_patches_active()
+
+
 def test_detaching_preserves_container_types():
     """`mx.checkpoint` hands the layer its own arguments back, so rebuilding a
     NamedTuple as a plain tuple turns `payload.ids` into an AttributeError."""

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -213,6 +213,30 @@ def test_structural_detection():
     assert not model_has_gated_delta_layers(_Broken())
 
 
+def test_structural_detection_matches_unnamed_linear_attention(monkeypatch):
+    """GLM-5.x holds the gate-decay pair on a `Glm5NextForgetGate` under a mixer
+    named `Glm5NextLinearAttention`; what separates it from an SSM gate carrying the
+    same parameters is that its defining module binds `gated_delta_update`."""
+    from unsloth_zoo.mlx.compile import model_has_gated_delta_layers
+
+    class _ForgetGate:
+        A_log = dt_bias = object()
+
+    class _SelfAttn: pass       # same module, no gate decay: must NOT match
+
+    _model = lambda *m: types.SimpleNamespace(named_modules=lambda: list(enumerate(m)))
+
+    for suffix, binds_update in (("linear_attention", True), ("ssm", False)):
+        module = types.ModuleType(f"fake_pkg.{suffix}")
+        if binds_update:
+            module.gated_delta_update = lambda *a, **k: None
+        monkeypatch.setitem(sys.modules, module.__name__, module)
+        _ForgetGate.__module__ = _SelfAttn.__module__ = module.__name__
+        mixer, gate, attn = types.SimpleNamespace(), _ForgetGate(), _SelfAttn()
+        assert bool(model_has_gated_delta_layers(_model(mixer, gate))) is binds_update
+        assert not model_has_gated_delta_layers(_model(mixer, attn))
+
+
 # -- gradient parity vs plain autodiff (Metal only) ---------------------------
 
 
@@ -276,7 +300,8 @@ def test_vjp_matches_plain_autodiff(impl, case):
 
 @requires_metal
 def test_patched_update_routes_training_to_kernel_path(monkeypatch):
-    """state=None + no mask must take the kernel VJP."""
+    """A call site asking for the differentiable path, or an open window, takes the
+    kernel VJP; an empty cache alone must not. Only the spy proves which ran."""
     import unsloth_zoo.gated_delta_vjp as gv
 
     called = {}
@@ -298,9 +323,20 @@ def test_patched_update_routes_training_to_kernel_path(monkeypatch):
     b = mx.random.normal((B, T, Hv))
     A_log = mx.random.normal((Hv,))
     dt_bias = mx.random.normal((Hv,))
-    y, s = gd.gated_delta_update(q, k, v, a, b, A_log, dt_bias, state=None)
-    mx.eval(y, s)
+    mx.eval(gd.gated_delta_update(q, k, v, a, b, A_log, dt_bias, state=None))
+    assert not called, "uncached inference was routed to the training VJP"
+
+    acquire_mlx_training_patches()
+    try:
+        mx.eval(gd.gated_delta_update(q, k, v, a, b, A_log, dt_bias, state=None))
+    finally:
+        release_mlx_training_patches()
     assert called.get("kernel"), "training call did not route to kernel VJP"
+
+    called.clear()
+    mx.eval(gd.gated_delta_update(q, k, v, a, b, A_log, dt_bias, state=None,
+                                  use_kernel=False))
+    assert called.get("kernel"), "use_kernel=False did not get the efficient VJP"
 
 
 def test_vlm_patch_rebinds_both_namespaces_and_sweep_skips_it(
@@ -451,3 +487,86 @@ def test_only_the_index_argument_is_detached(index_stop):
     rhs = mx.array([0, 2, 1, 3], dtype=mx.uint32)
     assert mx.gather_mm(a, b, None, rhs).shape == (4, 3, 2)
     assert mx.gather_mm(a, b, lhs_indices=None, rhs_indices=rhs).shape == (4, 3, 2)
+
+
+# -- the shared mlx-vlm gated-delta module ------------------------------------
+
+# mlx-vlm 0.6.5 keeps the shared module under `text_models`; 0.6.6 moved it up.
+_SHARED_GATED_DELTA = ("mlx_vlm.models.gated_delta",
+                       "mlx_vlm.models.text_models.gated_delta")
+
+
+@pytest.mark.parametrize("shared_name", _SHARED_GATED_DELTA)
+def test_shared_patch_rebinds_consumers_and_forwards_lower_bound(shared_name, monkeypatch):
+    seen = {}
+
+    def original(q, k, v, a, b, A_log, dt_bias,
+                 state=None, mask=None, use_kernel=True, **kw):
+        seen["kw"] = kw
+        return "cached", state
+
+    shared = types.ModuleType(shared_name)
+    consumer = types.ModuleType("mlx_vlm.models.glm5_next.language")
+    models_pkg = types.ModuleType("mlx_vlm.models")
+    shared.gated_delta_update = consumer.gated_delta_update = original
+    models_pkg.gated_delta = shared
+    monkeypatch.setitem(sys.modules, "mlx_vlm.models", models_pkg)
+    # Mutually exclusive layouts: hide whichever one is not under test.
+    for _name in _SHARED_GATED_DELTA:
+        monkeypatch.delitem(sys.modules, _name, raising=False)
+    monkeypatch.setitem(sys.modules, shared_name, shared)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.models.glm5_next.language", consumer)
+
+    from unsloth_zoo.gated_delta_vjp import patch_gated_delta_vlm_shared
+    patch_gated_delta_vlm_shared()
+
+    patched = shared.gated_delta_update
+    assert patched is not original
+    assert consumer.gated_delta_update is patched
+    assert shared._unsloth_gated_delta_patched
+
+    # A cached call keeps the fused kernel and must carry the gate lower bound.
+    assert patched(*[object()] * 7, state="kv", lower_bound=-5.0) == ("cached", "kv")
+    assert seen["kw"] == {"lower_bound": -5.0}
+
+    # Prefill is uncached too, so an empty state is not a training signal.
+    assert patched(*[object()] * 7) == ("cached", None)
+    # mlx-vlm had no `lower_bound` here before 0.6.9; do not invent one for it.
+    assert seen["kw"] == {}
+
+    # Inside a window it takes the training branch, which must gate through
+    # `compute_g_safe`: GLM-5.x clamps the decay and qwen3_5 does not.
+    import unsloth_zoo.gated_delta_vjp as gv
+    shared.compute_g = lambda *a: pytest.fail("bounded gate took the plain path")
+    shared.compute_g_safe = lambda A_log, a, dt, lb: seen.setdefault("bound", lb)
+    monkeypatch.setattr(gv, "gated_delta_kernel_supported", lambda *a: False)
+    monkeypatch.setattr(gv, "gated_delta_ops_efficient", lambda *a: "vjp")
+    z = mx.zeros((1, 4, 2, 8))
+    acquire_mlx_training_patches()
+    try:
+        assert patched(*[z] * 7, lower_bound=-5.0) == "vjp"
+    finally:
+        release_mlx_training_patches()
+    assert seen["bound"] == -5.0
+
+
+# -- fusions and caches the trainer must turn off -----------------------------
+
+class _FakeModel:
+    def __init__(self, *modules):
+        self._modules = modules
+
+    def modules(self):
+        return list(self._modules)
+
+    def named_modules(self):
+        return [(f"layers.{i}", m) for i, m in enumerate(self._modules)]
+
+
+def test_qwen35_attention_detection_follows_the_mro():
+    from unsloth_zoo.mlx.compile import model_has_qwen35_attention_layers
+
+    base = type("Qwen3_5Attention", (), {})
+    subclass = type("Qwen4ExpAttention", (base,), {})
+    assert model_has_qwen35_attention_layers(_FakeModel(subclass()))
+    assert not model_has_qwen35_attention_layers(_FakeModel(object()))

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -39,6 +39,7 @@ if not _HAS_REAL_MLX:
     simulate_mlx_on_torch()
 
 import mlx.core as mx  # noqa: E402  (real, or the torch shim on CI)
+import mlx.nn as nn  # noqa: E402
 
 from unsloth_zoo.mlx.loader import (  # noqa: E402
     _disable_fused_input_projections, _disable_fused_mrope)
@@ -430,6 +431,32 @@ def test_window_depth_accounting():
     # Outside a run there is nothing to close, and nothing to reopen.
     resume_mlx_training_patches(pause_mlx_training_patches())
     assert not mlx_training_patches_active()
+
+
+@requires_real_mlx
+def test_checkpointed_layer_detaches_integer_arguments():
+    """A layer that embeds the token ids it was handed derives a gather index,
+    and `mx.checkpoint` makes every argument a primal MLX wants a gradient for."""
+    from unsloth_zoo.mlx.utils import _patch_layer_class_for_gc, _unpatch_layer_class_gc
+
+    class _Layer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed, self.proj = nn.Embedding(8, 4), nn.Linear(4, 4)
+
+        def __call__(self, h, ids):
+            return self.proj(h) + self.embed(ids)
+
+    layer, ids, h = _Layer(), mx.array([0, 1, 2]), mx.zeros((3, 4))
+    plain = nn.value_and_grad(layer, lambda m: m(h, ids).sum())(layer)
+    _patch_layer_class_for_gc(_Layer)
+    try:
+        checkpointed = nn.value_and_grad(layer, lambda m: m(h, ids).sum())(layer)
+        mx.eval(plain, checkpointed)
+    finally:
+        _unpatch_layer_class_gc(_Layer)
+    assert checkpointed[0].item() == plain[0].item()
+    assert mx.allclose(checkpointed[1]["proj"]["weight"], plain[1]["proj"]["weight"]).item()
 
 
 @requires_real_mlx

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -495,9 +495,8 @@ def test_one_trainers_evaluation_leaves_another_threads_flag_alone():
 
 
 def test_resume_keeps_its_reference_when_another_run_acquired_mid_pause():
-    """A pauses as the sole holder, B acquires during the pause, A resumes. If the
-    resume assigns the depth instead of incrementing it, A's reference is lost and
-    B's release unpatches mlx.core while A is still differentiating."""
+    """If resume assigns the depth instead of incrementing it, A's reference is
+    lost and B's release unpatches mlx.core while A is still differentiating."""
     acquire_mlx_training_patches()                      # A trains
     try:
         paused = pause_mlx_training_patches()           # A evaluates, sole holder

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3623,7 +3623,7 @@ def _prepared_grid(model_type):
 
 def test_array_grid_families_keep_an_indexable_grid():
     """These vision towers open with `grid_thw.tolist()`; tuples raise there."""
-    for model_type in ("glm4v", "glm_ocr", "muse_glimmer"):
+    for model_type in ("glm4v", "glm_ocr", "muse_glimmer", "glm5_next"):
         grid = _prepared_grid(model_type)["image_grid_thw"]
         assert isinstance(grid, mx.array), model_type
         assert grid.tolist() == [[1, 16, 16]], model_type
@@ -3634,6 +3634,29 @@ def test_compile_patched_families_keep_the_traceable_tuple_grid():
     for model_type in ("qwen2_vl", "qwen2_5_vl", "qwen3_vl", "paddleocr_vl"):
         grid = _prepared_grid(model_type)["image_grid_thw"]
         assert grid == ((1, 16, 16),), model_type
+
+
+def _prepared_positions(model_type):
+    from unsloth_zoo.mlx.utils import _prepare_vlm_batch_for_compile
+
+    return _prepare_vlm_batch_for_compile({
+        "input_ids": mx.array([[1, 5, 5, 5, 5, 2]], dtype=mx.int32),
+        "attention_mask": mx.array([[1] * 6], dtype=mx.int32),
+        "image_grid_thw": mx.array([[1, 4, 4]], dtype=mx.int32),
+    }, {"model_type": model_type, "image_token_id": 5, "video_token_id": 6,
+        "vision_config": {"spatial_merge_size": 2}})
+
+
+def test_qwen_mrope_families_get_pipeline_built_position_ids():
+    """Without them the decoder falls back to mlx-vlm's `get_rope_index`, which
+    calls `.item()` on grid entries the pipeline hands it as plain ints."""
+    for model_type in ("qwen2_vl", "qwen3_vl", "qwen3_5", "qwen4_exp"):
+        prepared = _prepared_positions(model_type)
+        assert prepared["_unsloth_collated_position_ids"] is True, model_type
+        assert np.asarray(prepared["position_ids"]).shape == (3, 1, 6), model_type
+
+    # GLM-5.x reaches its vision grid directly instead, so it must not be here.
+    assert "position_ids" not in _prepared_positions("glm5_next")
 
 
 # --- audio alignment from stated spans, for families whose run carries no id ---

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -995,6 +995,16 @@ def test_vlm_only_architecture_routes_text_only_loads_to_mlx_vlm(monkeypatch):
     ) is True
 
 
+@pytest.mark.parametrize("model_type", ["muse_glimmer", "qwen4_exp", "glm5_next"])
+def test_verified_vlm_text_paths_stay_verified(model_type):
+    """Dropping one silently restores the mlx_lm "not supported" load error."""
+    from unsloth_zoo.mlx import loader
+
+    assert loader._mlx_vlm_text_path_is_verified(model_type) is True
+    assert loader._mlx_vlm_text_path_is_verified("qwen3_5") is False
+    assert loader._mlx_vlm_text_path_is_verified("") is False
+
+
 def test_architecture_neither_backend_ships_is_not_routed_to_mlx_vlm(monkeypatch):
     assert _route_text_only(
         monkeypatch, mlx_lm_class=None, vlm_text_path_verified=False

--- a/tests/test_qwen35_vjp_metal.py
+++ b/tests/test_qwen35_vjp_metal.py
@@ -142,13 +142,14 @@ def test_gated_delta_kernel_grad_raises_without_patch():
 # (b) GDN: patch fixes grad; output matches the use_kernel=False reference
 # --------------------------------------------------------------------------- #
 @metal_only
-def test_patch_gated_delta_vlm_fixes_grad_and_matches_reference():
+def test_patch_gated_delta_vlm_fixes_grad_and_matches_reference(monkeypatch):
     import importlib
 
     import mlx_vlm.models.qwen3_5.gated_delta as vlm_gd
     from unsloth_zoo.gated_delta_vjp import patch_gated_delta_vlm
 
     importlib.reload(vlm_gd)
+    vlm_gd._unsloth_gated_delta_patched = False
     # Reference forward (differentiable ops path) BEFORE patching.
     q, k, v, a, b, A_log, dt_bias = _gdn_inputs()
     ref_out, _ = vlm_gd.gated_delta_update(
@@ -157,30 +158,35 @@ def test_patch_gated_delta_vlm_fixes_grad_and_matches_reference():
     mx.eval(ref_out)
 
     patch_gated_delta_vlm()
-    assert getattr(vlm_gd, "_unsloth_gated_delta_patched", False)
+    assert vlm_gd.gated_delta_update.__name__ == "patched_vlm_gated_delta_update"
 
     def loss(q_, k_, v_):
         out = vlm_gd.gated_delta_update(
             q_, k_, v_, a, b, A_log, dt_bias,
-            state=None, mask=None, use_kernel=True,
+            state=None, mask=None, use_kernel=False,
         )
         y = out[0] if isinstance(out, tuple) else out
         return y.astype(mx.float32).sum()
 
-    val, (dq, dk, dv) = mx.value_and_grad(loss, argnums=(0, 1, 2))(q, k, v)
-    mx.eval(val, dq, dk, dv)
-
-    for name, g in (("dq", dq), ("dk", dk), ("dv", dv)):
-        assert bool(mx.all(mx.isfinite(g))), f"{name} non-finite after patch"
-    assert any(float(mx.abs(g).max()) > 0 for g in (dq, dk, dv)), "all grads zero"
-
-    pat_out, _ = vlm_gd.gated_delta_update(
+    # An empty cache alone is prefill: the fused kernel returns a raw list.
+    assert isinstance(vlm_gd.gated_delta_update(
         q, k, v, a, b, A_log, dt_bias, state=None, mask=None, use_kernel=True
+    ), list)
+
+    # Upstream's fallbacks differentiate too, and which exist varies by version.
+    for _n in ("gated_delta_ops", "gated_delta_chunked"):
+        monkeypatch.setattr(vlm_gd, _n, lambda *a: pytest.fail("upstream"), raising=False)
+
+    val, (dq, dk, dv) = mx.value_and_grad(loss, argnums=(0, 1, 2))(q, k, v)
+    pat_out, _ = vlm_gd.gated_delta_update(
+        q, k, v, a, b, A_log, dt_bias, state=None, mask=None, use_kernel=False
     )
-    mx.eval(pat_out)
-    assert mx.allclose(
-        ref_out.astype(mx.float32), pat_out.astype(mx.float32), rtol=2e-2, atol=2e-2
-    ), float(mx.abs(ref_out.astype(mx.float32) - pat_out.astype(mx.float32)).max())
+    mx.eval(val, dq, dk, dv, pat_out)
+
+    assert all(bool(mx.all(mx.isfinite(g))) for g in (dq, dk, dv)), "non-finite grads"
+    assert any(float(mx.abs(g).max()) > 0 for g in (dq, dk, dv)), "all grads zero"
+    assert mx.allclose(ref_out.astype(mx.float32), pat_out.astype(mx.float32),
+                       rtol=2e-2, atol=2e-2)
 
 
 # --------------------------------------------------------------------------- #
@@ -259,15 +265,17 @@ def test_end_to_end_training_step_all_patches():
     cfg = _tiny_text_config(full_attention_interval=2)  # 1 GDN + 1 attention layer
     model = qlang.Qwen3_5Model(cfg)
     mx.eval(model.parameters())
-    # The model must report training so use_kernel=not self.training picks the
-    # ops path on the inference branch; the patch handles state=None regardless.
+    # `use_kernel=not self.training` asks for the differentiable path.
     model.train()
 
-    # Apply the full PR 738 patch set, exactly as trainer.py does.
+    # Trainer order: patch_gated_delta's sweep warns about an unpatched copy.
     _fix_qwen35_attention_cache(model)
     _disable_fused_mrope(model)
-    patch_gated_delta()
     patch_gated_delta_vlm()
+    patch_gated_delta()
+
+    # Grads alone prove nothing: upstream's ops path differentiates too.
+    assert qlang.gated_delta_update.__name__ == "patched_vlm_gated_delta_update"
 
     inputs = mx.array([[1, 2, 3, 4, 5, 6]])
 

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -255,6 +255,14 @@ def gated_delta_ops_efficient(
 _WARNED_FOREIGN_GATED_DELTA: set[str] = set()
 
 
+def _is_training_call(state, use_kernel):
+    """An empty cache does not mark a training call -- prefill has one too. Call
+    sites say so with `use_kernel=not self.training`; GLM-5.x's passes neither, so
+    an open training window speaks for it."""
+    from .mlx.utils import mlx_training_patches_active
+    return state is None and (not use_kernel or mlx_training_patches_active())
+
+
 def patch_gated_delta():
     """Monkey-patch mlx_lm's gated_delta module to use our efficient VJP.
 
@@ -274,9 +282,7 @@ def patch_gated_delta():
             q, k, v, a, b, A_log, dt_bias,
             state=None, mask=None, use_kernel=True,
         ):
-            # state=None marks a training call (no cache); route it through
-            # the custom VJP, since gated_delta_kernel has none.
-            is_training_call = state is None
+            is_training_call = _is_training_call(state, use_kernel)
             beta = mx.sigmoid(b)
             g = gated_delta.compute_g(A_log, a, dt_bias)
             if state is None:
@@ -350,6 +356,10 @@ def patch_gated_delta_vlm():
     mlx_vlm (0.4.x - 0.5.x) from-imports mlx_lm's function instead;
     the sweep in patch_gated_delta() already rebinds those.
     """
+    import sys
+    # Importing it here would drag the mlx-vlm model packages into a text-only run.
+    if not any(name.startswith("mlx_vlm.models.qwen3_5") for name in sys.modules):
+        return
     try:
         from mlx_vlm.models.qwen3_5 import gated_delta as vlm_gated_delta
     except ImportError:
@@ -384,8 +394,7 @@ def patch_gated_delta_vlm():
         q, k, v, a, b, A_log, dt_bias,
         state=None, mask=None, use_kernel=True,
     ):
-        # state=None is training (use the VJP); inference keeps the kernel.
-        if state is not None:
+        if not _is_training_call(state, use_kernel):
             return original_update(
                 q, k, v, a, b, A_log, dt_bias,
                 state=state, mask=mask, use_kernel=use_kernel,
@@ -404,6 +413,53 @@ def patch_gated_delta_vlm():
         vlm_language.gated_delta_update = patched_vlm_gated_delta_update
     vlm_gated_delta._unsloth_gated_delta_patched = True
     print("Unsloth: Patched mlx-vlm GatedDeltaNet with memory-efficient custom VJP.")
+
+
+def patch_gated_delta_vlm_shared():
+    """Patch mlx_vlm's shared gated-delta update, wherever it lives.
+
+    GLM-5.x linear attention binds this rather than the per-model copy
+    `patch_gated_delta_vlm` covers, and never passes `use_kernel=not self.training`,
+    so training would reach the fused Metal kernel, which has no VJP."""
+    import sys
+    # 0.6.5 kept this under `text_models`; 0.6.6 moved it up to `models`.
+    vlm_gated_delta = (sys.modules.get("mlx_vlm.models.gated_delta")
+                       or sys.modules.get("mlx_vlm.models.text_models.gated_delta"))
+    if vlm_gated_delta is None:
+        return
+    if getattr(vlm_gated_delta, "_unsloth_gated_delta_patched", False):
+        return
+    original_update = vlm_gated_delta.gated_delta_update
+
+    def patched_shared_gated_delta_update(q, k, v, a, b, A_log, dt_bias,
+            state=None, mask=None, use_kernel=True, lower_bound=None):
+        if not _is_training_call(state, use_kernel):
+            # Pre-0.6.9 mlx-vlm has no `lower_bound` here, and no caller passes one.
+            bound = {} if lower_bound is None else {"lower_bound": lower_bound}
+            return original_update(q, k, v, a, b, A_log, dt_bias,
+                                   state=state, mask=mask, use_kernel=use_kernel, **bound)
+        beta = mx.sigmoid(b)
+        g = (vlm_gated_delta.compute_g(A_log, a, dt_bias) if lower_bound is None
+             else vlm_gated_delta.compute_g_safe(A_log, a, dt_bias, lower_bound))
+        B, Dk = q.shape[0], q.shape[-1]
+        Hv, Dv = v.shape[-2:]
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+        if gated_delta_kernel_supported(q, g, mask, v):
+            return gated_delta_kernel_efficient(q, k, v, g, beta, state, mask)
+        return gated_delta_ops_efficient(q, k, v, g, beta, state, mask)
+
+    vlm_gated_delta.gated_delta_update = patched_shared_gated_delta_update
+    vlm_gated_delta._unsloth_gated_delta_patched = True
+    # Consumers from-import the function; rebind their stale references.
+    rebound = []
+    for name, module in list(sys.modules.items()):
+        if module is None or not name.startswith("mlx_vlm.models"): continue
+        if getattr(module, "gated_delta_update", None) is original_update:
+            module.gated_delta_update = patched_shared_gated_delta_update
+            rebound.append(name)
+    if rebound:
+        print(f"Unsloth: Rebound gated_delta_update in {', '.join(sorted(rebound))}.")
+    print("Unsloth: Patched shared mlx-vlm GatedDeltaNet with custom VJP.")
 
 
 # --------------------------------------------------------------------------

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -263,10 +263,15 @@ def _is_training_call(state, use_kernel):
         return False
     if not use_kernel:
         return True
-    # Imported lazily and only on the path that needs it: this runs once per
-    # layer per decode step, and `unsloth_zoo.mlx.utils` is large enough that a
-    # pure-inference process should not pay for it until a caller is ambiguous.
-    from .mlx.utils import mlx_training_patches_active
+    # Absolute, not `from .mlx.utils import ...`: transformers' custom_object_save
+    # copies this file next to a checkpoint and resolves every relative import
+    # against that directory, where `mlx.utils.py` does not exist.
+    # tests/test_relative_imports_resolve.py enforces it.
+    #
+    # Lazy, and only on the path that needs it: this runs once per layer per
+    # decode step, and unsloth_zoo.mlx.utils is large enough that a pure-inference
+    # process should not pay for it until a call site is genuinely ambiguous.
+    from unsloth_zoo.mlx.utils import mlx_training_patches_active
     return mlx_training_patches_active()
 
 

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -259,8 +259,15 @@ def _is_training_call(state, use_kernel):
     """An empty cache does not mark a training call -- prefill has one too. Call
     sites say so with `use_kernel=not self.training`; GLM-5.x's passes neither, so
     an open training window speaks for it."""
+    if state is not None:
+        return False
+    if not use_kernel:
+        return True
+    # Imported lazily and only on the path that needs it: this runs once per
+    # layer per decode step, and `unsloth_zoo.mlx.utils` is large enough that a
+    # pure-inference process should not pay for it until a caller is ambiguous.
     from .mlx.utils import mlx_training_patches_active
-    return state is None and (not use_kernel or mlx_training_patches_active())
+    return mlx_training_patches_active()
 
 
 def patch_gated_delta():
@@ -273,7 +280,13 @@ def patch_gated_delta():
     rebind any stale reference to the original function.
     """
     import sys
-    from mlx_lm.models import gated_delta
+    try:
+        from mlx_lm.models import gated_delta
+    except ImportError:
+        # Reachable now that layers are matched structurally: a gated-delta mixer
+        # defined by mlx-vlm routes here even on an mlx_lm that has no copy of the
+        # module. mlx-vlm's own copies are patched by the two functions below.
+        return
 
     if not getattr(gated_delta, "_unsloth_gated_delta_patched", False):
         original_gated_delta_update = gated_delta.gated_delta_update
@@ -368,7 +381,10 @@ def patch_gated_delta_vlm():
         except ImportError:
             return
         patch_gated_delta()
-        from mlx_lm.models import gated_delta
+        try:
+            from mlx_lm.models import gated_delta
+        except ImportError:
+            return
         if (
             getattr(vlm_language, "gated_delta_update", None)
             is not gated_delta.gated_delta_update
@@ -383,7 +399,12 @@ def patch_gated_delta_vlm():
         from mlx_vlm.models.qwen3_5 import language as vlm_language
     except ImportError:
         vlm_language = None
-    from mlx_lm.models import gated_delta
+    try:
+        from mlx_lm.models import gated_delta
+    except ImportError:
+        # mlx-vlm ships its own copy from 0.6 on, but `compute_g` below is still
+        # taken from mlx_lm; without it there is nothing to patch with.
+        return
 
     if getattr(vlm_gated_delta, "_unsloth_gated_delta_patched", False):
         return

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -263,14 +263,10 @@ def _is_training_call(state, use_kernel):
         return False
     if not use_kernel:
         return True
-    # Absolute, not `from .mlx.utils import ...`: transformers' custom_object_save
-    # copies this file next to a checkpoint and resolves every relative import
-    # against that directory, where `mlx.utils.py` does not exist.
-    # tests/test_relative_imports_resolve.py enforces it.
-    #
-    # Lazy, and only on the path that needs it: this runs once per layer per
-    # decode step, and unsloth_zoo.mlx.utils is large enough that a pure-inference
-    # process should not pay for it until a call site is genuinely ambiguous.
+    # Absolute (test_relative_imports_resolve.py enforces it): custom_object_save
+    # copies this file beside a checkpoint, where `mlx.utils.py` does not exist.
+    # Lazy: this runs once per layer per decode step, so a pure-inference process
+    # should not import `unsloth_zoo.mlx.utils` until a call site is ambiguous.
     from unsloth_zoo.mlx.utils import mlx_training_patches_active
     return mlx_training_patches_active()
 
@@ -288,9 +284,8 @@ def patch_gated_delta():
     try:
         from mlx_lm.models import gated_delta
     except ImportError:
-        # Reachable now that layers are matched structurally: a gated-delta mixer
-        # defined by mlx-vlm routes here even on an mlx_lm that has no copy of the
-        # module. mlx-vlm's own copies are patched by the two functions below.
+        # Reachable since layers are matched structurally: an mlx-vlm-defined
+        # gated-delta mixer routes here even where mlx_lm has no such module.
         return
 
     if not getattr(gated_delta, "_unsloth_gated_delta_patched", False):
@@ -407,8 +402,8 @@ def patch_gated_delta_vlm():
     try:
         from mlx_lm.models import gated_delta
     except ImportError:
-        # mlx-vlm ships its own copy from 0.6 on, but `compute_g` below is still
-        # taken from mlx_lm; without it there is nothing to patch with.
+        # `compute_g` below still comes from mlx_lm even on 0.6+, which ships its
+        # own copy of the update; without it there is nothing to patch with.
         return
 
     if getattr(vlm_gated_delta, "_unsloth_gated_delta_patched", False):

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -37,6 +37,7 @@ import mlx.core as mx
 import numpy as np
 import pkgutil
 import re
+import sys
 import textwrap
 from typing import Any, Callable, Iterable, Mapping
 
@@ -1397,18 +1398,19 @@ def get_backend_compile_qualifications(model_or_arch) -> tuple[MLXVLMCompileQual
     return tuple(qualifications)
 
 
-def _module_is_gated_delta(module) -> bool:
-    """Match gated-delta (GDN linear attention) layers structurally.
+def _defined_beside_gated_delta_update(module) -> bool:
+    """Mamba/SSM mixers carry the same gate-decay parameters but never bind it."""
+    return hasattr(sys.modules.get(type(module).__module__), "gated_delta_update")
 
-    Class-name + parameter check: GatedDeltaNet / Qwen3NextGatedDeltaNet /
-    Qwen3_5GatedDeltaNet / KimiDeltaAttention all contain "delta" and carry
-    the A_log + dt_bias pair. Mamba/SSM mixers carry the same parameters but
-    never the name, so they are deliberately not matched here.
-    """
+
+def _module_is_gated_delta(module) -> bool:
+    """Match gated-delta (GDN linear attention) layers structurally: most name
+    themselves after the recurrence, but GLM-5.x calls it `Glm5NextLinearAttention`."""
+    if not (hasattr(module, "A_log") and hasattr(module, "dt_bias")):
+        return False
     return (
         "delta" in type(module).__name__.lower()
-        and hasattr(module, "A_log")
-        and hasattr(module, "dt_bias")
+        or _defined_beside_gated_delta_update(module)
     )
 
 
@@ -1419,6 +1421,16 @@ def model_has_gated_delta_layers(model) -> bool:
     except Exception:
         return False
     return any(_module_is_gated_delta(module) for _, module in modules)
+
+
+def model_has_qwen35_attention_layers(model) -> bool:
+    """qwen4_exp reuses mlx-vlm's Qwen3.5 attention class under its own model_type."""
+    try:
+        modules = model.named_modules()
+    except Exception:
+        return False
+    return any(any(b.__name__ == "Qwen3_5Attention" for b in type(m).__mro__)
+               for _, m in modules)
 
 
 def _model_repo_training_compile_block_reason(model_or_arch) -> str | None:

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2631,6 +2631,11 @@ def _get_mlx_lm_model_class(model_type: str):
 
 _VLM_TEXT_PATH_MODEL_TYPES = frozenset({
     "muse_glimmer",
+    # Hybrid linear-attention decoders mlx_lm has no class for. Both reproduce a
+    # fresh model bitwise across a width or batch change, so the position tensor
+    # qwen4_exp caches between calls never leaks into the next text batch.
+    "qwen4_exp",
+    "glm5_next",
 })
 
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -178,13 +178,15 @@ def _keep_norm_parameters_float32(model) -> None:
     if not needs_cast:
         return
 
-    model.update(tree_map_with_path(
+    casted = tree_map_with_path(
         lambda k, v: v.astype(mx.float32)
         if is_mlx_norm_parameter_path(k) and mx.issubdtype(v.dtype, mx.floating)
         else v,
         parameters,
-    ))
-    mx.eval(model.parameters())
+    )
+    model.update(casted)
+    # Evaluating the whole tree would page every weight into one command buffer.
+    mx.eval([v for k, v in tree_flatten(casted) if is_mlx_norm_parameter_path(k)])
 
 
 def _seed_mlx_random_state(random_state):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2562,19 +2562,38 @@ _VLM_MODEL_FIXUPS = (
 
 
 def _disable_fused_mrope(model):
-    """Flip fused_apply off so MRoPE training uses the differentiable
-    cos/sin fallback; the fused Metal kernel has no VJP."""
-    count = 0
+    """The fused MRoPE Metal kernel has no VJP; training needs the cos/sin fallback."""
+    changed = []
     try:
         modules = model.modules()
     except Exception:
-        return
+        return changed
     for module in modules:
         if getattr(module, "fused_apply", False):
             module.fused_apply = False
-            count += 1
-    if count:
-        print(f"Unsloth: Disabled fused MRoPE kernel on {count} modules for training (no VJP).")
+            changed.append(module)
+    if changed:
+        print(f"Unsloth: Disabled fused MRoPE kernel on {len(changed)} modules for training (no VJP).")
+    return changed
+
+
+def _disable_fused_input_projections(model):
+    """GLM-5.x linear attention concatenates the raw `.weight` of its six input
+    projections once and caches it: a LoRA wrapper has no `.weight` to read, and a
+    full fine-tune would keep the pre-training copy."""
+    changed = []
+    try:
+        modules = model.modules()
+    except Exception:
+        return changed
+    for module in modules:
+        if getattr(module, "fuse_in", False) and hasattr(module, "_fused_ready"):
+            module.fuse_in = False
+            module._fused_ready = False
+            changed.append(module)
+    if changed:
+        print(f"Unsloth: Disabled fused input projections on {len(changed)} modules.")
+    return changed
 
 
 def _safe_getsource(obj) -> str:
@@ -8222,6 +8241,8 @@ class FastMLXModel:
             _unfreeze_full_modules(_cpt_full_specs)
 
         _apply_mlx_lora_initialization(model, init_lora_weights)
+        # Adapters are invisible to a cached weight fusion.
+        _disable_fused_input_projections(model)
 
         # Gradient checkpointing: "mlx"/True -> apply; False/"none" -> skip.
         if isinstance(use_gradient_checkpointing, str):

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4908,12 +4908,23 @@ class MLXTrainer:
                 restore_mlx_norm_output_cast_state(_prev_norm_output_cast_state)
             except Exception:
                 pass
-            if _training_patches_held:
-                release_mlx_training_patches()
+            # Each guarded like its neighbours above: a failure restoring an
+            # optional fast path must not replace the exception that ended the run.
+            try:
+                if _training_patches_held:
+                    release_mlx_training_patches()
+            except Exception:
+                pass
             for _module in _unfused_projection_modules:
-                _module.fuse_in = True
+                try:
+                    _module.fuse_in = True
+                except Exception:
+                    pass
             for _module in _unfused_mrope_modules:
-                _module.fused_apply = True
+                try:
+                    _module.fused_apply = True
+                except Exception:
+                    pass
             # Restore Qwen3-VL vision-block flag to its pre-train value.
             try:
                 from . import compile as _mlx_compile

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -623,6 +623,7 @@ from .compile import (
     explain_compile_support,
     get_compile_qualification,
     model_has_gated_delta_layers,
+    model_has_qwen35_attention_layers,
     normalize_mlx_patch_mode,
     resolve_training_compile,
     trace_compile_application,
@@ -4834,16 +4835,21 @@ class MLXTrainer:
             # and marks the process as inside a training run.
             acquire_mlx_training_patches()
             _training_patches_held = True
-            # Qwen3.5-specific fixes
+            # Routed by module tree, not model_type: qwen4_exp reuses the Qwen3.5
+            # classes under its own name.
             config = getattr(model, "_config", {})
             model_type = config.get("model_type", "") if isinstance(config, dict) else ""
-            gated_delta_patched = False
-            if "qwen3_5" in model_type:
+            if model_has_gated_delta_layers(model):
+                from unsloth_zoo.gated_delta_vjp import (
+                    patch_gated_delta, patch_gated_delta_vlm, patch_gated_delta_vlm_shared)
+                # mlx-vlm's copies first, or patch_gated_delta's sweep warns about them.
+                patch_gated_delta_vlm()
+                patch_gated_delta_vlm_shared()
+                patch_gated_delta()
+            if model_has_qwen35_attention_layers(model):
                 from .loader import _fix_qwen35_attention_cache, _disable_fused_mrope
                 _fix_qwen35_attention_cache(model)
                 _disable_fused_mrope(model)
-                from unsloth_zoo.gated_delta_vjp import patch_gated_delta, patch_gated_delta_vlm
-                patch_gated_delta()
             # Qwen2/2.5/3-VL language towers share the fused MRoPE kernel with
             # no VJP; flip it off so training takes the differentiable fallback.
             if any(t in model_type for t in ("qwen3_vl", "qwen2_vl", "qwen2_5_vl")):

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4548,6 +4548,8 @@ class MLXTrainer:
             iter_mlx_norm_output_cast_classes(model)
         )
         _training_patches_held = False
+        _unfused_projection_modules = []
+        _unfused_mrope_modules = []
         # Save Qwen3-VL vision-block flag so finally restores it (not just False).
         _prev_qwen3_vision_cast = True
         try:
@@ -4849,12 +4851,15 @@ class MLXTrainer:
             if model_has_qwen35_attention_layers(model):
                 from .loader import _fix_qwen35_attention_cache, _disable_fused_mrope
                 _fix_qwen35_attention_cache(model)
-                _disable_fused_mrope(model)
+                _unfused_mrope_modules = _disable_fused_mrope(model)
+            # Full fine-tuning updates projections a fusion cached once.
+            from .loader import _disable_fused_input_projections
+            _unfused_projection_modules = _disable_fused_input_projections(model)
             # Qwen2/2.5/3-VL language towers share the fused MRoPE kernel with
             # no VJP; flip it off so training takes the differentiable fallback.
             if any(t in model_type for t in ("qwen3_vl", "qwen2_vl", "qwen2_5_vl")):
                 from .loader import _disable_fused_mrope
-                _disable_fused_mrope(model)
+                _unfused_mrope_modules += _disable_fused_mrope(model)
 
             # Register W&B/TensorBoard reporters after arg auto-tuning so the
             # W&B config snapshot reflects the settings actually used (e.g. VLM
@@ -4905,6 +4910,10 @@ class MLXTrainer:
                 pass
             if _training_patches_held:
                 release_mlx_training_patches()
+            for _module in _unfused_projection_modules:
+                _module.fuse_in = True
+            for _module in _unfused_mrope_modules:
+                _module.fused_apply = True
             # Restore Qwen3-VL vision-block flag to its pre-train value.
             try:
                 from . import compile as _mlx_compile

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -593,6 +593,10 @@ from .utils import (
     _is_vlm_model,
     _mlx_norm_path_part_is_norm,
     iter_mlx_norm_output_cast_classes,
+    acquire_mlx_training_patches,
+    pause_mlx_training_patches,
+    release_mlx_training_patches,
+    resume_mlx_training_patches,
     restore_mlx_norm_output_cast_state,
     set_mlx_norm_output_cast_to_input_dtype,
     snapshot_mlx_norm_output_cast_state,
@@ -4542,6 +4546,7 @@ class MLXTrainer:
         _prev_norm_output_cast_state = snapshot_mlx_norm_output_cast_state(
             iter_mlx_norm_output_cast_classes(model)
         )
+        _training_patches_held = False
         # Save Qwen3-VL vision-block flag so finally restores it (not just False).
         _prev_qwen3_vision_cast = True
         try:
@@ -4825,6 +4830,10 @@ class MLXTrainer:
                 apply_gradient_checkpointing(model)
                 _main_print("Unsloth: Using gradient checkpointing to reduce memory.")
 
+            # Keeps routers, gather-sort and sparse block selection differentiable,
+            # and marks the process as inside a training run.
+            acquire_mlx_training_patches()
+            _training_patches_held = True
             # Qwen3.5-specific fixes
             config = getattr(model, "_config", {})
             model_type = config.get("model_type", "") if isinstance(config, dict) else ""
@@ -4834,12 +4843,6 @@ class MLXTrainer:
                 _fix_qwen35_attention_cache(model)
                 _disable_fused_mrope(model)
                 from unsloth_zoo.gated_delta_vjp import patch_gated_delta, patch_gated_delta_vlm
-                patch_gated_delta()
-                patch_gated_delta_vlm()
-                gated_delta_patched = True
-            # Structural check: qwen3_next / kimi_linear also need the VJP.
-            if not gated_delta_patched and model_has_gated_delta_layers(model):
-                from unsloth_zoo.gated_delta_vjp import patch_gated_delta
                 patch_gated_delta()
             # Qwen2/2.5/3-VL language towers share the fused MRoPE kernel with
             # no VJP; flip it off so training takes the differentiable fallback.
@@ -4894,6 +4897,8 @@ class MLXTrainer:
                 restore_mlx_norm_output_cast_state(_prev_norm_output_cast_state)
             except Exception:
                 pass
+            if _training_patches_held:
+                release_mlx_training_patches()
             # Restore Qwen3-VL vision-block flag to its pre-train value.
             try:
                 from . import compile as _mlx_compile
@@ -6530,12 +6535,14 @@ class MLXTrainer:
             if _pf is not None:
                 _pf.quiesce()
             _metrics_before_eval = self._last_eval_metrics
+            _paused_window = pause_mlx_training_patches()
             try:
                 val_loss, ppl = self._evaluate(
                     current_eval_batches, preference_eval_fn or loss_fn,
                     is_vlm=is_vlm,
                 )
             finally:
+                resume_mlx_training_patches(_paused_window)
                 if _pf is not None:
                     _pf.resume()
             model.train()

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -512,13 +512,11 @@ def pause_mlx_training_patches() -> bool:
 def resume_mlx_training_patches(paused: bool) -> None:
     """Give back exactly what `pause_mlx_training_patches` took.
 
-    The physical reference is restored by INCREMENT, never by assignment: another
-    trainer may have acquired during the pause, and setting the depth to 1 there
-    would drop this run's reference, so that trainer's release would unpatch
-    `mlx.core` while this one is still differentiating.
-
-    The logical depth is restored from this context's own pause stack, so it does
-    not count a second run the way `acquire()` would.
+    By increment, never assignment: another trainer may have acquired during the
+    pause, and assigning 1 there would drop this run's reference, so that
+    trainer's release would unpatch `mlx.core` mid-differentiation. The logical
+    depth comes off this context's own stack, so it does not count a second run
+    the way `acquire()` would.
     """
     global _MLX_TRAINING_PATCH_DEPTH
     with _MLX_INDEX_GRADIENT_LOCK:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -510,16 +510,22 @@ def pause_mlx_training_patches() -> bool:
 
 
 def resume_mlx_training_patches(paused: bool) -> None:
-    """Reopen at the depth `pause_mlx_training_patches` closed from.
+    """Give back exactly what `pause_mlx_training_patches` took.
 
-    Deliberately not `acquire()`: that would count a second run, and the pause
-    never released one.
+    The physical reference is restored by INCREMENT, never by assignment: another
+    trainer may have acquired during the pause, and setting the depth to 1 there
+    would drop this run's reference, so that trainer's release would unpatch
+    `mlx.core` while this one is still differentiating.
+
+    The logical depth is restored from this context's own pause stack, so it does
+    not count a second run the way `acquire()` would.
     """
     global _MLX_TRAINING_PATCH_DEPTH
     with _MLX_INDEX_GRADIENT_LOCK:
-        if paused and _MLX_TRAINING_PATCH_DEPTH == 0:
-            _set_mlx_index_gradient_stop(True)
-            _MLX_TRAINING_PATCH_DEPTH = 1
+        if paused:
+            if _MLX_TRAINING_PATCH_DEPTH == 0:
+                _set_mlx_index_gradient_stop(True)
+            _MLX_TRAINING_PATCH_DEPTH += 1
     stack = _MLX_TRAINING_PAUSE_STACK.get()
     if stack:
         _MLX_TRAINING_ACTIVE_DEPTH.set(stack[-1])

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -28,6 +28,7 @@ import mlx.utils
 import ast
 import collections
 import contextlib
+import contextvars
 import copy
 import inspect
 import importlib
@@ -408,16 +409,29 @@ _MLX_INDEX_CONSUMERS = {  # index-argument positions, by op
 _MLX_INDEX_KEYWORDS = frozenset(("indices", "lhs_indices", "rhs_indices"))
 _MLX_INDEX_OP_NAMES = _MLX_INDEX_PRODUCERS + tuple(_MLX_INDEX_CONSUMERS)
 _MLX_INDEX_GRADIENT_LOCK = threading.RLock()
-# Two counters, because the two questions have different answers. The patch depth
-# is physical -- how many runs still need `mlx.core` wrapped -- and unpatching is
-# process-wide, so an inner run must not unpatch an outer one. The active depth is
-# logical: is THIS thread of control inside a training step. Evaluation can always
-# drop the logical flag (it takes no gradients) even when it cannot drop the
-# physical patches, and without that separation an evaluation nested under a
-# second run still looks like training to `_is_training_call`.
+# Two counters, because the two questions have different answers, and they have
+# different SCOPES for the same reason.
+#
+# The patch depth is physical -- how many runs still need `mlx.core` wrapped --
+# and `mlx.core` is process-wide, so this one is global under the lock and an
+# inner run must never unpatch an outer one.
+#
+# The active depth is logical: is THIS execution context inside a training step.
+# Evaluation can always drop it (it takes no gradients) even when it cannot drop
+# the physical patches. It is context-local because a global one is wrong in both
+# directions: global-and-never-cleared makes a nested evaluation read as training,
+# while global-and-always-cleared lets one trainer's evaluation clear the flag out
+# from under a second trainer that is still differentiating -- and that one is a
+# crash, since a call site like GLM-5.x's, which passes no `use_kernel`, would then
+# route its backward to the fused kernel that has no VJP. ContextVar isolates per
+# thread AND per asyncio Task, where `threading.local` would only cover the first.
 _MLX_TRAINING_PATCH_DEPTH = 0
-_MLX_TRAINING_ACTIVE_DEPTH = 0
-_MLX_TRAINING_PAUSE_STACK = []
+_MLX_TRAINING_ACTIVE_DEPTH = contextvars.ContextVar(
+    "unsloth_mlx_training_active_depth", default=0)
+# Immutable tuple, never a list: a mutable ContextVar default is shared by every
+# context that never set one, which would put the stack straight back in global scope.
+_MLX_TRAINING_PAUSE_STACK = contextvars.ContextVar(
+    "unsloth_mlx_training_pause_stack", default=())
 # MLX differentiates integer arrays, so only real index positions are detached.
 _MLX_INTEGER_DTYPES = frozenset((mx.int8, mx.int16, mx.int32, mx.int64,
                                  mx.uint8, mx.uint16, mx.uint32, mx.uint64))
@@ -462,41 +476,42 @@ def _set_mlx_index_gradient_stop(enabled: bool) -> None:
 def acquire_mlx_training_patches() -> None:
     """Reference-counted: the `mlx.core` patches are process-wide while trainer
     runs are not, so an inner run must not unpatch an outer one."""
-    global _MLX_TRAINING_PATCH_DEPTH, _MLX_TRAINING_ACTIVE_DEPTH
+    global _MLX_TRAINING_PATCH_DEPTH
     with _MLX_INDEX_GRADIENT_LOCK:
         if _MLX_TRAINING_PATCH_DEPTH == 0:
             _set_mlx_index_gradient_stop(True)
         _MLX_TRAINING_PATCH_DEPTH += 1
-        _MLX_TRAINING_ACTIVE_DEPTH += 1
+    _MLX_TRAINING_ACTIVE_DEPTH.set(_MLX_TRAINING_ACTIVE_DEPTH.get() + 1)
 
 
 def release_mlx_training_patches() -> None:
-    global _MLX_TRAINING_PATCH_DEPTH, _MLX_TRAINING_ACTIVE_DEPTH
+    global _MLX_TRAINING_PATCH_DEPTH
     with _MLX_INDEX_GRADIENT_LOCK:
         if _MLX_TRAINING_PATCH_DEPTH == 0:
             return
         _MLX_TRAINING_PATCH_DEPTH -= 1
-        if _MLX_TRAINING_ACTIVE_DEPTH > 0:
-            _MLX_TRAINING_ACTIVE_DEPTH -= 1
         if _MLX_TRAINING_PATCH_DEPTH == 0:
             _set_mlx_index_gradient_stop(False)
+    _MLX_TRAINING_ACTIVE_DEPTH.set(max(0, _MLX_TRAINING_ACTIVE_DEPTH.get() - 1))
 
 
 def pause_mlx_training_patches() -> bool:
     """Evaluation runs under `model.eval()` but inside the trainer's window, which
     would otherwise route it down the training paths.
 
-    The logical "inside a training step" flag is ALWAYS cleared, so an uncached
-    evaluation never reads as training. Removing the process-wide `mlx.core`
-    patches is refused while another run holds the window, and the return value
-    reports only that: True when they came off, False when another run still
-    needs them. Leaving them on costs nothing here, because they only stop
-    gradients flowing into gather indices and evaluation takes no gradients.
+    The logical "inside a training step" flag is ALWAYS cleared, but only for THIS
+    context, so an uncached evaluation never reads as training and a second trainer
+    differentiating on another thread keeps its own flag. Removing the process-wide
+    `mlx.core` patches is refused while another run holds the window, and the return
+    value reports only that: True when they came off, False when another run still
+    needs them. Leaving them on costs nothing here, because they only stop gradients
+    flowing into gather indices and evaluation takes no gradients.
     """
-    global _MLX_TRAINING_PATCH_DEPTH, _MLX_TRAINING_ACTIVE_DEPTH
+    global _MLX_TRAINING_PATCH_DEPTH
+    _MLX_TRAINING_PAUSE_STACK.set(
+        _MLX_TRAINING_PAUSE_STACK.get() + (_MLX_TRAINING_ACTIVE_DEPTH.get(),))
+    _MLX_TRAINING_ACTIVE_DEPTH.set(0)
     with _MLX_INDEX_GRADIENT_LOCK:
-        _MLX_TRAINING_PAUSE_STACK.append(_MLX_TRAINING_ACTIVE_DEPTH)
-        _MLX_TRAINING_ACTIVE_DEPTH = 0
         if _MLX_TRAINING_PATCH_DEPTH != 1:
             return False
         _MLX_TRAINING_PATCH_DEPTH = 0
@@ -510,17 +525,19 @@ def resume_mlx_training_patches(paused: bool) -> None:
     Deliberately not `acquire()`: that would count a second run, and the pause
     never released one.
     """
-    global _MLX_TRAINING_PATCH_DEPTH, _MLX_TRAINING_ACTIVE_DEPTH
+    global _MLX_TRAINING_PATCH_DEPTH
     with _MLX_INDEX_GRADIENT_LOCK:
         if paused and _MLX_TRAINING_PATCH_DEPTH == 0:
             _set_mlx_index_gradient_stop(True)
             _MLX_TRAINING_PATCH_DEPTH = 1
-        if _MLX_TRAINING_PAUSE_STACK:
-            _MLX_TRAINING_ACTIVE_DEPTH = _MLX_TRAINING_PAUSE_STACK.pop()
+    stack = _MLX_TRAINING_PAUSE_STACK.get()
+    if stack:
+        _MLX_TRAINING_ACTIVE_DEPTH.set(stack[-1])
+        _MLX_TRAINING_PAUSE_STACK.set(stack[:-1])
 
 
 def mlx_training_patches_active() -> bool:
-    return _MLX_TRAINING_ACTIVE_DEPTH > 0
+    return _MLX_TRAINING_ACTIVE_DEPTH.get() > 0
 
 
 def _get_transformer_layers(model):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -397,6 +397,101 @@ def set_mlx_norm_output_cast_to_input_dtype(enabled: bool, model=None) -> None:
         _set_mlx_norm_output_cast_classes(enabled, norm_classes)
 
 
+# MLX raises instead of returning zero when a backward pass reaches a
+# gather/scatter index, aborting every graph that derives indices from activations:
+# MoE routing, SwitchGLU's gather-sort, GLM-5.x's sparse mask. Detaching changes no
+# forward value; producers are wrapped too, since `__getitem__` hides the consumer.
+_MLX_INDEX_PRODUCERS = ("argpartition", "argsort", "argmax", "argmin")
+_MLX_INDEX_CONSUMERS = {  # index-argument positions, by op
+    "take": (1,), "take_along_axis": (1,), "put_along_axis": (1,),
+    "gather_mm": (2, 3), "gather_qmm": (4, 5)}
+_MLX_INDEX_KEYWORDS = frozenset(("indices", "lhs_indices", "rhs_indices"))
+_MLX_INDEX_OP_NAMES = _MLX_INDEX_PRODUCERS + tuple(_MLX_INDEX_CONSUMERS)
+_MLX_INDEX_GRADIENT_LOCK = threading.RLock()
+_MLX_TRAINING_PATCH_DEPTH = 0
+# MLX differentiates integer arrays, so only real index positions are detached.
+_MLX_INTEGER_DTYPES = frozenset((mx.int8, mx.int16, mx.int32, mx.int64,
+                                 mx.uint8, mx.uint16, mx.uint32, mx.uint64))
+
+
+def _detach_if_index(value):
+    return (mx.stop_gradient(value)
+            if getattr(value, "dtype", None) in _MLX_INTEGER_DTYPES else value)
+
+
+def _wrap_mlx_index_op(name, original):
+    positions = _MLX_INDEX_CONSUMERS.get(name)
+
+    @wraps(original)
+    def wrapper(*args, **kwargs):
+        if positions is None:  # producer: the result is entirely an index
+            return mx.stop_gradient(original(*args, **kwargs))
+        return original(
+            *(_detach_if_index(arg) if i in positions else arg
+              for i, arg in enumerate(args)),
+            **{key: _detach_if_index(value) if key in _MLX_INDEX_KEYWORDS
+               else value for key, value in kwargs.items()},
+        )
+
+    wrapper._unsloth_index_stop_gradient = True
+    wrapper._unsloth_index_original = original
+    return wrapper
+
+
+def _set_mlx_index_gradient_stop(enabled: bool) -> None:
+    for name in _MLX_INDEX_OP_NAMES:
+        current = getattr(mx, name, None)
+        if current is None:
+            continue
+        patched = bool(getattr(current, "_unsloth_index_stop_gradient", False))
+        if enabled and not patched:
+            setattr(mx, name, _wrap_mlx_index_op(name, current))
+        elif not enabled and patched:
+            setattr(mx, name, current._unsloth_index_original)
+
+
+def acquire_mlx_training_patches() -> None:
+    """Reference-counted: the `mlx.core` patches are process-wide while trainer
+    runs are not, so an inner run must not unpatch an outer one."""
+    global _MLX_TRAINING_PATCH_DEPTH
+    with _MLX_INDEX_GRADIENT_LOCK:
+        if _MLX_TRAINING_PATCH_DEPTH == 0:
+            _set_mlx_index_gradient_stop(True)
+        _MLX_TRAINING_PATCH_DEPTH += 1
+
+
+def release_mlx_training_patches() -> None:
+    global _MLX_TRAINING_PATCH_DEPTH
+    with _MLX_INDEX_GRADIENT_LOCK:
+        if _MLX_TRAINING_PATCH_DEPTH == 0:
+            return
+        _MLX_TRAINING_PATCH_DEPTH -= 1
+        if _MLX_TRAINING_PATCH_DEPTH == 0:
+            _set_mlx_index_gradient_stop(False)
+
+
+def pause_mlx_training_patches() -> bool:
+    """Evaluation runs under `model.eval()` but inside the trainer's window, which
+    would otherwise route it down the training paths. Refused while another run
+    holds the window, since unpatching is process-wide."""
+    global _MLX_TRAINING_PATCH_DEPTH
+    with _MLX_INDEX_GRADIENT_LOCK:
+        if _MLX_TRAINING_PATCH_DEPTH != 1:
+            return False
+        _MLX_TRAINING_PATCH_DEPTH = 0
+        _set_mlx_index_gradient_stop(False)
+        return True
+
+
+def resume_mlx_training_patches(paused: bool) -> None:
+    if paused:
+        acquire_mlx_training_patches()
+
+
+def mlx_training_patches_active() -> bool:
+    return _MLX_TRAINING_PATCH_DEPTH > 0
+
+
 def _get_transformer_layers(model):
     """Find transformer layers, unwrapping VLM wrappers if needed.
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -409,27 +409,19 @@ _MLX_INDEX_CONSUMERS = {  # index-argument positions, by op
 _MLX_INDEX_KEYWORDS = frozenset(("indices", "lhs_indices", "rhs_indices"))
 _MLX_INDEX_OP_NAMES = _MLX_INDEX_PRODUCERS + tuple(_MLX_INDEX_CONSUMERS)
 _MLX_INDEX_GRADIENT_LOCK = threading.RLock()
-# Two counters, because the two questions have different answers, and they have
-# different SCOPES for the same reason.
-#
-# The patch depth is physical -- how many runs still need `mlx.core` wrapped --
-# and `mlx.core` is process-wide, so this one is global under the lock and an
-# inner run must never unpatch an outer one.
-#
-# The active depth is logical: is THIS execution context inside a training step.
-# Evaluation can always drop it (it takes no gradients) even when it cannot drop
-# the physical patches. It is context-local because a global one is wrong in both
-# directions: global-and-never-cleared makes a nested evaluation read as training,
-# while global-and-always-cleared lets one trainer's evaluation clear the flag out
-# from under a second trainer that is still differentiating -- and that one is a
-# crash, since a call site like GLM-5.x's, which passes no `use_kernel`, would then
-# route its backward to the fused kernel that has no VJP. ContextVar isolates per
-# thread AND per asyncio Task, where `threading.local` would only cover the first.
+# Two depths, with different scopes. Physical: how many runs still need `mlx.core`
+# wrapped. Global under the lock, since unpatching is process-wide.
 _MLX_TRAINING_PATCH_DEPTH = 0
+# Logical: is THIS context inside a training step. Context-local because a global
+# one is wrong both ways -- never cleared, a nested evaluation reads as training;
+# always cleared, one trainer's evaluation clears the flag under another that is
+# still differentiating, and a call site passing no `use_kernel` (GLM-5.x) then
+# routes its backward to the fused kernel, which has no VJP. ContextVar covers
+# threads and asyncio Tasks; `threading.local` would cover only the first.
 _MLX_TRAINING_ACTIVE_DEPTH = contextvars.ContextVar(
     "unsloth_mlx_training_active_depth", default=0)
-# Immutable tuple, never a list: a mutable ContextVar default is shared by every
-# context that never set one, which would put the stack straight back in global scope.
+# Tuple, not list: a mutable ContextVar default is shared by every context that
+# never set one, putting the stack straight back in global scope.
 _MLX_TRAINING_PAUSE_STACK = contextvars.ContextVar(
     "unsloth_mlx_training_pause_stack", default=())
 # MLX differentiates integer arrays, so only real index positions are detached.
@@ -499,13 +491,11 @@ def pause_mlx_training_patches() -> bool:
     """Evaluation runs under `model.eval()` but inside the trainer's window, which
     would otherwise route it down the training paths.
 
-    The logical "inside a training step" flag is ALWAYS cleared, but only for THIS
-    context, so an uncached evaluation never reads as training and a second trainer
-    differentiating on another thread keeps its own flag. Removing the process-wide
-    `mlx.core` patches is refused while another run holds the window, and the return
-    value reports only that: True when they came off, False when another run still
-    needs them. Leaving them on costs nothing here, because they only stop gradients
-    flowing into gather indices and evaluation takes no gradients.
+    Always clears the logical flag, but only for THIS context, so a second trainer
+    on another thread keeps its own. The return value reports only whether the
+    process-wide patches came off: they stay while another run needs them, which
+    costs nothing, since they stop gradients into gather indices and evaluation
+    takes none.
     """
     global _MLX_TRAINING_PATCH_DEPTH
     _MLX_TRAINING_PAUSE_STACK.set(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -528,6 +528,16 @@ def _get_vision_encoder_layers(model):
     return None
 
 
+def _detach_integer_arrays(value):
+    """`mx.checkpoint` makes every argument a primal of the recomputed function,
+    so a layer that embeds the token ids it was handed derives a gather index."""
+    if isinstance(value, list):
+        return [_detach_integer_arrays(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_detach_integer_arrays(v) for v in value)
+    return _detach_if_index(value)
+
+
 def _patch_layer_class_for_gc(layer_cls):
     if getattr(layer_cls, '_orig_call', None) is not None:
         return  # already patched
@@ -539,6 +549,8 @@ def _patch_layer_class_for_gc(layer_cls):
         if slot is None:
             def inner_fn(params, *args, **kwargs):
                 self.update(params)
+                args = tuple(_detach_integer_arrays(a) for a in args)
+                kwargs = {k: _detach_integer_arrays(v) for k, v in kwargs.items()}
                 return fn(self, *args, **kwargs)
             return mx.checkpoint(inner_fn)(
                 self.trainable_parameters(), *args, **kwargs)
@@ -548,6 +560,8 @@ def _patch_layer_class_for_gc(layer_cls):
         def inner_fn(params, borrowed, *args, **kwargs):
             self.update(params)
             slot.install(borrowed)
+            args = tuple(_detach_integer_arrays(a) for a in args)
+            kwargs = {k: _detach_integer_arrays(v) for k, v in kwargs.items()}
             out = fn(self, *args, **kwargs)
             return out, slot.recorded()
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -408,7 +408,16 @@ _MLX_INDEX_CONSUMERS = {  # index-argument positions, by op
 _MLX_INDEX_KEYWORDS = frozenset(("indices", "lhs_indices", "rhs_indices"))
 _MLX_INDEX_OP_NAMES = _MLX_INDEX_PRODUCERS + tuple(_MLX_INDEX_CONSUMERS)
 _MLX_INDEX_GRADIENT_LOCK = threading.RLock()
+# Two counters, because the two questions have different answers. The patch depth
+# is physical -- how many runs still need `mlx.core` wrapped -- and unpatching is
+# process-wide, so an inner run must not unpatch an outer one. The active depth is
+# logical: is THIS thread of control inside a training step. Evaluation can always
+# drop the logical flag (it takes no gradients) even when it cannot drop the
+# physical patches, and without that separation an evaluation nested under a
+# second run still looks like training to `_is_training_call`.
 _MLX_TRAINING_PATCH_DEPTH = 0
+_MLX_TRAINING_ACTIVE_DEPTH = 0
+_MLX_TRAINING_PAUSE_STACK = []
 # MLX differentiates integer arrays, so only real index positions are detached.
 _MLX_INTEGER_DTYPES = frozenset((mx.int8, mx.int16, mx.int32, mx.int64,
                                  mx.uint8, mx.uint16, mx.uint32, mx.uint64))
@@ -453,29 +462,41 @@ def _set_mlx_index_gradient_stop(enabled: bool) -> None:
 def acquire_mlx_training_patches() -> None:
     """Reference-counted: the `mlx.core` patches are process-wide while trainer
     runs are not, so an inner run must not unpatch an outer one."""
-    global _MLX_TRAINING_PATCH_DEPTH
+    global _MLX_TRAINING_PATCH_DEPTH, _MLX_TRAINING_ACTIVE_DEPTH
     with _MLX_INDEX_GRADIENT_LOCK:
         if _MLX_TRAINING_PATCH_DEPTH == 0:
             _set_mlx_index_gradient_stop(True)
         _MLX_TRAINING_PATCH_DEPTH += 1
+        _MLX_TRAINING_ACTIVE_DEPTH += 1
 
 
 def release_mlx_training_patches() -> None:
-    global _MLX_TRAINING_PATCH_DEPTH
+    global _MLX_TRAINING_PATCH_DEPTH, _MLX_TRAINING_ACTIVE_DEPTH
     with _MLX_INDEX_GRADIENT_LOCK:
         if _MLX_TRAINING_PATCH_DEPTH == 0:
             return
         _MLX_TRAINING_PATCH_DEPTH -= 1
+        if _MLX_TRAINING_ACTIVE_DEPTH > 0:
+            _MLX_TRAINING_ACTIVE_DEPTH -= 1
         if _MLX_TRAINING_PATCH_DEPTH == 0:
             _set_mlx_index_gradient_stop(False)
 
 
 def pause_mlx_training_patches() -> bool:
     """Evaluation runs under `model.eval()` but inside the trainer's window, which
-    would otherwise route it down the training paths. Refused while another run
-    holds the window, since unpatching is process-wide."""
-    global _MLX_TRAINING_PATCH_DEPTH
+    would otherwise route it down the training paths.
+
+    The logical "inside a training step" flag is ALWAYS cleared, so an uncached
+    evaluation never reads as training. Removing the process-wide `mlx.core`
+    patches is refused while another run holds the window, and the return value
+    reports only that: True when they came off, False when another run still
+    needs them. Leaving them on costs nothing here, because they only stop
+    gradients flowing into gather indices and evaluation takes no gradients.
+    """
+    global _MLX_TRAINING_PATCH_DEPTH, _MLX_TRAINING_ACTIVE_DEPTH
     with _MLX_INDEX_GRADIENT_LOCK:
+        _MLX_TRAINING_PAUSE_STACK.append(_MLX_TRAINING_ACTIVE_DEPTH)
+        _MLX_TRAINING_ACTIVE_DEPTH = 0
         if _MLX_TRAINING_PATCH_DEPTH != 1:
             return False
         _MLX_TRAINING_PATCH_DEPTH = 0
@@ -484,12 +505,22 @@ def pause_mlx_training_patches() -> bool:
 
 
 def resume_mlx_training_patches(paused: bool) -> None:
-    if paused:
-        acquire_mlx_training_patches()
+    """Reopen at the depth `pause_mlx_training_patches` closed from.
+
+    Deliberately not `acquire()`: that would count a second run, and the pause
+    never released one.
+    """
+    global _MLX_TRAINING_PATCH_DEPTH, _MLX_TRAINING_ACTIVE_DEPTH
+    with _MLX_INDEX_GRADIENT_LOCK:
+        if paused and _MLX_TRAINING_PATCH_DEPTH == 0:
+            _set_mlx_index_gradient_stop(True)
+            _MLX_TRAINING_PATCH_DEPTH = 1
+        if _MLX_TRAINING_PAUSE_STACK:
+            _MLX_TRAINING_ACTIVE_DEPTH = _MLX_TRAINING_PAUSE_STACK.pop()
 
 
 def mlx_training_patches_active() -> bool:
-    return _MLX_TRAINING_PATCH_DEPTH > 0
+    return _MLX_TRAINING_ACTIVE_DEPTH > 0
 
 
 def _get_transformer_layers(model):
@@ -534,7 +565,12 @@ def _detach_integer_arrays(value):
     if isinstance(value, list):
         return [_detach_integer_arrays(v) for v in value]
     if isinstance(value, tuple):
-        return tuple(_detach_integer_arrays(v) for v in value)
+        detached = tuple(_detach_integer_arrays(v) for v in value)
+        # A NamedTuple is a tuple subclass; rebuilding it as a plain tuple would
+        # turn a layer's `payload.ids` into an AttributeError.
+        return type(value)(*detached) if hasattr(value, "_fields") else detached
+    if isinstance(value, dict):
+        return {k: _detach_integer_arrays(v) for k, v in value.items()}
     return _detach_if_index(value)
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2835,6 +2835,7 @@ _VLM_ARRAY_GRID_MODEL_TYPES = frozenset({
     "glm_ocr",
     # Not compile-patched, and opens with `grid_thw.tolist()`.
     "muse_glimmer",
+    "glm5_next",
 })
 
 
@@ -3283,6 +3284,7 @@ _VLM_QWEN_POSITION_MODEL_TYPES = frozenset({
     "qwen3_vl_moe",
     "qwen3_5",
     "qwen3_5_moe",
+    "qwen4_exp",
 })
 _VLM_POSITION_GENERATING_MODEL_TYPES = (
     _VLM_QWEN_POSITION_MODEL_TYPES | {"glm_ocr"}


### PR DESCRIPTION
Adds MLX training and inference support for [Qwen3.8-Flash-Next](https://modelscope.cn/models/Qwen/Qwen3.8-Flash-Next) (`qwen4_exp`) and [GLM-5.3-Flash](https://modelscope.cn/models/ZhipuAI/GLM-5.3-Flash) (`glm5_next`), both supported by mlx-vlm since 0.6.17. Neither trained before this: a text dataset failed at load, and once loaded the backward pass aborted in three different places.

One of those places is not specific to these two families — a stock mlx-lm MoE model fails backward at any sequence length with `model.train()` set — so the first commit fixes MoE training generally.

## Stacking

Stacked on #1040. That branch is not in this repository, so GitHub cannot use it as the base and the diff below includes #1040's commits; only the five commits from `fix(mlx): keep index-deriving graphs differentiable during training` onward belong to this PR. Rebasing onto `main` once #1040 merges will make the diff exact.

To make inference and training work in Unsloth Studio, this also needs unslothai/unsloth#9878, which stops the "New model architecture" dialog from offering an unactionable transformers upgrade on MLX hosts. Both `qwen4_exp` and `glm5_next` are absent from transformers, and no transformers version can make them loadable when mlx-vlm is what builds them.

## What was broken, and why

**MoE routing was not differentiable.** MLX raises rather than returning zero when a backward pass reaches the index argument of a gather or scatter, so any graph deriving indices from activations aborts. mlx-lm already detaches the expert index it hands to the switch linears, but the router's own score gather sits upstream and is undetached — `mlx_lm/models/qwen3_moe.py` takes `inds = mx.argpartition(gates, ...)` and then `mx.take_along_axis(gates, inds, axis=-1)` — so training fails with `[gather_axis] Cannot calculate VJP with respect to indices`. The same shape breaks SwitchGLU's expert gather-sort and GLM-5.x's sparse-attention mask scatter.

Index arguments are now detached at MLX's index producers (`argpartition`, `argsort`, `argmax`, `argmin`) and at the index-argument positions of its consumers (`take`, `take_along_axis`, `put_along_axis`, `gather_mm`, `gather_qmm`). Producers are wrapped as well as consumers because fancy indexing goes through `mx.array.__getitem__`, which cannot be patched on a C extension type, while detaching at `argsort` still reaches it. Only integer arrays at those positions are detached: MLX does differentiate integer arrays, so a gathered token-id tensor keeps whatever gradient it had, and a non-array is left alone — SwitchGLU's quantized path passes `lhs_indices=None`, and `mx.stop_gradient(None)` raises.

**Patch selection by `model_type` missed both families.** `qwen4_exp` reuses Qwen3.5's attention and gated-delta classes under its own name, and GLM-5.x calls its gated-delta mixer `Glm5NextLinearAttention`. Detection is now structural: a gated-delta layer is one carrying the `A_log`/`dt_bias` pair whose defining module also binds `gated_delta_update` (Mamba and SSM mixers carry the same parameters but never call it), and the walk covers every named module rather than the mixers alone — which is how GLM-5.x is reached, since it holds that pair on a separate `Glm5NextForgetGate`. Qwen3.5 attention is matched by walking the MRO so subclasses count.

**GLM-5.x reached a kernel with no VJP.** Its linear attention binds mlx-vlm's shared `models/gated_delta.py` update rather than the per-model copy, and its call site passes neither `use_kernel` nor a cache, so training reached the fused Metal kernel. The shared function is now patched too, honouring the `lower_bound` gate the `qwen3_5` signature does not carry, with consumers that from-imported it rebound. Whether a call needs the custom VJP is one predicate shared by all three patch sites: an empty cache does not say so on its own, because prefill starts with one too and the VJP costs several times the fused kernel there.

**Fused input projections hid live weights.** GLM-5.x linear attention concatenates the raw `.weight` of its six input projections once and caches the result, so a LoRA-wrapped module raises (no `.weight` to read) and a full fine-tune keeps the copy made before the first step. Fusion is now turned off where it would hide live weights, and restored afterwards so inference in the same process keeps the faster path. The fused MRoPE kernel was already being turned off for the same reason but was never turned back on; it now reports the modules it changed and the trainer re-fuses them.

**Two failures that only appear on a large real checkpoint.** `_keep_norm_parameters_float32` cast the normalization parameters and then called `mx.eval(model.parameters())`, forcing the entire parameter tree into a single Metal command buffer; since MLX loads weights lazily, on an 83 GB checkpoint that is the first materialization of every weight at once and the run dies with `[METAL] Command buffer execution failed: Caused GPU Timeout Error`. Only the casts are evaluated now. Separately, gradient checkpointing made any layer that embeds its own token ids fail backward with `[gather] Cannot calculate VJP with respect to indices`: `mx.checkpoint` turns every argument of the wrapped function into a primal of the recomputed one, so an integer argument that was a constant in the eager forward becomes something MLX wants a gradient for. Detaching inside the checkpointed function fixes it; detaching before the boundary does not, because the array is a declared primal either way.

**Image datasets failed on the first step, differently for each.** GLM-5.x's vision tower opens `rot_pos_emb` with `grid_thw.tolist()`, so the Python tuple form the pipeline hands every model type outside the array-grid set raised `AttributeError: 'tuple' object has no attribute 'tolist'`; its tower is not compile-patched, so the array form carries no tracer risk there. `qwen4_exp` reuses Qwen3.5's MRoPE but was not among the model types the pipeline builds position ids for, so nothing supplied them, the explicit-position path declined, and the model fell through to mlx-vlm's own `get_rope_index` — which calls `.item()` on grid entries the pipeline hands over as plain ints. Building the position ids keeps that call from happening at all.

**Text datasets failed at load.** A text-only request routes to mlx_lm unless the architecture is one whose mlx-vlm text path is known to train. Neither family was listed and mlx_lm has no class for either, so a text dataset failed with `ValueError: Model type qwen4_exp not supported` even though both train correctly once loaded. Both qualify: they are causal decoders whose outer call takes ids alone, and the per-call position state that keeps other multimodal wrappers off this path does not affect them — `glm5_next` keeps none, and `qwen4_exp` inherits the cached position tensor of its Qwen3.5 base, whose reuse is guarded on a matching batch and a sufficient cached length.

## Reviewer notes

The `mlx.core` index patches are process-wide, so they are installed behind a reference-counted window the trainer opens and releases in its `finally`. Nested trainer runs in one process do not unpatch each other, and the last one out restores `mlx.core`. Evaluation between training steps runs under `model.eval()` but inside that window, so the window is closed around it and reopened at the depth it had; without that, an uncached evaluation pass looks like training to anything consulting the window.

A direct call that asks for the fused kernel and then differentiates is indistinguishable from prefill and keeps the kernel. That is deliberate — the alternative is paying the VJP cost on every prefill.

## Not in this PR

GGUF export is still in progress for these architectures and is not part of this change; training, inference and adapter saving are unaffected. The remaining work is MoE-specific — an MLX checkpoint stacks its experts into single tensors that the export path has to split back apart — and is being carried on a separate branch (`fix/mlx-gguf-moe-experts`) that is not published yet. It will follow as its own PR.

## Validation

Verified end to end on a 3-bit Qwen3.8-Flash-Next checkpoint (48 layers, 512 experts, 83 GB) on Apple Silicon: loads on both the multimodal and the text path, and LoRA-trains from a text dataset on each of them with gradient checkpointing under both the standard and the chunked cross-entropy loss. Losses agree between the two loss paths at LR 0:

```text
CCE off  [4.589361, 4.410814, 4.540165, 4.862763]
CCE on   [4.589848, 4.410836, 4.540197, 4.862772]
```

`glm5_next`, whose full checkpoint does not fit locally, was verified against a shrunken but otherwise real one rather than by argument. Every earlier check on it had built the model straight from a config, so none of them touched `FastMLXModel.from_pretrained` — which is exactly where `qwen4_exp` failed.

The harness materializes a small checkpoint on disk: the published `config.json` with the layer counts and hidden sizes reduced, randomly initialized weights written as safetensors, and a real tokenizer of the same family (GLM-4.6V, 151,365 tokens) so the chat template is realistic. It then runs the whole path Studio runs — `text_only=True` load, `get_peft_model`, then `MLXTrainer` for four steps with gradient checkpointing and deliberately ragged batch widths, under both loss paths.

The load takes the allow-list branch, confirmed by its own log line, and this branch's other work fires on `glm5_next` too:

```text
Unsloth: Loading … via mlx-vlm (VLM)...
Unsloth: text_only=True requested for a multimodal wrapper; keeping the model on the mlx-vlm path and returning its tokenizer.
Unsloth: Disabled fused input projections on 5 modules.
Unsloth: Rebound gated_delta_update in mlx_vlm.models.glm5_next.language.
Unsloth: Patched shared mlx-vlm GatedDeltaNet with custom VJP.
```

Losses land just above `ln(151365) = 11.93`, which is what a randomly initialized checkpoint should report, and the two loss paths agree:

```text
CCE off  [12.3828, 12.3828, 12.3822, 12.4479]
CCE on   [12.3844, 12.3844, 12.3890, 12.4412]
```

Removing either allow-list entry reproduces exactly the `ValueError: Model type <arch> not supported` this fixes.

Training from an image dataset was verified on shrunken checkpoints of both architectures, materialized with the published vision token ids and driven by a real processor, through the multimodal path Studio uses for image data. Both train end to end with gradient checkpointing, mask image tokens from the loss, and report identical losses on the two loss paths:

```text
qwen4_exp   CCE off [12.4540, 12.4707]   CCE on [12.4540, 12.4707]
glm5_next   CCE off [12.2126, 12.2315]   CCE on [12.2126, 12.2315]
```

Position-state reuse was measured rather than assumed — priming a model with one shape and then running another reproduces a fresh, identically seeded model bitwise, across both width directions and both batch directions.

The mlx-vlm shared-module patch was checked against every release in the supported range (`>=4.4,<0.7.0`), covering both module layouts (`models/gated_delta.py` from 0.6.6, `models/text_models/gated_delta.py` before it) and the `lower_bound` parameter that appears in 0.6.9.

```bash
python -m pytest tests/test_mlx_gated_delta_vjp.py tests/test_mlx_vlm_label_masks.py tests/test_mlx_trainer_internals.py tests/test_qwen35_vjp_metal.py tests/test_mlx_switch_lora.py tests/test_mlx_runtime_cce_compile.py tests/test_mlx_training_e2e_metal.py tests/test_mlx_pr684_full_validation_metal.py -q
```





