### PR TITLE
MLX: escape sampled text, join the rank consensus, notice a missing eval cadence

### DIFF
--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -973,8 +973,12 @@ def _generation_common(tmp_path, **overrides):
     return common
 
 
-def _run_generation_trainer(trainer, monkeypatch, calls):
-    """Drive one training step whose evaluation samples, recording engine calls."""
+def _run_generation_trainer(trainer, monkeypatch, calls, generate_batch=None):
+    """Drive one training step whose evaluation samples, recording engine calls.
+
+    ``generate_batch`` replaces the recording stub, for tests that need the
+    engine to fail or to return text of their own choosing.
+    """
     import mlx.core as mx
     import mlx.nn as nn
     from mlx.utils import tree_map
@@ -997,7 +1001,9 @@ def _run_generation_trainer(trainer, monkeypatch, calls):
             for index, _ in enumerate(requests)
         ]
 
-    monkeypatch.setattr(generate_module, "generate_batch", fake_generate_batch)
+    monkeypatch.setattr(
+        generate_module, "generate_batch", generate_batch or fake_generate_batch,
+    )
 
     def value_and_grad_with_aux(model, fn):
         def wrapped(*args):
@@ -1498,3 +1504,121 @@ def test_the_best_metric_direction_reaches_callbacks_that_read_it(tmp_path):
             tmp_path, reference_free=True, generate_during_eval=False,
             metric_for_best_model="eval_rewards/accuracies")))
     assert trainer.args.greater_is_better is True
+
+
+def test_sampled_text_cannot_drive_the_terminal(tmp_path, monkeypatch, capsys):
+    """Prompts come from the dataset and completions from the model, so both are
+    untrusted text on its way to a terminal.
+
+    str.split() collapses whitespace and leaves ESC/BEL untouched, so an OSC
+    sequence reached the terminal intact and a CSI erase could rewrite the log
+    above it. Falsified against the whitespace-only version: the raw escapes
+    appear in the captured output.
+    """
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3),
+        eval_dataset={"ev\x1b[2Kil": rows(2)},
+        args=MLXDPOConfig(**_generation_common(tmp_path, reference_free=True)),
+    )
+
+    def hostile_generate_batch(model, tokenizer, requests, *, defaults=None):
+        return [
+            types.SimpleNamespace(
+                token_ids=[1, 2],
+                text="ok\x1b]52;c;U0VDUkVU\x07forged‮desrever",
+                logprobs=[0.0, 0.0], finish_reason="length", stop_match=None,
+            )
+            for _ in requests
+        ]
+
+    _run_generation_trainer(
+        trainer, monkeypatch, [], generate_batch=hostile_generate_batch,
+    )
+
+    printed = capsys.readouterr().out
+    assert "forged" in printed, "the text itself still shows"
+    for raw in ("\x1b]52", "\x07", "‮", "\x1b[2K"):
+        assert raw not in printed, f"{raw!r} reached the terminal"
+    assert "\\x1b" in printed, "the escape is shown, not executed"
+
+
+def test_a_failing_decode_joins_the_rank_consensus(tmp_path, monkeypatch):
+    """A rank that unwinds is a rank that never reaches the collective.
+
+    The caller keeps a raise off the run, but _sample_generations still calls
+    _distributed_should_stop() between the two decodes. A rank that left early
+    would strand a healthy peer waiting there, so the failing rank has to join a
+    consensus first. Falsified against an unguarded decode: no consensus is
+    joined at all.
+    """
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3), eval_dataset=rows(2),
+        args=MLXDPOConfig(**_generation_common(tmp_path, reference_free=True)),
+    )
+
+    joined = []
+    original = trainer._distributed_any_flag
+    monkeypatch.setattr(
+        trainer, "_distributed_any_flag",
+        lambda flag: (joined.append(bool(flag)), original(flag))[1],
+    )
+
+    def exploding_generate_batch(model, tokenizer, requests, *, defaults=None):
+        raise RuntimeError("engine out of memory")
+
+    result = _run_generation_trainer(
+        trainer, monkeypatch, [], generate_batch=exploding_generate_batch,
+    )
+
+    assert result is not None, "the run was aborted by a failed sampler"
+    assert True in joined, "the failing rank never joined the consensus"
+    assert trainer.last_generation_samples == []
+    assert trainer._last_eval_metrics, "the evaluation was discarded"
+
+
+def test_best_model_without_a_cadence_says_so(tmp_path, capsys):
+    """Asking for best-model selection and silently getting none is the worst of
+    the available outcomes: _run_best_tracking never runs, _best_step stays None
+    and the restore is skipped. A callback owning the cadence is legitimate, so
+    this is a notice, not a refusal."""
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    def _notice(eval_strategy=None, **overrides):
+        trainer = MLXDPOTrainer(
+            _tiny_model(), Tokenizer(), rows(3), eval_dataset=rows(2),
+            args=MLXDPOConfig(**_generation_common(
+                tmp_path, reference_free=True, generate_during_eval=False,
+                load_best_model_at_end=True, **overrides)),
+        )
+        # eval_strategy is not a config field; _ensure_callback_args_compat
+        # attaches it, so an epoch run carries it on the args object.
+        if eval_strategy is not None:
+            trainer.args.eval_strategy = eval_strategy
+        trainer._prepare_data(False)
+        return "no evaluation cadence is set" in capsys.readouterr().out
+
+    assert _notice(eval_steps=0) is True
+    assert _notice(eval_steps=1) is False
+    assert _notice(eval_steps=0, eval_strategy="epoch") is False
+
+
+def test_the_sampling_cadence_notice_understands_an_epoch_strategy(
+    tmp_path, capsys,
+):
+    """eval_strategy="epoch" evaluates every epoch without setting eval_steps,
+    so testing eval_steps alone called a real cadence "no cadence". Falsified
+    against the eval_steps-only test: the notice prints for the epoch run."""
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3), eval_dataset=rows(2),
+        args=MLXDPOConfig(**_generation_common(
+            tmp_path, reference_free=True, eval_steps=0)),
+    )
+    trainer.args.eval_strategy = "epoch"
+    trainer._prepare_data(False)
+    assert "no evaluation cadence" not in capsys.readouterr().out

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -1580,6 +1580,58 @@ def test_a_failing_decode_joins_the_rank_consensus(tmp_path, monkeypatch):
     assert trainer._last_eval_metrics, "the evaluation was discarded"
 
 
