### PR TITLE
Stop a Xet transport fault bypassing the HTTP rung, and give that rung a budget

### DIFF
--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -704,8 +704,7 @@ def _no_real_cache_hit(monkeypatch):
     monkeypatch.delenv("HF_HUB_DISABLE_XET", raising = False)
     monkeypatch.delenv("UNSLOTH_XET_ATTEMPTS", raising = False)
     monkeypatch.delenv("UNSLOTH_HTTP_ATTEMPTS", raising = False)
-    # The HTTP retry backoff is real seconds in production; tests assert the ladder, not the wait.
-    # Set through the knob rather than the module attribute, which also pins that 0 is honoured.
+    # Tests assert the ladder, not the wait. Set through the knob, which also pins that 0 is honoured.
     monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0")
 
 
@@ -746,8 +745,7 @@ class _FakeAttempt:
         )
         result = self._results[len(self.calls) - 1]
         if self.owned_incomplete is not None and result[0] == "stall":
-            # Fidelity: the real attempt publishes the basenames its child held open ONLY on the
-            # stall return, never on a fault, a crash or a deterministic error.
+            # Fidelity: the real attempt publishes its child's open basenames only on a stall.
             params["_owned_incomplete_blobs"] = set(self.owned_incomplete)
         return result
 
@@ -915,20 +913,17 @@ def test_is_retryable_download_error_classification():
         assert f(RepositoryNotFoundError("404 Client Error"), on_xet) is False, on_xet
         assert f(_Resp404("not found"), on_xet) is False, on_xet
         assert f(OSError(errno.ENOSPC, "No space left on device"), on_xet) is False, on_xet
-        # A local filesystem failure is not transport-attributable either: another transport writes
-        # to the same path.
+        # A local filesystem failure is not transport-attributable: the other transport writes there too.
         assert f(PermissionError("cache dir is read-only"), on_xet) is False, on_xet
 
-    # An UNRECOGNIZED error is decided by the rung. hf_xet reports a CAS fault as a bare RuntimeError
-    # carrying a Rust error chain, and reading it as deterministic skipped the HTTP rung entirely
-    # (unslothai/unsloth-zoo#1122). It costs one HTTP attempt to disprove on Xet; on HTTP, the last
-    # rung, an unknown error is surfaced rather than looped.
+    # An UNRECOGNIZED error is decided by the rung: hf_xet reports a CAS fault as a bare RuntimeError,
+    # and reading it as deterministic skipped the HTTP rung entirely (unslothai/unsloth-zoo#1122).
     cas = RuntimeError(
         "Task error: File reconstruction error: CAS Client Error: Format error: "
         "I/O error: error decoding response body"
     )
-    # It must reach the RUNG DEFAULT, not a hint: the wording belongs to xet-core, and a hint list
-    # that happened to cover this one chain would leave the next one deterministic again.
+    # It must reach the RUNG DEFAULT, not a hint: the wording belongs to xet-core, so a hint covering
+    # this one chain would leave the next one deterministic again.
     text = f"{type(cas).__name__}: {cas}".lower()
     assert not any(h in text for h in xf._TRANSIENT_ERROR_HINTS), "must not be hint-matched"
     assert f(cas, True) is True
@@ -1267,8 +1262,7 @@ def test_http_retry_resumes_instead_of_forcing_a_second_clean_redownload(monkeyp
     repo, which is a cost the budget must not introduce."""
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
-    # The unsafe partial is present at the transition and GONE once the forced child has run, which
-    # is what makes the following retries safe to resume.
+    # Present at the transition and GONE once the forced child ran: that is what makes a resume safe.
     seen = {"n": 0}
 
     def _unsafe(*a, **k):
@@ -1390,8 +1384,7 @@ def test_cancel_between_xet_attempts_spawns_nothing(monkeypatch):
         return result
 
     monkeypatch.setattr(xf, "_run_download_attempt", _cancel_after_first)
-    # Cancellation wins over the stall verdict: no second child on EITHER rung, and no destructive
-    # pre-HTTP purge, for a download the caller has already abandoned.
+    # Cancellation wins over the stall verdict: no second child on either rung, and no purge.
     with pytest.raises(RuntimeError, match = "Cancelled"):
         xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None, cancel_event = cancel)
     assert [c.disable_xet for c in fake.calls] == [False]
@@ -5537,9 +5530,7 @@ def test_a_concurrent_spawns_overlay_is_not_read_as_the_users_own_settings(monke
     assert int(rec["xet"][key]) == 1 * GB, "the child was sized from the peer's overlay"
 
 
-# ---------------------------------------------------------------------------------------------
 # Guard-integrity regressions: every value and every exit that could escape DownloadStallError.
-# ---------------------------------------------------------------------------------------------
 
 
 def test_http_retry_backoff_rejects_non_finite_and_clamps(monkeypatch):

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -1275,7 +1275,7 @@ def test_http_retry_resumes_instead_of_forcing_a_second_clean_redownload(monkeyp
         seen["n"] += 1
         return set()
 
-    monkeypatch.setattr(xf, "_unsafe_incomplete_partials", _unsafe)
+    monkeypatch.setattr(xf, "_incomplete_partial_names", _unsafe)
     fake = _install(
         monkeypatch,
         [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
@@ -1298,7 +1298,7 @@ def test_http_retry_keeps_forcing_while_the_unsafe_partial_survives(monkeypatch)
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
     monkeypatch.setattr(
-        xf, "_unsafe_incomplete_partials", lambda *a, **k: {"blob.incomplete"}
+        xf, "_incomplete_partial_names", lambda *a, **k: {"blob.incomplete"}
     )
     fake = _install(
         monkeypatch,
@@ -5831,12 +5831,6 @@ def _sparse(path, size = 64 * 1024 * 1024):
     return path
 
 
-def _contiguous(path, size = 1024):
-    """What huggingface_hub's append-mode HTTP path leaves behind: a fully written prefix."""
-    path.write_bytes(b"x" * size)
-    return path
-
-
 def _repo_cache(tmp_path, monkeypatch):
     blobs = tmp_path / "models--o--r" / "blobs"
     blobs.mkdir(parents = True)
@@ -5845,45 +5839,6 @@ def _repo_cache(tmp_path, monkeypatch):
         xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([tmp_path / "models--o--r"])
     )
     return blobs
-
-
-def test_sparseness_not_identity_decides_whether_a_partial_is_resumable(tmp_path, monkeypatch):
-    """The guard asks the FILE whether it can be resumed, which is the thing that actually matters.
-
-    A name cannot tell the sparse Xet partial from the resumable one huggingface_hub rewrites at the
-    same path under force_download, and an inode cannot either: it is unstable on overlayfs and FUSE
-    caches, absent on some Windows stats, reusable after an unlink, and a same-repo sibling taking
-    its own Xet retry produces the same "same name, new inode" signature as our own forced child
-    while leaving a FRESH sparse partial behind.
-    """
-    blobs = _repo_cache(tmp_path, monkeypatch)
-    sparse = _sparse(blobs / f"aaaa{xf.INCOMPLETE_SUFFIX}")
-    assert xf._partial_is_resumable(sparse) is False
-    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == {sparse.name}
-
-    sparse.unlink()
-    whole = _contiguous(blobs / f"aaaa{xf.INCOMPLETE_SUFFIX}")
-    assert xf._partial_is_resumable(whole) is True
-    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == set(), (
-        "the forced child's own append-mode partial is resumable and must not hold the latch"
-    )
-
-
-def test_a_siblings_fresh_sparse_partial_at_the_same_name_still_holds_the_latch(
-    tmp_path, monkeypatch
-):
-    """The case an inode test gets wrong. A concurrent same-repo ladder taking its own Xet retry
-    unlinks its partial and its next Xet child reopens the same blob name, producing exactly the
-    "same name, new inode" signature the forced HTTP child produces. The new file is a fresh SPARSE
-    Xet partial, so resuming it corrupts the blob just as the first one would."""
-    blobs = _repo_cache(tmp_path, monkeypatch)
-    first = _sparse(blobs / f"bbbb{xf.INCOMPLETE_SUFFIX}")
-    before = first.stat().st_ino
-    first.unlink()
-    second = _sparse(blobs / f"bbbb{xf.INCOMPLETE_SUFFIX}")
-    if second.stat().st_ino == before:
-        pytest.skip("this filesystem reused the inode, so the case cannot be staged here")
-    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == {second.name}
 
 
 def test_an_unreadable_cache_root_reports_unknown_not_empty(tmp_path, monkeypatch):
@@ -5895,43 +5850,57 @@ def test_an_unreadable_cache_root_reports_unknown_not_empty(tmp_path, monkeypatc
     the scan has to probe the root itself.
     """
     _repo_cache(tmp_path, monkeypatch)
-    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == set()
+    assert xf._incomplete_partial_names("model", "o/r", str(tmp_path)) == set()
 
     def _boom(*a, **k):
         raise OSError(13, "Permission denied")
 
     monkeypatch.setattr(pathlib.Path, "iterdir", _boom)
-    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) is None
+    assert xf._incomplete_partial_names("model", "o/r", str(tmp_path)) is None
 
     monkeypatch.undo()
     monkeypatch.setattr(xf, "hf_cache_root", lambda *a, **k: tmp_path / "gone-during-remount")
-    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) is None, (
+    assert xf._incomplete_partial_names("model", "o/r", str(tmp_path)) is None, (
         "a vanished cache root is a remount, not evidence that the partial was cleaned up"
     )
 
 
-def test_undeterminable_sparseness_counts_as_unsafe(tmp_path, monkeypatch):
-    """A filesystem that will not report allocation keeps the guard on.
+def test_a_surviving_partial_holds_the_latch_however_whole_it_looks(tmp_path, monkeypatch):
+    """Absence is the only evidence the guard accepts, and this is why.
 
-    Windows is the live case: NTFS materialises zeros when a writer seeks past the end rather than
-    leaving a hole, so "fully allocated" there does not mean "fully written", and reading it as
-    resumable would be the corrupting direction.
+    Three ways of judging a partial that is still on disk to be a safe prefix were tried here and
+    each released the guard on a real filesystem: the basename, which cannot tell the sparse Xet
+    partial from the resumable one huggingface_hub rewrites at the same path; the inode, which is
+    unstable on overlayfs and FUSE caches, absent from some Windows stats, reusable after an unlink,
+    and identical in shape to what a same-repo sibling's own Xet retry produces; and allocation
+    metadata, which is worse still, because XFS turns speculative preallocation into unwritten
+    extents that are counted in st_blocks and read back as zeros.
+
+    So a partial that is present holds the latch no matter how complete it looks. Getting this wrong
+    installs a zero-filled file under its sha256 blob name with no error at all, because the HTTP
+    path verifies size and not content.
     """
     blobs = _repo_cache(tmp_path, monkeypatch)
-    blob = _contiguous(blobs / f"cccc{xf.INCOMPLETE_SUFFIX}")
+    # Fully allocated, no holes, indistinguishable from a good prefix by any allocation test.
+    whole = blobs / f"aaaa{xf.INCOMPLETE_SUFFIX}"
+    whole.write_bytes(b"x" * 4096)
+    assert xf._incomplete_partial_names("model", "o/r", str(tmp_path)) == {whole.name}
 
-    class _NoBlocks:
-        """What os.stat returns where st_blocks does not exist (Windows, some network mounts)."""
-        st_size = 1024
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    monkeypatch.setenv("UNSLOTH_XET_ATTEMPTS", "1")
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "3")
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0")
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("retryable_error", "503"),
+         ("retryable_error", "503"), ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    http_forces = [c.force_download for c in fake.calls if c.disable_xet]
+    assert all(http_forces), f"a surviving partial was handed to a resuming child: {http_forces}"
 
-    class _FakeBlob:
-        name = blob.name
-
-        def stat(self):
-            return _NoBlocks()
-
-    monkeypatch.setattr(xf, "_windows_allocated_size", lambda *a, **k: None)
-    assert xf._partial_is_resumable(_FakeBlob()) is None
-    # And the scan carries that through as unsafe rather than silently dropping it.
-    monkeypatch.setattr(xf, "_partial_is_resumable", lambda b: None)
-    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == {blob.name}
+    whole.unlink()
+    assert xf._incomplete_partial_names("model", "o/r", str(tmp_path)) == set(), (
+        "once nothing is left there is nothing to resume over, which is the one safe release"
+    )

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -6001,3 +6001,62 @@ def test_hub_short_download_error_spends_the_http_retry_budget():
     # A genuinely local OSError under the Xet cache stays terminal, which is the rule this sits in.
     local = PermissionError(13, "Permission denied", "/home/u/.cache/huggingface/xet/chunks")
     assert xf._is_retryable_download_error(local, on_xet = True) is False
