### PR TITLE
Stop mlx-lm's ArraysCache.advance() stranding a Metal buffer per call in batched generation

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -325,6 +325,7 @@ jobs:
             tests/test_train_on_responses_list_labels.py \
             tests/test_mlx_preference.py \
             tests/test_mlx_trainer_internals.py \
+            tests/test_mlx_arrays_cache_advance.py \
             tests/test_mlx_quantized_optimizer_routing.py \
             tests/test_check_hf_model_exists_transport_errors.py \
             tests/test_hub_transport_errors_single_segment.py \

--- a/tests/test_mlx_arrays_cache_advance.py
+++ b/tests/test_mlx_arrays_cache_advance.py
@@ -1,0 +1,335 @@
+"""The ArraysCache.advance patch, on any platform.
+
+Everything that decides *whether* to rewrite a third-party class -- the body
+matcher, the install latch, the retry policy, the deferred arithmetic and the
+adoption of caches built before installation -- is plain Python. None of it needs
+mlx, Metal or Apple Silicon, and the companion Metal suite is opt-in behind a
+label, so this is the coverage that runs on every pull request.
+
+The Metal-only assertions (live buffer counts, real decoding) stay in
+tests/test_mlx_generate_metal.py.
+"""
+
+import importlib.util
+import sys
+import types
+
+import pytest
+
+if importlib.util.find_spec("mlx") is None:
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+import unsloth_zoo.mlx.generate as engine  # noqa: E402
+
+
+def stock_bodied_cache():
+    """A class carrying mlx-lm 0.31.3's advance, byte for byte."""
+
+    class ArraysCache:
+        lengths = left_padding = None
+
+        def advance(self, N):
+            if self.lengths is not None:
+                self.lengths -= N
+            if self.left_padding is not None:
+                self.left_padding -= N
+
+    return ArraysCache
+
+
+@pytest.fixture
+def fresh(monkeypatch):
+    """Un-latch the installer and let a test aim it at a class it owns."""
+
+    monkeypatch.setattr(engine, "_ARRAYS_CACHE_ADVANCE_RESOLVED", False)
+    monkeypatch.setattr(engine, "_VLM_ARRAYS_CACHE_ADVANCE_RESOLVED", False)
+
+    def aim(cls, module_name="mlx_lm.models.cache"):
+        module = types.ModuleType(module_name)
+        module.ArraysCache = cls
+        monkeypatch.setitem(sys.modules, module_name, module)
+        return cls
+
+    return aim
+
+
+# --------------------------------------------------------------------------
+# The matcher
+# --------------------------------------------------------------------------
+
+
+def test_matcher_accepts_the_body_it_reproduces():
+    assert engine._has_replaceable_advance(stock_bodied_cache())
+
+
+def test_matcher_rejects_the_opposite_sign():
+    class Incrementing:
+        lengths = left_padding = None
+
+        def advance(self, N):
+            if self.lengths is not None:
+                self.lengths += N
+            if self.left_padding is not None:
+                self.left_padding += N
+
+    assert not engine._has_replaceable_advance(Incrementing)
+
+
+def test_matcher_rejects_the_same_decrements_plus_a_side_effect():
+    class SideEffecting:
+        lengths = left_padding = None
+
+        def advance(self, N):
+            self.touched = True
+            if self.lengths is not None:
+                self.lengths -= N
+            if self.left_padding is not None:
+                self.left_padding -= N
+
+    assert not engine._has_replaceable_advance(SideEffecting)
+
+
+def test_matcher_rejects_a_defaulted_step():
+    class Defaulted:
+        lengths = left_padding = None
+
+        def advance(self, N=1):
+            if self.lengths is not None:
+                self.lengths -= N
+            if self.left_padding is not None:
+                self.left_padding -= N
+
+    assert not engine._has_replaceable_advance(Defaulted)
+
+
+def test_matcher_rejects_reads_already_mediated_by_descriptors():
+    class Descriptored:
+        lengths = property(lambda self: None, lambda self, v: None)
+        left_padding = property(lambda self: None, lambda self, v: None)
+
+        def advance(self, N):
+            if self.lengths is not None:
+                self.lengths -= N
+            if self.left_padding is not None:
+                self.left_padding -= N
+
+    assert not engine._has_replaceable_advance(Descriptored)
+
+
+def test_matcher_rejects_a_staticmethod_carrying_the_same_body():
+    # A plain attribute read unwraps staticmethod, so without an explicit check
+    # this compares a body that would be bound differently from the replacement.
+    cls = stock_bodied_cache()
+    cls.advance = staticmethod(cls.advance)
+    assert not engine._has_replaceable_advance(cls)
+
+
+# --------------------------------------------------------------------------
+# Installation
+# --------------------------------------------------------------------------
+
+
+def test_install_replaces_a_matching_class(fresh):
+    cls = fresh(stock_bodied_cache())
+    engine._install_arrays_cache_advance_fix()
+
+    assert isinstance(cls.__dict__["lengths"], property)
+    assert isinstance(cls.__dict__["left_padding"], property)
+    assert cls.advance is engine._deferred_advance
+    assert cls._unsloth_advance_patched is True
+    assert engine._ARRAYS_CACHE_ADVANCE_RESOLVED
+
+
+def test_install_leaves_a_non_matching_class_untouched(fresh):
+    class Clamping:
+        lengths = left_padding = None
+
+        def advance(self, N):
+            self.lengths = max(0, (self.lengths or 0) - N)
+
+    before = dict(vars(Clamping))
+    fresh(Clamping)
+    engine._install_arrays_cache_advance_fix()
+
+    assert Clamping.advance is before["advance"]
+    assert not hasattr(Clamping, "_unsloth_advance_patched")
+    assert not isinstance(vars(Clamping).get("lengths"), property)
+    # Declining is still a decision, so it is not retried on every call.
+    assert engine._ARRAYS_CACHE_ADVANCE_RESOLVED
+
+
+def test_install_is_idempotent(fresh, monkeypatch):
+    cls = fresh(stock_bodied_cache())
+    engine._install_arrays_cache_advance_fix()
+    installed = (cls.__dict__["lengths"], cls.__dict__["left_padding"], cls.advance)
+
+    monkeypatch.setattr(engine, "_ARRAYS_CACHE_ADVANCE_RESOLVED", False)
+    engine._install_arrays_cache_advance_fix()
+
+    assert (cls.__dict__["lengths"], cls.__dict__["left_padding"], cls.advance) == installed
+
+
+def test_a_failed_attempt_is_not_a_decision(fresh, monkeypatch):
+    fresh(stock_bodied_cache())
+
+    def explode(arrays_cache):
+        raise RuntimeError("transient")
+
+    monkeypatch.setattr(engine, "_has_replaceable_advance", explode)
+    engine._install_arrays_cache_advance_fix()
+    assert not engine._ARRAYS_CACHE_ADVANCE_RESOLVED
+
+    monkeypatch.undo()
+    monkeypatch.setattr(engine, "_ARRAYS_CACHE_ADVANCE_RESOLVED", False)
+    engine._install_arrays_cache_advance_fix()
+    assert engine._ARRAYS_CACHE_ADVANCE_RESOLVED
+
+
+def test_a_missing_mlx_lm_is_inert(fresh, monkeypatch):
+    # Every non-Apple platform: mlx-lm cannot be imported and nothing may raise.
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.cache", None)
+    engine._install_arrays_cache_advance_fix()
+    assert not engine._ARRAYS_CACHE_ADVANCE_RESOLVED
+
+
+def test_mlx_vlm_vendored_cache_is_patched_too(fresh):
+    # mlx-vlm re-exports mlx-lm's class up to 0.5.x and vendors its own copy of
+    # this same body from 0.6.4, so patching mlx-lm alone leaves the vision batch
+    # path leaking on the range the pins allow.
+    text_cache = fresh(stock_bodied_cache())
+    vision_cache = fresh(stock_bodied_cache(), "mlx_vlm.models.cache")
+    sys.modules.setdefault("mlx_vlm", types.ModuleType("mlx_vlm"))
+
+    engine._install_arrays_cache_advance_fix()
+
+    assert text_cache._unsloth_advance_patched is True
+    assert vision_cache._unsloth_advance_patched is True
+    assert vision_cache is not text_cache
+
+
+def test_mlx_vlm_is_not_imported_by_a_text_only_run(fresh, monkeypatch):
+    fresh(stock_bodied_cache())
+    monkeypatch.delitem(sys.modules, "mlx_vlm", raising=False)
+    engine._install_arrays_cache_advance_fix()
+    assert "mlx_vlm" not in sys.modules
+
+
+# --------------------------------------------------------------------------
+# The deferred arithmetic
+# --------------------------------------------------------------------------
+
+
+def test_advance_defers_and_folds_on_read(fresh):
+    cls = fresh(stock_bodied_cache())
+    engine._install_arrays_cache_advance_fix()
+
+    cache = cls()
+    cache.lengths, cache.left_padding = 10, 4
+    for _ in range(5):
+        cache.advance(2)
+
+    assert cache._lengths_pending == 10
+    assert cache.lengths == 0
+    assert cache.left_padding == -6
+    # Folding is a one-off: reading again must not subtract twice.
+    assert (cache.lengths, cache.left_padding) == (0, -6)
+
+
+def test_writing_a_field_supersedes_its_pending_count(fresh):
+    cls = fresh(stock_bodied_cache())
+    engine._install_arrays_cache_advance_fix()
+
+    cache = cls()
+    cache.lengths = 10
+    cache.advance(3)
+    cache.lengths = 7
+    assert cache.lengths == 7
+
+
+def test_advance_with_a_non_integer_step_keeps_stock_arithmetic(fresh):
+    # Stock accepts whatever the array subtraction accepts. A float cannot go in
+    # a Python counter, and deferring it would move the error to a later reader.
+    cls = fresh(stock_bodied_cache())
+    engine._install_arrays_cache_advance_fix()
+
+    cache = cls()
+    cache.lengths, cache.left_padding = 10.0, 4.0
+    cache.advance(2.5)
+
+    assert cache._lengths_pending == 0
+    assert cache.lengths == 7.5
+    assert cache.left_padding == 1.5
+
+
+def test_a_cache_built_before_installation_keeps_its_metadata(fresh):
+    cls = fresh(stock_bodied_cache())
+    legacy = cls()
+    legacy.__dict__.update(lengths=9, left_padding=2)
+
+    engine._install_arrays_cache_advance_fix()
+    legacy.advance(1)
+
+    assert (legacy.lengths, legacy.left_padding) == (8, 1)
+
+
+def test_a_partly_installed_class_is_still_correct(fresh):
+    # The six class assignments are not atomic and readers do not take the lock,
+    # so every prefix of the installation has to leave the class usable.
+    steps = [
+        lambda c: setattr(c, "_lengths", None),
+        lambda c: setattr(c, "_lengths_pending", 0),
+        lambda c: setattr(c, "_left_padding", None),
+        lambda c: setattr(c, "_left_padding_pending", 0),
+        lambda c: setattr(c, "lengths", engine._deferred_metadata("lengths")),
+        lambda c: setattr(c, "left_padding", engine._deferred_metadata("left_padding")),
+        lambda c: setattr(c, "advance", engine._deferred_advance),
+    ]
+    for prefix in range(len(steps) + 1):
+        cls = stock_bodied_cache()
+        for apply in steps[:prefix]:
+            apply(cls)
+        cache = cls()
+        cache.lengths, cache.left_padding = 8, 3
+        cache.advance(1)
+        assert (cache.lengths, cache.left_padding) == (7, 2), f"broken after {prefix} steps"
+
+
+# --------------------------------------------------------------------------
+# Ordering
+# --------------------------------------------------------------------------
+
+
+def test_generate_batch_installs_before_it_generates(monkeypatch):
+    order = []
+    real_install = engine._install_arrays_cache_advance_fix
+
+    def record_install():
+        order.append("install")
+        return real_install()
+
+    class Adapter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def generate(self, requests):
+            order.append("generate")
+            return []
+
+    import contextlib
+
+    monkeypatch.setattr(engine, "_install_arrays_cache_advance_fix", record_install)
+    monkeypatch.setattr(engine, "_TextBatchAdapter", Adapter)
+    monkeypatch.setattr(engine, "generation_mode", lambda model: contextlib.nullcontext())
+    monkeypatch.setattr(
+        engine, "_generation_cache_hygiene", lambda: contextlib.nullcontext()
+    )
+
+    engine.generate_batch(
+        object(),
+        object(),
+        [engine.GenerationRequest(prompt="hi", max_tokens=1)],
+        defaults=engine.GenerationDefaults(),
+    )
+
+    assert order == ["install", "generate"]