+def test_a_failed_reference_decode_publishes_no_samples(
+    tmp_path, monkeypatch, capsys,
+):
+    """A referenced run that loses its reference half skips the whole set.
+
+    reference=None is what ORPO and reference-free DPO publish, so keeping the
+    policy half would make a failed reference pass read as a legitimate
+    policy-only sample set -- and _decode has already printed that it is
+    skipping this evaluation's samples. Falsified against the unguarded
+    publish: two rows arrive, each with reference None.
+    """
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+    from unsloth_zoo.mlx.utils import iter_mlx_lora_modules
+
+    model = _tiny_model(lora=True)
+    trainer = MLXDPOTrainer(
+        model, Tokenizer(), rows(3), eval_dataset=rows(2),
+        args=MLXDPOConfig(**_generation_common(tmp_path)),
+    )
+
+    seen = []
+
+    def failing_reference(model, tokenizer, requests, *, defaults=None):
+        seen.append(1)
+        if len(seen) > 1:
+            raise RuntimeError("engine out of memory")
+        return [
+            types.SimpleNamespace(
+                token_ids=[1, 2], text=f"policy{index}", logprobs=[0.0, 0.0],
+                finish_reason="length", stop_match=None,
+            )
+            for index, _ in enumerate(requests)
+        ]
+
+    result = _run_generation_trainer(
+        trainer, monkeypatch, [], generate_batch=failing_reference,
+    )
+
+    assert result is not None, "the run was aborted by a failed sampler"
+    assert len(seen) == 2, "the policy decode ran, then the reference one failed"
+    assert trainer.last_generation_samples == [], (
+        "a policy-only set was published for a failed reference pass"
+    )
+    printed = capsys.readouterr().out
+    assert "reference generation failed" in printed
+    assert "policy0" not in printed, "samples printed after saying they are skipped"
+    assert all(
+        module.scale != 0.0 for _, module in iter_mlx_lora_modules(model)
+    ), "scales restored after the failure"
+    assert trainer._last_eval_metrics, "the evaluation itself still stands"
+
+
 def test_best_model_without_a_cadence_says_so(tmp_path, capsys):
     """Asking for best-model selection and silently getting none is the worst of
     the available outcomes: _run_best_tracking never runs, _best_step stays None
@@ -1653,3 +1705,22 @@ def test_an_eval_split_is_held_to_the_length_it_declares(tmp_path, monkeypatch):
     # The plan is built at the first evaluation, not at _prepare_data.
     with pytest.raises(ValueError, match="more rows than the 2 it declares"):
         _run_generation_trainer(trainer, monkeypatch, [])
+
+
+def test_a_step_cadence_under_eval_strategy_no_is_no_cadence(tmp_path, capsys):
+    """The loop gates its step cadence on _static_eval_cadence_enabled(), so
+    eval_steps > 0 under eval_strategy="no" evaluates never. Reading eval_steps
+    alone called that a cadence and suppressed the notice for the one case it
+    exists to report. Falsified against the eval_steps-only test: nothing prints.
+    """
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3), eval_dataset=rows(2),
+        args=MLXDPOConfig(**_generation_common(
+            tmp_path, reference_free=True, generate_during_eval=False,
+            load_best_model_at_end=True, eval_steps=1)),
+    )
+    trainer.args.eval_strategy = "no"
+    trainer._prepare_data(False)
+    assert "no evaluation cadence is set" in capsys.readouterr().out

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -1622,3 +1622,34 @@ def test_the_sampling_cadence_notice_understands_an_epoch_strategy(
     trainer.args.eval_strategy = "epoch"
     trainer._prepare_data(False)
     assert "no evaluation cadence" not in capsys.readouterr().out
+
+
+def test_an_eval_split_is_held_to_the_length_it_declares(tmp_path, monkeypatch):
+    """len() is checked at configuration time, but the plan builder iterates to
+    exhaustion, so the declared length bounded nothing: a split claiming 2 rows
+    and yielding 3 had all 3 scored, and an endless sized iterable would hang
+    rather than raise. Falsified against the unbounded loop: 3 rows are scored
+    and nothing is raised."""
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    class LyingSplit:
+        """Declares two rows, yields three."""
+
+        def __init__(self, rows_):
+            self._rows = rows_
+
+        def __len__(self):
+            return len(self._rows) - 1
+
+        def __iter__(self):
+            return iter(self._rows)
+
+    trainer = MLXDPOTrainer(
+        _tiny_model(), Tokenizer(), rows(3), eval_dataset=LyingSplit(rows(3)),
+        args=MLXDPOConfig(**_generation_common(
+            tmp_path, reference_free=True, max_steps=1, eval_steps=1,
+            generate_during_eval=False)),
+    )
+    # The plan is built at the first evaluation, not at _prepare_data.
+    with pytest.raises(ValueError, match="more rows than the 2 it declares"):
+        _run_generation_trainer(trainer, monkeypatch, [])

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -976,8 +976,8 @@ def _generation_common(tmp_path, **overrides):
 def _run_generation_trainer(trainer, monkeypatch, calls, generate_batch=None):
     """Drive one training step whose evaluation samples, recording engine calls.
 