+
+
+def _held_then_http(monkeypatch, first, http_first):
+    """Xet fails with *first*, HTTP then fails with *http_first*, and a later HTTP retry succeeds."""
+    outcomes = []
+    monkeypatch.setenv("UNSLOTH_XET_ATTEMPTS", "1")
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "2")
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0")
+    monkeypatch.setattr(xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append(ok))
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: False)
+    _install(monkeypatch, [first, http_first, ("ok", "/cache/x")])
+    return outcomes
+
+
+def test_an_http_crash_clears_an_unproven_xet_reason(monkeypatch):
+    """The symmetric case to the transient-HTTP-error branch, and it was missed.
+
+    Once HTTP has died the same way, the incident is shown to have hit both rungs, so it is not
+    evidence against this machine's Xet. Clearing only at the terminal exit meant a later HTTP retry
+    succeeding flushed the held reason and charged Xet, and two such downloads demote a healthy
+    machine to HTTP for 24 hours.
+    """
+    outcomes = _held_then_http(
+        monkeypatch, ("retryable_error", "503"), ("crashed", "exited (code=-9) without a result")
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert outcomes == [], "a fault both rungs met is not evidence against this machine's Xet"
+
+
+def test_an_http_crash_after_a_xet_crash_also_clears(monkeypatch):
+    """Same for a crash on both rungs."""
+    outcomes = _held_then_http(
+        monkeypatch, ("crashed", "exited (code=-9) without a result"),
+        ("crashed", "exited (code=-9) without a result"),
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert outcomes == []
+
+
+def test_an_http_crash_does_not_clear_a_proven_stall(monkeypatch):
+    """The counterpart that keeps the clearing honest: a stall the watchdog proved on this machine
+    is not unproven, so an HTTP crash afterwards must not discard it."""
+    outcomes = _held_then_http(
+        monkeypatch, ("stall", "no progress for 30s after 1.2 GB"),
+        ("crashed", "exited (code=-9) without a result"),
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert outcomes == [False], "the proven stall was dropped"
+
+
+def test_a_lone_xet_fault_rescued_by_http_is_still_charged(monkeypatch):
+    """And the control: with no matching HTTP failure, an HTTP success IS the proof that only the
+    Xet path was broken, so the tracker is charged exactly as before."""
+    outcomes = _held_then_http(
+        monkeypatch, ("retryable_error", "503"), ("ok", "/cache/x")
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert outcomes == [False]

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -6051,3 +6051,52 @@ def test_a_lone_xet_fault_rescued_by_http_is_still_charged(monkeypatch):
     )
     assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
     assert outcomes == [False]
+
+
+def _unknown_on_http(monkeypatch, *, health_demote = False, user_disable = False):
+    for var in ("UNSLOTH_DISABLE_XET", "HF_HUB_DISABLE_XET", "UNSLOTH_STABLE_DOWNLOADS"):
+        monkeypatch.delenv(var, raising = False)
+    if user_disable:
+        monkeypatch.setenv("UNSLOTH_DISABLE_XET", "1")
+    monkeypatch.setenv("UNSLOTH_XET_ATTEMPTS", "1")
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "1")
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: False)
+    monkeypatch.setattr(xf, "_record_xet_outcome", lambda ok, reason = "": None)
+    if health_demote:
+        demoted = _types.SimpleNamespace(use_xet = False, reason = "recent failures")
+        monkeypatch.setattr(xf, "_xet_health_or_none", lambda *a, **k: demoted)
+    else:
+        monkeypatch.setattr(xf, "_xet_health_or_none", lambda *a, **k: None)
+    script = [("error", "SomeBrandNewHubError: kaboom")]
+    if not (health_demote or user_disable):
+        script.insert(0, ("retryable_error", "503"))
+    _install(monkeypatch, script)
+
+
+def test_a_health_demotion_to_http_keeps_unknown_errors_inside_the_guard(monkeypatch):
+    """The health tracker can put a machine on HTTP before the ladder starts, and that demotion is
+    internal to this module. The caller's in-process fallback therefore still has Xet ENABLED, so
+    letting a bare RuntimeError escape there reproduces the unguarded hang this PR exists to stop.
+    Scoping the wrap by whether THIS ladder used Xet missed it."""
+    _unknown_on_http(monkeypatch, health_demote = True)
+    with pytest.raises(xf.DownloadStallError):
+        xf.snapshot_download_with_xet_fallback(DL_REPO, token = None)
+
+
+def test_an_explicit_user_disable_still_surfaces_unknown_errors_unchanged(monkeypatch):
+    """The counterpart, and the reason the wrap is scoped rather than universal: a user-level
+    disable is an environment variable the in-process load inherits, so its fallback really is
+    Xet-free and can still be allowed to run. Wrapping here would turn a load that currently
+    succeeds into a hard failure."""
+    _unknown_on_http(monkeypatch, user_disable = True)
+    with pytest.raises(RuntimeError) as exc:
+        xf.snapshot_download_with_xet_fallback(DL_REPO, token = None)
+    assert not isinstance(exc.value, xf.DownloadStallError)
+
+
+def test_falling_back_from_xet_still_keeps_unknown_errors_inside_the_guard(monkeypatch):
+    """Unchanged by the rescoping."""
+    _unknown_on_http(monkeypatch)
+    with pytest.raises(xf.DownloadStallError):
+        xf.snapshot_download_with_xet_fallback(DL_REPO, token = None)

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -5795,10 +5795,15 @@ def test_a_same_named_replacement_partial_releases_the_latch(monkeypatch):
     assert [c.force_download for c in fake.calls] == [False, True, False], (
         "a replacement partial is the forced child's own resumable work, not the unsafe one"
     )
-
-
 def test_blob_identity_scan_uses_the_inode(monkeypatch, tmp_path):
-    """Recreating the file under the same name yields a different identity on a real filesystem."""
+    """The scan reports an inode alongside the name, and the matcher never releases unsafely.
+
+    Deliberately NOT asserting that an unlink plus create always looks like a different file: the
+    kernel is free to hand the replacement the same inode, and a CI runner did exactly that. That
+    reuse is why the matcher is written to release only on evidence -- when the inode is reused the
+    identity matches, the partial reads as still present, and the latch stays on. Costing a clean
+    re-download is the right answer to an ambiguous filesystem; resuming is not.
+    """
     blobs = tmp_path / "blobs"
     blobs.mkdir()
     partial = blobs / f"deadbeef{xf.INCOMPLETE_SUFFIX}"
@@ -5810,8 +5815,15 @@ def test_blob_identity_scan_uses_the_inode(monkeypatch, tmp_path):
     partial.write_bytes(b"defg")
     after = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
     assert {n for (n, _) in after} == {partial.name}
-    assert not xf._surviving_unsafe_partials(before, after), (
-        "an unlink plus create must not look like the same partial"
+    if before == after:
+        # Inode reused: ambiguous, so the latch must stay on.
+        assert xf._surviving_unsafe_partials(before, after) == before
+    else:
+        assert not xf._surviving_unsafe_partials(before, after)
+    partial.unlink()
+    gone = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
+    assert not xf._surviving_unsafe_partials(before, gone), (
+        "a vanished name is the one unambiguous proof of disappearance"
     )
 
 

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -28,6 +28,7 @@ import errno
 import importlib.util
 import json
 import math
+import pathlib
 import os
 import subprocess
 import sys
@@ -1270,11 +1271,11 @@ def test_http_retry_resumes_instead_of_forcing_a_second_clean_redownload(monkeyp
     # is what makes the following retries safe to resume.
     seen = {"n": 0}
 
-    def _names(*a, **k):
+    def _unsafe(*a, **k):
         seen["n"] += 1
-        return {("blob.incomplete", 7)} if seen["n"] == 1 else set()
+        return set()
 
-    monkeypatch.setattr(xf, "_incomplete_blob_identities", _names)
+    monkeypatch.setattr(xf, "_unsafe_incomplete_partials", _unsafe)
     fake = _install(
         monkeypatch,
         [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
@@ -1297,7 +1298,7 @@ def test_http_retry_keeps_forcing_while_the_unsafe_partial_survives(monkeypatch)
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
     monkeypatch.setattr(
-        xf, "_incomplete_blob_identities", lambda *a, **k: {("blob.incomplete", 7)}
+        xf, "_unsafe_incomplete_partials", lambda *a, **k: {"blob.incomplete"}
     )
     fake = _install(
         monkeypatch,
@@ -5726,107 +5727,6 @@ def test_control_flow_exceptions_are_never_transport_faults():
         assert xf._is_retryable_download_error(exc, on_xet = True) is False, exc
         assert xf._is_retryable_download_error(exc, on_xet = False) is False, exc
 
-
-def test_the_verbatim_cas_fault_is_still_retryable_on_xet():
-    """Guard on the guard: none of the tightening above may cost the fix issue #1122 needed."""
-    cas = RuntimeError(
-        "Task error: File reconstruction error: CAS Client Error: "
-        "Format error: I/O error: error decoding response body"
-    )
-    assert xf._is_retryable_download_error(cas, on_xet = True) is True
-    assert xf._is_retryable_download_error(cas, on_xet = False) is False
-
-
-def test_uninspectable_cache_keeps_force_download_latched(monkeypatch):
-    """The un-latch must fail CLOSED. _active_incomplete_blob_sizes is fail-open by design (a
-    progress sensor must not abort a download over one unreadable blob), so an empty result from it
-    means "gone" and "could not look" alike. Releasing the guard on that answer would resume over a
-    sparse Xet partial on exactly the locked-down machines least able to recover from it."""
-    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
-    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
-    monkeypatch.setattr(xf, "_incomplete_blob_identities", lambda *a, **k: None)
-    fake = _install(
-        monkeypatch,
-        [("retryable_error", "503"), ("crashed", "died"), ("ok", "/cache/x")],
-    )
-    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
-    assert [c.force_download for c in fake.calls] == [False, True, True], (
-        "an uninspectable cache must not be read as proof the unsafe partial is gone"
-    )
-
-
-def test_strict_blob_scan_reports_failure_as_none(monkeypatch, tmp_path):
-    """The strict scan is the safety-critical twin of the fail-open sensor: it must distinguish
-    'nothing there' from 'could not look'."""
-    monkeypatch.setattr(xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([]))
-    assert xf._incomplete_blob_identities("model", "o/r", str(tmp_path)) == set()
-
-    def _boom(*a, **k):
-        raise OSError(13, "Permission denied")
-
-    monkeypatch.setattr(xf, "iter_active_repo_cache_dirs", _boom)
-    assert xf._incomplete_blob_identities("model", "o/r", str(tmp_path)) is None
-
-
-def test_a_same_named_replacement_partial_releases_the_latch(monkeypatch):
-    """The latch must key on IDENTITY, not on the basename.
-
-    ``force_download`` makes huggingface_hub unlink the ``.incomplete`` and immediately reopen the
-    same path in append mode. If that forced child then dies mid-transfer, the surviving file has
-    the old name but is a fresh, resumable HTTP partial. Matching on the name alone would read it
-    as the sparse Xet partial that is still there, keep the latch, and make every remaining child
-    throw those bytes away and restart from zero -- turning a corruption guard into a bandwidth
-    amplifier on exactly the flaky links that reach it."""
-    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
-    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
-    seen = {"n": 0}
-
-    def _identities(*a, **k):
-        seen["n"] += 1
-        # Same name throughout; the inode changes once the forced child recreates the file.
-        return {("blob.incomplete", 7 if seen["n"] == 1 else 8)}
-
-    monkeypatch.setattr(xf, "_incomplete_blob_identities", _identities)
-    fake = _install(
-        monkeypatch,
-        [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
-    )
-    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
-    assert [c.force_download for c in fake.calls] == [False, True, False], (
-        "a replacement partial is the forced child's own resumable work, not the unsafe one"
-    )
-def test_blob_identity_scan_uses_the_inode(monkeypatch, tmp_path):
-    """The scan reports an inode alongside the name, and the matcher never releases unsafely.
-
-    Deliberately NOT asserting that an unlink plus create always looks like a different file: the
-    kernel is free to hand the replacement the same inode, and a CI runner did exactly that. That
-    reuse is why the matcher is written to release only on evidence -- when the inode is reused the
-    identity matches, the partial reads as still present, and the latch stays on. Costing a clean
-    re-download is the right answer to an ambiguous filesystem; resuming is not.
-    """
-    blobs = tmp_path / "blobs"
-    blobs.mkdir()
-    partial = blobs / f"deadbeef{xf.INCOMPLETE_SUFFIX}"
-    partial.write_bytes(b"abc")
-    monkeypatch.setattr(xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([tmp_path]))
-    before = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
-    assert {n for (n, _) in before} == {partial.name}
-    partial.unlink()
-    partial.write_bytes(b"defg")
-    after = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
-    assert {n for (n, _) in after} == {partial.name}
-    if before == after:
-        # Inode reused: ambiguous, so the latch must stay on.
-        assert xf._surviving_unsafe_partials(before, after) == before
-    else:
-        assert not xf._surviving_unsafe_partials(before, after)
-    partial.unlink()
-    gone = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
-    assert not xf._surviving_unsafe_partials(before, gone), (
-        "a vanished name is the one unambiguous proof of disappearance"
-    )
-
-
 def _stall_then_fault_then(monkeypatch, final):
     """Xet stalls, a Xet retry faults, and the ladder ends on HTTP with *final*.
 
@@ -5882,28 +5782,6 @@ def test_an_unproven_failure_is_still_dropped_on_those_same_doors(monkeypatch):
         xf.snapshot_download_with_xet_fallback(DL_REPO, token = None)
     assert outcomes == [], "a fault both rungs met is not evidence against this machine's Xet"
 
-
-def test_an_unresolvable_inode_is_not_read_as_a_changed_one():
-    """``st_ino = 0`` means "the filesystem would not say", not "a different file".
-
-    Windows reaches this exactly when it matters: ``os.stat`` falls back to a directory entry that
-    carries no file index when the file is LOCKED, and a locked partial is precisely why the purge
-    failed and the latch engaged. So the transition scan can report 0 and a later scan, taken after
-    the handle is dropped, can report the real inode. Reading that asymmetry as a change would
-    release the guard on the machines least able to survive a corrupt blob.
-    """
-    captured = {("blob.incomplete", 0)}
-    assert xf._surviving_unsafe_partials(captured, {("blob.incomplete", 4242)}), (
-        "unresolved at capture, resolved later: the name is still there, so the latch must hold"
-    )
-    assert xf._surviving_unsafe_partials({("blob.incomplete", 4242)}, {("blob.incomplete", 0)}), (
-        "resolved at capture, unresolved later: still unknown, so the latch must hold"
-    )
-    assert not xf._surviving_unsafe_partials(captured, {("other.incomplete", 0)}), (
-        "the name is gone, which is the one unambiguous proof of disappearance"
-    )
-
-
 def test_a_partial_the_purge_could_not_scope_still_holds_the_latch(monkeypatch, tmp_path):
     """The unsafe set is UNSCOPED, and scoping it by the purge's owned-blob set is backwards.
 
@@ -5916,7 +5794,12 @@ def test_a_partial_the_purge_could_not_scope_still_holds_the_latch(monkeypatch, 
     blobs.mkdir(parents = True)
     # Left by an earlier crashed run: not owned by this download's child, so the purge spares it.
     stale = blobs / f"deadbeef{xf.INCOMPLETE_SUFFIX}"
-    stale.write_bytes(b"\0" * 64)
+    with open(stale, "wb") as fh:
+        # Sparse: full length with a hole, exactly what a killed parallel-chunk writer leaves.
+        fh.truncate(64 * 1024 * 1024)
+        fh.seek(64 * 1024 * 1024 - 4)
+        fh.write(b"tail")
+    monkeypatch.setattr(xf, "hf_cache_root", lambda *a, **k: tmp_path)
     monkeypatch.setattr(
         xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([tmp_path / "models--o--r"])
     )
@@ -5937,3 +5820,118 @@ def test_a_partial_the_purge_could_not_scope_still_holds_the_latch(monkeypatch, 
     assert all(http_forces), (
         f"a surviving sparse partial was handed to an unforced HTTP child: {http_forces}"
     )
+
+
+def _sparse(path, size = 64 * 1024 * 1024):
+    """A full-length file with a hole: what a killed parallel-chunk writer leaves behind."""
+    with open(path, "wb") as fh:
+        fh.truncate(size)
+        fh.seek(size - 4)
+        fh.write(b"tail")
+    return path
+
+
+def _contiguous(path, size = 1024):
+    """What huggingface_hub's append-mode HTTP path leaves behind: a fully written prefix."""
+    path.write_bytes(b"x" * size)
+    return path
+
+
+def _repo_cache(tmp_path, monkeypatch):
+    blobs = tmp_path / "models--o--r" / "blobs"
+    blobs.mkdir(parents = True)
+    monkeypatch.setattr(xf, "hf_cache_root", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(
+        xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([tmp_path / "models--o--r"])
+    )
+    return blobs
+
+
+def test_sparseness_not_identity_decides_whether_a_partial_is_resumable(tmp_path, monkeypatch):
+    """The guard asks the FILE whether it can be resumed, which is the thing that actually matters.
+
+    A name cannot tell the sparse Xet partial from the resumable one huggingface_hub rewrites at the
+    same path under force_download, and an inode cannot either: it is unstable on overlayfs and FUSE
+    caches, absent on some Windows stats, reusable after an unlink, and a same-repo sibling taking
+    its own Xet retry produces the same "same name, new inode" signature as our own forced child
+    while leaving a FRESH sparse partial behind.
+    """
+    blobs = _repo_cache(tmp_path, monkeypatch)
+    sparse = _sparse(blobs / f"aaaa{xf.INCOMPLETE_SUFFIX}")
+    assert xf._partial_is_resumable(sparse) is False
+    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == {sparse.name}
+
+    sparse.unlink()
+    whole = _contiguous(blobs / f"aaaa{xf.INCOMPLETE_SUFFIX}")
+    assert xf._partial_is_resumable(whole) is True
+    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == set(), (
+        "the forced child's own append-mode partial is resumable and must not hold the latch"
+    )
+
+
+def test_a_siblings_fresh_sparse_partial_at_the_same_name_still_holds_the_latch(
+    tmp_path, monkeypatch
+):
+    """The case an inode test gets wrong. A concurrent same-repo ladder taking its own Xet retry
+    unlinks its partial and its next Xet child reopens the same blob name, producing exactly the
+    "same name, new inode" signature the forced HTTP child produces. The new file is a fresh SPARSE
+    Xet partial, so resuming it corrupts the blob just as the first one would."""
+    blobs = _repo_cache(tmp_path, monkeypatch)
+    first = _sparse(blobs / f"bbbb{xf.INCOMPLETE_SUFFIX}")
+    before = first.stat().st_ino
+    first.unlink()
+    second = _sparse(blobs / f"bbbb{xf.INCOMPLETE_SUFFIX}")
+    if second.stat().st_ino == before:
+        pytest.skip("this filesystem reused the inode, so the case cannot be staged here")
+    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == {second.name}
+
+
+def test_an_unreadable_cache_root_reports_unknown_not_empty(tmp_path, monkeypatch):
+    """The half that has to be fail-CLOSED, and the trap under it.
+
+    ``hf_cache_root`` and ``_case_safe_repo_cache_dirs`` both swallow ``OSError`` and report an
+    unreadable or briefly absent root as "no directories", which reads as "every partial vanished".
+    A root that disappears after the guard engaged is a remount or a permission flap, not proof, so
+    the scan has to probe the root itself.
+    """
+    _repo_cache(tmp_path, monkeypatch)
+    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == set()
+
+    def _boom(*a, **k):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(pathlib.Path, "iterdir", _boom)
+    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) is None
+
+    monkeypatch.undo()
+    monkeypatch.setattr(xf, "hf_cache_root", lambda *a, **k: tmp_path / "gone-during-remount")
+    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) is None, (
+        "a vanished cache root is a remount, not evidence that the partial was cleaned up"
+    )
+
+
+def test_undeterminable_sparseness_counts_as_unsafe(tmp_path, monkeypatch):
+    """A filesystem that will not report allocation keeps the guard on.
+
+    Windows is the live case: NTFS materialises zeros when a writer seeks past the end rather than
+    leaving a hole, so "fully allocated" there does not mean "fully written", and reading it as
+    resumable would be the corrupting direction.
+    """
+    blobs = _repo_cache(tmp_path, monkeypatch)
+    blob = _contiguous(blobs / f"cccc{xf.INCOMPLETE_SUFFIX}")
+
+    class _NoBlocks:
+        """What os.stat returns where st_blocks does not exist (Windows, some network mounts)."""
+        st_size = 1024
+
+    class _FakeBlob:
+        name = blob.name
+
+        def stat(self):
+            return _NoBlocks()
+
+    monkeypatch.setattr(xf, "_windows_allocated_size", lambda *a, **k: None)
+    assert xf._partial_is_resumable(_FakeBlob()) is None
+    # And the scan carries that through as unsafe rather than silently dropping it.
+    monkeypatch.setattr(xf, "_partial_is_resumable", lambda b: None)
+    assert xf._unsafe_incomplete_partials("model", "o/r", str(tmp_path)) == {blob.name}

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -5790,7 +5790,7 @@ def test_a_partial_the_purge_could_not_scope_still_holds_the_latch(monkeypatch, 
     place. Filtering them out empties the unsafe set and hands the next HTTP child a sparse partial
     to resume, which finalizes a silently corrupt blob. Real cache layout, real scan.
     """
-    blobs = tmp_path / "models--o--r" / "blobs"
+    blobs = tmp_path / xf.repo_cache_dir_name("model", DL_REPO) / "blobs"
     blobs.mkdir(parents = True)
     # Left by an earlier crashed run: not owned by this download's child, so the purge spares it.
     stale = blobs / f"deadbeef{xf.INCOMPLETE_SUFFIX}"
@@ -5800,9 +5800,6 @@ def test_a_partial_the_purge_could_not_scope_still_holds_the_latch(monkeypatch, 
         fh.seek(64 * 1024 * 1024 - 4)
         fh.write(b"tail")
     monkeypatch.setattr(xf, "hf_cache_root", lambda *a, **k: tmp_path)
-    monkeypatch.setattr(
-        xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([tmp_path / "models--o--r"])
-    )
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
     fake = _install(
@@ -5831,13 +5828,16 @@ def _sparse(path, size = 64 * 1024 * 1024):
     return path
 
 
-def _repo_cache(tmp_path, monkeypatch):
-    blobs = tmp_path / "models--o--r" / "blobs"
+def _repo_cache(tmp_path, monkeypatch, repo_id = "o/r"):
+    """A real cache layout for *repo_id*, with the scan pointed at it.
+
+    Deliberately a real directory tree rather than a stubbed iterator: the scan does its own
+    single-listing repo-dir selection so an OSError there cannot be swallowed, and stubbing that
+    out would silently stop exercising it.
+    """
+    blobs = tmp_path / xf.repo_cache_dir_name("model", repo_id) / "blobs"
     blobs.mkdir(parents = True)
     monkeypatch.setattr(xf, "hf_cache_root", lambda *a, **k: tmp_path)
-    monkeypatch.setattr(
-        xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([tmp_path / "models--o--r"])
-    )
     return blobs
 
 
@@ -5880,11 +5880,11 @@ def test_a_surviving_partial_holds_the_latch_however_whole_it_looks(tmp_path, mo
     installs a zero-filled file under its sha256 blob name with no error at all, because the HTTP
     path verifies size and not content.
     """
-    blobs = _repo_cache(tmp_path, monkeypatch)
+    blobs = _repo_cache(tmp_path, monkeypatch, DL_REPO)
     # Fully allocated, no holes, indistinguishable from a good prefix by any allocation test.
     whole = blobs / f"aaaa{xf.INCOMPLETE_SUFFIX}"
     whole.write_bytes(b"x" * 4096)
-    assert xf._incomplete_partial_names("model", "o/r", str(tmp_path)) == {whole.name}
+    assert xf._incomplete_partial_names("model", DL_REPO, str(tmp_path)) == {whole.name}
 
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
@@ -5901,6 +5901,103 @@ def test_a_surviving_partial_holds_the_latch_however_whole_it_looks(tmp_path, mo
     assert all(http_forces), f"a surviving partial was handed to a resuming child: {http_forces}"
 
     whole.unlink()
-    assert xf._incomplete_partial_names("model", "o/r", str(tmp_path)) == set(), (
+    assert xf._incomplete_partial_names("model", DL_REPO, str(tmp_path)) == set(), (
         "once nothing is left there is nothing to resume over, which is the one safe release"
     )
+
+
+def test_the_repo_dir_scan_fails_closed_when_the_root_flaps(tmp_path, monkeypatch):
+    """One root listing, and any error out of it is reported as unknown.
+
+    The scan used to probe the root and then hand the repo-dir selection to a helper that lists the
+    root AGAIN and swallows OSError. A permission flap or a FUSE/network remount between the two
+    listings therefore came back as "no repo dirs", then as "no partials" -- the empty set that
+    releases the guard and lets the next child resume a sparse partial.
+    """
+    blobs = _repo_cache(tmp_path, monkeypatch)
+    (blobs / f"aaaa{xf.INCOMPLETE_SUFFIX}").write_bytes(b"x")
+    assert xf._incomplete_partial_names("model", "o/r", str(tmp_path)) is not None
+
+    real_iterdir = pathlib.Path.iterdir
+    listings = {"n": 0}
+
+    def _counting(self):
+        if self == tmp_path:
+            listings["n"] += 1
+        return real_iterdir(self)
+
+    monkeypatch.setattr(pathlib.Path, "iterdir", _counting)
+    xf._incomplete_partial_names("model", "o/r", str(tmp_path))
+    assert listings["n"] == 1, (
+        f"the root must be enumerated exactly once, not {listings['n']} times; a second listing is "
+        "where the swallowed OSError used to turn a flap into an empty set"
+    )
+
+    def _boom(self):
+        if self == tmp_path:
+            raise OSError(13, "Permission denied")
+        return real_iterdir(self)
+
+    monkeypatch.setattr(pathlib.Path, "iterdir", _boom)
+    assert xf._incomplete_partial_names("model", "o/r", str(tmp_path)) is None, (
+        "a root that stopped being readable is not evidence the partial was cleaned up"
+    )
+
+
+def test_a_partial_appearing_after_a_release_re_arms_the_guard(tmp_path, monkeypatch):
+    """The guard has to re-arm, not just release once.
+
+    A concurrent Xet downloader can create a partial under the same blob name after the guard
+    released, typically while this child is still waiting on the blob lock. Releasing permanently on
+    the first empty scan let that child resume it unforced and finalize a corrupt blob.
+    """
+    blobs = _repo_cache(tmp_path, monkeypatch, DL_REPO)
+    partial = blobs / f"aaaa{xf.INCOMPLETE_SUFFIX}"
+    partial.write_bytes(b"x" * 16)
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    monkeypatch.setenv("UNSLOTH_XET_ATTEMPTS", "1")
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "4")
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0")
+
+    calls = {"n": 0}
+    real = xf._incomplete_partial_names
+
+    def _staged(*a, **k):
+        # Gone by the second HTTP child (the guard releases), then a sibling recreates it.
+        calls["n"] += 1
+        if calls["n"] == 1:
+            partial.unlink()
+        elif calls["n"] == 2:
+            partial.write_bytes(b"y" * 16)
+        return real(*a, **k)
+
+    monkeypatch.setattr(xf, "_incomplete_partial_names", _staged)
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("retryable_error", "503"),
+         ("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    http_forces = [c.force_download for c in fake.calls if c.disable_xet]
+    assert http_forces[0] is True, "the first HTTP child re-downloads cleanly"
+    assert False in http_forces, "the guard must release once the partial is gone"
+    assert http_forces[-1] is True, (
+        f"a partial that reappeared after the release must re-arm the guard: {http_forces}"
+    )
+
+
+def test_hub_short_download_error_spends_the_http_retry_budget():
+    """huggingface_hub raises a bare EnvironmentError when a download ends at the wrong length, and
+    its own message says it is usually a network issue and to retry. Deciding builtin OSErrors by
+    class alone surfaced it immediately, so the HTTP retry budget this PR adds never applied to the
+    one failure it most obviously covers."""
+    msg = (
+        "Consistency check failed: file should be of size 100 but has size 40 (model.safetensors).\n"
+        "This is usually due to network issues while downloading the file. "
+        "Please retry with `force_download=True`."
+    )
+    assert xf._is_retryable_download_error(EnvironmentError(msg), on_xet = False) is True
+    # A genuinely local OSError under the Xet cache stays terminal, which is the rule this sits in.
+    local = PermissionError(13, "Permission denied", "/home/u/.cache/huggingface/xet/chunks")
+    assert xf._is_retryable_download_error(local, on_xet = True) is False

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -702,9 +702,9 @@ def _no_real_cache_hit(monkeypatch):
     monkeypatch.delenv("HF_HUB_DISABLE_XET", raising = False)
     monkeypatch.delenv("UNSLOTH_XET_ATTEMPTS", raising = False)
     monkeypatch.delenv("UNSLOTH_HTTP_ATTEMPTS", raising = False)
-    monkeypatch.delenv("UNSLOTH_HTTP_RETRY_BACKOFF", raising = False)
     # The HTTP retry backoff is real seconds in production; tests assert the ladder, not the wait.
-    monkeypatch.setattr(xf, "DEFAULT_HTTP_RETRY_BACKOFF", 0.0)
+    # Set through the knob rather than the module attribute, which also pins that 0 is honoured.
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0")
 
 
 class _FakeAttempt:
@@ -918,7 +918,12 @@ def test_is_retryable_download_error_classification():
         "Task error: File reconstruction error: CAS Client Error: Format error: "
         "I/O error: error decoding response body"
     )
+    # It must reach the RUNG DEFAULT, not a hint: the wording belongs to xet-core, and a hint list
+    # that happened to cover this one chain would leave the next one deterministic again.
+    text = f"{type(cas).__name__}: {cas}".lower()
+    assert not any(h in text for h in xf._TRANSIENT_ERROR_HINTS), "must not be hint-matched"
     assert f(cas, True) is True
+    assert f(cas, False) is False
     assert f(ValueError("unexpected response payload"), True) is True
     assert f(ValueError("unexpected response payload"), False) is False
 
@@ -1156,7 +1161,7 @@ def test_cancel_in_the_http_failure_window_reports_cancelled(monkeypatch):
 def test_wait_before_http_retry_is_interruptible(monkeypatch):
     """A cancel arriving during the backoff raises rather than spending another child on a download
     the caller has abandoned; without one the wait is a plain sleep."""
-    monkeypatch.setattr(xf, "DEFAULT_HTTP_RETRY_BACKOFF", 30.0)
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "30")
     cancel = threading.Event()
     cancel.set()
     started = time.monotonic()
@@ -1164,10 +1169,7 @@ def test_wait_before_http_retry_is_interruptible(monkeypatch):
         xf._wait_before_http_retry(cancel)
     assert time.monotonic() - started < 5.0, "must not sit out the whole backoff"
     # No cancel event: the wait is honoured, so keep it short here.
-    monkeypatch.setattr(xf, "DEFAULT_HTTP_RETRY_BACKOFF", 0.01)
-    xf._wait_before_http_retry(None)
-    # Junk in the env override falls back to the default rather than failing a download.
-    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "abc")
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0.01")
     xf._wait_before_http_retry(None)
 
 
@@ -1201,6 +1203,102 @@ def test_crash_on_xet_is_charged_only_when_http_rescues_it(monkeypatch):
     _install(monkeypatch, [("crashed", "boom"), ("ok", "/cache/x")])
     xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
     assert outcomes == [False]
+
+
+def test_offline_mode_is_deterministic_on_both_rungs(monkeypatch):
+    """OfflineModeIsEnabled subclasses builtin ConnectionError, so it is an OSError with no errno and
+    no builtin of its own name -- nothing else in the predicate catches it. Without an entry in the
+    name set the rung default would spend an HTTP child AND the destructive pre-HTTP purge on a repo
+    the user has deliberately switched offline."""
+    from huggingface_hub.errors import OfflineModeIsEnabled
+
+    assert "OfflineModeIsEnabled" in xf._DETERMINISTIC_ERROR_NAMES
+    exc = OfflineModeIsEnabled(
+        "Offline mode is enabled. To disable it, please unset the HF_HUB_OFFLINE environment variable."
+    )
+    assert isinstance(exc, OSError) and getattr(exc, "errno", None) is None
+    for on_xet in (True, False):
+        assert xf._is_retryable_download_error(exc, on_xet = on_xet) is False, on_xet
+
+
+def test_deterministic_http_error_does_not_charge_a_held_transport_fault(monkeypatch):
+    """A Xet fault held for proof, then an unrelated deterministic failure on HTTP (disk full): the
+    download succeeded on neither rung, so nothing ever showed the Xet path alone was broken. Two of
+    these would demote the machine to HTTP for 24h."""
+    outcomes = []
+    monkeypatch.setattr(xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append(ok))
+    _install(
+        monkeypatch,
+        [("retryable_error", "503 Service Unavailable"),
+         ("error", "OSError: [Errno 28] No space left on device")],
+    )
+    with pytest.raises(OSError, match = "No space left"):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert outcomes == [], "neither rung finished: not a Xet verdict"
+
+
+def test_a_stall_is_still_charged_when_a_later_error_ends_the_ladder(monkeypatch):
+    """The counterpart to the test above, and the invariant it must not break: a STALL stands on its
+    own as evidence, so a deterministic error afterwards still reports it."""
+    outcomes = []
+    monkeypatch.setattr(xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append(ok))
+    _install(
+        monkeypatch,
+        [("stall", None), ("error", "RepositoryNotFoundError: gone")],
+    )
+    with pytest.raises(Exception):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert outcomes == [False]
+
+
+def test_http_retry_resumes_instead_of_forcing_a_second_clean_redownload(monkeypatch):
+    """An unsafe partial that could not be cleared forces a clean re-download on the FIRST HTTP
+    child. Leaving force_download latched would make every retry in the new budget discard the
+    partial that child wrote and start again from zero -- the whole file per attempt on a large
+    repo, which is a cost the budget must not introduce."""
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert [c.force_download for c in fake.calls] == [False, True, False], (
+        "Xet as asked, one clean HTTP re-download, then resumable retries"
+    )
+
+
+def test_http_retry_keeps_a_caller_requested_force_download(monkeypatch):
+    """Handing force_download back means handing back what the CALLER asked for, not False."""
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(
+        DL_REPO, FILE, None, force_download = True) == "/cache/x"
+    assert [c.force_download for c in fake.calls] == [True, True, True]
+
+
+def test_http_retry_backoff_honours_zero(monkeypatch):
+    """0 is the value a CI run or a test harness actually reaches for. _env_seconds would read it as
+    junk and silently restore the full default, so this knob does not use it."""
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0")
+    assert xf._http_retry_backoff() == 0.0
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "1.5")
+    assert xf._http_retry_backoff() == 1.5
+    # Negative and unparseable are junk and fall back; unset falls back too.
+    for bad in ("abc", "-1", "  "):
+        monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", bad)
+        assert xf._http_retry_backoff() == xf.DEFAULT_HTTP_RETRY_BACKOFF, bad
+    monkeypatch.delenv("UNSLOTH_HTTP_RETRY_BACKOFF")
+    assert xf._http_retry_backoff() == xf.DEFAULT_HTTP_RETRY_BACKOFF
+    # A zero backoff really does return at once, with no cancel event in play.
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0")
+    started = time.monotonic()
+    xf._wait_before_http_retry(None)
+    assert time.monotonic() - started < 1.0
 
 
 def test_recovered_stall_is_not_charged_to_the_machine(monkeypatch):

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -1263,11 +1263,11 @@ def test_http_retry_resumes_instead_of_forcing_a_second_clean_redownload(monkeyp
     # is what makes the following retries safe to resume.
     seen = {"n": 0}
 
-    def _sizes(*a, **k):
+    def _names(*a, **k):
         seen["n"] += 1
-        return {"blob.incomplete": 1} if seen["n"] == 1 else {}
+        return {"blob.incomplete"} if seen["n"] == 1 else set()
 
-    monkeypatch.setattr(xf, "_active_incomplete_blob_sizes", _sizes)
+    monkeypatch.setattr(xf, "_incomplete_blob_names_strict", _names)
     fake = _install(
         monkeypatch,
         [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
@@ -1290,7 +1290,7 @@ def test_http_retry_keeps_forcing_while_the_unsafe_partial_survives(monkeypatch)
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
     monkeypatch.setattr(
-        xf, "_active_incomplete_blob_sizes", lambda *a, **k: {"blob.incomplete": 1}
+        xf, "_incomplete_blob_names_strict", lambda *a, **k: {"blob.incomplete"}
     )
     fake = _install(
         monkeypatch,
@@ -5728,3 +5728,34 @@ def test_the_verbatim_cas_fault_is_still_retryable_on_xet():
     )
     assert xf._is_retryable_download_error(cas, on_xet = True) is True
     assert xf._is_retryable_download_error(cas, on_xet = False) is False
+
+
+def test_uninspectable_cache_keeps_force_download_latched(monkeypatch):
+    """The un-latch must fail CLOSED. _active_incomplete_blob_sizes is fail-open by design (a
+    progress sensor must not abort a download over one unreadable blob), so an empty result from it
+    means "gone" and "could not look" alike. Releasing the guard on that answer would resume over a
+    sparse Xet partial on exactly the locked-down machines least able to recover from it."""
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    monkeypatch.setattr(xf, "_incomplete_blob_names_strict", lambda *a, **k: None)
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("crashed", "died"), ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert [c.force_download for c in fake.calls] == [False, True, True], (
+        "an uninspectable cache must not be read as proof the unsafe partial is gone"
+    )
+
+
+def test_strict_blob_scan_reports_failure_as_none(monkeypatch, tmp_path):
+    """The strict scan is the safety-critical twin of the fail-open sensor: it must distinguish
+    'nothing there' from 'could not look'."""
+    monkeypatch.setattr(xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([]))
+    assert xf._incomplete_blob_names_strict("model", "o/r", str(tmp_path)) == set()
+
+    def _boom(*a, **k):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(xf, "iter_active_repo_cache_dirs", _boom)
+    assert xf._incomplete_blob_names_strict("model", "o/r", str(tmp_path)) is None

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import errno
 import importlib.util
 import json
+import math
 import os
 import subprocess
 import sys
@@ -1258,6 +1259,15 @@ def test_http_retry_resumes_instead_of_forcing_a_second_clean_redownload(monkeyp
     repo, which is a cost the budget must not introduce."""
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    # The unsafe partial is present at the transition and GONE once the forced child has run, which
+    # is what makes the following retries safe to resume.
+    seen = {"n": 0}
+
+    def _sizes(*a, **k):
+        seen["n"] += 1
+        return {"blob.incomplete": 1} if seen["n"] == 1 else {}
+
+    monkeypatch.setattr(xf, "_active_incomplete_blob_sizes", _sizes)
     fake = _install(
         monkeypatch,
         [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
@@ -1265,6 +1275,30 @@ def test_http_retry_resumes_instead_of_forcing_a_second_clean_redownload(monkeyp
     assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
     assert [c.force_download for c in fake.calls] == [False, True, False], (
         "Xet as asked, one clean HTTP re-download, then resumable retries"
+    )
+
+
+def test_http_retry_keeps_forcing_while_the_unsafe_partial_survives(monkeypatch):
+    """The counterpart: a forced HTTP child that FAILED before replacing the partial must not make
+    the next child resumable.
+
+    huggingface_hub unlinks the .incomplete only after its HEAD/metadata call, so a child that died
+    on a 5xx there -- the degraded CDN this ladder exists for -- leaves the sparse Xet partial exactly
+    as it was. Resuming over it finalizes a silently corrupt blob, so "one HTTP child has run" is not
+    proof; only the partial's disappearance is.
+    """
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    monkeypatch.setattr(
+        xf, "_active_incomplete_blob_sizes", lambda *a, **k: {"blob.incomplete": 1}
+    )
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("crashed", "died in HEAD"), ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert [c.force_download for c in fake.calls] == [False, True, True], (
+        "the partial is still there, so the retry must re-download cleanly rather than resume it"
     )
 
 
@@ -1348,9 +1382,12 @@ def test_cancel_between_xet_attempts_spawns_nothing(monkeypatch):
         return result
 
     monkeypatch.setattr(xf, "_run_download_attempt", _cancel_after_first)
-    # The stall is real, so the ladder still leaves Xet -- but over HTTP, not another Xet child.
-    xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None, cancel_event = cancel)
-    assert [c.disable_xet for c in fake.calls] == [False, True]
+    # Cancellation wins over the stall verdict: no second child on EITHER rung, and no destructive
+    # pre-HTTP purge, for a download the caller has already abandoned.
+    with pytest.raises(RuntimeError, match = "Cancelled"):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None, cancel_event = cancel)
+    assert [c.disable_xet for c in fake.calls] == [False]
+    assert outcomes == []
 
 
 def test_stall_on_every_rung_raises_download_stall_error(monkeypatch):
@@ -5490,3 +5527,204 @@ def test_a_concurrent_spawns_overlay_is_not_read_as_the_users_own_settings(monke
         done.set()
         peer.join(5.0)
     assert int(rec["xet"][key]) == 1 * GB, "the child was sized from the peer's overlay"
+
+
+# ---------------------------------------------------------------------------------------------
+# Guard-integrity regressions: every value and every exit that could escape DownloadStallError.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_http_retry_backoff_rejects_non_finite_and_clamps(monkeypatch):
+    """nan / inf survive a `value < 0` test but not time.sleep or Event.wait.
+
+    nan raises ValueError, inf raises OverflowError, and a merely huge value exceeds Windows'
+    ~49.7 day PY_TIMEOUT_MAX and raises OverflowError there. None of those is a DownloadStallError,
+    so an escaping one is swallowed by the caller as "continuing with the normal load" -- exactly the
+    fall-through DownloadTransportError exists to prevent.
+    """
+    for raw in ("nan", "NaN", "inf", "-inf", "Infinity", "1e999"):
+        monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", raw)
+        assert xf._http_retry_backoff() == xf.DEFAULT_HTTP_RETRY_BACKOFF, raw
+    for raw, expected in (("0", 0.0), ("1.5", 1.5), ("  2.5  ", 2.5)):
+        monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", raw)
+        assert xf._http_retry_backoff() == expected, raw
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "999999999")
+    assert xf._http_retry_backoff() == xf._MAX_HTTP_RETRY_BACKOFF
+    # Whatever the knob says, the value must be usable by both wait primitives.
+    for raw in ("nan", "inf", "999999999"):
+        monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", raw)
+        delay = xf._http_retry_backoff()
+        assert math.isfinite(delay) and 0 <= delay <= xf._MAX_HTTP_RETRY_BACKOFF, raw
+
+
+def test_env_seconds_rejects_non_finite(monkeypatch):
+    """Same hole in the shared timeout parser: nan makes every deadline comparison False, so the
+    watchdog would never fire, and inf raises OverflowError inside the wait."""
+    for raw in ("nan", "inf", "-inf"):
+        monkeypatch.setenv("UNSLOTH_XET_STALL_TIMEOUT", raw)
+        assert xf._env_seconds("UNSLOTH_XET_STALL_TIMEOUT", 30.0) == 30.0, raw
+    monkeypatch.setenv("UNSLOTH_XET_STALL_TIMEOUT", "12.5")
+    assert xf._env_seconds("UNSLOTH_XET_STALL_TIMEOUT", 30.0) == 12.5
+
+
+def test_a_proven_stall_outranks_a_later_unproven_fault(monkeypatch):
+    """One reason slot, two kinds of evidence: a stall was proven by the watchdog on this machine, a
+    fault only counts once HTTP shows the network was fine. A fault must not overwrite a stall, or
+    the both-rungs-failed exit drops it and a genuinely stalling machine is never demoted.
+
+    Reachable exactly as the degraded CDN this ladder targets: Xet stalls, the Xet retry hits the CAS
+    fault, HTTP then fails too.
+    """
+    outcomes = []
+    monkeypatch.setattr(
+        xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append((ok, reason))
+    )
+    fake = _install(monkeypatch, [
+        ("stall", "no progress for 30s after 1.2 GB"),
+        ("retryable_error", "503"),
+        ("retryable_error", "503"),
+        ("retryable_error", "503"),
+    ])
+    with pytest.raises(xf.DownloadTransportError):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert [c.disable_xet for c in fake.calls] == [False, False, True, True]
+    assert len(outcomes) == 1 and outcomes[0][0] is False, outcomes
+    assert "stall" in outcomes[0][1].lower(), outcomes
+
+
+def test_a_proven_stall_survives_a_crash_on_the_second_xet_child(monkeypatch):
+    outcomes = []
+    monkeypatch.setattr(
+        xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append((ok, reason))
+    )
+    _install(monkeypatch, [
+        ("stall", "no progress for 30s after 1.2 GB"),
+        ("crashed", "died"),
+        ("crashed", "died"),
+        ("crashed", "died"),
+    ])
+    with pytest.raises(xf.DownloadTransportError):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert len(outcomes) == 1 and "stall" in outcomes[0][1].lower(), outcomes
+
+
+@pytest.mark.parametrize(
+    "verdict, payload",
+    [
+        ("stall", None),
+        ("error", "RepositoryNotFoundError: gone"),
+        ("retryable_error", "503"),
+        ("crashed", "died"),
+    ],
+)
+def test_cancel_wins_over_every_failure_verdict(monkeypatch, verdict, payload):
+    """Cancellation precedence has to be uniform. Per-branch checks meant a cancel landing on a
+    transient HTTP error reported Cancelled while the same cancel landing on a stall or a
+    deterministic error reported the download's own failure instead."""
+    outcomes = []
+    monkeypatch.setattr(xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append(ok))
+    cancel = threading.Event()
+    fake = _install(monkeypatch, [(verdict, payload), ("ok", "/cache/x")])
+    original = fake.__call__
+
+    def _cancel_after_first(*args, **kwargs):
+        result = original(*args, **kwargs)
+        cancel.set()
+        return result
+
+    monkeypatch.setattr(xf, "_run_download_attempt", _cancel_after_first)
+    with pytest.raises(RuntimeError, match = "Cancelled"):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None, cancel_event = cancel)
+    assert len(fake.calls) == 1, "a cancelled download must not buy another child"
+    assert outcomes == [], "a cancel says nothing about this machine's Xet"
+
+
+def test_cancel_skips_the_destructive_pre_http_purge(monkeypatch):
+    """The purge deletes .incomplete blobs. It must not run for a caller who has already given up."""
+    purges = []
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: purges.append(1))
+    cancel = threading.Event()
+    fake = _install(monkeypatch, [("retryable_error", "503"), ("ok", "/cache/x")])
+    original = fake.__call__
+
+    def _cancel_after_first(*args, **kwargs):
+        result = original(*args, **kwargs)
+        cancel.set()
+        return result
+
+    monkeypatch.setattr(xf, "_run_download_attempt", _cancel_after_first)
+    with pytest.raises(RuntimeError, match = "Cancelled"):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None, cancel_event = cancel)
+    assert purges == [], "no destructive purge after a cancel"
+
+
+def test_unknown_terminal_error_after_a_transport_fault_stays_guard_class(monkeypatch):
+    """An unrecognized error cannot be rebuilt by _raise_child_error, so it leaves as a bare
+    RuntimeError -- which the caller's `except DownloadStallError` misses, sending a transport that
+    just failed on both rungs into the unguarded in-process load. That is #1122 one rung further
+    along, so once a transport fault is established the terminal error stays inside the guard."""
+    _install(monkeypatch, [
+        ("retryable_error", "RuntimeError: CAS Client Error"),
+        ("error", "SomeBrandNewHubError: unrecognized"),
+    ])
+    with pytest.raises(xf.DownloadStallError):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+
+
+def test_a_known_deterministic_error_still_preserves_its_type(monkeypatch):
+    """The narrow form above must not swallow errors the caller relies on catching by type."""
+    from huggingface_hub.errors import RepositoryNotFoundError
+
+    _install(monkeypatch, [
+        ("retryable_error", "RuntimeError: CAS Client Error"),
+        ("error", "RepositoryNotFoundError: no such repo"),
+    ])
+    with pytest.raises(RepositoryNotFoundError):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+
+
+def test_local_oserror_under_the_xet_cache_dir_is_deterministic():
+    """str(OSError) embeds the FILENAME, and the Xet cache lives at ~/.cache/huggingface/xet/, so a
+    text scan reads a local permission error there as a transient 'xet' transport fault. Builtin
+    OSErrors are decided by class instead."""
+    denied = PermissionError(
+        13, "Permission denied", "/home/u/.cache/huggingface/xet/chunk-cache/ab/cd"
+    )
+    assert xf._is_retryable_download_error(denied, on_xet = True) is False
+    assert xf._is_retryable_download_error(denied, on_xet = False) is False
+
+    readonly = OSError(30, "Read-only file system", "/home/u/.cache/huggingface/xet/staging")
+    assert xf._is_retryable_download_error(readonly, on_xet = True) is False
+
+    # The network subclasses stay retryable, now by type rather than by wording.
+    for exc in (
+        ConnectionResetError(104, "Connection reset by peer"),
+        TimeoutError(110, "Connection timed out"),
+        BrokenPipeError(32, "Broken pipe"),
+    ):
+        assert xf._is_retryable_download_error(exc, on_xet = True) is True, exc
+        assert xf._is_retryable_download_error(exc, on_xet = False) is True, exc
+
+    # Disk full stays deterministic on both rungs.
+    full = OSError(errno.ENOSPC, "No space left on device", "/home/u/.cache/huggingface/hub/blob")
+    assert xf._is_retryable_download_error(full, on_xet = True) is False
+    assert xf._is_retryable_download_error(full, on_xet = False) is False
+
+
+def test_control_flow_exceptions_are_never_transport_faults():
+    """The child reports through `except BaseException`, so an interpreter shutdown reaches the
+    classifier. The rung default would call it retryable and spend an HTTP child plus the destructive
+    pre-HTTP purge because someone asked the process to stop."""
+    for exc in (KeyboardInterrupt(), SystemExit(1), GeneratorExit()):
+        assert xf._is_retryable_download_error(exc, on_xet = True) is False, exc
+        assert xf._is_retryable_download_error(exc, on_xet = False) is False, exc
+
+
+def test_the_verbatim_cas_fault_is_still_retryable_on_xet():
+    """Guard on the guard: none of the tightening above may cost the fix issue #1122 needed."""
+    cas = RuntimeError(
+        "Task error: File reconstruction error: CAS Client Error: "
+        "Format error: I/O error: error decoding response body"
+    )
+    assert xf._is_retryable_download_error(cas, on_xet = True) is True
+    assert xf._is_retryable_download_error(cas, on_xet = False) is False

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -5834,3 +5834,59 @@ def test_blob_identity_scan_uses_device_and_inode(monkeypatch, tmp_path):
     after = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
     assert {n for (n, _, _) in after} == {partial.name}
     assert not (before & after), "an unlink plus create must not look like the same partial"
+
+
+def _stall_then_fault_then(monkeypatch, final):
+    """Xet stalls, a Xet retry faults, and the ladder ends on HTTP with *final*.
+
+    The stall is PROVEN: the watchdog saw no progress on this machine, so it is charged whichever
+    door the ladder finally leaves by. The fault that follows it is unproven and must not displace
+    it. This shape is the degraded CDN the ladder exists for.
+    """
+    outcomes = []
+    monkeypatch.setenv("UNSLOTH_XET_ATTEMPTS", "2")
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "1")
+    monkeypatch.setattr(xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append(ok))
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: False)
+    _install(monkeypatch, [("stall", "no progress for 30s after 1.2 GB"),
+                           ("retryable_error", "503"), final])
+    return outcomes
+
+
+def test_a_proven_stall_is_charged_when_http_also_returns_an_incomplete_snapshot(monkeypatch):
+    """A terminal HTTP incomplete snapshot must not swallow a stall proven on this machine.
+
+    Dropping it means an actually stalling machine never reaches the tracker's two-failure demotion
+    threshold, so every later download keeps paying the full Xet stall timeout before falling back.
+    """
+    monkeypatch.setattr(xf, "_snapshot_payload_incomplete", lambda p, **k: p == "INCOMPLETE")
+    outcomes = _stall_then_fault_then(monkeypatch, ("ok", "INCOMPLETE"))
+    with pytest.raises(xf.DownloadStallError):
+        xf.snapshot_download_with_xet_fallback(DL_REPO, token = None)
+    assert outcomes == [False], "the proven Xet stall was dropped on the way out"
+
+
+def test_a_proven_stall_is_charged_when_http_stalls_too(monkeypatch):
+    """The same for the other terminal door: an HTTP stall raising directly."""
+    outcomes = _stall_then_fault_then(monkeypatch, ("stall", "no progress for 30s after 1 GB"))
+    with pytest.raises(xf.DownloadStallError):
+        xf.snapshot_download_with_xet_fallback(DL_REPO, token = None)
+    assert outcomes == [False], "the proven Xet stall was dropped on the way out"
+
+
+def test_an_unproven_failure_is_still_dropped_on_those_same_doors(monkeypatch):
+    """The counterpart, and the reason the flush is conditional: with no stall anywhere, a fault
+    that hit BOTH rungs is a degraded CDN, not a bad Xet path on this machine, so it stays unproven
+    and the tracker is not charged."""
+    outcomes = []
+    monkeypatch.setenv("UNSLOTH_XET_ATTEMPTS", "2")
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "1")
+    monkeypatch.setattr(xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append(ok))
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: False)
+    _install(monkeypatch, [("retryable_error", "503"), ("retryable_error", "503"),
+                           ("stall", "no progress for 30s after 1 GB")])
+    with pytest.raises(xf.DownloadStallError):
+        xf.snapshot_download_with_xet_fallback(DL_REPO, token = None)
+    assert outcomes == [], "a fault both rungs met is not evidence against this machine's Xet"

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -700,6 +700,11 @@ def _no_real_cache_hit(monkeypatch):
     monkeypatch.delenv("UNSLOTH_DISABLE_XET", raising = False)
     monkeypatch.delenv("UNSLOTH_STABLE_DOWNLOADS", raising = False)
     monkeypatch.delenv("HF_HUB_DISABLE_XET", raising = False)
+    monkeypatch.delenv("UNSLOTH_XET_ATTEMPTS", raising = False)
+    monkeypatch.delenv("UNSLOTH_HTTP_ATTEMPTS", raising = False)
+    monkeypatch.delenv("UNSLOTH_HTTP_RETRY_BACKOFF", raising = False)
+    # The HTTP retry backoff is real seconds in production; tests assert the ladder, not the wait.
+    monkeypatch.setattr(xf, "DEFAULT_HTTP_RETRY_BACKOFF", 0.0)
 
 
 class _FakeAttempt:
@@ -812,12 +817,15 @@ def test_crashed_child_retries_over_http(monkeypatch):
     assert [c.disable_xet for c in fake.calls] == [False, True]
 
 
-def test_crashed_child_on_both_transports_raises(monkeypatch):
-    """If the child crashes on Xet AND on HTTP, surface a hard error after both attempts."""
-    fake = _install(monkeypatch, [("crashed", "boom"), ("crashed", "boom")])
-    with pytest.raises(RuntimeError, match = "boom"):
+def test_crashed_child_on_every_rung_raises_transport_error(monkeypatch):
+    """A crash on Xet and on every HTTP child surfaces as DownloadTransportError once the budget is
+    spent -- not as a bare RuntimeError a caller would read as "carry on without the guard"."""
+    fake = _install(
+        monkeypatch, [("crashed", "boom"), ("crashed", "boom"), ("crashed", "boom")]
+    )
+    with pytest.raises(xf.DownloadTransportError, match = "boom"):
         xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
-    assert [c.disable_xet for c in fake.calls] == [False, True]
+    assert [c.disable_xet for c in fake.calls] == [False, True, True]
 
 
 def test_retryable_xet_error_retries_over_http(monkeypatch):
@@ -828,17 +836,34 @@ def test_retryable_xet_error_retries_over_http(monkeypatch):
     assert [c.disable_xet for c in fake.calls] == [False, True]
 
 
-def test_retryable_xet_error_on_both_transports_raises(monkeypatch):
-    """A transient error on both transports surfaces after both attempts rather than looping."""
-    fake = _install(monkeypatch, [("retryable_error", "503 Server Error"), ("retryable_error", "503 Server Error")])
-    with pytest.raises(RuntimeError, match = "503"):
+def test_retryable_error_on_every_rung_raises_transport_error(monkeypatch):
+    """A transient error on Xet and on every HTTP child surfaces after the budget rather than looping."""
+    err = ("retryable_error", "HfHubHTTPError: Server error '503 Service Unavailable' for url ...")
+    fake = _install(monkeypatch, [err, err, err])
+    with pytest.raises(xf.DownloadTransportError, match = "503"):
         xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
-    assert [c.disable_xet for c in fake.calls] == [False, True]
+    assert [c.disable_xet for c in fake.calls] == [False, True, True]
+
+
+def test_transport_error_is_a_stall_error_and_a_runtime_error(monkeypatch):
+    """The guard downstream puts around the supervised download is `except DownloadStallError`; a
+    transport error that is not one lets a retryable CDN fault fall through to the unguarded
+    in-process load, which is the hang in unslothai/unsloth-zoo#1122. Still a RuntimeError, so an
+    existing `except RuntimeError` keeps matching."""
+    assert issubclass(xf.DownloadTransportError, xf.DownloadStallError)
+    err = ("retryable_error", "HfHubHTTPError: Server error '503 Service Unavailable' for url ...")
+    _install(monkeypatch, [err, err, err])
+    with pytest.raises(xf.DownloadStallError) as excinfo:
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert isinstance(excinfo.value, RuntimeError)
+    assert "DownloadTransportError" in type(excinfo.value).__name__
 
 
 def test_is_retryable_download_error_classification():
-    """Transient transport failures (hf_xet/CAS, timeout, reset, 5xx/429) are retryable; deterministic Hub/OS and unknown errors are not."""
-    f = xf._is_retryable_download_error
+    """Transient transport failures (hf_xet/CAS, timeout, reset, 5xx/429) are retryable; deterministic
+    Hub/OS errors are not, on either rung."""
+    def f(exc, on_xet = True):
+        return xf._is_retryable_download_error(exc, on_xet = on_xet)
 
     # Transient transport failures -> retryable.
     assert f(Exception("hf_xet download failed: data processing error")) is True
@@ -875,12 +900,35 @@ def test_is_retryable_download_error_classification():
 
     assert f(_Resp404("not found")) is False
     assert f(OSError(errno.ENOSPC, "No space left on device")) is False
-    assert f(ValueError("unexpected response payload")) is False  # unknown -> deterministic
+    # Deterministic on BOTH rungs: the rung default must not widen the named/status/errno rules.
+    for on_xet in (True, False):
+        assert f(_Status416("Range Not Satisfiable"), on_xet) is False, on_xet
+        assert f(RepositoryNotFoundError("404 Client Error"), on_xet) is False, on_xet
+        assert f(_Resp404("not found"), on_xet) is False, on_xet
+        assert f(OSError(errno.ENOSPC, "No space left on device"), on_xet) is False, on_xet
+        # A local filesystem failure is not transport-attributable either: another transport writes
+        # to the same path.
+        assert f(PermissionError("cache dir is read-only"), on_xet) is False, on_xet
+
+    # An UNRECOGNIZED error is decided by the rung. hf_xet reports a CAS fault as a bare RuntimeError
+    # carrying a Rust error chain, and reading it as deterministic skipped the HTTP rung entirely
+    # (unslothai/unsloth-zoo#1122). It costs one HTTP attempt to disprove on Xet; on HTTP, the last
+    # rung, an unknown error is surfaced rather than looped.
+    cas = RuntimeError(
+        "Task error: File reconstruction error: CAS Client Error: Format error: "
+        "I/O error: error decoding response body"
+    )
+    assert f(cas, True) is True
+    assert f(ValueError("unexpected response payload"), True) is True
+    assert f(ValueError("unexpected response payload"), False) is False
 
 
 def test_local_entry_not_found_transient_is_retryable():
-    """A transient LocalEntryNotFoundError (HEAD connection error/timeout) is retryable; a genuine offline miss stays deterministic and type-preserved."""
-    f = xf._is_retryable_download_error
+    """A transient LocalEntryNotFoundError (HEAD connection error/timeout) is retryable; a genuine
+    offline miss stays deterministic and type-preserved -- on the Xet rung too, where the named
+    deterministic set still wins over the unknown-error default."""
+    def f(exc):
+        return xf._is_retryable_download_error(exc, on_xet = True)
 
     class LocalEntryNotFoundError(Exception):
         pass
@@ -1001,6 +1049,158 @@ def test_attempts_knob_rejects_junk_and_clamps(monkeypatch):
     assert xf.xet_attempts() == xf._MAX_XET_ATTEMPTS
     monkeypatch.delenv("UNSLOTH_XET_ATTEMPTS")
     assert xf.xet_attempts() == xf.DEFAULT_XET_ATTEMPTS
+
+
+def test_http_rung_retries_a_transient_error(monkeypatch):
+    """The Xet bridge CDN serves Xet-backed blobs over plain HTTP too, so a degraded CDN 5xx fails
+    BOTH rungs. A single HTTP child turned that retryable blip into a hard failure
+    (unslothai/unsloth-zoo#1122); the rung now gets its own budget."""
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503 Service Unavailable"),
+         ("retryable_error", "503 Service Unavailable"),
+         ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert [c.disable_xet for c in fake.calls] == [False, True, True]
+
+
+def test_http_rung_retries_a_crash(monkeypatch):
+    fake = _install(
+        monkeypatch, [("crashed", "boom"), ("crashed", "boom"), ("ok", "/cache/x")]
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert [c.disable_xet for c in fake.calls] == [False, True, True]
+
+
+def test_http_stall_still_raises_on_the_first_verdict(monkeypatch):
+    """The HTTP budget is for faults, not for hangs: the patient HTTP threshold has already waited
+    out everything a retry would wait for again."""
+    fake = _install(monkeypatch, [("retryable_error", "503"), ("stall", None)])
+    with pytest.raises(xf.DownloadStallError):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert [c.disable_xet for c in fake.calls] == [False, True]
+
+
+def test_http_attempts_knob_of_one_restores_the_single_http_rung(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "1")
+    fake = _install(
+        monkeypatch, [("retryable_error", "503"), ("retryable_error", "503")]
+    )
+    with pytest.raises(xf.DownloadTransportError):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert [c.disable_xet for c in fake.calls] == [False, True]
+
+
+def test_http_attempts_knob_extends_the_http_budget(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "3")
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("retryable_error", "503"),
+         ("retryable_error", "503"), ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert [c.disable_xet for c in fake.calls] == [False, True, True, True]
+
+
+def test_http_attempts_knob_rejects_junk_and_clamps(monkeypatch):
+    for bad in ("", "abc", "0", "-3", "  "):
+        monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", bad)
+        assert xf.http_attempts() == xf.DEFAULT_HTTP_ATTEMPTS, bad
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "999")
+    assert xf.http_attempts() == xf._MAX_HTTP_ATTEMPTS
+    monkeypatch.delenv("UNSLOTH_HTTP_ATTEMPTS")
+    assert xf.http_attempts() == xf.DEFAULT_HTTP_ATTEMPTS
+
+
+def test_http_retry_prepares_the_cache_exactly_once(monkeypatch):
+    """The purge belongs to the transport CHANGE. Repeating it per HTTP child would spare the partial
+    the failed child just wrote (younger than active_grace), leaving has_active_incomplete_blobs true
+    and forcing force_download -- so every retry would restart the download from zero."""
+    prepared = []
+    monkeypatch.setattr(
+        xf, "_default_prepare_for_http",
+        lambda repo_type, repo_id, cache_dir = None, **k: prepared.append((repo_type, repo_id)),
+    )
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: False)
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert prepared == [("model", DL_REPO)], "exactly once, at the transport change"
+    assert [c.force_download for c in fake.calls] == [False, False, False]
+
+
+def test_cancel_in_the_http_failure_window_reports_cancelled(monkeypatch):
+    """A cancel landing while the HTTP rung is failing ends the ladder as a cancel, not as a
+    transport error, and buys no further child."""
+    cancel = threading.Event()
+    fake = _install(
+        monkeypatch, [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")]
+    )
+    original = fake.__call__
+
+    def _cancel_after_second(*args, **kwargs):
+        result = original(*args, **kwargs)
+        if len(fake.calls) == 2:
+            cancel.set()
+        return result
+
+    monkeypatch.setattr(xf, "_run_download_attempt", _cancel_after_second)
+    with pytest.raises(RuntimeError, match = "Cancelled"):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None, cancel_event = cancel)
+    assert [c.disable_xet for c in fake.calls] == [False, True]
+
+
+def test_wait_before_http_retry_is_interruptible(monkeypatch):
+    """A cancel arriving during the backoff raises rather than spending another child on a download
+    the caller has abandoned; without one the wait is a plain sleep."""
+    monkeypatch.setattr(xf, "DEFAULT_HTTP_RETRY_BACKOFF", 30.0)
+    cancel = threading.Event()
+    cancel.set()
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match = "Cancelled"):
+        xf._wait_before_http_retry(cancel)
+    assert time.monotonic() - started < 5.0, "must not sit out the whole backoff"
+    # No cancel event: the wait is honoured, so keep it short here.
+    monkeypatch.setattr(xf, "DEFAULT_HTTP_RETRY_BACKOFF", 0.01)
+    xf._wait_before_http_retry(None)
+    # Junk in the env override falls back to the default rather than failing a download.
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "abc")
+    xf._wait_before_http_retry(None)
+
+
+def test_transient_xet_error_is_charged_only_when_http_rescues_it(monkeypatch):
+    """A CDN fault that fails BOTH rungs is not evidence against THIS MACHINE's Xet. Charging it
+    demoted a healthy machine to HTTP for 24h after two such downloads -- which is exactly what a
+    degraded CDN produces. Only an HTTP rescue proves the Xet path alone was broken."""
+    outcomes = []
+    monkeypatch.setattr(xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append(ok))
+    err = ("retryable_error", "503 Service Unavailable")
+    _install(monkeypatch, [err, err, err])
+    with pytest.raises(xf.DownloadTransportError):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert outcomes == [], "both rungs failed the same way: not a Xet verdict"
+
+    outcomes.clear()
+    _install(monkeypatch, [err, ("ok", "/cache/x")])
+    xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert outcomes == [False], "HTTP finished what Xet could not: charge it"
+
+
+def test_crash_on_xet_is_charged_only_when_http_rescues_it(monkeypatch):
+    outcomes = []
+    monkeypatch.setattr(xf, "_record_xet_outcome", lambda ok, reason = "": outcomes.append(ok))
+    _install(monkeypatch, [("crashed", "boom"), ("crashed", "boom"), ("crashed", "boom")])
+    with pytest.raises(xf.DownloadTransportError):
+        xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert outcomes == []
+
+    outcomes.clear()
+    _install(monkeypatch, [("crashed", "boom"), ("ok", "/cache/x")])
+    xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None)
+    assert outcomes == [False]
 
 
 def test_recovered_stall_is_not_charged_to_the_machine(monkeypatch):