--- a/tests/test_mlx_arrays_cache_advance.py
+++ b/tests/test_mlx_arrays_cache_advance.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
 """The ArraysCache.advance patch, on any platform.
 
 Everything that decides *whether* to rewrite a third-party class -- the body
@@ -54,9 +57,6 @@ def fresh(monkeypatch):
     return aim
 
 
-# --------------------------------------------------------------------------
-# The matcher
-# --------------------------------------------------------------------------
 
 
 def test_matcher_accepts_the_body_it_reproduces():
@@ -118,16 +118,12 @@ def test_matcher_rejects_reads_already_mediated_by_descriptors():
 
 
 def test_matcher_rejects_a_staticmethod_carrying_the_same_body():
-    # A plain attribute read unwraps staticmethod, so without an explicit check
-    # this compares a body that would be bound differently from the replacement.
+    # A plain read unwraps staticmethod, comparing a body bound differently from ours.
     cls = stock_bodied_cache()
     cls.advance = staticmethod(cls.advance)
     assert not engine._has_replaceable_advance(cls)
 
 
-# --------------------------------------------------------------------------
-# Installation
-# --------------------------------------------------------------------------
 
 
 def test_install_replaces_a_matching_class(fresh):
@@ -181,9 +177,8 @@ def test_a_failed_attempt_is_not_a_decision(fresh, monkeypatch):
     engine._install_arrays_cache_advance_fix()
     assert not engine._ARRAYS_CACHE_ADVANCE_RESOLVED
 
-    # Restore just the matcher. monkeypatch.undo() would also revert the module
-    # this fixture injected, leaving the retry with nothing to import and no way
-    # to tell "declined to latch" from "could not look".
+    # Not undo(): it reverts the injected module too, so the retry could not tell
+    # "declined to latch" from "nothing to look at".
     monkeypatch.setattr(engine, "_has_replaceable_advance", real_matcher)
     engine._install_arrays_cache_advance_fix()
     assert engine._ARRAYS_CACHE_ADVANCE_RESOLVED
@@ -198,9 +193,8 @@ def test_a_missing_mlx_lm_is_inert(fresh, monkeypatch):
 
 
 def test_mlx_vlm_vendored_cache_is_patched_too(fresh):
-    # mlx-vlm re-exports mlx-lm's class up to 0.5.x and vendors its own copy of
-    # this same body from 0.6.4, so patching mlx-lm alone leaves the vision batch
-    # path leaking on the range the pins allow.
+    # mlx-vlm vendors its own copy of this body from 0.6.4, which patching mlx-lm
+    # alone never reaches.
     text_cache = fresh(stock_bodied_cache())
     vision_cache = fresh(stock_bodied_cache(), "mlx_vlm.models.cache")
     sys.modules.setdefault("mlx_vlm", types.ModuleType("mlx_vlm"))
@@ -219,9 +213,6 @@ def test_mlx_vlm_is_not_imported_by_a_text_only_run(fresh, monkeypatch):
     assert "mlx_vlm" not in sys.modules
 
 
-# --------------------------------------------------------------------------
-# The deferred arithmetic
-# --------------------------------------------------------------------------
 
 
 def test_advance_defers_and_folds_on_read(fresh):
@@ -252,8 +243,7 @@ def test_writing_a_field_supersedes_its_pending_count(fresh):
 
 
 def test_advance_with_a_non_integer_step_keeps_stock_arithmetic(fresh):
-    # Stock accepts whatever the array subtraction accepts. A float cannot go in
-    # a Python counter, and deferring it would move the error to a later reader.
+    # A float cannot go in the counter, and deferring moves the error to a later reader.
     cls = fresh(stock_bodied_cache())
     engine._install_arrays_cache_advance_fix()
 
@@ -278,8 +268,7 @@ def test_a_cache_built_before_installation_keeps_its_metadata(fresh):
 
 
 def test_a_partly_installed_class_is_still_correct(fresh):
-    # The six class assignments are not atomic and readers do not take the lock,
-    # so every prefix of the installation has to leave the class usable.
+    # The class assignments are not atomic and readers do not take the lock.
     steps = [
         lambda c: setattr(c, "_lengths", None),
         lambda c: setattr(c, "_lengths_pending", 0),
@@ -299,9 +288,6 @@ def test_a_partly_installed_class_is_still_correct(fresh):
         assert (cache.lengths, cache.left_padding) == (7, 2), f"broken after {prefix} steps"
 
 
-# --------------------------------------------------------------------------
-# Ordering
-# --------------------------------------------------------------------------
 
 
 def test_generate_batch_installs_before_it_generates(monkeypatch):

--- a/tests/test_mlx_arrays_cache_advance.py
+++ b/tests/test_mlx_arrays_cache_advance.py
@@ -171,7 +171,8 @@ def test_install_is_idempotent(fresh, monkeypatch):
 
 
 def test_a_failed_attempt_is_not_a_decision(fresh, monkeypatch):
-    fresh(stock_bodied_cache())
+    cls = fresh(stock_bodied_cache())
+    real_matcher = engine._has_replaceable_advance
 
     def explode(arrays_cache):
         raise RuntimeError("transient")
@@ -180,10 +181,13 @@ def test_a_failed_attempt_is_not_a_decision(fresh, monkeypatch):
     engine._install_arrays_cache_advance_fix()
     assert not engine._ARRAYS_CACHE_ADVANCE_RESOLVED
 
-    monkeypatch.undo()
-    monkeypatch.setattr(engine, "_ARRAYS_CACHE_ADVANCE_RESOLVED", False)
+    # Restore just the matcher. monkeypatch.undo() would also revert the module
+    # this fixture injected, leaving the retry with nothing to import and no way
+    # to tell "declined to latch" from "could not look".
+    monkeypatch.setattr(engine, "_has_replaceable_advance", real_matcher)
     engine._install_arrays_cache_advance_fix()
     assert engine._ARRAYS_CACHE_ADVANCE_RESOLVED
+    assert cls._unsloth_advance_patched is True
 
 
 def test_a_missing_mlx_lm_is_inert(fresh, monkeypatch):

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -81,18 +81,44 @@ def test_generation_mode_restores_flags_and_limits_when_nested_or_raised():
 def test_batched_greedy_matches_sequential_and_preserves_sampled_ids():
     from mlx_lm import load, stream_generate
     from mlx_lm.sample_utils import make_sampler
+    import unsloth_zoo.mlx.generate as generate_module
     from unsloth_zoo.mlx.generate import (
         GenerationDefaults,
         GenerationRequest,
         generate_batch,
     )
     model, tokenizer = load(MODEL)
+    generate_module._ARRAYS_CACHE_ADVANCE_RESOLVED = False
     requests = [
         GenerationRequest(prompt="The capital of France is", max_tokens=8),
         GenerationRequest(prompt="Two plus two equals", max_tokens=8),
     ]
     defaults = GenerationDefaults()
-    batched = generate_batch(model, tokenizer, requests, defaults=defaults)
+    # The mlx-lm cache patch has to be installed before any decoding runs, so record
+    # the two calls in the order generate_batch makes them.
+    order = []
+    real_install = generate_module._install_arrays_cache_advance_fix
+    real_adapter_generate = generate_module._TextBatchAdapter.generate
+
+    def record_install():
+        order.append("install")
+        return real_install()
+
+    def record_generate(self, requests):
+        order.append("generate")
+        return real_adapter_generate(self, requests)
+
+    generate_module._install_arrays_cache_advance_fix = record_install
+    generate_module._TextBatchAdapter.generate = record_generate
+    try:
+        batched = generate_batch(model, tokenizer, requests, defaults=defaults)
+    finally:
+        generate_module._install_arrays_cache_advance_fix = real_install
+        generate_module._TextBatchAdapter.generate = real_adapter_generate
+    from mlx_lm.models.cache import ArraysCache
+    assert order == ["install", "generate"]
+    assert generate_module._ARRAYS_CACHE_ADVANCE_RESOLVED
+    assert isinstance(ArraysCache.left_padding, property)
     sequential = []
     for request in requests:
         prompt_ids = tokenizer.encode(request.prompt, add_special_tokens=False)
@@ -258,3 +284,131 @@ def test_vlm_stop_strings_cut_generation_through_the_public_path():
     # none, and never the stop string itself.
     assert free.text.startswith(stopped.text) and stop not in stopped.text
     assert len(stopped.token_ids) < len(free.token_ids)
+
+@metal_only
+def test_arrays_cache_advance_patch_only_replaces_the_body_it_reproduces():
+    from mlx_lm.models.cache import ArraysCache
+    import unsloth_zoo.mlx.generate as generate_module
+    from unsloth_zoo.mlx.generate import (
+        _has_replaceable_advance,
+        _install_arrays_cache_advance_fix,
+    )
+
+    _install_arrays_cache_advance_fix()
+    # Descriptors mediate these reads now, so the class is no longer a candidate and
+    # a second install must leave the ones already in place untouched.
+    assert not _has_replaceable_advance(ArraysCache)
+    installed = (ArraysCache.left_padding, ArraysCache.lengths)
+    generate_module._ARRAYS_CACHE_ADVANCE_RESOLVED = False
+    _install_arrays_cache_advance_fix()
+    assert (ArraysCache.left_padding, ArraysCache.lengths) == installed
+
+    # Candidacy follows the compiled body, so an advance that means something else is
+    # rejected however similar it reads.
+    class Incrementing:
+        lengths = left_padding = None
+
+        def advance(self, N):
+            if self.lengths is not None:
+                self.lengths += N
+            if self.left_padding is not None:
+                self.left_padding += N
+
+    class Decrementing(Incrementing):
+        # Deciding candidacy must never construct or run the candidate, so a matcher
+        # that reached for an instance would trip this rather than pass quietly.
+        def __init__(self):
+            raise AssertionError("candidacy must not instantiate the candidate")
+
+        def advance(self, N):
+            if self.lengths is not None:
+                self.lengths -= N
+            if self.left_padding is not None:
+                self.left_padding -= N
+
+    class DefaultedStep(Incrementing):
+        def advance(self, N=1):
+            if self.lengths is not None:
+                self.lengths -= N
+            if self.left_padding is not None:
+                self.left_padding -= N
+
+    assert not _has_replaceable_advance(Incrementing)
+    assert not _has_replaceable_advance(DefaultedStep)
+    assert _has_replaceable_advance(Decrementing)
+
+    # A failed attempt is not a decision, so installation stays available afterwards.
+    def raise_transient(arrays_cache):
+        raise RuntimeError("transient")
+
+    generate_module._ARRAYS_CACHE_ADVANCE_RESOLVED = False
+    generate_module._has_replaceable_advance = raise_transient
+    try:
+        _install_arrays_cache_advance_fix()
+        assert not generate_module._ARRAYS_CACHE_ADVANCE_RESOLVED
+    finally:
+        generate_module._has_replaceable_advance = _has_replaceable_advance
+    _install_arrays_cache_advance_fix()
+    assert generate_module._ARRAYS_CACHE_ADVANCE_RESOLVED
+
+@metal_only
+def test_arrays_cache_advance_defers_instead_of_stranding_metal_buffers():
+    from mlx_lm.models.cache import ArraysCache
+    from unsloth_zoo.mlx.generate import _install_arrays_cache_advance_fix
+
+    _install_arrays_cache_advance_fix()
+    cache = ArraysCache(1)
+    cache[0] = mx.zeros((2, 4))
+    cache.left_padding, cache.lengths = mx.array([0, 3]), mx.array([9, 5])
+    mx.eval(cache[0], cache.left_padding, cache.lengths)
+    mx.clear_cache()
+    before = mx.get_active_memory()
+    advances = [1] * 4000 + [2] * 4000
+    for step in advances:
+        cache.advance(step)
+    # Stock strands a live scalar buffer per field per call, which
+    # mx.clear_cache() cannot reclaim because it is active rather than cached.
+    assert mx.get_active_memory() - before < len(advances)
+    total = sum(advances)
+    assert cache.left_padding.tolist() == [-total, 3 - total]
+    assert cache.lengths.tolist() == [9 - total, 5 - total]
+
+    # Deferred advances have to survive mlx-lm's own metadata plumbing.
+    batch = ArraysCache.merge([ArraysCache(1), ArraysCache(1)])
+    batch[0] = mx.zeros((2, 4))
+    batch.left_padding = mx.array([0, 2])
+    batch.advance(1)
+    assert batch.make_mask(3).tolist() == [[True] * 3, [False, True, True]]
+    batch.filter(mx.array([1]))
+    assert batch.left_padding.tolist() == [1] and batch.batch_size == 1
+    batch.prepare(lengths=[4])
+    batch.advance(2)
+    assert (batch.lengths.tolist(), batch.left_padding.tolist()) == ([2], [-1])
+    batch.advance(3)
+    batch.prepare(lengths=[7])
+    # Re-arming a field replaces it outright, deferred count included.
+    assert batch.lengths.tolist() == [7]
+    batch.finalize()
+    batch.advance(5)
+    assert batch.lengths is None and batch.left_padding is None
+
+    # A cache built before the patch keeps its metadata instead of losing it to
+    # the descriptors that now shadow those names.
+    legacy = ArraysCache(1)
+    legacy.__dict__.clear()
+    legacy.__dict__.update(cache=[None], left_padding=mx.array([2]), lengths=None)
+    legacy.advance(1)
+    assert legacy.left_padding.tolist() == [1] and legacy.lengths is None
+
+    # extend() concatenates two caches carrying different deferred counts.
+    left = ArraysCache(1)
+    left[0] = mx.zeros((2, 4))
+    left.left_padding, left.lengths = mx.array([0, 4]), mx.array([6, 9])
+    right = ArraysCache(1)
+    right[0] = mx.zeros((1, 4))
+    right.left_padding, right.lengths = mx.array([7]), mx.array([3])
+    left.advance(2)
+    right.advance(5)
+    left.extend(right)
+    assert left.left_padding.tolist() == [-2, 2, 2]
+    assert left.lengths.tolist() == [4, 7, -2]

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -94,8 +94,7 @@ def test_batched_greedy_matches_sequential_and_preserves_sampled_ids():
         GenerationRequest(prompt="Two plus two equals", max_tokens=8),
     ]
     defaults = GenerationDefaults()
-    # The mlx-lm cache patch has to be installed before any decoding runs, so record
-    # the two calls in the order generate_batch makes them.
+    # The cache patch must be installed before any decoding runs.
     order = []
     real_install = generate_module._install_arrays_cache_advance_fix
     real_adapter_generate = generate_module._TextBatchAdapter.generate
@@ -295,16 +294,14 @@ def test_arrays_cache_advance_patch_only_replaces_the_body_it_reproduces():
     )
 
     _install_arrays_cache_advance_fix()
-    # Descriptors mediate these reads now, so the class is no longer a candidate and
-    # a second install must leave the ones already in place untouched.
+    # Descriptors now mediate these reads, so a second install must be a no-op.
     assert not _has_replaceable_advance(ArraysCache)
     installed = (ArraysCache.left_padding, ArraysCache.lengths)
     generate_module._ARRAYS_CACHE_ADVANCE_RESOLVED = False
     _install_arrays_cache_advance_fix()
     assert (ArraysCache.left_padding, ArraysCache.lengths) == installed
 
-    # Candidacy follows the compiled body, so an advance that means something else is
-    # rejected however similar it reads.
+    # Candidacy follows the compiled body, however similar a different one reads.
     class Incrementing:
         lengths = left_padding = None
 
@@ -315,8 +312,7 @@ def test_arrays_cache_advance_patch_only_replaces_the_body_it_reproduces():
                 self.left_padding += N
 
     class Decrementing(Incrementing):
-        # Deciding candidacy must never construct or run the candidate, so a matcher
-        # that reached for an instance would trip this rather than pass quietly.
+        # A matcher that reached for an instance trips this instead of passing quietly.
         def __init__(self):
             raise AssertionError("candidacy must not instantiate the candidate")
 
@@ -366,8 +362,7 @@ def test_arrays_cache_advance_defers_instead_of_stranding_metal_buffers():
     advances = [1] * 4000 + [2] * 4000
     for step in advances:
         cache.advance(step)
-    # Stock strands a live scalar buffer per field per call, which
-    # mx.clear_cache() cannot reclaim because it is active rather than cached.
+    # Stock strands a live scalar per field per call; clear_cache() cannot reclaim it.
     assert mx.get_active_memory() - before < len(advances)
     total = sum(advances)
     assert cache.left_padding.tolist() == [-total, 3 - total]
@@ -392,8 +387,7 @@ def test_arrays_cache_advance_defers_instead_of_stranding_metal_buffers():
     batch.advance(5)
     assert batch.lengths is None and batch.left_padding is None
 
-    # A cache built before the patch keeps its metadata instead of losing it to
-    # the descriptors that now shadow those names.
+    # A pre-patch cache keeps its metadata despite the descriptors now shadowing it.
     legacy = ArraysCache(1)
     legacy.__dict__.clear()
     legacy.__dict__.update(cache=[None], left_padding=mx.array([2]), lengths=None)

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -652,6 +652,117 @@ def _generation_cache_hygiene():
                 pass
 
 
+_ARRAYS_CACHE_ADVANCE_LOCK = threading.Lock()
+_ARRAYS_CACHE_ADVANCE_RESOLVED = False
+
+
+def _adopt_deferred_metadata(cache):
+    """Move a cache built before the patch onto the deferred slots."""
+
+    state = cache.__dict__
+    for name in ("lengths", "left_padding"):
+        if name in state:
+            state["_" + name] = state.pop(name)
+            state["_" + name + "_pending"] = 0
+
+
+def _deferred_metadata(name):
+    stored = "_" + name
+    pending = stored + "_pending"
+
+    def read(self):
+        _adopt_deferred_metadata(self)
+        value = getattr(self, stored)
+        outstanding = getattr(self, pending)
+        if outstanding and value is not None:
+            value = value - outstanding
+            setattr(self, stored, value)
+            setattr(self, pending, 0)
+        return value
+
+    def write(self, value):
+        _adopt_deferred_metadata(self)
+        setattr(self, stored, value)
+        setattr(self, pending, 0)
+
+    return property(read, write)
+
+
+def _deferred_advance(self, N):
+    _adopt_deferred_metadata(self)
+    if self._lengths is not None:
+        self._lengths_pending += N
+    if self._left_padding is not None:
+        self._left_padding_pending += N
+
+
+# Compared against the installed mlx-lm, never installed, never called. Comparing the
+# compiled body and signature identifies the implementation this patch reproduces
+# without depending on source files or formatting, and separates it from one whose
+# `advance` means something else.
+def _stock_advance(self, N):
+    if self.lengths is not None:
+        self.lengths -= N
+    if self.left_padding is not None:
+        self.left_padding -= N
+
+
+def _advance_identity(function):
+    code = function.__code__
+    return (
+        inspect.signature(function),
+        code.co_code,
+        code.co_consts,
+        code.co_names,
+        code.co_varnames,
+    )
+
+
+def _has_replaceable_advance(arrays_cache):
+    """Identify the exact ``advance`` this patch reproduces."""
+
+    if any(
+        hasattr(type(inspect.getattr_static(arrays_cache, name, None)), "__set__")
+        for name in ("lengths", "left_padding")
+    ):
+        return False
+    return _advance_identity(arrays_cache.advance) == _advance_identity(_stock_advance)
+
+
+def _install_arrays_cache_advance_fix():
+    """Keep mlx-lm's ``ArraysCache.advance`` from stranding a Metal buffer per call.
+
+    ``advance`` rebinds ``lengths``/``left_padding`` with ``-=``, building an
+    unevaluated subtract whose integer operand is materialised as a scalar array that
+    owns a live buffer. The metadata is absent from ``ArraysCache.state``, and during
+    batched decoding only the cache owning the shared mask has its chain forced each
+    step, so every other linear-attention layer strands one buffer per token until
+    Metal refuses to allocate. Deferring the subtraction into a Python counter keeps
+    the arithmetic and allocates nothing until the value is read.
+    """
+
+    global _ARRAYS_CACHE_ADVANCE_RESOLVED
+    with _ARRAYS_CACHE_ADVANCE_LOCK:
+        if _ARRAYS_CACHE_ADVANCE_RESOLVED:
+            return
+        try:
+            arrays_cache = importlib.import_module("mlx_lm.models.cache").ArraysCache
+            replaceable = _has_replaceable_advance(arrays_cache)
+        except Exception:
+            # A failed attempt is not a decision: retry on the next call.
+            return
+        # Any other body keeps stock.
+        if replaceable:
+            arrays_cache._lengths = None
+            arrays_cache._lengths_pending = 0
+            arrays_cache._left_padding = None
+            arrays_cache._left_padding_pending = 0
+            arrays_cache.lengths = _deferred_metadata("lengths")
+            arrays_cache.left_padding = _deferred_metadata("left_padding")
+            arrays_cache.advance = _deferred_advance
+        _ARRAYS_CACHE_ADVANCE_RESOLVED = True
+
+
 class _StopStringScanner:
     """Incrementally search new detokenized text with longest-stop lookback."""
 
@@ -1699,6 +1810,7 @@ def generate_batch(
             if is_vlm
             else "Text batched generation requires a tokenizer."
         )
+    _install_arrays_cache_advance_fix()
     with generation_mode(model):
         with _generation_cache_hygiene():
             adapter = (

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -662,10 +662,8 @@ _VLM_ARRAYS_CACHE_ADVANCE_RESOLVED = False
 def _adopt_deferred_metadata(cache):
     """Move a cache built before the patch onto the deferred slots.
 