-    ``generate_batch`` replaces the recording stub, for tests that need the
-    engine to fail or to return text of their own choosing.
+    ``generate_batch`` replaces the recording stub, for tests needing the engine
+    to fail or to return text of their own choosing.
     """
     import mlx.core as mx
     import mlx.nn as nn
@@ -1507,13 +1507,10 @@ def test_the_best_metric_direction_reaches_callbacks_that_read_it(tmp_path):
 
 
 def test_sampled_text_cannot_drive_the_terminal(tmp_path, monkeypatch, capsys):
-    """Prompts come from the dataset and completions from the model, so both are
-    untrusted text on its way to a terminal.
-
-    str.split() collapses whitespace and leaves ESC/BEL untouched, so an OSC
-    sequence reached the terminal intact and a CSI erase could rewrite the log
-    above it. Falsified against the whitespace-only version: the raw escapes
-    appear in the captured output.
+    """Dataset prompts and model completions are untrusted text bound for a
+    terminal, and str.split() leaves ESC/BEL untouched, so an OSC sequence
+    arrived intact and a CSI erase could rewrite the log above it. Falsified
+    against the whitespace-only version: the raw escapes appear in the output.
     """
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
 
@@ -1545,13 +1542,10 @@ def test_sampled_text_cannot_drive_the_terminal(tmp_path, monkeypatch, capsys):
 
 
 def test_a_failing_decode_joins_the_rank_consensus(tmp_path, monkeypatch):