@@ -4049,10 +4249,10 @@ def test_generic_hub_http_error_type_preserved_but_status_drives_retry():
         def __init__(self, code): self.status_code = code
     e503 = xf._instantiate_preserving_type(cls, "HfHubHTTPError: 503 service unavailable")
     e503.response = _Resp(503)
-    assert xf._is_retryable_download_error(e503) is True           # 5xx still retryable
+    assert xf._is_retryable_download_error(e503, on_xet = True) is True    # 5xx still retryable
     e403 = xf._instantiate_preserving_type(cls, "HfHubHTTPError: 403 forbidden")
     e403.response = _Resp(403)
-    assert xf._is_retryable_download_error(e403) is False          # 4xx deterministic
+    assert xf._is_retryable_download_error(e403, on_xet = True) is False   # 4xx wins over the rung
 
 
 def test_hfvalidationerror_type_preserved_across_spawn():
@@ -4062,7 +4262,7 @@ def test_hfvalidationerror_type_preserved_across_spawn():
     assert cls is not None and issubclass(cls, BaseException)
     inst = xf._instantiate_preserving_type(cls, "HFValidationError: bad repo id")
     assert type(inst).__name__ == "HFValidationError"
-    assert xf._is_retryable_download_error(inst) is False
+    assert xf._is_retryable_download_error(inst, on_xet = True) is False
 
 
 def test_oserror_subclass_type_preserved_across_spawn():
@@ -4073,7 +4273,7 @@ def test_oserror_subclass_type_preserved_across_spawn():
     # A deterministic PermissionError is reconstructed as a real PermissionError and not retried.
     perm = xf._instantiate_preserving_type(xf._resolve_exception_class("PermissionError"), "denied")
     assert isinstance(perm, PermissionError)
-    assert xf._is_retryable_download_error(perm) is False
+    assert xf._is_retryable_download_error(perm, on_xet = True) is False
     # An unrelated builtin (not OSError, not a Hub error name) is not resolved.
     assert xf._resolve_exception_class("ValueError") is None
 
@@ -4130,7 +4330,8 @@ def test_local_token_not_found_error_type_preserved():
     cls = xf._resolve_exception_class("LocalTokenNotFoundError")
     assert cls is not None and issubclass(cls, BaseException)
     assert xf._is_retryable_download_error(
-        xf._instantiate_preserving_type(cls, "LocalTokenNotFoundError: token required")) is False
+        xf._instantiate_preserving_type(cls, "LocalTokenNotFoundError: token required"),
+        on_xet = True) is False
 
 
 def test_metadata_directory_pattern_is_weightless(tmp_path):

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -714,6 +714,7 @@ class _FakeAttempt:
     def __init__(self, results):
         self._results = list(results)
         self.calls = []
+        self.owned_incomplete = None
 
     def __call__(
         self,
@@ -742,11 +743,16 @@ class _FakeAttempt:
                 repo_type = repo_type,
             )
         )
+        if self.owned_incomplete is not None:
+            # The real attempt reports the basenames its child held open this way, and the ladder
+            # pops the key back off; a fake that never sets it silently skips that scoping.
+            params["_owned_incomplete_blobs"] = set(self.owned_incomplete)
         return self._results[len(self.calls) - 1]
 
 
-def _install(monkeypatch, results):
+def _install(monkeypatch, results, owned_incomplete = None):
     fake = _FakeAttempt(results)
+    fake.owned_incomplete = owned_incomplete
     monkeypatch.setattr(xf, "_run_download_attempt", fake)
     return fake
 