-    Only a field the descriptors already mediate is moved. Installation assigns the
-    two properties one at a time, and a thread reading a cache in that window would
-    otherwise strip the field whose descriptor is not in place yet into a private
-    slot nothing reads, leaving ``cache.left_padding`` raising ``AttributeError``.
+    Mediated fields only: the two properties are installed one at a time, and moving
+    the other one mid-window would strip it into a slot nothing reads.
     """
 
     state = cache.__dict__
@@ -700,10 +698,8 @@ def _deferred_metadata(name):
 def _deferred_advance(self, N):
     _adopt_deferred_metadata(self)
     if not isinstance(N, int):
-        # Stock accepts whatever the array subtraction accepts, including a
-        # per-row array. That cannot go in a Python counter, and testing it for
-        # truth later would force the sync this patch exists to avoid, so keep
-        # the stock arithmetic for it.
+        # Stock takes anything the subtraction takes, including a per-row array;
+        # counting that would force the sync this patch exists to avoid.
         if self._lengths is not None:
             self.lengths = self.lengths - N
         if self._left_padding is not None:
@@ -715,10 +711,8 @@ def _deferred_advance(self, N):
         self._left_padding_pending += N
 
 
-# Compared against the installed mlx-lm, never installed, never called. Comparing the
-# compiled body and signature identifies the implementation this patch reproduces
-# without depending on source files or formatting, and separates it from one whose
-# `advance` means something else.
+# Never installed, never called: compiled body + signature identify the implementation
+# this patch reproduces, independent of source files and formatting.
 def _stock_advance(self, N):
     if self.lengths is not None:
         self.lengths -= N
@@ -745,9 +739,7 @@ def _has_replaceable_advance(arrays_cache):
         for name in ("lengths", "left_padding")
     ):
         return False
-    # A plain attribute read unwraps staticmethod and classmethod, so a candidate
-    # whose `advance` is not an ordinary method would be judged on a body that is
-    # bound differently from the one being installed.
+    # A plain read unwraps staticmethod, judging a body bound differently from ours.
     if not isinstance(
         inspect.getattr_static(arrays_cache, "advance", None), types.FunctionType
     ):
@@ -756,7 +748,7 @@ def _has_replaceable_advance(arrays_cache):
 
 
 def _install_deferred_metadata(arrays_cache):
-    """Put the deferred slots, descriptors and ``advance`` on one cache class."""
+    """Install the deferred slots, descriptors and ``advance`` on one cache class."""
 
     arrays_cache._lengths = None
     arrays_cache._lengths_pending = 0
@@ -764,8 +756,7 @@ def _install_deferred_metadata(arrays_cache):
     arrays_cache._left_padding_pending = 0
     arrays_cache.lengths = _deferred_metadata("lengths")
     arrays_cache.left_padding = _deferred_metadata("left_padding")
-    # Keep the replaced implementation reachable, and leave a marker, so a patched
-    # class is recognisable when someone is diffing behaviour against upstream.
+    # Marker + original, so a patched class is recognisable when diffing upstream.
     arrays_cache._unsloth_stock_advance = arrays_cache.advance
     arrays_cache.advance = _deferred_advance
     arrays_cache._unsloth_advance_patched = True
@@ -774,19 +765,14 @@ def _install_deferred_metadata(arrays_cache):
 def _install_arrays_cache_advance_fix():
     """Keep mlx-lm's ``ArraysCache.advance`` from stranding a Metal buffer per call.
 