-    """A rank that unwinds is a rank that never reaches the collective.
-
-    The caller keeps a raise off the run, but _sample_generations still calls
-    _distributed_should_stop() between the two decodes. A rank that left early
-    would strand a healthy peer waiting there, so the failing rank has to join a
-    consensus first. Falsified against an unguarded decode: no consensus is
-    joined at all.
+    """A rank that unwinds never reaches the _distributed_should_stop() call
+    between the two decodes, stranding a healthy peer there, so the failing rank
+    must join a consensus first. Falsified against an unguarded decode: no
+    consensus is joined at all.
     """
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
 
@@ -1583,13 +1577,11 @@ def test_a_failing_decode_joins_the_rank_consensus(tmp_path, monkeypatch):
 def test_a_failed_reference_decode_publishes_no_samples(
     tmp_path, monkeypatch, capsys,
 ):
-    """A referenced run that loses its reference half skips the whole set.
-
-    reference=None is what ORPO and reference-free DPO publish, so keeping the
-    policy half would make a failed reference pass read as a legitimate
-    policy-only sample set -- and _decode has already printed that it is
-    skipping this evaluation's samples. Falsified against the unguarded
-    publish: two rows arrive, each with reference None.
+    """A referenced run that loses its reference half skips the whole set:
+    reference=None is what ORPO and reference-free DPO publish, so the policy
+    half would read as a legitimate policy-only set, after _decode already said
+    it was skipping. Falsified against the unguarded publish: two rows arrive,
+    each with reference None.
     """
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
     from unsloth_zoo.mlx.utils import iter_mlx_lora_modules
@@ -1633,10 +1625,9 @@ def test_a_failed_reference_decode_publishes_no_samples(
 
 
 def test_best_model_without_a_cadence_says_so(tmp_path, capsys):
-    """Asking for best-model selection and silently getting none is the worst of
-    the available outcomes: _run_best_tracking never runs, _best_step stays None
-    and the restore is skipped. A callback owning the cadence is legitimate, so
-    this is a notice, not a refusal."""
+    """Asking for best-model selection and silently getting none is the worst
+    outcome: _best_step stays None and the restore is skipped. A callback owning
+    the cadence is legitimate, so this is a notice, not a refusal."""
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
 
     def _notice(eval_strategy=None, **overrides):
@@ -1646,8 +1637,7 @@ def test_best_model_without_a_cadence_says_so(tmp_path, capsys):
                 tmp_path, reference_free=True, generate_during_eval=False,
                 load_best_model_at_end=True, **overrides)),
         )
-        # eval_strategy is not a config field; _ensure_callback_args_compat
-        # attaches it, so an epoch run carries it on the args object.
+        # Not a config field; _ensure_callback_args_compat attaches it to args.
         if eval_strategy is not None:
             trainer.args.eval_strategy = eval_strategy
         trainer._prepare_data(False)
@@ -1661,9 +1651,9 @@ def test_best_model_without_a_cadence_says_so(tmp_path, capsys):
 def test_the_sampling_cadence_notice_understands_an_epoch_strategy(
     tmp_path, capsys,
 ):