@@ -1265,9 +1271,9 @@ def test_http_retry_resumes_instead_of_forcing_a_second_clean_redownload(monkeyp
 
     def _names(*a, **k):
         seen["n"] += 1
-        return {"blob.incomplete"} if seen["n"] == 1 else set()
+        return {("blob.incomplete", 1, 7)} if seen["n"] == 1 else set()
 
-    monkeypatch.setattr(xf, "_incomplete_blob_names_strict", _names)
+    monkeypatch.setattr(xf, "_incomplete_blob_identities", _names)
     fake = _install(
         monkeypatch,
         [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
@@ -1290,7 +1296,7 @@ def test_http_retry_keeps_forcing_while_the_unsafe_partial_survives(monkeypatch)
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
     monkeypatch.setattr(
-        xf, "_incomplete_blob_names_strict", lambda *a, **k: {"blob.incomplete"}
+        xf, "_incomplete_blob_identities", lambda *a, **k: {("blob.incomplete", 1, 7)}
     )
     fake = _install(
         monkeypatch,
@@ -5737,7 +5743,7 @@ def test_uninspectable_cache_keeps_force_download_latched(monkeypatch):
     sparse Xet partial on exactly the locked-down machines least able to recover from it."""
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
-    monkeypatch.setattr(xf, "_incomplete_blob_names_strict", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "_incomplete_blob_identities", lambda *a, **k: None)
     fake = _install(
         monkeypatch,
         [("retryable_error", "503"), ("crashed", "died"), ("ok", "/cache/x")],
@@ -5752,10 +5758,79 @@ def test_strict_blob_scan_reports_failure_as_none(monkeypatch, tmp_path):
     """The strict scan is the safety-critical twin of the fail-open sensor: it must distinguish
     'nothing there' from 'could not look'."""
     monkeypatch.setattr(xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([]))
-    assert xf._incomplete_blob_names_strict("model", "o/r", str(tmp_path)) == set()
+    assert xf._incomplete_blob_identities("model", "o/r", str(tmp_path)) == set()
 
     def _boom(*a, **k):
         raise OSError(13, "Permission denied")
 
     monkeypatch.setattr(xf, "iter_active_repo_cache_dirs", _boom)
-    assert xf._incomplete_blob_names_strict("model", "o/r", str(tmp_path)) is None
+    assert xf._incomplete_blob_identities("model", "o/r", str(tmp_path)) is None
+
+
+def test_a_same_named_replacement_partial_releases_the_latch(monkeypatch):
+    """The latch must key on IDENTITY, not on the basename.
+
+    ``force_download`` makes huggingface_hub unlink the ``.incomplete`` and immediately reopen the
+    same path in append mode. If that forced child then dies mid-transfer, the surviving file has
+    the old name but is a fresh, resumable HTTP partial. Matching on the name alone would read it
+    as the sparse Xet partial that is still there, keep the latch, and make every remaining child
+    throw those bytes away and restart from zero -- turning a corruption guard into a bandwidth
+    amplifier on exactly the flaky links that reach it."""
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    seen = {"n": 0}
+
+    def _identities(*a, **k):
+        seen["n"] += 1
+        # Same name throughout; the inode changes once the forced child recreates the file.
+        return {("blob.incomplete", 1, 7 if seen["n"] == 1 else 8)}
+
+    monkeypatch.setattr(xf, "_incomplete_blob_identities", _identities)
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert [c.force_download for c in fake.calls] == [False, True, False], (
+        "a replacement partial is the forced child's own resumable work, not the unsafe one"
+    )
+
+
+def test_a_live_siblings_partial_does_not_hold_the_latch(monkeypatch):
+    """The unsafe set is scoped by the same owned-blob set as the purge.
+
+    The purge deliberately spares a partial a LIVE sibling holds open. Counting that partial as
+    unsafe would keep force_download latched for the rest of the ladder while the sibling downloads
+    an entirely different file, so the scoping has to match on both sides."""
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    # Our child owned "mine"; "sibling" belongs to another live download and never goes away.
+    monkeypatch.setattr(
+        xf, "_incomplete_blob_identities",
+        lambda *a, **k: {("sibling.incomplete", 1, 9)},
+    )
+    fake = _install(
+        monkeypatch,
+        [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
+        owned_incomplete = {"mine.incomplete"},
+    )
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert [c.force_download for c in fake.calls] == [False, True, False], (
+        "the sibling's partial is not ours to wait on"
+    )
+
+
+def test_blob_identity_scan_uses_device_and_inode(monkeypatch, tmp_path):
+    """Recreating the file under the same name yields a different identity on a real filesystem."""
+    blobs = tmp_path / "blobs"
+    blobs.mkdir()
+    partial = blobs / f"deadbeef{xf.INCOMPLETE_SUFFIX}"
+    partial.write_bytes(b"abc")
+    monkeypatch.setattr(xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([tmp_path]))
+    before = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
+    assert {n for (n, _, _) in before} == {partial.name}
+    partial.unlink()
+    partial.write_bytes(b"defg")
+    after = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
+    assert {n for (n, _, _) in after} == {partial.name}
+    assert not (before & after), "an unlink plus create must not look like the same partial"

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -743,11 +743,12 @@ class _FakeAttempt:
                 repo_type = repo_type,
             )
         )
-        if self.owned_incomplete is not None:
-            # The real attempt reports the basenames its child held open this way, and the ladder
-            # pops the key back off; a fake that never sets it silently skips that scoping.
+        result = self._results[len(self.calls) - 1]
+        if self.owned_incomplete is not None and result[0] == "stall":
+            # Fidelity: the real attempt publishes the basenames its child held open ONLY on the
+            # stall return, never on a fault, a crash or a deterministic error.
             params["_owned_incomplete_blobs"] = set(self.owned_incomplete)
-        return self._results[len(self.calls) - 1]
+        return result
 
 
 def _install(monkeypatch, results, owned_incomplete = None):
@@ -1271,7 +1272,7 @@ def test_http_retry_resumes_instead_of_forcing_a_second_clean_redownload(monkeyp
 
     def _names(*a, **k):
         seen["n"] += 1
-        return {("blob.incomplete", 1, 7)} if seen["n"] == 1 else set()
+        return {("blob.incomplete", 7)} if seen["n"] == 1 else set()
 
     monkeypatch.setattr(xf, "_incomplete_blob_identities", _names)
     fake = _install(
@@ -1296,7 +1297,7 @@ def test_http_retry_keeps_forcing_while_the_unsafe_partial_survives(monkeypatch)
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
     monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
     monkeypatch.setattr(
-        xf, "_incomplete_blob_identities", lambda *a, **k: {("blob.incomplete", 1, 7)}
+        xf, "_incomplete_blob_identities", lambda *a, **k: {("blob.incomplete", 7)}
     )
     fake = _install(
         monkeypatch,
@@ -5783,7 +5784,7 @@ def test_a_same_named_replacement_partial_releases_the_latch(monkeypatch):
     def _identities(*a, **k):
         seen["n"] += 1
         # Same name throughout; the inode changes once the forced child recreates the file.
-        return {("blob.incomplete", 1, 7 if seen["n"] == 1 else 8)}
+        return {("blob.incomplete", 7 if seen["n"] == 1 else 8)}
 
     monkeypatch.setattr(xf, "_incomplete_blob_identities", _identities)
     fake = _install(
@@ -5796,31 +5797,7 @@ def test_a_same_named_replacement_partial_releases_the_latch(monkeypatch):
     )
 
 
-def test_a_live_siblings_partial_does_not_hold_the_latch(monkeypatch):
-    """The unsafe set is scoped by the same owned-blob set as the purge.
-
-    The purge deliberately spares a partial a LIVE sibling holds open. Counting that partial as
-    unsafe would keep force_download latched for the rest of the ladder while the sibling downloads
-    an entirely different file, so the scoping has to match on both sides."""
-    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
-    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
-    # Our child owned "mine"; "sibling" belongs to another live download and never goes away.
-    monkeypatch.setattr(
-        xf, "_incomplete_blob_identities",
-        lambda *a, **k: {("sibling.incomplete", 1, 9)},
-    )
-    fake = _install(
-        monkeypatch,
-        [("retryable_error", "503"), ("retryable_error", "503"), ("ok", "/cache/x")],
-        owned_incomplete = {"mine.incomplete"},
-    )
-    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
-    assert [c.force_download for c in fake.calls] == [False, True, False], (
-        "the sibling's partial is not ours to wait on"
-    )
-
-
-def test_blob_identity_scan_uses_device_and_inode(monkeypatch, tmp_path):
+def test_blob_identity_scan_uses_the_inode(monkeypatch, tmp_path):
     """Recreating the file under the same name yields a different identity on a real filesystem."""
     blobs = tmp_path / "blobs"
     blobs.mkdir()
@@ -5828,12 +5805,14 @@ def test_blob_identity_scan_uses_device_and_inode(monkeypatch, tmp_path):
     partial.write_bytes(b"abc")
     monkeypatch.setattr(xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([tmp_path]))
     before = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
-    assert {n for (n, _, _) in before} == {partial.name}
+    assert {n for (n, _) in before} == {partial.name}
     partial.unlink()
     partial.write_bytes(b"defg")
     after = xf._incomplete_blob_identities("model", "o/r", str(tmp_path))
-    assert {n for (n, _, _) in after} == {partial.name}
-    assert not (before & after), "an unlink plus create must not look like the same partial"
+    assert {n for (n, _) in after} == {partial.name}
+    assert not xf._surviving_unsafe_partials(before, after), (
+        "an unlink plus create must not look like the same partial"
+    )
 
 
 def _stall_then_fault_then(monkeypatch, final):
@@ -5890,3 +5869,59 @@ def test_an_unproven_failure_is_still_dropped_on_those_same_doors(monkeypatch):
     with pytest.raises(xf.DownloadStallError):
         xf.snapshot_download_with_xet_fallback(DL_REPO, token = None)
     assert outcomes == [], "a fault both rungs met is not evidence against this machine's Xet"
+
+
+def test_an_unresolvable_inode_is_not_read_as_a_changed_one():
+    """``st_ino = 0`` means "the filesystem would not say", not "a different file".
+
+    Windows reaches this exactly when it matters: ``os.stat`` falls back to a directory entry that
+    carries no file index when the file is LOCKED, and a locked partial is precisely why the purge
+    failed and the latch engaged. So the transition scan can report 0 and a later scan, taken after
+    the handle is dropped, can report the real inode. Reading that asymmetry as a change would
+    release the guard on the machines least able to survive a corrupt blob.
+    """
+    captured = {("blob.incomplete", 0)}
+    assert xf._surviving_unsafe_partials(captured, {("blob.incomplete", 4242)}), (
+        "unresolved at capture, resolved later: the name is still there, so the latch must hold"
+    )
+    assert xf._surviving_unsafe_partials({("blob.incomplete", 4242)}, {("blob.incomplete", 0)}), (
+        "resolved at capture, unresolved later: still unknown, so the latch must hold"
+    )
+    assert not xf._surviving_unsafe_partials(captured, {("other.incomplete", 0)}), (
+        "the name is gone, which is the one unambiguous proof of disappearance"
+    )
+
+
+def test_a_partial_the_purge_could_not_scope_still_holds_the_latch(monkeypatch, tmp_path):
+    """The unsafe set is UNSCOPED, and scoping it by the purge's owned-blob set is backwards.
+
+    The purge skips every blob outside that set, so the partials that SURVIVE it are exactly the
+    ones outside it, and they are why has_active_incomplete_blobs() returned True in the first
+    place. Filtering them out empties the unsafe set and hands the next HTTP child a sparse partial
+    to resume, which finalizes a silently corrupt blob. Real cache layout, real scan.
+    """
+    blobs = tmp_path / "models--o--r" / "blobs"
+    blobs.mkdir(parents = True)
+    # Left by an earlier crashed run: not owned by this download's child, so the purge spares it.
+    stale = blobs / f"deadbeef{xf.INCOMPLETE_SUFFIX}"
+    stale.write_bytes(b"\0" * 64)
+    monkeypatch.setattr(
+        xf, "iter_active_repo_cache_dirs", lambda *a, **k: iter([tmp_path / "models--o--r"])
+    )
+    monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
+    monkeypatch.setattr(xf, "has_active_incomplete_blobs", lambda *a, **k: True)
+    fake = _install(
+        monkeypatch,
+        [("stall", "no progress for 30s after 1.2 GB"), ("retryable_error", "503"),
+         ("retryable_error", "503"), ("ok", "/cache/x")],
+        owned_incomplete = {f"cafebabe{xf.INCOMPLETE_SUFFIX}"},
+    )
+    monkeypatch.setenv("UNSLOTH_XET_ATTEMPTS", "1")
+    monkeypatch.setenv("UNSLOTH_HTTP_ATTEMPTS", "3")
+    monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0")
+    assert xf.hf_hub_download_with_xet_fallback(DL_REPO, FILE, None) == "/cache/x"
+    assert stale.exists(), "the purge is scoped, so this partial is still there"
+    http_forces = [c.force_download for c in fake.calls if c.disable_xet]
+    assert all(http_forces), (
+        f"a surviving sparse partial was handed to an unforced HTTP child: {http_forces}"
+    )

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -82,6 +82,7 @@ from unsloth_zoo.hf_cache_state import (
     _sentence_transformers_subfolder_incomplete,
     _weight_shard_index_complete,
     blob_bytes_present,
+    repo_cache_dir_name,
     has_active_incomplete_blobs,
     hf_cache_root,
     iter_active_repo_cache_dirs,
@@ -149,6 +150,11 @@ DEFAULT_HTTP_RETRY_BACKOFF = 5.0
 # ~49.7 days (``PY_TIMEOUT_MAX``) -- past it they raise OverflowError, which is NOT a
 # DownloadStallError and so escapes the caller's guard into the unguarded in-process load.
 _MAX_HTTP_RETRY_BACKOFF = 300.0
+# huggingface_hub's short-download error, raised as a bare EnvironmentError so nothing about its
+# TYPE says "network". See file_download.py's consistency_error_message.
+_HUB_CONSISTENCY_ERROR_RE = re.compile(
+    r"consistency check failed: file should be of size", re.IGNORECASE
+)
 
 # "The disk cannot take it" errnos, built defensively: CPython compiles each errno constant behind an
 # #ifdef, so which names exist is a platform property (EDQUOT reaches Windows only through a
@@ -631,9 +637,24 @@ def _incomplete_partial_names(
         root = hf_cache_root(cache_dir = cache_dir)
         if root is None:
             return None
-        # Deliberately allowed to raise: this is the probe the helpers below swallow.
-        list(root.iterdir())
-        for entry in iter_active_repo_cache_dirs(repo_type, repo_id, cache_dir = cache_dir):
+        # The repo-dir selection is done HERE, off a single root listing, rather than through
+        # iter_active_repo_cache_dirs. That helper swallows OSError on its own root listing and on
+        # its case-collision probe, so a permission flap or a remount between two enumerations came
+        # back as "no repo dirs" and then as "no partials" -- the empty set that releases the guard.
+        # One listing, and every error out of it surfaces. The rule below mirrors
+        # _case_safe_repo_cache_dirs: prefer an exact-case match, accept a single folded match only
+        # on a case-insensitive filesystem, and attribute a 2+ way collision to neither repo.
+        target = repo_cache_dir_name(repo_type, repo_id)
+        folded_target = target.lower()
+        entries = [e for e in root.iterdir() if e.name.lower() == folded_target]
+        exact = [e for e in entries if e.name == target]
+        if exact:
+            repo_dirs = exact
+        elif len(entries) == 1 and (root / target).exists():
+            repo_dirs = entries
+        else:
+            repo_dirs = []
+        for entry in repo_dirs:
             blobs_dir = entry / "blobs"
             if not blobs_dir.is_dir():
                 continue
@@ -1303,6 +1324,15 @@ def _is_retryable_download_error(exc: BaseException, *, on_xet: bool) -> bool:
     # reads as a transient transport fault -- the very case this rule exists to exclude. The network
     # subclasses stay retryable by type, which is also more robust than matching their wording.
     if _is_builtin_oserror(exc):
+        # One exception to the class rule, and it is not a local filesystem error at all:
+        # huggingface_hub raises a bare EnvironmentError (an alias of OSError) when a download ends
+        # at the wrong length, and says so itself -- "This is usually due to network issues while
+        # downloading the file. Please retry". A short response is precisely what the HTTP retry
+        # budget added by this PR is for, so deciding it by class alone would surface it immediately
+        # and never spend that budget. Matched on the Hub's own wording, which cannot collide with a
+        # filename the way the "xet" hint does.
+        if _HUB_CONSISTENCY_ERROR_RE.search(str(exc)):
+            return True
         return isinstance(exc, (ConnectionError, TimeoutError, BrokenPipeError, BlockingIOError))
     text = f"{name}: {exc}".lower()
     if any(hint in text for hint in _TRANSIENT_ERROR_HINTS):
@@ -2571,36 +2601,48 @@ def _download_with_xet_fallback(
                 )
                 params = {**params, "force_download": True}
                 forced_clean_redownload = True
-        elif disable_xet and forced_clean_redownload:
-            # Release the latch only once the repo has NO *.incomplete partial left at all.
-            # "One HTTP child has run" is not proof of that: huggingface_hub unlinks the .incomplete
-            # only after the HEAD/metadata call, so a child that died on a 5xx there -- the degraded
-            # CDN this ladder exists for -- leaves the sparse Xet partial untouched, and handing the
-            # next child force_download=False would resume it into a corrupt blob.
+        elif disable_xet:
+            # Re-read before EVERY later HTTP child, in both directions. Releasing once and never
+            # looking again was wrong: a concurrent Xet downloader can create a partial under the
+            # same blob name after the release -- typically while this child is still waiting on the
+            # blob lock -- and that child would then resume it unforced and finalize a corrupt blob.
             #
-            # Absence is the ONLY evidence used, deliberately. Judging a partial that is still there
-            # to be a safe prefix is not something the filesystem can support: the name cannot tell
-            # a sparse Xet partial from the resumable one huggingface_hub rewrites at the same path,
-            # the inode is unstable on overlayfs and FUSE caches and reusable after an unlink, and
-            # allocation metadata is worse still -- XFS unwritten extents report a partial with
-            # hundreds of megabytes of holes as fully allocated. Each of those was tried here and
-            # each released the guard on a real filesystem. The cost of not judging is that a
-            # partial the forced child itself wrote keeps the latch on, so the remaining retries
-            # re-download rather than resume. That is bandwidth; the alternative was the blob.
+            # Release only once the repo has NO *.incomplete left at all. "One HTTP child has run" is
+            # not proof of that: huggingface_hub unlinks the .incomplete only after the HEAD/metadata
+            # call, so a child that died on a 5xx there -- the degraded CDN this ladder exists for --
+            # leaves the sparse Xet partial untouched.
             #
-            # Re-read per child rather than compared against a set captured at the transition, so a
-            # partial that appears AFTER a release re-arms the guard.
+            # Absence is the ONLY evidence accepted, deliberately. Judging a partial that is still
+            # there to be a safe prefix is not something the filesystem can support: the name cannot
+            # tell a sparse Xet partial from the resumable one huggingface_hub rewrites at the same
+            # path, the inode is unstable on overlayfs and FUSE caches and reusable after an unlink,
+            # and allocation metadata is worse still, because XFS unwritten extents report a partial
+            # with hundreds of megabytes of holes as fully allocated. Each was tried here and each
+            # released the guard on a real filesystem. The cost is that a partial the forced child
+            # itself wrote also holds the latch, so the remaining retries re-download rather than
+            # resume. That is bandwidth; the alternative was the blob.
             present = _incomplete_partial_names(repo_type, repo_id, cache_dir)
-            if present is not None and not present:
-                forced_clean_redownload = False
-                params = {**params, "force_download": caller_force_download}
-            else:
-                logger.debug(
-                    "Keeping force_download for '%s': %s",
-                    label,
-                    "cache not inspectable" if present is None
-                    else f"{len(present)} partial(s) still present",
+            if forced_clean_redownload:
+                if present is not None and not present:
+                    forced_clean_redownload = False
+                    params = {**params, "force_download": caller_force_download}
+                else:
+                    logger.debug(
+                        "Keeping force_download for '%s': %s",
+                        label,
+                        "cache not inspectable" if present is None
+                        else f"{len(present)} partial(s) still present",
+                    )
+            elif present:
+                # Positive evidence only. An uninspectable cache leaves the guard as it was rather
+                # than forcing a clean re-download on every machine whose cache briefly cannot be
+                # read, which would be a heavy cost for no proof.
+                logger.warning(
+                    "Partial for '%s' appeared after the guard was released; forcing a clean "
+                    "HTTP re-download instead of an unsafe resume.", label
                 )
+                forced_clean_redownload = True
+                params = {**params, "force_download": True}
 
         kind_result, payload = _run_download_attempt(
             repo_id,
@@ -2705,11 +2747,13 @@ def _download_with_xet_fallback(
             # which is not a DownloadStallError -- so the caller logs "continuing with the normal
             # load" and hands a transport that just failed twice to the unguarded in-process path.
             # That is issue #1122's shape, one rung further along. Keep it inside the guard.
-            # Scoped, not universal: only once Xet has ALREADY failed in a way that was held pending
-            # an HTTP rescue (a transport fault, a child crash, or an incomplete snapshot -- whatever
-            # set pending_needs_http_success). A ladder that started on HTTP, or one whose Xet rung
-            # was fine, still surfaces an unknown error exactly as it does today.
-            if pending_needs_http_success and disable_xet:
+            # Scoped, not universal: only once the ladder has ALREADY fallen back from Xet. Keying
+            # this on pending_needs_http_success instead left a hole, because a PROVEN stall is held
+            # with that flag False: Xet child 1 stalls, the Xet retry faults without displacing the
+            # stall, HTTP then raises something unrecognized, and the bare RuntimeError escaped the
+            # guard on exactly the run that had already failed twice. A ladder that started on HTTP,
+            # or one whose Xet rung was fine, still surfaces an unknown error as it does today.
+            if started_on_xet and disable_xet:
                 type_name = payload.split(":", 1)[0].strip() if ":" in (payload or "") else ""
                 if _resolve_exception_class(type_name) is None:
                     raise DownloadTransportError(payload)
@@ -2739,6 +2783,13 @@ def _download_with_xet_fallback(
                     f"{label}: transient HTTP error, retrying "
                     f"(attempt {http_used + 1} of {http_budget})",
                 )
+                # HTTP has now met the SAME fault, which settles the question the held reason was
+                # waiting on: the incident was shared, not Xet-specific. Drop it here rather than at
+                # the terminal exit, because a later HTTP retry succeeding would otherwise flush it
+                # and charge Xet for a CDN that had simply recovered. A proven stall still survives.
+                if pending_needs_http_success:
+                    pending_xet_failure = None
+                    pending_needs_http_success = False
                 _wait_before_http_retry(cancel_event)
                 continue
             # Both rungs met the same transport fault: that is not evidence against this machine's

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -136,29 +136,25 @@ DEFAULT_XET_ATTEMPTS = 2
 # Past this the ladder just burns time before the transport that would have worked.
 _MAX_XET_ATTEMPTS = 8
 
-# HTTP attempts before the ladder gives up. The last rung has nowhere to fall back to, and the fault
-# it most often meets is a 5xx from the Xet bridge CDN, which serves Xet-backed blobs over plain HTTP
-# too -- so a degraded CDN fails BOTH rungs and a single HTTP child turns a retryable blip into a hard
-# failure. 1 restores the single-attempt HTTP rung.
+# HTTP attempts before the ladder gives up. The Xet bridge CDN serves Xet-backed blobs over plain
+# HTTP too, so a degraded CDN fails BOTH rungs and a single HTTP child would turn a retryable blip
+# into a hard failure. 1 restores the single-attempt HTTP rung.
 DEFAULT_HTTP_ATTEMPTS = 2
 _MAX_HTTP_ATTEMPTS = 8
-# Wait between HTTP children so a CDN shedding load is not hit again in the same instant.
-# ``UNSLOTH_HTTP_RETRY_BACKOFF`` overrides it, and 0 means "retry at once" rather than "junk".
+# Wait between HTTP children so a CDN shedding load is not hit again at once. 0 means "retry at
+# once", not "junk"; ``UNSLOTH_HTTP_RETRY_BACKOFF`` overrides.
 DEFAULT_HTTP_RETRY_BACKOFF = 5.0
-# Ceiling on that wait. A backoff is not a timeout: past a few minutes the ladder is just holding the
-# caller hostage, and the value reaches ``time.sleep`` / ``Event.wait``, whose Windows limit is
-# ~49.7 days (``PY_TIMEOUT_MAX``) -- past it they raise OverflowError, which is NOT a
+# Ceiling on that wait: past a few minutes the ladder just holds the caller hostage, and past
+# PY_TIMEOUT_MAX ``time.sleep`` / ``Event.wait`` raise OverflowError, which is not a
 # DownloadStallError and so escapes the caller's guard into the unguarded in-process load.
 _MAX_HTTP_RETRY_BACKOFF = 300.0
-# huggingface_hub's short-download error, raised as a bare EnvironmentError so nothing about its
-# TYPE says "network". See file_download.py's consistency_error_message.
+# hub's short-download error: a bare EnvironmentError, so nothing in its TYPE says "network".
 _HUB_CONSISTENCY_ERROR_RE = re.compile(
     r"consistency check failed: file should be of size", re.IGNORECASE
 )
 
-# "The disk cannot take it" errnos, built defensively: CPython compiles each errno constant behind an
-# #ifdef, so which names exist is a platform property (EDQUOT reaches Windows only through a
-# WSAEDQUOT fallback). A bare errno.EDQUOT would be an AttributeError on a build without it.
+# "The disk cannot take it" errnos, read defensively: which errno names exist is a platform property
+# (CPython #ifdefs each one), so a bare errno.EDQUOT would be an AttributeError on a build without it.
 _DISK_FULL_ERRNOS = frozenset(
     code for code in (getattr(errno, name, None) for name in ("ENOSPC", "EDQUOT"))
     if code is not None
@@ -637,13 +633,10 @@ def _incomplete_partial_names(
         root = hf_cache_root(cache_dir = cache_dir)
         if root is None:
             return None
-        # The repo-dir selection is done HERE, off a single root listing, rather than through
-        # iter_active_repo_cache_dirs. That helper swallows OSError on its own root listing and on
-        # its case-collision probe, so a permission flap or a remount between two enumerations came
-        # back as "no repo dirs" and then as "no partials" -- the empty set that releases the guard.
-        # One listing, and every error out of it surfaces. The rule below mirrors
-        # _case_safe_repo_cache_dirs: prefer an exact-case match, accept a single folded match only
-        # on a case-insensitive filesystem, and attribute a 2+ way collision to neither repo.
+        # Selected off ONE root listing rather than via iter_active_repo_cache_dirs, which swallows
+        # OSError and reported a permission flap or a remount as "no repo dirs" and then "no
+        # partials" -- the empty set that releases the guard. Here every error surfaces. The rule
+        # mirrors _case_safe_repo_cache_dirs: exact case, else a lone folded match, else neither.
         target = repo_cache_dir_name(repo_type, repo_id)
         folded_target = target.lower()
         entries = [e for e in root.iterdir() if e.name.lower() == folded_target]
@@ -1157,9 +1150,8 @@ _DETERMINISTIC_ERROR_NAMES = frozenset({
     "LocalTokenNotFoundError",  # a missing required token fails identically either way
     "BadRequestError",
     "HFValidationError",        # a malformed repo id / revision never reaches the network
-    # Subclasses builtin ConnectionError, so it is an OSError with no errno and no builtin of its own
-    # name: nothing below catches it, and the rung default would spend an HTTP child AND the
-    # destructive pre-HTTP purge on a repo the user has switched offline.
+    # An OSError (via builtin ConnectionError) with no errno, so nothing below catches it and the rung
+    # default would spend an HTTP child plus the destructive purge on a repo the user switched offline.
     "OfflineModeIsEnabled",
 })
 # TYPE reconstructed across the spawn but NOT retry-deterministic: ``HfHubHTTPError`` bases both
@@ -1289,11 +1281,10 @@ def _is_retryable_download_error(exc: BaseException, *, on_xet: bool) -> bool:
     rather than looped.
     """
     name = type(exc).__name__
-    # Control flow, not transport. The child reports via `except BaseException`, so these reach the
-    # classifier, and the rung default would answer "retryable" -- spending an HTTP child AND the
-    # destructive pre-HTTP purge because someone asked the process to stop. Programming errors are
-    # deliberately NOT listed: for those the rung default's "one HTTP attempt to disprove it" trade
-    # still holds, but nothing can make an interpreter shutdown a CDN problem.
+    # Control flow, not transport: the child reports via `except BaseException`, so these reach the
+    # classifier and the rung default would call them retryable, spending an HTTP child plus the
+    # destructive purge. Programming errors stay unlisted -- the "one HTTP attempt to disprove it"
+    # trade still holds for those, but nothing makes an interpreter shutdown a CDN problem.
     if isinstance(exc, (KeyboardInterrupt, SystemExit, GeneratorExit)):
         return False
     # LocalEntryNotFoundError wraps BOTH a genuine offline / uncached miss (deterministic) AND a
@@ -1305,10 +1296,9 @@ def _is_retryable_download_error(exc: BaseException, *, on_xet: bool) -> bool:
         return True
     if name in _DETERMINISTIC_ERROR_NAMES:
         return False
-    # Disk full / quota: another transport cannot help. errno codes are #ifdef'd per platform in
-    # CPython, so read them defensively -- an AttributeError here would fire inside the child's
-    # `except BaseException` while it is REPORTING a failure, turning a clean deterministic error
-    # into a resultless "crashed" verdict that then spends the whole HTTP budget on it.
+    # Disk full / quota: another transport cannot help. errnos are read defensively because an
+    # AttributeError here would fire inside the child's `except BaseException` while it is REPORTING
+    # a failure, turning a clean deterministic error into a "crashed" verdict that spends the budget.
     if isinstance(exc, OSError) and getattr(exc, "errno", None) in _DISK_FULL_ERRNOS:
         return False
     # HTTP status (HfHubHTTPError carries a requests / httpx response): 5xx / 429 / 408 transient,
@@ -1318,19 +1308,14 @@ def _is_retryable_download_error(exc: BaseException, *, on_xet: bool) -> bool:
         status = getattr(exc, "status_code", None)
     if isinstance(status, int):
         return status >= 500 or status in (408, 429)
-    # A builtin OSError is decided by its CLASS, before the text scan. Deciding it by text does not
-    # work: str(OSError) embeds the FILENAME, and the Xet cache lives at ~/.cache/huggingface/xet/,
-    # so a local PermissionError or read-only-filesystem error under it matches the "xet" hint and
-    # reads as a transient transport fault -- the very case this rule exists to exclude. The network
-    # subclasses stay retryable by type, which is also more robust than matching their wording.
+    # A builtin OSError is decided by its CLASS, before the text scan: str(OSError) embeds the
+    # FILENAME and the Xet cache lives at ~/.cache/huggingface/xet/, so a local PermissionError or
+    # read-only-filesystem error under it matches the "xet" hint and would read as a transient
+    # transport fault. Network subclasses stay retryable by type, which is robust to their wording.
     if _is_builtin_oserror(exc):
-        # One exception to the class rule, and it is not a local filesystem error at all:
-        # huggingface_hub raises a bare EnvironmentError (an alias of OSError) when a download ends
-        # at the wrong length, and says so itself -- "This is usually due to network issues while
-        # downloading the file. Please retry". A short response is precisely what the HTTP retry
-        # budget added by this PR is for, so deciding it by class alone would surface it immediately
-        # and never spend that budget. Matched on the Hub's own wording, which cannot collide with a
-        # filename the way the "xet" hint does.
+        # One exception: the Hub raises a bare EnvironmentError for a short download and says itself
+        # it is usually a network issue, which is exactly what the HTTP retry budget is for. Matched
+        # on the Hub's own wording, which cannot collide with a filename the way the "xet" hint does.
         if _HUB_CONSISTENCY_ERROR_RE.search(str(exc)):
             return True
         return isinstance(exc, (ConnectionError, TimeoutError, BrokenPipeError, BlockingIOError))
@@ -1442,9 +1427,8 @@ def _download_child_entry(
         path = _child_download(kind = kind, params = params, token = token, repo_type = repo_type)
         result_queue.put({"ok": True, "path": path})
     except BaseException as e:  # noqa: BLE001 - report every failure to the parent
-        # Classify here where the exception (status, errno, type) is intact, so the parent retries a
-        # transient failure over HTTP yet surfaces a deterministic one without a second attempt. The
-        # rung decides an unrecognized error, and only this child knows which one it ran on.
+        # Classify here, where status / errno / type are still intact. The rung decides an
+        # unrecognized error, and only this child knows which rung it ran on.
         result_queue.put({
             "ok": False,
             "error": _scrub_in_child(f"{type(e).__name__}: {e}", token),
@@ -2525,23 +2509,21 @@ def _download_with_xet_fallback(
     # HTTP children this download may spend, and how many it has spent.
     http_budget = http_attempts()
     http_used = 0
-    # force_download as the CALLER asked for it, so a clean re-download forced by an uncleared partial
-    # can be handed back once that partial is provably gone.
+    # The caller's own force_download, handed back once the partial that forced a clean re-download
+    # is provably gone.
     caller_force_download = params.get("force_download", False)
     forced_clean_redownload = False
-    # The Xet -> HTTP purge runs at the TRANSITION only. Repeating it per HTTP child would spare the
-    # partial the failed HTTP child just wrote (it is younger than active_grace), leaving
-    # has_active_incomplete_blobs true and forcing force_download, so every HTTP retry would restart
-    # the download from zero instead of resuming it.
+    # The Xet -> HTTP purge runs at the TRANSITION only: repeating it per HTTP child would spare the
+    # partial that child just wrote (younger than active_grace), forcing force_download so every
+    # retry restarts from zero instead of resuming.
     http_prepared = False
     # Health is reported ONCE per logical download, not once per child: the tracker demotes a machine
     # for 24h after two CONSECUTIVE failures, so charging both attempts would let one bad download
     # pin it, against the "one is noise, two is a pattern" rule the tracker is built on.
     pending_xet_failure: Optional[str] = None
-    # Whether that held reason still needs proof. A STALL stands on its own, so it is charged even if
-    # the ladder later leaves by another door. A transport fault or a crash does not: a degraded CDN
-    # fails both rungs identically, so only HTTP finishing what Xet could not shows the Xet path alone
-    # was the broken one.
+    # Whether that held reason still needs proof: a STALL stands on its own and is charged whichever
+    # door the ladder leaves by, but a fault or a crash does not, since a degraded CDN fails both
+    # rungs and only HTTP finishing what Xet could not shows the Xet path alone was broken.
     pending_needs_http_success = False
 
     def _flush_pending_failure() -> None:
@@ -2602,25 +2584,21 @@ def _download_with_xet_fallback(
                 params = {**params, "force_download": True}
                 forced_clean_redownload = True
         elif disable_xet:
-            # Re-read before EVERY later HTTP child, in both directions. Releasing once and never
-            # looking again was wrong: a concurrent Xet downloader can create a partial under the
-            # same blob name after the release -- typically while this child is still waiting on the
-            # blob lock -- and that child would then resume it unforced and finalize a corrupt blob.
+            # Re-read before EVERY later HTTP child, in both directions: a concurrent Xet downloader
+            # can create a partial under the same blob name after a release (typically while this
+            # child waits on the blob lock), and resuming it unforced finalizes a corrupt blob.
             #
-            # Release only once the repo has NO *.incomplete left at all. "One HTTP child has run" is
-            # not proof of that: huggingface_hub unlinks the .incomplete only after the HEAD/metadata
-            # call, so a child that died on a 5xx there -- the degraded CDN this ladder exists for --
-            # leaves the sparse Xet partial untouched.
+            # Release only on NO *.incomplete at all. "One HTTP child has run" is not proof: hub
+            # unlinks the .incomplete only after the HEAD/metadata call, so a child that died on a
+            # 5xx there -- the degraded CDN this ladder exists for -- leaves the Xet partial intact.
             #
-            # Absence is the ONLY evidence accepted, deliberately. Judging a partial that is still
-            # there to be a safe prefix is not something the filesystem can support: the name cannot
-            # tell a sparse Xet partial from the resumable one huggingface_hub rewrites at the same
-            # path, the inode is unstable on overlayfs and FUSE caches and reusable after an unlink,
-            # and allocation metadata is worse still, because XFS unwritten extents report a partial
-            # with hundreds of megabytes of holes as fully allocated. Each was tried here and each
-            # released the guard on a real filesystem. The cost is that a partial the forced child
-            # itself wrote also holds the latch, so the remaining retries re-download rather than
-            # resume. That is bandwidth; the alternative was the blob.
+            # ABSENCE is the only evidence accepted. Judging a surviving partial to be a safe prefix
+            # was tried three ways and each released the guard on a real filesystem: the NAME cannot
+            # tell a sparse Xet partial from the resumable one hub rewrites at the same path, the
+            # INODE is unstable on overlayfs / FUSE and reused after an unlink, and ALLOCATION
+            # metadata reports XFS unwritten extents as fully allocated. The cost is that a partial
+            # the forced child itself wrote also holds the latch, so the remaining retries
+            # re-download rather than resume. That is bandwidth; the alternative was the blob.
             present = _incomplete_partial_names(repo_type, repo_id, cache_dir)
             if forced_clean_redownload:
                 if present is not None and not present:
@@ -2634,9 +2612,8 @@ def _download_with_xet_fallback(
                         else f"{len(present)} partial(s) still present",
                     )
             elif present:
-                # Positive evidence only. An uninspectable cache leaves the guard as it was rather
-                # than forcing a clean re-download on every machine whose cache briefly cannot be
-                # read, which would be a heavy cost for no proof.
+                # Positive evidence only: an uninspectable cache leaves the guard as it was rather
+                # than forcing a clean re-download for no proof.
                 logger.warning(
                     "Partial for '%s' appeared after the guard was released; forcing a clean "
                     "HTTP re-download instead of an unsafe resume.", label
@@ -2659,8 +2636,7 @@ def _download_with_xet_fallback(
         )
 
         # An incomplete snapshot rides on "ok" but is a FAILURE, so classify it before the cancel
-        # check rather than inside the success branch: it is one of the verdicts that used to run the
-        # destructive purge and spend another child after the caller had given up.
+        # check: it used to run the destructive purge and spend another child after a cancel.
         incomplete_snapshot = kind_result == "ok" and kind == "snapshot" and (
             _snapshot_payload_incomplete(
                 payload,
@@ -2671,13 +2647,10 @@ def _download_with_xet_fallback(
             )
         )
 
-        # Cancellation wins over every FAILURE verdict, uniformly. Without this the precedence is
-        # per-branch: a cancel landing on a transient HTTP error reported "Cancelled", but the same
-        # cancel landing on a stall, a deterministic error or an incomplete snapshot reported the
-        # download's own error instead -- and on a Xet verdict it went on to run the destructive
-        # pre-HTTP purge and spend another child for a caller that had already given up. A genuine
-        # success is deliberately exempt: the bytes are on disk either way, so returning them is
-        # kinder than discarding finished work.
+        # Cancellation wins over every FAILURE verdict, uniformly. Per-branch precedence let a cancel
+        # landing on a stall, a deterministic error or an incomplete snapshot report the download's
+        # own error, and on a Xet verdict run the destructive purge and spend another child. A
+        # genuine success is exempt: the bytes are on disk, so returning them beats discarding them.
         if (
             (kind_result != "ok" or incomplete_snapshot)
             and cancel_event is not None
@@ -2700,17 +2673,13 @@ def _download_with_xet_fallback(
                     )
                     _safe_status(on_status, f"{label}: incomplete snapshot, retrying over HTTP")
                     # Held pending an HTTP rescue, like the fault and crash branches: a short
-                    # snapshot is a transport symptom too (the Hub hands one back on a timed-out or
-                    # offline metadata trip), so a CDN bad enough to shorten BOTH rungs is not
-                    # evidence against this machine's Xet. Recording it here charged the tracker even
-                    # when the ladder went on to fail or be cancelled, and two such downloads demote
-                    # a healthy machine to HTTP for 24h.
+                    # snapshot is a transport symptom too, so a CDN bad enough to shorten BOTH rungs
+                    # is not evidence against this machine's Xet (two such demote it for 24h).
                     _hold_unproven_xet_failure("Xet returned an incomplete snapshot")
                     disable_xet = True
                     continue
-                # Both rungs came back short: as with the fault branch, an UNPROVEN reason is not
-                # evidence against this machine's Xet, but a stall the watchdog proved on this machine
-                # survives and must still be charged on the way out.
+                # Both rungs came back short: an UNPROVEN reason is not evidence against this
+                # machine's Xet, but a watchdog-proven stall survives and is still charged.
                 if pending_needs_http_success:
                     pending_xet_failure = None
                 _flush_pending_failure()
@@ -2724,8 +2693,7 @@ def _download_with_xet_fallback(
                 pending_xet_failure = None
                 _record_xet_outcome(True)
             elif started_on_xet:
-                # HTTP finished what Xet could not, which is what turns a held Xet failure into
-                # evidence: the network was fine and only the Xet path was not. Charge it now.
+                # HTTP finished what Xet could not, so the held failure is now evidence. Charge it.
                 _flush_pending_failure()
             return payload  # type: ignore[return-value]
         if kind_result == "cancelled":
@@ -2734,25 +2702,18 @@ def _download_with_xet_fallback(
             raise RuntimeError("Cancelled")
         if kind_result == "error":
             # Deterministic failure (auth / not-found / gated / disk-full): the other transport fails
-            # identically. _raise_child_error preserves the original type across the spawn. An earlier
-            # STALL was still evidence, so report it before the raise leaves the ladder -- but a held
-            # transport fault is not, and this is easy to reach now that every unrecognized Xet error
-            # holds one: a Xet CAS fault followed by an HTTP child that fills the disk would otherwise
-            # charge the machine for a download that never succeeded on either rung.
+            # identically, and _raise_child_error preserves the original type across the spawn. An
+            # earlier STALL is still evidence and is reported before the raise; a held transport
+            # fault is not, since the download then succeeded on neither rung.
             if pending_needs_http_success:
                 pending_xet_failure = None
             _flush_pending_failure()
-            # An UNRECOGNIZED error ending the ladder after a transport fault already sent us here
-            # would leave as a bare RuntimeError (_raise_child_error cannot rebuild an unknown class),
-            # which is not a DownloadStallError -- so the caller logs "continuing with the normal
-            # load" and hands a transport that just failed twice to the unguarded in-process path.
-            # That is issue #1122's shape, one rung further along. Keep it inside the guard.
-            # Scoped, not universal: only once the ladder has ALREADY fallen back from Xet. Keying
-            # this on pending_needs_http_success instead left a hole, because a PROVEN stall is held
-            # with that flag False: Xet child 1 stalls, the Xet retry faults without displacing the
-            # stall, HTTP then raises something unrecognized, and the bare RuntimeError escaped the
-            # guard on exactly the run that had already failed twice. A ladder that started on HTTP,
-            # or one whose Xet rung was fine, still surfaces an unknown error as it does today.
+            # An UNRECOGNIZED error here leaves as a bare RuntimeError (_raise_child_error cannot
+            # rebuild an unknown class), which is not a DownloadStallError -- so the caller logs
+            # "continuing with the normal load" and hands a twice-failed transport to the unguarded
+            # in-process path: issue #1122 one rung further along. Keep it inside the guard.
+            # Scoped to a ladder that ALREADY fell back from Xet; keying it on
+            # pending_needs_http_success left a hole, since a PROVEN stall is held with that False.
             if started_on_xet and disable_xet:
                 type_name = payload.split(":", 1)[0].strip() if ":" in (payload or "") else ""
                 if _resolve_exception_class(type_name) is None:
@@ -2767,7 +2728,7 @@ def _download_with_xet_fallback(
                     "with HF_HUB_DISABLE_XET=1: %s", label, payload
                 )
                 _safe_status(on_status, f"{label}: transient Xet error, retrying over HTTP")
-                # HELD, not recorded: a transient fault is only evidence against THIS MACHINE's Xet if
+                # HELD, not recorded: a transient fault only counts against THIS MACHINE's Xet if
                 # HTTP then succeeds. A degraded CDN fails both rungs, and charging it here demoted a
                 # perfectly good machine to HTTP for 24h after two such downloads.
                 _hold_unproven_xet_failure("transient Xet transport error")
@@ -2783,10 +2744,9 @@ def _download_with_xet_fallback(
                     f"{label}: transient HTTP error, retrying "
                     f"(attempt {http_used + 1} of {http_budget})",
                 )
-                # HTTP has now met the SAME fault, which settles the question the held reason was
-                # waiting on: the incident was shared, not Xet-specific. Drop it here rather than at
-                # the terminal exit, because a later HTTP retry succeeding would otherwise flush it
-                # and charge Xet for a CDN that had simply recovered. A proven stall still survives.
+                # HTTP met the SAME fault, so the incident was shared, not Xet-specific. Dropped here
+                # rather than at the terminal exit, or a later HTTP success would flush it and charge
+                # Xet for a CDN that had simply recovered. A proven stall still survives.
                 if pending_needs_http_success:
                     pending_xet_failure = None
                     pending_needs_http_success = False
@@ -2820,11 +2780,9 @@ def _download_with_xet_fallback(
                     f"{label}: download crashed, retrying "
                     f"(attempt {http_used + 1} of {http_budget})",
                 )
-                # HTTP has now died the same way, which settles what the held reason was waiting on:
-                # the incident hit both rungs and is not evidence against this machine's Xet. Drop it
-                # here rather than at the terminal exit, or a later HTTP retry succeeding flushes it
-                # and charges Xet for an incident that had simply passed. Same rule as the transient
-                # HTTP error branch above. A PROVEN stall is not unproven and survives.
+                # HTTP died the same way, so the incident hit both rungs and is not evidence against
+                # this machine's Xet. Same rule (and same reason for dropping it here rather than at
+                # the terminal exit) as the transient HTTP branch above. A PROVEN stall survives.
                 if pending_needs_http_success:
                     pending_xet_failure = None
                     pending_needs_http_success = False
@@ -2872,8 +2830,8 @@ def _download_with_xet_fallback(
             _flush_pending_failure()
             disable_xet = True
             continue
-        # An HTTP stall is not evidence against Xet on its own, but a Xet stall held from an earlier
-        # attempt already was, and this exit is the last door out of the ladder.
+        # An HTTP stall says nothing about Xet, but a Xet stall held from an earlier attempt does,
+        # and this is the last door out of the ladder.
         if pending_needs_http_success:
             pending_xet_failure = None
         _flush_pending_failure()

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -2820,6 +2820,14 @@ def _download_with_xet_fallback(
                     f"{label}: download crashed, retrying "
                     f"(attempt {http_used + 1} of {http_budget})",
                 )
+                # HTTP has now died the same way, which settles what the held reason was waiting on:
+                # the incident hit both rungs and is not evidence against this machine's Xet. Drop it
+                # here rather than at the terminal exit, or a later HTTP retry succeeding flushes it
+                # and charges Xet for an incident that had simply passed. Same rule as the transient
+                # HTTP error branch above. A PROVEN stall is not unproven and survives.
+                if pending_needs_http_success:
+                    pending_xet_failure = None
+                    pending_needs_http_success = False
                 _wait_before_http_retry(cancel_event)
                 continue
             if pending_needs_http_success:

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -81,7 +81,6 @@ from unsloth_zoo.hf_cache_state import (
     _selected_shard_index_incomplete,
     _sentence_transformers_subfolder_incomplete,
     _weight_shard_index_complete,
-    _windows_allocated_size,
     blob_bytes_present,
     has_active_incomplete_blobs,
     hf_cache_root,
@@ -605,47 +604,29 @@ def _active_incomplete_blob_sizes(
     return sizes
 
 
-def _partial_is_resumable(blob: Path) -> Optional[bool]:
-    """Is *blob* an ``.incomplete`` an HTTP resume can safely continue? ``None`` if undeterminable.
-
-    This is the property the corruption guard actually cares about, and it is readable from the file
-    rather than inferred from its name or inode. huggingface_hub's HTTP path appends, so its partial
-    is a contiguous prefix: fully allocated up to its length. A partial written by parallel chunk
-    writers (hf_transfer, older hf_xet) has holes -- full ``st_size``, far fewer blocks. Resuming
-    over that one appends past the holes and finalizes a silently corrupt blob.
-
-    Windows deliberately answers ``None`` for anything not visibly sparse. NTFS materialises zeros
-    when a writer seeks past the end instead of leaving a hole, so "fully allocated" there does not
-    mean "fully written", and treating it as resumable would be the corrupting direction. Sparse is
-    still conclusive when it is visible, so that direction is trusted on every platform.
-    """
-    st = blob.stat()
-    if st.st_size == 0:
-        return True
-    blocks = getattr(st, "st_blocks", None)
-    if blocks is not None:
-        return blocks * 512 >= st.st_size
-    allocated = _windows_allocated_size(blob)
-    if allocated is not None and allocated < st.st_size:
-        return False
-    return None
-
-
-def _unsafe_incomplete_partials(
+def _incomplete_partial_names(
     repo_type: Optional[str], repo_id: str, cache_dir: Optional[str] = None
 ) -> Optional[set]:
-    """Names of the repo's ``*.incomplete`` partials that are NOT safe to resume over.
+    """Names of the repo's ``*.incomplete`` partials, or ``None`` if the cache could not be read.
 
-    ``None`` means the cache could not be inspected, which is not the same answer as "none of them"
-    and must never release the guard. Getting that distinction right takes an explicit probe of the
-    cache root: ``hf_cache_root`` and ``_case_safe_repo_cache_dirs`` both swallow ``OSError`` and
-    report an unreadable or briefly absent root as "no directories", which reads as "everything
-    vanished". A root that disappears after the guard engaged is a remount or a permission flap, not
-    proof, so it is reported as unknown here.
+    ``None`` is not the same answer as "none of them" and must never release the guard above. Getting
+    that distinction right takes an explicit probe of the cache root: ``hf_cache_root`` and
+    ``_case_safe_repo_cache_dirs`` both swallow ``OSError`` and report an unreadable or briefly
+    absent root as "no directories", which reads as "everything vanished". A root that disappears
+    after the guard engaged is a remount or a permission flap, not proof.
 
-    Undeterminable safety counts as unsafe, so a filesystem that will not answer keeps the guard on.
+    Only ABSENCE is reported, never a judgement about a partial that is still there. Whether a
+    surviving partial is a valid prefix that an HTTP resume can safely continue is not recoverable
+    from the filesystem: allocation metadata cannot express it. XFS turns speculative preallocation
+    into unwritten extents that are allocated, counted in ``st_blocks``, and read back as zeros, so a
+    partial with hundreds of megabytes of holes reports itself fully allocated; ext4 ``bigalloc``
+    clusters, XFS extent-size hints and ZFS records hide any gap smaller than one allocation unit;
+    a gap under one block is invisible to ``st_blocks`` and to ``SEEK_HOLE`` alike; and a FUSE or
+    network server supplies ``st_blocks`` itself, so one that synthesises it from the size reports
+    every sparse file as whole. Answering that question wrongly installs a zero-filled blob under its
+    sha256 name with no error, because the HTTP path verifies size and not content.
     """
-    unsafe: set = set()
+    names: set = set()
     try:
         root = hf_cache_root(cache_dir = cache_dir)
         if root is None:
@@ -657,19 +638,11 @@ def _unsafe_incomplete_partials(
             if not blobs_dir.is_dir():
                 continue
             for blob in blobs_dir.iterdir():
-                if not blob.name.endswith(INCOMPLETE_SUFFIX):
-                    continue
-                try:
-                    resumable = _partial_is_resumable(blob)
-                except FileNotFoundError:
-                    # Vanished between listing and stat, which is the disappearance being looked
-                    # for, not a failure to look.
-                    continue
-                if resumable is not True:
-                    unsafe.add(blob.name)
+                if blob.name.endswith(INCOMPLETE_SUFFIX):
+                    names.add(blob.name)
     except Exception:
         return None
-    return unsafe
+    return names
 
 
 def _child_rss(pid: int) -> Optional[int]:
@@ -2599,32 +2572,34 @@ def _download_with_xet_fallback(
                 params = {**params, "force_download": True}
                 forced_clean_redownload = True
         elif disable_xet and forced_clean_redownload:
-            # Release the latch only once no partial that is unsafe to resume is on disk.
-            # "One HTTP child has run" is NOT proof of that: huggingface_hub unlinks the .incomplete
+            # Release the latch only once the repo has NO *.incomplete partial left at all.
+            # "One HTTP child has run" is not proof of that: huggingface_hub unlinks the .incomplete
             # only after the HEAD/metadata call, so a child that died on a 5xx there -- the degraded
-            # CDN this ladder exists for -- leaves the sparse Xet partial untouched. Handing the next
-            # child force_download=False would then resume it and finalize a corrupt blob.
+            # CDN this ladder exists for -- leaves the sparse Xet partial untouched, and handing the
+            # next child force_download=False would resume it into a corrupt blob.
             #
-            # The question is asked of the FILE, not of its name or its inode. A name cannot tell the
-            # sparse Xet partial from the resumable one huggingface_hub rewrites at the same path
-            # under force_download, and an inode cannot either: it is unstable on overlayfs and FUSE
-            # caches, absent on some Windows stats, reusable after an unlink, and a same-repo sibling
-            # taking its own Xet retry produces the same "same name, new inode" signature as our own
-            # forced child while leaving a FRESH sparse partial behind. Sparseness is none of those
-            # things -- it is what actually makes a resume unsafe.
+            # Absence is the ONLY evidence used, deliberately. Judging a partial that is still there
+            # to be a safe prefix is not something the filesystem can support: the name cannot tell
+            # a sparse Xet partial from the resumable one huggingface_hub rewrites at the same path,
+            # the inode is unstable on overlayfs and FUSE caches and reusable after an unlink, and
+            # allocation metadata is worse still -- XFS unwritten extents report a partial with
+            # hundreds of megabytes of holes as fully allocated. Each of those was tried here and
+            # each released the guard on a real filesystem. The cost of not judging is that a
+            # partial the forced child itself wrote keeps the latch on, so the remaining retries
+            # re-download rather than resume. That is bandwidth; the alternative was the blob.
             #
-            # Re-read each time rather than intersecting with a set captured at the transition, so a
-            # partial that appears AFTER the release still re-arms the guard.
-            unsafe_now = _unsafe_incomplete_partials(repo_type, repo_id, cache_dir)
-            if unsafe_now is not None and not unsafe_now:
+            # Re-read per child rather than compared against a set captured at the transition, so a
+            # partial that appears AFTER a release re-arms the guard.
+            present = _incomplete_partial_names(repo_type, repo_id, cache_dir)
+            if present is not None and not present:
                 forced_clean_redownload = False
                 params = {**params, "force_download": caller_force_download}
             else:
                 logger.debug(
                     "Keeping force_download for '%s': %s",
                     label,
-                    "cache not inspectable" if unsafe_now is None
-                    else f"{len(unsafe_now)} partial(s) unsafe to resume",
+                    "cache not inspectable" if present is None
+                    else f"{len(present)} partial(s) still present",
                 )
 
         kind_result, payload = _run_download_attempt(

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -2492,6 +2492,10 @@ def _download_with_xet_fallback(
     # force itself onto HTTP from the start.
     with _SPAWN_ENV_LOCK:
         disable_xet = xet_force_disabled()
+    # WHY Xet is off matters on the way out: a user-level disable is an env var the caller's
+    # in-process fallback inherits, while the health demotion below is internal to this module and
+    # leaves that fallback with Xet still ENABLED. See the terminal unknown-error wrap.
+    xet_disabled_by_user = disable_xet
 
     # Skip a doomed Xet attempt on a machine already known to be bad at it (too little RAM,
     # unreachable CAS, recent failures): the ladder still recovers, but the user would pay the full
@@ -2712,9 +2716,12 @@ def _download_with_xet_fallback(
             # rebuild an unknown class), which is not a DownloadStallError -- so the caller logs
             # "continuing with the normal load" and hands a twice-failed transport to the unguarded
             # in-process path: issue #1122 one rung further along. Keep it inside the guard.
-            # Scoped to a ladder that ALREADY fell back from Xet; keying it on
-            # pending_needs_http_success left a hole, since a PROVEN stall is held with that False.
-            if started_on_xet and disable_xet:
+            # Scoped by WHY Xet is off, not by whether this ladder used it. pending_needs_http_success
+            # left a hole (a PROVEN stall is held with it False); started_on_xet left another (the
+            # health tracker can demote a machine to HTTP before the ladder begins, and that demotion
+            # is internal, so the caller's in-process fallback still has Xet ENABLED). Only an
+            # explicit user disable is left alone: that one is an env var the fallback inherits.
+            if disable_xet and not xet_disabled_by_user:
                 type_name = payload.split(":", 1)[0].strip() if ":" in (payload or "") else ""
                 if _resolve_exception_class(type_name) is None:
                     raise DownloadTransportError(payload)

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -81,6 +81,7 @@ from unsloth_zoo.hf_cache_state import (
     _selected_shard_index_incomplete,
     _sentence_transformers_subfolder_incomplete,
     _weight_shard_index_complete,
+    _windows_allocated_size,
     blob_bytes_present,
     has_active_incomplete_blobs,
     hf_cache_root,
@@ -604,33 +605,53 @@ def _active_incomplete_blob_sizes(
     return sizes
 
 
-def _incomplete_blob_identities(
+def _partial_is_resumable(blob: Path) -> Optional[bool]:
+    """Is *blob* an ``.incomplete`` an HTTP resume can safely continue? ``None`` if undeterminable.
+
+    This is the property the corruption guard actually cares about, and it is readable from the file
+    rather than inferred from its name or inode. huggingface_hub's HTTP path appends, so its partial
+    is a contiguous prefix: fully allocated up to its length. A partial written by parallel chunk
+    writers (hf_transfer, older hf_xet) has holes -- full ``st_size``, far fewer blocks. Resuming
+    over that one appends past the holes and finalizes a silently corrupt blob.
+
+    Windows deliberately answers ``None`` for anything not visibly sparse. NTFS materialises zeros
+    when a writer seeks past the end instead of leaving a hole, so "fully allocated" there does not
+    mean "fully written", and treating it as resumable would be the corrupting direction. Sparse is
+    still conclusive when it is visible, so that direction is trusted on every platform.
+    """
+    st = blob.stat()
+    if st.st_size == 0:
+        return True
+    blocks = getattr(st, "st_blocks", None)
+    if blocks is not None:
+        return blocks * 512 >= st.st_size
+    allocated = _windows_allocated_size(blob)
+    if allocated is not None and allocated < st.st_size:
+        return False
+    return None
+
+
+def _unsafe_incomplete_partials(
     repo_type: Optional[str], repo_id: str, cache_dir: Optional[str] = None
 ) -> Optional[set]:
-    """``{(name, inode)}`` for the repo's ``*.incomplete`` partials, ``None`` if unreadable.
+    """Names of the repo's ``*.incomplete`` partials that are NOT safe to resume over.
 
-    Two deliberate differences from ``_active_incomplete_blob_sizes``:
+    ``None`` means the cache could not be inspected, which is not the same answer as "none of them"
+    and must never release the guard. Getting that distinction right takes an explicit probe of the
+    cache root: ``hf_cache_root`` and ``_case_safe_repo_cache_dirs`` both swallow ``OSError`` and
+    report an unreadable or briefly absent root as "no directories", which reads as "everything
+    vanished". A root that disappears after the guard engaged is a remount or a permission flap, not
+    proof, so it is reported as unknown here.
 
-    Fail-CLOSED. That helper swallows per-file and outer errors and returns whatever it managed to
-    read, which is right for a progress sensor, where an unreadable blob should not abort a
-    download. It is wrong for a safety check, where an empty result would then mean "gone" and
-    "could not look" alike -- and the caller releases a corruption guard on that answer.
-
-    Identity, not name alone. The name cannot distinguish the sparse Xet partial the purge failed
-    to remove from the fresh, resumable one huggingface_hub writes at the SAME path after unlinking
-    it under ``force_download``, so a name-only check re-latches on the very HTTP progress it should
-    be preserving and restarts every remaining child from zero. The inode separates them, because an
-    unlink plus create changes it.
-
-    ``st_ino`` is reported as ``0`` when the filesystem could not supply one -- notably on Windows,
-    where ``os.stat`` falls back to a directory entry that carries no file index precisely when the
-    file is locked, which is also the reason the purge failed and the latch engaged. That zero is
-    carried through rather than hidden, and ``_surviving_unsafe_partials`` treats it as unresolvable
-    rather than as a difference. ``st_dev`` is left out on purpose: it is not stable across an
-    autofs remount of a network cache, which would read as a change with no change.
+    Undeterminable safety counts as unsafe, so a filesystem that will not answer keeps the guard on.
     """
-    identities: set = set()
+    unsafe: set = set()
     try:
+        root = hf_cache_root(cache_dir = cache_dir)
+        if root is None:
+            return None
+        # Deliberately allowed to raise: this is the probe the helpers below swallow.
+        list(root.iterdir())
         for entry in iter_active_repo_cache_dirs(repo_type, repo_id, cache_dir = cache_dir):
             blobs_dir = entry / "blobs"
             if not blobs_dir.is_dir():
@@ -639,35 +660,16 @@ def _incomplete_blob_identities(
                 if not blob.name.endswith(INCOMPLETE_SUFFIX):
                     continue
                 try:
-                    st = blob.stat()
+                    resumable = _partial_is_resumable(blob)
                 except FileNotFoundError:
-                    # Vanished between listing and stat. That is the disappearance this scan looks
-                    # for, not a failure to look, so skip it rather than failing closed.
+                    # Vanished between listing and stat, which is the disappearance being looked
+                    # for, not a failure to look.
                     continue
-                identities.add((blob.name, getattr(st, "st_ino", 0) or 0))
+                if resumable is not True:
+                    unsafe.add(blob.name)
     except Exception:
         return None
-    return identities
-
-
-def _surviving_unsafe_partials(captured: set, present: set) -> set:
-    """Which of the *captured* unsafe partials are still on disk, per *present*.
-
-    Only a vanished NAME counts as disappearance. A name that is still there with a different inode
-    is the case the identity test exists for, but only when both scans could actually resolve one:
-    an unresolvable inode on either side means the answer is unknown, and unknown has to read as
-    "still there", or the guard releases on exactly the locked-file and remounted-cache machines
-    least able to survive a corrupt blob.
-    """
-    present_names = {name for name, _ in present}
-    unresolved_names = {name for name, ino in present if not ino}
-    surviving = set()
-    for name, ino in captured:
-        if name not in present_names:
-            continue
-        if not ino or name in unresolved_names or (name, ino) in present:
-            surviving.add((name, ino))
-    return surviving
+    return unsafe
 
 
 def _child_rss(pid: int) -> Optional[int]:
@@ -2524,10 +2526,6 @@ def _download_with_xet_fallback(
     # can be handed back once that partial is provably gone.
     caller_force_download = params.get("force_download", False)
     forced_clean_redownload = False
-    # The exact unsafe partials seen at the transition, or None if the cache could not be read.
-    # The latch is released only when NONE of them is still on disk -- see the un-latch branch below
-    # for why "a child ran" is not enough, and why None must not count as "gone".
-    unsafe_partials: Optional[set] = set()
     # The Xet -> HTTP purge runs at the TRANSITION only. Repeating it per HTTP child would spare the
     # partial the failed HTTP child just wrote (it is younger than active_grace), leaving
     # has_active_incomplete_blobs true and forcing force_download, so every HTTP retry would restart
@@ -2600,45 +2598,33 @@ def _download_with_xet_fallback(
                 )
                 params = {**params, "force_download": True}
                 forced_clean_redownload = True
-                # Remember WHICH partials are unsafe, so the latch can be released on evidence.
-                # An uninspectable cache yields None, which keeps the latch on forever below --
-                # a clean re-download costs bandwidth, resuming over a sparse partial costs the blob.
-                # Deliberately UNSCOPED, unlike the purge above. Scoping this by owned_incomplete
-                # looks symmetric and is backwards: the purge skips every blob outside that set, so
-                # the partials that SURVIVE it are exactly the ones outside it -- they are why
-                # has_active_incomplete_blobs() just returned True. Filtering them out empties the
-                # set, releases the latch on the next iteration, and hands the next child a sparse
-                # partial to resume. The cost of not scoping is that a live sibling's partial can
-                # hold the latch and make retries re-download; that is bandwidth, and the guard is
-                # here to protect the blob.
-                unsafe_partials = _incomplete_blob_identities(repo_type, repo_id, cache_dir)
         elif disable_xet and forced_clean_redownload:
-            # Release the latch only once every partial that was unsafe at the transition is gone.
-            # "One HTTP child has run" is NOT proof it did: huggingface_hub unlinks the .incomplete
+            # Release the latch only once no partial that is unsafe to resume is on disk.
+            # "One HTTP child has run" is NOT proof of that: huggingface_hub unlinks the .incomplete
             # only after the HEAD/metadata call, so a child that died on a 5xx there -- the degraded
             # CDN this ladder exists for -- leaves the sparse Xet partial untouched. Handing the next
-            # child force_download=False would then resume it, and an HTTP resume over a sparse Xet
-            # partial finalizes a silently corrupt blob, which is what the purge above prevents.
-            # Fail closed on both halves: a scan that could not run (None, either now or at the
-            # transition) is not evidence of disappearance, so the latch stays on. Matched on
-            # ``(name, dev, ino)``, so a same-named replacement written by the forced HTTP child
-            # counts as disappearance -- that partial IS resumable, and re-latching on it would
-            # throw away the bytes this ladder just paid for.
-            present = _incomplete_blob_identities(repo_type, repo_id, cache_dir)
-            still_unsafe = (
-                None if (unsafe_partials is None or present is None)
-                else _surviving_unsafe_partials(unsafe_partials, present)
-            )
-            if still_unsafe is not None and not still_unsafe:
+            # child force_download=False would then resume it and finalize a corrupt blob.
+            #
+            # The question is asked of the FILE, not of its name or its inode. A name cannot tell the
+            # sparse Xet partial from the resumable one huggingface_hub rewrites at the same path
+            # under force_download, and an inode cannot either: it is unstable on overlayfs and FUSE
+            # caches, absent on some Windows stats, reusable after an unlink, and a same-repo sibling
+            # taking its own Xet retry produces the same "same name, new inode" signature as our own
+            # forced child while leaving a FRESH sparse partial behind. Sparseness is none of those
+            # things -- it is what actually makes a resume unsafe.
+            #
+            # Re-read each time rather than intersecting with a set captured at the transition, so a
+            # partial that appears AFTER the release still re-arms the guard.
+            unsafe_now = _unsafe_incomplete_partials(repo_type, repo_id, cache_dir)
+            if unsafe_now is not None and not unsafe_now:
                 forced_clean_redownload = False
-                unsafe_partials = set()
                 params = {**params, "force_download": caller_force_download}
             else:
                 logger.debug(
                     "Keeping force_download for '%s': %s",
                     label,
-                    "cache not inspectable" if still_unsafe is None
-                    else f"{len(still_unsafe)} unsafe partial(s) still present",
+                    "cache not inspectable" if unsafe_now is None
+                    else f"{len(unsafe_now)} partial(s) unsafe to resume",
                 )
 
         kind_result, payload = _run_download_attempt(

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -607,26 +607,27 @@ def _active_incomplete_blob_sizes(
 def _incomplete_blob_identities(
     repo_type: Optional[str], repo_id: str, cache_dir: Optional[str] = None
 ) -> Optional[set]:
-    """``{(name, st_dev, st_ino)}`` for the repo's ``*.incomplete`` partials, ``None`` if unreadable.
+    """``{(name, inode)}`` for the repo's ``*.incomplete`` partials, ``None`` if unreadable.
 
     Two deliberate differences from ``_active_incomplete_blob_sizes``:
 
     Fail-CLOSED. That helper swallows per-file and outer errors and returns whatever it managed to
     read, which is right for a progress sensor, where an unreadable blob should not abort a
     download. It is wrong for a safety check, where an empty result would then mean "gone" and
-    "could not look" alike -- and the caller below releases a guard on that answer.
+    "could not look" alike -- and the caller releases a corruption guard on that answer.
 
-    Identity, not name. The name alone cannot tell the sparse Xet partial the purge failed to remove
-    from a fresh, resumable partial huggingface_hub wrote at the SAME path after unlinking it under
-    ``force_download``, so a name-only check re-latches on the very HTTP progress it should be
-    preserving and restarts every remaining child from zero. ``(dev, ino)`` survives that: an unlink
-    plus create changes the inode. Two known-imprecise cases, both erring the way the pre-latch code
-    already behaved rather than the corrupting way: a filesystem reporting ``st_ino = 0`` (some FAT /
-    network mounts) degrades to the name-only test, which keeps the latch on; and an inode reused
-    immediately for the replacement releases it, exactly as unconditional release would have.
+    Identity, not name alone. The name cannot distinguish the sparse Xet partial the purge failed
+    to remove from the fresh, resumable one huggingface_hub writes at the SAME path after unlinking
+    it under ``force_download``, so a name-only check re-latches on the very HTTP progress it should
+    be preserving and restarts every remaining child from zero. The inode separates them, because an
+    unlink plus create changes it.
 
-    Size and mtime are deliberately NOT part of the identity: the unsafe partial can be appended to
-    by a live sibling, and keying on either would then read that growth as disappearance.
+    ``st_ino`` is reported as ``0`` when the filesystem could not supply one -- notably on Windows,
+    where ``os.stat`` falls back to a directory entry that carries no file index precisely when the
+    file is locked, which is also the reason the purge failed and the latch engaged. That zero is
+    carried through rather than hidden, and ``_surviving_unsafe_partials`` treats it as unresolvable
+    rather than as a difference. ``st_dev`` is left out on purpose: it is not stable across an
+    autofs remount of a network cache, which would read as a change with no change.
     """
     identities: set = set()
     try:
@@ -640,13 +641,33 @@ def _incomplete_blob_identities(
                 try:
                     st = blob.stat()
                 except FileNotFoundError:
-                    # Vanished between listing and stat. That is the disappearance this scan is
-                    # looking for, not a failure to look, so skip it rather than failing closed.
+                    # Vanished between listing and stat. That is the disappearance this scan looks
+                    # for, not a failure to look, so skip it rather than failing closed.
                     continue
-                identities.add((blob.name, st.st_dev, st.st_ino))
+                identities.add((blob.name, getattr(st, "st_ino", 0) or 0))
     except Exception:
         return None
     return identities
+
+
+def _surviving_unsafe_partials(captured: set, present: set) -> set:
+    """Which of the *captured* unsafe partials are still on disk, per *present*.
+
+    Only a vanished NAME counts as disappearance. A name that is still there with a different inode
+    is the case the identity test exists for, but only when both scans could actually resolve one:
+    an unresolvable inode on either side means the answer is unknown, and unknown has to read as
+    "still there", or the guard releases on exactly the locked-file and remounted-cache machines
+    least able to survive a corrupt blob.
+    """
+    present_names = {name for name, _ in present}
+    unresolved_names = {name for name, ino in present if not ino}
+    surviving = set()
+    for name, ino in captured:
+        if name not in present_names:
+            continue
+        if not ino or name in unresolved_names or (name, ino) in present:
+            surviving.add((name, ino))
+    return surviving
 
 
 def _child_rss(pid: int) -> Optional[int]:
@@ -2582,13 +2603,15 @@ def _download_with_xet_fallback(
                 # Remember WHICH partials are unsafe, so the latch can be released on evidence.
                 # An uninspectable cache yields None, which keeps the latch on forever below --
                 # a clean re-download costs bandwidth, resuming over a sparse partial costs the blob.
-                # Scoped by the same owned-blob set as the purge above: a partial the purge spared
-                # because a LIVE sibling holds it is not ours to wait on, and leaving it in would
-                # hold the latch for the whole ladder while that sibling downloads something else.
-                seen = _incomplete_blob_identities(repo_type, repo_id, cache_dir)
-                if seen is not None and owned_incomplete is not None:
-                    seen = {ident for ident in seen if ident[0] in owned_incomplete}
-                unsafe_partials = seen
+                # Deliberately UNSCOPED, unlike the purge above. Scoping this by owned_incomplete
+                # looks symmetric and is backwards: the purge skips every blob outside that set, so
+                # the partials that SURVIVE it are exactly the ones outside it -- they are why
+                # has_active_incomplete_blobs() just returned True. Filtering them out empties the
+                # set, releases the latch on the next iteration, and hands the next child a sparse
+                # partial to resume. The cost of not scoping is that a live sibling's partial can
+                # hold the latch and make retries re-download; that is bandwidth, and the guard is
+                # here to protect the blob.
+                unsafe_partials = _incomplete_blob_identities(repo_type, repo_id, cache_dir)
         elif disable_xet and forced_clean_redownload:
             # Release the latch only once every partial that was unsafe at the transition is gone.
             # "One HTTP child has run" is NOT proof it did: huggingface_hub unlinks the .incomplete
@@ -2604,7 +2627,7 @@ def _download_with_xet_fallback(
             present = _incomplete_blob_identities(repo_type, repo_id, cache_dir)
             still_unsafe = (
                 None if (unsafe_partials is None or present is None)
-                else (unsafe_partials & present)
+                else _surviving_unsafe_partials(unsafe_partials, present)
             )
             if still_unsafe is not None and not still_unsafe:
                 forced_clean_redownload = False

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -14,12 +14,21 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Xet-primary HF downloads with a Xet retry, then an automatic HTTP fallback, on a no-progress stall.
+"""Xet-primary HF downloads with a Xet retry, then an automatic HTTP fallback, on a stall or a fault.
 
 Xet (``hf_xet``) is fast but can hang with no progress, no exception, and an un-killable native thread.
 ``HF_HUB_DISABLE_XET`` is read at import time, so the fallback runs in a fresh ``spawn`` child (not a
 thread) that sets the env before importing ``huggingface_hub``. Cached files short-circuit with no
 child; deterministic errors (401/403/404/disk-full) and cancellation propagate without a fallback.
+
+The transport also changes on a transient fault, a crash and an incomplete snapshot, not only on a
+stall, and on Xet an UNRECOGNIZED error counts as transient: hf_xet reports a CAS fault as a bare
+``RuntimeError`` whose Rust error chain this package does not own, and treating that as deterministic
+skipped the HTTP rung entirely. HTTP is the last rung and gets ``UNSLOTH_HTTP_ATTEMPTS`` children
+(default 2) of its own, because the Xet bridge CDN serves Xet-backed blobs over plain HTTP too and one
+degraded CDN therefore fails both rungs. Exhausting them raises ``DownloadTransportError``, a
+``DownloadStallError``, so a caller's guard around the supervised download cannot be bypassed by a
+retryable CDN error and fall through to the unguarded in-process load.
 
 A DATA-phase stall spends one more Xet child (``UNSLOTH_XET_ATTEMPTS``, default 2) before the
 transport changes, since that hang is usually a wedged CAS stream that clears on a fresh process.
@@ -85,6 +94,7 @@ logger = logging.getLogger(__name__)
 # Explicit list keeps stdlib imports out of Unsloth's `import *` re-export shim.
 __all__ = [
     "DownloadStallError",
+    "DownloadTransportError",
     "hf_hub_download_with_xet_fallback",
     "snapshot_download_with_xet_fallback",
     "start_watchdog",
@@ -94,10 +104,12 @@ __all__ = [
     "child_should_disable_xet",
     "is_data_phase_stall",
     "xet_attempts",
+    "http_attempts",
     "DEFAULT_STALL_TIMEOUT",
     "DEFAULT_CONNECT_TIMEOUT",
     "DEFAULT_HTTP_STALL_TIMEOUT",
     "DEFAULT_XET_ATTEMPTS",
+    "DEFAULT_HTTP_ATTEMPTS",
 ]
 
 _CTX = mp.get_context("spawn")
@@ -119,6 +131,15 @@ DEFAULT_POLL_INTERVAL = 5.0
 DEFAULT_XET_ATTEMPTS = 2
 # Past this the ladder just burns time before the transport that would have worked.
 _MAX_XET_ATTEMPTS = 8
+
+# HTTP attempts before the ladder gives up. The last rung has nowhere to fall back to, and the fault
+# it most often meets is a 5xx from the Xet bridge CDN, which serves Xet-backed blobs over plain HTTP
+# too -- so a degraded CDN fails BOTH rungs and a single HTTP child turns a retryable blip into a hard
+# failure. 1 restores the single-attempt HTTP rung.
+DEFAULT_HTTP_ATTEMPTS = 2
+_MAX_HTTP_ATTEMPTS = 8
+# Wait between HTTP children so a CDN shedding load is not hit again in the same instant.
+DEFAULT_HTTP_RETRY_BACKOFF = 5.0
 
 # A child buffering from the network grows RSS at roughly the wire rate. Well above allocator noise
 # but far below one poll's worth of even a thin link (20 Mbit/s is ~12 MB per 5s tick), so a
@@ -180,6 +201,27 @@ def xet_attempts() -> int:
         logger.warning("Ignoring non-positive UNSLOTH_XET_ATTEMPTS=%r", raw)
         return DEFAULT_XET_ATTEMPTS
     return min(value, _MAX_XET_ATTEMPTS)
+
+
+def http_attempts() -> int:
+    """HTTP attempts to spend before failing, from ``UNSLOTH_HTTP_ATTEMPTS``.
+
+    Same junk / non-positive handling and clamp as ``xet_attempts``. Spent only on a transient
+    transport failure or a crash: an HTTP STALL still raises on the first verdict, since the patient
+    HTTP threshold has already waited out everything a retry would wait for again.
+    """
+    raw = os.environ.get("UNSLOTH_HTTP_ATTEMPTS")
+    if not raw:
+        return DEFAULT_HTTP_ATTEMPTS
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning("Ignoring non-integer UNSLOTH_HTTP_ATTEMPTS=%r", raw)
+        return DEFAULT_HTTP_ATTEMPTS
+    if value <= 0:
+        logger.warning("Ignoring non-positive UNSLOTH_HTTP_ATTEMPTS=%r", raw)
+        return DEFAULT_HTTP_ATTEMPTS
+    return min(value, _MAX_HTTP_ATTEMPTS)
 
 
 def is_data_phase_stall(message: str) -> bool:
@@ -282,6 +324,19 @@ def _record_xet_outcome(ok: bool, reason: str = "") -> None:
 
 class DownloadStallError(RuntimeError):
     """Raised when no download progress is observed for too long. Unsloth re-imports this canonical type."""
+
+
+class DownloadTransportError(DownloadStallError):
+    """Raised when every transport failed with a transient transport error (CDN 5xx, CAS fault, child
+    crash) rather than a hang.
+
+    A SUBCLASS of DownloadStallError deliberately: the guard a caller puts around the supervised
+    download is ``except DownloadStallError``, and the whole point of the supervised child is that
+    control must not reach the in-process load, which still has Xet enabled and no watchdog. Raising a
+    bare RuntimeError here let a retryable CDN blip be swallowed as "could not pre-download, continuing
+    with the normal load" and become the unbounded silent hang this module exists to prevent. Still a
+    RuntimeError, so an existing ``except RuntimeError`` keeps matching.
+    """
 
 
 def is_hf_xet_available() -> bool:
@@ -1000,7 +1055,8 @@ _TYPE_PRESERVE_ONLY_NAMES = frozenset({
 # Substrings marking a transient transport failure (hf_xet / CAS error, timeout, reset, 5xx / 429)
 # that an HTTP retry may recover.
 _TRANSIENT_ERROR_HINTS = (
-    "xet", "casclient", "cas_", "timeout", "timed out", "connection", "reset by peer",
+    "xet", "casclient", "cas_", "cas client", "file reconstruction",
+    "timeout", "timed out", "connection", "reset by peer",
     "temporarily", "try again", "incompleteread", "protocolerror", "remotedisconnected",
     "broken pipe", "ssl", "eof occurred", "502", "503", "504", "500 server", "429",
     "too many requests", "service unavailable", "bad gateway", "gateway time",
@@ -1103,11 +1159,19 @@ def _raise_child_error(message: str) -> None:
     raise exc
 
 
-def _is_retryable_download_error(exc: BaseException) -> bool:
+def _is_retryable_download_error(exc: BaseException, *, on_xet: bool) -> bool:
     """True when a captured exception looks like a transient transport failure (``hf_xet`` / CAS error,
     reset, timeout, 5xx / 429) the OTHER transport may recover, vs a deterministic Hub error (auth,
-    not-found, gated, disk-full). Unknown errors count as deterministic, so a real repeatable failure is
-    surfaced rather than looped between transports."""
+    not-found, gated, disk-full).
+
+    An UNRECOGNIZED error is decided by the rung it happened on. hf_xet reports a CAS fault as a bare
+    ``RuntimeError`` carrying a Rust error chain whose wording this package does not own and cannot
+    keep an allow-list complete for -- "Task error: File reconstruction error: CAS Client Error: Format
+    error: I/O error: error decoding response body" matches none of the hints below -- so on Xet an
+    unknown error is treated as transport-attributable. That costs one HTTP attempt to disprove, against
+    surrendering the supervised path to an unguarded in-process load, which is the worse trade by far.
+    HTTP is the last rung, where an unknown error is surfaced rather than looped.
+    """
     name = type(exc).__name__
     # LocalEntryNotFoundError wraps BOTH a genuine offline / uncached miss (deterministic) AND a
     # TRANSIENT HEAD connection error / timeout for an uncached file. Retry the transient sub-case; a
@@ -1129,7 +1193,14 @@ def _is_retryable_download_error(exc: BaseException) -> bool:
     if isinstance(status, int):
         return status >= 500 or status in (408, 429)
     text = f"{name}: {exc}".lower()
-    return any(hint in text for hint in _TRANSIENT_ERROR_HINTS)
+    if any(hint in text for hint in _TRANSIENT_ERROR_HINTS):
+        return True
+    # A builtin OSError reaching this far is a LOCAL filesystem failure (permission, missing dir,
+    # read-only cache): the network subclasses (TimeoutError, ConnectionResetError, ...) all match a
+    # hint above. The other transport writes to the same path, so the rung default must not apply.
+    if _is_builtin_oserror(exc):
+        return False
+    return on_xet
 
 
 def _child_download(*, kind: str, params: dict, token: Optional[str], repo_type: str) -> str:
@@ -1235,11 +1306,12 @@ def _download_child_entry(
         result_queue.put({"ok": True, "path": path})
     except BaseException as e:  # noqa: BLE001 - report every failure to the parent
         # Classify here where the exception (status, errno, type) is intact, so the parent retries a
-        # transient failure over HTTP yet surfaces a deterministic one without a second attempt.
+        # transient failure over HTTP yet surfaces a deterministic one without a second attempt. The
+        # rung decides an unrecognized error, and only this child knows which one it ran on.
         result_queue.put({
             "ok": False,
             "error": _scrub_in_child(f"{type(e).__name__}: {e}", token),
-            "retryable": _is_retryable_download_error(e),
+            "retryable": _is_retryable_download_error(e, on_xet = not disable_xet),
         })
 
 
@@ -2250,6 +2322,20 @@ def _snapshot_payload_incomplete(
     )
 
 
+def _wait_before_http_retry(cancel_event: Optional[threading.Event]) -> None:
+    """Back off between HTTP children so a CDN shedding load is not hit again in the same instant.
+
+    Interruptible: a cancel arriving during the wait raises immediately rather than spending another
+    child on a download the caller has already abandoned.
+    """
+    delay = _env_seconds("UNSLOTH_HTTP_RETRY_BACKOFF", DEFAULT_HTTP_RETRY_BACKOFF)
+    if cancel_event is None:
+        time.sleep(delay)
+        return
+    if cancel_event.wait(delay):
+        raise RuntimeError("Cancelled")
+
+
 def _download_with_xet_fallback(
     *,
     repo_id: str,
@@ -2269,9 +2355,12 @@ def _download_with_xet_fallback(
     """Shared transport ladder: Xet primary, HTTP last. Returns the local path.
 
     Xet gets ``xet_attempts()`` children (2 by default) before the transport changes, spent only on
-    a DATA-phase stall; every other failure keeps the single-attempt ladder. HTTP is the last rung
-    and is never retried back to Xet. Bounded: each iteration returns, raises, spends one Xet
-    attempt, or flips to HTTP, and a stall on HTTP raises.
+    a DATA-phase stall; every other Xet failure flips straight to HTTP. HTTP is the last rung and is
+    never retried back to Xet, but it gets ``http_attempts()`` children of its own (2 by default) on a
+    transient failure or a crash, because the Xet bridge CDN serves Xet-backed blobs over plain HTTP
+    too and a degraded CDN therefore fails BOTH rungs. A stall on HTTP still raises on the first
+    verdict. Bounded: each iteration returns, raises, spends one Xet attempt, spends one HTTP attempt,
+    or flips to HTTP.
     """
     if cancel_event is not None and cancel_event.is_set():
         raise RuntimeError("Cancelled")
@@ -2296,13 +2385,21 @@ def _download_with_xet_fallback(
     # Xet children this download may spend before HTTP, and how many it has spent.
     xet_budget = xet_attempts() if started_on_xet else 0
     xet_used = 0
+    # HTTP children this download may spend, and how many it has spent.
+    http_budget = http_attempts()
+    http_used = 0
+    # The Xet -> HTTP purge runs at the TRANSITION only. Repeating it per HTTP child would spare the
+    # partial the failed HTTP child just wrote (it is younger than active_grace), leaving
+    # has_active_incomplete_blobs true and forcing force_download, so every HTTP retry would restart
+    # the download from zero instead of resuming it.
+    http_prepared = False
     # Health is reported ONCE per logical download, not once per child: the tracker demotes a machine
     # for 24h after two CONSECUTIVE failures, so charging both attempts would let one bad download
     # pin it, against the "one is noise, two is a pattern" rule the tracker is built on.
     pending_xet_failure: Optional[str] = None
 
     def _flush_pending_failure() -> None:
-        """Report a deferred stall on the way out of the Xet phase (exactly once)."""
+        """Report a deferred Xet failure on the way out of the ladder (exactly once)."""
         nonlocal pending_xet_failure
         if pending_xet_failure is not None:
             _record_xet_outcome(False, pending_xet_failure)
@@ -2310,6 +2407,12 @@ def _download_with_xet_fallback(
 
     while True:
         if disable_xet:
+            http_used += 1
+        else:
+            xet_used += 1
+
+        if disable_xet and not http_prepared:
+            http_prepared = True
             # Purge a non-HTTP partial first (an HTTP resume over a sparse Xet/hf_transfer partial
             # silently corrupts the blob), scoped to the stalled child's own partials so a same-repo
             # sibling is spared. An injected (Unsloth) hook keeps the plain (repo_type, repo_id) signature.
@@ -2336,8 +2439,6 @@ def _download_with_xet_fallback(
                     "HTTP re-download instead of an unsafe resume.", label
                 )
                 params = {**params, "force_download": True}
-        else:
-            xet_used += 1
 
         kind_result, payload = _run_download_attempt(
             repo_id,
@@ -2385,6 +2486,10 @@ def _download_with_xet_fallback(
                 # earlier attempt recovered from is dropped rather than reported.
                 pending_xet_failure = None
                 _record_xet_outcome(True)
+            elif started_on_xet:
+                # HTTP finished what Xet could not, which is what turns a held Xet failure into
+                # evidence: the network was fine and only the Xet path was not. Charge it now.
+                _flush_pending_failure()
             return payload  # type: ignore[return-value]
         if kind_result == "cancelled":
             # The user's decision says nothing about this machine's Xet health.
@@ -2397,18 +2502,40 @@ def _download_with_xet_fallback(
             _flush_pending_failure()
             _raise_child_error(payload)
         if kind_result == "retryable_error":
-            # Transient transport failure (hf_xet CAS timeout, 5xx, reset): retry HTTP once, else raise.
+            # Transient transport failure (hf_xet CAS fault, 5xx, reset): change transport, then spend
+            # the HTTP budget, then surface it as a stall-class error rather than a bare RuntimeError.
             if not disable_xet:
                 logger.warning(
                     "Download for '%s' hit a transient Xet transport error -- retrying "
                     "with HF_HUB_DISABLE_XET=1: %s", label, payload
                 )
                 _safe_status(on_status, f"{label}: transient Xet error, retrying over HTTP")
-                pending_xet_failure = None
-                _record_xet_outcome(False, _xet_failure_reason("transient Xet transport error"))
+                # HELD, not recorded: a transient fault is only evidence against THIS MACHINE's Xet if
+                # HTTP then succeeds. A degraded CDN fails both rungs, and charging it here demoted a
+                # perfectly good machine to HTTP for 24h after two such downloads.
+                pending_xet_failure = _xet_failure_reason("transient Xet transport error")
                 disable_xet = True
                 continue
-            raise RuntimeError(payload)
+            # A cancel landing in the failure window ends the ladder as a cancel, not as a transport
+            # error: the caller has stopped caring about the result either way.
+            if cancel_event is not None and cancel_event.is_set():
+                pending_xet_failure = None
+                raise RuntimeError("Cancelled")
+            if http_used < http_budget:
+                logger.warning(
+                    "Download for '%s' hit a transient error on HTTP -- retrying "
+                    "(attempt %d of %d): %s", label, http_used + 1, http_budget, payload
+                )
+                _safe_status(
+                    on_status,
+                    f"{label}: transient HTTP error, retrying "
+                    f"(attempt {http_used + 1} of {http_budget})",
+                )
+                _wait_before_http_retry(cancel_event)
+                continue
+            # Both rungs met the same transport fault: not this machine's Xet.
+            pending_xet_failure = None
+            raise DownloadTransportError(payload)
         if kind_result == "crashed":
             # Process-level crash with no captured exception: HTTP may still succeed, so retry once.
             if not disable_xet:
@@ -2417,11 +2544,27 @@ def _download_with_xet_fallback(
                     "retrying with HF_HUB_DISABLE_XET=1", label
                 )
                 _safe_status(on_status, f"{label}: download crashed, retrying over HTTP")
-                pending_xet_failure = None
-                _record_xet_outcome(False, _xet_failure_reason("Xet download process crashed"))
+                # Held for the same reason as a transient error: only an HTTP rescue proves it was Xet.
+                pending_xet_failure = _xet_failure_reason("Xet download process crashed")
                 disable_xet = True
                 continue
-            raise RuntimeError(payload)
+            if cancel_event is not None and cancel_event.is_set():
+                pending_xet_failure = None
+                raise RuntimeError("Cancelled")
+            if http_used < http_budget:
+                logger.warning(
+                    "Download process for '%s' crashed on HTTP -- retrying (attempt %d of %d)",
+                    label, http_used + 1, http_budget,
+                )
+                _safe_status(
+                    on_status,
+                    f"{label}: download crashed, retrying "
+                    f"(attempt {http_used + 1} of {http_budget})",
+                )
+                _wait_before_http_retry(cancel_event)
+                continue
+            pending_xet_failure = None
+            raise DownloadTransportError(payload)
         # kind_result == "stall"
         if not disable_xet:
             # Another Xet child first, while the budget lasts and the hang looks recoverable. Only a
@@ -2483,11 +2626,13 @@ def hf_hub_download_with_xet_fallback(
     on_status: Optional[Callable[[str], None]] = None,
     prepare_for_http_fn: Optional[Callable[[str, str], None]] = None,
 ) -> str:
-    """Download a single file with Xet primary and HTTP as a stall-only fallback; return the local path.
+    """Download a single file with Xet primary and HTTP as the fallback; return the local path.
 
     Raises ``RuntimeError("Cancelled")`` if *cancel_event* is set, re-raises a deterministic child error
-    unchanged, and raises ``DownloadStallError`` only if BOTH transports stall. ``local_files_only=True``
-    resolves from cache in-process with no child (HF offline semantics).
+    unchanged, raises ``DownloadStallError`` if BOTH transports stall, and ``DownloadTransportError``
+    (a ``DownloadStallError``) once a transient transport fault has exhausted both. Neither is ever
+    raised while an untried rung remains. ``local_files_only=True`` resolves from cache in-process with
+    no child (HF offline semantics).
     """
     repo_type = repo_type or "model"  # HF treats None as the default model repo.
     # Expand ~ as huggingface_hub does, so the probe and the child resolve to the same location.
@@ -2567,8 +2712,13 @@ def snapshot_download_with_xet_fallback(
     on_status: Optional[Callable[[str], None]] = None,
     prepare_for_http_fn: Optional[Callable[[str, str], None]] = None,
 ) -> str:
-    """Download a whole repo snapshot with Xet primary and HTTP as a stall-only fallback; return the
-    local snapshot dir.
+    """Download a whole repo snapshot with Xet primary and HTTP as the fallback; return the local
+    snapshot dir.
+
+    Raises as ``hf_hub_download_with_xet_fallback`` does; in particular a transient transport fault
+    that exhausts both rungs raises ``DownloadTransportError`` rather than a bare ``RuntimeError``, so
+    the caller cannot mistake it for "could not pre-download, carry on" and hand a degraded transport
+    to the unguarded in-process load this function exists to protect.
 
     Used by Unsloth's ``from_pretrained`` to warm the cache in a killable child BEFORE the in-process
     load (which then hits a warm cache and cannot hang on a native Xet thread). A fully cached repo

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -604,6 +604,31 @@ def _active_incomplete_blob_sizes(
     return sizes
 
 
+def _incomplete_blob_names_strict(
+    repo_type: Optional[str], repo_id: str, cache_dir: Optional[str] = None
+) -> Optional[set]:
+    """``*.incomplete`` names for the repo, or ``None`` if the cache could not be inspected.
+
+    ``_active_incomplete_blob_sizes`` is deliberately fail-OPEN: it swallows per-file and outer
+    errors and returns whatever it managed to read, which is right for a progress sensor, where an
+    unreadable blob should not abort a download. It is wrong for a safety check, where an empty
+    result would then mean "gone" and "could not look" alike -- and the caller below releases a
+    guard on that answer. Same walk, fail-CLOSED: any error is reported as ``None``.
+    """
+    names: set = set()
+    try:
+        for entry in iter_active_repo_cache_dirs(repo_type, repo_id, cache_dir = cache_dir):
+            blobs_dir = entry / "blobs"
+            if not blobs_dir.is_dir():
+                continue
+            for blob in blobs_dir.iterdir():
+                if blob.name.endswith(INCOMPLETE_SUFFIX):
+                    names.add(blob.name)
+    except Exception:
+        return None
+    return names
+
+
 def _child_rss(pid: int) -> Optional[int]:
     """Resident bytes of child *pid*, or ``None`` when undeterminable.
 
@@ -2458,9 +2483,10 @@ def _download_with_xet_fallback(
     # can be handed back once that partial is provably gone.
     caller_force_download = params.get("force_download", False)
     forced_clean_redownload = False
-    # The exact unsafe partials seen at the transition. The latch is released only when NONE of them
-    # is still on disk -- see the un-latch branch below for why "a child ran" is not enough.
-    unsafe_partials: set = set()
+    # The exact unsafe partials seen at the transition, or None if the cache could not be read.
+    # The latch is released only when NONE of them is still on disk -- see the un-latch branch below
+    # for why "a child ran" is not enough, and why None must not count as "gone".
+    unsafe_partials: Optional[set] = set()
     # The Xet -> HTTP purge runs at the TRANSITION only. Repeating it per HTTP child would spare the
     # partial the failed HTTP child just wrote (it is younger than active_grace), leaving
     # has_active_incomplete_blobs true and forcing force_download, so every HTTP retry would restart
@@ -2534,9 +2560,10 @@ def _download_with_xet_fallback(
                 params = {**params, "force_download": True}
                 forced_clean_redownload = True
                 # Remember WHICH partials are unsafe, so the latch can be released on evidence.
-                unsafe_partials = set(
-                    _active_incomplete_blob_sizes(repo_type, repo_id, cache_dir)
-                )
+                # An uninspectable cache yields None, which keeps the latch on forever below --
+                # a clean re-download costs bandwidth, resuming over a sparse partial costs the blob.
+                seen = _incomplete_blob_names_strict(repo_type, repo_id, cache_dir)
+                unsafe_partials = seen if seen is not None else None
         elif disable_xet and forced_clean_redownload:
             # Release the latch only once every partial that was unsafe at the transition is gone.
             # "One HTTP child has run" is NOT proof it did: huggingface_hub unlinks the .incomplete
@@ -2544,17 +2571,23 @@ def _download_with_xet_fallback(
             # CDN this ladder exists for -- leaves the sparse Xet partial untouched. Handing the next
             # child force_download=False would then resume it, and an HTTP resume over a sparse Xet
             # partial finalizes a silently corrupt blob, which is what the purge above prevents.
-            still_unsafe = unsafe_partials & set(
-                _active_incomplete_blob_sizes(repo_type, repo_id, cache_dir)
+            # Fail closed on both halves: a scan that could not run (None, either now or at the
+            # transition) is not evidence of disappearance, so the latch stays on.
+            present = _incomplete_blob_names_strict(repo_type, repo_id, cache_dir)
+            still_unsafe = (
+                None if (unsafe_partials is None or present is None)
+                else (unsafe_partials & present)
             )
-            if not still_unsafe:
+            if still_unsafe is not None and not still_unsafe:
                 forced_clean_redownload = False
                 unsafe_partials = set()
                 params = {**params, "force_download": caller_force_download}
             else:
                 logger.debug(
-                    "Keeping force_download for '%s': %d unsafe partial(s) still present",
-                    label, len(still_unsafe),
+                    "Keeping force_download for '%s': %s",
+                    label,
+                    "cache not inspectable" if still_unsafe is None
+                    else f"{len(still_unsafe)} unsafe partial(s) still present",
                 )
 
         kind_result, payload = _run_download_attempt(
@@ -2655,8 +2688,10 @@ def _download_with_xet_fallback(
             # which is not a DownloadStallError -- so the caller logs "continuing with the normal
             # load" and hands a transport that just failed twice to the unguarded in-process path.
             # That is issue #1122's shape, one rung further along. Keep it inside the guard.
-            # Deliberately narrow: only when a transport fault is already established, so an ordinary
-            # unknown error on a healthy ladder still falls through as it does today.
+            # Scoped, not universal: only once Xet has ALREADY failed in a way that was held pending
+            # an HTTP rescue (a transport fault, a child crash, or an incomplete snapshot -- whatever
+            # set pending_needs_http_success). A ladder that started on HTTP, or one whose Xet rung
+            # was fine, still surfaces an unknown error exactly as it does today.
             if pending_needs_http_success and disable_xet:
                 type_name = payload.split(":", 1)[0].strip() if ":" in (payload or "") else ""
                 if _resolve_exception_class(type_name) is None:

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -2682,7 +2682,12 @@ def _download_with_xet_fallback(
                     _hold_unproven_xet_failure("Xet returned an incomplete snapshot")
                     disable_xet = True
                     continue
-                pending_xet_failure = None
+                # Both rungs came back short: as with the fault branch, an UNPROVEN reason is not
+                # evidence against this machine's Xet, but a stall the watchdog proved on this machine
+                # survives and must still be charged on the way out.
+                if pending_needs_http_success:
+                    pending_xet_failure = None
+                _flush_pending_failure()
                 raise DownloadStallError(
                     f"Download for '{label}' returned an incomplete snapshot even with "
                     f"HF_HUB_DISABLE_XET=1 -- missing files, check your network connection"
@@ -2824,6 +2829,11 @@ def _download_with_xet_fallback(
             _flush_pending_failure()
             disable_xet = True
             continue
+        # An HTTP stall is not evidence against Xet on its own, but a Xet stall held from an earlier
+        # attempt already was, and this exit is the last door out of the ladder.
+        if pending_needs_http_success:
+            pending_xet_failure = None
+        _flush_pending_failure()
         raise DownloadStallError(
             f"Download stalled for '{label}' even with HF_HUB_DISABLE_XET=1 "
             f"-- check your network connection"

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -25,10 +25,11 @@ The transport also changes on a transient fault, a crash and an incomplete snaps
 stall, and on Xet an UNRECOGNIZED error counts as transient: hf_xet reports a CAS fault as a bare
 ``RuntimeError`` whose Rust error chain this package does not own, and treating that as deterministic
 skipped the HTTP rung entirely. HTTP is the last rung and gets ``UNSLOTH_HTTP_ATTEMPTS`` children
-(default 2) of its own, because the Xet bridge CDN serves Xet-backed blobs over plain HTTP too and one
-degraded CDN therefore fails both rungs. Exhausting them raises ``DownloadTransportError``, a
-``DownloadStallError``, so a caller's guard around the supervised download cannot be bypassed by a
-retryable CDN error and fall through to the unguarded in-process load.
+(default 2, ``UNSLOTH_HTTP_RETRY_BACKOFF`` seconds apart) of its own, because the Xet bridge CDN serves
+Xet-backed blobs over plain HTTP too and one degraded CDN therefore fails both rungs. Exhausting them
+raises ``DownloadTransportError``, a ``DownloadStallError``, so a caller's guard around the
+supervised download cannot be bypassed by a retryable CDN error and fall through to the unguarded
+in-process load.
 
 A DATA-phase stall spends one more Xet child (``UNSLOTH_XET_ATTEMPTS``, default 2) before the
 transport changes, since that hang is usually a wedged CAS stream that clears on a fresh process.
@@ -110,6 +111,7 @@ __all__ = [
     "DEFAULT_HTTP_STALL_TIMEOUT",
     "DEFAULT_XET_ATTEMPTS",
     "DEFAULT_HTTP_ATTEMPTS",
+    "DEFAULT_HTTP_RETRY_BACKOFF",
 ]
 
 _CTX = mp.get_context("spawn")
@@ -139,6 +141,7 @@ _MAX_XET_ATTEMPTS = 8
 DEFAULT_HTTP_ATTEMPTS = 2
 _MAX_HTTP_ATTEMPTS = 8
 # Wait between HTTP children so a CDN shedding load is not hit again in the same instant.
+# ``UNSLOTH_HTTP_RETRY_BACKOFF`` overrides it, and 0 means "retry at once" rather than "junk".
 DEFAULT_HTTP_RETRY_BACKOFF = 5.0
 
 # A child buffering from the network grows RSS at roughly the wire rate. Well above allocator noise
@@ -222,6 +225,28 @@ def http_attempts() -> int:
         logger.warning("Ignoring non-positive UNSLOTH_HTTP_ATTEMPTS=%r", raw)
         return DEFAULT_HTTP_ATTEMPTS
     return min(value, _MAX_HTTP_ATTEMPTS)
+
+
+def _http_retry_backoff() -> float:
+    """Seconds to wait between HTTP children, from ``UNSLOTH_HTTP_RETRY_BACKOFF``.
+
+    Not ``_env_seconds``: that treats non-positive as junk, which is right for a timeout but wrong
+    here, where 0 is the meaningful "retry at once" a test harness or a CI run actually reaches for
+    and silently restoring the full default would be a surprise. Only negative / unparseable falls
+    back.
+    """
+    raw = os.environ.get("UNSLOTH_HTTP_RETRY_BACKOFF")
+    if not raw:
+        return DEFAULT_HTTP_RETRY_BACKOFF
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning("Ignoring non-numeric UNSLOTH_HTTP_RETRY_BACKOFF=%r", raw)
+        return DEFAULT_HTTP_RETRY_BACKOFF
+    if value < 0:
+        logger.warning("Ignoring negative UNSLOTH_HTTP_RETRY_BACKOFF=%r", raw)
+        return DEFAULT_HTTP_RETRY_BACKOFF
+    return value
 
 
 def is_data_phase_stall(message: str) -> bool:
@@ -1045,6 +1070,10 @@ _DETERMINISTIC_ERROR_NAMES = frozenset({
     "LocalTokenNotFoundError",  # a missing required token fails identically either way
     "BadRequestError",
     "HFValidationError",        # a malformed repo id / revision never reaches the network
+    # Subclasses builtin ConnectionError, so it is an OSError with no errno and no builtin of its own
+    # name: nothing below catches it, and the rung default would spend an HTTP child AND the
+    # destructive pre-HTTP purge on a repo the user has switched offline.
+    "OfflineModeIsEnabled",
 })
 # TYPE reconstructed across the spawn but NOT retry-deterministic: ``HfHubHTTPError`` bases both
 # deterministic 4xx and transient 5xx / 429, so its retry stays status-code driven while the parent
@@ -1055,8 +1084,7 @@ _TYPE_PRESERVE_ONLY_NAMES = frozenset({
 # Substrings marking a transient transport failure (hf_xet / CAS error, timeout, reset, 5xx / 429)
 # that an HTTP retry may recover.
 _TRANSIENT_ERROR_HINTS = (
-    "xet", "casclient", "cas_", "cas client", "file reconstruction",
-    "timeout", "timed out", "connection", "reset by peer",
+    "xet", "casclient", "cas_", "timeout", "timed out", "connection", "reset by peer",
     "temporarily", "try again", "incompleteread", "protocolerror", "remotedisconnected",
     "broken pipe", "ssl", "eof occurred", "502", "503", "504", "500 server", "429",
     "too many requests", "service unavailable", "bad gateway", "gateway time",
@@ -1165,12 +1193,13 @@ def _is_retryable_download_error(exc: BaseException, *, on_xet: bool) -> bool:
     not-found, gated, disk-full).
 
     An UNRECOGNIZED error is decided by the rung it happened on. hf_xet reports a CAS fault as a bare
-    ``RuntimeError`` carrying a Rust error chain whose wording this package does not own and cannot
-    keep an allow-list complete for -- "Task error: File reconstruction error: CAS Client Error: Format
-    error: I/O error: error decoding response body" matches none of the hints below -- so on Xet an
-    unknown error is treated as transport-attributable. That costs one HTTP attempt to disprove, against
-    surrendering the supervised path to an unguarded in-process load, which is the worse trade by far.
-    HTTP is the last rung, where an unknown error is surfaced rather than looped.
+    ``RuntimeError`` carrying a Rust error chain -- "Task error: File reconstruction error: CAS Client
+    Error: Format error: I/O error: error decoding response body" -- which matches none of the hints
+    below and is worded by xet-core rather than by this package, so the list cannot be kept complete
+    from here. On Xet an unknown error is therefore treated as transport-attributable: that costs one
+    HTTP attempt to disprove, against surrendering the supervised path to an unguarded in-process
+    load, which is the worse trade by far. HTTP is the last rung, where an unknown error is surfaced
+    rather than looped.
     """
     name = type(exc).__name__
     # LocalEntryNotFoundError wraps BOTH a genuine offline / uncached miss (deterministic) AND a
@@ -2328,7 +2357,7 @@ def _wait_before_http_retry(cancel_event: Optional[threading.Event]) -> None:
     Interruptible: a cancel arriving during the wait raises immediately rather than spending another
     child on a download the caller has already abandoned.
     """
-    delay = _env_seconds("UNSLOTH_HTTP_RETRY_BACKOFF", DEFAULT_HTTP_RETRY_BACKOFF)
+    delay = _http_retry_backoff()
     if cancel_event is None:
         time.sleep(delay)
         return
@@ -2388,6 +2417,10 @@ def _download_with_xet_fallback(
     # HTTP children this download may spend, and how many it has spent.
     http_budget = http_attempts()
     http_used = 0
+    # force_download as the CALLER asked for it, so a clean re-download forced by an uncleared partial
+    # can be handed back after the first HTTP child has done it.
+    caller_force_download = params.get("force_download", False)
+    forced_clean_redownload = False
     # The Xet -> HTTP purge runs at the TRANSITION only. Repeating it per HTTP child would spare the
     # partial the failed HTTP child just wrote (it is younger than active_grace), leaving
     # has_active_incomplete_blobs true and forcing force_download, so every HTTP retry would restart
@@ -2397,6 +2430,11 @@ def _download_with_xet_fallback(
     # for 24h after two CONSECUTIVE failures, so charging both attempts would let one bad download
     # pin it, against the "one is noise, two is a pattern" rule the tracker is built on.
     pending_xet_failure: Optional[str] = None
+    # Whether that held reason still needs proof. A STALL stands on its own, so it is charged even if
+    # the ladder later leaves by another door. A transport fault or a crash does not: a degraded CDN
+    # fails both rungs identically, so only HTTP finishing what Xet could not shows the Xet path alone
+    # was the broken one.
+    pending_needs_http_success = False
 
     def _flush_pending_failure() -> None:
         """Report a deferred Xet failure on the way out of the ladder (exactly once)."""
@@ -2439,6 +2477,13 @@ def _download_with_xet_fallback(
                     "HTTP re-download instead of an unsafe resume.", label
                 )
                 params = {**params, "force_download": True}
+                forced_clean_redownload = True
+        elif disable_xet and forced_clean_redownload:
+            # The clean re-download has already happened, so the partial on disk is now HTTP-written
+            # and resumable. Leaving force_download latched would make every retry in the new budget
+            # discard it and start again from zero -- on a large repo, the whole file per attempt.
+            forced_clean_redownload = False
+            params = {**params, "force_download": caller_force_download}
 
         kind_result, payload = _run_download_attempt(
             repo_id,
@@ -2497,8 +2542,13 @@ def _download_with_xet_fallback(
             raise RuntimeError("Cancelled")
         if kind_result == "error":
             # Deterministic failure (auth / not-found / gated / disk-full): the other transport fails
-            # identically. _raise_child_error preserves the original type across the spawn. An
-            # earlier stall was still evidence, so report it before the raise leaves the ladder.
+            # identically. _raise_child_error preserves the original type across the spawn. An earlier
+            # STALL was still evidence, so report it before the raise leaves the ladder -- but a held
+            # transport fault is not, and this is easy to reach now that every unrecognized Xet error
+            # holds one: a Xet CAS fault followed by an HTTP child that fills the disk would otherwise
+            # charge the machine for a download that never succeeded on either rung.
+            if pending_needs_http_success:
+                pending_xet_failure = None
             _flush_pending_failure()
             _raise_child_error(payload)
         if kind_result == "retryable_error":
@@ -2514,6 +2564,7 @@ def _download_with_xet_fallback(
                 # HTTP then succeeds. A degraded CDN fails both rungs, and charging it here demoted a
                 # perfectly good machine to HTTP for 24h after two such downloads.
                 pending_xet_failure = _xet_failure_reason("transient Xet transport error")
+                pending_needs_http_success = True
                 disable_xet = True
                 continue
             # A cancel landing in the failure window ends the ladder as a cancel, not as a transport
@@ -2546,6 +2597,7 @@ def _download_with_xet_fallback(
                 _safe_status(on_status, f"{label}: download crashed, retrying over HTTP")
                 # Held for the same reason as a transient error: only an HTTP rescue proves it was Xet.
                 pending_xet_failure = _xet_failure_reason("Xet download process crashed")
+                pending_needs_http_success = True
                 disable_xet = True
                 continue
             if cancel_event is not None and cancel_event.is_set():
@@ -2587,6 +2639,7 @@ def _download_with_xet_fallback(
                 )
                 # Held, not recorded: if the next attempt succeeds this stall was noise.
                 pending_xet_failure = _xet_failure_reason("Xet download stalled")
+                pending_needs_http_success = False
                 _purge_owned_partials_for_xet_retry(
                     repo_type, repo_id, cache_dir = cache_dir,
                     owned_incomplete_blobs = params.pop("_owned_incomplete_blobs", None),

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -604,29 +604,49 @@ def _active_incomplete_blob_sizes(
     return sizes
 
 
-def _incomplete_blob_names_strict(
+def _incomplete_blob_identities(
     repo_type: Optional[str], repo_id: str, cache_dir: Optional[str] = None
 ) -> Optional[set]:
-    """``*.incomplete`` names for the repo, or ``None`` if the cache could not be inspected.
+    """``{(name, st_dev, st_ino)}`` for the repo's ``*.incomplete`` partials, ``None`` if unreadable.
 
-    ``_active_incomplete_blob_sizes`` is deliberately fail-OPEN: it swallows per-file and outer
-    errors and returns whatever it managed to read, which is right for a progress sensor, where an
-    unreadable blob should not abort a download. It is wrong for a safety check, where an empty
-    result would then mean "gone" and "could not look" alike -- and the caller below releases a
-    guard on that answer. Same walk, fail-CLOSED: any error is reported as ``None``.
+    Two deliberate differences from ``_active_incomplete_blob_sizes``:
+
+    Fail-CLOSED. That helper swallows per-file and outer errors and returns whatever it managed to
+    read, which is right for a progress sensor, where an unreadable blob should not abort a
+    download. It is wrong for a safety check, where an empty result would then mean "gone" and
+    "could not look" alike -- and the caller below releases a guard on that answer.
+
+    Identity, not name. The name alone cannot tell the sparse Xet partial the purge failed to remove
+    from a fresh, resumable partial huggingface_hub wrote at the SAME path after unlinking it under
+    ``force_download``, so a name-only check re-latches on the very HTTP progress it should be
+    preserving and restarts every remaining child from zero. ``(dev, ino)`` survives that: an unlink
+    plus create changes the inode. Two known-imprecise cases, both erring the way the pre-latch code
+    already behaved rather than the corrupting way: a filesystem reporting ``st_ino = 0`` (some FAT /
+    network mounts) degrades to the name-only test, which keeps the latch on; and an inode reused
+    immediately for the replacement releases it, exactly as unconditional release would have.
+
+    Size and mtime are deliberately NOT part of the identity: the unsafe partial can be appended to
+    by a live sibling, and keying on either would then read that growth as disappearance.
     """
-    names: set = set()
+    identities: set = set()
     try:
         for entry in iter_active_repo_cache_dirs(repo_type, repo_id, cache_dir = cache_dir):
             blobs_dir = entry / "blobs"
             if not blobs_dir.is_dir():
                 continue
             for blob in blobs_dir.iterdir():
-                if blob.name.endswith(INCOMPLETE_SUFFIX):
-                    names.add(blob.name)
+                if not blob.name.endswith(INCOMPLETE_SUFFIX):
+                    continue
+                try:
+                    st = blob.stat()
+                except FileNotFoundError:
+                    # Vanished between listing and stat. That is the disappearance this scan is
+                    # looking for, not a failure to look, so skip it rather than failing closed.
+                    continue
+                identities.add((blob.name, st.st_dev, st.st_ino))
     except Exception:
         return None
-    return names
+    return identities
 
 
 def _child_rss(pid: int) -> Optional[int]:
@@ -2562,8 +2582,13 @@ def _download_with_xet_fallback(
                 # Remember WHICH partials are unsafe, so the latch can be released on evidence.
                 # An uninspectable cache yields None, which keeps the latch on forever below --
                 # a clean re-download costs bandwidth, resuming over a sparse partial costs the blob.
-                seen = _incomplete_blob_names_strict(repo_type, repo_id, cache_dir)
-                unsafe_partials = seen if seen is not None else None
+                # Scoped by the same owned-blob set as the purge above: a partial the purge spared
+                # because a LIVE sibling holds it is not ours to wait on, and leaving it in would
+                # hold the latch for the whole ladder while that sibling downloads something else.
+                seen = _incomplete_blob_identities(repo_type, repo_id, cache_dir)
+                if seen is not None and owned_incomplete is not None:
+                    seen = {ident for ident in seen if ident[0] in owned_incomplete}
+                unsafe_partials = seen
         elif disable_xet and forced_clean_redownload:
             # Release the latch only once every partial that was unsafe at the transition is gone.
             # "One HTTP child has run" is NOT proof it did: huggingface_hub unlinks the .incomplete
@@ -2572,8 +2597,11 @@ def _download_with_xet_fallback(
             # child force_download=False would then resume it, and an HTTP resume over a sparse Xet
             # partial finalizes a silently corrupt blob, which is what the purge above prevents.
             # Fail closed on both halves: a scan that could not run (None, either now or at the
-            # transition) is not evidence of disappearance, so the latch stays on.
-            present = _incomplete_blob_names_strict(repo_type, repo_id, cache_dir)
+            # transition) is not evidence of disappearance, so the latch stays on. Matched on
+            # ``(name, dev, ino)``, so a same-named replacement written by the forced HTTP child
+            # counts as disappearance -- that partial IS resumable, and re-latching on it would
+            # throw away the bytes this ladder just paid for.
+            present = _incomplete_blob_identities(repo_type, repo_id, cache_dir)
             still_unsafe = (
                 None if (unsafe_partials is None or present is None)
                 else (unsafe_partials & present)

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import builtins
 import errno
 import importlib.util
+import math
 import multiprocessing as mp
 import logging
 import os
@@ -143,6 +144,19 @@ _MAX_HTTP_ATTEMPTS = 8
 # Wait between HTTP children so a CDN shedding load is not hit again in the same instant.
 # ``UNSLOTH_HTTP_RETRY_BACKOFF`` overrides it, and 0 means "retry at once" rather than "junk".
 DEFAULT_HTTP_RETRY_BACKOFF = 5.0
+# Ceiling on that wait. A backoff is not a timeout: past a few minutes the ladder is just holding the
+# caller hostage, and the value reaches ``time.sleep`` / ``Event.wait``, whose Windows limit is
+# ~49.7 days (``PY_TIMEOUT_MAX``) -- past it they raise OverflowError, which is NOT a
+# DownloadStallError and so escapes the caller's guard into the unguarded in-process load.
+_MAX_HTTP_RETRY_BACKOFF = 300.0
+
+# "The disk cannot take it" errnos, built defensively: CPython compiles each errno constant behind an
+# #ifdef, so which names exist is a platform property (EDQUOT reaches Windows only through a
+# WSAEDQUOT fallback). A bare errno.EDQUOT would be an AttributeError on a build without it.
+_DISK_FULL_ERRNOS = frozenset(
+    code for code in (getattr(errno, name, None) for name in ("ENOSPC", "EDQUOT"))
+    if code is not None
+)
 
 # A child buffering from the network grows RSS at roughly the wire rate. Well above allocator noise
 # but far below one poll's worth of even a thin link (20 Mbit/s is ~12 MB per 5s tick), so a
@@ -170,7 +184,12 @@ _POLL_INTERVAL = 0.5
 
 
 def _env_seconds(name: str, default: float) -> float:
-    """Read a positive float override from the environment; ignore junk rather than crash a load."""
+    """Read a positive finite float override from the environment; ignore junk rather than crash a load.
+
+    ``nan`` and ``inf`` parse as floats and pass a ``value <= 0`` test, but every consumer of this
+    value ends up in ``time.sleep`` / ``Event.wait`` / a deadline comparison, where ``nan`` makes
+    every comparison False (no deadline ever fires) and ``inf`` raises OverflowError. Reject both.
+    """
     raw = os.environ.get(name)
     if not raw:
         return default
@@ -179,8 +198,8 @@ def _env_seconds(name: str, default: float) -> float:
     except (TypeError, ValueError):
         logger.warning("Ignoring non-numeric %s=%r", name, raw)
         return default
-    if value <= 0:
-        logger.warning("Ignoring non-positive %s=%r", name, raw)
+    if not math.isfinite(value) or value <= 0:
+        logger.warning("Ignoring non-positive or non-finite %s=%r", name, raw)
         return default
     return value
 
@@ -232,8 +251,14 @@ def _http_retry_backoff() -> float:
 
     Not ``_env_seconds``: that treats non-positive as junk, which is right for a timeout but wrong
     here, where 0 is the meaningful "retry at once" a test harness or a CI run actually reaches for
-    and silently restoring the full default would be a surprise. Only negative / unparseable falls
-    back.
+    and silently restoring the full default would be a surprise. Only negative / non-finite /
+    unparseable falls back, and the result is clamped to ``_MAX_HTTP_RETRY_BACKOFF``.
+
+    ``float()`` accepts ``nan`` and ``inf`` and both survive a ``value < 0`` test, so they have to be
+    rejected by name: this value is handed to ``time.sleep`` / ``Event.wait``, where ``nan`` raises
+    ValueError and ``inf`` raises OverflowError. Neither is a ``DownloadStallError``, so an escaping
+    one would be swallowed by the caller as "could not pre-download, continuing with the normal load"
+    -- the exact fall-through ``DownloadTransportError`` exists to prevent.
     """
     raw = os.environ.get("UNSLOTH_HTTP_RETRY_BACKOFF")
     if not raw:
@@ -243,10 +268,10 @@ def _http_retry_backoff() -> float:
     except (TypeError, ValueError):
         logger.warning("Ignoring non-numeric UNSLOTH_HTTP_RETRY_BACKOFF=%r", raw)
         return DEFAULT_HTTP_RETRY_BACKOFF
-    if value < 0:
-        logger.warning("Ignoring negative UNSLOTH_HTTP_RETRY_BACKOFF=%r", raw)
+    if not math.isfinite(value) or value < 0:
+        logger.warning("Ignoring negative or non-finite UNSLOTH_HTTP_RETRY_BACKOFF=%r", raw)
         return DEFAULT_HTTP_RETRY_BACKOFF
-    return value
+    return min(value, _MAX_HTTP_RETRY_BACKOFF)
 
 
 def is_data_phase_stall(message: str) -> bool:
@@ -1202,6 +1227,13 @@ def _is_retryable_download_error(exc: BaseException, *, on_xet: bool) -> bool:
     rather than looped.
     """
     name = type(exc).__name__
+    # Control flow, not transport. The child reports via `except BaseException`, so these reach the
+    # classifier, and the rung default would answer "retryable" -- spending an HTTP child AND the
+    # destructive pre-HTTP purge because someone asked the process to stop. Programming errors are
+    # deliberately NOT listed: for those the rung default's "one HTTP attempt to disprove it" trade
+    # still holds, but nothing can make an interpreter shutdown a CDN problem.
+    if isinstance(exc, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+        return False
     # LocalEntryNotFoundError wraps BOTH a genuine offline / uncached miss (deterministic) AND a
     # TRANSIENT HEAD connection error / timeout for an uncached file. Retry the transient sub-case; a
     # true offline miss (no transient hint) falls through to the deterministic set below.
@@ -1211,8 +1243,11 @@ def _is_retryable_download_error(exc: BaseException, *, on_xet: bool) -> bool:
         return True
     if name in _DETERMINISTIC_ERROR_NAMES:
         return False
-    # Disk full / quota: another transport cannot help.
-    if isinstance(exc, OSError) and getattr(exc, "errno", None) in (errno.ENOSPC, errno.EDQUOT):
+    # Disk full / quota: another transport cannot help. errno codes are #ifdef'd per platform in
+    # CPython, so read them defensively -- an AttributeError here would fire inside the child's
+    # `except BaseException` while it is REPORTING a failure, turning a clean deterministic error
+    # into a resultless "crashed" verdict that then spends the whole HTTP budget on it.
+    if isinstance(exc, OSError) and getattr(exc, "errno", None) in _DISK_FULL_ERRNOS:
         return False
     # HTTP status (HfHubHTTPError carries a requests / httpx response): 5xx / 429 / 408 transient,
     # other 4xx (401 / 403 / 404 / 416) deterministic.
@@ -1221,14 +1256,16 @@ def _is_retryable_download_error(exc: BaseException, *, on_xet: bool) -> bool:
         status = getattr(exc, "status_code", None)
     if isinstance(status, int):
         return status >= 500 or status in (408, 429)
+    # A builtin OSError is decided by its CLASS, before the text scan. Deciding it by text does not
+    # work: str(OSError) embeds the FILENAME, and the Xet cache lives at ~/.cache/huggingface/xet/,
+    # so a local PermissionError or read-only-filesystem error under it matches the "xet" hint and
+    # reads as a transient transport fault -- the very case this rule exists to exclude. The network
+    # subclasses stay retryable by type, which is also more robust than matching their wording.
+    if _is_builtin_oserror(exc):
+        return isinstance(exc, (ConnectionError, TimeoutError, BrokenPipeError, BlockingIOError))
     text = f"{name}: {exc}".lower()
     if any(hint in text for hint in _TRANSIENT_ERROR_HINTS):
         return True
-    # A builtin OSError reaching this far is a LOCAL filesystem failure (permission, missing dir,
-    # read-only cache): the network subclasses (TimeoutError, ConnectionResetError, ...) all match a
-    # hint above. The other transport writes to the same path, so the rung default must not apply.
-    if _is_builtin_oserror(exc):
-        return False
     return on_xet
 
 
@@ -2418,9 +2455,12 @@ def _download_with_xet_fallback(
     http_budget = http_attempts()
     http_used = 0
     # force_download as the CALLER asked for it, so a clean re-download forced by an uncleared partial
-    # can be handed back after the first HTTP child has done it.
+    # can be handed back once that partial is provably gone.
     caller_force_download = params.get("force_download", False)
     forced_clean_redownload = False
+    # The exact unsafe partials seen at the transition. The latch is released only when NONE of them
+    # is still on disk -- see the un-latch branch below for why "a child ran" is not enough.
+    unsafe_partials: set = set()
     # The Xet -> HTTP purge runs at the TRANSITION only. Repeating it per HTTP child would spare the
     # partial the failed HTTP child just wrote (it is younger than active_grace), leaving
     # has_active_incomplete_blobs true and forcing force_download, so every HTTP retry would restart
@@ -2442,6 +2482,21 @@ def _download_with_xet_fallback(
         if pending_xet_failure is not None:
             _record_xet_outcome(False, pending_xet_failure)
             pending_xet_failure = None
+
+    def _hold_unproven_xet_failure(reason: str) -> None:
+        """Hold a fault / crash pending an HTTP rescue, WITHOUT displacing a stall already held.
+
+        There is one reason slot, and a stall outranks a fault: a stall was proven by the watchdog on
+        this machine, whereas a fault is only evidence once HTTP shows the network was fine. Letting
+        a fault overwrite a stall also flips ``pending_needs_http_success`` to True, so a later
+        both-rungs-failed exit would drop the stall as well and the machine would never be charged
+        for it. Reachable exactly as the degraded CDN this ladder targets: Xet child 1 stalls, child
+        2 raises the CAS fault, HTTP then fails too.
+        """
+        nonlocal pending_xet_failure, pending_needs_http_success
+        if pending_xet_failure is None:
+            pending_xet_failure = _xet_failure_reason(reason)
+            pending_needs_http_success = True
 
     while True:
         if disable_xet:
@@ -2478,12 +2533,29 @@ def _download_with_xet_fallback(
                 )
                 params = {**params, "force_download": True}
                 forced_clean_redownload = True
+                # Remember WHICH partials are unsafe, so the latch can be released on evidence.
+                unsafe_partials = set(
+                    _active_incomplete_blob_sizes(repo_type, repo_id, cache_dir)
+                )
         elif disable_xet and forced_clean_redownload:
-            # The clean re-download has already happened, so the partial on disk is now HTTP-written
-            # and resumable. Leaving force_download latched would make every retry in the new budget
-            # discard it and start again from zero -- on a large repo, the whole file per attempt.
-            forced_clean_redownload = False
-            params = {**params, "force_download": caller_force_download}
+            # Release the latch only once every partial that was unsafe at the transition is gone.
+            # "One HTTP child has run" is NOT proof it did: huggingface_hub unlinks the .incomplete
+            # only after the HEAD/metadata call, so a child that died on a 5xx there -- the degraded
+            # CDN this ladder exists for -- leaves the sparse Xet partial untouched. Handing the next
+            # child force_download=False would then resume it, and an HTTP resume over a sparse Xet
+            # partial finalizes a silently corrupt blob, which is what the purge above prevents.
+            still_unsafe = unsafe_partials & set(
+                _active_incomplete_blob_sizes(repo_type, repo_id, cache_dir)
+            )
+            if not still_unsafe:
+                forced_clean_redownload = False
+                unsafe_partials = set()
+                params = {**params, "force_download": caller_force_download}
+            else:
+                logger.debug(
+                    "Keeping force_download for '%s': %d unsafe partial(s) still present",
+                    label, len(still_unsafe),
+                )
 
         kind_result, payload = _run_download_attempt(
             repo_id,
@@ -2499,14 +2571,37 @@ def _download_with_xet_fallback(
             on_status = on_status,
         )
 
-        if kind_result == "ok":
-            if kind == "snapshot" and _snapshot_payload_incomplete(
+        # An incomplete snapshot rides on "ok" but is a FAILURE, so classify it before the cancel
+        # check rather than inside the success branch: it is one of the verdicts that used to run the
+        # destructive purge and spend another child after the caller had given up.
+        incomplete_snapshot = kind_result == "ok" and kind == "snapshot" and (
+            _snapshot_payload_incomplete(
                 payload,
                 repo_type = repo_type,
                 allow_patterns = params.get("allow_patterns"),
                 ignore_patterns = params.get("ignore_patterns"),
                 variant = variant,
-            ):
+            )
+        )
+
+        # Cancellation wins over every FAILURE verdict, uniformly. Without this the precedence is
+        # per-branch: a cancel landing on a transient HTTP error reported "Cancelled", but the same
+        # cancel landing on a stall, a deterministic error or an incomplete snapshot reported the
+        # download's own error instead -- and on a Xet verdict it went on to run the destructive
+        # pre-HTTP purge and spend another child for a caller that had already given up. A genuine
+        # success is deliberately exempt: the bytes are on disk either way, so returning them is
+        # kinder than discarding finished work.
+        if (
+            (kind_result != "ok" or incomplete_snapshot)
+            and cancel_event is not None
+            and cancel_event.is_set()
+        ):
+            # The user's decision says nothing about this machine's Xet health.
+            pending_xet_failure = None
+            raise RuntimeError("Cancelled")
+
+        if kind_result == "ok":
+            if incomplete_snapshot:
                 # HF can hand back an existing incomplete snapshot dir (offline / timed-out) instead of
                 # fetching: never load it in-process. Retry over HTTP, then fail loudly. (Patterned /
                 # non-model requests judge their own subset, so a valid weightless snapshot is not
@@ -2517,11 +2612,16 @@ def _download_with_xet_fallback(
                         "retrying with HF_HUB_DISABLE_XET=1", label
                     )
                     _safe_status(on_status, f"{label}: incomplete snapshot, retrying over HTTP")
-                    # Supersedes any deferred stall: one outcome per download.
-                    pending_xet_failure = None
-                    _record_xet_outcome(False, "Xet returned an incomplete snapshot")
+                    # Held pending an HTTP rescue, like the fault and crash branches: a short
+                    # snapshot is a transport symptom too (the Hub hands one back on a timed-out or
+                    # offline metadata trip), so a CDN bad enough to shorten BOTH rungs is not
+                    # evidence against this machine's Xet. Recording it here charged the tracker even
+                    # when the ladder went on to fail or be cancelled, and two such downloads demote
+                    # a healthy machine to HTTP for 24h.
+                    _hold_unproven_xet_failure("Xet returned an incomplete snapshot")
                     disable_xet = True
                     continue
+                pending_xet_failure = None
                 raise DownloadStallError(
                     f"Download for '{label}' returned an incomplete snapshot even with "
                     f"HF_HUB_DISABLE_XET=1 -- missing files, check your network connection"
@@ -2550,6 +2650,17 @@ def _download_with_xet_fallback(
             if pending_needs_http_success:
                 pending_xet_failure = None
             _flush_pending_failure()
+            # An UNRECOGNIZED error ending the ladder after a transport fault already sent us here
+            # would leave as a bare RuntimeError (_raise_child_error cannot rebuild an unknown class),
+            # which is not a DownloadStallError -- so the caller logs "continuing with the normal
+            # load" and hands a transport that just failed twice to the unguarded in-process path.
+            # That is issue #1122's shape, one rung further along. Keep it inside the guard.
+            # Deliberately narrow: only when a transport fault is already established, so an ordinary
+            # unknown error on a healthy ladder still falls through as it does today.
+            if pending_needs_http_success and disable_xet:
+                type_name = payload.split(":", 1)[0].strip() if ":" in (payload or "") else ""
+                if _resolve_exception_class(type_name) is None:
+                    raise DownloadTransportError(payload)
             _raise_child_error(payload)
         if kind_result == "retryable_error":
             # Transient transport failure (hf_xet CAS fault, 5xx, reset): change transport, then spend
@@ -2563,15 +2674,9 @@ def _download_with_xet_fallback(
                 # HELD, not recorded: a transient fault is only evidence against THIS MACHINE's Xet if
                 # HTTP then succeeds. A degraded CDN fails both rungs, and charging it here demoted a
                 # perfectly good machine to HTTP for 24h after two such downloads.
-                pending_xet_failure = _xet_failure_reason("transient Xet transport error")
-                pending_needs_http_success = True
+                _hold_unproven_xet_failure("transient Xet transport error")
                 disable_xet = True
                 continue
-            # A cancel landing in the failure window ends the ladder as a cancel, not as a transport
-            # error: the caller has stopped caring about the result either way.
-            if cancel_event is not None and cancel_event.is_set():
-                pending_xet_failure = None
-                raise RuntimeError("Cancelled")
             if http_used < http_budget:
                 logger.warning(
                     "Download for '%s' hit a transient error on HTTP -- retrying "
@@ -2584,8 +2689,11 @@ def _download_with_xet_fallback(
                 )
                 _wait_before_http_retry(cancel_event)
                 continue
-            # Both rungs met the same transport fault: not this machine's Xet.
-            pending_xet_failure = None
+            # Both rungs met the same transport fault: that is not evidence against this machine's
+            # Xet, so an UNPROVEN reason is dropped. A held stall was proven on its own and survives.
+            if pending_needs_http_success:
+                pending_xet_failure = None
+            _flush_pending_failure()
             raise DownloadTransportError(payload)
         if kind_result == "crashed":
             # Process-level crash with no captured exception: HTTP may still succeed, so retry once.
@@ -2596,13 +2704,9 @@ def _download_with_xet_fallback(
                 )
                 _safe_status(on_status, f"{label}: download crashed, retrying over HTTP")
                 # Held for the same reason as a transient error: only an HTTP rescue proves it was Xet.
-                pending_xet_failure = _xet_failure_reason("Xet download process crashed")
-                pending_needs_http_success = True
+                _hold_unproven_xet_failure("Xet download process crashed")
                 disable_xet = True
                 continue
-            if cancel_event is not None and cancel_event.is_set():
-                pending_xet_failure = None
-                raise RuntimeError("Cancelled")
             if http_used < http_budget:
                 logger.warning(
                     "Download process for '%s' crashed on HTTP -- retrying (attempt %d of %d)",
@@ -2615,7 +2719,9 @@ def _download_with_xet_fallback(
                 )
                 _wait_before_http_retry(cancel_event)
                 continue
-            pending_xet_failure = None
+            if pending_needs_http_success:
+                pending_xet_failure = None
+            _flush_pending_failure()
             raise DownloadTransportError(payload)
         # kind_result == "stall"
         if not disable_xet:


### PR DESCRIPTION
Fixes #1122.

Two failures were reported there as one. Both end the same way: the supervised child raises something the caller does not recognize as "the guarded download failed", so unsloth logs *"continuing with the normal load"* and hands control to the in-process `from_pretrained` — which still has Xet enabled and no watchdog. That is the unbounded silent hang this module exists to prevent, reached from a CDN error that clears on a retry.

## The CAS fault genuinely never reached HTTP

`hf_xet` reports it as a bare `RuntimeError` carrying a Rust error chain:

```
Task error: File reconstruction error: CAS Client Error: Format error: I/O error: error decoding response body
```

`_TRANSIENT_ERROR_HINTS` has `"casclient"` and `"cas_"` — not `"cas client"` — and the message carries no `xet`, `timeout`, `connection` or status code. Nothing matched, so `_is_retryable_download_error` returned False, the ladder took the `error` branch, and `_raise_child_error` re-raised without ever trying the other transport. That is the issue title exactly.

Growing the substring list is not the fix, because the wording belongs to xet-core rather than to this package and cannot be kept complete from here. An **unrecognized** error on the Xet rung is now treated as transport-attributable: it costs one HTTP attempt to disprove, against surrendering the supervised path to an unguarded in-process load. HTTP stays the rung where an unknown error is surfaced rather than looped, and the named / status / errno rules are unchanged on **both** rungs. A builtin `OSError` reaching that far is a local filesystem failure (permission, read-only cache) and stays deterministic, since the other transport writes to the same path.

## The 503 half is not what the issue says it is

I should correct my own report. A `HfHubHTTPError` carrying `status_code=503` already classified as retryable, so **the fallback did run**. But with `HF_HUB_DISABLE_XET=1`, `huggingface_hub` still fetches Xet-backed blobs through the Xet bridge CDN — the `us.aws.cdn.hf.co/xet-bridge-us/` URL in the log is the *HTTP* rung's own request — so the degraded CDN failed that rung too, and one child was all it got. `RuntimeError: HfHubHTTPError: Server error '503 ...'` can only come from `raise RuntimeError(payload)` on the exhausted branch.

So the substantive fix there is a budget, not a classification change. Xet gets `xet_attempts()` children; HTTP now gets `http_attempts()` (`UNSLOTH_HTTP_ATTEMPTS`, default 2, same junk/clamp handling as `xet_attempts`) with a backoff between them. That is what the evidence in the issue calls for: plain `curl` of the same shard from the same pod in the same minute ran at 6.6 MB/s, and `UNSLOTH_STABLE_DOWNLOADS=1` completed at 17.7 MB/s. A **stall** on HTTP still raises on the first verdict — the patient HTTP threshold has already waited out everything a retry would wait for again.

## Keeping the guard

Exhausting both rungs now raises `DownloadTransportError`, a subclass of `DownloadStallError`, so the guard the caller already has (`except DownloadStallError: raise` in `unsloth/models/_utils.py`) keeps holding with no change on that side. It is still a `RuntimeError`, so an existing `except RuntimeError` keeps matching.

## Two things that had to come with it

**The purge is gated to the transport change.** Running `_default_prepare_for_http` per HTTP child would spare the partial the failed child just wrote (younger than `active_grace`), leaving `has_active_incomplete_blobs` true and forcing `force_download` — so every retry would have restarted the download from zero. Pinned by a test.

**Health is charged only once HTTP rescues the download.** The `retryable_error` and `crashed` branches recorded a Xet failure immediately, and the tracker demotes a machine to HTTP for 24h after two *consecutive* failures. A CDN fault that fails both rungs is not evidence against that machine's Xet, and two such downloads in a row is precisely what a degraded CDN produces — which is what I hit. Both branches now hold the reason in the existing `pending_xet_failure` and charge it only when HTTP finishes what Xet could not. Pre-existing, but widened by the classification change, so it is fixed here rather than left behind it.

A cancel landing in the HTTP failure window now ends the ladder as a cancel rather than as a transport error, and the backoff is interruptible.

## Tests

12 new cases in `tests/test_hf_xet_fallback.py`, using the existing `_install` / `_FakeAttempt` seam: the verbatim CAS chain on each rung, the deterministic rules holding on both rungs, HTTP retry on a transient error and on a crash, an HTTP stall still raising immediately, the `UNSLOTH_HTTP_ATTEMPTS` knob (one / extended / junk / clamp), the purge running exactly once, cancel precedence, the interruptible backoff, and the health deferral for both branches. Two existing tests asserted the old single-HTTP-attempt behaviour and were updated rather than removed.

Verified on Linux (WSL, Python 3.12): **255 passed before, 267 after**, with the same 3 pre-existing failures that need `unsloth` installed. `ruff --select E9,F63,F7,F82`, `compileall`, `enforce_kwargs_spacing.py` and `lint_dynamic_exec.py` are clean on both changed files. On Windows the file's ~210 `symlink_to` calls hit `WinError 1314` without Developer Mode; that failing set is byte-identical before and after at 112 tests, which is why the Linux run is the one quoted above.

## Compatibility

`DownloadTransportError` and `http_attempts` / `DEFAULT_HTTP_ATTEMPTS` are added to `__all__`. Nothing is removed. `_is_retryable_download_error` gains a required keyword-only `on_xet`; it is private and has one call site in the package.