-    ``advance`` rebinds ``lengths``/``left_padding`` with ``-=``, building an
-    unevaluated subtract whose integer operand is materialised as a scalar array that
-    owns a live buffer. The metadata is absent from ``ArraysCache.state``, and during
-    batched decoding only the cache owning the shared mask has its chain forced each
-    step, so every other linear-attention layer strands one buffer per token until
-    Metal refuses to allocate. Deferring the subtraction into a Python counter keeps
-    the arithmetic and allocates nothing until the value is read.
+    ``-=`` rebinds to an unevaluated subtract whose scalar operand owns a live buffer.
+    The metadata is absent from ``ArraysCache.state``, so during batched decode only
+    the mask-owning cache is forced and every other linear-attention layer strands one
+    buffer per token. A Python counter keeps the arithmetic and allocates nothing.
 
-    mlx-vlm is visited too. It re-exports mlx-lm's class up to 0.5.x, vendors its own
-    copy carrying this same body from 0.6.4, and only defers for itself from 0.6.17,
-    so on the pinned range the vision batch path leaks through a second class that
-    patching mlx-lm alone does not reach. It is visited only once it is already
-    imported, so a text-only run does not pull in an optional dependency.
+    mlx-vlm needs visiting separately: it re-exports mlx-lm's class up to 0.5.x, vendors
+    this same body from 0.6.4, and only defers for itself from 0.6.17. Visited only once
+    already imported, so a text-only run does not pull in an optional dependency.
     """
 
     global _ARRAYS_CACHE_ADVANCE_RESOLVED, _VLM_ARRAYS_CACHE_ADVANCE_RESOLVED
@@ -801,7 +787,6 @@ def _install_arrays_cache_advance_fix():
             except Exception:
                 # A failed attempt is not a decision: retry on the next call.
                 return
-            # Any other body keeps stock.
             if replaceable:
                 _install_deferred_metadata(arrays_cache)
             seen.append(arrays_cache)

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -23,7 +23,9 @@ import importlib
 import inspect
 import math
 import os
+import sys
 import threading
+import types
 import warnings
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -654,14 +656,21 @@ def _generation_cache_hygiene():
 
 _ARRAYS_CACHE_ADVANCE_LOCK = threading.Lock()
 _ARRAYS_CACHE_ADVANCE_RESOLVED = False
+_VLM_ARRAYS_CACHE_ADVANCE_RESOLVED = False
 
 
 def _adopt_deferred_metadata(cache):
-    """Move a cache built before the patch onto the deferred slots."""
+    """Move a cache built before the patch onto the deferred slots.
+
+    Only a field the descriptors already mediate is moved. Installation assigns the
+    two properties one at a time, and a thread reading a cache in that window would
+    otherwise strip the field whose descriptor is not in place yet into a private
+    slot nothing reads, leaving ``cache.left_padding`` raising ``AttributeError``.
+    """
 
     state = cache.__dict__
     for name in ("lengths", "left_padding"):
-        if name in state:
+        if name in state and isinstance(getattr(type(cache), name, None), property):
             state["_" + name] = state.pop(name)
             state["_" + name + "_pending"] = 0
 
@@ -690,6 +699,16 @@ def _deferred_metadata(name):
 
 def _deferred_advance(self, N):
     _adopt_deferred_metadata(self)
+    if not isinstance(N, int):
+        # Stock accepts whatever the array subtraction accepts, including a
+        # per-row array. That cannot go in a Python counter, and testing it for
+        # truth later would force the sync this patch exists to avoid, so keep
+        # the stock arithmetic for it.
+        if self._lengths is not None:
+            self.lengths = self.lengths - N
+        if self._left_padding is not None:
+            self.left_padding = self.left_padding - N
+        return
     if self._lengths is not None:
         self._lengths_pending += N
     if self._left_padding is not None:
@@ -726,7 +745,30 @@ def _has_replaceable_advance(arrays_cache):
         for name in ("lengths", "left_padding")
     ):
         return False
+    # A plain attribute read unwraps staticmethod and classmethod, so a candidate
+    # whose `advance` is not an ordinary method would be judged on a body that is
+    # bound differently from the one being installed.
+    if not isinstance(
+        inspect.getattr_static(arrays_cache, "advance", None), types.FunctionType
+    ):
+        return False
     return _advance_identity(arrays_cache.advance) == _advance_identity(_stock_advance)
+
+
+def _install_deferred_metadata(arrays_cache):
+    """Put the deferred slots, descriptors and ``advance`` on one cache class."""
+
+    arrays_cache._lengths = None
+    arrays_cache._lengths_pending = 0
+    arrays_cache._left_padding = None
+    arrays_cache._left_padding_pending = 0
+    arrays_cache.lengths = _deferred_metadata("lengths")
+    arrays_cache.left_padding = _deferred_metadata("left_padding")
+    # Keep the replaced implementation reachable, and leave a marker, so a patched
+    # class is recognisable when someone is diffing behaviour against upstream.
+    arrays_cache._unsloth_stock_advance = arrays_cache.advance
+    arrays_cache.advance = _deferred_advance
+    arrays_cache._unsloth_advance_patched = True
 
 
 def _install_arrays_cache_advance_fix():
@@ -739,28 +781,43 @@ def _install_arrays_cache_advance_fix():
     step, so every other linear-attention layer strands one buffer per token until
     Metal refuses to allocate. Deferring the subtraction into a Python counter keeps
     the arithmetic and allocates nothing until the value is read.
+
+    mlx-vlm is visited too. It re-exports mlx-lm's class up to 0.5.x, vendors its own
+    copy carrying this same body from 0.6.4, and only defers for itself from 0.6.17,
+    so on the pinned range the vision batch path leaks through a second class that
+    patching mlx-lm alone does not reach. It is visited only once it is already
+    imported, so a text-only run does not pull in an optional dependency.
     """
 