-    """eval_strategy="epoch" evaluates every epoch without setting eval_steps,
-    so testing eval_steps alone called a real cadence "no cadence". Falsified
-    against the eval_steps-only test: the notice prints for the epoch run."""
+    """eval_strategy="epoch" is a cadence without eval_steps, so reading
+    eval_steps alone called a real cadence "no cadence". Falsified against the
+    eval_steps-only test: the notice prints for the epoch run."""
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
 
     trainer = MLXDPOTrainer(
@@ -1677,11 +1667,10 @@ def test_the_sampling_cadence_notice_understands_an_epoch_strategy(
 
 
 def test_an_eval_split_is_held_to_the_length_it_declares(tmp_path, monkeypatch):
-    """len() is checked at configuration time, but the plan builder iterates to
-    exhaustion, so the declared length bounded nothing: a split claiming 2 rows
-    and yielding 3 had all 3 scored, and an endless sized iterable would hang
-    rather than raise. Falsified against the unbounded loop: 3 rows are scored
-    and nothing is raised."""
+    """len() is checked at configuration time but the plan builder iterates to
+    exhaustion, so a split claiming 2 rows and yielding 3 had all 3 scored, and
+    an endless sized iterable would hang. Falsified against the unbounded loop:
+    3 rows are scored and nothing is raised."""
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
 
     class LyingSplit:
@@ -1708,10 +1697,9 @@ def test_an_eval_split_is_held_to_the_length_it_declares(tmp_path, monkeypatch):
 
 
 def test_a_step_cadence_under_eval_strategy_no_is_no_cadence(tmp_path, capsys):
-    """The loop gates its step cadence on _static_eval_cadence_enabled(), so
-    eval_steps > 0 under eval_strategy="no" evaluates never. Reading eval_steps
-    alone called that a cadence and suppressed the notice for the one case it
-    exists to report. Falsified against the eval_steps-only test: nothing prints.
+    """eval_steps > 0 under eval_strategy="no" evaluates never, so reading
+    eval_steps alone suppressed the notice for the one case it exists to report.
+    Falsified against the eval_steps-only test: nothing prints.
     """
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -945,7 +945,9 @@ def _escape_terminal_controls(text):
     Prompts come from the dataset and completions from the model, and
     str.split() strips only whitespace: ESC/BEL survive, so an OSC sequence
     reaches the clipboard and a CSI one rewrites the log above. Only Cc/Cf are
-    escaped, so CJK, emoji and backslashes stay as they are.
+    escaped, so CJK and backslashes stay as they are. Emoji do too unless they
+    join with U+200D, which is Cf: escaping the whole class also catches the
+    Unicode tag block, the carrier for invisible-text smuggling.
     """
     return "".join(
         (
@@ -6479,6 +6481,12 @@ class MLXTrainer:
                     finally:
                         for module, scale in zip(modules, scales):
                             module.scale = scale
+                    if reference is None:
+                        # _decode already said it is skipping this evaluation.
+                        # Publishing the policy half is what an unreferenced
+                        # objective publishes, so the failure would be invisible.
+                        self.last_generation_samples = []
+                        return
             elapsed = time.perf_counter() - started
 
             samples = [
@@ -7869,10 +7877,15 @@ class MLXTrainer:
             # A cadence is optional -- a callback can raise should_evaluate --
             # but selecting a best model reads a metric only an evaluation makes.
             _sampling_eval = bool(getattr(args, "generate_during_eval", False))
-            # An epoch strategy is a cadence too, and is resolved separately
-            # from eval_steps, so testing eval_steps alone misreports it.
+            # Read eval_strategy the way the loop's trigger does: it gates the
+            # step cadence on _static_eval_cadence_enabled(), so eval_steps > 0
+            # under "no" evaluates never, and "epoch" is a cadence without
+            # eval_steps at all.
             _eval_cadence = (
-                _resolve_interval_steps(args.eval_steps, 1) > 0
+                (
+                    _resolve_interval_steps(args.eval_steps, 1) > 0
+                    and self._static_eval_cadence_enabled()
+                )
                 or self._epoch_cadence_enabled("eval_strategy")
             )
             if self.eval_dataset is None and (

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -5893,10 +5893,29 @@ class MLXTrainer:
                 _generation_budget[split_name] = [
                     0, int(args.num_generation_prompts),
                 ]
+            # The plan builder iterates to exhaustion, so the length checked at
+            # configuration time bounds nothing. Hold the split to it: a longer
+            # one scores rows the validation never saw, an endless one hangs.
+            try:
+                expected = len(split)
+            except (TypeError, AttributeError):
+                expected = None
+            seen = 0
             for raw in split:
+                if expected is not None and seen >= expected:
+                    raise ValueError(
+                        "Unsloth MLX preference: the eval dataset yielded more "
+                        f"rows than the {expected} it declares."
+                    )
+                seen += 1
                 yield (
                     self.formatting_func(raw)
                     if self.formatting_func is not None else raw
+                )
+            if expected is not None and seen != expected:
+                raise ValueError(
+                    f"Unsloth MLX preference: the eval dataset yielded {seen} "
+                    f"rows but declares {expected}."
                 )
 
         def _capture_generation_prompt(split_name, prompt_text):

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -47,6 +47,7 @@ from pathlib import Path
 import random
 import socket
 import time
+import unicodedata
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -938,8 +939,30 @@ def _build_generation_defaults(args):
         ) from error
 
 
+def _escape_terminal_controls(text):
+    """Show control characters instead of executing them.
+
+    Prompts come from the dataset and completions from the model, and
+    str.split() strips only whitespace: ESC/BEL survive, so an OSC sequence
+    reaches the clipboard and a CSI one rewrites the log above. Only Cc/Cf are
+    escaped, so CJK, emoji and backslashes stay as they are.
+    """
+    return "".join(
+        (
+            character
+            if unicodedata.category(character) not in ("Cc", "Cf")
+            else (
+                f"\\x{ord(character):02x}"
+                if ord(character) <= 0xFF
+                else f"\\u{ord(character):04x}"
+            )
+        )
+        for character in str(text)
+    )
+
+
 def _one_line(text, width):
-    flat = " ".join(str(text).split())
+    flat = _escape_terminal_controls(" ".join(str(text).split()))
     return flat if len(flat) <= width else flat[: width - 1] + "\u2026"
 
 
@@ -6387,9 +6410,45 @@ class MLXTrainer:
 
                 defaults = self._generation_defaults
                 started = time.perf_counter()
-                policy = generate_batch(
-                    model, self.tokenizer, requests, defaults=defaults,
-                )
+                def _decode(label):
+                    """Decode on every rank, or on none of them.
+
+                    A rank that unwinds never reaches the
+                    _distributed_should_stop() collective below, stranding
+                    peers there. Join a consensus first and skip together, as
+                    _evaluate_batch_totals does.
+                    """
+                    result = None
+                    local_error = None
+                    try:
+                        result = generate_batch(
+                            model, self.tokenizer, requests, defaults=defaults,
+                        )
+                    except BaseException as error:
+                        local_error = error
+                    failed_any = self._distributed_any_flag(local_error is not None)
+                    if local_error is not None and not isinstance(
+                        local_error, Exception
+                    ):
+                        # Captured only to join the consensus.
+                        raise local_error
+                    if failed_any:
+                        detail = (
+                            f"{local_error}" if local_error is not None
+                            else "a peer rank failed"
+                        )
+                        _main_print(
+                            f"  Gen   {label} generation failed ({detail}); "
+                            "skipping samples for this evaluation."
+                        )
+                        return None
+                    return result
+
+                policy = _decode("policy")
+                if policy is None:
+                    self.last_generation_samples = []
+                    return
+
                 reference = None
                 modules = tuple(getattr(_sampling_reference, "modules", ()) or ())
                 if modules and not self._distributed_should_stop():
@@ -6397,9 +6456,7 @@ class MLXTrainer:
                     try:
                         for module in modules:
                             module.scale = 0.0
-                        reference = generate_batch(
-                            model, self.tokenizer, requests, defaults=defaults,
-                        )
+                        reference = _decode("reference")
                     finally:
                         for module, scale in zip(modules, scales):
                             module.scale = scale
@@ -6423,7 +6480,12 @@ class MLXTrainer:
                 f"{sampled} tokens | {elapsed:.1f}s"
             )
             for index, sample in enumerate(samples):
-                tag = "" if sample["split"] is None else f" [{sample['split']}]"
+                # A caller-supplied dict key, no more trusted than the prompt.
+                tag = (
+                    ""
+                    if sample["split"] is None
+                    else f" [{_one_line(sample['split'], 32)}]"
+                )
                 _main_print(f"    {index + 1}{tag} {_one_line(sample['prompt'], 96)}")
                 _main_print(f"        policy    {_one_line(sample['policy'], 96)}")
                 if sample["reference"] is not None:
@@ -7788,6 +7850,12 @@ class MLXTrainer:
             # A cadence is optional -- a callback can raise should_evaluate --
             # but selecting a best model reads a metric only an evaluation makes.
             _sampling_eval = bool(getattr(args, "generate_during_eval", False))
+            # An epoch strategy is a cadence too, and is resolved separately
+            # from eval_steps, so testing eval_steps alone misreports it.
+            _eval_cadence = (
+                _resolve_interval_steps(args.eval_steps, 1) > 0
+                or self._epoch_cadence_enabled("eval_strategy")
+            )
             if self.eval_dataset is None and (
                 args.load_best_model_at_end or args.early_stopping_patience > 0
             ):
@@ -7852,12 +7920,31 @@ class MLXTrainer:
                         "at least 1."
                     )
                 self._generation_defaults = _build_generation_defaults(args)
-                if _resolve_interval_steps(args.eval_steps, 1) <= 0:
+                if not _eval_cadence:
                     print(
                         "Unsloth: generate_during_eval is on but no evaluation "
                         "cadence is set; sampling runs only when a callback "
                         "requests an evaluation."
                     )
+            # Without a cadence nothing raises an evaluation, so _best_step
+            # stays None and the restore is skipped: best-model loading was
+            # asked for and silently not done. A callback may own the cadence,
+            # so notice rather than refuse.
+            if (
+                self.eval_dataset is not None
+                and not _eval_cadence
+                and (
+                    args.load_best_model_at_end
+                    or args.early_stopping_patience > 0
+                )
+            ):
+                print(
+                    "Unsloth: load_best_model_at_end/early_stopping_patience "
+                    "need evaluations to select between, but no evaluation "
+                    "cadence is set. Set eval_steps > 0 or "
+                    "eval_strategy='epoch', or have a callback request "
+                    "evaluations; otherwise no best model is tracked."
+                )
             if (
                 self._batches is not None
                 or getattr(self, "_eval_batches_labeled", None) is not None

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -942,12 +942,9 @@ def _build_generation_defaults(args):
 def _escape_terminal_controls(text):
     """Show control characters instead of executing them.
 
-    Prompts come from the dataset and completions from the model, and
-    str.split() strips only whitespace: ESC/BEL survive, so an OSC sequence
-    reaches the clipboard and a CSI one rewrites the log above. Only Cc/Cf are
-    escaped, so CJK and backslashes stay as they are. Emoji do too unless they
-    join with U+200D, which is Cf: escaping the whole class also catches the
-    Unicode tag block, the carrier for invisible-text smuggling.
+    Dataset prompts and model completions are untrusted: str.split() leaves
+    ESC/BEL intact. Escaping all of Cc/Cf also covers U+200D joiners and the
+    Unicode tag block, while leaving CJK and backslashes alone.
     """
     return "".join(
         (
@@ -5895,9 +5892,9 @@ class MLXTrainer:
                 _generation_budget[split_name] = [
                     0, int(args.num_generation_prompts),
                 ]
-            # The plan builder iterates to exhaustion, so the length checked at
-            # configuration time bounds nothing. Hold the split to it: a longer
-            # one scores rows the validation never saw, an endless one hangs.
+            # The plan builder iterates to exhaustion, so hold the split to the
+            # length it declares: a longer one scores unvalidated rows, an
+            # endless one hangs.
             try:
                 expected = len(split)
             except (TypeError, AttributeError):
@@ -6435,9 +6432,8 @@ class MLXTrainer:
                     """Decode on every rank, or on none of them.
 
                     A rank that unwinds never reaches the
-                    _distributed_should_stop() collective below, stranding
-                    peers there. Join a consensus first and skip together, as
-                    _evaluate_batch_totals does.
+                    _distributed_should_stop() collective below and strands its
+                    peers, so join a consensus first and skip together.
                     """
                     result = None
                     local_error = None
@@ -6482,9 +6478,8 @@ class MLXTrainer:
                         for module, scale in zip(modules, scales):
                             module.scale = scale
                     if reference is None:
-                        # _decode already said it is skipping this evaluation.
-                        # Publishing the policy half is what an unreferenced
-                        # objective publishes, so the failure would be invisible.
+                        # The policy half alone is indistinguishable from what an
+                        # unreferenced objective publishes, hiding the failure.
                         self.last_generation_samples = []
                         return
             elapsed = time.perf_counter() - started
@@ -7877,10 +7872,8 @@ class MLXTrainer:
             # A cadence is optional -- a callback can raise should_evaluate --
             # but selecting a best model reads a metric only an evaluation makes.
             _sampling_eval = bool(getattr(args, "generate_during_eval", False))
-            # Read eval_strategy the way the loop's trigger does: it gates the
-            # step cadence on _static_eval_cadence_enabled(), so eval_steps > 0
-            # under "no" evaluates never, and "epoch" is a cadence without
-            # eval_steps at all.
+            # Match the loop's trigger: eval_steps > 0 under eval_strategy "no"
+            # evaluates never, and "epoch" is a cadence without eval_steps.
             _eval_cadence = (
                 (
                     _resolve_interval_steps(args.eval_steps, 1) > 0
@@ -7958,10 +7951,8 @@ class MLXTrainer:
                         "cadence is set; sampling runs only when a callback "
                         "requests an evaluation."
                     )
-            # Without a cadence nothing raises an evaluation, so _best_step
-            # stays None and the restore is skipped: best-model loading was
-            # asked for and silently not done. A callback may own the cadence,
-            # so notice rather than refuse.
+            # Without a cadence _best_step stays None and the restore is
+            # silently skipped. A callback may own the cadence, so only notice.
             if (
                 self.eval_dataset is not None
                 and not _eval_cadence


### PR DESCRIPTION
Three follow-ups to #1011, which merged before these could go onto its branch. Each is pinned by a test that was mutation-checked: revert the fix and exactly that test fails.

## Sampled text could drive the terminal

`generate_during_eval` prints held-out prompts and model completions. Prompts come from the dataset and completions from the model, so both are untrusted text on its way to a terminal, and `_one_line` collapsed whitespace with `str.split()`, which strips whitespace only:

```
_one_line("safe\x1b]52;c;U0VDUkVU\x07forged", 96)
-> "safe\x1b]52;c;U0VDUkVU\x07forged"
```

ESC, BEL and the rest of C0/C1 survive, so an OSC sequence reaches the clipboard and a CSI sequence erases the lines above it, leaving the surrounding training log reading as something it is not. U+202E reverses the apparent order of everything after it. Split labels bypassed `_one_line` entirely, so a dict eval dataset printed its key raw.

Only `Cc`/`Cf` are escaped, so CJK, emoji, combining marks and backslashes are unchanged, which `repr()` would not have given us.

## A failing decode left its peers at the collective

`_sample_generations` is wrapped, which keeps a raise from the engine off the run. The remaining half is that a rank which unwinds never reaches the `_distributed_should_stop()` call between the two decodes, so a healthy peer waits there for a partner that has already left. Referenced DPO is the configuration that reaches it, since it is the one that decodes twice.

Both decodes now join a rank-wide consensus and skip together, the shape `_evaluate_batch_totals` already uses for this hazard. Interrupts still propagate unwrapped.

## Best-model selection with no evaluation cadence was silent

With an eval dataset, `load_best_model_at_end=True` and the default `eval_steps=0`, nothing raises an evaluation: `_run_best_tracking` never runs, `_best_step` stays `None`, and the restore is guarded on exactly that. Best-model loading was asked for and silently not done. A callback may legitimately own the cadence, so this notices rather than refuses.

The same helper fixes the neighbouring `generate_during_eval` notice, which reported `eval_strategy="epoch"` as no cadence because it tested `eval_steps` alone.

## Verification

- 301 tests across `tests/test_mlx_preference.py` and `tests/test_mlx_trainer_internals.py`.
- 39 MLX test files swept, no failures.
- A compatibility matrix run twice, 14/14 both times: in a venv with no mlx installed, where `is_mlx_available()` must stay False and the MLX modules must not load, and against real mlx 0.32.2 through the `mlx-cpu` manylinux wheel. It covers the pre-PR config payload round-trip, the `MLXTrainingConfig(**kwargs)` call shape Studio uses on Apple Silicon, the best-metric direction, and CJK/emoji/backslash passthrough. Without this change the matrix fails its terminal check.

One note, not a defect. The `self.model.eval()` around `_sample_generations` looks redundant: `generate_batch` already enters `generation_mode(model)`, which snapshots the training flags, calls `model.eval()` and restores them in a `finally` (`unsloth_zoo/mlx/generate.py:555-600`, entered at `generate.py:1702`). Harmless as belt and braces, but worth knowing if it was thought to be load bearing.
