### PR TITLE
fix(mlx): restore MoE tensor names for GGUF export

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -355,6 +355,22 @@ jobs:
         # inherit module state from another MLX test file.
         run: python -m pytest tests/test_mlx_save_lora_adapters_filter.py -v
 
+      - name: pytest MLX GGUF export gates (HARD GATE)
+        # One invocation each, for the reason above: tests/mlx_simulation/ replaces
+        # sys.modules["mlx.core"] process-wide, so a file collected after another
+        # inherits its shim.
+        #
+        # These are here because they were in NO job, which is the failure the
+        # comment above already lists four times. The MoE name-restoration work
+        # changed the arguments _prepare_mlx_gguf_export_directory is called with and
+        # took 13 tests in test_mlx_save_export_edge_cases.py down; every check on
+        # that pull request stayed green, because `pytest tests/ --collect-only`
+        # proves only that a file imports.
+        run: |
+          python -m pytest tests/test_mlx_save_export_regressions.py -v
+          python -m pytest tests/test_mlx_save_export_edge_cases.py -v
+          python -m pytest tests/test_mlx_moe_gguf_export_invariants.py -v
+
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests
         # Run as SEPARATE pytest invocation: tests/security/conftest.py installs a
         # session-scoped network_blocker autouse fixture that would otherwise block

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -178,6 +178,11 @@ jobs:
         # ordering and stop-string contracts.
         run: python -m pytest tests/test_mlx_generate_metal.py -v -rs
 
+      - name: tests/test_mlx_gguf_moe_export_metal.py
+        # GGUF staging on a real mlx-lm MoE model: stacked switch_mlp experts
+        # must come back out under the per-expert HF names llama.cpp maps.
+        run: python -m pytest tests/test_mlx_gguf_moe_export_metal.py -v -rs
+
       - name: tests/test_mlx_cpt_partition_metal.py
         # CPT partition, target normalization and full-module save routing.
         run: python -m pytest tests/test_mlx_cpt_partition_metal.py -v -rs

--- a/tests/mlx_simulation/mlx_stub.py
+++ b/tests/mlx_simulation/mlx_stub.py
@@ -375,10 +375,9 @@ class array(metaclass=_ArrayMeta):
         if data is None:
             return torch.tensor([])
         if isinstance(data, torch.Tensor):
-            # A copy, as mlx's own constructor is: `mx.array(a)` placement-news a fresh
-            # array, so a later `a += b` (which reassigns only a's descriptor) cannot
-            # write through it. Handing `data` back aliased instead, which silently
-            # disarmed every defensive copy the code under test makes.
+            # A copy, as mlx's own constructor is: `mx.array(a)` builds a fresh array,
+            # so a later `a += b` (which reassigns only a's descriptor) cannot write
+            # through it. Aliasing `data` disarmed every defensive copy under test.
             out = data.to(dtype) if dtype is not None else data
             return out.clone() if out is data else out
         return torch.tensor(data, dtype=dtype)

--- a/tests/mlx_simulation/mlx_stub.py
+++ b/tests/mlx_simulation/mlx_stub.py
@@ -375,7 +375,12 @@ class array(metaclass=_ArrayMeta):
         if data is None:
             return torch.tensor([])
         if isinstance(data, torch.Tensor):
-            return data.to(dtype) if dtype is not None else data
+            # A copy, as mlx's own constructor is: `mx.array(a)` placement-news a fresh
+            # array, so a later `a += b` (which reassigns only a's descriptor) cannot
+            # write through it. Handing `data` back aliased instead, which silently
+            # disarmed every defensive copy the code under test makes.
+            out = data.to(dtype) if dtype is not None else data
+            return out.clone() if out is data else out
         return torch.tensor(data, dtype=dtype)
 
 

--- a/tests/test_mlx_gguf_moe_export_metal.py
+++ b/tests/test_mlx_gguf_moe_export_metal.py
@@ -130,3 +130,83 @@ def test_moe_staging_recovers_names_a_real_sanitizer_only_renamed(tmp_path):
     restored = model.sanitize(dict(rewritten))
     for name, tensor in staged.items():
         assert bool(mx.array_equal(restored[name], tensor)), name
+
+
+KIMI_LINEAR_CONFIG = dict(
+    model_type="kimi_linear", vocab_size=256, hidden_size=64, intermediate_size=128,
+    moe_intermediate_size=32, num_hidden_layers=2, num_attention_heads=4,
+    num_key_value_heads=4, num_experts=4, first_k_dense_replace=0, rms_norm_eps=1e-5,
+    rope_theta=1e4, max_position_embeddings=512, head_dim=16, kv_lora_rank=16,
+    num_experts_per_token=2, num_shared_experts=1, qk_nope_head_dim=16,
+    qk_rope_head_dim=16, v_head_dim=16, model_max_length=512,
+    tie_word_embeddings=False, routed_scaling_factor=1.0,
+    linear_attn_config={"kda_layers": [1], "short_conv_kernel_size": 4,
+                        "head_dim": 16, "num_heads": 4},
+)
+
+
+def _stage_real_model(path, module, config, shards=1):
+    """Write what save_merged_model produces for one real mlx-lm model."""
+    model = module.Model(module.ModelArgs.from_dict(config))
+    staged = {n: t.astype(mx.bfloat16) for n, t in tree_flatten(model.parameters())}
+    mx.eval(*staged.values())
+    path.mkdir(parents=True, exist_ok=True)
+    names, weight_map = sorted(staged), {}
+    for shard in range(shards):
+        part = {n: staged[n] for i, n in enumerate(names) if i % shards == shard}
+        file = f"model-{shard + 1:05d}-of-{shards:05d}.safetensors"
+        mx.save_safetensors(str(path / file), part, metadata={"format": "mlx"})
+        weight_map.update({n: file for n in part})
+    index = json.dumps({"weight_map": weight_map})
+    (path / "model.safetensors.index.json").write_text(index)
+    return model, staged
+
+
+def _restores_bitwise(model, path, staged):
+    """Assert mlx-lm's own sanitize maps the rewritten directory back exactly.
+
+    Also checks the index still names the shard each tensor is really in.
+    """
+    rewritten = {}
+    index = json.loads((path / "model.safetensors.index.json").read_text())
+    for file in sorted(path.glob("*.safetensors")):
+        held = mx.load(str(file))
+        for name in held:
+            assert index["weight_map"].get(name) == file.name, name
+        rewritten.update(held)
+    assert set(index["weight_map"]) == set(rewritten)
+
+    restored = model.sanitize(dict(rewritten))
+    # Exactly the checkpoint, not a superset: a tensor left behind under its MLX
+    # name is invisible to the round-trip, because the sanitizer overwrites it
+    # from the one that replaced it, and llama.cpp rejects what it cannot map.
+    assert set(restored) == set(staged)
+    for name, tensor in staged.items():
+        assert bool(mx.array_equal(restored[name], tensor)), name
+    return rewritten
+
+
+@metal_only
+def test_moe_staging_restores_a_layout_a_real_sanitizer_moved(tmp_path):
+    """Kimi Linear renames its KDA convolutions and swaps two of their axes."""
+    import unsloth_zoo.mlx.utils as mutils
+    from mlx_lm.models import kimi_linear
+
+    path = tmp_path / "merged"
+    model, staged = _stage_real_model(path, kimi_linear, KIMI_LINEAR_CONFIG)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model)
+
+    rewritten = _restores_bitwise(model, path, staged)
+    moved = rewritten["model.layers.0.self_attn.k_conv1d.weight"]
+    staged_conv = staged["model.layers.0.self_attn.k_conv.conv.weight"]
+    assert tuple(moved.shape) == (staged_conv.shape[0], 1, staged_conv.shape[1])
+    # The whole MoE block is relocated, not only the expert tensors, and only
+    # the converter-side spellings of all of it are mappable.
+    for leaf in ("experts.3.w2.weight", "gate.weight", "gate.e_score_correction_bias",
+                 "shared_experts.down_proj.weight"):
+        assert f"model.layers.1.block_sparse_moe.{leaf}" in rewritten
+    assert not any(
+        ".mlp." in name or ".switch_mlp." in name or "_conv.conv." in name
+        for name in rewritten
+    )

--- a/tests/test_mlx_gguf_moe_export_metal.py
+++ b/tests/test_mlx_gguf_moe_export_metal.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Real-runtime check that GGUF staging restores the per-expert tensor names a real
 mlx-lm MoE model was built from: llama.cpp cannot map MLX's stacked ``switch_mlp``
 parameters, so the staged directory has to carry the HF names."""

--- a/tests/test_mlx_gguf_moe_export_metal.py
+++ b/tests/test_mlx_gguf_moe_export_metal.py
@@ -62,7 +62,7 @@ def test_moe_staging_restores_names_mlx_sanitize_maps_back_bitwise(tmp_path):
     # exact tensors the model was saved from.
     restored = model.sanitize(dict(rewritten))
     for name in stacked_names:
-        assert bool(mx.array_equal(restored[name], staged[name])), name
+        assert _bytes_identical(restored[name], staged[name]), name
 
 
 @metal_only
@@ -85,7 +85,7 @@ def test_moe_staging_holds_no_more_shards_open_as_a_checkpoint_is_split(
             return loaded
 
         monkeypatch.setattr(mutils.mx, "load", counting_load)
-        assert mutils._plan_mlx_moe_expert_unstacking(model, files)
+        assert mutils._plan_mlx_moe_gguf_rewrite(model, files)[0]
         monkeypatch.undo()
         return peak - before
 
@@ -95,118 +95,7 @@ def test_moe_staging_holds_no_more_shards_open_as_a_checkpoint_is_split(
     assert descriptor_growth(2) >= descriptor_growth(32)
 
 
-STEP3P5_CONFIG = dict(
-    model_type="step3p5", vocab_size=256, hidden_size=64, intermediate_size=128,
-    moe_intermediate_size=32, num_hidden_layers=2, num_attention_heads=4,
-    num_key_value_heads=4, num_attention_groups=1, moe_num_experts=4, moe_top_k=2,
-    rms_norm_eps=1e-5, rope_theta=1e4, head_dim=16, max_position_embeddings=512,
-    share_expert_dim=32, moe_layers_enum="0,1", tie_word_embeddings=False,
-)
-
-
-@metal_only
-def test_moe_staging_recovers_names_a_real_sanitizer_only_renamed(tmp_path):
-    """step3p5 keeps its experts fused in HF and is renamed, never un-stacked."""
-    import unsloth_zoo.mlx.utils as mutils
-    from mlx_lm.models import step3p5
-
-    model = step3p5.Model(step3p5.ModelArgs.from_dict(STEP3P5_CONFIG))
-    staged = {n: t.astype(mx.bfloat16) for n, t in tree_flatten(model.parameters())}
-    mx.eval(*staged.values())
-    path = tmp_path / "merged"
-    path.mkdir()
-    mx.save_safetensors(str(path / "model.safetensors"), staged, {"format": "mlx"})
-
-    rewritten = mutils._prepare_moe_gguf_export_directory(path, model=model)
-    # Every MLX-only name, plus the norms whose stored value is one above the
-    # checkpoint convention llama.cpp reads.
-    assert rewritten == len([n for n in staged if ".mlp." in n or "norm" in n])
-
-    rewritten = mx.load(str(path / "model.safetensors"))
-    assert "model.layers.0.moe.gate_proj.weight" in rewritten
-    assert "model.layers.0.share_expert.down_proj.weight" in rewritten
-    # The expert tensors stay fused: llama.cpp reads them in exactly this shape.
-    assert rewritten["model.layers.0.moe.gate_proj.weight"].ndim == 3
-    restored = model.sanitize(dict(rewritten))
-    for name, tensor in staged.items():
-        assert bool(mx.array_equal(restored[name], tensor)), name
-
-
-KIMI_LINEAR_CONFIG = dict(
-    model_type="kimi_linear", vocab_size=256, hidden_size=64, intermediate_size=128,
-    moe_intermediate_size=32, num_hidden_layers=2, num_attention_heads=4,
-    num_key_value_heads=4, num_experts=4, first_k_dense_replace=0, rms_norm_eps=1e-5,
-    rope_theta=1e4, max_position_embeddings=512, head_dim=16, kv_lora_rank=16,
-    num_experts_per_token=2, num_shared_experts=1, qk_nope_head_dim=16,
-    qk_rope_head_dim=16, v_head_dim=16, model_max_length=512,
-    tie_word_embeddings=False, routed_scaling_factor=1.0,
-    linear_attn_config={"kda_layers": [1], "short_conv_kernel_size": 4,
-                        "head_dim": 16, "num_heads": 4},
-)
-
-
-def _stage_real_model(path, module, config, shards=1):
-    """Write what save_merged_model produces for one real mlx-lm model."""
-    model = module.Model(module.ModelArgs.from_dict(config))
-    staged = {n: t.astype(mx.bfloat16) for n, t in tree_flatten(model.parameters())}
-    mx.eval(*staged.values())
-    path.mkdir(parents=True, exist_ok=True)
-    names, weight_map = sorted(staged), {}
-    for shard in range(shards):
-        part = {n: staged[n] for i, n in enumerate(names) if i % shards == shard}
-        file = f"model-{shard + 1:05d}-of-{shards:05d}.safetensors"
-        mx.save_safetensors(str(path / file), part, metadata={"format": "mlx"})
-        weight_map.update({n: file for n in part})
-    index = json.dumps({"weight_map": weight_map})
-    (path / "model.safetensors.index.json").write_text(index)
-    return model, staged
-
-
-def _restores_bitwise(model, path, staged):
-    """Assert mlx-lm's own sanitize maps the rewritten directory back exactly.
-
-    Also checks the index still names the shard each tensor is really in.
-    """
-    rewritten = {}
-    index = json.loads((path / "model.safetensors.index.json").read_text())
-    for file in sorted(path.glob("*.safetensors")):
-        held = mx.load(str(file))
-        for name in held:
-            assert index["weight_map"].get(name) == file.name, name
-        rewritten.update(held)
-    assert set(index["weight_map"]) == set(rewritten)
-
-    restored = model.sanitize(dict(rewritten))
-    # Exactly the checkpoint, not a superset: a tensor left behind under its MLX
-    # name is invisible to the round-trip, because the sanitizer overwrites it
-    # from the one that replaced it, and llama.cpp rejects what it cannot map.
-    assert set(restored) == set(staged)
-    for name, tensor in staged.items():
-        assert bool(mx.array_equal(restored[name], tensor)), name
-    return rewritten
-
-
-@metal_only
-def test_moe_staging_restores_a_layout_a_real_sanitizer_moved(tmp_path):
-    """Kimi Linear renames its KDA convolutions and swaps two of their axes."""
-    import unsloth_zoo.mlx.utils as mutils
-    from mlx_lm.models import kimi_linear
-
-    path = tmp_path / "merged"
-    model, staged = _stage_real_model(path, kimi_linear, KIMI_LINEAR_CONFIG)
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model)
-
-    rewritten = _restores_bitwise(model, path, staged)
-    moved = rewritten["model.layers.0.self_attn.k_conv1d.weight"]
-    staged_conv = staged["model.layers.0.self_attn.k_conv.conv.weight"]
-    assert tuple(moved.shape) == (staged_conv.shape[0], 1, staged_conv.shape[1])
-    # The whole MoE block is relocated, not only the expert tensors, and only
-    # the converter-side spellings of all of it are mappable.
-    for leaf in ("experts.3.w2.weight", "gate.weight", "gate.e_score_correction_bias",
-                 "shared_experts.down_proj.weight"):
-        assert f"model.layers.1.block_sparse_moe.{leaf}" in rewritten
-    assert not any(
-        ".mlp." in name or ".switch_mlp." in name or "_conv.conv." in name
-        for name in rewritten
-    )
+def _bytes_identical(actual, expected):
+    """The same tensor as stored: dtype, shape and bits, not numeric equality."""
+    return (actual.dtype == expected.dtype and actual.shape == expected.shape
+            and bool(mx.all(mx.view(actual, mx.uint8) == mx.view(expected, mx.uint8))))

--- a/tests/test_mlx_gguf_moe_export_metal.py
+++ b/tests/test_mlx_gguf_moe_export_metal.py
@@ -1,0 +1,95 @@
+"""Real-runtime check that GGUF staging restores the per-expert tensor names a real
+mlx-lm MoE model was built from: llama.cpp cannot map MLX's stacked ``switch_mlp``
+parameters, so the staged directory has to carry the HF names."""
+
+import json
+import os
+
+import pytest
+try:
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+    _METAL = mx.metal.is_available()
+except Exception:
+    pytest.skip("requires mlx", allow_module_level=True)
+metal_only = pytest.mark.skipif(not _METAL, reason="requires Apple Silicon Metal")
+
+CONFIG = dict(
+    model_type="qwen3_moe", hidden_size=64, num_hidden_layers=2, intermediate_size=128,
+    moe_intermediate_size=32, num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+    rms_norm_eps=1e-6, vocab_size=128, num_experts=4, num_experts_per_tok=2,
+    decoder_sparse_step=1, mlp_only_layers=[], norm_topk_prob=True, rope_theta=1e6,
+    tie_word_embeddings=False, max_position_embeddings=512,
+)
+
+
+def _stage_merged_moe_model(path, shards=1):
+    from mlx_lm.models import qwen3_moe
+
+    model = qwen3_moe.Model(qwen3_moe.ModelArgs.from_dict(CONFIG))
+    weights = {n: t.astype(mx.bfloat16) for n, t in tree_flatten(model.parameters())}
+    mx.eval(*weights.values())
+    path.mkdir(parents=True, exist_ok=True)
+    names, weight_map = sorted(weights), {}
+    for shard in range(shards):
+        part = {n: weights[n] for i, n in enumerate(names) if i % shards == shard}
+        file = f"model-{shard + 1:05d}-of-{shards:05d}.safetensors"
+        mx.save_safetensors(str(path / file), part, metadata={"format": "mlx"})
+        weight_map.update({n: file for n in part})
+    index = json.dumps({"weight_map": weight_map})
+    (path / "model.safetensors.index.json").write_text(index)
+    return model, weights
+
+
+@metal_only
+def test_moe_staging_restores_names_mlx_sanitize_maps_back_bitwise(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    path = tmp_path / "merged"
+    model, staged = _stage_merged_moe_model(path)
+    stacked_names = sorted(name for name in staged if ".switch_mlp." in name)
+    assert len(stacked_names) == 3 * CONFIG["num_hidden_layers"]
+    split = mutils._prepare_moe_gguf_export_directory(path, model=model)
+    assert split == len(stacked_names)
+
+    rewritten = mx.load(str(path / "model-00001-of-00001.safetensors"))
+    assert not any(".switch_mlp." in name for name in rewritten)
+    assert "model.layers.0.mlp.experts.3.gate_proj.weight" in rewritten
+    index = json.loads((path / "model.safetensors.index.json").read_text())
+    assert set(index["weight_map"]) == set(rewritten)
+
+    # Replaying mlx-lm's own HF -> MLX map must land the rewritten names back on the
+    # exact tensors the model was saved from.
+    restored = model.sanitize(dict(rewritten))
+    for name in stacked_names:
+        assert bool(mx.array_equal(restored[name], staged[name])), name
+
+
+@metal_only
+def test_moe_staging_holds_no_more_shards_open_as_a_checkpoint_is_split(
+    monkeypatch, tmp_path
+):
+    import unsloth_zoo.mlx.utils as mutils
+
+    def descriptor_growth(shards):
+        path = tmp_path / f"merged-{shards}"
+        model, _ = _stage_merged_moe_model(path, shards=shards)
+        files = sorted(path.glob("*.safetensors"))
+        peak = before = len(os.listdir("/dev/fd"))
+        real_load = mutils.mx.load
+
+        def counting_load(*args, **kwargs):
+            nonlocal peak
+            loaded = real_load(*args, **kwargs)
+            peak = max(peak, len(os.listdir("/dev/fd")))
+            return loaded
+
+        monkeypatch.setattr(mutils.mx, "load", counting_load)
+        assert mutils._plan_mlx_moe_expert_unstacking(model, files)
+        monkeypatch.undo()
+        return peak - before
+
+    # A slope, not a ceiling: fixed loading and sampling cost cancels, so only
+    # retention that scales with the checkpoint shows. The small checkpoint goes
+    # first so warm-up lands in the baseline.
+    assert descriptor_growth(2) >= descriptor_growth(32)

--- a/tests/test_mlx_gguf_moe_export_metal.py
+++ b/tests/test_mlx_gguf_moe_export_metal.py
@@ -93,3 +93,40 @@ def test_moe_staging_holds_no_more_shards_open_as_a_checkpoint_is_split(
     # retention that scales with the checkpoint shows. The small checkpoint goes
     # first so warm-up lands in the baseline.
     assert descriptor_growth(2) >= descriptor_growth(32)
+
+
+STEP3P5_CONFIG = dict(
+    model_type="step3p5", vocab_size=256, hidden_size=64, intermediate_size=128,
+    moe_intermediate_size=32, num_hidden_layers=2, num_attention_heads=4,
+    num_key_value_heads=4, num_attention_groups=1, moe_num_experts=4, moe_top_k=2,
+    rms_norm_eps=1e-5, rope_theta=1e4, head_dim=16, max_position_embeddings=512,
+    share_expert_dim=32, moe_layers_enum="0,1", tie_word_embeddings=False,
+)
+
+
+@metal_only
+def test_moe_staging_recovers_names_a_real_sanitizer_only_renamed(tmp_path):
+    """step3p5 keeps its experts fused in HF and is renamed, never un-stacked."""
+    import unsloth_zoo.mlx.utils as mutils
+    from mlx_lm.models import step3p5
+
+    model = step3p5.Model(step3p5.ModelArgs.from_dict(STEP3P5_CONFIG))
+    staged = {n: t.astype(mx.bfloat16) for n, t in tree_flatten(model.parameters())}
+    mx.eval(*staged.values())
+    path = tmp_path / "merged"
+    path.mkdir()
+    mx.save_safetensors(str(path / "model.safetensors"), staged, {"format": "mlx"})
+
+    rewritten = mutils._prepare_moe_gguf_export_directory(path, model=model)
+    # Every MLX-only name, plus the norms whose stored value is one above the
+    # checkpoint convention llama.cpp reads.
+    assert rewritten == len([n for n in staged if ".mlp." in n or "norm" in n])
+
+    rewritten = mx.load(str(path / "model.safetensors"))
+    assert "model.layers.0.moe.gate_proj.weight" in rewritten
+    assert "model.layers.0.share_expert.down_proj.weight" in rewritten
+    # The expert tensors stay fused: llama.cpp reads them in exactly this shape.
+    assert rewritten["model.layers.0.moe.gate_proj.weight"].ndim == 3
+    restored = model.sanitize(dict(rewritten))
+    for name, tensor in staged.items():
+        assert bool(mx.array_equal(restored[name], tensor)), name

--- a/tests/test_mlx_gguf_moe_export_metal.py
+++ b/tests/test_mlx_gguf_moe_export_metal.py
@@ -14,9 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Real-runtime check that GGUF staging restores the per-expert tensor names a real
-mlx-lm MoE model was built from: llama.cpp cannot map MLX's stacked ``switch_mlp``
-parameters, so the staged directory has to carry the HF names."""
+"""Real-runtime check that GGUF staging restores the per-expert HF tensor names a real
+mlx-lm MoE model was built from: llama.cpp cannot map stacked ``switch_mlp``."""
 
 import json
 import os
@@ -75,7 +74,7 @@ def test_moe_staging_restores_names_mlx_sanitize_maps_back_bitwise(tmp_path):
     assert set(index["weight_map"]) == set(rewritten)
 
     # Replaying mlx-lm's own HF -> MLX map must land the rewritten names back on the
-    # exact tensors the model was saved from.
+    # tensors the model was saved from.
     restored = model.sanitize(dict(rewritten))
     for name in stacked_names:
         assert _bytes_identical(restored[name], staged[name]), name
@@ -105,9 +104,8 @@ def test_moe_staging_holds_no_more_shards_open_as_a_checkpoint_is_split(
         monkeypatch.undo()
         return peak - before
 
-    # A slope, not a ceiling: fixed loading and sampling cost cancels, so only
-    # retention that scales with the checkpoint shows. The small checkpoint goes
-    # first so warm-up lands in the baseline.
+    # A slope, not a ceiling: fixed cost cancels, so only retention that scales with
+    # the checkpoint shows. Small checkpoint first, so warm-up lands in the baseline.
     assert descriptor_growth(2) >= descriptor_growth(32)
 
 

--- a/tests/test_mlx_moe_gguf_export_invariants.py
+++ b/tests/test_mlx_moe_gguf_export_invariants.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Invariants the MoE GGUF staging pass has to hold whatever it is handed.
 
 The pass in `unsloth_zoo/mlx/utils.py` rewrites a staged checkpoint in place, so the

--- a/tests/test_mlx_moe_gguf_export_invariants.py
+++ b/tests/test_mlx_moe_gguf_export_invariants.py
@@ -355,3 +355,54 @@ def test_a_merge_survives_a_sanitizer_that_offsets_a_norm_in_place(tmp_path):
 
     assert mutils._prepare_moe_gguf_export_directory(path, model=model) > 0
     assert sorted(_staged(path)) == sorted(model.checkpoint)
+
+
+def test_a_layout_the_vlm_pass_already_inverted_is_not_inverted_again(
+    tmp_path, monkeypatch
+):
+    """The two passes run back to back over one directory, so the second reads what the
+    first wrote. An adjacent-axis move is its own inverse, so a second inversion replays
+    to exactly what is on disk and the confirmation accepts it: the tensor would ship
+    transposed off the HF layout llama.cpp reads. `depthwise_conv1d.weight` is the shape
+    both passes claim (_vlm_gguf_tensor_candidates transposes (0, 2, 1); (2, 1) is in
+    _MOE_TENSOR_LAYOUTS)."""
+    import json
+
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    name = "vision_tower.depthwise_conv1d.weight"
+    hf = mx.reshape(mx.arange(2 * 3 * 4, dtype=mx.float32), (2, 3, 4))
+
+    class Model:
+        @staticmethod
+        def sanitize(weights):
+            return {n: (mx.moveaxis(t, 2, 1) if getattr(t, "ndim", 0) == 3 else t)
+                    for n, t in weights.items()}
+
+        def named_modules(self):
+            yield "", self
+
+    model = Model()
+    path = tmp_path / "merged"
+    path.mkdir()
+    (path / "config.json").write_text(json.dumps({"model_type": "fake_vlm"}))
+    mx.save_safetensors(str(path / "model-00001-of-00001.safetensors"),
+                        {name: Model.sanitize({name: hf})[name]},
+                        metadata={"format": "mlx"})
+    (path / "model.safetensors.index.json").write_text(json.dumps(
+        {"weight_map": {name: "model-00001-of-00001.safetensors"}}))
+    monkeypatch.setattr(mutils, "_build_mlx_vlm_sanitize_pipelines",
+                        lambda config, model=None: [[(Model, None)]])
+
+    norm_offsets = mutils._mlx_sanitizer_norm_offsets(model)
+    relaid_out = set()
+    assert mutils._prepare_mlx_gguf_export_directory(
+        path, model=model, replay_sanitizers=True, norm_offsets=norm_offsets,
+        relaid_out=relaid_out) == 1
+    assert relaid_out == {name}
+    assert mutils._prepare_moe_gguf_export_directory(
+        path, model=model, source_norm_offsets=norm_offsets,
+        source_layouts=relaid_out) == 0
+
+    assert mutils._mlx_arrays_match(_staged(path)[name], hf)

--- a/tests/test_mlx_moe_gguf_export_invariants.py
+++ b/tests/test_mlx_moe_gguf_export_invariants.py
@@ -14,17 +14,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Invariants the MoE GGUF staging pass has to hold whatever it is handed.
-
-The pass in `unsloth_zoo/mlx/utils.py` rewrites a staged checkpoint in place, so the
-properties that matter are not "does it recover this architecture" -- the suite beside
-this one covers that -- but "what does it do to a directory it cannot help", "does it
-give the same answer twice", and "is what it wrote the checkpoint the model was saved
-from rather than merely something the sanitizer accepts".
-
-Every fixture here is synthetic and runs on `tests/mlx_simulation/`, so the file needs
-no mlx and no Apple hardware.
-"""
+"""Invariants the MoE GGUF staging pass holds whatever it is handed: what it does to a
+directory it cannot help, whether it answers twice alike, and whether what it wrote is
+the checkpoint the model was saved from and not merely something sanitize() accepts.
+Synthetic fixtures on `tests/mlx_simulation/`, so no mlx and no Apple hardware."""
 
 import copy
 import hashlib
@@ -62,9 +55,6 @@ def _staged(path):
         for file in sorted(path.glob("*.safetensors"))
         for name, tensor in mutils.mx.load(str(file)).items()
     }
-
-
-# --- what it does to a directory it cannot help -------------------------------------
 
 
 def test_a_refused_confirmation_writes_nothing(tmp_path, monkeypatch):
@@ -129,9 +119,6 @@ def test_an_empty_directory_is_not_a_crash(tmp_path):
     assert list(path.iterdir()) == []
 
 
-# --- what it does to a checkpoint that already works --------------------------------
-
-
 @pytest.mark.parametrize("shards", [1, 2, 5])
 def test_a_model_whose_sanitizer_rewrites_nothing_is_byte_identical(tmp_path, shards):
     """Dense exports pay a scan and nothing else: no shard and no index may move."""
@@ -180,9 +167,6 @@ def test_the_pass_leaves_the_model_it_was_given_as_it_found_it(tmp_path):
     assert set(model.expected) == set(before_expected)
     for name, tensor in before_expected.items():
         assert mutils._mlx_arrays_match(model.expected[name], tensor), name
-
-
-# --- what it wrote ------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("shards", [1, 2, 3, 5, 7])
@@ -240,9 +224,8 @@ def test_no_stacked_expert_name_survives_the_pass(tmp_path):
 
 
 def test_a_single_expert_checkpoint_is_refused_rather_than_half_recovered(tmp_path):
-    """One expert leaves the stack ambiguous, and the pass declines it. The export is
-    then exactly what it is without this pass, which is the contract; recovering it
-    would be an improvement, not a fix."""
+    """One expert leaves the stack ambiguous, so the pass declines: the export is then
+    exactly what it is without this pass, which is the contract."""
     import unsloth_zoo.mlx.utils as mutils
 
     reg = _regressions()
@@ -259,9 +242,8 @@ def test_a_single_expert_checkpoint_is_refused_rather_than_half_recovered(tmp_pa
 def test_the_recovered_checkpoint_is_the_one_the_model_was_saved_from(
     tmp_path, num_experts, with_bias
 ):
-    """The oracle: a preimage the sanitizer accepts is not enough, it has to be *the*
-    preimage. Sanitizing the recovered directory has to return the staged tensors, and
-    the recovered names have to be the per-expert HF ones the converter reads."""
+    """The oracle: any preimage sanitize() accepts is not enough, it has to be *the*
+    preimage, under the per-expert HF names the converter reads."""
     import unsloth_zoo.mlx.utils as mutils
 
     reg = _regressions()
@@ -284,15 +266,9 @@ def test_the_recovered_checkpoint_is_the_one_the_model_was_saved_from(
 
 
 def test_a_helper_called_from_inside_a_comprehension_is_still_read():
-    """The vocabulary walk must not depend on the interpreter.
-
-    Before 3.12 a comprehension compiles to its own code object, so a helper called
-    from inside one is absent from the enclosing `co_names`; 3.12 inlines it and the
-    same sanitizer reads differently. pyproject supports 3.9 upwards, and a sanitizer
-    spelling its rename in a dict comprehension is the ordinary shape, so a walk that
-    stops at the comprehension quietly recovers fewer architectures on the older
-    interpreters than the newer ones.
-    """
+    """The vocabulary walk must not depend on the interpreter: before PEP 709 (3.12) a
+    comprehension compiles to its own code object, so a helper called from inside one --
+    the ordinary shape for a rename -- is absent from the enclosing `co_names`."""
     import unsloth_zoo.mlx.utils as mutils
 
     class Model:
@@ -337,12 +313,10 @@ def test_experts_come_back_in_the_order_the_sanitizer_stacked_them(tmp_path):
 def test_a_merge_survives_a_sanitizer_that_offsets_a_norm_in_place(tmp_path):
     """mlx-vlm's Qwen3.5-VL-MoE splits `experts.gate_up_proj` into two `switch_mlp`
     tensors and offsets a 1-D norm with `+=` in the same sanitize
-    (mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py:38-48 and :89). Under mlx that `+=`
-    reassigns the caller's own array descriptor, so a probe handed straight to the
-    sanitizer is written through. The merge proof's floor probe shares its marker
-    objects with the set it later compares, so measuring the floor without a copy put
-    it one offset ahead of every recipe and no merge was ever proved: the export kept
-    the MLX spelling llama.cpp cannot map.
+    (mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py:38-48 and :89), writing through to the
+    caller's array. The merge proof's floor probe shares marker objects with the set it
+    compares, so an uncopied floor sat one offset ahead of every recipe, no merge was
+    ever proved, and the export kept the MLX spelling llama.cpp cannot map.
     """
     import unsloth_zoo.mlx.utils as mutils
 

--- a/tests/test_mlx_moe_gguf_export_invariants.py
+++ b/tests/test_mlx_moe_gguf_export_invariants.py
@@ -267,6 +267,37 @@ def test_the_recovered_checkpoint_is_the_one_the_model_was_saved_from(
         assert mutils._mlx_arrays_match(replayed[name], tensor), name
 
 
+def test_a_helper_called_from_inside_a_comprehension_is_still_read():
+    """The vocabulary walk must not depend on the interpreter.
+
+    Before 3.12 a comprehension compiles to its own code object, so a helper called
+    from inside one is absent from the enclosing `co_names`; 3.12 inlines it and the
+    same sanitizer reads differently. pyproject supports 3.9 upwards, and a sanitizer
+    spelling its rename in a dict comprehension is the ordinary shape, so a walk that
+    stops at the comprehension quietly recovers fewer architectures on the older
+    interpreters than the newer ones.
+    """
+    import unsloth_zoo.mlx.utils as mutils
+
+    class Model:
+        def sanitize(self, weights):
+            return _renamed_through_a_comprehension(weights)
+
+    vocabulary = mutils._mlx_sanitizer_vocabulary(mutils._mlx_moe_sanitizers(Model()))
+    assert "model.layers." in vocabulary
+    assert "language_model.model.layers." in vocabulary
+
+
+def _renamed_through_a_comprehension(weights):
+    # The call this test is about: reached only from inside the comprehension.
+    return {_a_spelling_only_the_helper_holds(name): tensor
+            for name, tensor in weights.items()}
+
+
+def _a_spelling_only_the_helper_holds(name):
+    return name.replace("model.layers.", "language_model.model.layers.")
+
+
 def test_experts_come_back_in_the_order_the_sanitizer_stacked_them(tmp_path):
     """Expert 3's weights must be expert 3's, not expert 0's: a permutation replays
     identically only if the sanitizer's own order is reproduced."""

--- a/tests/test_mlx_moe_gguf_export_invariants.py
+++ b/tests/test_mlx_moe_gguf_export_invariants.py
@@ -1,0 +1,287 @@
+"""Invariants the MoE GGUF staging pass has to hold whatever it is handed.
+
+The pass in `unsloth_zoo/mlx/utils.py` rewrites a staged checkpoint in place, so the
+properties that matter are not "does it recover this architecture" -- the suite beside
+this one covers that -- but "what does it do to a directory it cannot help", "does it
+give the same answer twice", and "is what it wrote the checkpoint the model was saved
+from rather than merely something the sanitizer accepts".
+
+Every fixture here is synthetic and runs on `tests/mlx_simulation/`, so the file needs
+no mlx and no Apple hardware.
+"""
+
+import copy
+import hashlib
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_torch_shim():
+    pytest.importorskip("torch")
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+def _digest(path):
+    """Every file in the staging directory, by content."""
+    return {
+        file.name: hashlib.sha256(file.read_bytes()).hexdigest()
+        for file in sorted(path.iterdir())
+    }
+
+
+def _regressions():
+    """The neighbouring suite's model and staging fixtures."""
+    import test_mlx_save_export_regressions as module
+    return module
+
+
+def _staged(path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    return {
+        name: tensor
+        for file in sorted(path.glob("*.safetensors"))
+        for name, tensor in mutils.mx.load(str(file)).items()
+    }
+
+
+# --- what it does to a directory it cannot help -------------------------------------
+
+
+def test_a_refused_confirmation_writes_nothing(tmp_path, monkeypatch):
+    """The whole-directory proof is the last gate before any file is touched."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model()
+    # Unpatched, this fixture is one the pass does rewrite.
+    rewritten = reg._stage_moe_directory(tmp_path / "rewritten", model, shards=2)
+    assert mutils._prepare_moe_gguf_export_directory(rewritten, model=model) > 0
+
+    refused = reg._stage_moe_directory(tmp_path / "refused", model, shards=2)
+    before = _digest(refused)
+    monkeypatch.setattr(mutils, "_confirmed_mlx_moe_rewrite", lambda *a, **k: False)
+    assert mutils._prepare_moe_gguf_export_directory(refused, model=model) == 0
+    assert _digest(refused) == before
+
+
+@pytest.mark.parametrize("failure", ["raises", "returns_none", "returns_a_list"])
+def test_a_broken_sanitizer_is_refused_not_obeyed(tmp_path, failure):
+    """A sanitizer that cannot be replayed leaves the directory exactly as staged."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model()
+    path = reg._stage_moe_directory(tmp_path, model, shards=2)
+    before = _digest(path)
+
+    def broken(weights):
+        if failure == "raises":
+            raise RuntimeError("this sanitizer is not replayable")
+        return None if failure == "returns_none" else list(weights)
+
+    type(model).sanitize = staticmethod(broken)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert _digest(path) == before
+
+
+@pytest.mark.parametrize("model", [None, object()])
+def test_a_model_the_pass_cannot_read_is_not_a_crash(tmp_path, model):
+    """`save_pretrained_gguf` calls this unconditionally, so it must tolerate anything."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    staged = reg._make_moe_model()
+    path = reg._stage_moe_directory(tmp_path, staged, shards=2)
+    before = _digest(path)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert _digest(path) == before
+
+
+def test_an_empty_directory_is_not_a_crash(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    path = tmp_path / "empty"
+    path.mkdir()
+    assert mutils._prepare_moe_gguf_export_directory(
+        path, model=reg._make_moe_model()
+    ) == 0
+    assert list(path.iterdir()) == []
+
+
+# --- what it does to a checkpoint that already works --------------------------------
+
+
+@pytest.mark.parametrize("shards", [1, 2, 5])
+def test_a_model_whose_sanitizer_rewrites_nothing_is_byte_identical(tmp_path, shards):
+    """Dense exports pay a scan and nothing else: no shard and no index may move."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model(stacks=False)
+    path = reg._stage_moe_directory(tmp_path, model, shards=shards)
+    before, index_before = _digest(path), (
+        path / "model.safetensors.index.json").read_text()
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert _digest(path) == before
+    assert (path / "model.safetensors.index.json").read_text() == index_before
+
+
+def test_a_second_pass_over_a_rewritten_directory_changes_nothing(tmp_path):
+    """Restoring names twice must not restore them twice over."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model()
+    path = reg._stage_moe_directory(tmp_path, model, shards=2)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) > 0
+    once = _digest(path)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert _digest(path) == once
+
+
+def test_the_pass_leaves_the_model_it_was_given_as_it_found_it(tmp_path):
+    """Replay runs on the live trained model, thousands of times, during planning."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model()
+    path = reg._stage_moe_directory(tmp_path, model, shards=2)
+    before_attributes = dict(vars(model))
+    before_modules = dict(model.switch_modules)
+    before_expected = copy.copy(model.expected)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) > 0
+
+    assert set(vars(model)) == set(before_attributes)
+    assert model.switch_modules == before_modules
+    assert set(model.expected) == set(before_expected)
+    for name, tensor in before_expected.items():
+        assert mutils._mlx_arrays_match(model.expected[name], tensor), name
+
+
+# --- what it wrote ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shards", [1, 2, 3, 5, 7])
+def test_the_result_does_not_depend_on_how_the_checkpoint_was_split(tmp_path, shards):
+    """Sharding is a storage detail; the recovered checkpoint must not see it."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model()
+    single = reg._stage_moe_directory(tmp_path / "one", model, shards=1)
+    mutils._prepare_moe_gguf_export_directory(single, model=model)
+    expected = _staged(single)
+
+    path = reg._stage_moe_directory(tmp_path / f"split{shards}", model, shards=shards)
+    mutils._prepare_moe_gguf_export_directory(path, model=model)
+    got = _staged(path)
+
+    assert set(got) == set(expected)
+    for name, tensor in expected.items():
+        assert mutils._mlx_arrays_match(got[name], tensor), name
+
+
+@pytest.mark.parametrize("shards", [1, 2, 3])
+def test_the_index_still_describes_the_directory_it_indexes(tmp_path, shards):
+    """A GGUF converter reads the index first; a name it lists must be findable."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model()
+    path = reg._stage_moe_directory(tmp_path, model, shards=shards)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) > 0
+
+    weight_map = json.loads(
+        (path / "model.safetensors.index.json").read_text())["weight_map"]
+    shard_names = {
+        file.name: set(mutils.mx.load(str(file)))
+        for file in sorted(path.glob("*.safetensors"))
+    }
+    assert set(weight_map) == set().union(*shard_names.values())
+    for name, file in weight_map.items():
+        assert name in shard_names[file], f"{name} is not in {file}"
+
+
+def test_no_stacked_expert_name_survives_the_pass(tmp_path):
+    """The whole point: llama.cpp has no mapping for a `switch_mlp` tensor."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model()
+    path = reg._stage_moe_directory(tmp_path, model, shards=2)
+    assert any(".switch_mlp." in name for name in _staged(path))
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) > 0
+    assert not any(".switch_mlp." in name for name in _staged(path))
+
+
+def test_a_single_expert_checkpoint_is_refused_rather_than_half_recovered(tmp_path):
+    """One expert leaves the stack ambiguous, and the pass declines it. The export is
+    then exactly what it is without this pass, which is the contract; recovering it
+    would be an improvement, not a fix."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model(num_experts=1)
+    path = reg._stage_moe_directory(tmp_path, model, shards=2)
+    before = _digest(path)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert _digest(path) == before
+
+
+@pytest.mark.parametrize("num_experts", [2, 3, 16])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_the_recovered_checkpoint_is_the_one_the_model_was_saved_from(
+    tmp_path, num_experts, with_bias
+):
+    """The oracle: a preimage the sanitizer accepts is not enough, it has to be *the*
+    preimage. Sanitizing the recovered directory has to return the staged tensors, and
+    the recovered names have to be the per-expert HF ones the converter reads."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model(num_experts=num_experts, with_bias=with_bias)
+    path = reg._stage_moe_directory(tmp_path, model, shards=2)
+    staged = _staged(path)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) > 0
+    recovered = _staged(path)
+
+    for layer in range(2):
+        for leaf in ("gate_proj", "up_proj", "down_proj"):
+            for expert in range(num_experts):
+                name = f"model.layers.{layer}.mlp.experts.{expert}.{leaf}.weight"
+                assert name in recovered, name
+
+    replayed = model.sanitize(dict(recovered))
+    for name, tensor in staged.items():
+        assert mutils._mlx_arrays_match(replayed[name], tensor), name
+
+
+def test_experts_come_back_in_the_order_the_sanitizer_stacked_them(tmp_path):
+    """Expert 3's weights must be expert 3's, not expert 0's: a permutation replays
+    identically only if the sanitizer's own order is reproduced."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    reg = _regressions()
+    model = reg._make_moe_model(num_experts=3)
+    path = reg._stage_moe_directory(tmp_path, model, shards=1)
+    stacked = dict(_staged(path))
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) > 0
+    recovered = _staged(path)
+
+    for layer in range(2):
+        for leaf in ("gate_proj", "up_proj", "down_proj"):
+            source = stacked[f"model.layers.{layer}.mlp.switch_mlp.{leaf}.weight"]
+            for expert in range(3):
+                name = f"model.layers.{layer}.mlp.experts.{expert}.{leaf}.weight"
+                assert mutils._mlx_arrays_match(recovered[name], source[expert]), name

--- a/tests/test_mlx_moe_gguf_export_invariants.py
+++ b/tests/test_mlx_moe_gguf_export_invariants.py
@@ -357,22 +357,25 @@ def test_a_merge_survives_a_sanitizer_that_offsets_a_norm_in_place(tmp_path):
     assert sorted(_staged(path)) == sorted(model.checkpoint)
 
 
+@pytest.mark.parametrize("shape", [(2, 3, 4), (2, 3, 3)])
 def test_a_layout_the_vlm_pass_already_inverted_is_not_inverted_again(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, shape
 ):
     """The two passes run back to back over one directory, so the second reads what the
     first wrote. An adjacent-axis move is its own inverse, so a second inversion replays
     to exactly what is on disk and the confirmation accepts it: the tensor would ship
     transposed off the HF layout llama.cpp reads. `depthwise_conv1d.weight` is the shape
     both passes claim (_vlm_gguf_tensor_candidates transposes (0, 2, 1); (2, 1) is in
-    _MOE_TENSOR_LAYOUTS)."""
+    _MOE_TENSOR_LAYOUTS). The equal-extent shape is the one a shape comparison cannot
+    see: the axes swap, the shape does not."""
     import json
 
     import unsloth_zoo.mlx.utils as mutils
 
     mx = mutils.mx
     name = "vision_tower.depthwise_conv1d.weight"
-    hf = mx.reshape(mx.arange(2 * 3 * 4, dtype=mx.float32), (2, 3, 4))
+    size = shape[0] * shape[1] * shape[2]
+    hf = mx.reshape(mx.arange(size, dtype=mx.float32), shape)
 
     class Model:
         @staticmethod

--- a/tests/test_mlx_moe_gguf_export_invariants.py
+++ b/tests/test_mlx_moe_gguf_export_invariants.py
@@ -316,3 +316,52 @@ def test_experts_come_back_in_the_order_the_sanitizer_stacked_them(tmp_path):
             for expert in range(3):
                 name = f"model.layers.{layer}.mlp.experts.{expert}.{leaf}.weight"
                 assert mutils._mlx_arrays_match(recovered[name], source[expert]), name
+
+
+def test_a_merge_survives_a_sanitizer_that_offsets_a_norm_in_place(tmp_path):
+    """mlx-vlm's Qwen3.5-VL-MoE splits `experts.gate_up_proj` into two `switch_mlp`
+    tensors and offsets a 1-D norm with `+=` in the same sanitize
+    (mlx_vlm/models/qwen3_5_moe/qwen3_5_moe.py:38-48 and :89). Under mlx that `+=`
+    reassigns the caller's own array descriptor, so a probe handed straight to the
+    sanitizer is written through. The merge proof's floor probe shares its marker
+    objects with the set it later compares, so measuring the floor without a copy put
+    it one offset ahead of every recipe and no merge was ever proved: the export kept
+    the MLX spelling llama.cpp cannot map.
+    """
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class Model:
+        def __init__(self):
+            self.checkpoint = {
+                "model.layers.0.mlp.fused.weight":
+                    mx.reshape(mx.arange(8, dtype=mx.float32), (4, 2)),
+                "model.layers.0.post_attention_layernorm.weight":
+                    mx.arange(2, dtype=mx.float32) + 5.0,
+            }
+            self.expected = self.sanitize(dict(self.checkpoint))
+
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            out = {}
+            for name, tensor in weights.items():
+                if "fused" in name:
+                    for leaf, half in zip(("left", "right"),
+                                          mx.split(tensor, 2, axis=0)):
+                        out[name.replace("fused", leaf)] = half
+                else:
+                    out[name] = tensor
+            for name in list(out):
+                if name.endswith("layernorm.weight") and out[name].ndim == 1:
+                    out[name] += 1.0
+            return out
+
+    reg = _regressions()
+    model = Model()
+    path = reg._stage_moe_directory(tmp_path, model, shards=1)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) > 0
+    assert sorted(_staged(path)) == sorted(model.checkpoint)

--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -16,6 +16,12 @@ import threading
 import types
 from pathlib import Path, PureWindowsPath
 
+# `os.geteuid` is POSIX-only and these decorators run at collection time, so a
+# bare call takes the whole module out on Windows (tests/test_llama_cpp_prebuilt.py:30
+# guards the same way).
+IS_POSIX = os.name == "posix"
+
+
 import pytest
 import torch
 
@@ -658,7 +664,8 @@ def test_sidecars_unicode_names_and_spaces_in_paths(tmp_path):
     assert (dst / "tokenizer_配置.json").exists()
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="permission checks no-op as root")
+@pytest.mark.skipif(not IS_POSIX or os.geteuid() == 0,
+                    reason="permission checks no-op as root / non-POSIX")
 def test_sidecars_unreadable_source_propagates_loudly(tmp_path):
     import unsloth_zoo.mlx.utils as mutils
 
@@ -723,7 +730,8 @@ def test_read_json_file_directory_path_returns_empty(tmp_path):
     assert loader._read_json_file(tmp_path) == {}
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="permission checks no-op as root")
+@pytest.mark.skipif(not IS_POSIX or os.geteuid() == 0,
+                    reason="permission checks no-op as root / non-POSIX")
 def test_read_json_file_permission_error_returns_empty(tmp_path):
     import unsloth_zoo.mlx.loader as loader
 
@@ -1112,13 +1120,14 @@ def _gguf_export_scaffold(
     monkeypatch.setattr(
         mutils,
         "_prepare_mlx_gguf_export_directory",
-        lambda path, model=None, replay_sanitizers=True, norm_offsets=None: 0,
+        lambda path, model=None, replay_sanitizers=True, norm_offsets=None,
+               relaid_out=None: 0,
     )
     # The MoE pass also runs on every export, and this scaffold has no shards for it.
     monkeypatch.setattr(
         mutils,
         "_prepare_moe_gguf_export_directory",
-        lambda path, model=None, source_norm_offsets=None: 0,
+        lambda path, model=None, source_norm_offsets=None, source_layouts=(): 0,
     )
     monkeypatch.setattr(llama_cpp, "LLAMA_CPP_DEFAULT_DIR", str(tmp_path / "unused"))
     monkeypatch.setattr(

--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -1114,8 +1114,7 @@ def _gguf_export_scaffold(
         "_prepare_mlx_gguf_export_directory",
         lambda path, model=None, replay_sanitizers=True, norm_offsets=None: 0,
     )
-    # The MoE pass runs beside the one above on every export, and this scaffold's
-    # directory holds none of the shards it would read.
+    # The MoE pass also runs on every export, and this scaffold has no shards for it.
     monkeypatch.setattr(
         mutils,
         "_prepare_moe_gguf_export_directory",

--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -1112,7 +1112,14 @@ def _gguf_export_scaffold(
     monkeypatch.setattr(
         mutils,
         "_prepare_mlx_gguf_export_directory",
-        lambda path, model=None, replay_sanitizers=True: 0,
+        lambda path, model=None, replay_sanitizers=True, norm_offsets=None: 0,
+    )
+    # The MoE pass runs beside the one above on every export, and this scaffold's
+    # directory holds none of the shards it would read.
+    monkeypatch.setattr(
+        mutils,
+        "_prepare_moe_gguf_export_directory",
+        lambda path, model=None, source_norm_offsets=None: 0,
     )
     monkeypatch.setattr(llama_cpp, "LLAMA_CPP_DEFAULT_DIR", str(tmp_path / "unused"))
     monkeypatch.setattr(

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -3513,3 +3513,296 @@ def test_trusted_dir_matches_every_llama_cpp_default_dir_spelling(monkeypatch, t
             folder = value  # exactly what LLAMA_CPP_DEFAULT_DIR would hold
         assert _trusted(monkeypatch, folder, home, env_value=value) is True, \
             f"UNSLOTH_LLAMA_CPP_PATH={value!r} should stay trusted"
+
+def _make_moe_model(container="switch_mlp", group="experts", leaf_alias=None,
+                    wrap_in_lora=False, reverse_experts=False, stacks=True,
+                    with_bias=False, rename_leaves=None, hf_parent="mlp",
+                    num_experts=3, num_layers=2):
+    """A minimal MLX-shaped MoE model whose sanitize stacks per-expert weights."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    leaf_alias = leaf_alias or {}
+    leaves = ("gate_proj", "up_proj", "down_proj")
+    params = ("weight", "bias") if with_bias else ("weight",)
+
+    def marked(marker, *shape):
+        size = num_experts
+        for dim in shape:
+            size *= dim
+        return marker + mx.reshape(
+            mx.arange(size, dtype=mx.float32), (num_experts, *shape)
+        )
+
+    class SwitchLinear:
+        def __init__(self, marker):
+            self.weight = marked(marker, 4, 2)
+            if with_bias:
+                self.bias = marked(marker, 4)
+
+        @property
+        def num_experts(self):
+            return self.weight.shape[0]
+
+    class LoraWrapper:
+        def __init__(self, linear):
+            self.linear = linear
+
+    class Model:
+        def __init__(self):
+            self.switch_modules = {}
+            self.expected = {}
+            for layer in range(num_layers):
+                for offset, leaf in enumerate(leaves):
+                    path = f"model.layers.{layer}.mlp.{container}.{leaf}"
+                    module = SwitchLinear(10 * layer + offset)
+                    self.switch_modules[path] = module
+                    for param in params:
+                        self.expected[f"{path}.{param}"] = getattr(module, param)
+
+        def named_modules(self):
+            yield "", self
+            for path, module in self.switch_modules.items():
+                if wrap_in_lora:
+                    yield path, LoraWrapper(module)
+                    yield f"{path}.linear", module
+                else:
+                    yield path, module
+
+        def sanitize(self, weights):
+            if not stacks:
+                return weights
+            for legacy, canonical in (rename_leaves or {}).items():
+                for old in [n for n in weights if f".{legacy}." in n]:
+                    new = old.replace(f".{legacy}.", f".{canonical}.")
+                    weights[new] = weights.pop(old)
+            for layer in range(num_layers):
+                prefix = f"model.layers.{layer}.mlp"
+                source_prefix = f"model.layers.{layer}.{hf_parent}"
+                for leaf in leaves:
+                    source = leaf_alias.get(leaf, leaf)
+                    for param in params:
+                        keys = [
+                            f"{source_prefix}.{group}.{expert}.{source}.{param}"
+                            for expert in range(num_experts)
+                        ]
+                        if not all(key in weights for key in keys):
+                            continue
+                        joined = [weights.pop(key) for key in keys]
+                        if reverse_experts:
+                            joined.reverse()
+                        weights[f"{prefix}.{container}.{leaf}.{param}"] = mx.stack(
+                            joined
+                        )
+            return weights
+
+    return Model()
+
+
+def _stage_moe_directory(tmp_path, model, shards=1):
+    import unsloth_zoo.mlx.utils as mutils
+
+    path = tmp_path / "merged"
+    path.mkdir(exist_ok=True)
+    names = sorted(model.expected)
+    weight_map = {}
+    for shard in range(shards):
+        part = {
+            name: model.expected[name]
+            for index, name in enumerate(names)
+            if index % shards == shard
+        }
+        file = f"model-{shard + 1:05d}-of-{shards:05d}.safetensors"
+        mutils.mx.save_safetensors(str(path / file), part, metadata={"format": "mlx"})
+        weight_map.update({name: file for name in part})
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map})
+    )
+    return path
+
+
+def _staged_shards(path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    return {f.name: mutils.mx.load(str(f)) for f in sorted(path.glob("*.safetensors"))}
+
+
+def _staged_tensors(path):
+    return {n: t for shard in _staged_shards(path).values() for n, t in shard.items()}
+
+
+def test_moe_gguf_export_splits_stacked_experts_into_hf_tensors(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_moe_model()
+    path = _stage_moe_directory(tmp_path, model)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
+
+    tensors = _staged_tensors(path)
+    assert not any(".switch_mlp." in name for name in tensors)
+    for stacked_name, stacked in model.expected.items():
+        prefix, leaf = stacked_name.split(".switch_mlp.")
+        leaf = leaf.removesuffix(".weight")
+        for expert in range(stacked.shape[0]):
+            assert mutils._mlx_arrays_match(
+                tensors[f"{prefix}.experts.{expert}.{leaf}.weight"], stacked[expert]
+            )
+
+    index = json.loads((path / "model.safetensors.index.json").read_text())
+    assert set(index["weight_map"]) == set(tensors)
+
+
+def test_moe_gguf_export_splits_sharded_experts_and_biases(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_moe_model(with_bias=True, num_layers=4)
+    path = _stage_moe_directory(tmp_path, model, shards=3)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 24
+
+    shards = _staged_shards(path)
+    assert len(shards) == 3
+    tensors = _staged_tensors(path)
+    assert mutils._mlx_arrays_match(
+        tensors["model.layers.3.mlp.experts.2.up_proj.bias"],
+        model.expected["model.layers.3.mlp.switch_mlp.up_proj.bias"][2],
+    )
+    # Every rewritten tensor has to be indexed to the shard that now holds it.
+    weight_map = json.loads((path / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    assert set(weight_map) == set(tensors)
+    assert all(name in shards[shard] for name, shard in weight_map.items())
+
+
+@pytest.mark.parametrize(
+    ("model_kwargs", "restored_name"),
+    [
+        ({"container": "experts"}, "model.layers.1.mlp.experts.2.down_proj.weight"),
+        ({"leaf_alias": {"gate_proj": "w1", "down_proj": "w2", "up_proj": "w3"}},
+         "model.layers.1.mlp.experts.2.w2.weight"),
+        ({"group": "mlp"}, "model.layers.1.mlp.mlp.2.down_proj.weight"),
+        # LFM2 renames w1/w2/w3 to gate/down/up before stacking, so both namings
+        # replay cleanly; only the legacy one names tensors llama.cpp reads.
+        ({"rename_leaves": {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}},
+         "model.layers.1.mlp.experts.2.w2.weight"),
+    ],
+)
+def test_moe_gguf_export_recovers_expert_naming_conventions(
+    tmp_path, model_kwargs, restored_name
+):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_moe_model(**model_kwargs)
+    container = model_kwargs.get("container", "switch_mlp")
+    path = _stage_moe_directory(tmp_path, model)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
+    assert mutils._mlx_arrays_match(
+        _staged_tensors(path)[restored_name],
+        model.expected[f"model.layers.1.mlp.{container}.down_proj.weight"][2],
+    )
+
+
+def test_moe_gguf_export_finds_switch_modules_behind_lora_wrappers(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_moe_model(wrap_in_lora=True)
+    path = _stage_moe_directory(tmp_path, model)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
+    assert mutils._mlx_arrays_match(
+        _staged_tensors(path)["model.layers.1.mlp.experts.1.up_proj.weight"],
+        model.expected["model.layers.1.mlp.switch_mlp.up_proj.weight"][1],
+    )
+
+
+@pytest.mark.parametrize(
+    "model_kwargs",
+    [{"stacks": False}, {"reverse_experts": True}, {"hf_parent": "block_sparse_moe"}],
+)
+def test_moe_gguf_export_leaves_unrecoverable_expert_layouts_untouched(
+    tmp_path, model_kwargs
+):
+    # Llama 4 stacks its experts in HF too and llama.cpp maps that layout
+    # already, so a layout we cannot invert has to survive exactly as saved.
+    # Kimi Linear reads block_sparse_moe.experts and writes mlp.switch_mlp; a
+    # relocated parent module is not recoverable from the stacked name.
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_moe_model(**model_kwargs)
+    path = _stage_moe_directory(tmp_path, model)
+    before = (path / "model-00001-of-00001.safetensors").read_bytes()
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
+
+
+def test_moe_gguf_export_leaves_models_without_stacked_experts_alone(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    class Conv:
+        def __init__(self, weight):
+            self.weight = weight
+
+    class Model:
+        def __init__(self):
+            weight = mutils.mx.zeros((4, 2, 3))
+            self.conv = Conv(weight)
+            self.expected = {"vision_tower.patch_embed.proj.weight": weight}
+
+        def named_modules(self):
+            yield "", self
+            yield "vision_tower.patch_embed.proj", self.conv
+
+    model = Model()
+    path = _stage_moe_directory(tmp_path, model)
+    before = (path / "model-00001-of-00001.safetensors").read_bytes()
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
+
+
+def test_save_pretrained_gguf_hands_the_converter_per_expert_moe_tensors(
+    monkeypatch, tmp_path
+):
+    import unsloth_zoo.llama_cpp as llama_cpp
+    import unsloth_zoo.mlx.utils as mutils
+
+    monkeypatch.setitem(sys.modules, "gguf", types.ModuleType("gguf"))
+
+    llama_root = tmp_path / "llama.cpp"
+    llama_root.mkdir()
+    for name in ("convert_hf_to_gguf.py", "llama-quantize"):
+        (llama_root / name).write_text("# stub", encoding="utf-8")
+    converted = {}
+
+    def fake_save_merged_model(model, tokenizer, path, dequantize=False):
+        _stage_moe_directory(Path(path).parent, model).rename(path)
+        (Path(path) / "config.json").write_text("{}", encoding="utf-8")
+
+    def fake_convert_to_gguf(**kwargs):
+        converted["tensors"] = sorted(_staged_tensors(Path(kwargs["input_folder"])))
+        Path(f"{kwargs['model_name']}.F16.gguf").write_bytes(b"GGUF")
+
+    converter = str(llama_root / "convert_hf_to_gguf.py")
+    monkeypatch.setattr(mutils, "save_merged_model", fake_save_merged_model)
+    monkeypatch.setattr(mutils, "_is_vlm_model", lambda model: False)
+    monkeypatch.setattr(llama_cpp, "LLAMA_CPP_DEFAULT_DIR", str(llama_root))
+    monkeypatch.setattr(llama_cpp, "check_llama_cpp",
+        lambda folder: (str(llama_root / "llama-quantize"), converter))
+    monkeypatch.setattr(llama_cpp, "_download_convert_hf_to_gguf",
+        lambda: (converter, set(), set()))
+    monkeypatch.setattr(llama_cpp, "convert_to_gguf", fake_convert_to_gguf)
+
+    mutils.save_pretrained_gguf(
+        _make_moe_model(),
+        tokenizer=object(),
+        save_directory=tmp_path / "out",
+        quantization_method="not_quantized",
+        first_conversion="f16",
+    )
+
+    assert "model.layers.0.mlp.experts.2.gate_proj.weight" in converted["tensors"]
+    assert not any(".switch_mlp." in name for name in converted["tensors"])

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -4012,3 +4012,53 @@ def test_moe_gguf_export_stacks_experts_a_sanitizer_split_one_per_expert(tmp_pat
     assert sorted(rewritten) == sorted(model.checkpoint)
     for name, tensor in model.checkpoint.items():
         assert rewritten[name].tolist() == tensor.tolist()
+
+
+def _relocated(name):
+    """A rename spelled outside the sanitizer, as mlx-vlm's qwen4_exp spells its own."""
+    if name.startswith("outer.inner."):
+        return "inner.outer." + name[len("outer.inner."):]
+    return name
+
+
+def _relocate_outside(self, weights):
+    return {_relocated(name): tensor for name, tensor in weights.items()}
+
+
+def _relocating_model(mx, sanitize, others):
+    """A checkpoint one namespace move restores, with `others` names outside it."""
+    class Model:
+        def __init__(self):
+            self.checkpoint = {
+                f"outer.inner.layers.{layer}.{leaf}":
+                    mx.arange(8, dtype=mx.float32).reshape(2, 4) + 10 * layer + index
+                for layer in range(2) for index, leaf in enumerate(("mlp.w", "attn.w"))}
+            self.checkpoint.update(
+                (f"vision.layers.{n}.w",
+                 mx.arange(8, dtype=mx.float32).reshape(2, 4) + 100 + n)
+                for n in range(others))
+
+        def named_modules(self):
+            yield "", self
+
+    Model.sanitize = sanitize
+    model = Model()
+    model.expected = model.sanitize(dict(model.checkpoint))
+    return model
+
+
+def test_moe_gguf_export_reads_the_names_a_sanitizer_spells_in_what_it_calls(tmp_path):
+    """A relocation only the helper reaches, kept under the limit to isolate it."""
+    import unsloth_zoo.mlx.utils as mutils
+    mx = mutils.mx
+    model = _relocating_model(mx, _relocate_outside, others=6)
+    assert not any("outer" in const for const in
+                   type(model).sanitize.__code__.co_consts if isinstance(const, str))
+    assert "outer.inner." in mutils._mlx_sanitizer_vocabulary(
+        mutils._mlx_moe_sanitizers(model))
+    assert sum("outer.inner." in name for name in model.expected) <= int(
+        len(model.expected) * mutils._MOE_VOCABULARY_UBIQUITY)
+    path = _stage_moe_directory(tmp_path, model)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 4
+    assert sorted(_staged_tensors(path)) == sorted(model.checkpoint)
+

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1657,6 +1657,12 @@ def test_gguf_save_prepares_the_export_directory_for_every_model(
         calls["path"] = Path(path)
         calls["model"] = model
         calls["replay_sanitizers"] = replay_sanitizers
+        return 0
+
+    def fake_moe_prepare(path, model=None, source_norm_offsets=None):
+        # Raising here rather than above is what makes the MoE pass something this test
+        # reaches: it used to stop at the first one.
+        calls["moe_model"] = model
         raise _StopAfterExportPrep
 
     monkeypatch.setattr(mutils, "_is_vlm_model", lambda _model: is_vlm)
@@ -1664,6 +1670,8 @@ def test_gguf_save_prepares_the_export_directory_for_every_model(
         mutils, "save_merged_model", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(mutils, "_prepare_mlx_gguf_export_directory", fake_prepare)
+    monkeypatch.setattr(
+        mutils, "_prepare_moe_gguf_export_directory", fake_moe_prepare)
 
     model = object()
     with pytest.raises(_StopAfterExportPrep):
@@ -1671,6 +1679,7 @@ def test_gguf_save_prepares_the_export_directory_for_every_model(
 
     assert calls["model"] is model
     assert calls["replay_sanitizers"] is is_vlm
+    assert calls["moe_model"] is model
 
 
 def test_vlm_rewrite_handles_same_name_layout_transforms(monkeypatch):
@@ -3517,8 +3526,8 @@ def test_trusted_dir_matches_every_llama_cpp_default_dir_spelling(monkeypatch, t
 def _make_moe_model(container="switch_mlp", group="experts", leaf_alias=None,
                     wrap_in_lora=False, reverse_experts=False, stacks=True,
                     with_bias=False, rename_leaves=None, hf_parent="mlp",
-                    num_experts=3, num_layers=2):
-    """A minimal MLX-shaped MoE model whose sanitize stacks per-expert weights."""
+                    num_experts=3, num_layers=2, alters_a_sibling_once_split=False):
+    """A tiny model whose sanitize stacks per-expert tensors, as mlx-lm's do."""
     import unsloth_zoo.mlx.utils as mutils
 
     mx = mutils.mx
@@ -3559,6 +3568,11 @@ def _make_moe_model(container="switch_mlp", group="experts", leaf_alias=None,
                     self.switch_modules[path] = module
                     for param in params:
                         self.expected[f"{path}.{param}"] = getattr(module, param)
+            if alters_a_sibling_once_split:
+                for layer in range(num_layers):
+                    self.expected[f"model.layers.{layer}.mlp.sibling.weight"] = (
+                        mx.arange(4, dtype=mx.float32) + layer
+                    )
 
         def named_modules(self):
             yield "", self
@@ -3572,6 +3586,7 @@ def _make_moe_model(container="switch_mlp", group="experts", leaf_alias=None,
         def sanitize(self, weights):
             if not stacks:
                 return weights
+            split = False
             for legacy, canonical in (rename_leaves or {}).items():
                 for old in [n for n in weights if f".{legacy}." in n]:
                     new = old.replace(f".{legacy}.", f".{canonical}.")
@@ -3594,6 +3609,12 @@ def _make_moe_model(container="switch_mlp", group="experts", leaf_alias=None,
                         weights[f"{prefix}.{container}.{leaf}.{param}"] = mx.stack(
                             joined
                         )
+                        split = True
+            if alters_a_sibling_once_split and split:
+                for layer in range(num_layers):
+                    sibling = f"model.layers.{layer}.mlp.sibling.weight"
+                    if sibling in weights:
+                        weights[sibling] = weights[sibling] * 2.0
             return weights
 
     return Model()
@@ -3603,7 +3624,7 @@ def _stage_moe_directory(tmp_path, model, shards=1):
     import unsloth_zoo.mlx.utils as mutils
 
     path = tmp_path / "merged"
-    path.mkdir(exist_ok=True)
+    path.mkdir(exist_ok=True, parents=True)
     names = sorted(model.expected)
     weight_map = {}
     for shard in range(shards):
@@ -3653,230 +3674,6 @@ def test_moe_gguf_export_splits_stacked_experts_into_hf_tensors(tmp_path):
     assert set(index["weight_map"]) == set(tensors)
 
 
-def test_moe_gguf_export_splits_sharded_experts_and_biases(tmp_path):
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_moe_model(with_bias=True, num_layers=4)
-    path = _stage_moe_directory(tmp_path, model, shards=3)
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 24
-
-    shards = _staged_shards(path)
-    assert len(shards) == 3
-    tensors = _staged_tensors(path)
-    assert mutils._mlx_arrays_match(
-        tensors["model.layers.3.mlp.experts.2.up_proj.bias"],
-        model.expected["model.layers.3.mlp.switch_mlp.up_proj.bias"][2],
-    )
-    # Every rewritten tensor has to be indexed to the shard that now holds it.
-    weight_map = json.loads((path / "model.safetensors.index.json").read_text())[
-        "weight_map"
-    ]
-    assert set(weight_map) == set(tensors)
-    assert all(name in shards[shard] for name, shard in weight_map.items())
-
-
-@pytest.mark.parametrize(
-    ("model_kwargs", "restored_name"),
-    [
-        ({"container": "experts"}, "model.layers.1.mlp.experts.2.down_proj.weight"),
-        ({"leaf_alias": {"gate_proj": "w1", "down_proj": "w2", "up_proj": "w3"}},
-         "model.layers.1.mlp.experts.2.w2.weight"),
-        ({"group": "mlp"}, "model.layers.1.mlp.mlp.2.down_proj.weight"),
-        # LFM2 renames w1/w2/w3 to gate/down/up before stacking, so both namings
-        # replay cleanly; only the legacy one names tensors llama.cpp reads.
-        ({"rename_leaves": {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}},
-         "model.layers.1.mlp.experts.2.w2.weight"),
-    ],
-)
-def test_moe_gguf_export_recovers_expert_naming_conventions(
-    tmp_path, model_kwargs, restored_name
-):
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_moe_model(**model_kwargs)
-    container = model_kwargs.get("container", "switch_mlp")
-    path = _stage_moe_directory(tmp_path, model)
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
-    assert mutils._mlx_arrays_match(
-        _staged_tensors(path)[restored_name],
-        model.expected[f"model.layers.1.mlp.{container}.down_proj.weight"][2],
-    )
-
-
-def test_moe_gguf_export_finds_switch_modules_behind_lora_wrappers(tmp_path):
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_moe_model(wrap_in_lora=True)
-    path = _stage_moe_directory(tmp_path, model)
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
-    assert mutils._mlx_arrays_match(
-        _staged_tensors(path)["model.layers.1.mlp.experts.1.up_proj.weight"],
-        model.expected["model.layers.1.mlp.switch_mlp.up_proj.weight"][1],
-    )
-
-
-@pytest.mark.parametrize(
-    "model_kwargs",
-    [{"stacks": False}, {"reverse_experts": True}, {"hf_parent": "block_sparse_moe"}],
-)
-def test_moe_gguf_export_leaves_unrecoverable_expert_layouts_untouched(
-    tmp_path, model_kwargs
-):
-    # Llama 4 stacks its experts in HF too and llama.cpp maps that layout
-    # already, so a layout we cannot invert has to survive exactly as saved.
-    # Kimi Linear reads block_sparse_moe.experts and writes mlp.switch_mlp; a
-    # relocated parent module is not recoverable from the stacked name.
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_moe_model(**model_kwargs)
-    path = _stage_moe_directory(tmp_path, model)
-    before = (path / "model-00001-of-00001.safetensors").read_bytes()
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
-    assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
-
-
-def test_moe_gguf_export_leaves_models_without_stacked_experts_alone(tmp_path):
-    import unsloth_zoo.mlx.utils as mutils
-
-    class Conv:
-        def __init__(self, weight):
-            self.weight = weight
-
-    class Model:
-        def __init__(self):
-            weight = mutils.mx.zeros((4, 2, 3))
-            self.conv = Conv(weight)
-            self.expected = {"vision_tower.patch_embed.proj.weight": weight}
-
-        def named_modules(self):
-            yield "", self
-            yield "vision_tower.patch_embed.proj", self.conv
-
-    model = Model()
-    path = _stage_moe_directory(tmp_path, model)
-    before = (path / "model-00001-of-00001.safetensors").read_bytes()
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
-    assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
-
-
-def test_save_pretrained_gguf_hands_the_converter_per_expert_moe_tensors(
-    monkeypatch, tmp_path
-):
-    import unsloth_zoo.llama_cpp as llama_cpp
-    import unsloth_zoo.mlx.utils as mutils
-
-    monkeypatch.setitem(sys.modules, "gguf", types.ModuleType("gguf"))
-
-    llama_root = tmp_path / "llama.cpp"
-    llama_root.mkdir()
-    for name in ("convert_hf_to_gguf.py", "llama-quantize"):
-        (llama_root / name).write_text("# stub", encoding="utf-8")
-    converted = {}
-
-    def fake_save_merged_model(model, tokenizer, path, dequantize=False):
-        _stage_moe_directory(Path(path).parent, model).rename(path)
-        (Path(path) / "config.json").write_text("{}", encoding="utf-8")
-
-    def fake_convert_to_gguf(**kwargs):
-        converted["tensors"] = sorted(_staged_tensors(Path(kwargs["input_folder"])))
-        Path(f"{kwargs['model_name']}.F16.gguf").write_bytes(b"GGUF")
-
-    converter = str(llama_root / "convert_hf_to_gguf.py")
-    monkeypatch.setattr(mutils, "save_merged_model", fake_save_merged_model)
-    monkeypatch.setattr(mutils, "_is_vlm_model", lambda model: False)
-    monkeypatch.setattr(llama_cpp, "LLAMA_CPP_DEFAULT_DIR", str(llama_root))
-    monkeypatch.setattr(llama_cpp, "check_llama_cpp",
-        lambda folder: (str(llama_root / "llama-quantize"), converter))
-    monkeypatch.setattr(llama_cpp, "_download_convert_hf_to_gguf",
-        lambda: (converter, set(), set()))
-    monkeypatch.setattr(llama_cpp, "convert_to_gguf", fake_convert_to_gguf)
-
-    mutils.save_pretrained_gguf(
-        _make_moe_model(),
-        tokenizer=object(),
-        save_directory=tmp_path / "out",
-        quantization_method="not_quantized",
-        first_conversion="f16",
-    )
-
-    assert "model.layers.0.mlp.experts.2.gate_proj.weight" in converted["tensors"]
-    assert not any(".switch_mlp." in name for name in converted["tensors"])
-
-
-def test_moe_gguf_export_recovers_names_a_sanitizer_only_renamed(tmp_path):
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES)
-    path = _stage_moe_directory(tmp_path, model)
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
-
-    tensors = _staged_tensors(path)
-    assert not any(".switch_mlp." in name for name in tensors)
-    assert mutils._mlx_arrays_match(
-        tensors["model.layers.1.moe.gate_proj.weight"],
-        model.expected["model.layers.1.mlp.switch_mlp.gate_proj.weight"],
-    )
-    assert mutils._mlx_arrays_match(
-        tensors["model.layers.1.moe.router_bias.weight"],
-        model.expected["model.layers.1.mlp.gate.router_bias.weight"],
-    )
-    index = json.loads((path / "model.safetensors.index.json").read_text())
-    assert set(index["weight_map"]) == set(tensors)
-
-
-def test_moe_gguf_export_keeps_a_recovered_name_a_later_substitution_could_undo(
-    tmp_path
-):
-    # Recovering `.mlp.share_expert.` to `.share_expert.` makes the reverse
-    # substitution available, and applying it restores the name the checkpoint
-    # already holds, leaving a replay with nothing to prove.
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES)
-    path = _stage_moe_directory(tmp_path, model)
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
-    assert mutils._mlx_arrays_match(
-        _staged_tensors(path)["model.layers.1.share_expert.down_proj.weight"],
-        model.expected["model.layers.1.mlp.share_expert.down_proj.weight"],
-    )
-
-
-def test_moe_gguf_export_leaves_a_sanitizer_with_no_readable_names_alone(tmp_path):
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES, readable=False)
-    path = _stage_moe_directory(tmp_path, model)
-    before = (path / "model-00001-of-00001.safetensors").read_bytes()
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
-    assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
-
-
-def test_moe_gguf_export_skips_substituting_a_fragment_every_tensor_carries():
-    import unsloth_zoo.mlx.utils as mutils
-
-    names = [f"model.layers.{layer}.{leaf}.weight" for layer in range(4)
-             for leaf in ("mlp.gate", "self_attn.q_proj", "self_attn.k_proj")]
-    offered = set(mutils._mlx_moe_rename_candidates(
-        (".weight", ".mlp.gate.", ".moe."), names
-    ))
-    # `.weight` names the checkpoint's shape rather than one block's layout, so
-    # substituting it can only produce nonsense to replay.
-    assert not any(replaced == ".weight" for replaced, _ in offered)
-    assert (".mlp.gate.", ".moe.") in offered
-
-
-RENAMED_LEAVES = ("mlp.switch_mlp.gate_proj", "mlp.gate.router_bias",
-                  "mlp.share_expert.down_proj")
-
-
 def _make_quirky_moe_model(quirk=None, leaves=("mlp.switch_mlp.gate_proj",),
                            extra=(), width=1, num_layers=2, readable=True):
     """A model whose sanitize also shifts or moves what it renames."""
@@ -3923,12 +3720,12 @@ def _make_quirky_moe_model(quirk=None, leaves=("mlp.switch_mlp.gate_proj",),
                 )
                 if first in renamed and second in renamed:
                     renamed[first], renamed[second] = renamed[second], renamed[first]
-            elif vanilla and quirk:
+            elif quirk and (vanilla or quirk == "always_scaled"):
                 for name in [n for n in renamed if "layernorm" in n or "gate.weight" in n]:
                     tensor = renamed[name]
                     if quirk in ("constant", "wide"):
                         tensor = tensor + 1.0
-                    elif quirk == "scaled":
+                    elif quirk in ("scaled", "always_scaled"):
                         tensor = tensor * 2.0
                     elif quirk == "stepped":
                         # Uniform across the first two elements only, so a corner probe reads it as +1.
@@ -3951,50 +3748,32 @@ def _make_quirky_moe_model(quirk=None, leaves=("mlp.switch_mlp.gate_proj",),
     return model
 
 
-def test_moe_gguf_export_undoes_a_constant_a_sanitizer_adds(tmp_path):
-    # llama.cpp adds the same constant back, so exporting the stored value would
-    # double it: a silently wrong GGUF rather than a failed conversion.
+def test_moe_gguf_export_recovers_names_a_sanitizer_only_renamed(tmp_path):
     import unsloth_zoo.mlx.utils as mutils
 
-    model = _make_quirky_moe_model("constant", extra=("input_layernorm",))
+    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES)
     path = _stage_moe_directory(tmp_path, model)
 
-    # Two names recovered and two norms corrected: a tensor whose value moved is
-    # rewritten as surely as one whose name did.
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 4
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
+
     tensors = _staged_tensors(path)
-    assert mutils._mlx_arrays_match(
-        tensors["model.layers.1.input_layernorm.weight"],
-        model.expected["model.layers.1.input_layernorm.weight"] - 1.0,
-    )
+    assert not any(".switch_mlp." in name for name in tensors)
     assert mutils._mlx_arrays_match(
         tensors["model.layers.1.moe.gate_proj.weight"],
         model.expected["model.layers.1.mlp.switch_mlp.gate_proj.weight"],
     )
+    assert mutils._mlx_arrays_match(
+        tensors["model.layers.1.moe.router_bias.weight"],
+        model.expected["model.layers.1.mlp.gate.router_bias.weight"],
+    )
+    index = json.loads((path / "model.safetensors.index.json").read_text())
+    assert set(index["weight_map"]) == set(tensors)
 
 
-@pytest.mark.parametrize(
-    ("quirk", "shape"),
-    [
-        # A scaling reads differently from each probe; a per-element shift reads
-        # alike from both but is no single constant; and a shift uniform across
-        # the first two elements only would read as +1 from a sampled corner.
-        ("scaled", {"extra": ("input_layernorm",)}),
-        ("elementwise", {"extra": ("input_layernorm",)}),
-        ("stepped", {"extra": ("input_layernorm",)}),
-        # Carrying a wide tensor whole would materialize the checkpoint, so a
-        # constant measured from its corner is not proof of one anywhere else.
-        ("wide", {"extra": ("mlp.gate",), "width": 4}),
-        # Every probe used to carry one value, so any same-shaped tensor
-        # satisfied any other's expectation; probes spread alike then leave a
-        # swap of two neighbours looking like a constant offset.
-        ("swaps", {"extra": ("self_attn.q_proj", "self_attn.k_proj")}),
-    ],
-)
-def test_moe_gguf_export_refuses_what_it_cannot_prove(tmp_path, quirk, shape):
+def test_moe_gguf_export_leaves_a_sanitizer_with_no_readable_names_alone(tmp_path):
     import unsloth_zoo.mlx.utils as mutils
 
-    model = _make_quirky_moe_model(quirk, **shape)
+    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES, readable=False)
     path = _stage_moe_directory(tmp_path, model)
     before = (path / "model-00001-of-00001.safetensors").read_bytes()
 
@@ -4002,169 +3781,68 @@ def test_moe_gguf_export_refuses_what_it_cannot_prove(tmp_path, quirk, shape):
     assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
 
 
-def test_moe_gguf_export_does_not_undo_an_offset_the_source_already_gave_up(tmp_path):
-    # The norm convention is restored before this runs, from the source
-    # checkpoint. Measuring from the sanitizer alone reaches a source that never
-    # revealed one, so the two measurements must not both be subtracted.
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_quirky_moe_model("constant", extra=("input_layernorm",))
-    path = _stage_moe_directory(tmp_path, model)
-
-    assert mutils._prepare_moe_gguf_export_directory(
-        path, model=model,
-        source_norm_offsets={"model.layers.1.input_layernorm.weight": 1.0},
-    ) == 3
-    tensors = _staged_tensors(path)
-    assert mutils._mlx_arrays_match(
-        tensors["model.layers.1.input_layernorm.weight"],
-        model.expected["model.layers.1.input_layernorm.weight"],
-    )
-    # The layer the source did not cover still has to be corrected here.
-    assert mutils._mlx_arrays_match(
-        tensors["model.layers.0.input_layernorm.weight"],
-        model.expected["model.layers.0.input_layernorm.weight"] - 1.0,
-    )
+RENAMED_LEAVES = ("mlp.switch_mlp.gate_proj", "mlp.gate.router_bias",
+                  "mlp.share_expert.down_proj")
 
 
-def test_moe_gguf_export_leaves_a_tensor_the_sanitizer_drops_unnamed(tmp_path):
-    # A dropped tensor is reproduced under neither spelling, so nothing about a
-    # rename of it is ever proved. Renaming it anyway can turn a name llama.cpp
-    # reads into one it does not.
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_quirky_moe_model("drops", extra=("mtp",), num_layers=1)
-    model.expected["model.mtp.0.weight"] = model.expected.pop(
-        "model.layers.0.mtp.weight"
-    )
-    path = _stage_moe_directory(tmp_path, model)
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 1
-    tensors = _staged_tensors(path)
-    assert "model.layers.0.moe.gate_proj.weight" in tensors
-    assert "model.mtp.0.weight" in tensors
-
-
-def test_moe_gguf_export_treats_a_failed_source_measurement_as_an_answer(
-    monkeypatch, tmp_path
-):
-    # None means the source could not be read, which is a measurement. Re-reading
-    # it here could succeed where the caller's read failed, and then the two
-    # passes would be subtracting against different answers.
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_quirky_moe_model("constant", extra=("input_layernorm",))
-    path = _stage_moe_directory(tmp_path, model)
-    monkeypatch.setattr(
-        mutils, "_mlx_sanitizer_norm_offsets",
-        lambda model: pytest.fail("re-read a source the caller had already read"),
-    )
-
-    assert mutils._prepare_moe_gguf_export_directory(
-        path, model=model, source_norm_offsets=None
-    ) == 4
-    assert mutils._mlx_arrays_match(
-        _staged_tensors(path)["model.layers.1.input_layernorm.weight"],
-        model.expected["model.layers.1.input_layernorm.weight"] - 1.0,
-    )
-
-
-def test_moe_gguf_export_builds_each_probe_once_for_the_whole_search(monkeypatch):
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES)
-    staged = {n: mutils.mx.zeros(t.shape, dtype=t.dtype)
-              for n, t in model.expected.items()}
-    built, real = [], mutils._mlx_moe_offset_probe
-    monkeypatch.setattr(
-        mutils, "_mlx_moe_offset_probe",
-        lambda *args: built.append(args[1]) or real(*args))
-    mutils._build_mlx_moe_rename_plan(model, staged, None)
-    # Two probes per tensor for the search however many candidates were tried,
-    # because one cache outlives all of them, and two more for the single pass
-    # that confirms the plan that won.
-    assert len(built) <= 4 * len(staged)
-
-
-def _make_probe_reading_moe_model(moves_when, dtype=None):
-    """A model whose sanitize decides on an axis move by the tensor it is handed."""
+def _make_one_family_moe_model(family):
+    """A checkpoint one family alone can restore, for measuring what a pass costs."""
     import unsloth_zoo.mlx.utils as mutils
 
     mx = mutils.mx
-    dtype = dtype or mx.float32
 
     class Model:
         def __init__(self):
-            self.expected = {
-                f"model.layers.{layer}.self_attn.{leaf}": (value + layer).astype(dtype)
-                for layer in range(2)
-                for leaf, value in (
-                    ("conv.conv.weight", mx.reshape(mx.arange(24, dtype=mx.float32), (2, 4, 3))),
-                    ("q_proj.weight", mx.zeros((4, 4))),
-                    ("o_proj.weight", mx.zeros((4, 4))),
-                )
-            }
+            if family == "merge":
+                # The halves differ, so the rebuilt tensor can disagree about their order.
+                self.expected = {
+                    f"model.layers.0.mlp.{leaf}.weight":
+                        mx.array([[1.0, 2.0], [3.0, 4.0]]) + 10.0 * index
+                    for index, leaf in enumerate(("left", "right"))
+                }
+            else:
+                self.expected = {
+                    "model.layers.0.self_attn.conv.weight":
+                        mx.arange(8, dtype=mx.float32).reshape(2, 2, 2)
+                }
 
         def named_modules(self):
             yield "", self
 
         def sanitize(self, weights):
-            remappings = ((".moved.", ".conv.conv."),)
             out = {}
             for name, tensor in weights.items():
-                for source, target in remappings:
-                    if source in name and getattr(tensor, "ndim", 0) == 3:
-                        if moves_when(tensor):
-                            tensor = mx.moveaxis(tensor, 2, 1)
-                        name = name.replace(source, target)
-                        break
-                out[name] = tensor
+                if family == "layout":
+                    out[name] = mx.moveaxis(tensor, 2, 1)
+                elif "fused" in name:
+                    halves = mx.split(tensor, 2, axis=0)
+                    for leaf, half in zip(("left", "right"), halves):
+                        out[name.replace("fused", leaf)] = half
+                else:
+                    out[name] = tensor
             return out
 
     return Model()
 
 
-@pytest.mark.parametrize(
-    "moves_when, staged_dtype",
-    (
-        # Only for the corner a probe carries, never for the tensor written.
-        (lambda t: t.shape[1] == 2, None),
-        # Only for the tensor written, which a corner cannot show. The plan this
-        # produces is a plain rename, so it is not an axis move that goes wrong.
-        (lambda t: t.shape[1] > t.shape[2], None),
-        # Only for the dtype a probe carries, never for the checkpoint's own.
-        (lambda t: t.dtype.size == 4, "float16"),
-    ),
-    ids=("only_for_a_corner", "only_for_the_tensor_written", "only_for_a_probes_dtype"),
-)
-def test_moe_gguf_export_refuses_what_only_a_probe_shows(
-    moves_when, staged_dtype, tmp_path
-):
+def test_moe_gguf_export_rebuilds_a_tensor_a_sanitizer_split(tmp_path):
     import unsloth_zoo.mlx.utils as mutils
 
-    model = _make_probe_reading_moe_model(
-        moves_when, staged_dtype and getattr(mutils.mx, staged_dtype)
-    )
-    path = _stage_moe_directory(tmp_path, model)
-    before = (path / "model-00001-of-00001.safetensors").read_bytes()
-
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
-    assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
-
-
-def test_moe_gguf_export_keeps_an_axis_move_the_written_tensor_also_shows(tmp_path):
-    # The confirmation must not refuse everything it cannot see from a corner:
-    # this sanitizer moves the axis for the reconstruction as well, so the plan
-    # holds and the checkpoint comes back from it exactly.
-    import unsloth_zoo.mlx.utils as mutils
-
-    model = _make_probe_reading_moe_model(lambda t: t.shape[1] <= t.shape[2])
+    model = _make_one_family_moe_model("merge")
     path = _stage_moe_directory(tmp_path, model)
 
     assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 2
-    rewritten = _staged_tensors(path)
-    moved = rewritten["model.layers.1.self_attn.moved.weight"]
-    assert tuple(moved.shape) == (2, 3, 4)
-    restored = model.sanitize(dict(rewritten))
-    for name, tensor in model.expected.items():
-        assert mutils._mlx_arrays_match(restored[name], tensor), name
+    fused = _staged_tensors(path)["model.layers.0.mlp.fused.weight"]
+    assert fused.tolist() == [[1.0, 2.0], [3.0, 4.0], [11.0, 12.0], [13.0, 14.0]]
+
+
+def test_moe_gguf_export_restores_an_axis_a_sanitizer_moved(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_one_family_moe_model("layout")
+    path = _stage_moe_directory(tmp_path, model)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 1
+    moved = _staged_tensors(path)["model.layers.0.self_attn.conv.weight"]
+    assert moved.tolist() == mutils.mx.moveaxis(
+        model.expected["model.layers.0.self_attn.conv.weight"], 1, 2).tolist()

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -3967,53 +3967,6 @@ def test_moe_gguf_export_leaves_a_sanitizer_that_writes_to_itself_as_it_found_it
     assert model.language_model["lm_head"] == "the head this model was trained with"
 
 
-def test_moe_gguf_export_stacks_experts_a_sanitizer_split_one_per_expert(tmp_path):
-    """A split into one tensor per expert, which no pair of parts can propose.
-
-    DBRX names the parts by index, so no vocabulary fragment stands for one and
-    the merge family cannot reach them. The second leaf keeps a recipe proved on
-    the first from standing for both: only `w2` is transposed as well as split.
-    """
-    import unsloth_zoo.mlx.utils as mutils
-
-    mx = mutils.mx
-
-    class Model:
-        def __init__(self):
-            self.checkpoint = {
-                f"blocks.{layer}.ffn.experts.mlp.{leaf}":
-                    mx.arange(24, dtype=mx.float32).reshape(12, 2) + layer
-                for layer in range(2)
-                for leaf in ("w1", "w2")
-            }
-            self.expected = self.sanitize(dict(self.checkpoint))
-
-        def named_modules(self):
-            yield "", self
-
-        def sanitize(self, weights):
-            out = {}
-            for name, tensor in weights.items():
-                if "experts.mlp" not in name:
-                    out[name] = tensor
-                    continue
-                for expert, part in enumerate(mx.split(tensor, 3, axis=0)):
-                    out[name.replace(".mlp", f".{expert}") + ".weight"] = (
-                        part.T if name.endswith("w2") else part
-                    )
-            return out
-
-    model = Model()
-    assert len(model.expected) == 12
-    assert all(name.endswith(".weight") for name in model.expected)
-    path = _stage_moe_directory(tmp_path, model)
-    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 12
-    rewritten = _staged_tensors(path)
-    assert sorted(rewritten) == sorted(model.checkpoint)
-    for name, tensor in model.checkpoint.items():
-        assert rewritten[name].tolist() == tensor.tolist()
-
-
 def _relocated(name):
     """A rename spelled outside the sanitizer, as mlx-vlm's qwen4_exp spells its own."""
     if name.startswith("outer.inner."):
@@ -4078,6 +4031,172 @@ def test_moe_gguf_export_relocates_a_namespace_every_tensor_carries(tmp_path):
     path = _stage_moe_directory(tmp_path, model)
     assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 4
     assert sorted(_staged_tensors(path)) == sorted(model.checkpoint)
+
+
+@pytest.mark.parametrize("added,rewrites", (("namespace", 0), ("reordered", 7), ("root", 7), ("container", 2), ("always", 7)))
+def test_moe_gguf_export_keeps_a_namespace_a_sanitizer_adds_back(added, rewrites, tmp_path):
+    """A namespace mlx-vlm's Gemma models add back replays either way, so the tower keeps the checkpoint's own spelling; the container the experts sit under is added back alike, and so is a bare `model.` outside a tower, which llama.cpp maps under other roots as readily as that one."""
+    import unsloth_zoo.mlx.utils as mutils
+    mx = mutils.mx
+    tensor = lambda n: mx.arange(8, dtype=mx.float32).reshape(2, 4) + n
+    prefix = {"namespace": "language_model.model.", "reordered": "model.language_model.",
+              "root": "", "container": "model.", "always": "language_model."}[added]
+
+    class Model:
+        # The names outside the tower hold each fragment under the ubiquity limit, where it is
+        # offered as a substitution rather than as a whole-name move.
+        # None of the leaves are ones the converter already reads, which a rewrite holds back.
+        checkpoint = {f"{prefix}layers.0.self_attn.{leaf}.weight": tensor(i)
+                      for i, leaf in enumerate(("q_norm", "k_norm", "sinks", "gate", "bias"))}
+        checkpoint.update((f"{prefix}layers.0.mlp.experts.{leaf}.weight", tensor(i))
+                          for i, leaf in enumerate(("down_proj", "gate_proj")))
+        checkpoint.update((f"vision_tower.layers.{n}.w", tensor(n)) for n in range(16))
+
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            out = {}
+            for name, value in weights.items():
+                # "always" is the sanitizer the staged names do not replay through.
+                if added == "always":
+                    name = name.replace("language_model.", "language_model.model.")
+                elif added == "namespace" and "language_model.model" not in name:
+                    name = name.replace("language_model", "language_model.model")
+                elif added == "reordered":
+                    name = name.replace("model.language_model.", "language_model.model.")
+                elif added == "root" and name.startswith("layers."):
+                    name = "model." + name
+                elif added == "container" and "experts." in name and "switch_glu" not in name:
+                    name = name.replace("mlp.experts.", "mlp.experts.switch_glu.")
+                out[name] = value
+            return out
+
+    model = Model()
+    model.expected = model.sanitize(dict(Model.checkpoint))
+    path = _stage_moe_directory(tmp_path, model)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == rewrites
+    assert sorted(_staged_tensors(path)) == sorted(Model.checkpoint)
+
+
+def test_moe_gguf_export_refuses_a_rename_onto_a_name_the_split_rebuilds():
+    """Two names reaching the replay as one hide the loss, so the split's names count too."""
+    import unsloth_zoo.mlx.utils as mutils
+    mx = mutils.mx
+
+    class Model:
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            return {name.replace("old.", "new."): value for name, value in weights.items()}
+
+    staged = {
+        "a.b.new.w": mx.arange(4, dtype=mx.float32).reshape(1, 4),
+        "a.b.experts.w": mx.arange(8, dtype=mx.float32).reshape(2, 4),
+    }
+    # The colliding name is the second the split rebuilds, so reading only the first misses it.
+    split_plan = {"a.b.experts.w": ["a.b.other.w", "a.b.old.w"]}
+    assert mutils._build_mlx_moe_rename_plan(Model(), staged, split_plan)[0] == {}
+
+
+def test_moe_gguf_export_keeps_a_container_drop_when_the_namespace_goes_back(tmp_path):
+    """A sanitizer adding back both leaves the tower no rename that moved the namespace alone, and reading the namespace back must not bring the container with it."""
+    import unsloth_zoo.mlx.utils as mutils
+    mx = mutils.mx
+    tensor = lambda n: mx.arange(8, dtype=mx.float32).reshape(2, 4) + n
+
+    class Model:
+        checkpoint = {f"language_model.model.layers.0.mlp.experts.{leaf}.weight": tensor(i)
+                      for i, leaf in enumerate(("down_proj", "gate_proj"))}
+        checkpoint.update((f"vision_tower.layers.{n}.w", tensor(n)) for n in range(16))
+
+        def named_modules(self):
+            yield "", self
+
+        # Its two literals are the whole vocabulary a rewrite reads, so the search reaches
+        # the spelling that drops both and the namespace has to be read back onto it.
+        def sanitize(self, weights):
+            out = {}
+            for name, value in weights.items():
+                if name.startswith("language_model.") and "language_model.model" not in name:
+                    name = name.replace("language_model.", "language_model.model.")
+                if "experts." in name and "switch_glu" not in name:
+                    name = name.replace("mlp.experts.", "mlp.experts.switch_glu.")
+                out[name] = value
+            return out
+
+    model = Model()
+    model.expected = model.sanitize(dict(Model.checkpoint))
+    path = _stage_moe_directory(tmp_path, model)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 2
+    assert sorted(_staged_tensors(path)) == sorted(Model.checkpoint)
+
+
+def test_moe_gguf_export_reads_a_namespace_back_only_onto_the_names_that_left_it():
+    """One left it, one never left it, one arrived from outside, one left the tower entirely."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    left = {
+        "language_model.model.layers.0.mlp.experts.down_proj.weight":
+            "language_model.layers.0.mlp.experts.down_proj.weight",
+    }
+    stayed = {
+        "language_model.model.norm.weight": "language_model.model.norm.weight",
+        "vision_tower.blocks.0.w": "language_model.visual.blocks.0.w",
+        "language_model.model.aux.weight": "visual.aux.weight",
+    }
+    for name, renamed in left.items():
+        assert mutils._mlx_moe_dropped_the_gguf_namespace_in_the_tower(name, renamed)
+    for name, renamed in stayed.items():
+        assert not mutils._mlx_moe_dropped_the_gguf_namespace_in_the_tower(name, renamed)
+
+
+def test_moe_gguf_export_stacks_experts_a_sanitizer_split_one_per_expert(tmp_path):
+    """A split into one tensor per expert, which no pair of parts can propose.
+
+    DBRX names the parts by index, so no vocabulary fragment stands for one and
+    the merge family cannot reach them. The second leaf keeps a recipe proved on
+    the first from standing for both: only `w2` is transposed as well as split.
+    """
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class Model:
+        def __init__(self):
+            self.checkpoint = {
+                f"blocks.{layer}.ffn.experts.mlp.{leaf}":
+                    mx.arange(24, dtype=mx.float32).reshape(12, 2) + layer
+                for layer in range(2)
+                for leaf in ("w1", "w2")
+            }
+            self.expected = self.sanitize(dict(self.checkpoint))
+
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            out = {}
+            for name, tensor in weights.items():
+                if "experts.mlp" not in name:
+                    out[name] = tensor
+                    continue
+                for expert, part in enumerate(mx.split(tensor, 3, axis=0)):
+                    out[name.replace(".mlp", f".{expert}") + ".weight"] = (
+                        part.T if name.endswith("w2") else part
+                    )
+            return out
+
+    model = Model()
+    assert len(model.expected) == 12
+    assert all(name.endswith(".weight") for name in model.expected)
+    path = _stage_moe_directory(tmp_path, model)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 12
+    rewritten = _staged_tensors(path)
+    assert sorted(rewritten) == sorted(model.checkpoint)
+    for name, tensor in model.checkpoint.items():
+        assert rewritten[name].tolist() == tensor.tolist()
 
 
 def test_moe_gguf_export_splits_a_tensor_a_sanitizer_fused_from_a_named_group(tmp_path):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1660,8 +1660,7 @@ def test_gguf_save_prepares_the_export_directory_for_every_model(
         return 0
 
     def fake_moe_prepare(path, model=None, source_norm_offsets=None):
-        # Raising here rather than above is what makes the MoE pass something this test
-        # reaches: it used to stop at the first one.
+        # Raising here, not above, is what makes this test reach the MoE pass.
         calls["moe_model"] = model
         raise _StopAfterExportPrep
 
@@ -3696,8 +3695,7 @@ def _make_quirky_moe_model(quirk=None, leaves=("mlp.switch_mlp.gate_proj",),
             yield "", self
 
         def sanitize(self, weights):
-            # A literal table, as mlx-lm writes them: the names live in this function's
-            # constants, which is where the rewrite reads them from.
+            # A literal table, as mlx-lm writes them: the rewrite reads these constants.
             remappings = (
                 (".moe.gate_proj.", ".mlp.switch_mlp.gate_proj."),
                 (".moe.router_bias.", ".mlp.gate.router_bias."),
@@ -3851,10 +3849,8 @@ def test_moe_gguf_export_restores_an_axis_a_sanitizer_moved(tmp_path):
 def _make_composed_moe_model():
     """A model whose expert tensors only the two sanitizers together reproduce.
 
-    The outer sanitizer relocates the MoE block and splits its fused expert tensor
-    while the inner renames what is left inside it, so neither reproduces a saved name
-    alone. The inner reads the whole leaf, so of the three fragments between the saved
-    name and the checkpoint's the last two prove together or not at all. The tensors
+    The outer relocates the MoE block and splits its fused expert tensor, the inner
+    renames what is left inside it, so neither reproduces a saved name alone. Tensors
     outside the block, reproduced by both, hold the floor.
     """
     import unsloth_zoo.mlx.utils as mutils
@@ -3877,7 +3873,7 @@ def _make_composed_moe_model():
             self.checkpoint = {
                 "outer.inner.layers.0.mlp.experts.gate_up_proj":
                     mx.arange(24, dtype=mx.float32).reshape(2, 3, 4),
-                # Untouched by both sanitizers: without them a fragment every name carries reads
+                # Untouched by both: otherwise a fragment every name carries would read
                 # as the checkpoint's own shape, which the search will not substitute.
                 "vision.blocks.0.attn.proj": mx.arange(4, dtype=mx.float32).reshape(2, 2),
                 "vision.blocks.1.attn.proj": mx.arange(4, dtype=mx.float32).reshape(2, 2),
@@ -3892,8 +3888,8 @@ def _make_composed_moe_model():
         def sanitize(self, weights):
             out = {}
             for name, tensor in weights.items():
-                # Both under the checkpoint's namespace: the split is how the relocated block is
-                # stored, not something that happens to any tensor with the name.
+                # Both under the checkpoint's namespace: the split is how the relocated
+                # block is stored, not something any tensor with the name gets.
                 if "outer.inner" in name:
                     name = name.replace("outer.inner", "inner.outer")
                     if "gate_up_proj" in name:
@@ -3924,12 +3920,9 @@ def test_moe_gguf_export_replays_the_sanitizers_a_model_composes(tmp_path):
 
 def test_moe_gguf_export_leaves_a_sanitizer_that_writes_to_itself_as_it_found_it(
         tmp_path):
-    """The export must not change the model it planned against.
-
-    Gemma 3 ties its output head and drops `lm_head` when handed weights without
-    `lm_head.weight`, and the search hands it every spelling of that name. What
-    is exported is one thing; the model the caller goes on to run is another.
-    """
+    """The export must not change the model it planned against: Gemma 3 ties its head
+    and drops `lm_head` when handed weights without `lm_head.weight`, and the search
+    hands it every spelling of that name."""
     import unsloth_zoo.mlx.utils as mutils
 
     mx = mutils.mx
@@ -4035,7 +4028,7 @@ def test_moe_gguf_export_relocates_a_namespace_every_tensor_carries(tmp_path):
 
 @pytest.mark.parametrize("added,rewrites", (("namespace", 0), ("reordered", 7), ("root", 7), ("container", 2), ("always", 7)))
 def test_moe_gguf_export_keeps_a_namespace_a_sanitizer_adds_back(added, rewrites, tmp_path):
-    """A namespace mlx-vlm's Gemma models add back replays either way, so the tower keeps the checkpoint's own spelling; the container the experts sit under is added back alike, and so is a bare `model.` outside a tower, which llama.cpp maps under other roots as readily as that one."""
+    """A namespace mlx-vlm's Gemma models add back replays either way, so the tower keeps the checkpoint's own spelling."""
     import unsloth_zoo.mlx.utils as mutils
     mx = mutils.mx
     tensor = lambda n: mx.arange(8, dtype=mx.float32).reshape(2, 4) + n
@@ -4043,9 +4036,8 @@ def test_moe_gguf_export_keeps_a_namespace_a_sanitizer_adds_back(added, rewrites
               "root": "", "container": "model.", "always": "language_model."}[added]
 
     class Model:
-        # The names outside the tower hold each fragment under the ubiquity limit, where it is
-        # offered as a substitution rather than as a whole-name move.
-        # None of the leaves are ones the converter already reads, which a rewrite holds back.
+        # Names outside the tower keep each fragment under the ubiquity limit, and no
+        # leaf is one the converter already reads (which a rewrite holds back).
         checkpoint = {f"{prefix}layers.0.self_attn.{leaf}.weight": tensor(i)
                       for i, leaf in enumerate(("q_norm", "k_norm", "sinks", "gate", "bias"))}
         checkpoint.update((f"{prefix}layers.0.mlp.experts.{leaf}.weight", tensor(i))
@@ -4101,7 +4093,7 @@ def test_moe_gguf_export_refuses_a_rename_onto_a_name_the_split_rebuilds():
 
 
 def test_moe_gguf_export_keeps_a_container_drop_when_the_namespace_goes_back(tmp_path):
-    """A sanitizer adding back both leaves the tower no rename that moved the namespace alone, and reading the namespace back must not bring the container with it."""
+    """Reading the namespace back must not bring the container with it."""
     import unsloth_zoo.mlx.utils as mutils
     mx = mutils.mx
     tensor = lambda n: mx.arange(8, dtype=mx.float32).reshape(2, 4) + n
@@ -4114,8 +4106,8 @@ def test_moe_gguf_export_keeps_a_container_drop_when_the_namespace_goes_back(tmp
         def named_modules(self):
             yield "", self
 
-        # Its two literals are the whole vocabulary a rewrite reads, so the search reaches
-        # the spelling that drops both and the namespace has to be read back onto it.
+        # Its two literals are the whole vocabulary, so the search reaches the spelling
+        # that drops both and the namespace has to be read back onto it.
         def sanitize(self, weights):
             out = {}
             for name, value in weights.items():
@@ -4155,9 +4147,8 @@ def test_moe_gguf_export_reads_a_namespace_back_only_onto_the_names_that_left_it
 def test_moe_gguf_export_stacks_experts_a_sanitizer_split_one_per_expert(tmp_path):
     """A split into one tensor per expert, which no pair of parts can propose.
 
-    DBRX names the parts by index, so no vocabulary fragment stands for one and
-    the merge family cannot reach them. The second leaf keeps a recipe proved on
-    the first from standing for both: only `w2` is transposed as well as split.
+    DBRX names parts by index, so no fragment stands for one. Only `w2` is transposed
+    as well as split, so a recipe proved on the first leaf cannot stand for both.
     """
     import unsloth_zoo.mlx.utils as mutils
 

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -4025,6 +4025,11 @@ def _relocate_outside(self, weights):
     return {_relocated(name): tensor for name, tensor in weights.items()}
 
 
+def _relocate_inside(self, weights):
+    return {name.replace("outer.inner.", "inner.outer."): tensor
+            for name, tensor in weights.items()}
+
+
 def _relocating_model(mx, sanitize, others):
     """A checkpoint one namespace move restores, with `others` names outside it."""
     class Model:
@@ -4057,6 +4062,18 @@ def test_moe_gguf_export_reads_the_names_a_sanitizer_spells_in_what_it_calls(tmp
     assert "outer.inner." in mutils._mlx_sanitizer_vocabulary(
         mutils._mlx_moe_sanitizers(model))
     assert sum("outer.inner." in name for name in model.expected) <= int(
+        len(model.expected) * mutils._MOE_VOCABULARY_UBIQUITY)
+    path = _stage_moe_directory(tmp_path, model)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 4
+    assert sorted(_staged_tensors(path)) == sorted(model.checkpoint)
+
+
+def test_moe_gguf_export_relocates_a_namespace_every_tensor_carries(tmp_path):
+    """A fragment past the ubiquity limit, admitted because every name starts with it."""
+    import unsloth_zoo.mlx.utils as mutils
+    mx = mutils.mx
+    model = _relocating_model(mx, _relocate_inside, others=0)
+    assert sum("inner.outer." in name for name in model.expected) > int(
         len(model.expected) * mutils._MOE_VOCABULARY_UBIQUITY)
     path = _stage_moe_directory(tmp_path, model)
     assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 4

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -3965,3 +3965,50 @@ def test_moe_gguf_export_leaves_a_sanitizer_that_writes_to_itself_as_it_found_it
     mutils._prepare_moe_gguf_export_directory(path, model=model)
     assert model.language_model.tied is False
     assert model.language_model["lm_head"] == "the head this model was trained with"
+
+
+def test_moe_gguf_export_stacks_experts_a_sanitizer_split_one_per_expert(tmp_path):
+    """A split into one tensor per expert, which no pair of parts can propose.
+
+    DBRX names the parts by index, so no vocabulary fragment stands for one and
+    the merge family cannot reach them. The second leaf keeps a recipe proved on
+    the first from standing for both: only `w2` is transposed as well as split.
+    """
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class Model:
+        def __init__(self):
+            self.checkpoint = {
+                f"blocks.{layer}.ffn.experts.mlp.{leaf}":
+                    mx.arange(24, dtype=mx.float32).reshape(12, 2) + layer
+                for layer in range(2)
+                for leaf in ("w1", "w2")
+            }
+            self.expected = self.sanitize(dict(self.checkpoint))
+
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            out = {}
+            for name, tensor in weights.items():
+                if "experts.mlp" not in name:
+                    out[name] = tensor
+                    continue
+                for expert, part in enumerate(mx.split(tensor, 3, axis=0)):
+                    out[name.replace(".mlp", f".{expert}") + ".weight"] = (
+                        part.T if name.endswith("w2") else part
+                    )
+            return out
+
+    model = Model()
+    assert len(model.expected) == 12
+    assert all(name.endswith(".weight") for name in model.expected)
+    path = _stage_moe_directory(tmp_path, model)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 12
+    rewritten = _staged_tensors(path)
+    assert sorted(rewritten) == sorted(model.checkpoint)
+    for name, tensor in model.checkpoint.items():
+        assert rewritten[name].tolist() == tensor.tolist()

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -4076,9 +4076,95 @@ def test_moe_gguf_export_builds_each_probe_once_for_the_whole_search(monkeypatch
     staged = {n: mutils.mx.zeros(t.shape, dtype=t.dtype)
               for n, t in model.expected.items()}
     built, real = [], mutils._mlx_moe_offset_probe
-    monkeypatch.setattr(mutils, "_mlx_moe_offset_probe",
-                        lambda shape, value: built.append(value) or real(shape, value))
+    monkeypatch.setattr(
+        mutils, "_mlx_moe_offset_probe",
+        lambda *args: built.append(args[1]) or real(*args))
     mutils._build_mlx_moe_rename_plan(model, staged, None)
-    # At most two probes per tensor however many candidates were tried: one
-    # cache outlives the whole search, rather than one per candidate.
-    assert len(built) <= 2 * len(staged)
+    # Two probes per tensor for the search however many candidates were tried,
+    # because one cache outlives all of them, and two more for the single pass
+    # that confirms the plan that won.
+    assert len(built) <= 4 * len(staged)
+
+
+def _make_probe_reading_moe_model(moves_when, dtype=None):
+    """A model whose sanitize decides on an axis move by the tensor it is handed."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    dtype = dtype or mx.float32
+
+    class Model:
+        def __init__(self):
+            self.expected = {
+                f"model.layers.{layer}.self_attn.{leaf}": (value + layer).astype(dtype)
+                for layer in range(2)
+                for leaf, value in (
+                    ("conv.conv.weight", mx.reshape(mx.arange(24, dtype=mx.float32), (2, 4, 3))),
+                    ("q_proj.weight", mx.zeros((4, 4))),
+                    ("o_proj.weight", mx.zeros((4, 4))),
+                )
+            }
+
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            remappings = ((".moved.", ".conv.conv."),)
+            out = {}
+            for name, tensor in weights.items():
+                for source, target in remappings:
+                    if source in name and getattr(tensor, "ndim", 0) == 3:
+                        if moves_when(tensor):
+                            tensor = mx.moveaxis(tensor, 2, 1)
+                        name = name.replace(source, target)
+                        break
+                out[name] = tensor
+            return out
+
+    return Model()
+
+
+@pytest.mark.parametrize(
+    "moves_when, staged_dtype",
+    (
+        # Only for the corner a probe carries, never for the tensor written.
+        (lambda t: t.shape[1] == 2, None),
+        # Only for the tensor written, which a corner cannot show. The plan this
+        # produces is a plain rename, so it is not an axis move that goes wrong.
+        (lambda t: t.shape[1] > t.shape[2], None),
+        # Only for the dtype a probe carries, never for the checkpoint's own.
+        (lambda t: t.dtype.size == 4, "float16"),
+    ),
+    ids=("only_for_a_corner", "only_for_the_tensor_written", "only_for_a_probes_dtype"),
+)
+def test_moe_gguf_export_refuses_what_only_a_probe_shows(
+    moves_when, staged_dtype, tmp_path
+):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_probe_reading_moe_model(
+        moves_when, staged_dtype and getattr(mutils.mx, staged_dtype)
+    )
+    path = _stage_moe_directory(tmp_path, model)
+    before = (path / "model-00001-of-00001.safetensors").read_bytes()
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
+
+
+def test_moe_gguf_export_keeps_an_axis_move_the_written_tensor_also_shows(tmp_path):
+    # The confirmation must not refuse everything it cannot see from a corner:
+    # this sanitizer moves the axis for the reconstruction as well, so the plan
+    # holds and the checkpoint comes back from it exactly.
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_probe_reading_moe_model(lambda t: t.shape[1] <= t.shape[2])
+    path = _stage_moe_directory(tmp_path, model)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 2
+    rewritten = _staged_tensors(path)
+    moved = rewritten["model.layers.1.self_attn.moved.weight"]
+    assert tuple(moved.shape) == (2, 3, 4)
+    restored = model.sanitize(dict(rewritten))
+    for name, tensor in model.expected.items():
+        assert mutils._mlx_arrays_match(restored[name], tensor), name

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -3846,3 +3846,122 @@ def test_moe_gguf_export_restores_an_axis_a_sanitizer_moved(tmp_path):
     moved = _staged_tensors(path)["model.layers.0.self_attn.conv.weight"]
     assert moved.tolist() == mutils.mx.moveaxis(
         model.expected["model.layers.0.self_attn.conv.weight"], 1, 2).tolist()
+
+
+def _make_composed_moe_model():
+    """A model whose expert tensors only the two sanitizers together reproduce.
+
+    The outer sanitizer relocates the MoE block and splits its fused expert tensor
+    while the inner renames what is left inside it, so neither reproduces a saved name
+    alone. The inner reads the whole leaf, so of the three fragments between the saved
+    name and the checkpoint's the last two prove together or not at all. The tensors
+    outside the block, reproduced by both, hold the floor.
+    """
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class Language:
+        def sanitize(self, weights):
+            out = {}
+            for name, tensor in weights.items():
+                parent, found, leaf = name.rpartition(".experts.")
+                if found and "." not in leaf:
+                    name = f"{parent}.switch_mlp.{leaf}.weight"
+                out[name] = tensor
+            return out
+
+    class Model:
+        def __init__(self):
+            self.language_model = Language()
+            self.checkpoint = {
+                "outer.inner.layers.0.mlp.experts.gate_up_proj":
+                    mx.arange(24, dtype=mx.float32).reshape(2, 3, 4),
+                # Untouched by both sanitizers: without them a fragment every name carries reads
+                # as the checkpoint's own shape, which the search will not substitute.
+                "vision.blocks.0.attn.proj": mx.arange(4, dtype=mx.float32).reshape(2, 2),
+                "vision.blocks.1.attn.proj": mx.arange(4, dtype=mx.float32).reshape(2, 2),
+            }
+            self.expected = self.language_model.sanitize(
+                self.sanitize(dict(self.checkpoint))
+            )
+
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            out = {}
+            for name, tensor in weights.items():
+                # Both under the checkpoint's namespace: the split is how the relocated block is
+                # stored, not something that happens to any tensor with the name.
+                if "outer.inner" in name:
+                    name = name.replace("outer.inner", "inner.outer")
+                    if "gate_up_proj" in name:
+                        middle = tensor.shape[-1] // 2
+                        for leaf, half in (("gate_proj", tensor[..., :middle]),
+                                           ("up_proj", tensor[..., middle:])):
+                            out[name.replace("gate_up_proj", leaf)] = mx.moveaxis(
+                                half, 1, 2)
+                        continue
+                out[name] = tensor
+            return out
+
+    return Model()
+
+
+def test_moe_gguf_export_replays_the_sanitizers_a_model_composes(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_composed_moe_model()
+    assert sorted(model.expected)[0].endswith("switch_mlp.gate_proj.weight")
+    path = _stage_moe_directory(tmp_path, model)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 2
+    rewritten = _staged_tensors(path)
+    assert sorted(rewritten) == sorted(model.checkpoint)
+    for name, tensor in model.checkpoint.items():
+        assert rewritten[name].tolist() == tensor.tolist()
+
+
+def test_moe_gguf_export_leaves_a_sanitizer_that_writes_to_itself_as_it_found_it(
+        tmp_path):
+    """The export must not change the model it planned against.
+
+    Gemma 3 ties its output head and drops `lm_head` when handed weights without
+    `lm_head.weight`, and the search hands it every spelling of that name. What
+    is exported is one thing; the model the caller goes on to run is another.
+    """
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+
+    class Language(dict):
+        def __init__(self):
+            super().__init__(lm_head="the head this model was trained with")
+            self.tied = False
+
+        def sanitize(self, weights):
+            if "lm_head.weight" not in weights:
+                self.tied = True
+                self.pop("lm_head", None)
+            return weights
+
+    class Model:
+        def __init__(self):
+            self.language_model = Language()
+            self.expected = {
+                "lm_head.weight": mx.array([[1.0, 2.0]]),
+                "model.layers.0.mlp.switch_mlp.gate_proj.weight":
+                    mx.array([[3.0, 4.0]]),
+            }
+
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            return self.language_model.sanitize(weights)
+
+    model = Model()
+    path = _stage_moe_directory(tmp_path, model)
+    mutils._prepare_moe_gguf_export_directory(path, model=model)
+    assert model.language_model.tied is False
+    assert model.language_model["lm_head"] == "the head this model was trained with"

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1653,15 +1653,19 @@ def test_gguf_save_prepares_the_export_directory_for_every_model(
 
     calls = {}
 
-    def fake_prepare(path, model=None, replay_sanitizers=True, norm_offsets=None):
+    def fake_prepare(path, model=None, replay_sanitizers=True, norm_offsets=None,
+                     relaid_out=None):
         calls["path"] = Path(path)
         calls["model"] = model
         calls["replay_sanitizers"] = replay_sanitizers
+        calls["relaid_out"] = relaid_out
         return 0
 
-    def fake_moe_prepare(path, model=None, source_norm_offsets=None):
+    def fake_moe_prepare(path, model=None, source_norm_offsets=None,
+                         source_layouts=()):
         # Raising here, not above, is what makes this test reach the MoE pass.
         calls["moe_model"] = model
+        calls["source_layouts"] = source_layouts
         raise _StopAfterExportPrep
 
     monkeypatch.setattr(mutils, "_is_vlm_model", lambda _model: is_vlm)
@@ -1679,6 +1683,9 @@ def test_gguf_save_prepares_the_export_directory_for_every_model(
     assert calls["model"] is model
     assert calls["replay_sanitizers"] is is_vlm
     assert calls["moe_model"] is model
+    # The names the first pass re-laid-out reach the second, or it moves those axes
+    # a second time: an adjacent-axis move is its own inverse, so the replay accepts it.
+    assert calls["relaid_out"] is calls["source_layouts"]
 
 
 def test_vlm_rewrite_handles_same_name_layout_transforms(monkeypatch):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1653,7 +1653,7 @@ def test_gguf_save_prepares_the_export_directory_for_every_model(
 
     calls = {}
 
-    def fake_prepare(path, model=None, replay_sanitizers=True):
+    def fake_prepare(path, model=None, replay_sanitizers=True, norm_offsets=None):
         calls["path"] = Path(path)
         calls["model"] = model
         calls["replay_sanitizers"] = replay_sanitizers
@@ -3806,3 +3806,279 @@ def test_save_pretrained_gguf_hands_the_converter_per_expert_moe_tensors(
 
     assert "model.layers.0.mlp.experts.2.gate_proj.weight" in converted["tensors"]
     assert not any(".switch_mlp." in name for name in converted["tensors"])
+
+
+def test_moe_gguf_export_recovers_names_a_sanitizer_only_renamed(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES)
+    path = _stage_moe_directory(tmp_path, model)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
+
+    tensors = _staged_tensors(path)
+    assert not any(".switch_mlp." in name for name in tensors)
+    assert mutils._mlx_arrays_match(
+        tensors["model.layers.1.moe.gate_proj.weight"],
+        model.expected["model.layers.1.mlp.switch_mlp.gate_proj.weight"],
+    )
+    assert mutils._mlx_arrays_match(
+        tensors["model.layers.1.moe.router_bias.weight"],
+        model.expected["model.layers.1.mlp.gate.router_bias.weight"],
+    )
+    index = json.loads((path / "model.safetensors.index.json").read_text())
+    assert set(index["weight_map"]) == set(tensors)
+
+
+def test_moe_gguf_export_keeps_a_recovered_name_a_later_substitution_could_undo(
+    tmp_path
+):
+    # Recovering `.mlp.share_expert.` to `.share_expert.` makes the reverse
+    # substitution available, and applying it restores the name the checkpoint
+    # already holds, leaving a replay with nothing to prove.
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES)
+    path = _stage_moe_directory(tmp_path, model)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 6
+    assert mutils._mlx_arrays_match(
+        _staged_tensors(path)["model.layers.1.share_expert.down_proj.weight"],
+        model.expected["model.layers.1.mlp.share_expert.down_proj.weight"],
+    )
+
+
+def test_moe_gguf_export_leaves_a_sanitizer_with_no_readable_names_alone(tmp_path):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES, readable=False)
+    path = _stage_moe_directory(tmp_path, model)
+    before = (path / "model-00001-of-00001.safetensors").read_bytes()
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
+
+
+def test_moe_gguf_export_skips_substituting_a_fragment_every_tensor_carries():
+    import unsloth_zoo.mlx.utils as mutils
+
+    names = [f"model.layers.{layer}.{leaf}.weight" for layer in range(4)
+             for leaf in ("mlp.gate", "self_attn.q_proj", "self_attn.k_proj")]
+    offered = set(mutils._mlx_moe_rename_candidates(
+        (".weight", ".mlp.gate.", ".moe."), names
+    ))
+    # `.weight` names the checkpoint's shape rather than one block's layout, so
+    # substituting it can only produce nonsense to replay.
+    assert not any(replaced == ".weight" for replaced, _ in offered)
+    assert (".mlp.gate.", ".moe.") in offered
+
+
+RENAMED_LEAVES = ("mlp.switch_mlp.gate_proj", "mlp.gate.router_bias",
+                  "mlp.share_expert.down_proj")
+
+
+def _make_quirky_moe_model(quirk=None, leaves=("mlp.switch_mlp.gate_proj",),
+                           extra=(), width=1, num_layers=2, readable=True):
+    """A model whose sanitize also shifts or moves what it renames."""
+    import unsloth_zoo.mlx.utils as mutils
+
+    mx = mutils.mx
+    shape = (4,) if width == 1 else (4, width)
+
+    class Model:
+        def __init__(self):
+            self.expected = {
+                f"model.layers.{layer}.{leaf}.weight": mx.reshape(
+                    mx.arange(4 * width, dtype=mx.float32), shape
+                ) + layer
+                for layer in range(num_layers)
+                for leaf in leaves + extra
+            }
+
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            # A literal table, as mlx-lm writes them: the names live in this function's
+            # constants, which is where the rewrite reads them from.
+            remappings = (
+                (".moe.gate_proj.", ".mlp.switch_mlp.gate_proj."),
+                (".moe.router_bias.", ".mlp.gate.router_bias."),
+                (".share_expert.down_proj.", ".mlp.share_expert.down_proj."),
+                ("model.mtp.", "model.discarded."),
+            )
+            renamed, vanilla = {}, False
+            for name, tensor in weights.items():
+                for source, target in remappings:
+                    if source in name and target not in name:
+                        name, vanilla = name.replace(source, target), True
+                        break
+                if quirk == "drops" and "discarded" in name:
+                    continue
+                renamed[name] = tensor
+            if quirk == "swaps":
+                first, second = (
+                    f"model.layers.{n}.mlp.switch_mlp.gate_proj.weight"
+                    for n in (0, 1)
+                )
+                if first in renamed and second in renamed:
+                    renamed[first], renamed[second] = renamed[second], renamed[first]
+            elif vanilla and quirk:
+                for name in [n for n in renamed if "layernorm" in n or "gate.weight" in n]:
+                    tensor = renamed[name]
+                    if quirk in ("constant", "wide"):
+                        tensor = tensor + 1.0
+                    elif quirk == "scaled":
+                        tensor = tensor * 2.0
+                    elif quirk == "stepped":
+                        # Uniform across the first two elements only, so a corner probe reads it as +1.
+                        tensor = tensor + mx.reshape(mx.concatenate(
+                            [mx.ones(2, dtype=tensor.dtype),
+                             mx.full((tensor.size - 2,), 2.0, dtype=tensor.dtype)]
+                        ), tensor.shape)
+                    else:
+                        tensor = tensor + mx.reshape(
+                            mx.arange(tensor.size, dtype=tensor.dtype), tensor.shape
+                        )
+                    renamed[name] = tensor
+            return renamed
+
+    model = Model()
+    if not readable:
+        # A sanitize with no reachable constants must leave the checkpoint alone.
+        model.sanitize = lambda weights: dict(weights)
+        type(model).sanitize = None
+    return model
+
+
+def test_moe_gguf_export_undoes_a_constant_a_sanitizer_adds(tmp_path):
+    # llama.cpp adds the same constant back, so exporting the stored value would
+    # double it: a silently wrong GGUF rather than a failed conversion.
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_quirky_moe_model("constant", extra=("input_layernorm",))
+    path = _stage_moe_directory(tmp_path, model)
+
+    # Two names recovered and two norms corrected: a tensor whose value moved is
+    # rewritten as surely as one whose name did.
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 4
+    tensors = _staged_tensors(path)
+    assert mutils._mlx_arrays_match(
+        tensors["model.layers.1.input_layernorm.weight"],
+        model.expected["model.layers.1.input_layernorm.weight"] - 1.0,
+    )
+    assert mutils._mlx_arrays_match(
+        tensors["model.layers.1.moe.gate_proj.weight"],
+        model.expected["model.layers.1.mlp.switch_mlp.gate_proj.weight"],
+    )
+
+
+@pytest.mark.parametrize(
+    ("quirk", "shape"),
+    [
+        # A scaling reads differently from each probe; a per-element shift reads
+        # alike from both but is no single constant; and a shift uniform across
+        # the first two elements only would read as +1 from a sampled corner.
+        ("scaled", {"extra": ("input_layernorm",)}),
+        ("elementwise", {"extra": ("input_layernorm",)}),
+        ("stepped", {"extra": ("input_layernorm",)}),
+        # Carrying a wide tensor whole would materialize the checkpoint, so a
+        # constant measured from its corner is not proof of one anywhere else.
+        ("wide", {"extra": ("mlp.gate",), "width": 4}),
+        # Every probe used to carry one value, so any same-shaped tensor
+        # satisfied any other's expectation; probes spread alike then leave a
+        # swap of two neighbours looking like a constant offset.
+        ("swaps", {"extra": ("self_attn.q_proj", "self_attn.k_proj")}),
+    ],
+)
+def test_moe_gguf_export_refuses_what_it_cannot_prove(tmp_path, quirk, shape):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_quirky_moe_model(quirk, **shape)
+    path = _stage_moe_directory(tmp_path, model)
+    before = (path / "model-00001-of-00001.safetensors").read_bytes()
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 0
+    assert (path / "model-00001-of-00001.safetensors").read_bytes() == before
+
+
+def test_moe_gguf_export_does_not_undo_an_offset_the_source_already_gave_up(tmp_path):
+    # The norm convention is restored before this runs, from the source
+    # checkpoint. Measuring from the sanitizer alone reaches a source that never
+    # revealed one, so the two measurements must not both be subtracted.
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_quirky_moe_model("constant", extra=("input_layernorm",))
+    path = _stage_moe_directory(tmp_path, model)
+
+    assert mutils._prepare_moe_gguf_export_directory(
+        path, model=model,
+        source_norm_offsets={"model.layers.1.input_layernorm.weight": 1.0},
+    ) == 3
+    tensors = _staged_tensors(path)
+    assert mutils._mlx_arrays_match(
+        tensors["model.layers.1.input_layernorm.weight"],
+        model.expected["model.layers.1.input_layernorm.weight"],
+    )
+    # The layer the source did not cover still has to be corrected here.
+    assert mutils._mlx_arrays_match(
+        tensors["model.layers.0.input_layernorm.weight"],
+        model.expected["model.layers.0.input_layernorm.weight"] - 1.0,
+    )
+
+
+def test_moe_gguf_export_leaves_a_tensor_the_sanitizer_drops_unnamed(tmp_path):
+    # A dropped tensor is reproduced under neither spelling, so nothing about a
+    # rename of it is ever proved. Renaming it anyway can turn a name llama.cpp
+    # reads into one it does not.
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_quirky_moe_model("drops", extra=("mtp",), num_layers=1)
+    model.expected["model.mtp.0.weight"] = model.expected.pop(
+        "model.layers.0.mtp.weight"
+    )
+    path = _stage_moe_directory(tmp_path, model)
+
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 1
+    tensors = _staged_tensors(path)
+    assert "model.layers.0.moe.gate_proj.weight" in tensors
+    assert "model.mtp.0.weight" in tensors
+
+
+def test_moe_gguf_export_treats_a_failed_source_measurement_as_an_answer(
+    monkeypatch, tmp_path
+):
+    # None means the source could not be read, which is a measurement. Re-reading
+    # it here could succeed where the caller's read failed, and then the two
+    # passes would be subtracting against different answers.
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_quirky_moe_model("constant", extra=("input_layernorm",))
+    path = _stage_moe_directory(tmp_path, model)
+    monkeypatch.setattr(
+        mutils, "_mlx_sanitizer_norm_offsets",
+        lambda model: pytest.fail("re-read a source the caller had already read"),
+    )
+
+    assert mutils._prepare_moe_gguf_export_directory(
+        path, model=model, source_norm_offsets=None
+    ) == 4
+    assert mutils._mlx_arrays_match(
+        _staged_tensors(path)["model.layers.1.input_layernorm.weight"],
+        model.expected["model.layers.1.input_layernorm.weight"] - 1.0,
+    )
+
+
+def test_moe_gguf_export_builds_each_probe_once_for_the_whole_search(monkeypatch):
+    import unsloth_zoo.mlx.utils as mutils
+
+    model = _make_quirky_moe_model(leaves=RENAMED_LEAVES)
+    staged = {n: mutils.mx.zeros(t.shape, dtype=t.dtype)
+              for n, t in model.expected.items()}
+    built, real = [], mutils._mlx_moe_offset_probe
+    monkeypatch.setattr(mutils, "_mlx_moe_offset_probe",
+                        lambda shape, value: built.append(value) or real(shape, value))
+    mutils._build_mlx_moe_rename_plan(model, staged, None)
+    # At most two probes per tensor however many candidates were tried: one
+    # cache outlives the whole search, rather than one per candidate.
+    assert len(built) <= 2 * len(staged)

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -4079,3 +4079,46 @@ def test_moe_gguf_export_relocates_a_namespace_every_tensor_carries(tmp_path):
     assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 4
     assert sorted(_staged_tensors(path)) == sorted(model.checkpoint)
 
+
+def test_moe_gguf_export_splits_a_tensor_a_sanitizer_fused_from_a_named_group(tmp_path):
+    """Parts fused into one staged tensor, named and ordered by the sanitizer's tuple."""
+    import unsloth_zoo.mlx.utils as mutils
+    mx = mutils.mx
+    class Model:
+        def __init__(self):
+            self.checkpoint = {
+                f"model.layers.{layer}.attn.{part}":
+                    mx.arange(6, dtype=mx.float32).reshape(3, 2) + 10 * layer + index
+                for layer in range(2) for index, part in enumerate(
+                    ("q_conv.weight", "k_conv.weight", "v_conv.weight"))}
+
+        def named_modules(self):
+            yield "", self
+
+        def sanitize(self, weights):
+            out, held = {}, {}
+            for name, tensor in weights.items():
+                for part in ("q_conv.weight", "k_conv.weight", "v_conv.weight"):
+                    if name.endswith(part):
+                        held.setdefault(name[: -len(part)], {})[part] = tensor
+                        break
+                else:
+                    out[name] = tensor
+            for head, found in held.items():
+                if len(found) == 3:
+                    out[head + "conv.weight"] = mx.concatenate(
+                        [found["q_conv.weight"], found["k_conv.weight"],
+                         found["v_conv.weight"]], axis=0)
+                else:
+                    out.update((head + part, value) for part, value in found.items())
+            return out
+
+    model = Model()
+    model.expected = model.sanitize(dict(model.checkpoint))
+    assert sorted(model.expected) == ["model.layers.0.attn.conv.weight",
+                                      "model.layers.1.attn.conv.weight"]
+    path = _stage_moe_directory(tmp_path, model)
+    assert mutils._prepare_moe_gguf_export_directory(path, model=model) == 2
+    rewritten = _staged_tensors(path)
+    assert sorted(rewritten) == sorted(model.checkpoint)
+    assert all(rewritten[n].tolist() == v.tolist() for n, v in model.checkpoint.items())

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14759,12 +14759,14 @@ def _sync_gguf_nextn_layer_config(config, model):
 
 
 def _prepare_mlx_gguf_export_directory(
-    path, model=None, replay_sanitizers=True, norm_offsets=_UNMEASURED
+    path, model=None, replay_sanitizers=True, norm_offsets=_UNMEASURED,
+    relaid_out=None,
 ):
     """Restore HF tensor names, layouts and norm convention in the export dir.
 
     ``replay_sanitizers`` gates the VLM-only name/layout inversion; the norm correction
-    always runs. ``norm_offsets`` is one source measurement shared by every pass."""
+    always runs. ``norm_offsets`` is one source measurement shared by every pass, and
+    ``relaid_out`` collects the names whose axes this pass moved, for the same reason."""
     path = Path(path)
     config_path = path / "config.json"
     if not config_path.exists():
@@ -14812,6 +14814,14 @@ def _prepare_mlx_gguf_export_directory(
                 raise RuntimeError(
                     f"Unsloth: duplicate tensor name after GGUF rewrite: {new_name}"
                 )
+            # A moved axis shows in the shape. The MoE pass reads this directory after
+            # it, and an adjacent-axis move is its own inverse, so replaying the
+            # sanitizer over a second inversion hands back what is on disk and the
+            # confirmation accepts it: the tensor would ship transposed off HF layout.
+            if relaid_out is not None and getattr(
+                tensor, "shape", None
+            ) != getattr(original_tensor, "shape", None):
+                relaid_out.add(new_name)
             updated[new_name] = tensor
             name_map[name] = new_name
             file_rewritten += int(changed)
@@ -16160,7 +16170,8 @@ def _mlx_staged_tensor_stubs(files):
     return staged
 
 
-def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None):
+def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None,
+                               source_layouts=()):
     staged = _mlx_staged_tensor_stubs(files)
     stacked = _mlx_stacked_expert_tensor_names(model, staged)
     # A block relocation shows as ordinary renames on its router and shared experts.
@@ -16209,6 +16220,9 @@ def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None):
         for name, constant in offsets.items()
         if name not in (source_norm_offsets or {})
     }
+    # Nor move an axis the pass before this one already moved back.
+    layouts = {name: layout for name, layout in layouts.items()
+               if name not in (source_layouts or ())}
     # Never take away a name the converter already reads.
     plan = {name: names for name, names in plan.items()
             if not _kept_for_the_gguf_converter(name)}
@@ -16218,7 +16232,7 @@ def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None):
 
 
 def _prepare_moe_gguf_export_directory(
-    path, model=None, source_norm_offsets=_UNMEASURED
+    path, model=None, source_norm_offsets=_UNMEASURED, source_layouts=()
 ):
     """Restore the MoE tensor names and values llama.cpp converters read."""
     path = Path(path)
@@ -16227,7 +16241,7 @@ def _prepare_moe_gguf_export_directory(
     if source_norm_offsets is _UNMEASURED:
         source_norm_offsets = _mlx_sanitizer_norm_offsets(model)
     plan, offsets, layouts, merges = _plan_mlx_moe_gguf_rewrite(
-        model, files, source_norm_offsets
+        model, files, source_norm_offsets, source_layouts
     )
     if not plan and not merges and not offsets and not layouts:
         return 0
@@ -17130,13 +17144,15 @@ def save_pretrained_gguf(
         save_merged_model(model, tokenizer, tmp_path, dequantize=True)
         # Measured once so both passes subtract against the same answer.
         norm_offsets = _mlx_sanitizer_norm_offsets(model)
+        relaid_out = set()
         rewritten = _prepare_mlx_gguf_export_directory(
             tmp_path, model=model, replay_sanitizers=is_vlm_model,
-            norm_offsets=norm_offsets,
+            norm_offsets=norm_offsets, relaid_out=relaid_out,
         )
         # Must run after the norm pass, whose offsets are keyed by the saved names.
         rewritten += _prepare_moe_gguf_export_directory(
             tmp_path, model=model, source_norm_offsets=norm_offsets,
+            source_layouts=relaid_out,
         )
         if rewritten:
             print(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14823,6 +14823,187 @@ def _prepare_mlx_gguf_export_directory(path, model=None, replay_sanitizers=True)
     return rewritten
 
 
+# mlx-lm stacks an MoE block's per-expert HF tensors into one SwitchLinear parameter,
+# whose name llama.cpp cannot map. Legacy leaf names come first and the identity map
+# last: where a sanitizer renames then stacks (LFM2 turns w1/w2/w3 into gate/down/up)
+# both replay, and only the legacy one names tensors the converter reads.
+_MOE_EXPERT_GROUPS = ("experts", "mlp")
+_MOE_EXPERT_LEAF_ALIASES = (
+    {"gate_proj": "w1", "down_proj": "w2", "up_proj": "w3"},
+    {"fc1": "up_proj", "fc2": "down_proj"},
+    {},
+)
+_MOE_EXPERT_PARAMS = ("weight", "bias")
+
+
+def _is_mlx_switch_expert_module(module):
+    num_experts = getattr(module, "num_experts", None)
+    if not isinstance(num_experts, int):
+        return False
+    shape = getattr(getattr(module, "weight", None), "shape", None)
+    return shape is not None and len(shape) == 3 and shape[0] == num_experts
+
+
+def _mlx_stacked_expert_tensor_names(model, tensor_names):
+    named_modules = getattr(model, "named_modules", None)
+    if not callable(named_modules):
+        return {}
+
+    stacked = {}
+    for path, module in named_modules():
+        if not path or not _is_mlx_switch_expert_module(module):
+            continue
+        # LoRA keeps the base SwitchLinear at ".linear", so the module path is
+        # one or more components longer than the saved parameter path.
+        while path and f"{path}.weight" not in tensor_names:
+            path = path.rsplit(".", 1)[0] if "." in path else ""
+        if not path or path.count(".") < 2:
+            continue
+        for param in _MOE_EXPERT_PARAMS:
+            name = f"{path}.{param}"
+            if name in tensor_names:
+                stacked[name] = module.num_experts
+    return stacked
+
+
+def _mlx_moe_sanitizers(model):
+    """Sanitizers that may own an MoE block's expert stacking."""
+    sanitizers = []
+    for owner in (model, getattr(model, "language_model", None),
+                  getattr(model, "text_model", None)):
+        if owner is None or getattr(owner, "sanitize", None) is None:
+            continue
+        if all(existing is not owner for existing in sanitizers):
+            sanitizers.append(owner)
+    return sanitizers
+
+
+def _mlx_moe_expert_names(name, num_experts, group, leaf_alias):
+    base, param = name.rsplit(".", 1)
+    prefix, _container, leaf = base.rsplit(".", 2)
+    leaf = leaf_alias.get(leaf, leaf)
+    return [f"{prefix}.{group}.{e}.{leaf}.{param}" for e in range(num_experts)]
+
+
+def _mlx_moe_probe_tensor(shape, value):
+    """A marker tensor of the same rank as a per-expert slice, but tiny."""
+    return mx.full(tuple(min(dim, 2) for dim in shape), value, dtype=mx.float32)
+
+
+def _mlx_moe_probe_is_stacked_in_order(stacked, num_experts):
+    shape = getattr(stacked, "shape", None)
+    if shape is None or len(shape) < 1 or shape[0] != num_experts:
+        return False
+    try:
+        markers = mx.reshape(stacked, (num_experts, -1))[:, 0]
+        return bool(
+            mx.array_equal(markers, mx.arange(num_experts, dtype=markers.dtype))
+        )
+    except Exception:
+        return False
+
+
+def _candidate_mlx_moe_unstack_plans(stacked):
+    """Yield per-expert naming plans to try, most trustworthy first."""
+    for group in _MOE_EXPERT_GROUPS:
+        for leaf_alias in _MOE_EXPERT_LEAF_ALIASES:
+            yield {
+                name: _mlx_moe_expert_names(name, num_experts, group, leaf_alias)
+                for name, num_experts in stacked.items()
+            }
+
+
+def _build_mlx_moe_expert_unstack_plan(model, stacked, staged):
+    """Recover per-expert HF names, then prove them by replaying sanitize()."""
+    sanitizers = _mlx_moe_sanitizers(model)
+    # Sanitizers read non-expert weights too, so replay against the whole
+    # checkpoint. Only the markers are evaluated; MLX keeps the rest lazy.
+    others = {name: tensor for name, tensor in staged.items() if name not in stacked}
+    for plan in _candidate_mlx_moe_unstack_plans(stacked):
+        probe = dict(others)
+        for name, expert_names in plan.items():
+            slice_shape = tuple(staged[name].shape)[1:]
+            for expert, expert_name in enumerate(expert_names):
+                probe[expert_name] = _mlx_moe_probe_tensor(slice_shape, expert)
+        if len(probe) != len(others) + sum(len(v) for v in plan.values()):
+            continue
+        for sanitizer in sanitizers:
+            try:
+                sanitized = sanitizer.sanitize(dict(probe))
+            except Exception:
+                continue
+            if all(
+                _mlx_moe_probe_is_stacked_in_order(sanitized.get(name), stacked[name])
+                for name in plan
+            ):
+                return plan
+    return None
+
+
+def _plan_mlx_moe_expert_unstacking(model, files):
+    """Plan the per-expert rewrite without holding the whole checkpoint open."""
+    # Planning needs every tensor's name, shape and dtype, never its values, so
+    # stand-ins let each shard close again. Keeping the real ones would hold a
+    # descriptor and a mapping per shard for the length of the plan.
+    staged = {}
+    for file in files:
+        for name, tensor in mx.load(str(file)).items():
+            staged[name] = mx.zeros(tensor.shape, dtype=tensor.dtype)
+    stacked = _mlx_stacked_expert_tensor_names(model, staged)
+    if not stacked:
+        return None
+    # Architectures whose stacked layout llama.cpp already maps (Llama 4 keeps its
+    # experts fused in HF too) have no per-expert names to recover.
+    return _build_mlx_moe_expert_unstack_plan(model, stacked, staged)
+
+
+def _prepare_moe_gguf_export_directory(path, model=None):
+    """Split stacked MLX MoE experts back into per-expert HF tensors."""
+    path = Path(path)
+    files = sorted(path.glob("*.safetensors"))
+    plan = _plan_mlx_moe_expert_unstacking(model, files)
+    if not plan:
+        return 0
+
+    name_map = {}
+    for file in files:
+        # One shard at a time: mx.eval below materializes everything this shard
+        # holds, so keeping earlier shards alive would scale with the model.
+        tensors = mx.load(str(file))
+        if not any(name in plan for name in tensors):
+            continue
+        updated = {}
+        for name, tensor in tensors.items():
+            expert_names = plan.get(name)
+            if expert_names is None:
+                updated[name] = tensor
+                continue
+            for expert, expert_name in enumerate(expert_names):
+                updated[expert_name] = tensor[expert]
+            name_map[name] = expert_names
+        # mx.load() arrays may be file-backed; saving over the source can
+        # truncate them before they materialize, so write beside and replace.
+        mx.eval(*updated.values())
+        tmp_file = file.with_name(f"{file.stem}.tmp{file.suffix}")
+        mx.save_safetensors(str(tmp_file), updated, metadata={"format": "mlx"})
+        os.replace(tmp_file, file)
+        del updated, tensors
+
+    index_path = path / "model.safetensors.index.json"
+    if name_map and index_path.exists():
+        with open(index_path, "r") as f:
+            index_data = json.load(f)
+        weight_map = {}
+        for name, shard in index_data.get("weight_map", {}).items():
+            for expert_name in name_map.get(name, (name,)):
+                weight_map[expert_name] = shard
+        index_data["weight_map"] = dict(sorted(weight_map.items()))
+        with open(index_path, "w") as f:
+            json.dump(index_data, f, indent=4)
+
+    return len(name_map)
+
+
 _CORE_SAVE_FILENAMES = {
     "config.json",
     "model.safetensors.index.json",
@@ -15653,6 +15834,9 @@ def save_pretrained_gguf(
         rewritten = _prepare_mlx_gguf_export_directory(
             tmp_path, model=model, replay_sanitizers=is_vlm_model
         )
+        # After the norm convention is restored, so the offsets it measures are
+        # still keyed by the names the merged save wrote.
+        rewritten += _prepare_moe_gguf_export_directory(tmp_path, model=model)
         if rewritten:
             print(
                 f"Unsloth: Rewrote {rewritten} MLX tensors "

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -15039,29 +15039,82 @@ def _build_mlx_moe_expert_unstack_plan(model, stacked, staged, parents=(("", "")
 # architectures no static table anticipated; the replay decides whether one applies.
 _MOE_VOCABULARY_DEPTH = 5
 _MOE_VOCABULARY_UBIQUITY = 0.5
+# How far a sanitizer's calls are followed. Every installed architecture spells its names
+# one call away, so two is measured margin for one that delegates twice.
+_MOE_VOCABULARY_CALLS = 2
 
 
-def _mlx_sanitizer_vocabulary(sanitizers):
-    """Name fragments a sanitizer mentions, read from its constant pool."""
-    found = set()
+def _mlx_sanitizer_own_functions(found, package, mentioned):
+    """The package's own functions one global name reaches.
+
+    Only the attributes named beside a class, since following every method would cost a
+    vocabulary the sanitizer never mentions.
+    """
+    def owned(value):
+        return (inspect.isfunction(value)
+                and (getattr(value, "__module__", "") or "").split(".")[0] == package)
+
+    if isinstance(found, type):
+        return [value for name, value in vars(found).items()
+                if name in mentioned and owned(value)]
+    return [found] if owned(found) else []
+
+
+def _mlx_sanitizer_code(sanitizers):
+    """Every code object a sanitizer reaches inside the model's own package.
+
+    Only the model's own package is followed: a walk into mlx or numpy would cost
+    a vocabulary of everything and prove nothing.
+    """
+    reached, walked = [], set()
+
+    def walk(function, calls):
+        code = getattr(function, "__code__", None)
+        if code is None or code in walked:
+            return
+        walked.add(code)
+        reached.append(code)
+        if calls >= _MOE_VOCABULARY_CALLS:
+            return
+        package = (getattr(function, "__module__", "") or "").split(".")[0]
+        namespace = getattr(function, "__globals__", None) or {}
+        mentioned = set(code.co_names)
+        for name in code.co_names:
+            for called in _mlx_sanitizer_own_functions(
+                namespace.get(name), package, mentioned
+            ):
+                walk(called, calls + 1)
+
+    for sanitizer in sanitizers:
+        for owner in getattr(sanitizer, "owners", (sanitizer,)):
+            walk(getattr(type(owner), "sanitize", None), 0)
+    return reached
+
+
+def _mlx_sanitizer_constants(codes, keep):
+    found = []
 
     def collect(obj, depth):
         if depth > _MOE_VOCABULARY_DEPTH:
             return
-        if isinstance(obj, str):
-            found.add(obj)
-        elif isinstance(obj, (tuple, list, frozenset)):
+        if keep(obj):
+            found.append(obj)
+        if isinstance(obj, (tuple, list, frozenset)):
             for item in obj:
                 collect(item, depth + 1)
         elif hasattr(obj, "co_consts"):
             for item in obj.co_consts:
                 collect(item, depth + 1)
 
-    for sanitizer in sanitizers:
-        for owner in getattr(sanitizer, "owners", (sanitizer,)):
-            sanitize = getattr(type(owner), "sanitize", None)
-            collect(getattr(sanitize, "__code__", None), 0)
-    return sorted(f for f in found if len(f) > 1 and not f.isspace())
+    for code in codes:
+        collect(code, 0)
+    return found
+
+
+def _mlx_sanitizer_vocabulary(sanitizers):
+    found = _mlx_sanitizer_constants(
+        _mlx_sanitizer_code(sanitizers), lambda obj: isinstance(obj, str))
+    return sorted({f for f in found if len(f) > 1 and not f.isspace()})
 
 
 def _mlx_moe_rename_candidates(vocabulary, names, ubiquity=_MOE_VOCABULARY_UBIQUITY):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -31,6 +31,7 @@ import contextlib
 import contextvars
 import copy
 import inspect
+import itertools
 import importlib
 import importlib.util
 import json
@@ -14508,6 +14509,23 @@ def _has_vlm_gguf_rewrite_candidate(name, tensor):
     return _has_vlm_gguf_tensor_candidate(name, tensor)
 
 
+def _mlx_tensors_identical(actual, expected):
+    """The same tensor as stored: dtype and bits, not numeric equality."""
+    held = getattr(actual, "dtype", None)
+    wanted = getattr(expected, "dtype", None)
+    if (held is None) != (wanted is None) or (held is not None and held != wanted):
+        return False
+    if held is not None and getattr(actual, "shape", None) == getattr(expected, "shape", None):
+        try:
+            # Flattened first: a scalar cannot be viewed as a type of another
+            # size, and a checkpoint may hold one.
+            return bool(mx.all(mx.view(mx.reshape(actual, (-1,)), mx.uint8)
+                               == mx.view(mx.reshape(expected, (-1,)), mx.uint8)))
+        except Exception:
+            pass
+    return _mlx_arrays_match(actual, expected)
+
+
 def _mlx_arrays_match(actual, expected):
     """Compare MLX-like arrays without assuming a concrete backend type."""
     shape = getattr(actual, "shape", None)
@@ -15031,30 +15049,26 @@ def _mlx_moe_renamed(names, replaced, replacement):
     return renamed if len(set(renamed.values())) == len(renamed) else {}
 
 
-# Two probes, as (base, spread): tensor at position n is marked base + n * spread.
-# One probe cannot tell a constant offset from a coincidence, and two that spread
-# their tensors alike cannot tell one from a sanitizer that swapped two of them,
-# since the gap between neighbours is then itself a constant.
+# Two probes, as (base, spread): tensor at position n is marked base + n * spread. One
+# cannot tell a constant offset from a coincidence, nor -- a 1-D marker being one repeated
+# value -- a doubled tensor from one with a constant added. Two spreading alike could not
+# tell a constant from a swap, the gap between neighbours being constant too.
 _MOE_PROBE_MARKERS = ((3.0, 1.0), (5.0, 7.0))
 
-
-def _mlx_moe_offset_probe(shape, value, truncated=True, dtype=None):
+def _mlx_moe_replay_marker(shape, value):
     """A marker for replay measurement, full width where a shift can hide.
 
-    1-D tensors are carried whole, since a shift varying along one would read as a
-    constant from a truncated corner. Wider ones are truncated to avoid materializing
-    the checkpoint, and counted rather than filled so an axis move shows: truncation
-    can leave two axes equal, and a filled marker would read a transpose as no change.
+    1-D tensors are carried whole, since a shift along one reads as a constant from a
+    truncated corner. Wider ones are truncated to avoid materializing the checkpoint, and
+    counted rather than filled so an axis move still shows.
     """
     if len(shape) == 1:
-        return mx.full(shape, value, dtype=dtype or mx.float32)
-    if truncated:
-        shape = tuple(min(dim, 2) for dim in shape)
+        return mx.full(shape, value, dtype=mx.float32)
+    shape = tuple(min(dim, 2) for dim in shape)
     size = 1
     for dim in shape:
         size *= dim
-    marker = mx.reshape(mx.arange(size, dtype=mx.float32), shape) + value
-    return marker if dtype is None else marker.astype(dtype)
+    return mx.reshape(mx.arange(size, dtype=mx.float32), shape) + value
 
 
 def _mlx_moe_constant_offset(sanitized, marker):
@@ -15109,16 +15123,16 @@ def _mlx_moe_replay_match(sanitized, marker):
     return None
 
 
-def _mlx_moe_replayed_offsets(sanitizers, proposal, staged, markers=None, required=()):
+def _mlx_moe_replayed_corrections(sanitizers, proposal, staged, markers=None, required=()):
     """For each saved tensor a sanitizer still produces, how it produced it.
 
-    Sanitizers do more than rename: step3p5 stores a norm weight one greater than
-    the checkpoint and llama.cpp adds the same one back, so exporting the stored
-    value would double it, and Kimi Linear's KDA convolutions arrive transposed.
+    Sanitizers do more than rename: step3p5 stores a norm weight one greater than the
+    checkpoint and llama.cpp adds the same one back, and Kimi Linear's KDA convolutions
+    arrive transposed.
     """
     markers = {} if markers is None else markers
     for sanitizer in sanitizers:
-        offsets, replays = {}, []
+        corrections, replays = {}, []
         for base, spread in _MOE_PROBE_MARKERS:
             probe = {}
             # A distinct value per tensor, so a sanitizer that swapped two
@@ -15126,7 +15140,7 @@ def _mlx_moe_replayed_offsets(sanitizers, proposal, staged, markers=None, requir
             for position, (name, proposed) in enumerate(proposal.items()):
                 shape, value = tuple(staged[name].shape), base + position * spread
                 if (shape, value) not in markers:
-                    markers[shape, value] = _mlx_moe_offset_probe(shape, value)
+                    markers[shape, value] = _mlx_moe_replay_marker(shape, value)
                 probe[proposed] = markers[shape, value]
             try:
                 sanitized = sanitizer.sanitize(dict(probe))
@@ -15147,13 +15161,13 @@ def _mlx_moe_replayed_offsets(sanitizers, proposal, staged, markers=None, requir
                 for probe, sanitized in replays
             }
             if len(found) == 1 and None not in found:
-                offsets[name] = found.pop()
-        if offsets:
-            return offsets
+                corrections[name] = found.pop()
+        if corrections:
+            return corrections
     return {}
 
 
-def _completed_mlx_moe_rename_candidate(candidate, offsets, unproven, vocabulary, replay):
+def _completed_mlx_moe_rename_candidate(candidate, corrections, unproven, vocabulary, replay):
     """Try to finish a candidate with a second substitution on what it missed."""
     for replaced, replacement in _mlx_moe_rename_candidates(
         vocabulary, [candidate[name] for name in unproven], ubiquity=1
@@ -15172,14 +15186,401 @@ def _completed_mlx_moe_rename_candidate(candidate, offsets, unproven, vocabulary
             continue
         if len(set(repaired.values())) != len(repaired):
             continue
-        repaired_offsets = replay(repaired, unproven)
-        if unproven <= set(repaired_offsets):
-            return repaired, repaired_offsets
-    return candidate, offsets
+        repaired_corrections = replay(repaired, unproven)
+        if unproven <= set(repaired_corrections):
+            return repaired, repaired_corrections
+    return candidate, corrections
 
 
-def _confirmed_mlx_moe_rewrite(sanitizers, proposal, constants, layouts, staged,
-                               required):
+# The splits reached here are in two: a gate/up pair, or an MLA key/value pair.
+# Of the installed sanitizers, four split in two and one -- DBRX -- splits into
+# one tensor per expert, which this grouping does not reach and which leaves that
+# checkpoint as it stands rather than rewriting it wrongly. Widening the grouping
+# costs a factor of the vocabulary per extra part. The
+# merge is probed with a truncated last axis first so a shape-agnostic split
+# costs a corner rather than the whole tensor, and rounds bound how many
+# siblings one failure at a time can pull into a grouping.
+_MOE_MERGE_PARTS = 2
+_MOE_MERGE_PROBE_WIDTHS = (2, None)
+_MOE_MERGE_ROUNDS = 4
+# A group of one is carried through under its restored name rather than merged.
+_MOE_MERGE_KEPT = ((None,), 0, False)
+
+
+def _mlx_moe_moved_shape(shape, layout):
+    """The shape a part has once the axis move a sanitizer applied is undone."""
+    if layout is None:
+        return tuple(shape)
+    return tuple(mx.moveaxis(mx.zeros(tuple(shape)), layout[1], layout[0]).shape)
+
+
+def _mlx_moe_group_recipe(parts, recipe):
+    """The recipe a group follows: the merge, or the identity for a lone part."""
+    return (parts,) + (recipe if len(parts) > 1 else _MOE_MERGE_KEPT)
+
+
+def _mlx_moe_merged(parts, recipe):
+    """Rebuild the checkpoint tensor a sanitizer split into `parts`."""
+    _, layouts, axis, flattened = recipe
+    merged = mx.concatenate(
+        [
+            part if layout is None else mx.moveaxis(part, layout[1], layout[0])
+            for part, layout in zip(parts, layouts)
+        ],
+        axis=axis,
+    )
+    if flattened:
+        shape = tuple(merged.shape)
+        leading = 1
+        for dim in shape[: axis + 1]:
+            leading *= dim
+        merged = mx.reshape(merged, (leading,) + shape[axis + 1 :])
+    return merged
+
+
+def _mlx_moe_merge_recipes(shapes):
+    ranks = {len(shape) for shape in shapes}
+    if len(ranks) != 1:
+        return
+    rank = ranks.pop()
+    choices = [None] + [layout for layout in _MOE_TENSOR_LAYOUTS if max(layout) < rank]
+    for layouts in itertools.product(choices, repeat=len(shapes)):
+        moved = [
+            _mlx_moe_moved_shape(shape, layout)
+            for shape, layout in zip(shapes, layouts)
+        ]
+        for axis in range(rank):
+            if any(
+                shape[:axis] + shape[axis + 1 :]
+                != moved[0][:axis] + moved[0][axis + 1 :]
+                for shape in moved
+            ):
+                continue
+            # A sanitizer that reshapes cannot tell a merged tensor from the same values
+            # folded into its leading axes, so the flatter form goes first: a checkpoint
+            # stores a projection weight flat, and a split needing the axes rejects it.
+            for flattened in (True, False):
+                if flattened and (axis == 0 or axis + 1 == rank):
+                    continue
+                yield layouts, axis, flattened
+
+
+def _mlx_moe_merge_groups(staged, substitutions):
+    """The staged tensors each substituted name collects, in substitution order.
+
+    Checkpoint order would let one layer collect its parts the other way round.
+    Whether one arrangement holds for every group is what the proof reads.
+    """
+    groups = {}
+    for name in staged:
+        target, rank = name, len(substitutions)
+        for position, (replaced, replacement) in enumerate(substitutions):
+            if replaced in target:
+                target = target.replace(replaced, replacement)
+                rank = min(rank, position)
+        if target != name:
+            groups.setdefault(target, []).append((rank, name))
+    return {
+        target: [name for _, name in sorted(parts)] for target, parts in groups.items()
+    }
+
+
+def _mlx_moe_merge_arrivals(staged, vocabulary):
+    """For each staged name, the names one substitution could restore it to."""
+    arrivals = {}
+    for replaced, replacement in _mlx_moe_rename_candidates(vocabulary, list(staged)):
+        for name, target in _mlx_moe_renamed(staged, replaced, replacement).items():
+            if target not in staged:
+                arrivals.setdefault(name, {}).setdefault(target, (replaced, replacement))
+    return arrivals
+
+
+def _proved_mlx_moe_merge_recipe(sanitizer, staged, groups, recipes, width,
+                                 native=False):
+    """The recipe under which the sanitizer reproduces every merged part.
+
+    Yields the name of a tensor the sanitizer wanted and did not find, which is
+    what a grouping still misses.
+    """
+    merged_parts = {part for parts in groups.values() for part in parts}
+    others, floor_probe = {}, {}
+    for position, (name, tensor) in enumerate(staged.items()):
+        dtype = getattr(tensor, "dtype", mx.float32) if native else mx.float32
+        marker = mx.full(tuple(tensor.shape), float(position), dtype=dtype)
+        floor_probe[name] = marker
+        if name not in merged_parts:
+            others[name] = marker
+    # The floor: a sanitizer can drop a sibling once the fused tensor is present. Read
+    # from the whole checkpoint, since what it does to a sibling can depend on the parts.
+    try:
+        floor = sanitizer.sanitize(dict(floor_probe))
+    except Exception:
+        return
+    kept = {name: floor[name] for name in others if name in floor}
+
+    for recipe in recipes:
+        probe, expected, seed = {}, {}, 0
+        try:
+            for target, parts in groups.items():
+                markers = []
+                for part in parts:
+                    shape = tuple(staged[part].shape)
+                    if width is not None:
+                        shape = shape[:-1] + (min(shape[-1], width),)
+                    size = 1
+                    for dim in shape:
+                        size *= dim
+                    marker = mx.reshape(
+                        mx.arange(seed, seed + size, dtype=mx.float32), shape
+                    )
+                    if native:
+                        marker = marker.astype(staged[part].dtype)
+                    markers.append(marker)
+                    expected[part] = marker
+                    seed += size
+                probe[target] = _mlx_moe_merged(
+                    markers, _mlx_moe_group_recipe(parts, recipe)
+                )
+        except Exception:
+            # A truncated probe only fits a recipe that leaves the last axis
+            # alone; the full-width pass reaches the rest.
+            continue
+        probe.update(others)
+        try:
+            sanitized = sanitizer.sanitize(dict(probe))
+        except KeyError as missing:
+            yield None, missing.args[0] if missing.args else None
+            continue
+        except Exception:
+            continue
+        if any(
+            not _mlx_arrays_match(sanitized.get(name), value)
+            for name, value in kept.items()
+        ):
+            continue
+        # A group at a time: the comparison materializes the marker and what was built
+        # from it, so holding all at once would cost the checkpoint again.
+        proved = True
+        for target, parts in groups.items():
+            for part in parts:
+                proved = proved and _mlx_arrays_match(
+                    sanitized.pop(part, None), expected.pop(part)
+                )
+            probe.pop(target, None)
+            if not proved:
+                break
+        if proved:
+            yield recipe, None
+            return
+
+
+def _proved_mlx_moe_merge_plan(sanitizers, staged, arrivals, target, substitutions,
+                               attempted):
+    """The rewrite one set of substitutions proves, completed from what it fails on."""
+    count = len(substitutions)
+    for _ in range(_MOE_MERGE_ROUNDS):
+        groups = _mlx_moe_merge_groups(staged, substitutions)
+        parts = groups.get(target)
+        if not parts or len(parts) != count or set(groups) & set(staged):
+            return None
+        shapes = [tuple(staged[part].shape) for part in parts]
+        # A recipe is an arrangement rather than a size, so groups agree on rank and not
+        # extent: layers holding different widths are still split the same way.
+        ranks = {len(shape) for shape in shapes}
+        if any(
+            {len(staged[part].shape) for part in group} != ranks
+            for group in groups.values()
+            if len(group) > 1
+        ):
+            return None
+        # Every layer's target collects the same parts, so the grouping is what has been
+        # tried, not the target it was read off. Recording it only once it is worth
+        # replaying keeps one that never got that far from being lost to one that did.
+        grouping = tuple(sorted((t, tuple(g)) for t, g in groups.items()))
+        if grouping in attempted:
+            return None
+        attempted.add(grouping)
+        wanted = None
+        for width in _MOE_MERGE_PROBE_WIDTHS:
+            for sanitizer in sanitizers:
+                for recipe, missing in _proved_mlx_moe_merge_recipe(
+                    sanitizer, staged, groups, _mlx_moe_merge_recipes(shapes), width
+                ):
+                    if recipe is None:
+                        wanted = wanted or missing
+                        continue
+                    # A corner in float32 makes the search affordable and can support a recipe the
+                    # whole tensor contradicts. Rejecting one here lets the full-width pass find the
+                    # recipe that does hold, which refusing the finished rewrite could only lose.
+                    if not any(
+                        confirmed is not None
+                        for confirmed, _ in _proved_mlx_moe_merge_recipe(
+                            sanitizer, staged, groups, [recipe], None, native=True
+                        )
+                    ):
+                        continue
+                    return {
+                        merged: _mlx_moe_group_recipe(group, recipe)
+                        for merged, group in groups.items()
+                    }
+        # A sanitizer that pops a sibling unconditionally throws until the probe carries
+        # it, and names the one it wanted, so the companion rename is read off the
+        # failure rather than searched for.
+        claimed = {part for group in groups.values() for part in group}
+        companion = next(
+            (
+                arrivals[name][wanted]
+                for name in staged
+                if wanted in arrivals.get(name, ()) and name not in claimed
+            ),
+            None,
+        )
+        if companion is None or companion in substitutions:
+            return None
+        substitutions = substitutions + [companion]
+    return None
+
+
+def _build_mlx_moe_merge_plan(model, staged):
+    """Recover checkpoint tensors a sanitizer split into several staged ones.
+
+    GraniteMoE stores a layer's gate and up projections as one tensor, so no rename
+    reaches them: the checkpoint name has no staged counterpart at all. Proposing the
+    concatenation with the name makes the pair provable, and a marker with no two
+    elements alike proves the arrangement, not just the shape.
+    """
+    sanitizers = _mlx_moe_sanitizers(model)
+    vocabulary = _mlx_sanitizer_vocabulary(sanitizers)
+    if not vocabulary:
+        return {}
+    arrivals = _mlx_moe_merge_arrivals(staged, vocabulary)
+    collected = {}
+    for name, targets in arrivals.items():
+        for target in targets:
+            collected.setdefault(target, []).append(name)
+
+    # The same grouping is reached from every layer's target, so replaying it
+    # once is what keeps the search from scaling with the layer count.
+    attempted = set()
+    for target, sources in collected.items():
+        for chosen in itertools.permutations(sources, _MOE_MERGE_PARTS):
+            if len({len(staged[name].shape) for name in chosen}) != 1:
+                continue
+            substitutions = [arrivals[name][target] for name in chosen]
+            if len({replaced for replaced, _ in substitutions}) != len(chosen):
+                continue
+            plan = _proved_mlx_moe_merge_plan(
+                sanitizers, staged, arrivals, target, substitutions, attempted
+            )
+            if plan:
+                return plan
+    return {}
+
+
+def _mlx_moe_merge_placement(files, merges):
+    """Which shard receives each merged tensor, and which shard holds each part.
+
+    Parts may live in different shards, so the merged tensor goes in the first of
+    theirs to be written, which leaves the rest still there to be read: rewriting
+    a shard drops the parts it held.
+    """
+    owned, owner, anchors = {}, {}, {}
+    if merges:
+        consumed = {part for parts, *_ in merges.values() for part in parts}
+        for file in files:
+            for name in mx.load(str(file)):
+                if name in consumed:
+                    owner[name] = file
+        for target, recipe in merges.items():
+            anchor = min(recipe[0], key=lambda part: files.index(owner[part]))
+            owned.setdefault(owner[anchor], {})[target] = recipe
+            anchors[target] = anchor
+    return owned, owner, anchors
+
+
+def _mlx_moe_written_order(files, plan, merges, owned):
+    """Every name the rewrite writes, in the order it will be read back in.
+
+    Asked rather than predicted: what a file hands back depends on its names alone,
+    so a file of one byte apiece answers it without writing the checkpoint again.
+    """
+    consumed = {part for parts, *_ in merges.values() for part in parts}
+    order = []
+    with tempfile.TemporaryDirectory() as directory:
+        probe = Path(directory) / "order.safetensors"
+        for file in files:
+            names = []
+            for name in mx.load(str(file)):
+                if name not in consumed:
+                    names.extend(plan.get(name) or (name,))
+            names.extend(owned.get(file, ()))
+            if not names:
+                continue
+            mx.save_safetensors(
+                str(probe), {name: mx.zeros((1,), dtype=mx.uint8) for name in names}
+            )
+            order.extend(mx.load(str(probe)))
+    return order
+
+
+def _mlx_moe_shard_merges(file, tensors, owner, owned):
+    """Every merged tensor one shard receives, built from the shards holding the parts.
+
+    A call rather than a block, so what it read is let go when it returns: a name
+    still bound to a shard would keep that shard alive through the writes after.
+    """
+    built, loaded = {}, {}
+    for target, recipe in owned.items():
+        parts = recipe[0]
+        values = {}
+        for part_file in {owner[part] for part in parts}:
+            if part_file == file:
+                shard = tensors
+            else:
+                # Opened once for every merge this shard receives: one shard can anchor a merge
+                # for each layer with their parts in another, a descriptor apiece if reopened.
+                shard = loaded.get(part_file)
+                if shard is None:
+                    shard = loaded[part_file] = mx.load(str(part_file))
+            values.update({part: shard[part] for part in parts
+                           if owner[part] == part_file})
+        built[target] = _mlx_moe_merged([values[part] for part in parts], recipe)
+    return built
+
+
+def _mlx_moe_rewritten_checkpoint(staged, plan, offsets, layouts, merges):
+    """The names and tensors the rewrite writes, or None if two of them collide.
+
+    Refused rather than resolved: each tensor is placed in a shard one of its
+    sources came from, so two reconstructions sharing a name survive in different
+    shards and the index picks by position, which no single mapping stands for.
+    """
+    consumed = {part for parts, *_ in merges.values() for part in parts}
+    written = {
+        target: _mlx_moe_merged([staged[part] for part in recipe[0]], recipe)
+        for target, recipe in merges.items()
+    }
+    for name, tensor in staged.items():
+        if name in consumed:
+            continue
+        offset = offsets.get(name)
+        if offset:
+            tensor = (tensor - offset).astype(tensor.dtype)
+        layout = layouts.get(name)
+        if layout:
+            tensor = mx.moveaxis(tensor, layout[1], layout[0])
+        expert_names = plan.get(name) or (name,)
+        values = ((tensor,) if len(expert_names) == 1
+                  else [tensor[expert] for expert in range(len(expert_names))])
+        for expert_name, value in zip(expert_names, values):
+            if expert_name in written:
+                return None
+            written[expert_name] = value
+    return written
+
+
+def _confirmed_mlx_moe_rewrite(sanitizers, files, plan, offsets, layouts, merges,
+                               restored=(), owned=None):
     """Whether replaying the whole rewrite hands the staged checkpoint back.
 
     On the checkpoint rather than on markers: at bfloat16's eight significant bits a
@@ -15192,36 +15593,135 @@ def _confirmed_mlx_moe_rewrite(sanitizers, proposal, constants, layouts, staged,
     every tensor the rewrite claims has to come back whatever the floor says. One the
     source checkpoint already corrected is held to neither.
     """
+    claimed = set(plan) | set(offsets) | set(layouts)
+    claimed.update(part for parts, *_ in merges.values() for part in parts)
+    order = _mlx_moe_written_order(files, plan, merges, owned or {})
     for sanitizer in sanitizers:
-        for base, spread in _MOE_PROBE_MARKERS:
-            probe, expected = {}, {}
-            for position, (name, proposed) in enumerate(proposal.items()):
-                tensor = staged[name]
-                marker = _mlx_moe_offset_probe(
-                    tuple(tensor.shape),
-                    base + position * spread,
-                    False,
-                    getattr(tensor, "dtype", None),
-                )
-                expected[name] = marker
-                constant, layout = constants.get(name), layouts.get(name)
-                if constant:
-                    marker = marker - constant
-                if layout:
-                    marker = mx.moveaxis(marker, layout[1], layout[0])
-                probe[proposed] = marker
-            try:
-                sanitized = sanitizer.sanitize(dict(probe))
-            except Exception:
-                break
-            if any(
-                not _mlx_arrays_match(sanitized.get(name), expected[name])
-                for name in required
-            ):
-                break
-        else:
+        floor = _mlx_moe_floor_names(sanitizer, files, claimed)
+        if floor is None:
+            continue
+        # Which written names each staged tensor accounts for, so that both it
+        # and they can be let go the moment it has been compared.
+        produced, required = {}, floor - set(restored)
+        for file in files:
+            for name in mx.load(str(file)):
+                produced[name] = tuple(plan.get(name) or (name,))
+        for parts, *_ in merges.values():
+            for part in parts[:-1]:
+                produced[part] = ()
+        for target, (parts, *_) in merges.items():
+            produced[parts[-1]] = (target,)
+        # Every replay here assumes the sanitizer reads a mapping and not an order, and
+        # replaying reversed makes that assumption falsifiable rather than silent. Any
+        # disagreement is refused, since the disagreement is what says order was read.
+        forwards = _replayed_mlx_moe_rewrite(
+            sanitizer, files, plan, offsets, layouts, merges, produced, required,
+            order, reverse=False)
+        if forwards is _MOE_REWRITE_COLLIDES:
+            return False
+        if forwards is None:
+            continue
+        # Compared as the second replay produces it, so that one replay's
+        # residue is held rather than both.
+        if _replayed_mlx_moe_rewrite(
+            sanitizer, files, plan, offsets, layouts, merges, produced, required,
+            order, reverse=True, mirrored=forwards
+        ) is not None:
             return True
     return False
+
+
+def _mlx_moe_floor_names(sanitizer, files, claimed):
+    """Every staged name the rewrite has to hand back, or None if it cannot run."""
+    required = set()
+    try:
+        floor = sanitizer.sanitize(_mlx_staged_checkpoint(files))
+        for file in files:
+            for name, tensor in mx.load(str(file)).items():
+                if name in claimed or _mlx_tensors_identical(
+                    floor.pop(name, None), tensor
+                ):
+                    required.add(name)
+                tensor = None
+    except Exception:
+        return None
+    return required
+
+
+_MOE_REWRITE_COLLIDES = object()
+
+
+def _replayed_mlx_moe_rewrite(sanitizer, files, plan, offsets, layouts, merges,
+                              produced, required, order, reverse, mirrored=None):
+    """Replay the rewritten checkpoint once, against the shards as they stand.
+
+    Answers with whatever the replay produced that the shards could not account for,
+    which is all the other replay has to be compared with. Given `mirrored`, what that
+    one left over, each is compared as produced. None says this replay did not hand the
+    checkpoint back, disagreed with the other, or could not run; `_MOE_REWRITE_COLLIDES`
+    says the plan wants one name twice.
+
+    One replay is alive at a time: each holds every shard open while its tensors are
+    needed, and a checkpoint may have more shards than that allows.
+    """
+    try:
+        written = _mlx_moe_rewritten_checkpoint(
+            _mlx_staged_checkpoint(files), plan, offsets, layouts, merges)
+        if written is None:
+            return _MOE_REWRITE_COLLIDES
+        # The order the rewritten directory hands back follows the names, which the
+        # rewrite changes, so it is neither the staged order nor its reverse.
+        written = {name: written[name] for name in
+                   (reversed(order) if reverse else order) if name in written}
+        out = sanitizer.sanitize(dict(written))
+        # Compared one tensor at a time and dropped from every mapping holding it: a
+        # sanitizer rebuilds a stacked expert tensor to hand it back.
+        unaccounted = {}
+        for file in files:
+            for name, tensor in mx.load(str(file)).items():
+                replayed = out.pop(name, None)
+                if name in required:
+                    if not _mlx_tensors_identical(replayed, tensor):
+                        return None
+                elif not _kept_mlx_moe_residue(unaccounted, mirrored, name,
+                                               _mlx_tensor_held(replayed)):
+                    return None
+                tensor = replayed = None
+                for written_name in produced[name]:
+                    written.pop(written_name, None)
+        for name in list(out):
+            if not _kept_mlx_moe_residue(unaccounted, mirrored, name,
+                                         _mlx_tensor_held(out.pop(name))):
+                return None
+        # A name the other replay produced and this one did not.
+        if mirrored:
+            return None
+    except Exception:
+        return None
+    return unaccounted
+
+
+def _kept_mlx_moe_residue(unaccounted, mirrored, name, tensor):
+    """Hold one residue for the other replay, or hold it to what that one left.
+
+    The name is looked up before the value: a name the other replay never produced is a
+    disagreement whatever it holds.
+    """
+    if mirrored is None:
+        unaccounted[name] = tensor
+        return True
+    if name not in mirrored:
+        return False
+    return _mlx_tensors_identical(mirrored.pop(name), tensor)
+
+
+def _mlx_tensor_held(tensor):
+    """A tensor holding its own memory, so the shard it was read from can close: a replay's output can be a view of the shards it was given."""
+    if tensor is None:
+        return None
+    held = mx.array(tensor)
+    mx.eval(held)
+    return held
 
 
 def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
@@ -15247,7 +15747,7 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
     def replay(proposal, required=frozenset()):
         probe = dict(proposal)
         probe.update((name, name) for name in claimed)
-        return _mlx_moe_replayed_offsets(
+        return _mlx_moe_replayed_corrections(
             sanitizers, probe, {**staged, **claimed}, markers, required
         )
 
@@ -15258,8 +15758,8 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
     open_names = [name for name in staged if name not in held]
     proposal = {name: name for name in open_names}
     # The floor: whatever the sanitizer reproduces from the checkpoint must survive.
-    offsets = replay(proposal)
-    baseline = set(offsets)
+    corrections = replay(proposal)
+    baseline = set(corrections)
     for replaced, replacement in _mlx_moe_rename_candidates(vocabulary, open_names):
         renamed = _mlx_moe_renamed(proposal.values(), replaced, replacement)
         if not renamed:
@@ -15278,31 +15778,60 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
             continue
         # Names this candidate leaves alone must keep coming back and the ones it renamed
         # must not: falling short on exactly those is what the completion reads.
-        candidate_offsets = replay(candidate, baseline - recovered)
+        candidate_corrections = replay(candidate, baseline - recovered)
         # One relocation can leave a tensor short by moving two ways at once: Kimi Linear's
         # router bias changes parent module and gains a `.gate.` component. Completing for
         # exactly the names it missed reaches those without trying every pair.
-        unproven = (baseline | recovered) - set(candidate_offsets)
+        unproven = (baseline | recovered) - set(candidate_corrections)
         if unproven and unproven <= recovered:
-            candidate, candidate_offsets = _completed_mlx_moe_rename_candidate(
-                candidate, candidate_offsets, unproven, vocabulary, replay
+            candidate, candidate_corrections = _completed_mlx_moe_rename_candidate(
+                candidate, candidate_corrections, unproven, vocabulary, replay
             )
             recovered = {name for name, p in candidate.items() if p != name}
         # Both halves matter: the floor keeps what the sanitizer already reproduces, and
         # `recovered` makes each new name earn its place -- a name the sanitizer drops is
         # reproduced under neither spelling, so it would be renamed on no evidence at all.
-        if set(candidate_offsets) >= baseline | recovered:
-            proposal, offsets = candidate, candidate_offsets
-    constants = {name: constant for name, (constant, _) in offsets.items() if constant}
-    layouts = {name: layout for name, (_, layout) in offsets.items() if layout}
-    probe = dict(proposal)
-    probe.update((name, name) for name in claimed)
-    if not _confirmed_mlx_moe_rewrite(
-        sanitizers, probe, constants, layouts, {**staged, **claimed}, set(offsets)
-    ):
-        return {}, {}, {}
+        if set(candidate_corrections) >= baseline | recovered:
+            proposal, corrections = candidate, candidate_corrections
+    constants = {name: constant for name, (constant, _) in corrections.items() if constant}
+    layouts = {name: layout for name, (_, layout) in corrections.items() if layout}
     renames = {name: p for name, p in proposal.items() if p != name}
     return renames, constants, layouts
+
+
+# The per-layer projections llama.cpp maps under `model.layers.{bid}.`, spelled the
+# way mlx-lm spells them. Deliberately the wider set -- a pure MoE model has no dense
+# feed-forward -- since a rewrite never takes one of these away, whatever it reads.
+_GGUF_MAPPED_LAYER_LEAVES = frozenset((
+    "self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj", "self_attn.o_proj",
+    "mlp.gate_proj", "mlp.up_proj", "mlp.down_proj",
+))
+
+
+def _kept_for_the_gguf_converter(name):
+    """Whether this is a name the rewrite leaves alone.
+
+    Answered from the names alone -- telling "unmappable" from "already mapped" exactly
+    would need llama.cpp's own per-architecture table -- so it answers for the HF layer
+    prefix and not for every name that table maps: a checkpoint spelling its layers
+    otherwise has names mapped there and not held back here, which no rewrite reaches on
+    any architecture measured. It errs towards keeping, since taking away a name the
+    converter reads breaks a working export: mlx-lm rebuilds dense Hunyuan's
+    `mlp.gate_and_up_proj` from the two parts beside it, and llama.cpp maps the parts and
+    not the whole.
+    """
+    parts = name.split(".")
+    return (len(parts) > 4 and parts[0] == "model" and parts[1] == "layers"
+            and parts[2].isdigit()
+            and ".".join(parts[3:-1]) in _GGUF_MAPPED_LAYER_LEAVES)
+
+
+def _mlx_staged_checkpoint(files):
+    """Every staged tensor, read afresh from the shards."""
+    staged = {}
+    for file in files:
+        staged.update(mx.load(str(file)))
+    return staged
 
 
 def _mlx_staged_tensor_stubs(files):
@@ -15315,19 +15844,7 @@ def _mlx_staged_tensor_stubs(files):
     return staged
 
 
-def _plan_mlx_moe_expert_unstacking(model, files):
-    """Plan the per-expert rewrite without holding the whole checkpoint open."""
-    staged = _mlx_staged_tensor_stubs(files)
-    stacked = _mlx_stacked_expert_tensor_names(model, staged)
-    if not stacked:
-        return None
-    # Architectures whose stacked layout llama.cpp already maps (Llama 4 keeps
-    # its experts fused in HF too) have no per-expert names to recover. Leaving
-    # them exactly as saved is what keeps their working export working.
-    return _build_mlx_moe_expert_unstack_plan(model, stacked, staged)
-
-
-def _plan_mlx_moe_gguf_rewrite(model, files):
+def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None):
     staged = _mlx_staged_tensor_stubs(files)
     stacked = _mlx_stacked_expert_tensor_names(model, staged)
     # A block relocation shows on its router and shared experts, which are ordinary
@@ -15335,56 +15852,87 @@ def _plan_mlx_moe_gguf_rewrite(model, files):
     parents = _mlx_moe_parent_substitutions(
         _build_mlx_moe_rename_plan(model, staged, None, exclude=stacked)[0]
     )
-    # Architectures whose stacked layout llama.cpp already maps (Llama 4 keeps
-    # its experts fused in HF too) have no per-expert names to recover. Leaving
-    # them exactly as saved is what keeps their working export working.
+    # Architectures whose stacked layout llama.cpp already maps (Llama 4 keeps its
+    # experts fused in HF too) have no per-expert names to recover.
     split = (
         _build_mlx_moe_expert_unstack_plan(model, stacked, staged, parents)
         if stacked
         else None
     )
-    renames, offsets, layouts = _build_mlx_moe_rename_plan(model, staged, split)
+    # Tensors a sanitizer split apart have no staged counterpart to rename, so
+    # they are rebuilt first and then kept out of the rename search.
+    merges = _build_mlx_moe_merge_plan(model, staged)
+    consumed = {part for parts, *_ in merges.values() for part in parts}
+    renames, offsets, layouts = _build_mlx_moe_rename_plan(
+        model, staged, split, exclude=consumed
+    )
     plan = dict(split or {})
     # A rename is a one-name split, so the rewrite below needs no second path.
     plan.update((name, [renamed]) for name, renamed in renames.items())
-    return plan, offsets, layouts
-
-
-def _prepare_moe_gguf_export_directory(
-    path, model=None, source_norm_offsets=_UNMEASURED
-):
-    """Restore the MoE tensor names and values llama.cpp converters read.
-
-    Experts are split per-expert only where HF stores them that way, names a
-    sanitizer relocated are put back, and a constant it added is subtracted.
-    """
-    path = Path(path)
-    files = sorted(path.glob("*.safetensors"))
-    plan, offsets, layouts = _plan_mlx_moe_gguf_rewrite(model, files)
-    if not plan:
-        return 0
-    # The norm convention has already been restored for every offset the source
-    # checkpoint revealed. Measuring from the sanitizer alone needs no source,
-    # which is what reaches an already-converted one, but it must not subtract a
-    # second time from what the source covered. The caller passes the one
-    # measurement both passes act on, so they cannot disagree.
-    if source_norm_offsets is _UNMEASURED:
-        source_norm_offsets = _mlx_sanitizer_norm_offsets(model)
+    # Measuring from the sanitizer alone needs no source, which is what reaches an
+    # already-converted checkpoint, but it must not subtract a second time from what
+    # the source measurement covered.
     offsets = {
         name: constant
         for name, constant in offsets.items()
         if name not in (source_norm_offsets or {})
     }
+    # Nothing the converter already reads is taken away, whatever the sanitizer
+    # can rebuild it from.
+    plan = {name: names for name, names in plan.items()
+            if not _kept_for_the_gguf_converter(name)}
+    merges = {target: recipe for target, recipe in merges.items()
+              if not any(_kept_for_the_gguf_converter(part) for part in recipe[0])}
+    return plan, offsets, layouts, merges
 
+
+def _prepare_moe_gguf_export_directory(
+    path, model=None, source_norm_offsets=_UNMEASURED
+):
+    """Restore the MoE tensor names and values llama.cpp converters read."""
+    path = Path(path)
+    files = sorted(path.glob("*.safetensors"))
+    # The caller passes the one norm measurement both passes act on, so they
+    # cannot disagree about what the source checkpoint already covered.
+    if source_norm_offsets is _UNMEASURED:
+        source_norm_offsets = _mlx_sanitizer_norm_offsets(model)
+    plan, offsets, layouts, merges = _plan_mlx_moe_gguf_rewrite(
+        model, files, source_norm_offsets
+    )
+    if not plan and not merges and not offsets and not layouts:
+        return 0
+
+    # The one pass holding every shard open.
+    owned, owner, anchors = _mlx_moe_merge_placement(files, merges)
+    if not _confirmed_mlx_moe_rewrite(
+        _mlx_moe_sanitizers(model), files, plan, offsets, layouts, merges,
+        source_norm_offsets or {}, owned,
+    ):
+        return 0
+
+    # A merge is built as its receiving shard is written, so what is held is one shard
+    # rather than the checkpoint.
     name_map = {}
+    consumed = {part: target for target, (parts, *_) in merges.items() for part in parts}
+    for target, anchor in anchors.items():
+        name_map[anchor] = (target,)
+        for part in merges[target][0]:
+            if part != anchor:
+                name_map[part] = ()
+
     for file in files:
         # One shard at a time: mx.eval below materializes everything this shard
         # holds, so keeping earlier shards alive would scale with the model.
         tensors = mx.load(str(file))
-        if not any(name in plan or name in offsets for name in tensors):
+        if file not in owned and not any(
+            name in plan or name in offsets or name in layouts or name in consumed
+            for name in tensors
+        ):
             continue
-        updated = {}
+        updated = _mlx_moe_shard_merges(file, tensors, owner, owned.get(file, {}))
         for name, tensor in tensors.items():
+            if name in consumed:
+                continue
             offset = offsets.get(name)
             if offset:
                 tensor = (tensor - offset).astype(tensor.dtype)
@@ -15394,7 +15942,7 @@ def _prepare_moe_gguf_export_directory(
             expert_names = plan.get(name)
             if expert_names is None:
                 updated[name] = tensor
-                if offset:
+                if offset or layout:
                     name_map[name] = (name,)
                 continue
             if len(expert_names) == 1:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -15539,7 +15539,10 @@ def _proved_mlx_moe_merge_recipe(sanitizer, staged, groups, recipes, width,
     # The floor: a sanitizer can drop a sibling once the fused tensor is present. Read
     # from the whole checkpoint, since what it does to a sibling can depend on the parts.
     try:
-        floor = sanitizer.sanitize(dict(floor_probe))
+        # Through the probe, like every other replay: `others` holds the same marker
+        # objects, so a sanitizer offsetting a norm with `+=` would write through and
+        # the floor would be measured one step ahead of the recipes it gates.
+        floor = _mlx_moe_sanitized_probe(sanitizer, floor_probe)
     except Exception:
         return
     kept = {name: floor[name] for name in others if name in floor}

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -30,6 +30,7 @@ import collections
 import contextlib
 import contextvars
 import copy
+import dis
 import inspect
 import itertools
 import importlib
@@ -14947,6 +14948,47 @@ def _mlx_moe_sanitizers(model):
     ]
 
 
+def _mlx_moe_sanitized_probe(sanitizer, probe):
+    """Replay a probe, copying the tensors a sanitizer writing in place could reach.
+
+    mlx-vlm offsets a norm weight with `+=`, which writes through to the caller's
+    tensor, so an uncopied probe is measured against itself -- and the markers being
+    cached by shape, one written to misreports every later tensor sharing it. Only the
+    1-D tensors an offset is read from are copied; wider ones would cost a
+    synchronization the search is otherwise free of.
+    """
+    if _mlx_sanitizer_writes_in_place(sanitizer):
+        probe = {
+            name: mx.array(tensor) if getattr(tensor, "ndim", 0) == 1 else tensor
+            for name, tensor in probe.items()
+        }
+    return sanitizer.sanitize(dict(probe))
+
+
+def _mlx_augmented_assignment(instruction):
+    """Both spellings: 3.11 replaced `INPLACE_*` with a `BINARY_OP` carrying the operator, and this package supports 3.9."""
+    return (instruction.opname.startswith("INPLACE_")
+            or (instruction.opname == "BINARY_OP"
+                and instruction.argrepr.endswith("=")))
+
+
+def _mlx_sanitizer_writes_in_place(sanitizer):
+    """Whether a sanitizer's code holds an augmented assignment, which may write through.
+
+    Read from the code because measuring costs the synchronization this exists to
+    avoid, and answered for the operator rather than the type it applies to: a store
+    into a tensor is spelled like the store into the dictionary every sanitizer builds.
+    One that writes some other way is left to the confirmation.
+    """
+    if getattr(sanitizer, "_writes_in_place", None) is None:
+        sanitizer._writes_in_place = any(
+            _mlx_augmented_assignment(instruction)
+            for code in _mlx_sanitizer_code([sanitizer])
+            for instruction in dis.get_instructions(code)
+        )
+    return sanitizer._writes_in_place
+
+
 def _mlx_moe_expert_names(name, num_experts, group, leaf_alias, parent=("", "")):
     base, param = name.rsplit(".", 1)
     prefix, _container, leaf = base.rsplit(".", 2)
@@ -15024,7 +15066,7 @@ def _build_mlx_moe_expert_unstack_plan(model, stacked, staged, parents=(("", "")
             continue
         for sanitizer in sanitizers:
             try:
-                sanitized = sanitizer.sanitize(dict(probe))
+                sanitized = _mlx_moe_sanitized_probe(sanitizer, probe)
             except Exception:
                 continue
             if all(
@@ -15283,7 +15325,7 @@ def _mlx_moe_replayed_corrections(sanitizers, proposal, staged, markers=None, re
                     markers[shape, value] = _mlx_moe_replay_marker(shape, value)
                 probe[proposed] = markers[shape, value]
             try:
-                sanitized = sanitizer.sanitize(dict(probe))
+                sanitized = _mlx_moe_sanitized_probe(sanitizer, probe)
             except Exception:
                 replays = []
                 break
@@ -15492,7 +15534,7 @@ def _proved_mlx_moe_merge_recipe(sanitizer, staged, groups, recipes, width,
             continue
         probe.update(others)
         try:
-            sanitized = sanitizer.sanitize(dict(probe))
+            sanitized = _mlx_moe_sanitized_probe(sanitizer, probe)
         except KeyError as missing:
             yield None, missing.args[0] if missing.args else None
             continue

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14471,17 +14471,26 @@ def _vlm_gguf_name_candidates(name):
     return candidates
 
 
+def _vlm_gguf_layout_candidates(name, tensor):
+    """The candidates that only move axes, named apart so a caller can tell one won.
+
+    A permutation of equally sized axes leaves the shape alone, so a caller comparing
+    shapes cannot see it; the MoE pass reads this directory next and would move those
+    axes a second time."""
+    shape = getattr(tensor, "shape", ())
+    if len(shape) == 5:
+        return [mx.transpose(tensor, (0, 4, 1, 2, 3))]
+    if len(shape) == 4:
+        return [mx.transpose(tensor, (0, 3, 1, 2))]
+    if len(shape) == 3 and "depthwise_conv1d.weight" in name:
+        return [mx.transpose(tensor, (0, 2, 1))]
+    return []
+
+
 def _vlm_gguf_tensor_candidates(name, tensor, norm_offset=1.0):
     """Yield HF-layout tensor candidates for an MLX VLM tensor."""
-    candidates = []
+    candidates = _vlm_gguf_layout_candidates(name, tensor)
     shape = getattr(tensor, "shape", ())
-
-    if len(shape) == 5:
-        candidates.append(mx.transpose(tensor, (0, 4, 1, 2, 3)))
-    elif len(shape) == 4:
-        candidates.append(mx.transpose(tensor, (0, 3, 1, 2)))
-    elif len(shape) == 3 and "depthwise_conv1d.weight" in name:
-        candidates.append(mx.transpose(tensor, (0, 2, 1)))
 
     if norm_offset and len(shape) == 1 and mx.issubdtype(tensor.dtype, mx.floating):
         candidates.append(tensor - norm_offset)
@@ -14814,13 +14823,15 @@ def _prepare_mlx_gguf_export_directory(
                 raise RuntimeError(
                     f"Unsloth: duplicate tensor name after GGUF rewrite: {new_name}"
                 )
-            # A moved axis shows in the shape. The MoE pass reads this directory after
-            # it, and an adjacent-axis move is its own inverse, so replaying the
-            # sanitizer over a second inversion hands back what is on disk and the
-            # confirmation accepts it: the tensor would ship transposed off HF layout.
-            if relaid_out is not None and getattr(
-                tensor, "shape", None
-            ) != getattr(original_tensor, "shape", None):
+            # Which candidate won, not what the shape says: a permutation of equally
+            # sized axes leaves the shape alone. The MoE pass reads this directory
+            # after this one, and an adjacent-axis move is its own inverse, so
+            # replaying the sanitizer over a second inversion hands back what is on
+            # disk and the confirmation accepts it, transposed off HF layout.
+            if relaid_out is not None and changed and any(
+                _mlx_arrays_match(tensor, candidate)
+                for candidate in _vlm_gguf_layout_candidates(name, original_tensor)
+            ):
                 relaid_out.add(new_name)
             updated[new_name] = tensor
             name_map[name] = new_name

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -15117,6 +15117,32 @@ def _mlx_sanitizer_vocabulary(sanitizers):
     return sorted({f for f in found if len(f) > 1 and not f.isspace()})
 
 
+def _mlx_sanitizer_fusion_groups(sanitizers):
+    """Each tuple of names a sanitizer holds, with the fragments beside it.
+
+    Which names belong to one split would otherwise cost the vocabulary to the
+    power of the part count. A sanitizer that fuses several tensors names them in
+    one tuple, so the tuple is the group, in the order they were concatenated, and
+    only the fragments from the same function are worth substituting into.
+    """
+    def named(obj):
+        return (isinstance(obj, tuple) and 1 < len(obj) <= _MOE_SPLIT_PARTS
+                and len(set(obj)) == len(obj)
+                and all(isinstance(item, str) and len(item) > 1 for item in obj))
+
+    found = {}
+    for code in _mlx_sanitizer_code(sanitizers):
+        groups = _mlx_sanitizer_constants([code], named)
+        if not groups:
+            continue
+        fragments = {f for f in _mlx_sanitizer_constants(
+            [code], lambda obj: isinstance(obj, str))
+            if len(f) > 1 and not f.isspace()}
+        for group in groups:
+            found.setdefault(tuple(group), set()).update(fragments)
+    return [(group, sorted(fragments)) for group, fragments in sorted(found.items())]
+
+
 def _mlx_moe_rename_candidates(vocabulary, names, ubiquity=_MOE_VOCABULARY_UBIQUITY):
     """Substitutions worth trying, as (replaced, replacement) pairs.
 
@@ -15330,8 +15356,12 @@ def _mlx_moe_group_recipe(parts, recipe):
 
 
 def _mlx_moe_merged(parts, recipe):
-    """Rebuild the checkpoint tensor a sanitizer split into `parts`."""
-    _, layouts, axis, flattened = recipe
+    """Rebuild the checkpoint tensor a sanitizer split into `parts`.
+
+    A share says the sanitizer went the other way and fused several checkpoint
+    tensors into the one part read here, so what comes back is one slice of it.
+    """
+    _, layouts, axis, flattened, *share = recipe
     merged = mx.concatenate(
         [
             part if layout is None else mx.moveaxis(part, layout[1], layout[0])
@@ -15345,6 +15375,9 @@ def _mlx_moe_merged(parts, recipe):
         for dim in shape[: axis + 1]:
             leading *= dim
         merged = mx.reshape(merged, (leading,) + shape[axis + 1 :])
+    if share and share[0] is not None:
+        index, count = share[0]
+        merged = mx.split(merged, count, axis=axis)[index]
     return merged
 
 
@@ -15752,6 +15785,121 @@ def _build_mlx_moe_expert_stack_plan(model, staged):
     return plan
 
 
+# How many tensors one staged tensor is split back into. Three covers the KDA
+# convolutions glm5_next fuses; a group longer than this is a table of names
+# rather than the parts of one tensor.
+_MOE_SPLIT_PARTS = 4
+
+
+def _mlx_moe_split_recipes(rank, count):
+    """Every way one staged tensor could be the concatenation of `count` parts.
+
+    Both directions of every axis move, unlike a merge's: a merge undoes what the
+    sanitizer did to a part it was given, a split does it to one it hands over.
+    """
+    moves = [layout for layout in _MOE_TENSOR_LAYOUTS if max(layout) < rank]
+    # Moved layouts first, identity last: a sanitizer only moves an axis because
+    # some checkpoint stores it the other way, so where both replay -- as they do
+    # for glm5_next's convolutions -- the moved one is what llama.cpp reads.
+    for layout in moves + [(after, before) for before, after in moves] + [None]:
+        for axis in range(rank):
+            yield (layout,), axis
+
+
+def _proved_mlx_moe_name_split(sanitizer, staged, source, proposals, recipes):
+    """The naming and recipe under which the sanitizer fuses parts into `source`.
+
+    A merge's proof reads markers back under the names it gave; here the names are
+    new, so what has to come back is the one tensor they were built into. The floor
+    is replayed once for the source: what it holds does not depend on the naming.
+    """
+    others = {name: mx.full(tuple(tensor.shape), float(position), dtype=mx.float32)
+              for position, (name, tensor) in enumerate(staged.items())
+              if name != source}
+    try:
+        floor = sanitizer.sanitize(dict(others))
+    except Exception:
+        return None
+    # The floor, as the merge proof reads it, against the source arriving as parts.
+    kept = {name: floor[name] for name in others if name in floor}
+
+    shape = tuple(staged[source].shape)
+    for layouts, axis in recipes:
+        for targets in proposals:
+            if shape[axis] % len(targets):
+                continue
+            part = shape[:axis] + (shape[axis] // len(targets),) + shape[axis + 1:]
+            size, seed, markers = 1, 0, []
+            for dim in part:
+                size *= dim
+            for _ in targets:
+                markers.append(mx.reshape(
+                    mx.arange(seed, seed + size, dtype=mx.float32), part))
+                seed += size
+            try:
+                expected = mx.concatenate(markers, axis=axis)
+                layout = layouts[0]
+                probe = dict(others)
+                for name, marker in zip(targets, markers):
+                    probe[name] = (marker if layout is None
+                                   else mx.moveaxis(marker, layout[0], layout[1]))
+                sanitized = sanitizer.sanitize(probe)
+            except Exception:
+                continue
+            if not _mlx_arrays_match(sanitized.get(source), expected):
+                continue
+            if any(not _mlx_arrays_match(sanitized.get(name), value)
+                   for name, value in kept.items()):
+                continue
+            return targets, layouts, axis
+    return None
+
+
+def _build_mlx_moe_name_split_plan(model, staged, claimed):
+    """Recover checkpoint tensors a sanitizer fused into one staged tensor.
+
+    glm5_next concatenates a layer's three KDA convolutions and moves an axis, so
+    neither a rename nor a merge reaches them: the checkpoint holds the parts and
+    the staged form the whole. Each part is a share of the tensor it came from.
+    """
+    sanitizers = _mlx_moe_sanitizers(model)
+    groups = _mlx_sanitizer_fusion_groups(sanitizers)
+    if not groups:
+        return {}
+
+    plan = {}
+    for source in sorted(staged):
+        if source in claimed or _kept_for_the_gguf_converter(source):
+            continue
+        rank = len(staged[source].shape)
+        # The names first, since they are string work and a replay is not.
+        proposals = []
+        for group, fragments in groups:
+            for replaced in fragments:
+                if replaced not in source or replaced in group:
+                    continue
+                targets = [source.replace(replaced, name) for name in group]
+                if len(set(targets)) != len(targets) or any(
+                    name == source or name in staged for name in targets
+                ):
+                    continue
+                if targets not in proposals:
+                    proposals.append(targets)
+        if not proposals:
+            continue
+        recipes = list(_mlx_moe_split_recipes(rank, len(proposals[0])))
+        for sanitizer in sanitizers:
+            proved = _proved_mlx_moe_name_split(
+                sanitizer, staged, source, proposals, recipes)
+            if proved is None:
+                continue
+            targets, layouts, axis = proved
+            for index, name in enumerate(targets):
+                plan[name] = ([source], layouts, axis, False, (index, len(targets)))
+            break
+    return plan
+
+
 def _mlx_moe_merge_placement(files, merges):
     """Which shard receives each merged tensor, and which shard holds each part.
 
@@ -16153,6 +16301,19 @@ def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None):
             offsets.pop(part, None)
             layouts.pop(part, None)
     merges.update(late)
+    # A fused tensor has no staged counterpart, so the split runs over what nothing
+    # else claimed, and its own rename is dropped: the parts carry the name now, and
+    # two reconstructions of one tensor is not a checkpoint.
+    fused = _build_mlx_moe_name_split_plan(
+        model, staged,
+        set(merges) | {part for parts, *_ in merges.values() for part in parts}
+        | set(split or {}))
+    for parts, *_ in fused.values():
+        for part in parts:
+            renames.pop(part, None)
+            offsets.pop(part, None)
+            layouts.pop(part, None)
+    merges.update(fused)
     plan = dict(split or {})
     # A rename is a one-name split, so the rewrite below needs no second path.
     plan.update((name, [renamed]) for name, renamed in renames.items())
@@ -16201,10 +16362,13 @@ def _prepare_moe_gguf_export_directory(
     # rather than the checkpoint.
     name_map = {}
     consumed = {part: target for target, (parts, *_) in merges.items() for part in parts}
-    for target, anchor in anchors.items():
-        name_map[anchor] = (target,)
+    # A split's targets all read one tensor, so its anchor collects them rather
+    # than the last one winning and the index losing the rest.
+    for target, anchor in sorted(anchors.items()):
+        name_map[anchor] = name_map.get(anchor, ()) + (target,)
+    for target, anchor in sorted(anchors.items()):
         for part in merges[target][0]:
-            if part != anchor:
+            if part != anchor and part not in name_map:
                 name_map[part] = ()
 
     for file in files:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -15123,15 +15123,29 @@ def _mlx_moe_rename_candidates(vocabulary, names, ubiquity=_MOE_VOCABULARY_UBIQU
     ``ubiquity`` of 1 offers every fragment, which is right once the names have
     been narrowed to the few a candidate could not account for.
     """
-    # A fragment carried by most tensors names the checkpoint's shape, not one
-    # block's layout, so substituting it can only produce nonsense to replay.
     limit = max(1, int(len(names) * ubiquity))
     for replaced in vocabulary:
-        if sum(replaced in name for name in names) not in range(1, limit + 1):
+        carried = [name for name in names if replaced in name]
+        if not carried:
             continue
+        # A fragment carried by most tensors names the checkpoint's shape, not one block's
+        # layout -- unless every name carrying it starts with it, which is a namespace, and
+        # a relocated namespace is what qwen4_exp's 86 of 88 names differ by.
+        relocation = len(carried) > limit
+        if relocation and not all(name.startswith(replaced) for name in carried):
+            continue
+        # A relocation moves a namespace and does not invent one, so it is only
+        # offered fragments spelling the same components in another order: pairing
+        # one with the whole vocabulary costs a replay per name in the checkpoint.
+        components = sorted(part for part in replaced.split(".") if part)
         for replacement in vocabulary:
-            if replacement != replaced:
-                yield replaced, replacement
+            if replacement == replaced:
+                continue
+            if relocation and sorted(
+                part for part in replacement.split(".") if part
+            ) != components:
+                continue
+            yield replaced, replacement
         # A checkpoint can spell a tensor with one fragment fewer rather than a
         # different one -- mlx-lm appends `.weight` to a name carried bare -- and no
         # fragment stands for its absence.

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14893,16 +14893,58 @@ def _mlx_stacked_expert_tensor_names(model, tensor_names):
     return stacked
 
 
+class _MlxReplayedSanitizers:
+    """Sanitizers replayed in order, leaving no module of the model changed.
+
+    A vision-language model's saved names are the composition's image, so no
+    single sanitizer reproduces them. And some write to their module: Gemma 3 ties
+    its output head and drops `lm_head` when what arrives carries no
+    `lm_head.weight`, which is exactly what a search renaming that tensor hands it.
+    """
+
+    def __init__(self, owners, held):
+        self.owners = tuple(owners)
+        self.held = tuple(held)
+
+    def sanitize(self, weights):
+        # An mlx `Module` is a dict of its parameters and children with
+        # everything else an ordinary attribute, and Gemma 3 writes one of each.
+        state = [(module, dict(module) if isinstance(module, dict) else None,
+                  dict(vars(module))) for module in self.held]
+        try:
+            for owner in self.owners:
+                weights = owner.sanitize(weights)
+            return weights
+        finally:
+            for module, items, attributes in state:
+                if items is not None:
+                    # Through `dict`: a `Module` reads `update` as replacing its parameters from a
+                    # nested tree rather than as putting its own items back.
+                    dict.clear(module)
+                    dict.update(module, items)
+                vars(module).clear()
+                vars(module).update(attributes)
+
+
 def _mlx_moe_sanitizers(model):
-    """Sanitizers that may own an MoE block's expert stacking."""
-    sanitizers = []
-    for owner in (model, getattr(model, "language_model", None),
+    """Sanitizers that may own an MoE block's expert stacking.
+
+    The composition first, since a VLM's saved names are only its image; the parts
+    after, since a sub-model owning a whole block is still reproduced by one of them.
+    """
+    owners = []
+    for owner in (model, getattr(model, "vision_tower", None),
+                  getattr(model, "language_model", None),
                   getattr(model, "text_model", None)):
         if owner is None or getattr(owner, "sanitize", None) is None:
             continue
-        if all(existing is not owner for existing in sanitizers):
-            sanitizers.append(owner)
-    return sanitizers
+        if all(existing is not owner for existing in owners):
+            owners.append(owner)
+    if len(owners) < 2:
+        return [_MlxReplayedSanitizers(owners, owners)]
+    return [_MlxReplayedSanitizers(owners, owners)] + [
+        _MlxReplayedSanitizers([owner], owners) for owner in owners
+    ]
 
 
 def _mlx_moe_expert_names(name, num_experts, group, leaf_alias, parent=("", "")):
@@ -15016,8 +15058,9 @@ def _mlx_sanitizer_vocabulary(sanitizers):
                 collect(item, depth + 1)
 
     for sanitizer in sanitizers:
-        sanitize = getattr(type(sanitizer), "sanitize", None)
-        collect(getattr(sanitize, "__code__", None), 0)
+        for owner in getattr(sanitizer, "owners", (sanitizer,)):
+            sanitize = getattr(type(owner), "sanitize", None)
+            collect(getattr(sanitize, "__code__", None), 0)
     return sorted(f for f in found if len(f) > 1 and not f.isspace())
 
 
@@ -15036,6 +15079,10 @@ def _mlx_moe_rename_candidates(vocabulary, names, ubiquity=_MOE_VOCABULARY_UBIQU
         for replacement in vocabulary:
             if replacement != replaced:
                 yield replaced, replacement
+        # A checkpoint can spell a tensor with one fragment fewer rather than a
+        # different one -- mlx-lm appends `.weight` to a name carried bare -- and no
+        # fragment stands for its absence.
+        yield replaced, ""
 
 
 def _mlx_moe_renamed(names, replaced, replacement):
@@ -15273,13 +15320,15 @@ def _mlx_moe_merge_groups(staged, substitutions):
     """
     groups = {}
     for name in staged:
-        target, rank = name, len(substitutions)
-        for position, (replaced, replacement) in enumerate(substitutions):
-            if replaced in target:
-                target = target.replace(replaced, replacement)
-                rank = min(rank, position)
-        if target != name:
-            groups.setdefault(target, []).append((rank, name))
+        for rank, (replaced, replacement) in enumerate(substitutions):
+            # The first match only: one part's fragment can be a fragment of the fused name
+            # the other restores to -- `up_proj` inside `gate_up_proj` -- so applying the
+            # rest in turn would land the two parts of one split in two groups.
+            if replaced in name:
+                target = name.replace(replaced, replacement)
+                if target != name:
+                    groups.setdefault(target, []).append((rank, name))
+                break
     return {
         target: [name for _, name in sorted(parts)] for target, parts in groups.items()
     }
@@ -15441,7 +15490,7 @@ def _proved_mlx_moe_merge_plan(sanitizers, staged, arrivals, target, substitutio
     return None
 
 
-def _build_mlx_moe_merge_plan(model, staged):
+def _build_mlx_moe_merge_plan(model, staged, sanitizers=None):
     """Recover checkpoint tensors a sanitizer split into several staged ones.
 
     GraniteMoE stores a layer's gate and up projections as one tensor, so no rename
@@ -15449,10 +15498,13 @@ def _build_mlx_moe_merge_plan(model, staged):
     concatenation with the name makes the pair provable, and a marker with no two
     elements alike proves the arrangement, not just the shape.
     """
-    sanitizers = _mlx_moe_sanitizers(model)
-    vocabulary = _mlx_sanitizer_vocabulary(sanitizers)
+    owned = _mlx_moe_sanitizers(model)
+    vocabulary = _mlx_sanitizer_vocabulary(owned)
     if not vocabulary:
         return {}
+    # The vocabulary is the model's own either way: a sanitizer wrapped to
+    # spell its output differently carries no name fragments of its own.
+    sanitizers = sanitizers or owned
     arrivals = _mlx_moe_merge_arrivals(staged, vocabulary)
     collected = {}
     for name, targets in arrivals.items():
@@ -15475,6 +15527,51 @@ def _build_mlx_moe_merge_plan(model, staged):
             if plan:
                 return plan
     return {}
+
+
+class _MlxRelabelledSanitizer:
+    """A sanitizer whose output is spelled the way a proved rename spells it."""
+
+    def __init__(self, inner, renames):
+        self.inner, self.renames = inner, renames
+        self.owners = getattr(inner, "owners", (inner,))
+
+    def sanitize(self, weights):
+        return {self.renames.get(name, name): tensor
+                for name, tensor in self.inner.sanitize(weights).items()}
+
+
+def _build_mlx_moe_renamed_merge_plan(model, staged, renames):
+    """Merges the checkpoint still needs once the renames have been proved.
+
+    A sanitizer that splits as well as relocates leaves no staged name one substitution
+    from the checkpoint's: Qwen3-VL-MoE saves `switch_mlp.gate_proj.weight` for a
+    checkpoint holding `experts.gate_up_proj`. From the proved name it is one, so the
+    search runs again there with both sides relabelled to checkpoint names.
+    """
+    if not renames:
+        return {}
+    renamed = {renames.get(name, name): tensor for name, tensor in staged.items()}
+    # A rename can land on a name the search never saw, since names a merge claimed
+    # are held out of it, and two staged tensors under one name is not a checkpoint.
+    if len(renamed) != len(staged):
+        return {}
+    merges = _build_mlx_moe_merge_plan(
+        model, renamed,
+        [_MlxRelabelledSanitizer(sanitizer, renames)
+         for sanitizer in _mlx_moe_sanitizers(model)],
+    )
+    staged_names = {proved: name for name, proved in renames.items()}
+    restored = {}
+    for target, (parts, *recipe) in merges.items():
+        parts = [staged_names.get(part, part) for part in parts]
+        # A group no rename touched is one the first search saw under these very names
+        # and reaches the same recipe; dropping it keeps this search to what the renames
+        # made reachable.
+        if all(part not in renames for part in parts):
+            continue
+        restored[target] = (parts, *recipe)
+    return restored
 
 
 def _mlx_moe_merge_placement(files, merges):
@@ -15769,12 +15866,12 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
             for name, proposed in proposal.items()
         }
         recovered = {name for name, p in candidate.items() if p != name}
-        # A substitution that maps a recovered name back onto the one already
-        # saved has nothing left to prove and would pass by vacancy, undoing an
-        # earlier one. Recovered names may be refined, never dropped.
+        # A substitution mapping a recovered name back onto the saved one would pass by
+        # vacancy, undoing an earlier one. Recovered names may be refined, never dropped,
+        # so equalling the last candidate is enough and losing one is not.
         if len(set(candidate.values())) != len(candidate):
             continue
-        if not recovered > {name for name, p in proposal.items() if p != name}:
+        if not recovered >= {name for name, p in proposal.items() if p != name}:
             continue
         # Names this candidate leaves alone must keep coming back and the ones it renamed
         # must not: falling short on exactly those is what the completion reads.
@@ -15866,6 +15963,17 @@ def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None):
     renames, offsets, layouts = _build_mlx_moe_rename_plan(
         model, staged, split, exclude=consumed
     )
+    # A sanitizer that splits a tensor as well as relocating it is out of the
+    # first search's reach, and in the second's once the relocation is proved.
+    late = _build_mlx_moe_renamed_merge_plan(model, staged, renames)
+    # A part goes into its merge as the checkpoint holds it, so whatever the
+    # renames proved for one the merge consumes goes with it.
+    for parts, *_ in late.values():
+        for part in parts:
+            renames.pop(part, None)
+            offsets.pop(part, None)
+            layouts.pop(part, None)
+    merges.update(late)
     plan = dict(split or {})
     # A rename is a one-name split, so the rewrite below needs no second path.
     plan.update((name, [renamed]) for name, renamed in renames.items())

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -15145,8 +15145,22 @@ def _mlx_sanitizer_code(sanitizers):
             return
         package = (getattr(function, "__module__", "") or "").split(".")[0]
         namespace = getattr(function, "__globals__", None) or {}
-        mentioned = set(code.co_names)
-        for name in code.co_names:
+        # The nested code objects too, not this one alone. Before 3.12 a comprehension
+        # compiles to its own code object, so a helper called from inside one does not
+        # appear in `code.co_names` and the walk stops at the comprehension -- and a
+        # sanitizer spelling its rename in a dict comprehension is the ordinary shape.
+        # 3.12 inlines them, which is why this only ever showed on the older
+        # interpreters pyproject still supports.
+        names, mentioned, pending = [], set(), [code]
+        while pending:
+            current = pending.pop(0)
+            for name in current.co_names:
+                if name not in mentioned:
+                    mentioned.add(name)
+                    names.append(name)
+            pending.extend(const for const in current.co_consts
+                           if hasattr(const, "co_consts"))
+        for name in names:
             for called in _mlx_sanitizer_own_functions(
                 namespace.get(name), package, mentioned
             ):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14887,11 +14887,32 @@ def _mlx_moe_sanitizers(model):
     return sanitizers
 
 
-def _mlx_moe_expert_names(name, num_experts, group, leaf_alias):
+def _mlx_moe_expert_names(name, num_experts, group, leaf_alias, parent=("", "")):
     base, param = name.rsplit(".", 1)
     prefix, _container, leaf = base.rsplit(".", 2)
+    replaced, replacement = parent
+    if replaced:
+        if replaced not in prefix:
+            return None
+        prefix = prefix.replace(replaced, replacement)
     leaf = leaf_alias.get(leaf, leaf)
     return [f"{prefix}.{group}.{e}.{leaf}.{param}" for e in range(num_experts)]
+
+
+def _mlx_moe_parent_substitutions(renames):
+    """The module relocations a set of proved renames is made of.
+
+    A relocated block moves its router and shared experts too, and those are plain
+    renames, so the relocation is read off them once rather than per candidate.
+    """
+    substitutions = [("", "")]
+    for name, renamed in renames.items():
+        head = len(os.path.commonprefix([name, renamed]))
+        tail = len(os.path.commonprefix([name[::-1], renamed[::-1]]))
+        replaced, replacement = name[head:len(name) - tail], renamed[head:len(renamed) - tail]
+        if replaced and (replaced, replacement) not in substitutions:
+            substitutions.append((replaced, replacement))
+    return substitutions
 
 
 def _mlx_moe_probe_tensor(shape, value):
@@ -14912,23 +14933,28 @@ def _mlx_moe_probe_is_stacked_in_order(stacked, num_experts):
         return False
 
 
-def _candidate_mlx_moe_unstack_plans(stacked):
+def _candidate_mlx_moe_unstack_plans(stacked, parents=(("", ""),)):
     """Yield per-expert naming plans to try, most trustworthy first."""
-    for group in _MOE_EXPERT_GROUPS:
-        for leaf_alias in _MOE_EXPERT_LEAF_ALIASES:
-            yield {
-                name: _mlx_moe_expert_names(name, num_experts, group, leaf_alias)
-                for name, num_experts in stacked.items()
-            }
+    for parent in parents:
+        for group in _MOE_EXPERT_GROUPS:
+            for leaf_alias in _MOE_EXPERT_LEAF_ALIASES:
+                plan = {
+                    name: _mlx_moe_expert_names(
+                        name, num_experts, group, leaf_alias, parent
+                    )
+                    for name, num_experts in stacked.items()
+                }
+                if all(names is not None for names in plan.values()):
+                    yield plan
 
 
-def _build_mlx_moe_expert_unstack_plan(model, stacked, staged):
+def _build_mlx_moe_expert_unstack_plan(model, stacked, staged, parents=(("", ""),)):
     """Recover per-expert HF names, then prove them by replaying sanitize()."""
     sanitizers = _mlx_moe_sanitizers(model)
     # Sanitizers read non-expert weights too, so replay against the whole
     # checkpoint. Only the markers are evaluated; MLX keeps the rest lazy.
     others = {name: tensor for name, tensor in staged.items() if name not in stacked}
-    for plan in _candidate_mlx_moe_unstack_plans(stacked):
+    for plan in _candidate_mlx_moe_unstack_plans(stacked, parents):
         probe = dict(others)
         for name, expert_names in plan.items():
             slice_shape = tuple(staged[name].shape)[1:]
@@ -14977,11 +15003,15 @@ def _mlx_sanitizer_vocabulary(sanitizers):
     return sorted(f for f in found if len(f) > 1 and not f.isspace())
 
 
-def _mlx_moe_rename_candidates(vocabulary, names):
-    """Substitutions worth trying, as (replaced, replacement) pairs."""
+def _mlx_moe_rename_candidates(vocabulary, names, ubiquity=_MOE_VOCABULARY_UBIQUITY):
+    """Substitutions worth trying, as (replaced, replacement) pairs.
+
+    ``ubiquity`` of 1 offers every fragment, which is right once the names have
+    been narrowed to the few a candidate could not account for.
+    """
     # A fragment carried by most tensors names the checkpoint's shape, not one
     # block's layout, so substituting it can only produce nonsense to replay.
-    limit = max(1, int(len(names) * _MOE_VOCABULARY_UBIQUITY))
+    limit = max(1, int(len(names) * ubiquity))
     for replaced in vocabulary:
         if sum(replaced in name for name in names) not in range(1, limit + 1):
             continue
@@ -15008,18 +15038,23 @@ def _mlx_moe_renamed(names, replaced, replacement):
 _MOE_PROBE_MARKERS = ((3.0, 1.0), (5.0, 7.0))
 
 
-def _mlx_moe_offset_probe(shape, value):
-    """A marker for offset measurement, full width where a shift can hide.
+def _mlx_moe_offset_probe(shape, value, truncated=True, dtype=None):
+    """A marker for replay measurement, full width where a shift can hide.
 
-    Every RMSNorm weight is 1-D, and so is every value shift mlx-lm applies, so
-    those are carried whole: a shift that varies along the tensor would read as
-    a constant from a truncated corner and be subtracted from the wrong halves.
-    Wider tensors stay truncated because carrying them whole would materialize
-    the checkpoint.
+    1-D tensors are carried whole, since a shift varying along one would read as a
+    constant from a truncated corner. Wider ones are truncated to avoid materializing
+    the checkpoint, and counted rather than filled so an axis move shows: truncation
+    can leave two axes equal, and a filled marker would read a transpose as no change.
     """
     if len(shape) == 1:
-        return mx.full(shape, value, dtype=mx.float32)
-    return _mlx_moe_probe_tensor(shape, value)
+        return mx.full(shape, value, dtype=dtype or mx.float32)
+    if truncated:
+        shape = tuple(min(dim, 2) for dim in shape)
+    size = 1
+    for dim in shape:
+        size *= dim
+    marker = mx.reshape(mx.arange(size, dtype=mx.float32), shape) + value
+    return marker if dtype is None else marker.astype(dtype)
 
 
 def _mlx_moe_constant_offset(sanitized, marker):
@@ -15044,13 +15079,42 @@ def _mlx_moe_constant_offset(sanitized, marker):
         return None
 
 
-def _mlx_moe_replayed_offsets(sanitizers, proposal, staged, markers=None):
-    """For each saved tensor a sanitizer still produces, the constant it adds.
+# Axis pairs an mlx-lm sanitizer moves, as (source, destination) HF to MLX. Kimi
+# Linear's KDA convolutions are stored (d_inner, d_conv, 1) where the checkpoint
+# holds (d_inner, 1, d_conv).
+_MOE_TENSOR_LAYOUTS = ((2, 1), (1, 0), (2, 0))
 
-    mlx-lm sanitizers do not only rename: step3p5 stores a norm weight one
-    greater than the checkpoint it was loaded from, and llama.cpp adds the same
-    one back, so exporting the stored value would double it. Measuring the offset
-    from two markers inverts it exactly and rejects anything not affine.
+
+def _mlx_moe_replay_match(sanitized, marker):
+    """What a sanitizer did to one marker: a constant added and an axis moved.
+
+    Measured with the name rather than after it, since a sanitizer that re-lays a
+    tensor out cannot be inverted by renaming. None when neither explains it.
+    """
+    if sanitized is marker:
+        return 0.0, None
+    if sanitized is None:
+        return None
+    constant = _mlx_moe_constant_offset(sanitized, marker)
+    if constant is not None:
+        return constant, None
+    shape = tuple(getattr(sanitized, "shape", ()))
+    if sorted(shape) != sorted(tuple(marker.shape)):
+        return None
+    for source, destination in _MOE_TENSOR_LAYOUTS:
+        if max(source, destination) >= len(marker.shape):
+            continue
+        if _mlx_arrays_match(sanitized, mx.moveaxis(marker, source, destination)):
+            return 0.0, (source, destination)
+    return None
+
+
+def _mlx_moe_replayed_offsets(sanitizers, proposal, staged, markers=None, required=()):
+    """For each saved tensor a sanitizer still produces, how it produced it.
+
+    Sanitizers do more than rename: step3p5 stores a norm weight one greater than
+    the checkpoint and llama.cpp adds the same one back, so exporting the stored
+    value would double it, and Kimi Linear's KDA convolutions arrive transposed.
     """
     markers = {} if markers is None else markers
     for sanitizer in sanitizers:
@@ -15065,15 +15129,21 @@ def _mlx_moe_replayed_offsets(sanitizers, proposal, staged, markers=None):
                     markers[shape, value] = _mlx_moe_offset_probe(shape, value)
                 probe[proposed] = markers[shape, value]
             try:
-                replays.append((probe, sanitizer.sanitize(dict(probe))))
+                sanitized = sanitizer.sanitize(dict(probe))
             except Exception:
                 replays = []
                 break
+            # A candidate already short of what it has to keep costs one replay and no
+            # comparisons rather than two and all; nothing below recovers a missing name.
+            if not required <= set(sanitized):
+                replays = []
+                break
+            replays.append((probe, sanitized))
         if not replays:
             continue
         for name, proposed in proposal.items():
             found = {
-                _mlx_moe_constant_offset(sanitized.get(name), probe[proposed])
+                _mlx_moe_replay_match(sanitized.get(name), probe[proposed])
                 for probe, sanitized in replays
             }
             if len(found) == 1 and None not in found:
@@ -15083,12 +15153,83 @@ def _mlx_moe_replayed_offsets(sanitizers, proposal, staged, markers=None):
     return {}
 
 
-def _build_mlx_moe_rename_plan(model, staged, split_plan):
+def _completed_mlx_moe_rename_candidate(candidate, offsets, unproven, vocabulary, replay):
+    """Try to finish a candidate with a second substitution on what it missed."""
+    for replaced, replacement in _mlx_moe_rename_candidates(
+        vocabulary, [candidate[name] for name in unproven], ubiquity=1
+    ):
+        repaired = dict(candidate)
+        fixed = _mlx_moe_renamed(
+            [candidate[name] for name in unproven], replaced, replacement
+        )
+        if not fixed:
+            continue
+        for name in unproven:
+            repaired[name] = fixed.get(candidate[name], candidate[name])
+        # A second substitution putting a name back to the one already saved proves
+        # nothing: that name is reproduced by definition.
+        if any(repaired[name] == name for name in unproven):
+            continue
+        if len(set(repaired.values())) != len(repaired):
+            continue
+        repaired_offsets = replay(repaired, unproven)
+        if unproven <= set(repaired_offsets):
+            return repaired, repaired_offsets
+    return candidate, offsets
+
+
+def _confirmed_mlx_moe_rewrite(sanitizers, proposal, constants, layouts, staged,
+                               required):
+    """Whether replaying the whole rewrite hands the staged checkpoint back.
+
+    On the checkpoint rather than on markers: at bfloat16's eight significant bits a
+    marker stops being distinguishable, and two tensors the sanitizer cannot tell apart
+    are two the rewrite cannot get wrong.
+
+    Each reconstruction was proved alone; what reaches the sanitizer is all of them at
+    once, and two that hold apart need not hold together. Doing nothing is the floor: a
+    tensor the sanitizer already does not reproduce is not the rewrite's to lose, and
+    every tensor the rewrite claims has to come back whatever the floor says. One the
+    source checkpoint already corrected is held to neither.
+    """
+    for sanitizer in sanitizers:
+        for base, spread in _MOE_PROBE_MARKERS:
+            probe, expected = {}, {}
+            for position, (name, proposed) in enumerate(proposal.items()):
+                tensor = staged[name]
+                marker = _mlx_moe_offset_probe(
+                    tuple(tensor.shape),
+                    base + position * spread,
+                    False,
+                    getattr(tensor, "dtype", None),
+                )
+                expected[name] = marker
+                constant, layout = constants.get(name), layouts.get(name)
+                if constant:
+                    marker = marker - constant
+                if layout:
+                    marker = mx.moveaxis(marker, layout[1], layout[0])
+                probe[proposed] = marker
+            try:
+                sanitized = sanitizer.sanitize(dict(probe))
+            except Exception:
+                break
+            if any(
+                not _mlx_arrays_match(sanitized.get(name), expected[name])
+                for name in required
+            ):
+                break
+        else:
+            return True
+    return False
+
+
+def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
     """Recover names and values a sanitizer changed, proving each by replaying it."""
     sanitizers = _mlx_moe_sanitizers(model)
     vocabulary = _mlx_sanitizer_vocabulary(sanitizers)
     if not vocabulary:
-        return {}, {}
+        return {}, {}, {}
 
     # Architectures that relocate a whole MoE block rename its experts and its
     # router together, so the probe has to carry both reconstructions at once.
@@ -15103,14 +15244,18 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan):
     # candidate re-marks the same tensors.
     markers = {}
 
-    def replay(proposal):
+    def replay(proposal, required=frozenset()):
         probe = dict(proposal)
         probe.update((name, name) for name in claimed)
         return _mlx_moe_replayed_offsets(
-            sanitizers, probe, {**staged, **claimed}, markers
+            sanitizers, probe, {**staged, **claimed}, markers, required
         )
 
-    open_names = [name for name in staged if name not in (split_plan or {})]
+    # A stacked expert tensor is recovered by splitting, not renaming, so a
+    # substitution must not be judged on whether it also names one. Leaving them out
+    # lets the relocation be read off the router tensors before the split plan.
+    held = set(split_plan or {}) | set(exclude)
+    open_names = [name for name in staged if name not in held]
     proposal = {name: name for name in open_names}
     # The floor: whatever the sanitizer reproduces from the checkpoint must survive.
     offsets = replay(proposal)
@@ -15131,14 +15276,33 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan):
             continue
         if not recovered > {name for name, p in proposal.items() if p != name}:
             continue
-        candidate_offsets = replay(candidate)
+        # Names this candidate leaves alone must keep coming back and the ones it renamed
+        # must not: falling short on exactly those is what the completion reads.
+        candidate_offsets = replay(candidate, baseline - recovered)
+        # One relocation can leave a tensor short by moving two ways at once: Kimi Linear's
+        # router bias changes parent module and gains a `.gate.` component. Completing for
+        # exactly the names it missed reaches those without trying every pair.
+        unproven = (baseline | recovered) - set(candidate_offsets)
+        if unproven and unproven <= recovered:
+            candidate, candidate_offsets = _completed_mlx_moe_rename_candidate(
+                candidate, candidate_offsets, unproven, vocabulary, replay
+            )
+            recovered = {name for name, p in candidate.items() if p != name}
         # Both halves matter: the floor keeps what the sanitizer already reproduces, and
         # `recovered` makes each new name earn its place -- a name the sanitizer drops is
         # reproduced under neither spelling, so it would be renamed on no evidence at all.
         if set(candidate_offsets) >= baseline | recovered:
             proposal, offsets = candidate, candidate_offsets
+    constants = {name: constant for name, (constant, _) in offsets.items() if constant}
+    layouts = {name: layout for name, (_, layout) in offsets.items() if layout}
+    probe = dict(proposal)
+    probe.update((name, name) for name in claimed)
+    if not _confirmed_mlx_moe_rewrite(
+        sanitizers, probe, constants, layouts, {**staged, **claimed}, set(offsets)
+    ):
+        return {}, {}, {}
     renames = {name: p for name, p in proposal.items() if p != name}
-    return renames, {name: c for name, c in offsets.items() if c}
+    return renames, constants, layouts
 
 
 def _mlx_staged_tensor_stubs(files):
@@ -15166,17 +15330,24 @@ def _plan_mlx_moe_expert_unstacking(model, files):
 def _plan_mlx_moe_gguf_rewrite(model, files):
     staged = _mlx_staged_tensor_stubs(files)
     stacked = _mlx_stacked_expert_tensor_names(model, staged)
+    # A block relocation shows on its router and shared experts, which are ordinary
+    # renames, so learn it there before spending it on the expert tensors.
+    parents = _mlx_moe_parent_substitutions(
+        _build_mlx_moe_rename_plan(model, staged, None, exclude=stacked)[0]
+    )
     # Architectures whose stacked layout llama.cpp already maps (Llama 4 keeps
     # its experts fused in HF too) have no per-expert names to recover. Leaving
     # them exactly as saved is what keeps their working export working.
     split = (
-        _build_mlx_moe_expert_unstack_plan(model, stacked, staged) if stacked else None
+        _build_mlx_moe_expert_unstack_plan(model, stacked, staged, parents)
+        if stacked
+        else None
     )
-    renames, offsets = _build_mlx_moe_rename_plan(model, staged, split)
+    renames, offsets, layouts = _build_mlx_moe_rename_plan(model, staged, split)
     plan = dict(split or {})
     # A rename is a one-name split, so the rewrite below needs no second path.
     plan.update((name, [renamed]) for name, renamed in renames.items())
-    return plan, offsets
+    return plan, offsets, layouts
 
 
 def _prepare_moe_gguf_export_directory(
@@ -15189,7 +15360,7 @@ def _prepare_moe_gguf_export_directory(
     """
     path = Path(path)
     files = sorted(path.glob("*.safetensors"))
-    plan, offsets = _plan_mlx_moe_gguf_rewrite(model, files)
+    plan, offsets, layouts = _plan_mlx_moe_gguf_rewrite(model, files)
     if not plan:
         return 0
     # The norm convention has already been restored for every offset the source
@@ -15217,6 +15388,9 @@ def _prepare_moe_gguf_export_directory(
             offset = offsets.get(name)
             if offset:
                 tensor = (tensor - offset).astype(tensor.dtype)
+            layout = layouts.get(name)
+            if layout:
+                tensor = mx.moveaxis(tensor, layout[1], layout[0])
             expert_names = plan.get(name)
             if expert_names is None:
                 updated[name] = tensor

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14915,6 +14915,13 @@ class _MlxReplayedSanitizers:
         try:
             for owner in self.owners:
                 weights = owner.sanitize(weights)
+                # Every caller reads the result as a mapping, and most read it outside
+                # the guard they replay under, so a sanitize that forgot its `return`
+                # would raise out of `save_pretrained_gguf` mid-save. Refusing here is
+                # read as the failed replay it is, and the export is then exactly what
+                # it is without this pass.
+                if not isinstance(weights, Mapping):
+                    raise TypeError("sanitize did not return a mapping")
             return weights
         finally:
             for module, items, attributes in state:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14571,6 +14571,11 @@ def _rewrite_mlx_vlm_tensor_for_gguf(name, tensor, sanitize_steps, norm_offset=1
     return name, tensor, False
 
 
+# `None` is a real measurement -- the source could not be read. Only this says
+# nobody has measured yet, so the two passes never act on different answers.
+_UNMEASURED = object()
+
+
 _MLX_NORM_OFFSET_TOLERANCE = 1e-6
 _MLX_NORM_OFFSET_PROBE = 1.0
 
@@ -14736,11 +14741,14 @@ def _sync_gguf_nextn_layer_config(config, model):
     return changed
 
 
-def _prepare_mlx_gguf_export_directory(path, model=None, replay_sanitizers=True):
+def _prepare_mlx_gguf_export_directory(
+    path, model=None, replay_sanitizers=True, norm_offsets=_UNMEASURED
+):
     """Restore HF tensor names, layouts and norm convention in the export dir.
 
     ``replay_sanitizers`` gates the mlx-vlm name/layout inversion, VLM-only; the
-    norm correction runs for every model.
+    norm correction runs for every model. ``norm_offsets`` lets a caller running
+    more than one pass measure the source once and hand both the same answer.
     """
     path = Path(path)
     config_path = path / "config.json"
@@ -14754,7 +14762,8 @@ def _prepare_mlx_gguf_export_directory(path, model=None, replay_sanitizers=True)
         if replay_sanitizers
         else []
     )
-    norm_offsets = _mlx_sanitizer_norm_offsets(model)
+    if norm_offsets is _UNMEASURED:
+        norm_offsets = _mlx_sanitizer_norm_offsets(model)
     if not sanitize_steps and not norm_offsets:
         if config_changed:
             with open(config_path, "w") as f:
@@ -14940,46 +14949,285 @@ def _build_mlx_moe_expert_unstack_plan(model, stacked, staged):
     return None
 
 
-def _plan_mlx_moe_expert_unstacking(model, files):
-    """Plan the per-expert rewrite without holding the whole checkpoint open."""
-    # Planning needs every tensor's name, shape and dtype, never its values, so
-    # stand-ins let each shard close again. Keeping the real ones would hold a
-    # descriptor and a mapping per shard for the length of the plan.
+# Read from the sanitizer's constant pool rather than tabulated, which covers
+# architectures no static table anticipated; the replay decides whether one applies.
+_MOE_VOCABULARY_DEPTH = 5
+_MOE_VOCABULARY_UBIQUITY = 0.5
+
+
+def _mlx_sanitizer_vocabulary(sanitizers):
+    """Name fragments a sanitizer mentions, read from its constant pool."""
+    found = set()
+
+    def collect(obj, depth):
+        if depth > _MOE_VOCABULARY_DEPTH:
+            return
+        if isinstance(obj, str):
+            found.add(obj)
+        elif isinstance(obj, (tuple, list, frozenset)):
+            for item in obj:
+                collect(item, depth + 1)
+        elif hasattr(obj, "co_consts"):
+            for item in obj.co_consts:
+                collect(item, depth + 1)
+
+    for sanitizer in sanitizers:
+        sanitize = getattr(type(sanitizer), "sanitize", None)
+        collect(getattr(sanitize, "__code__", None), 0)
+    return sorted(f for f in found if len(f) > 1 and not f.isspace())
+
+
+def _mlx_moe_rename_candidates(vocabulary, names):
+    """Substitutions worth trying, as (replaced, replacement) pairs."""
+    # A fragment carried by most tensors names the checkpoint's shape, not one
+    # block's layout, so substituting it can only produce nonsense to replay.
+    limit = max(1, int(len(names) * _MOE_VOCABULARY_UBIQUITY))
+    for replaced in vocabulary:
+        if sum(replaced in name for name in names) not in range(1, limit + 1):
+            continue
+        for replacement in vocabulary:
+            if replacement != replaced:
+                yield replaced, replacement
+
+
+def _mlx_moe_renamed(names, replaced, replacement):
+    """Apply one substitution, keeping only the names it actually changes."""
+    renamed = {}
+    for name in names:
+        if replaced in name:
+            candidate = name.replace(replaced, replacement)
+            if candidate != name:
+                renamed[name] = candidate
+    return renamed if len(set(renamed.values())) == len(renamed) else {}
+
+
+# Two probes, as (base, spread): tensor at position n is marked base + n * spread.
+# One probe cannot tell a constant offset from a coincidence, and two that spread
+# their tensors alike cannot tell one from a sanitizer that swapped two of them,
+# since the gap between neighbours is then itself a constant.
+_MOE_PROBE_MARKERS = ((3.0, 1.0), (5.0, 7.0))
+
+
+def _mlx_moe_offset_probe(shape, value):
+    """A marker for offset measurement, full width where a shift can hide.
+
+    Every RMSNorm weight is 1-D, and so is every value shift mlx-lm applies, so
+    those are carried whole: a shift that varies along the tensor would read as
+    a constant from a truncated corner and be subtracted from the wrong halves.
+    Wider tensors stay truncated because carrying them whole would materialize
+    the checkpoint.
+    """
+    if len(shape) == 1:
+        return mx.full(shape, value, dtype=mx.float32)
+    return _mlx_moe_probe_tensor(shape, value)
+
+
+def _mlx_moe_constant_offset(sanitized, marker):
+    # A sanitizer hands back what it does not change, so identity settles almost
+    # every tensor. The comparison below costs a device synchronization each.
+    if sanitized is marker:
+        return 0.0
+    if sanitized is None or tuple(getattr(sanitized, "shape", ())) != tuple(marker.shape):
+        return None
+    try:
+        difference = mx.reshape(sanitized.astype(mx.float32) - marker, (-1,))
+        if not bool(mx.all(difference == difference[0])):
+            return None
+        constant = float(difference[0])
+        # Only a full-width probe proves a constant: a truncated one can show a shift
+        # uniform in the corner and not beyond it, so a wider tensor is only ever
+        # accepted as untouched.
+        if constant and len(marker.shape) != 1:
+            return None
+        return constant
+    except Exception:
+        return None
+
+
+def _mlx_moe_replayed_offsets(sanitizers, proposal, staged, markers=None):
+    """For each saved tensor a sanitizer still produces, the constant it adds.
+
+    mlx-lm sanitizers do not only rename: step3p5 stores a norm weight one
+    greater than the checkpoint it was loaded from, and llama.cpp adds the same
+    one back, so exporting the stored value would double it. Measuring the offset
+    from two markers inverts it exactly and rejects anything not affine.
+    """
+    markers = {} if markers is None else markers
+    for sanitizer in sanitizers:
+        offsets, replays = {}, []
+        for base, spread in _MOE_PROBE_MARKERS:
+            probe = {}
+            # A distinct value per tensor, so a sanitizer that swapped two
+            # same-shaped tensors could not be read as having left both alone.
+            for position, (name, proposed) in enumerate(proposal.items()):
+                shape, value = tuple(staged[name].shape), base + position * spread
+                if (shape, value) not in markers:
+                    markers[shape, value] = _mlx_moe_offset_probe(shape, value)
+                probe[proposed] = markers[shape, value]
+            try:
+                replays.append((probe, sanitizer.sanitize(dict(probe))))
+            except Exception:
+                replays = []
+                break
+        if not replays:
+            continue
+        for name, proposed in proposal.items():
+            found = {
+                _mlx_moe_constant_offset(sanitized.get(name), probe[proposed])
+                for probe, sanitized in replays
+            }
+            if len(found) == 1 and None not in found:
+                offsets[name] = found.pop()
+        if offsets:
+            return offsets
+    return {}
+
+
+def _build_mlx_moe_rename_plan(model, staged, split_plan):
+    """Recover names and values a sanitizer changed, proving each by replaying it."""
+    sanitizers = _mlx_moe_sanitizers(model)
+    vocabulary = _mlx_sanitizer_vocabulary(sanitizers)
+    if not vocabulary:
+        return {}, {}
+
+    # Architectures that relocate a whole MoE block rename its experts and its
+    # router together, so the probe has to carry both reconstructions at once.
+    claimed = {}
+    for name, expert_names in (split_plan or {}).items():
+        for expert_name in expert_names:
+            claimed[expert_name] = mx.zeros(
+                tuple(staged[name].shape)[1:], dtype=staged[name].dtype
+            )
+
+    # One cache for the whole search: shapes repeat across layers and every
+    # candidate re-marks the same tensors.
+    markers = {}
+
+    def replay(proposal):
+        probe = dict(proposal)
+        probe.update((name, name) for name in claimed)
+        return _mlx_moe_replayed_offsets(
+            sanitizers, probe, {**staged, **claimed}, markers
+        )
+
+    open_names = [name for name in staged if name not in (split_plan or {})]
+    proposal = {name: name for name in open_names}
+    # The floor: whatever the sanitizer reproduces from the checkpoint must survive.
+    offsets = replay(proposal)
+    baseline = set(offsets)
+    for replaced, replacement in _mlx_moe_rename_candidates(vocabulary, open_names):
+        renamed = _mlx_moe_renamed(proposal.values(), replaced, replacement)
+        if not renamed:
+            continue
+        candidate = {
+            name: renamed.get(proposed, proposed)
+            for name, proposed in proposal.items()
+        }
+        recovered = {name for name, p in candidate.items() if p != name}
+        # A substitution that maps a recovered name back onto the one already
+        # saved has nothing left to prove and would pass by vacancy, undoing an
+        # earlier one. Recovered names may be refined, never dropped.
+        if len(set(candidate.values())) != len(candidate):
+            continue
+        if not recovered > {name for name, p in proposal.items() if p != name}:
+            continue
+        candidate_offsets = replay(candidate)
+        # Both halves matter: the floor keeps what the sanitizer already reproduces, and
+        # `recovered` makes each new name earn its place -- a name the sanitizer drops is
+        # reproduced under neither spelling, so it would be renamed on no evidence at all.
+        if set(candidate_offsets) >= baseline | recovered:
+            proposal, offsets = candidate, candidate_offsets
+    renames = {name: p for name, p in proposal.items() if p != name}
+    return renames, {name: c for name, c in offsets.items() if c}
+
+
+def _mlx_staged_tensor_stubs(files):
+    # Planning never reads a value, so stand-ins let each shard close again.
+    # Keeping the real ones would hold a descriptor and a mapping per shard.
     staged = {}
     for file in files:
         for name, tensor in mx.load(str(file)).items():
             staged[name] = mx.zeros(tensor.shape, dtype=tensor.dtype)
+    return staged
+
+
+def _plan_mlx_moe_expert_unstacking(model, files):
+    """Plan the per-expert rewrite without holding the whole checkpoint open."""
+    staged = _mlx_staged_tensor_stubs(files)
     stacked = _mlx_stacked_expert_tensor_names(model, staged)
     if not stacked:
         return None
-    # Architectures whose stacked layout llama.cpp already maps (Llama 4 keeps its
-    # experts fused in HF too) have no per-expert names to recover.
+    # Architectures whose stacked layout llama.cpp already maps (Llama 4 keeps
+    # its experts fused in HF too) have no per-expert names to recover. Leaving
+    # them exactly as saved is what keeps their working export working.
     return _build_mlx_moe_expert_unstack_plan(model, stacked, staged)
 
 
-def _prepare_moe_gguf_export_directory(path, model=None):
-    """Split stacked MLX MoE experts back into per-expert HF tensors."""
+def _plan_mlx_moe_gguf_rewrite(model, files):
+    staged = _mlx_staged_tensor_stubs(files)
+    stacked = _mlx_stacked_expert_tensor_names(model, staged)
+    # Architectures whose stacked layout llama.cpp already maps (Llama 4 keeps
+    # its experts fused in HF too) have no per-expert names to recover. Leaving
+    # them exactly as saved is what keeps their working export working.
+    split = (
+        _build_mlx_moe_expert_unstack_plan(model, stacked, staged) if stacked else None
+    )
+    renames, offsets = _build_mlx_moe_rename_plan(model, staged, split)
+    plan = dict(split or {})
+    # A rename is a one-name split, so the rewrite below needs no second path.
+    plan.update((name, [renamed]) for name, renamed in renames.items())
+    return plan, offsets
+
+
+def _prepare_moe_gguf_export_directory(
+    path, model=None, source_norm_offsets=_UNMEASURED
+):
+    """Restore the MoE tensor names and values llama.cpp converters read.
+
+    Experts are split per-expert only where HF stores them that way, names a
+    sanitizer relocated are put back, and a constant it added is subtracted.
+    """
     path = Path(path)
     files = sorted(path.glob("*.safetensors"))
-    plan = _plan_mlx_moe_expert_unstacking(model, files)
+    plan, offsets = _plan_mlx_moe_gguf_rewrite(model, files)
     if not plan:
         return 0
+    # The norm convention has already been restored for every offset the source
+    # checkpoint revealed. Measuring from the sanitizer alone needs no source,
+    # which is what reaches an already-converted one, but it must not subtract a
+    # second time from what the source covered. The caller passes the one
+    # measurement both passes act on, so they cannot disagree.
+    if source_norm_offsets is _UNMEASURED:
+        source_norm_offsets = _mlx_sanitizer_norm_offsets(model)
+    offsets = {
+        name: constant
+        for name, constant in offsets.items()
+        if name not in (source_norm_offsets or {})
+    }
 
     name_map = {}
     for file in files:
         # One shard at a time: mx.eval below materializes everything this shard
         # holds, so keeping earlier shards alive would scale with the model.
         tensors = mx.load(str(file))
-        if not any(name in plan for name in tensors):
+        if not any(name in plan or name in offsets for name in tensors):
             continue
         updated = {}
         for name, tensor in tensors.items():
+            offset = offsets.get(name)
+            if offset:
+                tensor = (tensor - offset).astype(tensor.dtype)
             expert_names = plan.get(name)
             if expert_names is None:
                 updated[name] = tensor
+                if offset:
+                    name_map[name] = (name,)
                 continue
-            for expert, expert_name in enumerate(expert_names):
-                updated[expert_name] = tensor[expert]
+            if len(expert_names) == 1:
+                updated[expert_names[0]] = tensor
+            else:
+                for expert, expert_name in enumerate(expert_names):
+                    updated[expert_name] = tensor[expert]
             name_map[name] = expert_names
         # mx.load() arrays may be file-backed; saving over the source can
         # truncate them before they materialize, so write beside and replace.
@@ -15831,12 +16079,18 @@ def save_pretrained_gguf(
         is_vlm_model = _is_vlm_model(model)
         print("Unsloth: Merging LoRA weights and saving to 16-bit...")
         save_merged_model(model, tokenizer, tmp_path, dequantize=True)
+        # Measured once: both passes subtract against the same answer, and the
+        # source checkpoint is read once rather than per pass.
+        norm_offsets = _mlx_sanitizer_norm_offsets(model)
         rewritten = _prepare_mlx_gguf_export_directory(
-            tmp_path, model=model, replay_sanitizers=is_vlm_model
+            tmp_path, model=model, replay_sanitizers=is_vlm_model,
+            norm_offsets=norm_offsets,
         )
         # After the norm convention is restored, so the offsets it measures are
         # still keyed by the names the merged save wrote.
-        rewritten += _prepare_moe_gguf_export_directory(tmp_path, model=model)
+        rewritten += _prepare_moe_gguf_export_directory(
+            tmp_path, model=model, source_norm_offsets=norm_offsets,
+        )
         if rewritten:
             print(
                 f"Unsloth: Rewrote {rewritten} MLX tensors "

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14511,15 +14511,14 @@ def _has_vlm_gguf_rewrite_candidate(name, tensor):
 
 
 def _mlx_tensors_identical(actual, expected):
-    """The same tensor as stored: dtype and bits, not numeric equality."""
+    """Same dtype and same bits, not numeric equality."""
     held = getattr(actual, "dtype", None)
     wanted = getattr(expected, "dtype", None)
     if (held is None) != (wanted is None) or (held is not None and held != wanted):
         return False
     if held is not None and getattr(actual, "shape", None) == getattr(expected, "shape", None):
         try:
-            # Flattened first: a scalar cannot be viewed as a type of another
-            # size, and a checkpoint may hold one.
+            # Flattened first: a scalar cannot be viewed as another-sized type.
             return bool(mx.all(mx.view(mx.reshape(actual, (-1,)), mx.uint8)
                                == mx.view(mx.reshape(expected, (-1,)), mx.uint8)))
         except Exception:
@@ -14590,8 +14589,7 @@ def _rewrite_mlx_vlm_tensor_for_gguf(name, tensor, sanitize_steps, norm_offset=1
     return name, tensor, False
 
 
-# `None` is a real measurement -- the source could not be read. Only this says
-# nobody has measured yet, so the two passes never act on different answers.
+# Distinct from None, which is a real measurement (source unreadable).
 _UNMEASURED = object()
 
 
@@ -14765,10 +14763,8 @@ def _prepare_mlx_gguf_export_directory(
 ):
     """Restore HF tensor names, layouts and norm convention in the export dir.
 
-    ``replay_sanitizers`` gates the mlx-vlm name/layout inversion, VLM-only; the
-    norm correction runs for every model. ``norm_offsets`` lets a caller running
-    more than one pass measure the source once and hand both the same answer.
-    """
+    ``replay_sanitizers`` gates the VLM-only name/layout inversion; the norm correction
+    always runs. ``norm_offsets`` is one source measurement shared by every pass."""
     path = Path(path)
     config_path = path / "config.json"
     if not config_path.exists():
@@ -14851,10 +14847,8 @@ def _prepare_mlx_gguf_export_directory(
     return rewritten
 
 
-# mlx-lm stacks an MoE block's per-expert HF tensors into one SwitchLinear parameter,
-# whose name llama.cpp cannot map. Legacy leaf names come first and the identity map
-# last: where a sanitizer renames then stacks (LFM2 turns w1/w2/w3 into gate/down/up)
-# both replay, and only the legacy one names tensors the converter reads.
+# mlx-lm stacks per-expert HF tensors into one SwitchLinear name llama.cpp cannot map.
+# Legacy leaf names first, identity last: only they name tensors the converter reads.
 _MOE_EXPERT_GROUPS = ("experts", "mlp")
 _MOE_EXPERT_LEAF_ALIASES = (
     {"gate_proj": "w1", "down_proj": "w2", "up_proj": "w3"},
@@ -14881,8 +14875,7 @@ def _mlx_stacked_expert_tensor_names(model, tensor_names):
     for path, module in named_modules():
         if not path or not _is_mlx_switch_expert_module(module):
             continue
-        # LoRA keeps the base SwitchLinear at ".linear", so the module path is
-        # one or more components longer than the saved parameter path.
+        # LoRA keeps the base SwitchLinear at ".linear", lengthening the module path.
         while path and f"{path}.weight" not in tensor_names:
             path = path.rsplit(".", 1)[0] if "." in path else ""
         if not path or path.count(".") < 2:
@@ -14895,39 +14888,28 @@ def _mlx_stacked_expert_tensor_names(model, tensor_names):
 
 
 class _MlxReplayedSanitizers:
-    """Sanitizers replayed in order, leaving no module of the model changed.
-
-    A vision-language model's saved names are the composition's image, so no
-    single sanitizer reproduces them. And some write to their module: Gemma 3 ties
-    its output head and drops `lm_head` when what arrives carries no
-    `lm_head.weight`, which is exactly what a search renaming that tensor hands it.
-    """
+    """Sanitizers replayed in order, leaving no module of the model changed: Gemma 3
+    ties its head and drops `lm_head` if handed no `lm_head.weight`."""
 
     def __init__(self, owners, held):
         self.owners = tuple(owners)
         self.held = tuple(held)
 
     def sanitize(self, weights):
-        # An mlx `Module` is a dict of its parameters and children with
-        # everything else an ordinary attribute, and Gemma 3 writes one of each.
+        # An mlx `Module` is a dict of parameters/children plus plain attributes.
         state = [(module, dict(module) if isinstance(module, dict) else None,
                   dict(vars(module))) for module in self.held]
         try:
             for owner in self.owners:
                 weights = owner.sanitize(weights)
-                # Every caller reads the result as a mapping, and most read it outside
-                # the guard they replay under, so a sanitize that forgot its `return`
-                # would raise out of `save_pretrained_gguf` mid-save. Refusing here is
-                # read as the failed replay it is, and the export is then exactly what
-                # it is without this pass.
+                # A failed replay writes nothing: the export is then what it was without this pass.
                 if not isinstance(weights, Mapping):
                     raise TypeError("sanitize did not return a mapping")
             return weights
         finally:
             for module, items, attributes in state:
                 if items is not None:
-                    # Through `dict`: a `Module` reads `update` as replacing its parameters from a
-                    # nested tree rather than as putting its own items back.
+                    # Through `dict`: `Module.update` reads a nested parameter tree.
                     dict.clear(module)
                     dict.update(module, items)
                 vars(module).clear()
@@ -14935,11 +14917,7 @@ class _MlxReplayedSanitizers:
 
 
 def _mlx_moe_sanitizers(model):
-    """Sanitizers that may own an MoE block's expert stacking.
-
-    The composition first, since a VLM's saved names are only its image; the parts
-    after, since a sub-model owning a whole block is still reproduced by one of them.
-    """
+    """Sanitizers that may own an MoE block's expert stacking, composition first."""
     owners = []
     for owner in (model, getattr(model, "vision_tower", None),
                   getattr(model, "language_model", None),
@@ -14956,14 +14934,10 @@ def _mlx_moe_sanitizers(model):
 
 
 def _mlx_moe_sanitized_probe(sanitizer, probe):
-    """Replay a probe, copying the tensors a sanitizer writing in place could reach.
-
-    mlx-vlm offsets a norm weight with `+=`, which writes through to the caller's
-    tensor, so an uncopied probe is measured against itself -- and the markers being
-    cached by shape, one written to misreports every later tensor sharing it. Only the
-    1-D tensors an offset is read from are copied; wider ones would cost a
-    synchronization the search is otherwise free of.
-    """
+    """Replay a probe, copying the tensors a sanitizer writing in place could reach:
+    mlx-vlm offsets a norm weight with `+=`, writing through to the caller's tensor and
+    to every later tensor sharing that shape-cached marker. 1-D only, as wider copies
+    would cost a synchronization."""
     if _mlx_sanitizer_writes_in_place(sanitizer):
         probe = {
             name: mx.array(tensor) if getattr(tensor, "ndim", 0) == 1 else tensor
@@ -14973,20 +14947,15 @@ def _mlx_moe_sanitized_probe(sanitizer, probe):
 
 
 def _mlx_augmented_assignment(instruction):
-    """Both spellings: 3.11 replaced `INPLACE_*` with a `BINARY_OP` carrying the operator, and this package supports 3.9."""
+    """Both spellings: 3.11 replaced `INPLACE_*` with `BINARY_OP`, and we support 3.9."""
     return (instruction.opname.startswith("INPLACE_")
             or (instruction.opname == "BINARY_OP"
                 and instruction.argrepr.endswith("=")))
 
 
 def _mlx_sanitizer_writes_in_place(sanitizer):
-    """Whether a sanitizer's code holds an augmented assignment, which may write through.
-
-    Read from the code because measuring costs the synchronization this exists to
-    avoid, and answered for the operator rather than the type it applies to: a store
-    into a tensor is spelled like the store into the dictionary every sanitizer builds.
-    One that writes some other way is left to the confirmation.
-    """
+    """Whether a sanitizer's code holds an augmented assignment, which may write
+    through. From bytecode, since measuring costs the synchronization this avoids."""
     if getattr(sanitizer, "_writes_in_place", None) is None:
         sanitizer._writes_in_place = any(
             _mlx_augmented_assignment(instruction)
@@ -15012,26 +14981,16 @@ _GGUF_TEXT_TOWER_NAMESPACE = "language_model.model"
 
 
 def _mlx_moe_dropped_the_gguf_namespace_in_the_tower(name, renamed):
-    """Whether this rename keeps a text tower but drops the namespace llama.cpp maps it under.
-
-    The converter strips `language_model.` and looks the rest up under `model.`, so a
-    rename off `language_model.model.` onto a `language_model.` that no longer carries it
-    moves the tensor out of the tables. Both ends are read, so a tensor renamed into the
-    tower never counts as having left it. Only a text tower is answered: outside one,
-    `transformer.blocks`, `encoder.layers` and a bare `layers` are each mapped under some
-    architecture, and nothing about a name says which a checkpoint is spelled in.
-    """
+    """Whether this rename keeps a text tower but drops the namespace llama.cpp maps it
+    under: the converter strips `language_model.` and looks the rest up under `model.`,
+    so a rename off `language_model.model.` moves the tensor out of the tables."""
     return (name.startswith(_GGUF_TEXT_TOWER_NAMESPACE + ".")
             and renamed.startswith("language_model.")
             and not renamed.startswith(_GGUF_TEXT_TOWER_NAMESPACE + "."))
 
 
 def _mlx_moe_parent_substitutions(renames):
-    """The module relocations a set of proved renames is made of.
-
-    A relocated block moves its router and shared experts too, and those are plain
-    renames, so the relocation is read off them once rather than per candidate.
-    """
+    """The module relocations a set of proved renames is made of."""
     substitutions = [("", "")]
     for name, renamed in renames.items():
         head = len(os.path.commonprefix([name, renamed]))
@@ -15043,7 +15002,7 @@ def _mlx_moe_parent_substitutions(renames):
 
 
 def _mlx_moe_probe_tensor(shape, value):
-    """A marker tensor of the same rank as a per-expert slice, but tiny."""
+    """A tiny marker of the same rank as a per-expert slice."""
     return mx.full(tuple(min(dim, 2) for dim in shape), value, dtype=mx.float32)
 
 
@@ -15078,8 +15037,7 @@ def _candidate_mlx_moe_unstack_plans(stacked, parents=(("", ""),)):
 def _build_mlx_moe_expert_unstack_plan(model, stacked, staged, parents=(("", ""),)):
     """Recover per-expert HF names, then prove them by replaying sanitize()."""
     sanitizers = _mlx_moe_sanitizers(model)
-    # Sanitizers read non-expert weights too, so replay against the whole
-    # checkpoint. Only the markers are evaluated; MLX keeps the rest lazy.
+    # Sanitizers read non-expert weights too, so replay against the whole checkpoint.
     others = {name: tensor for name, tensor in staged.items() if name not in stacked}
     for plan in _candidate_mlx_moe_unstack_plans(stacked, parents):
         probe = dict(others)
@@ -15102,21 +15060,14 @@ def _build_mlx_moe_expert_unstack_plan(model, stacked, staged, parents=(("", "")
     return None
 
 
-# Read from the sanitizer's constant pool rather than tabulated, which covers
-# architectures no static table anticipated; the replay decides whether one applies.
+# From the sanitizer's constant pool, not a table, so unanticipated architectures work.
 _MOE_VOCABULARY_DEPTH = 5
 _MOE_VOCABULARY_UBIQUITY = 0.5
-# How far a sanitizer's calls are followed. Every installed architecture spells its names
-# one call away, so two is measured margin for one that delegates twice.
 _MOE_VOCABULARY_CALLS = 2
 
 
 def _mlx_sanitizer_own_functions(found, package, mentioned):
-    """The package's own functions one global name reaches.
-
-    Only the attributes named beside a class, since following every method would cost a
-    vocabulary the sanitizer never mentions.
-    """
+    """The package's own functions one global name reaches, only those named beside a class."""
     def owned(value):
         return (inspect.isfunction(value)
                 and (getattr(value, "__module__", "") or "").split(".")[0] == package)
@@ -15128,11 +15079,8 @@ def _mlx_sanitizer_own_functions(found, package, mentioned):
 
 
 def _mlx_sanitizer_code(sanitizers):
-    """Every code object a sanitizer reaches inside the model's own package.
-
-    Only the model's own package is followed: a walk into mlx or numpy would cost
-    a vocabulary of everything and prove nothing.
-    """
+    """Every code object a sanitizer reaches inside the model's own package; a walk
+    into mlx or numpy would cost a vocabulary of everything and prove nothing."""
     reached, walked = [], set()
 
     def walk(function, calls):
@@ -15145,12 +15093,8 @@ def _mlx_sanitizer_code(sanitizers):
             return
         package = (getattr(function, "__module__", "") or "").split(".")[0]
         namespace = getattr(function, "__globals__", None) or {}
-        # The nested code objects too, not this one alone. Before 3.12 a comprehension
-        # compiles to its own code object, so a helper called from inside one does not
-        # appear in `code.co_names` and the walk stops at the comprehension -- and a
-        # sanitizer spelling its rename in a dict comprehension is the ordinary shape.
-        # 3.12 inlines them, which is why this only ever showed on the older
-        # interpreters pyproject still supports.
+        # Descend into nested code objects: before PEP 709 (3.12) a comprehension gets
+        # its own, hiding from `co_names` the helper a rename is spelled in.
         names, mentioned, pending = [], set(), [code]
         while pending:
             current = pending.pop(0)
@@ -15199,13 +15143,8 @@ def _mlx_sanitizer_vocabulary(sanitizers):
 
 
 def _mlx_sanitizer_fusion_groups(sanitizers):
-    """Each tuple of names a sanitizer holds, with the fragments beside it.
-
-    Which names belong to one split would otherwise cost the vocabulary to the
-    power of the part count. A sanitizer that fuses several tensors names them in
-    one tuple, so the tuple is the group, in the order they were concatenated, and
-    only the fragments from the same function are worth substituting into.
-    """
+    """Each tuple of names a sanitizer holds, with the fragments beside it. A fuser
+    names its inputs in one tuple in concatenation order, so the tuple is the group."""
     def named(obj):
         return (isinstance(obj, tuple) and 1 < len(obj) <= _MOE_SPLIT_PARTS
                 and len(set(obj)) == len(obj)
@@ -15225,25 +15164,19 @@ def _mlx_sanitizer_fusion_groups(sanitizers):
 
 
 def _mlx_moe_rename_candidates(vocabulary, names, ubiquity=_MOE_VOCABULARY_UBIQUITY):
-    """Substitutions worth trying, as (replaced, replacement) pairs.
-
-    ``ubiquity`` of 1 offers every fragment, which is right once the names have
-    been narrowed to the few a candidate could not account for.
-    """
+    """Substitutions worth trying, as (replaced, replacement) pairs; ``ubiquity`` of 1
+    offers every fragment, right once ``names`` is already narrowed."""
     limit = max(1, int(len(names) * ubiquity))
     for replaced in vocabulary:
         carried = [name for name in names if replaced in name]
         if not carried:
             continue
-        # A fragment carried by most tensors names the checkpoint's shape, not one block's
-        # layout -- unless every name carrying it starts with it, which is a namespace, and
-        # a relocated namespace is what qwen4_exp's 86 of 88 names differ by.
+        # A fragment on most tensors names the checkpoint's shape, not a block layout,
+        # unless every carrier starts with it: a relocated namespace, as in qwen4_exp.
         relocation = len(carried) > limit
         if relocation and not all(name.startswith(replaced) for name in carried):
             continue
-        # A relocation moves a namespace and does not invent one, so it is only
-        # offered fragments spelling the same components in another order: pairing
-        # one with the whole vocabulary costs a replay per name in the checkpoint.
+        # A relocation moves a namespace, so only its own components reordered are offered.
         components = sorted(part for part in replaced.split(".") if part)
         for replacement in vocabulary:
             if replacement == replaced:
@@ -15253,14 +15186,12 @@ def _mlx_moe_rename_candidates(vocabulary, names, ubiquity=_MOE_VOCABULARY_UBIQU
             ) != components:
                 continue
             yield replaced, replacement
-        # A checkpoint can spell a tensor with one fragment fewer rather than a
-        # different one -- mlx-lm appends `.weight` to a name carried bare -- and no
-        # fragment stands for its absence.
+        # Deletion: mlx-lm appends `.weight` to a name carried bare.
         yield replaced, ""
 
 
 def _mlx_moe_renamed(names, replaced, replacement):
-    """Apply one substitution, keeping only the names it actually changes."""
+    """Apply one substitution, keeping only the names it changes."""
     renamed = {}
     for name in names:
         if replaced in name:
@@ -15270,19 +15201,14 @@ def _mlx_moe_renamed(names, replaced, replacement):
     return renamed if len(set(renamed.values())) == len(renamed) else {}
 
 
-# Two probes, as (base, spread): tensor at position n is marked base + n * spread. One
-# cannot tell a constant offset from a coincidence, nor -- a 1-D marker being one repeated
-# value -- a doubled tensor from one with a constant added. Two spreading alike could not
-# tell a constant from a swap, the gap between neighbours being constant too.
+# Two probes, as (base, spread): tensor n is marked base + n * spread. One cannot tell a
+# doubled 1-D tensor from an offset one; two alike could not tell a constant from a swap.
 _MOE_PROBE_MARKERS = ((3.0, 1.0), (5.0, 7.0))
 
 def _mlx_moe_replay_marker(shape, value):
-    """A marker for replay measurement, full width where a shift can hide.
-
-    1-D tensors are carried whole, since a shift along one reads as a constant from a
-    truncated corner. Wider ones are truncated to avoid materializing the checkpoint, and
-    counted rather than filled so an axis move still shows.
-    """
+    """A marker for replay measurement: 1-D whole, since a shift along one reads as a
+    constant from a truncated corner; wider ones truncated, and counted rather than
+    filled so an axis move still shows."""
     if len(shape) == 1:
         return mx.full(shape, value, dtype=mx.float32)
     shape = tuple(min(dim, 2) for dim in shape)
@@ -15293,8 +15219,7 @@ def _mlx_moe_replay_marker(shape, value):
 
 
 def _mlx_moe_constant_offset(sanitized, marker):
-    # A sanitizer hands back what it does not change, so identity settles almost
-    # every tensor. The comparison below costs a device synchronization each.
+    # Identity settles almost every tensor; the comparison below costs a sync each.
     if sanitized is marker:
         return 0.0
     if sanitized is None or tuple(getattr(sanitized, "shape", ())) != tuple(marker.shape):
@@ -15304,9 +15229,7 @@ def _mlx_moe_constant_offset(sanitized, marker):
         if not bool(mx.all(difference == difference[0])):
             return None
         constant = float(difference[0])
-        # Only a full-width probe proves a constant: a truncated one can show a shift
-        # uniform in the corner and not beyond it, so a wider tensor is only ever
-        # accepted as untouched.
+        # Only a full-width probe proves a constant, so wider ones must be untouched.
         if constant and len(marker.shape) != 1:
             return None
         return constant
@@ -15314,18 +15237,14 @@ def _mlx_moe_constant_offset(sanitized, marker):
         return None
 
 
-# Axis pairs an mlx-lm sanitizer moves, as (source, destination) HF to MLX. Kimi
-# Linear's KDA convolutions are stored (d_inner, d_conv, 1) where the checkpoint
-# holds (d_inner, 1, d_conv).
+# Axis pairs an mlx-lm sanitizer moves, (source, destination) HF to MLX: Kimi Linear
+# stores KDA convolutions (d_inner, d_conv, 1) for (d_inner, 1, d_conv).
 _MOE_TENSOR_LAYOUTS = ((2, 1), (1, 0), (2, 0))
 
 
 def _mlx_moe_replay_match(sanitized, marker):
-    """What a sanitizer did to one marker: a constant added and an axis moved.
-
-    Measured with the name rather than after it, since a sanitizer that re-lays a
-    tensor out cannot be inverted by renaming. None when neither explains it.
-    """
+    """What a sanitizer did to one marker: a constant added and an axis moved, or None.
+    Measured with the name, since a re-laid-out tensor cannot be inverted by renaming."""
     if sanitized is marker:
         return 0.0, None
     if sanitized is None:
@@ -15345,19 +15264,14 @@ def _mlx_moe_replay_match(sanitized, marker):
 
 
 def _mlx_moe_replayed_corrections(sanitizers, proposal, staged, markers=None, required=()):
-    """For each saved tensor a sanitizer still produces, how it produced it.
-
-    Sanitizers do more than rename: step3p5 stores a norm weight one greater than the
-    checkpoint and llama.cpp adds the same one back, and Kimi Linear's KDA convolutions
-    arrive transposed.
-    """
+    """For each saved tensor a sanitizer still produces, how it produced it: step3p5
+    stores a norm weight one greater, Kimi Linear's KDA convolutions transposed."""
     markers = {} if markers is None else markers
     for sanitizer in sanitizers:
         corrections, replays = {}, []
         for base, spread in _MOE_PROBE_MARKERS:
             probe = {}
-            # A distinct value per tensor, so a sanitizer that swapped two
-            # same-shaped tensors could not be read as having left both alone.
+            # A distinct value per tensor, so a swap of two same-shaped ones shows.
             for position, (name, proposed) in enumerate(proposal.items()):
                 shape, value = tuple(staged[name].shape), base + position * spread
                 if (shape, value) not in markers:
@@ -15368,8 +15282,7 @@ def _mlx_moe_replayed_corrections(sanitizers, proposal, staged, markers=None, re
             except Exception:
                 replays = []
                 break
-            # A candidate already short of what it has to keep costs one replay and no
-            # comparisons rather than two and all; nothing below recovers a missing name.
+            # Nothing below recovers a missing name, so bail on the first replay.
             if not required <= set(sanitized):
                 replays = []
                 break
@@ -15389,7 +15302,7 @@ def _mlx_moe_replayed_corrections(sanitizers, proposal, staged, markers=None, re
 
 
 def _completed_mlx_moe_rename_candidate(candidate, corrections, unproven, vocabulary, replay):
-    """Try to finish a candidate with a second substitution on what it missed."""
+    """Finish a candidate with a second substitution on what it missed."""
     for replaced, replacement in _mlx_moe_rename_candidates(
         vocabulary, [candidate[name] for name in unproven], ubiquity=1
     ):
@@ -15401,8 +15314,7 @@ def _completed_mlx_moe_rename_candidate(candidate, corrections, unproven, vocabu
             continue
         for name in unproven:
             repaired[name] = fixed.get(candidate[name], candidate[name])
-        # A second substitution putting a name back to the one already saved proves
-        # nothing: that name is reproduced by definition.
+        # Restoring a name to the one already saved proves nothing.
         if any(repaired[name] == name for name in unproven):
             continue
         if len(set(repaired.values())) != len(repaired):
@@ -15413,10 +15325,8 @@ def _completed_mlx_moe_rename_candidate(candidate, corrections, unproven, vocabu
     return candidate, corrections
 
 
-# The splits reached here are in two: a gate/up pair, or an MLA key/value pair. DBRX
-# splits per expert instead, which the stack family reaches -- widening this grouping
-# would cost a factor of the vocabulary per part, and a per-expert split's parts carry no
-# name to substitute.
+# Splits reached here are in two (gate/up, or MLA key/value); DBRX's per-expert split
+# belongs to the stack family. Widening costs a factor of the vocabulary per part.
 _MOE_MERGE_PARTS = 2
 _MOE_MERGE_PROBE_WIDTHS = (2, None)
 _MOE_MERGE_ROUNDS = 4
@@ -15425,23 +15335,20 @@ _MOE_MERGE_KEPT = ((None,), 0, False)
 
 
 def _mlx_moe_moved_shape(shape, layout):
-    """The shape a part has once the axis move a sanitizer applied is undone."""
+    """The shape a part has once the sanitizer's axis move is undone."""
     if layout is None:
         return tuple(shape)
     return tuple(mx.moveaxis(mx.zeros(tuple(shape)), layout[1], layout[0]).shape)
 
 
 def _mlx_moe_group_recipe(parts, recipe):
-    """The recipe a group follows: the merge, or the identity for a lone part."""
+    """A group's recipe: the merge, or the identity for a lone part."""
     return (parts,) + (recipe if len(parts) > 1 else _MOE_MERGE_KEPT)
 
 
 def _mlx_moe_merged(parts, recipe):
-    """Rebuild the checkpoint tensor a sanitizer split into `parts`.
-
-    A share says the sanitizer went the other way and fused several checkpoint
-    tensors into the one part read here, so what comes back is one slice of it.
-    """
+    """Rebuild the checkpoint tensor a sanitizer split into `parts`. A share means it
+    instead fused several into one part, so what comes back is one slice of it."""
     _, layouts, axis, flattened, *share = recipe
     merged = mx.concatenate(
         [
@@ -15480,9 +15387,7 @@ def _mlx_moe_merge_recipes(shapes):
                 for shape in moved
             ):
                 continue
-            # A sanitizer that reshapes cannot tell a merged tensor from the same values
-            # folded into its leading axes, so the flatter form goes first: a checkpoint
-            # stores a projection weight flat, and a split needing the axes rejects it.
+            # A reshape hides the difference between a merge and its flattening, so flatter first.
             for flattened in (True, False):
                 if flattened and (axis == 0 or axis + 1 == rank):
                     continue
@@ -15490,17 +15395,12 @@ def _mlx_moe_merge_recipes(shapes):
 
 
 def _mlx_moe_merge_groups(staged, substitutions):
-    """The staged tensors each substituted name collects, in substitution order.
-
-    Checkpoint order would let one layer collect its parts the other way round.
-    Whether one arrangement holds for every group is what the proof reads.
-    """
+    """The staged tensors each substituted name collects, in substitution order:
+    checkpoint order would let one layer collect its parts the other way round."""
     groups = {}
     for name in staged:
         for rank, (replaced, replacement) in enumerate(substitutions):
-            # The first match only: one part's fragment can be a fragment of the fused name
-            # the other restores to -- `up_proj` inside `gate_up_proj` -- so applying the
-            # rest in turn would land the two parts of one split in two groups.
+            # First match only: `up_proj` sits inside `gate_up_proj`, splitting a group in two.
             if replaced in name:
                 target = name.replace(replaced, replacement)
                 if target != name:
@@ -15523,11 +15423,8 @@ def _mlx_moe_merge_arrivals(staged, vocabulary):
 
 def _proved_mlx_moe_merge_recipe(sanitizer, staged, groups, recipes, width,
                                  native=False):
-    """The recipe under which the sanitizer reproduces every merged part.
-
-    Yields the name of a tensor the sanitizer wanted and did not find, which is
-    what a grouping still misses.
-    """
+    """The recipe under which the sanitizer reproduces every merged part, else the name
+    of a tensor it wanted and did not find."""
     merged_parts = {part for parts in groups.values() for part in parts}
     others, floor_probe = {}, {}
     for position, (name, tensor) in enumerate(staged.items()):
@@ -15536,12 +15433,10 @@ def _proved_mlx_moe_merge_recipe(sanitizer, staged, groups, recipes, width,
         floor_probe[name] = marker
         if name not in merged_parts:
             others[name] = marker
-    # The floor: a sanitizer can drop a sibling once the fused tensor is present. Read
-    # from the whole checkpoint, since what it does to a sibling can depend on the parts.
+    # The floor: a sanitizer can drop a sibling once the fused tensor is present.
     try:
-        # Through the probe, like every other replay: `others` holds the same marker
-        # objects, so a sanitizer offsetting a norm with `+=` would write through and
-        # the floor would be measured one step ahead of the recipes it gates.
+        # Must go through the probe helper: `floor_probe` shares marker objects with
+        # `others`, so an in-place `+=` measures the floor one step ahead.
         floor = _mlx_moe_sanitized_probe(sanitizer, floor_probe)
     except Exception:
         return
@@ -15571,8 +15466,7 @@ def _proved_mlx_moe_merge_recipe(sanitizer, staged, groups, recipes, width,
                     markers, _mlx_moe_group_recipe(parts, recipe)
                 )
         except Exception:
-            # A truncated probe only fits a recipe that leaves the last axis
-            # alone; the full-width pass reaches the rest.
+            # A truncated probe only fits recipes leaving the last axis alone.
             continue
         probe.update(others)
         try:
@@ -15587,8 +15481,7 @@ def _proved_mlx_moe_merge_recipe(sanitizer, staged, groups, recipes, width,
             for name, value in kept.items()
         ):
             continue
-        # A group at a time: the comparison materializes the marker and what was built
-        # from it, so holding all at once would cost the checkpoint again.
+        # A group at a time: comparing materializes both sides.
         proved = True
         for target, parts in groups.items():
             for part in parts:
@@ -15613,8 +15506,7 @@ def _proved_mlx_moe_merge_plan(sanitizers, staged, arrivals, target, substitutio
         if not parts or len(parts) != count or set(groups) & set(staged):
             return None
         shapes = [tuple(staged[part].shape) for part in parts]
-        # A recipe is an arrangement rather than a size, so groups agree on rank and not
-        # extent: layers holding different widths are still split the same way.
+        # A recipe is an arrangement, not a size, so groups agree on rank and not extent.
         ranks = {len(shape) for shape in shapes}
         if any(
             {len(staged[part].shape) for part in group} != ranks
@@ -15622,9 +15514,7 @@ def _proved_mlx_moe_merge_plan(sanitizers, staged, arrivals, target, substitutio
             if len(group) > 1
         ):
             return None
-        # Every layer's target collects the same parts, so the grouping is what has been
-        # tried, not the target it was read off. Recording it only once it is worth
-        # replaying keeps one that never got that far from being lost to one that did.
+        # Keyed by the grouping, not the target, and only once worth replaying.
         grouping = tuple(sorted((t, tuple(g)) for t, g in groups.items()))
         if grouping in attempted:
             return None
@@ -15638,9 +15528,7 @@ def _proved_mlx_moe_merge_plan(sanitizers, staged, arrivals, target, substitutio
                     if recipe is None:
                         wanted = wanted or missing
                         continue
-                    # A corner in float32 makes the search affordable and can support a recipe the
-                    # whole tensor contradicts. Rejecting one here lets the full-width pass find the
-                    # recipe that does hold, which refusing the finished rewrite could only lose.
+                    # A float32 corner can support a recipe the tensor contradicts: confirm natively.
                     if not any(
                         confirmed is not None
                         for confirmed, _ in _proved_mlx_moe_merge_recipe(
@@ -15652,9 +15540,7 @@ def _proved_mlx_moe_merge_plan(sanitizers, staged, arrivals, target, substitutio
                         merged: _mlx_moe_group_recipe(group, recipe)
                         for merged, group in groups.items()
                     }
-        # A sanitizer that pops a sibling unconditionally throws until the probe carries
-        # it, and names the one it wanted, so the companion rename is read off the
-        # failure rather than searched for.
+        # A sanitizer popping a sibling throws naming what it wanted: read the companion off it.
         claimed = {part for group in groups.values() for part in group}
         companion = next(
             (
@@ -15671,19 +15557,13 @@ def _proved_mlx_moe_merge_plan(sanitizers, staged, arrivals, target, substitutio
 
 
 def _build_mlx_moe_merge_plan(model, staged, sanitizers=None):
-    """Recover checkpoint tensors a sanitizer split into several staged ones.
-
-    GraniteMoE stores a layer's gate and up projections as one tensor, so no rename
-    reaches them: the checkpoint name has no staged counterpart at all. Proposing the
-    concatenation with the name makes the pair provable, and a marker with no two
-    elements alike proves the arrangement, not just the shape.
-    """
+    """Recover checkpoint tensors a sanitizer split into several staged ones, as
+    GraniteMoE's fused gate/up projection no rename reaches."""
     owned = _mlx_moe_sanitizers(model)
     vocabulary = _mlx_sanitizer_vocabulary(owned)
     if not vocabulary:
         return {}
-    # The vocabulary is the model's own either way: a sanitizer wrapped to
-    # spell its output differently carries no name fragments of its own.
+    # The vocabulary stays the model's own: a wrapped sanitizer has no fragments.
     sanitizers = sanitizers or owned
     arrivals = _mlx_moe_merge_arrivals(staged, vocabulary)
     collected = {}
@@ -15691,8 +15571,6 @@ def _build_mlx_moe_merge_plan(model, staged, sanitizers=None):
         for target in targets:
             collected.setdefault(target, []).append(name)
 
-    # The same grouping is reached from every layer's target, so replaying it
-    # once is what keeps the search from scaling with the layer count.
     attempted = set()
     for target, sources in collected.items():
         for chosen in itertools.permutations(sources, _MOE_MERGE_PARTS):
@@ -15710,7 +15588,7 @@ def _build_mlx_moe_merge_plan(model, staged, sanitizers=None):
 
 
 class _MlxRelabelledSanitizer:
-    """A sanitizer whose output is spelled the way a proved rename spells it."""
+    """A sanitizer relabelled to spell its output the way a proved rename does."""
 
     def __init__(self, inner, renames):
         self.inner, self.renames = inner, renames
@@ -15722,18 +15600,13 @@ class _MlxRelabelledSanitizer:
 
 
 def _build_mlx_moe_renamed_merge_plan(model, staged, renames):
-    """Merges the checkpoint still needs once the renames have been proved.
-
-    A sanitizer that splits as well as relocates leaves no staged name one substitution
-    from the checkpoint's: Qwen3-VL-MoE saves `switch_mlp.gate_proj.weight` for a
-    checkpoint holding `experts.gate_up_proj`. From the proved name it is one, so the
-    search runs again there with both sides relabelled to checkpoint names.
-    """
+    """Merges the checkpoint still needs once the renames have been proved: splitting
+    plus relocating leaves no staged name one substitution from the checkpoint's, but
+    the proved name is one away (Qwen3-VL-MoE)."""
     if not renames:
         return {}
     renamed = {renames.get(name, name): tensor for name, tensor in staged.items()}
-    # A rename can land on a name the search never saw, since names a merge claimed
-    # are held out of it, and two staged tensors under one name is not a checkpoint.
+    # Two staged tensors under one name is not a checkpoint.
     if len(renamed) != len(staged):
         return {}
     merges = _build_mlx_moe_merge_plan(
@@ -15745,9 +15618,7 @@ def _build_mlx_moe_renamed_merge_plan(model, staged, renames):
     restored = {}
     for target, (parts, *recipe) in merges.items():
         parts = [staged_names.get(part, part) for part in parts]
-        # A group no rename touched is one the first search saw under these very names
-        # and reaches the same recipe; dropping it keeps this search to what the renames
-        # made reachable.
+        # A group no rename touched was already covered by the first search.
         if all(part not in renames for part in parts):
             continue
         restored[target] = (parts, *recipe)
@@ -15755,11 +15626,9 @@ def _build_mlx_moe_renamed_merge_plan(model, staged, renames):
 
 
 def _mlx_moe_expert_stacks(staged):
-    """Staged names alike but for one component spelling a run of experts.
-
-    DBRX builds each part's name with an f-string, leaving no fragment standing
-    for the index, so the run itself is what identifies them.
-    """
+    """Staged names alike but for one component spelling a run of experts. DBRX builds
+    each with an f-string, so no fragment stands for the index and the run identifies
+    them."""
     runs = {}
     for name in staged:
         components = name.split(".")
@@ -15774,11 +15643,9 @@ def _mlx_moe_expert_stacks(staged):
 
 
 def _mlx_moe_stack_recipes(rank, count):
-    """Every concatenation of the parts one split produced, arranged alike.
-
-    A sanitizer splits every expert the same way, so one layout stands for all and the
-    search stays layouts times axes rather than layouts to the expert count.
-    """
+    """Every concatenation of the parts one split produced, all arranged alike: every
+    expert is split the same way, so the search stays layouts times axes rather than
+    layouts to the expert count."""
     choices = [None] + [layout for layout in _MOE_TENSOR_LAYOUTS
                         if max(layout) < rank]
     for layout in choices:
@@ -15795,9 +15662,7 @@ def _proved_mlx_moe_expert_stack(sanitizers, staged, heads, tail, fragment,
     stripped = fragment.strip(".")
     if not stripped or "." in stripped:
         return None
-    # The checkpoint may or may not carry the `.weight` mlx-lm appends -- DBRX's
-    # converter reads the fused name only without it -- so the two spellings are
-    # separate proposals.
+    # DBRX's converter reads the fused name only without the `.weight` mlx-lm appends.
     for trimmed in (False, True):
         groups = {}
         for head, parts in heads.items():
@@ -15807,13 +15672,10 @@ def _proved_mlx_moe_expert_stack(sanitizers, staged, heads, tail, fragment,
                     break
                 target = target[: -len(".weight")]
             groups[target] = parts
-        # Short when the spelling did not apply to every head, and a spelling
-        # only some of them can take is not one.
+        # Short when the spelling did not apply to every head.
         if len(groups) != len(heads):
             continue
-        # A group cannot rebuild one of its own parts, which a fragment spelling an index
-        # in the run reaches. Nothing else refuses it: the floor holds the parts out, so
-        # it cannot see the rest written away.
+        # A group cannot rebuild its own part, and the floor holds the parts out.
         if any(target in parts for target, parts in groups.items()):
             continue
         for width in _MOE_MERGE_PROBE_WIDTHS:
@@ -15834,26 +15696,19 @@ def _proved_mlx_moe_expert_stack(sanitizers, staged, heads, tail, fragment,
 
 
 def _build_mlx_moe_expert_stack_plan(model, staged):
-    """Recover a checkpoint tensor a sanitizer split into one tensor per expert.
-
-    Neither a rename nor a merge reaches DBRX's: the parts are told apart by index
-    rather than by name, and there are as many as the model has experts, which no
-    arrangement of a pair can propose. So the run of indices finds a group, the
-    vocabulary only names what it restores to, and the parts go in index order.
-    """
+    """Recover a checkpoint tensor a sanitizer split into one tensor per expert: DBRX's
+    parts are told apart by index, so the run of indices finds the group."""
     sanitizers = _mlx_moe_sanitizers(model)
     vocabulary = _mlx_sanitizer_vocabulary(sanitizers)
     if not vocabulary:
         return {}
-    # Grouping by the tail the indexed component precedes is what separates a
-    # run of expert indices from the run of layer indices beside it.
+    # Grouping by the tail separates a run of expert indices from one of layer indices.
     by_tail = {}
     for (head, tail), parts in _mlx_moe_expert_stacks(staged).items():
         by_tail.setdefault(tail, {})[head] = parts
 
     plan = {}
     for tail, heads in sorted(by_tail.items()):
-        # Rank rather than extent, as a merge reads it.
         ranks = {len(staged[part].shape) for parts in heads.values() for part in parts}
         counts = {len(parts) for parts in heads.values()}
         if len(ranks) != 1 or len(counts) != 1:
@@ -15869,34 +15724,24 @@ def _build_mlx_moe_expert_stack_plan(model, staged):
     return plan
 
 
-# How many tensors one staged tensor is split back into. Three covers the KDA
-# convolutions glm5_next fuses; a group longer than this is a table of names
-# rather than the parts of one tensor.
+# How many tensors one staged tensor splits back into; longer is a name table.
 _MOE_SPLIT_PARTS = 4
 
 
 def _mlx_moe_split_recipes(rank, count):
-    """Every way one staged tensor could be the concatenation of `count` parts.
-
-    Both directions of every axis move, unlike a merge's: a merge undoes what the
-    sanitizer did to a part it was given, a split does it to one it hands over.
-    """
+    """Every way one staged tensor could be the concatenation of `count` parts. Both
+    directions of every axis move, unlike a merge's: a merge undoes what the sanitizer
+    did to a part it was given, a split does it to one it hands over."""
     moves = [layout for layout in _MOE_TENSOR_LAYOUTS if max(layout) < rank]
-    # Moved layouts first, identity last: a sanitizer only moves an axis because
-    # some checkpoint stores it the other way, so where both replay -- as they do
-    # for glm5_next's convolutions -- the moved one is what llama.cpp reads.
+    # Moved layouts first, identity last: where both replay the moved one is right.
     for layout in moves + [(after, before) for before, after in moves] + [None]:
         for axis in range(rank):
             yield (layout,), axis
 
 
 def _proved_mlx_moe_name_split(sanitizer, staged, source, proposals, recipes):
-    """The naming and recipe under which the sanitizer fuses parts into `source`.
-
-    A merge's proof reads markers back under the names it gave; here the names are
-    new, so what has to come back is the one tensor they were built into. The floor
-    is replayed once for the source: what it holds does not depend on the naming.
-    """
+    """The naming and recipe under which the sanitizer fuses parts into `source`: the
+    names are new, so what must come back is the one tensor they were built into."""
     others = {name: mx.full(tuple(tensor.shape), float(position), dtype=mx.float32)
               for position, (name, tensor) in enumerate(staged.items())
               if name != source}
@@ -15904,7 +15749,6 @@ def _proved_mlx_moe_name_split(sanitizer, staged, source, proposals, recipes):
         floor = sanitizer.sanitize(dict(others))
     except Exception:
         return None
-    # The floor, as the merge proof reads it, against the source arriving as parts.
     kept = {name: floor[name] for name in others if name in floor}
 
     shape = tuple(staged[source].shape)
@@ -15940,12 +15784,8 @@ def _proved_mlx_moe_name_split(sanitizer, staged, source, proposals, recipes):
 
 
 def _build_mlx_moe_name_split_plan(model, staged, claimed):
-    """Recover checkpoint tensors a sanitizer fused into one staged tensor.
-
-    glm5_next concatenates a layer's three KDA convolutions and moves an axis, so
-    neither a rename nor a merge reaches them: the checkpoint holds the parts and
-    the staged form the whole. Each part is a share of the tensor it came from.
-    """
+    """Recover checkpoint tensors a sanitizer fused into one staged tensor, as glm5_next
+    does a layer's three KDA convolutions. Each part is a share of what it came from."""
     sanitizers = _mlx_moe_sanitizers(model)
     groups = _mlx_sanitizer_fusion_groups(sanitizers)
     if not groups:
@@ -15956,7 +15796,7 @@ def _build_mlx_moe_name_split_plan(model, staged, claimed):
         if source in claimed or _kept_for_the_gguf_converter(source):
             continue
         rank = len(staged[source].shape)
-        # The names first, since they are string work and a replay is not.
+        # Names first: string work, unlike a replay.
         proposals = []
         for group, fragments in groups:
             for replaced in fragments:
@@ -15985,12 +15825,8 @@ def _build_mlx_moe_name_split_plan(model, staged, claimed):
 
 
 def _mlx_moe_merge_placement(files, merges):
-    """Which shard receives each merged tensor, and which shard holds each part.
-
-    Parts may live in different shards, so the merged tensor goes in the first of
-    theirs to be written, which leaves the rest still there to be read: rewriting
-    a shard drops the parts it held.
-    """
+    """Which shard receives each merged tensor, and which holds each part. Rewriting a
+    shard drops the parts it held, so a merge goes in the first of its parts'."""
     owned, owner, anchors = {}, {}, {}
     if merges:
         consumed = {part for parts, *_ in merges.values() for part in parts}
@@ -16006,11 +15842,9 @@ def _mlx_moe_merge_placement(files, merges):
 
 
 def _mlx_moe_written_order(files, plan, merges, owned):
-    """Every name the rewrite writes, in the order it will be read back in.
-
-    Asked rather than predicted: what a file hands back depends on its names alone,
-    so a file of one byte apiece answers it without writing the checkpoint again.
-    """
+    """Every name the rewrite writes, in the order it will be read back in. Asked, not
+    predicted: order depends on the names alone, so a file of one byte apiece answers
+    it without writing the checkpoint again."""
     consumed = {part for parts, *_ in merges.values() for part in parts}
     order = []
     with tempfile.TemporaryDirectory() as directory:
@@ -16032,10 +15866,7 @@ def _mlx_moe_written_order(files, plan, merges, owned):
 
 def _mlx_moe_shard_merges(file, tensors, owner, owned):
     """Every merged tensor one shard receives, built from the shards holding the parts.
-
-    A call rather than a block, so what it read is let go when it returns: a name
-    still bound to a shard would keep that shard alive through the writes after.
-    """
+    A call, not a block, so the shards it read are released when it returns."""
     built, loaded = {}, {}
     for target, recipe in owned.items():
         parts = recipe[0]
@@ -16044,8 +15875,7 @@ def _mlx_moe_shard_merges(file, tensors, owner, owned):
             if part_file == file:
                 shard = tensors
             else:
-                # Opened once for every merge this shard receives: one shard can anchor a merge
-                # for each layer with their parts in another, a descriptor apiece if reopened.
+                # Cached: one shard can anchor a merge per layer, a descriptor apiece if reopened.
                 shard = loaded.get(part_file)
                 if shard is None:
                     shard = loaded[part_file] = mx.load(str(part_file))
@@ -16056,12 +15886,8 @@ def _mlx_moe_shard_merges(file, tensors, owner, owned):
 
 
 def _mlx_moe_rewritten_checkpoint(staged, plan, offsets, layouts, merges):
-    """The names and tensors the rewrite writes, or None if two of them collide.
-
-    Refused rather than resolved: each tensor is placed in a shard one of its
-    sources came from, so two reconstructions sharing a name survive in different
-    shards and the index picks by position, which no single mapping stands for.
-    """
+    """The names and tensors the rewrite writes, or None if two collide: colliding
+    reconstructions land in different shards and the index picks by position."""
     consumed = {part for parts, *_ in merges.values() for part in parts}
     written = {
         target: _mlx_moe_merged([staged[part] for part in recipe[0]], recipe)
@@ -16090,16 +15916,10 @@ def _confirmed_mlx_moe_rewrite(sanitizers, files, plan, offsets, layouts, merges
                                restored=(), owned=None):
     """Whether replaying the whole rewrite hands the staged checkpoint back.
 
-    On the checkpoint rather than on markers: at bfloat16's eight significant bits a
-    marker stops being distinguishable, and two tensors the sanitizer cannot tell apart
-    are two the rewrite cannot get wrong.
-
-    Each reconstruction was proved alone; what reaches the sanitizer is all of them at
-    once, and two that hold apart need not hold together. Doing nothing is the floor: a
-    tensor the sanitizer already does not reproduce is not the rewrite's to lose, and
-    every tensor the rewrite claims has to come back whatever the floor says. One the
-    source checkpoint already corrected is held to neither.
-    """
+    On the checkpoint, not markers, which bfloat16's eight bits cannot tell apart, and
+    all at once, since reconstructions proved singly need not hold together. The floor
+    is doing nothing: what the sanitizer already fails to reproduce is not the
+    rewrite's to lose, but everything the rewrite claims must come back."""
     claimed = set(plan) | set(offsets) | set(layouts)
     claimed.update(part for parts, *_ in merges.values() for part in parts)
     order = _mlx_moe_written_order(files, plan, merges, owned or {})
@@ -16107,8 +15927,7 @@ def _confirmed_mlx_moe_rewrite(sanitizers, files, plan, offsets, layouts, merges
         floor = _mlx_moe_floor_names(sanitizer, files, claimed)
         if floor is None:
             continue
-        # Which written names each staged tensor accounts for, so that both it
-        # and they can be let go the moment it has been compared.
+        # Which written names each staged tensor accounts for, to release both early.
         produced, required = {}, floor - set(restored)
         for file in files:
             for name in mx.load(str(file)):
@@ -16118,9 +15937,7 @@ def _confirmed_mlx_moe_rewrite(sanitizers, files, plan, offsets, layouts, merges
                 produced[part] = ()
         for target, (parts, *_) in merges.items():
             produced[parts[-1]] = (target,)
-        # Every replay here assumes the sanitizer reads a mapping and not an order, and
-        # replaying reversed makes that assumption falsifiable rather than silent. Any
-        # disagreement is refused, since the disagreement is what says order was read.
+        # Replaying reversed falsifies the assumption that sanitize reads a mapping.
         forwards = _replayed_mlx_moe_rewrite(
             sanitizer, files, plan, offsets, layouts, merges, produced, required,
             order, reverse=False)
@@ -16128,8 +15945,7 @@ def _confirmed_mlx_moe_rewrite(sanitizers, files, plan, offsets, layouts, merges
             return False
         if forwards is None:
             continue
-        # Compared as the second replay produces it, so that one replay's
-        # residue is held rather than both.
+        # Compared as the second replay produces it, holding one residue not both.
         if _replayed_mlx_moe_rewrite(
             sanitizer, files, plan, offsets, layouts, merges, produced, required,
             order, reverse=True, mirrored=forwards
@@ -16162,27 +15978,21 @@ def _replayed_mlx_moe_rewrite(sanitizer, files, plan, offsets, layouts, merges,
                               produced, required, order, reverse, mirrored=None):
     """Replay the rewritten checkpoint once, against the shards as they stand.
 
-    Answers with whatever the replay produced that the shards could not account for,
-    which is all the other replay has to be compared with. Given `mirrored`, what that
-    one left over, each is compared as produced. None says this replay did not hand the
-    checkpoint back, disagreed with the other, or could not run; `_MOE_REWRITE_COLLIDES`
-    says the plan wants one name twice.
-
-    One replay is alive at a time: each holds every shard open while its tensors are
-    needed, and a checkpoint may have more shards than that allows.
-    """
+    Answers with the residue the shards could not account for; given `mirrored` (the
+    other replay's residue), each is compared as produced. None says this replay did not
+    hand the checkpoint back, disagreed, or could not run; `_MOE_REWRITE_COLLIDES` says
+    the plan wants one name twice. Only one replay may be alive: each holds every
+    shard."""
     try:
         written = _mlx_moe_rewritten_checkpoint(
             _mlx_staged_checkpoint(files), plan, offsets, layouts, merges)
         if written is None:
             return _MOE_REWRITE_COLLIDES
-        # The order the rewritten directory hands back follows the names, which the
-        # rewrite changes, so it is neither the staged order nor its reverse.
+        # Read-back order follows the rewritten names, not the staged order.
         written = {name: written[name] for name in
                    (reversed(order) if reverse else order) if name in written}
         out = sanitizer.sanitize(dict(written))
-        # Compared one tensor at a time and dropped from every mapping holding it: a
-        # sanitizer rebuilds a stacked expert tensor to hand it back.
+        # One at a time, dropped from every mapping holding it.
         unaccounted = {}
         for file in files:
             for name, tensor in mx.load(str(file)).items():
@@ -16200,7 +16010,7 @@ def _replayed_mlx_moe_rewrite(sanitizer, files, plan, offsets, layouts, merges,
             if not _kept_mlx_moe_residue(unaccounted, mirrored, name,
                                          _mlx_tensor_held(out.pop(name))):
                 return None
-        # A name the other replay produced and this one did not.
+        # Leftovers: a name the other replay produced and this one did not.
         if mirrored:
             return None
     except Exception:
@@ -16209,11 +16019,8 @@ def _replayed_mlx_moe_rewrite(sanitizer, files, plan, offsets, layouts, merges,
 
 
 def _kept_mlx_moe_residue(unaccounted, mirrored, name, tensor):
-    """Hold one residue for the other replay, or hold it to what that one left.
-
-    The name is looked up before the value: a name the other replay never produced is a
-    disagreement whatever it holds.
-    """
+    """Hold one residue for the other replay, or hold it to what that one left. Name
+    before value: one the other replay never produced is a disagreement."""
     if mirrored is None:
         unaccounted[name] = tensor
         return True
@@ -16223,7 +16030,7 @@ def _kept_mlx_moe_residue(unaccounted, mirrored, name, tensor):
 
 
 def _mlx_tensor_held(tensor):
-    """A tensor holding its own memory, so the shard it was read from can close: a replay's output can be a view of the shards it was given."""
+    """A copy owning its memory, since a replay's output can be a view of a shard."""
     if tensor is None:
         return None
     held = mx.array(tensor)
@@ -16238,8 +16045,7 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
     if not vocabulary:
         return {}, {}, {}
 
-    # Architectures that relocate a whole MoE block rename its experts and its
-    # router together, so the probe has to carry both reconstructions at once.
+    # A relocated MoE block renames experts and router together.
     claimed = {}
     for name, expert_names in (split_plan or {}).items():
         for expert_name in expert_names:
@@ -16247,8 +16053,7 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
                 tuple(staged[name].shape)[1:], dtype=staged[name].dtype
             )
 
-    # One cache for the whole search: shapes repeat across layers and every
-    # candidate re-marks the same tensors.
+    # One cache for the whole search: every candidate re-marks the same shapes.
     markers = {}
 
     def replay(proposal, required=frozenset()):
@@ -16258,22 +16063,15 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
             sanitizers, probe, {**staged, **claimed}, markers, required
         )
 
-    # Read once: this is the whole split plan's output, and the check below runs for
-    # every candidate a search offers.
     claimed_names = frozenset(claimed)
 
     def produced_once(proposal):
-        """Whether every name it produces is distinct from the others and from the split's.
-
-        Two names landing on one, or on one the split already reconstructs, reach the
-        replay through a single probe entry, so it cannot see the loss.
-        """
+        """Whether every name it produces is distinct from the others and the split's:
+        two landing on one reach the replay through a single probe entry."""
         produced = proposal.values()
         return len(set(produced)) == len(proposal) and claimed_names.isdisjoint(produced)
 
-    # A stacked expert tensor is recovered by splitting, not renaming, so a
-    # substitution must not be judged on whether it also names one. Leaving them out
-    # lets the relocation be read off the router tensors before the split plan.
+    # Stacked expert tensors are recovered by splitting, so hold them out here.
     held = set(split_plan or {}) | set(exclude)
     open_names = [name for name in staged if name not in held]
     proposal = {name: name for name in open_names}
@@ -16289,19 +16087,13 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
             for name, proposed in proposal.items()
         }
         recovered = {name for name, p in candidate.items() if p != name}
-        # A substitution mapping a recovered name back onto the saved one would pass by
-        # vacancy, undoing an earlier one. Recovered names may be refined, never dropped,
-        # so equalling the last candidate is enough and losing one is not.
+        # Recovered names may be refined, never dropped: mapping one back passes by vacancy.
         if not produced_once(candidate):
             continue
         if not recovered >= {name for name, p in proposal.items() if p != name}:
             continue
-        # Names this candidate leaves alone must keep coming back and the ones it renamed
-        # must not: falling short on exactly those is what the completion reads.
         candidate_corrections = replay(candidate, baseline - recovered)
-        # One relocation can leave a tensor short by moving two ways at once: Kimi Linear's
-        # router bias changes parent module and gains a `.gate.` component. Completing for
-        # exactly the names it missed reaches those without trying every pair.
+        # One relocation can move two ways at once (Kimi Linear), so complete on what missed.
         unproven = (baseline | recovered) - set(candidate_corrections)
         if unproven and unproven <= recovered:
             candidate, candidate_corrections = _completed_mlx_moe_rename_candidate(
@@ -16310,15 +16102,10 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
             if not produced_once(candidate):
                 continue
             recovered = {name for name, p in candidate.items() if p != name}
-        # Both halves matter: the floor keeps what the sanitizer already reproduces, and
-        # `recovered` makes each new name earn its place -- a name the sanitizer drops is
-        # reproduced under neither spelling, so it would be renamed on no evidence at all.
+        # `recovered` stops a name the sanitizer drops being renamed on no evidence.
         if set(candidate_corrections) >= baseline | recovered:
             proposal, corrections = candidate, candidate_corrections
-    # Several spellings replay alike, and the one the checkpoint was loaded from is worth
-    # no less than another, so the namespace it carries goes back on the names that left
-    # it wherever that replays as well. Only the namespace: a container the sanitizer adds
-    # back stays dropped, and where nothing else moved this leaves no rename at all.
+    # Where several spellings replay alike, prefer the loaded checkpoint's namespace.
     restored = {name: _GGUF_TEXT_TOWER_NAMESPACE + renamed[len("language_model"):]
                 for name, renamed in proposal.items()
                 if _mlx_moe_dropped_the_gguf_namespace_in_the_tower(name, renamed)}
@@ -16326,9 +16113,7 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
         candidate = {**proposal, **restored}
         recovered = {name for name, p in candidate.items() if p != name}
         candidate_corrections = replay(candidate, set(corrections) - recovered)
-        # Measured against what the search settled on rather than against the floor:
-        # the floor is what the staged names alone reproduce, which putting them back
-        # meets by construction.
+        # Against what the search settled on: the floor is met by construction.
         if (produced_once(candidate)
                 and set(candidate_corrections) >= set(corrections) | recovered):
             proposal, corrections = candidate, candidate_corrections
@@ -16338,9 +16123,8 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
     return renames, constants, layouts
 
 
-# The per-layer projections llama.cpp maps under `model.layers.{bid}.`, spelled the
-# way mlx-lm spells them. Deliberately the wider set -- a pure MoE model has no dense
-# feed-forward -- since a rewrite never takes one of these away, whatever it reads.
+# The per-layer projections llama.cpp maps under `model.layers.{bid}.`, as mlx-lm
+# spells them. Deliberately wider than any one architecture needs.
 _GGUF_MAPPED_LAYER_LEAVES = frozenset((
     "self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj", "self_attn.o_proj",
     "mlp.gate_proj", "mlp.up_proj", "mlp.down_proj",
@@ -16350,15 +16134,9 @@ _GGUF_MAPPED_LAYER_LEAVES = frozenset((
 def _kept_for_the_gguf_converter(name):
     """Whether this is a name the rewrite leaves alone.
 
-    Answered from the names alone -- telling "unmappable" from "already mapped" exactly
-    would need llama.cpp's own per-architecture table -- so it answers for the HF layer
-    prefix and not for every name that table maps: a checkpoint spelling its layers
-    otherwise has names mapped there and not held back here, which no rewrite reaches on
-    any architecture measured. It errs towards keeping, since taking away a name the
-    converter reads breaks a working export: mlx-lm rebuilds dense Hunyuan's
-    `mlp.gate_and_up_proj` from the two parts beside it, and llama.cpp maps the parts and
-    not the whole.
-    """
+    Exactness would need llama.cpp's own per-architecture table, so this reads the HF
+    layer prefix and errs towards keeping: taking away a name the converter reads
+    breaks a working export (mlx-lm rebuilds dense Hunyuan's `mlp.gate_and_up_proj`)."""
     parts = name.split(".")
     return (len(parts) > 4 and parts[0] == "model" and parts[1] == "layers"
             and parts[2].isdigit()
@@ -16375,7 +16153,6 @@ def _mlx_staged_checkpoint(files):
 
 def _mlx_staged_tensor_stubs(files):
     # Planning never reads a value, so stand-ins let each shard close again.
-    # Keeping the real ones would hold a descriptor and a mapping per shard.
     staged = {}
     for file in files:
         for name, tensor in mx.load(str(file)).items():
@@ -16386,40 +16163,33 @@ def _mlx_staged_tensor_stubs(files):
 def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None):
     staged = _mlx_staged_tensor_stubs(files)
     stacked = _mlx_stacked_expert_tensor_names(model, staged)
-    # A block relocation shows on its router and shared experts, which are ordinary
-    # renames, so learn it there before spending it on the expert tensors.
+    # A block relocation shows as ordinary renames on its router and shared experts.
     parents = _mlx_moe_parent_substitutions(
         _build_mlx_moe_rename_plan(model, staged, None, exclude=stacked)[0]
     )
-    # Architectures whose stacked layout llama.cpp already maps (Llama 4 keeps its
-    # experts fused in HF too) have no per-expert names to recover.
+    # Architectures llama.cpp already maps stacked (Llama 4) have no names to recover.
     split = (
         _build_mlx_moe_expert_unstack_plan(model, stacked, staged, parents)
         if stacked
         else None
     )
-    # Tensors a sanitizer split apart have no staged counterpart to rename, so
-    # they are rebuilt first and then kept out of the rename search.
+    # Split tensors have no staged counterpart to rename: rebuild first, then exclude.
     merges = _build_mlx_moe_expert_stack_plan(model, staged)
     merges.update(_build_mlx_moe_merge_plan(model, staged))
     consumed = {part for parts, *_ in merges.values() for part in parts}
     renames, offsets, layouts = _build_mlx_moe_rename_plan(
         model, staged, split, exclude=consumed
     )
-    # A sanitizer that splits a tensor as well as relocating it is out of the
-    # first search's reach, and in the second's once the relocation is proved.
+    # Splitting plus relocating needs the relocation proved first.
     late = _build_mlx_moe_renamed_merge_plan(model, staged, renames)
-    # A part goes into its merge as the checkpoint holds it, so whatever the
-    # renames proved for one the merge consumes goes with it.
+    # A part enters its merge as the checkpoint holds it, so drop its own rename.
     for parts, *_ in late.values():
         for part in parts:
             renames.pop(part, None)
             offsets.pop(part, None)
             layouts.pop(part, None)
     merges.update(late)
-    # A fused tensor has no staged counterpart, so the split runs over what nothing
-    # else claimed, and its own rename is dropped: the parts carry the name now, and
-    # two reconstructions of one tensor is not a checkpoint.
+    # A fused tensor has no staged counterpart, so drop its rename: parts carry it now.
     fused = _build_mlx_moe_name_split_plan(
         model, staged,
         set(merges) | {part for parts, *_ in merges.values() for part in parts}
@@ -16433,16 +16203,13 @@ def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None):
     plan = dict(split or {})
     # A rename is a one-name split, so the rewrite below needs no second path.
     plan.update((name, [renamed]) for name, renamed in renames.items())
-    # Measuring from the sanitizer alone needs no source, which is what reaches an
-    # already-converted checkpoint, but it must not subtract a second time from what
-    # the source measurement covered.
+    # Never subtract twice from what the source measurement already covered.
     offsets = {
         name: constant
         for name, constant in offsets.items()
         if name not in (source_norm_offsets or {})
     }
-    # Nothing the converter already reads is taken away, whatever the sanitizer
-    # can rebuild it from.
+    # Never take away a name the converter already reads.
     plan = {name: names for name, names in plan.items()
             if not _kept_for_the_gguf_converter(name)}
     merges = {target: recipe for target, recipe in merges.items()
@@ -16456,8 +16223,7 @@ def _prepare_moe_gguf_export_directory(
     """Restore the MoE tensor names and values llama.cpp converters read."""
     path = Path(path)
     files = sorted(path.glob("*.safetensors"))
-    # The caller passes the one norm measurement both passes act on, so they
-    # cannot disagree about what the source checkpoint already covered.
+    # One shared measurement, so the two passes cannot disagree about the source.
     if source_norm_offsets is _UNMEASURED:
         source_norm_offsets = _mlx_sanitizer_norm_offsets(model)
     plan, offsets, layouts, merges = _plan_mlx_moe_gguf_rewrite(
@@ -16466,7 +16232,6 @@ def _prepare_moe_gguf_export_directory(
     if not plan and not merges and not offsets and not layouts:
         return 0
 
-    # The one pass holding every shard open.
     owned, owner, anchors = _mlx_moe_merge_placement(files, merges)
     if not _confirmed_mlx_moe_rewrite(
         _mlx_moe_sanitizers(model), files, plan, offsets, layouts, merges,
@@ -16474,12 +16239,9 @@ def _prepare_moe_gguf_export_directory(
     ):
         return 0
 
-    # A merge is built as its receiving shard is written, so what is held is one shard
-    # rather than the checkpoint.
     name_map = {}
     consumed = {part: target for target, (parts, *_) in merges.items() for part in parts}
-    # A split's targets all read one tensor, so its anchor collects them rather
-    # than the last one winning and the index losing the rest.
+    # A split's anchor collects its targets; otherwise the index loses all but one.
     for target, anchor in sorted(anchors.items()):
         name_map[anchor] = name_map.get(anchor, ()) + (target,)
     for target, anchor in sorted(anchors.items()):
@@ -16488,8 +16250,7 @@ def _prepare_moe_gguf_export_directory(
                 name_map[part] = ()
 
     for file in files:
-        # One shard at a time: mx.eval below materializes everything this shard
-        # holds, so keeping earlier shards alive would scale with the model.
+        # One shard at a time: the mx.eval below materializes all of it.
         tensors = mx.load(str(file))
         if file not in owned and not any(
             name in plan or name in offsets or name in layouts or name in consumed
@@ -16518,8 +16279,7 @@ def _prepare_moe_gguf_export_directory(
                 for expert, expert_name in enumerate(expert_names):
                     updated[expert_name] = tensor[expert]
             name_map[name] = expert_names
-        # mx.load() arrays may be file-backed; saving over the source can
-        # truncate them before they materialize, so write beside and replace.
+        # mx.load() arrays may be file-backed: write beside the source and replace.
         mx.eval(*updated.values())
         tmp_file = file.with_name(f"{file.stem}.tmp{file.suffix}")
         mx.save_safetensors(str(tmp_file), updated, metadata={"format": "mlx"})
@@ -17368,15 +17128,13 @@ def save_pretrained_gguf(
         is_vlm_model = _is_vlm_model(model)
         print("Unsloth: Merging LoRA weights and saving to 16-bit...")
         save_merged_model(model, tokenizer, tmp_path, dequantize=True)
-        # Measured once: both passes subtract against the same answer, and the
-        # source checkpoint is read once rather than per pass.
+        # Measured once so both passes subtract against the same answer.
         norm_offsets = _mlx_sanitizer_norm_offsets(model)
         rewritten = _prepare_mlx_gguf_export_directory(
             tmp_path, model=model, replay_sanitizers=is_vlm_model,
             norm_offsets=norm_offsets,
         )
-        # After the norm convention is restored, so the offsets it measures are
-        # still keyed by the names the merged save wrote.
+        # Must run after the norm pass, whose offsets are keyed by the saved names.
         rewritten += _prepare_moe_gguf_export_directory(
             tmp_path, model=model, source_norm_offsets=norm_offsets,
         )

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -15239,14 +15239,10 @@ def _completed_mlx_moe_rename_candidate(candidate, corrections, unproven, vocabu
     return candidate, corrections
 
 
-# The splits reached here are in two: a gate/up pair, or an MLA key/value pair.
-# Of the installed sanitizers, four split in two and one -- DBRX -- splits into
-# one tensor per expert, which this grouping does not reach and which leaves that
-# checkpoint as it stands rather than rewriting it wrongly. Widening the grouping
-# costs a factor of the vocabulary per extra part. The
-# merge is probed with a truncated last axis first so a shape-agnostic split
-# costs a corner rather than the whole tensor, and rounds bound how many
-# siblings one failure at a time can pull into a grouping.
+# The splits reached here are in two: a gate/up pair, or an MLA key/value pair. DBRX
+# splits per expert instead, which the stack family reaches -- widening this grouping
+# would cost a factor of the vocabulary per part, and a per-expert split's parts carry no
+# name to substitute.
 _MOE_MERGE_PARTS = 2
 _MOE_MERGE_PROBE_WIDTHS = (2, None)
 _MOE_MERGE_ROUNDS = 4
@@ -15572,6 +15568,121 @@ def _build_mlx_moe_renamed_merge_plan(model, staged, renames):
             continue
         restored[target] = (parts, *recipe)
     return restored
+
+
+def _mlx_moe_expert_stacks(staged):
+    """Staged names alike but for one component spelling a run of experts.
+
+    DBRX builds each part's name with an f-string, leaving no fragment standing
+    for the index, so the run itself is what identifies them.
+    """
+    runs = {}
+    for name in staged:
+        components = name.split(".")
+        for position, component in enumerate(components):
+            if component.isdigit() and str(int(component)) == component:
+                key = (".".join(components[:position]),
+                       ".".join(components[position + 1:]))
+                runs.setdefault(key, {})[int(component)] = name
+    return {key: [found[index] for index in range(len(found))]
+            for key, found in runs.items()
+            if len(found) > 1 and sorted(found) == list(range(len(found)))}
+
+
+def _mlx_moe_stack_recipes(rank, count):
+    """Every concatenation of the parts one split produced, arranged alike.
+
+    A sanitizer splits every expert the same way, so one layout stands for all and the
+    search stays layouts times axes rather than layouts to the expert count.
+    """
+    choices = [None] + [layout for layout in _MOE_TENSOR_LAYOUTS
+                        if max(layout) < rank]
+    for layout in choices:
+        for axis in range(rank):
+            for flattened in (True, False):
+                if flattened and (axis == 0 or axis + 1 == rank):
+                    continue
+                yield (layout,) * count, axis, flattened
+
+
+def _proved_mlx_moe_expert_stack(sanitizers, staged, heads, tail, fragment,
+                                 recipes):
+    """The rewrite one fragment proves, for every group of experts it names."""
+    stripped = fragment.strip(".")
+    if not stripped or "." in stripped:
+        return None
+    # The checkpoint may or may not carry the `.weight` mlx-lm appends -- DBRX's
+    # converter reads the fused name only without it -- so the two spellings are
+    # separate proposals.
+    for trimmed in (False, True):
+        groups = {}
+        for head, parts in heads.items():
+            target = ".".join(filter(None, (head, stripped, tail)))
+            if trimmed:
+                if not target.endswith(".weight"):
+                    break
+                target = target[: -len(".weight")]
+            groups[target] = parts
+        # Short when the spelling did not apply to every head, and a spelling
+        # only some of them can take is not one.
+        if len(groups) != len(heads):
+            continue
+        # A group cannot rebuild one of its own parts, which a fragment spelling an index
+        # in the run reaches. Nothing else refuses it: the floor holds the parts out, so
+        # it cannot see the rest written away.
+        if any(target in parts for target, parts in groups.items()):
+            continue
+        for width in _MOE_MERGE_PROBE_WIDTHS:
+            for sanitizer in sanitizers:
+                for recipe, _ in _proved_mlx_moe_merge_recipe(
+                    sanitizer, staged, groups, recipes, width
+                ):
+                    if recipe is None or not any(
+                        confirmed is not None
+                        for confirmed, _ in _proved_mlx_moe_merge_recipe(
+                            sanitizer, staged, groups, [recipe], None, native=True
+                        )
+                    ):
+                        continue
+                    return {target: (parts, *recipe)
+                            for target, parts in groups.items()}
+    return None
+
+
+def _build_mlx_moe_expert_stack_plan(model, staged):
+    """Recover a checkpoint tensor a sanitizer split into one tensor per expert.
+
+    Neither a rename nor a merge reaches DBRX's: the parts are told apart by index
+    rather than by name, and there are as many as the model has experts, which no
+    arrangement of a pair can propose. So the run of indices finds a group, the
+    vocabulary only names what it restores to, and the parts go in index order.
+    """
+    sanitizers = _mlx_moe_sanitizers(model)
+    vocabulary = _mlx_sanitizer_vocabulary(sanitizers)
+    if not vocabulary:
+        return {}
+    # Grouping by the tail the indexed component precedes is what separates a
+    # run of expert indices from the run of layer indices beside it.
+    by_tail = {}
+    for (head, tail), parts in _mlx_moe_expert_stacks(staged).items():
+        by_tail.setdefault(tail, {})[head] = parts
+
+    plan = {}
+    for tail, heads in sorted(by_tail.items()):
+        # Rank rather than extent, as a merge reads it.
+        ranks = {len(staged[part].shape) for parts in heads.values() for part in parts}
+        counts = {len(parts) for parts in heads.values()}
+        if len(ranks) != 1 or len(counts) != 1:
+            continue
+        recipes = list(_mlx_moe_stack_recipes(ranks.pop(), counts.pop()))
+        for fragment in vocabulary:
+            proved = _proved_mlx_moe_expert_stack(
+                sanitizers, staged, heads, tail, fragment, recipes
+            )
+            if proved:
+                plan.update(proved)
+                break
+    return plan
 
 
 def _mlx_moe_merge_placement(files, merges):
@@ -15958,7 +16069,8 @@ def _plan_mlx_moe_gguf_rewrite(model, files, source_norm_offsets=None):
     )
     # Tensors a sanitizer split apart have no staged counterpart to rename, so
     # they are rebuilt first and then kept out of the rename search.
-    merges = _build_mlx_moe_merge_plan(model, staged)
+    merges = _build_mlx_moe_expert_stack_plan(model, staged)
+    merges.update(_build_mlx_moe_merge_plan(model, staged))
     consumed = {part for parts, *_ in merges.values() for part in parts}
     renames, offsets, layouts = _build_mlx_moe_rename_plan(
         model, staged, split, exclude=consumed

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -15001,6 +15001,24 @@ def _mlx_moe_expert_names(name, num_experts, group, leaf_alias, parent=("", ""))
     return [f"{prefix}.{group}.{e}.{leaf}.{param}" for e in range(num_experts)]
 
 
+_GGUF_TEXT_TOWER_NAMESPACE = "language_model.model"
+
+
+def _mlx_moe_dropped_the_gguf_namespace_in_the_tower(name, renamed):
+    """Whether this rename keeps a text tower but drops the namespace llama.cpp maps it under.
+
+    The converter strips `language_model.` and looks the rest up under `model.`, so a
+    rename off `language_model.model.` onto a `language_model.` that no longer carries it
+    moves the tensor out of the tables. Both ends are read, so a tensor renamed into the
+    tower never counts as having left it. Only a text tower is answered: outside one,
+    `transformer.blocks`, `encoder.layers` and a bare `layers` are each mapped under some
+    architecture, and nothing about a name says which a checkpoint is spelled in.
+    """
+    return (name.startswith(_GGUF_TEXT_TOWER_NAMESPACE + ".")
+            and renamed.startswith("language_model.")
+            and not renamed.startswith(_GGUF_TEXT_TOWER_NAMESPACE + "."))
+
+
 def _mlx_moe_parent_substitutions(renames):
     """The module relocations a set of proved renames is made of.
 
@@ -16216,6 +16234,19 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
             sanitizers, probe, {**staged, **claimed}, markers, required
         )
 
+    # Read once: this is the whole split plan's output, and the check below runs for
+    # every candidate a search offers.
+    claimed_names = frozenset(claimed)
+
+    def produced_once(proposal):
+        """Whether every name it produces is distinct from the others and from the split's.
+
+        Two names landing on one, or on one the split already reconstructs, reach the
+        replay through a single probe entry, so it cannot see the loss.
+        """
+        produced = proposal.values()
+        return len(set(produced)) == len(proposal) and claimed_names.isdisjoint(produced)
+
     # A stacked expert tensor is recovered by splitting, not renaming, so a
     # substitution must not be judged on whether it also names one. Leaving them out
     # lets the relocation be read off the router tensors before the split plan.
@@ -16237,7 +16268,7 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
         # A substitution mapping a recovered name back onto the saved one would pass by
         # vacancy, undoing an earlier one. Recovered names may be refined, never dropped,
         # so equalling the last candidate is enough and losing one is not.
-        if len(set(candidate.values())) != len(candidate):
+        if not produced_once(candidate):
             continue
         if not recovered >= {name for name, p in proposal.items() if p != name}:
             continue
@@ -16252,11 +16283,30 @@ def _build_mlx_moe_rename_plan(model, staged, split_plan, exclude=()):
             candidate, candidate_corrections = _completed_mlx_moe_rename_candidate(
                 candidate, candidate_corrections, unproven, vocabulary, replay
             )
+            if not produced_once(candidate):
+                continue
             recovered = {name for name, p in candidate.items() if p != name}
         # Both halves matter: the floor keeps what the sanitizer already reproduces, and
         # `recovered` makes each new name earn its place -- a name the sanitizer drops is
         # reproduced under neither spelling, so it would be renamed on no evidence at all.
         if set(candidate_corrections) >= baseline | recovered:
+            proposal, corrections = candidate, candidate_corrections
+    # Several spellings replay alike, and the one the checkpoint was loaded from is worth
+    # no less than another, so the namespace it carries goes back on the names that left
+    # it wherever that replays as well. Only the namespace: a container the sanitizer adds
+    # back stays dropped, and where nothing else moved this leaves no rename at all.
+    restored = {name: _GGUF_TEXT_TOWER_NAMESPACE + renamed[len("language_model"):]
+                for name, renamed in proposal.items()
+                if _mlx_moe_dropped_the_gguf_namespace_in_the_tower(name, renamed)}
+    if restored:
+        candidate = {**proposal, **restored}
+        recovered = {name for name, p in candidate.items() if p != name}
+        candidate_corrections = replay(candidate, set(corrections) - recovered)
+        # Measured against what the search settled on rather than against the floor:
+        # the floor is what the staged names alone reproduce, which putting them back
+        # meets by construction.
+        if (produced_once(candidate)
+                and set(candidate_corrections) >= set(corrections) | recovered):
             proposal, corrections = candidate, candidate_corrections
     constants = {name: constant for name, (constant, _) in corrections.items() if constant}
     layouts = {name: layout for name, (_, layout) in corrections.items() if layout}


### PR DESCRIPTION
## The problem

A Mixture-of-Experts model fine-tuned through the MLX backend cannot be exported to GGUF. `save_pretrained_gguf` stages the merged checkpoint and hands it to llama.cpp, which refuses it before writing anything:

```text
ValueError: Can not map tensor 'model.layers.0.mlp.switch_mlp.down_proj.weight'
```

The cause is that mlx-lm and mlx-vlm rewrite a checkpoint on load. Each model's `sanitize()` renames tensors, stacks per-expert weights into one, fuses several tensors into one, splits one into several, and moves whole namespaces. What MLX then holds — and what the staging directory writes back out — is the MLX spelling, and llama.cpp's converters only read the Hugging Face one. Vision-language MoE models are affected worst, because their sanitizers compose: the language model's runs inside the wrapper's, so no single one accounts for the saved names.

## What this changes

A pass over the staging directory that restores the names and layouts the converters read, by inverting each model's own `sanitize()` rather than by hard-coding any architecture.

Nothing is guessed. Every candidate reconstruction is proved: the model's own sanitizer is replayed over it, and it is accepted only if that returns the staged checkpoint byte-identically. The names it substitutes are read out of the sanitizer's own constants, including those in the helper functions it calls, so an architecture that spells its rename in a module-level helper is reached as well as one that spells it inline.

Six reconstruction shapes are recognised, each proved the same way: a rename, a stacked expert tensor split back into one per expert, several tensors merged into the one the checkpoint holds, one tensor split into a group the sanitizer named, an axis re-laid out inside a merge, and a namespace every tensor carries relocated as a whole.

**The whole directory is confirmed before anything is written.** Each reconstruction is proved alone, but what reaches a sanitizer is all of them at once, and two that hold apart need not hold together. The finished rewrite is replayed as a unit, forwards and in reverse, and refused unless it hands the staged checkpoint back. A refusal writes nothing, so an architecture this cannot recover fails exactly as it does today rather than producing a GGUF whose tensors the model does not claim.

### One preimage is not as good as another

Where several spellings replay identically, the checkpoint's own is the one the converter reads. mlx-vlm's Gemma models add `language_model.model` to names that lack it, so `language_model.X` and `language_model.model.X` both replay and no replay tells them apart. llama.cpp strips `language_model.` and keys its tensor tables under `model.`, so only the longer spelling maps. A rename that takes a name off `language_model.model.` and leaves it under a `language_model.` that no longer carries it therefore has that namespace read back on, adopted only where the replay proves it at least as well. Only the namespace is read back, so a rename that also dropped an expert container keeps the container dropped.

Outside a text tower nothing is assumed: `transformer.blocks`, `encoder.layers`, `backbone.layers` and a bare `layers` are each mapped under some architecture, and nothing about a name says which a checkpoint is spelled in, so those are left to the replay that proved them.

## Validation

Every architecture below was built from its own config dataclasses, exported, and run through llama.cpp's converter (b10639) twice — once against `main` and once against this branch — so each row says what this branch changed rather than what happens to pass.

**Fixed: refused on `main`, converts here.**

| architecture | tensors restored |
|---|---|
| `glm5_next` | 102 |
| `qwen3_5_moe` | 74 as a vision-language fixture, 41 as a text one |
| `kimi_linear` | 41 |
| `glm4v_moe` | 31 |
| `qwen3_vl_moe` | 27 |
| `step3p5` | 25 |
| `dbrx` | 24 |
| `qwen3_next` | 11 |
| `deepseek`, `deepseek_v2`, `ernie4_5_moe`, `gemma4`, `gemma4_text`, `granitemoe`, `lfm2_moe`, `mixtral`, `olmoe`, `qwen2_moe`, `qwen3_moe` | 6 each |

Nineteen architectures, plus `minimax` under the caveat below.

**Unaffected: converts on `main`, still converts here.** `gemma3n` (rewrites nothing), `qwen3_vl` (25 restored), `qwen3_5` (31 restored). Dense models are byte-identical through the pass, which is the evidence that it does not touch what already worked.

**Still refused, on both trees.** `qwen4_exp` (88 restored, see below), `moondream3` and `diffusion_gemma` (llama.cpp registers no architecture matching either, so no GGUF could satisfy it), `step3p7` (`Can not map tensor 'ln_pre.bias'`, a vision-tower name outside what this recovers).

```bash
python -m pytest tests/test_mlx_save_export_regressions.py -q
python -m pytest tests/test_mlx_gguf_moe_export_metal.py -q
```

The two files run as separate invocations because the MLX simulation shim the first one installs is process-wide.

## Known limitations

**The search's result depends on `PYTHONHASHSEED`.** Where several spellings replay alike, the one it settles on follows set and dict iteration order, which varies per process, so an architecture whose preimage is ambiguous can export differently from one run to the next. `minimax` is the measured case: it converts at seed 0 and is refused at seeds 1 and 2, identically with this change and without it. It is listed apart from the table above for that reason. Making the choice deterministic is a property of the search's design rather than of this change, and is left for follow-up.

**`qwen4_exp` has its names fully restored — 88 tensors, and replaying its sanitizer over the result returns every staged tensor byte-identically — but its converter still refuses it, for a reason outside this repository.** mlx-vlm deliberately drops the multi-token-prediction tensors on load, so the exported checkpoint has no MTP head and no config value that can say so, and the converter asserts on their absence. Its `--no-mtp` escape is gated by the same flag that refuses `--mtp`, which that architecture turns off because its MTP block borrows the trunk's embedding and cannot be published alone. Splitting those two gates is a converter-side change; the export already detects that assertion and retries with `--no-mtp`, so nothing here needs to change when it lands.

**What is held back is answered from names alone.** Telling "unmappable" from "already mapped" exactly would need llama.cpp's own per-architecture tensor table, which is not available at the point the rewrite runs. The pass therefore answers for the Hugging Face layer prefix and errs towards keeping, since taking away a name the converter already reads would break a working export.

## Scope and tradeoffs

The pass runs only over MoE checkpoints and returns immediately when a model's sanitizer offers no names to work with, so dense exports pay one scan and nothing else.

Every reconstruction is proved by replay and the finished directory is confirmed as a whole, so the failure mode is a refusal rather than a wrong GGUF: an architecture this cannot recover fails exactly as it does on `main`.