-    global _ARRAYS_CACHE_ADVANCE_RESOLVED
+    global _ARRAYS_CACHE_ADVANCE_RESOLVED, _VLM_ARRAYS_CACHE_ADVANCE_RESOLVED
     with _ARRAYS_CACHE_ADVANCE_LOCK:
-        if _ARRAYS_CACHE_ADVANCE_RESOLVED:
+        if _ARRAYS_CACHE_ADVANCE_RESOLVED and _VLM_ARRAYS_CACHE_ADVANCE_RESOLVED:
             return
-        try:
-            arrays_cache = importlib.import_module("mlx_lm.models.cache").ArraysCache
-            replaceable = _has_replaceable_advance(arrays_cache)
-        except Exception:
-            # A failed attempt is not a decision: retry on the next call.
-            return
-        # Any other body keeps stock.
-        if replaceable:
-            arrays_cache._lengths = None
-            arrays_cache._lengths_pending = 0
-            arrays_cache._left_padding = None
-            arrays_cache._left_padding_pending = 0
-            arrays_cache.lengths = _deferred_metadata("lengths")
-            arrays_cache.left_padding = _deferred_metadata("left_padding")
-            arrays_cache.advance = _deferred_advance
-        _ARRAYS_CACHE_ADVANCE_RESOLVED = True
+        seen = []
+        if not _ARRAYS_CACHE_ADVANCE_RESOLVED:
+            try:
+                arrays_cache = importlib.import_module("mlx_lm.models.cache").ArraysCache
+                replaceable = _has_replaceable_advance(arrays_cache)
+            except Exception:
+                # A failed attempt is not a decision: retry on the next call.
+                return
+            # Any other body keeps stock.
+            if replaceable:
+                _install_deferred_metadata(arrays_cache)
+            seen.append(arrays_cache)
+            _ARRAYS_CACHE_ADVANCE_RESOLVED = True
+        if not _VLM_ARRAYS_CACHE_ADVANCE_RESOLVED and "mlx_vlm" in sys.modules:
+            try:
+                vlm_cache = importlib.import_module("mlx_vlm.models.cache").ArraysCache
+                # Up to mlx-vlm 0.5.x this is mlx-lm's class, already decided above.
+                replaceable = vlm_cache not in seen and _has_replaceable_advance(
+                    vlm_cache
+                )
+            except Exception:
+                return
+            if replaceable:
+                _install_deferred_metadata(vlm_cache)
+            _VLM_ARRAYS_CACHE_ADVANCE_RESOLVED = True
 
 
 class _StopStringScanner:


### PR DESCRIPTION
## The bug

`model.fast_generate` on an MLX model with linear-attention layers leaks one live Metal buffer per layer per decode token. A long enough batched generation terminates the process:

```text
RuntimeError: [metal::malloc] Resource limit (499000) exceeded.
```

Measured on `Qwen/Qwen3.5-0.8B` (24 layers: 18 GatedDeltaNet + 6 full attention) at batch 2, death arrives at decode token 29,316. A 48-layer `qwen3_next` (36 linear layers) would die near 14.3k tokens. The bytes are trivial — 4 B per call — but the buffer *count* is what trips Metal's resource limit.

The worst case is a GRPO-style rollout: N identical prompts in one `fast_generate` call.

## Root cause

`ArraysCache.advance` in mlx-lm 0.31.3 (`mlx_lm/models/cache.py`):

```python
def advance(self, N):
    if self.lengths is not None:
        self.lengths -= N
    if self.left_padding is not None:
        self.left_padding -= N
```

Each `-=` rebinds to a new **unevaluated** graph node. The Python-int operand is eagerly converted to an `mx.array` scalar that already owns a Metal buffer, and the dead node pins it. `mx.clear_cache()` cannot reclaim it: the buffer is active, not cached.

Nothing collapses that chain during decode. The metadata is absent from `ArraysCache.state`, and `GenerationBatch._step` evaluates only `inputs` and `_current_logprobs`. Only the cache that owns the shared SSM mask has `make_mask` rebuilt each forward, so exactly one cache per model stays evaluated and every other linear-attention layer accumulates. On Qwen3.5-0.8B that is 17 of 18 caches, or 68.3 B — precisely 17 int32 scalars — per decode step.

