### PR TITLE
Forward the inspection half of the loader API from _ModelingLoader

### DIFF
--- a/unsloth_zoo/fused_losses/forward_install.py
+++ b/unsloth_zoo/fused_losses/forward_install.py
@@ -349,9 +349,8 @@ class _ModelingLoader(importlib.abc.Loader):
     def __init__(self, inner):
         self._inner = inner
 
-    # Forward the inspection half of the loader API. Defined rather than routed
-    # through __getattr__ so the class itself carries them: hasattr and
-    # mock.patch.object look them up on the type, which skips __getattr__.
+    # Defined, not routed through __getattr__: hasattr and mock.patch.object
+    # look these up on the type, which skips __getattr__.
     def get_source(self, name):
         return self._inner.get_source(name)
 

--- a/unsloth_zoo/fused_losses/forward_install.py
+++ b/unsloth_zoo/fused_losses/forward_install.py
@@ -349,6 +349,21 @@ class _ModelingLoader(importlib.abc.Loader):
     def __init__(self, inner):
         self._inner = inner
 
+    # Forward the inspection half of the loader API. Defined rather than routed
+    # through __getattr__ so the class itself carries them: hasattr and
+    # mock.patch.object look them up on the type, which skips __getattr__.
+    def get_source(self, name):
+        return self._inner.get_source(name)
+
+    def get_code(self, name):
+        return self._inner.get_code(name)
+
+    def get_filename(self, name):
+        return self._inner.get_filename(name)
+
+    def is_package(self, name):
+        return self._inner.is_package(name)
+
     def create_module(self, spec):
         if hasattr(self._inner, "create_module"):
             return self._inner.create_module(spec)


### PR DESCRIPTION
`MLX (Linux CPU: numerics + suites)` is currently failing on `main`, and it is a HARD GATE, so the lane is red on main and on every pull request branched from it. It is not caused by any of the recent MLX changes; it is the fused-forward loader wrapper.

## What breaks

`_ModelingLoader` (`unsloth_zoo/fused_losses/forward_install.py`) wraps the real loader for `transformers.models.*.modeling_*` and forwards only `create_module` and `exec_module`. Once `_ModelingFinder` is installed, `get_source`, `get_code`, `get_filename` and `is_package` are gone:

```
loader: _ModelingLoader
has get_source: False | has get_code: False
```

`_transformers_scales_inside_embedding` reads transformers *through the loader* deliberately, because importing a modeling module needs torch and torch is absent alongside MLX on macOS arm64. Both of its reads raise `AttributeError`, both are caught, and the probe returns `None`:

```
assert probe("gemma3_text") is True
AssertionError: assert None is True
```

That is `tests/test_mlx_neftune_quant_map.py::test_embed_scale_probe_reads_the_installed_transformers`, the first assertion, and it is the step the gate fails on. Confirmed the same job and the same step fail on `main` itself at 91383f0f, so this is not specific to any branch.

## The fix

Forward the inspection half of the loader API to the wrapped loader.

Defined as four methods rather than routed through `__getattr__` on purpose: `hasattr` and `mock.patch.object` look these up on the type, and `__getattr__` is an instance protocol that class lookup skips. An `__getattr__` version gets the probe answering again but still fails the same test two assertions later, where it patches `get_source` on the loader class.

## Verification

- `tests/test_mlx_neftune_quant_map.py` 37 passed, 8 skipped (was 1 failed, 36 passed).
- `tests/test_fused_forward_install.py` 18 passed, 11 skipped.
- Removing either `get_source` or `get_code` puts the gate back to failing, so the coverage is real rather than incidental.

Run against real mlx 0.32.2 through the `mlx-cpu` manylinux wheel, which is the same runtime the failing job uses.