### Why it hides

The metadata is armed only on the batch path: `_merge_caches` → `ArraysCache.merge` sets `left_padding` when the merged caches are empty. `finalize()` clears it, but `prompt()` only calls `prepare()`/`finalize()` when `max_padding > 0`. So:

| path | affected |
|---|---|
| `model.generate` → `stream_generate` (single stream) | no — metadata never armed |
| batch, **unequal** prompt lengths | no — right padding triggers `finalize()`, which clears it |
| batch, **equal** prompt lengths (including batch-of-1) | **yes** |

That asymmetry is inverted from intuition: ragged batches are safe, identical batches leak. It survives casual testing and shows up in rollouts.

## The change

`generate_batch` installs a replacement `ArraysCache.advance` that accumulates the count in a Python int, plus properties over `lengths` and `left_padding` that fold that count into a single `value - pending` node the first time the field is read. Nothing is allocated per call, and nothing is evaluated inside the forward pass.

Evaluating eagerly in `advance` was the obvious alternative and is worse: it would add one host sync per linear-attention layer per decode token, inside the forward, to keep a 4-byte scalar tidy.

Because `lengths` and `left_padding` are read from outside `cache.py` as well as by `merge`/`extend`/`filter`/`make_mask` inside it, the fold has to happen on read, which is why these become properties rather than the accumulator being kept privately. A subclass would not work either — mlx-lm constructs these caches itself.

### Installation is deliberately conservative

Rewriting a third-party class at runtime is the risk this PR carries, so the install is gated:

- It runs only from `generate_batch`, once per process, under a lock, with the decision published only after it completes. A failed attempt — mlx-lm not importable, candidacy check raising — is retried rather than latched.
- A class is a candidate only if its `advance` matches `_stock_advance` (a reference function carrying the 0.31.3 body, never installed and never called) on **compiled body and signature**: `inspect.signature`, `co_code`, `co_consts`, `co_names`, `co_varnames`. Both are compiled by the running interpreter, so this is exact-operations identity, not a name-table heuristic and not a version string.
- Anything else keeps stock behaviour. The guard fails *toward* stock: an mlx-lm that still leaks but compiles differently is simply not patched, rather than having semantics silently overwritten.

Measured discrimination:

| candidate `advance` | replaced |
|---|---|
| mlx-lm 0.31.3 | yes |
| same body, reformatted, comments added | yes |
| `+=` instead of `-=` | no |
| clamped with `mx.maximum` | no |
| same decrements plus an unrelated side effect | no |
| `def advance(self, N=1)` | no |
| metadata reads already mediated by descriptors | no |

Deciding candidacy never constructs or invokes the candidate.

Also handled: a cache constructed before installation adopts its plain attributes rather than losing them to the new descriptors.

## Scope

- mlx-vlm ships its own `ArraysCache` that already defers advancement, so the vision batch path is untouched.
- `BatchKVCache.offset` looks like the same pattern but does not accumulate — RoPE consumes it each step, which collapses the chain. Confirmed by measurement, below.
- `model.generate` is unaffected and unchanged.

## Validation

mlx 0.32.2, mlx-lm 0.31.3, Apple silicon.

**Buffer-count stress**, one armed cache, `resource_limit` 499000:

```text
before:  !! DIED at advance #498999: RuntimeError: [metal::malloc] Resource limit (499000) exceeded.
after:   # survived 5000000 advances in 0.82s, left_padding=[-5000000]
```

**Real decode**, `Qwen/Qwen3.5-0.8B` through `mlx_lm.generate.BatchGenerator`, B=2, 600 steps, measuring what force-evaluating the metadata afterwards releases — i.e. the size of the pending chain:

```text
before:  released by forced eval = 41076 B (68.5 B/step)
after:   released by forced eval =   272 B (0.5 B/step, constant rather than per-step)
```

Sampled tokens and final `left_padding` are identical between the two runs.

**Public path**, `generate_batch` (the engine behind `model.fast_generate`) with four identical prompts, the rollout shape where `max_padding == 0` and `finalize()` never runs: generated token ids identical with and without the change.

**No other cache on this path accumulates.** Force-evaluating every array-valued metadata field across all 24 caches of a live batch (18 `ArraysCache` + 6 `BatchKVCache`) releases 228 B total after 400 steps — constant, not per-step.

**Equivalence.** A differential run over `left_padding`, `lengths`, `make_mask`, `filter`, `extend` (including two caches carrying different deferred counts), `merge`, `prepare` and `finalize` produces byte-identical output before and after; only memory differs. Dtypes are unchanged.

**Cost.** 20,000 isolated `advance` calls: 0.0996 s before, 0.0034 s after. The replacement is strictly less work — it allocates nothing.

**Tests.** `tests/test_mlx_generate_metal.py` gains coverage for the memory contract, the arithmetic across mlx-lm's own metadata plumbing, pre-patch cache adoption, candidacy in both directions, idempotence, retry after a failed attempt, and the requirement that installation happens before any decoding. Every added assertion was mutation-checked: thirteen mutations of the production change each fail the tests.

## Related

Same `[metal::malloc]` signature as unslothai/unsloth#6990, but a different site — that one was the training loop, this is batched generation.
