### PR TITLE
MLX: drain GPU work before clearing the cache around a generation burst

### DIFF
--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -3,6 +3,7 @@ import contextlib
 import importlib.util
 import inspect
 import pathlib
+import sys
 import types
 from dataclasses import make_dataclass
 import pytest
@@ -158,6 +159,66 @@ def test_falsey_defaults_are_not_silently_replaced(monkeypatch):
     with pytest.warns(RuntimeWarning, match="clear_cache"), pytest.raises(ValueError, match="body"):
         with _generation_cache_hygiene():
             raise ValueError("body")
+
+def _record_cache_calls(monkeypatch, *, has_clear_cache=True):
+    events = []
+    monkeypatch.setattr(
+        "mlx.core.synchronize",
+        lambda stream=None: events.append(f"synchronize:{stream if stream else 'default'}"),
+    )
+    if has_clear_cache:
+        monkeypatch.setattr("mlx.core.clear_cache", lambda: events.append("clear_cache"))
+    else:
+        monkeypatch.delattr("mlx.core.clear_cache", raising=False)
+    return events
+
+def test_both_cache_clears_drain_gpu_work_first(monkeypatch):
+    events = _record_cache_calls(monkeypatch)
+    with _generation_cache_hygiene():
+        events.append("body")
+    assert events == [
+        "synchronize:default", "clear_cache", "body", "synchronize:default", "clear_cache",
+    ]
+
+def test_the_generation_stream_is_drained_not_just_the_default_one(monkeypatch):
+    # Generation runs on mlx-lm's / mlx-vlm's own thread-local stream, so draining
+    # only the default stream would leave exactly the work we care about in flight.
+    events = _record_cache_calls(monkeypatch)
+    # mlx-vlm moves this symbol between release layouts, so every candidate counts.
+    for name in ("mlx_lm.generate", "mlx_vlm.generate.dispatch"):
+        monkeypatch.setitem(
+            sys.modules, name,
+            types.SimpleNamespace(generation_stream=f"stream<{name}>"),
+        )
+
+    with _generation_cache_hygiene():
+        pass
+
+    assert events.count("synchronize:stream<mlx_lm.generate>") == 2
+    assert events.count("synchronize:stream<mlx_vlm.generate.dispatch>") == 2
+    assert events.index("synchronize:stream<mlx_lm.generate>") < events.index("clear_cache")
+
+def test_the_exit_clear_still_drains_when_the_body_raised(monkeypatch):
+    events = _record_cache_calls(monkeypatch)
+    with pytest.raises(ValueError, match="body"):
+        with _generation_cache_hygiene():
+            raise ValueError("body")
+    assert events == [
+        "synchronize:default", "clear_cache", "synchronize:default", "clear_cache",
+    ]
+
+@pytest.mark.parametrize("metal", [
+    types.SimpleNamespace(),
+    # Refused even when the pre-0.22 shape is present: this path never accepted it.
+    types.SimpleNamespace(clear_cache=lambda: None),
+])
+def test_missing_clear_cache_is_rejected_before_any_work(monkeypatch, metal):
+    events = _record_cache_calls(monkeypatch, has_clear_cache=False)
+    monkeypatch.setattr("mlx.core.metal", metal, raising=False)
+    with pytest.raises(RuntimeError, match="clear_cache missing"):
+        with _generation_cache_hygiene():
+            pytest.fail("body must not run when the runtime cannot clear its cache")
+    assert events == []
 
 def test_training_flag_restore_attempts_every_module():
     class Module:

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -169,7 +169,12 @@ def _record_cache_calls(monkeypatch, *, has_clear_cache=True):
     if has_clear_cache:
         monkeypatch.setattr("mlx.core.clear_cache", lambda: events.append("clear_cache"))
     else:
-        monkeypatch.delattr("mlx.core.clear_cache", raising=False)
+        # None, not delattr: under tests/mlx_simulation the attribute cannot be
+        # removed -- the shim synthesises a trampoline for any missing name, so
+        # getattr() still returns something callable and the guard never fires.
+        # A non-callable is what the guard actually tests for, and it reads the
+        # same on real MLX and on the shim.
+        monkeypatch.setattr("mlx.core.clear_cache", None, raising=False)
     return events
 
 def test_both_cache_clears_drain_gpu_work_first(monkeypatch):

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -164,7 +164,11 @@ def _record_cache_calls(monkeypatch, *, has_clear_cache=True):
     events = []
     monkeypatch.setattr(
         "mlx.core.synchronize",
-        lambda stream=None: events.append(f"synchronize:{stream if stream else 'default'}"),
+        # `is None`, not truthiness: a falsey stream object is still a stream, and
+        # labelling it "default" would make an over-drain indistinguishable from a hit.
+        lambda stream=None: events.append(
+            f"synchronize:{'default' if stream is None else stream}"
+        ),
     )
     if has_clear_cache:
         monkeypatch.setattr("mlx.core.clear_cache", lambda: events.append("clear_cache"))
@@ -202,6 +206,80 @@ def test_the_generation_stream_is_drained_not_just_the_default_one(monkeypatch):
     assert events.count("synchronize:stream<mlx_lm.generate>") == 2
     assert events.count("synchronize:stream<mlx_vlm.generate.dispatch>") == 2
     assert events.index("synchronize:stream<mlx_lm.generate>") < events.index("clear_cache")
+
+def _fake_stream_module(monkeypatch, name, stream):
+    monkeypatch.setitem(sys.modules, name, types.SimpleNamespace(generation_stream=stream))
+
+def test_the_speculative_decoding_stream_is_drained_too(monkeypatch):
+    # mlx_vlm.speculative.common owns its own stream from 0.6.0 on, created on import
+    # and never routed through wired_limit, so nothing else ever drains it.
+    events = _record_cache_calls(monkeypatch)
+    _fake_stream_module(monkeypatch, "mlx_vlm.speculative.common", "stream<speculative>")
+
+    with _generation_cache_hygiene():
+        pass
+
+    assert events.count("synchronize:stream<speculative>") == 2
+
+def test_one_stream_shared_by_several_modules_is_drained_once(monkeypatch):
+    # 0.6.x defines generation_stream in mlx_vlm/generate/common.py and re-exports it
+    # from every candidate name, so identity, not name, decides what is outstanding.
+    events = _record_cache_calls(monkeypatch)
+    shared = "stream<shared>"
+    for name in ("mlx_vlm.generate", "mlx_vlm.generate.dispatch", "mlx_vlm.generate.ar"):
+        _fake_stream_module(monkeypatch, name, shared)
+
+    with _generation_cache_hygiene():
+        pass
+
+    assert events.count("synchronize:stream<shared>") == 2
+
+def test_a_stream_that_cannot_be_drained_does_not_stop_the_clear(monkeypatch):
+    # A plain mx.new_stream (mlx-vlm 0.4.4, the pin floor) raises when synchronized
+    # from a thread that did not create it. Not draining is the old behaviour and is
+    # survivable; losing the clear, or the generation burst, is not.
+    events = _record_cache_calls(monkeypatch)
+    def synchronize(stream=None):
+        if stream == "stream<foreign>":
+            raise RuntimeError("There is no Stream(gpu, 0) in current thread")
+        events.append(f"synchronize:{'default' if stream is None else stream}")
+    monkeypatch.setattr("mlx.core.synchronize", synchronize)
+    _fake_stream_module(monkeypatch, "mlx_lm.generate", "stream<foreign>")
+
+    with _generation_cache_hygiene():
+        events.append("body")
+
+    assert events == [
+        "synchronize:default", "clear_cache", "body", "synchronize:default", "clear_cache",
+    ]
+
+def test_a_module_getattr_that_raises_does_not_stop_the_clear(monkeypatch):
+    events = _record_cache_calls(monkeypatch)
+    module = types.ModuleType("mlx_vlm.generate")
+    def module_getattr(name):
+        raise RuntimeError(f"lazy attribute {name} exploded")
+    module.__getattr__ = module_getattr
+    monkeypatch.setitem(sys.modules, "mlx_vlm.generate", module)
+
+    with _generation_cache_hygiene():
+        events.append("body")
+
+    assert events == [
+        "synchronize:default", "clear_cache", "body", "synchronize:default", "clear_cache",
+    ]
+
+def test_a_runtime_without_synchronize_still_clears(monkeypatch):
+    # mx.synchronize has shipped since mlx 0.12.0, two releases before any clear_cache
+    # shape, so this is about partial test doubles rather than a real runtime -- but a
+    # missing drain must degrade to the pre-drain behaviour, not to an AttributeError.
+    events = _record_cache_calls(monkeypatch)
+    monkeypatch.setattr("mlx.core.synchronize", None, raising=False)
+    _fake_stream_module(monkeypatch, "mlx_lm.generate", "stream<mlx_lm>")
+
+    with _generation_cache_hygiene():
+        events.append("body")
+
+    assert events == ["clear_cache", "body", "clear_cache"]
 
 def test_the_exit_clear_still_drains_when_the_body_raised(monkeypatch):
     events = _record_cache_calls(monkeypatch)

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -164,8 +164,7 @@ def _record_cache_calls(monkeypatch, *, has_clear_cache=True):
     events = []
     monkeypatch.setattr(
         "mlx.core.synchronize",
-        # `is None`, not truthiness: a falsey stream object is still a stream, and
-        # labelling it "default" would make an over-drain indistinguishable from a hit.
+        # `is None`: a falsey stream labelled "default" would hide an over-drain.
         lambda stream=None: events.append(
             f"synchronize:{'default' if stream is None else stream}"
         ),
@@ -173,11 +172,8 @@ def _record_cache_calls(monkeypatch, *, has_clear_cache=True):
     if has_clear_cache:
         monkeypatch.setattr("mlx.core.clear_cache", lambda: events.append("clear_cache"))
     else:
-        # None, not delattr: under tests/mlx_simulation the attribute cannot be
-        # removed -- the shim synthesises a trampoline for any missing name, so
-        # getattr() still returns something callable and the guard never fires.
-        # A non-callable is what the guard actually tests for, and it reads the
-        # same on real MLX and on the shim.
+        # None, not delattr: tests/mlx_simulation trampolines any missing name, so a
+        # deleted attribute stays callable and the guard never fires.
         monkeypatch.setattr("mlx.core.clear_cache", None, raising=False)
     return events
 
@@ -190,10 +186,7 @@ def test_both_cache_clears_drain_gpu_work_first(monkeypatch):
     ]
 
 def test_the_generation_stream_is_drained_not_just_the_default_one(monkeypatch):
-    # Generation runs on mlx-lm's / mlx-vlm's own thread-local stream, so draining
-    # only the default stream would leave exactly the work we care about in flight.
     events = _record_cache_calls(monkeypatch)
-    # mlx-vlm moves this symbol between release layouts, so every candidate counts.
     for name in ("mlx_lm.generate", "mlx_vlm.generate.dispatch"):
         monkeypatch.setitem(
             sys.modules, name,
@@ -211,8 +204,7 @@ def _fake_stream_module(monkeypatch, name, stream):
     monkeypatch.setitem(sys.modules, name, types.SimpleNamespace(generation_stream=stream))
 
 def test_the_speculative_decoding_stream_is_drained_too(monkeypatch):
-    # mlx_vlm.speculative.common owns its own stream from 0.6.0 on, created on import
-    # and never routed through wired_limit, so nothing else ever drains it.
+    # Created on import and never routed through wired_limit: nothing else drains it.
     events = _record_cache_calls(monkeypatch)
     _fake_stream_module(monkeypatch, "mlx_vlm.speculative.common", "stream<speculative>")
 
@@ -222,8 +214,7 @@ def test_the_speculative_decoding_stream_is_drained_too(monkeypatch):
     assert events.count("synchronize:stream<speculative>") == 2
 
 def test_one_stream_shared_by_several_modules_is_drained_once(monkeypatch):
-    # 0.6.x defines generation_stream in mlx_vlm/generate/common.py and re-exports it
-    # from every candidate name, so identity, not name, decides what is outstanding.
+    # 0.6.x re-exports one stream from every candidate name, so identity decides.
     events = _record_cache_calls(monkeypatch)
     shared = "stream<shared>"
     for name in ("mlx_vlm.generate", "mlx_vlm.generate.dispatch", "mlx_vlm.generate.ar"):
@@ -235,9 +226,7 @@ def test_one_stream_shared_by_several_modules_is_drained_once(monkeypatch):
     assert events.count("synchronize:stream<shared>") == 2
 
 def test_a_stream_that_cannot_be_drained_does_not_stop_the_clear(monkeypatch):
-    # A plain mx.new_stream (mlx-vlm 0.4.4, the pin floor) raises when synchronized
-    # from a thread that did not create it. Not draining is the old behaviour and is
-    # survivable; losing the clear, or the generation burst, is not.
+    # A plain mx.new_stream (the mlx-vlm pin floor) raises off its creating thread.
     events = _record_cache_calls(monkeypatch)
     def synchronize(stream=None):
         if stream == "stream<foreign>":
@@ -269,9 +258,7 @@ def test_a_module_getattr_that_raises_does_not_stop_the_clear(monkeypatch):
     ]
 
 def test_a_runtime_without_synchronize_still_clears(monkeypatch):
-    # mx.synchronize has shipped since mlx 0.12.0, two releases before any clear_cache
-    # shape, so this is about partial test doubles rather than a real runtime -- but a
-    # missing drain must degrade to the pre-drain behaviour, not to an AttributeError.
+    # No real runtime is this shape, but a partial test double is.
     events = _record_cache_calls(monkeypatch)
     monkeypatch.setattr("mlx.core.synchronize", None, raising=False)
     _fake_stream_module(monkeypatch, "mlx_lm.generate", "stream<mlx_lm>")

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -618,31 +618,21 @@ def generation_mode(model):
                 pass
 
 
-# mlx-lm and mlx-vlm both run generation on their own thread-local stream, so a
-# no-argument mx.synchronize() -- which waits on the default stream -- drains none of it.
-# Only already-imported modules are inspected: a cleanup path must not import mlx-vlm.
-# mlx_vlm.speculative.common owns a SECOND stream in every 0.6.x, created on import and
-# never routed through wired_limit, so it is listed here but not in _VLM_STREAM_MODULES,
-# which resolves wired_limit and must not grow a module that does not export one.
+# Speculative decoding's stream belongs here but not in _VLM_STREAM_MODULES, which may
+# only hold modules exporting wired_limit.
 def _drain_stream_modules():
-    # A function, not a module constant: _VLM_STREAM_MODULES is defined further down.
+    # A function, not a constant: _VLM_STREAM_MODULES is defined further down.
     return ("mlx_lm.generate",) + _VLM_STREAM_MODULES + ("mlx_vlm.speculative.common",)
 
 
 def _drain_generation_streams(mx):
-    """Best effort: a drain that cannot run must not stop the cache clear.
+    """Drain the generation streams, best effort, before the caller clears the cache.
 
-    Both call sites reached clear_cache() unconditionally before this existed, and
-    draining is a safety margin on top of that, not a precondition for it. The calls
-    below can genuinely fail: at the mlx-vlm pin floor (0.4.4) generation_stream is a
-    plain mx.new_stream, and synchronizing one of those from a thread that did not
-    create it raises "There is no Stream(gpu, N) in current thread". Failing to drain
-    is no worse than the old behaviour; refusing to clear, or killing the burst the
-    entry call sits in front of, is strictly worse.
-
-    Draining a thread-local stream from a foreign thread does not raise, but it does
-    not drain either -- mlx maps it through a thread_local table and creates a fresh
-    stream on miss -- so this is only effective on the thread that generated.
+    A no-argument mx.synchronize() waits on the default stream, not these. Best effort
+    because they can fail: at the mlx-vlm pin floor generation_stream is a plain
+    mx.new_stream, which raises when synchronized off its creating thread, and losing
+    the drain must never cost the caller its clear. Only effective on the generating
+    thread: elsewhere a thread-local stream drains nothing instead of raising.
     """
 
     synchronize = getattr(mx, "synchronize", None)
@@ -651,10 +641,10 @@ def _drain_generation_streams(mx):
     drained = []
     for name in _drain_stream_modules():
         try:
+            # sys.modules only, so cleanup never imports mlx-vlm; a module __getattr__
+            # runs arbitrary code and getattr swallows only AttributeError.
             stream = getattr(sys.modules.get(name), "generation_stream", None)
         except Exception:
-            # Module-level __getattr__ runs arbitrary code; getattr's default only
-            # swallows AttributeError.
             continue
         # 0.6.x aliases one object across every mlx_vlm.generate name.
         if stream is None or any(stream is seen for seen in drained):

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -621,12 +621,53 @@ def generation_mode(model):
 # mlx-lm and mlx-vlm both run generation on their own thread-local stream, so a
 # no-argument mx.synchronize() -- which waits on the default stream -- drains none of it.
 # Only already-imported modules are inspected: a cleanup path must not import mlx-vlm.
+# mlx_vlm.speculative.common owns a SECOND stream in every 0.6.x, created on import and
+# never routed through wired_limit, so it is listed here but not in _VLM_STREAM_MODULES,
+# which resolves wired_limit and must not grow a module that does not export one.
+def _drain_stream_modules():
+    # A function, not a module constant: _VLM_STREAM_MODULES is defined further down.
+    return ("mlx_lm.generate",) + _VLM_STREAM_MODULES + ("mlx_vlm.speculative.common",)
+
+
 def _drain_generation_streams(mx):
-    for name in ("mlx_lm.generate",) + _VLM_STREAM_MODULES:
-        stream = getattr(sys.modules.get(name), "generation_stream", None)
-        if stream is not None:
-            mx.synchronize(stream)
-    mx.synchronize()
+    """Best effort: a drain that cannot run must not stop the cache clear.
+
+    Both call sites reached clear_cache() unconditionally before this existed, and
+    draining is a safety margin on top of that, not a precondition for it. The calls
+    below can genuinely fail: at the mlx-vlm pin floor (0.4.4) generation_stream is a
+    plain mx.new_stream, and synchronizing one of those from a thread that did not
+    create it raises "There is no Stream(gpu, N) in current thread". Failing to drain
+    is no worse than the old behaviour; refusing to clear, or killing the burst the
+    entry call sits in front of, is strictly worse.
+
+    Draining a thread-local stream from a foreign thread does not raise, but it does
+    not drain either -- mlx maps it through a thread_local table and creates a fresh
+    stream on miss -- so this is only effective on the thread that generated.
+    """
+
+    synchronize = getattr(mx, "synchronize", None)
+    if not callable(synchronize):
+        return
+    drained = []
+    for name in _drain_stream_modules():
+        try:
+            stream = getattr(sys.modules.get(name), "generation_stream", None)
+        except Exception:
+            # Module-level __getattr__ runs arbitrary code; getattr's default only
+            # swallows AttributeError.
+            continue
+        # 0.6.x aliases one object across every mlx_vlm.generate name.
+        if stream is None or any(stream is seen for seen in drained):
+            continue
+        drained.append(stream)
+        try:
+            synchronize(stream)
+        except Exception:
+            continue
+    try:
+        synchronize()
+    except Exception:
+        pass
 
 
 @contextmanager

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -23,6 +23,7 @@ import importlib
 import inspect
 import math
 import os
+import sys
 import threading
 import warnings
 from collections.abc import Mapping
@@ -617,6 +618,17 @@ def generation_mode(model):
                 pass
 
 
+# mlx-lm and mlx-vlm both run generation on their own thread-local stream, so a
+# no-argument mx.synchronize() -- which waits on the default stream -- drains none of it.
+# Only already-imported modules are inspected: a cleanup path must not import mlx-vlm.
+def _drain_generation_streams(mx):
+    for name in ("mlx_lm.generate",) + _VLM_STREAM_MODULES:
+        stream = getattr(sys.modules.get(name), "generation_stream", None)
+        if stream is not None:
+            mx.synchronize(stream)
+    mx.synchronize()
+
+
 @contextmanager
 def _generation_cache_hygiene():
     """Cache hygiene around one burst; limits stay owned by ``generation_mode``."""
@@ -628,6 +640,8 @@ def _generation_cache_hygiene():
         raise RuntimeError(
             "Unsupported MLX runtime API shape (mlx.core.clear_cache missing)."
         )
+    # MLX pins buffers a live command buffer reads, but not an output array dropped mid-flight.
+    _drain_generation_streams(mx)
     clear_cache()
     active_error = None
     try:
@@ -637,14 +651,15 @@ def _generation_cache_hygiene():
         raise
     finally:
         try:
+            _drain_generation_streams(mx)
             clear_cache()
-        except BaseException as clear_error:
+        except BaseException as cleanup_error:
             if active_error is None:
                 raise
             try:
                 warnings.warn(
-                    "mlx.core.clear_cache() failed while preserving an active "
-                    f"{type(active_error).__name__}: {clear_error}",
+                    "mlx.core.synchronize()/clear_cache() failed while preserving an "
+                    f"active {type(active_error).__name__}: {cleanup_error}",
                     RuntimeWarning,
                     stacklevel=2,
                 )


### PR DESCRIPTION
Both `mx.clear_cache()` calls in `_generation_cache_hygiene` released MLX's buffer pool without first draining submitted GPU work.

## Why this is reachable

The async work belongs to mlx-lm, not to this repo — grepping here for `async_eval` finds nothing, which makes the hazard look inapplicable. In the pinned mlx-lm, `GenerationBatch._step` submits the next step with `mx.async_eval` **before** yielding, and this repo's batch adapters drive exactly that loop while the stop-string scanner breaks out of it early. So a clear can run with command buffers still in flight, which is the ordinary case rather than an edge case.

## What the drain actually buys

Scoped honestly: MLX keeps buffers that a live command buffer reads alive through that command buffer's completion handler, so the common case is already safe — which is why mlx-lm itself clears every 256 tokens right after `mx.async_eval` without synchronizing. The completion handler does **not** pin the evaluated array's own output buffer, so an output array dropped mid-flight can still reach the pool. Draining first keeps the release independent of that.

This is defensive ordering. No fault was reproduced, and none is claimed.

## Cost

`mx.synchronize()` measured at ~33 us (max 46 us), twice per generation burst and never per token. Interleaved A/B over a real 4-prompt x 64-token burst on a small model — the worst case for this ratio — was 862.4 ms with versus 859.6 ms without, a +0.33% median delta against ~30 ms run-to-run noise.

## Also

The `RuntimeWarning` raised when cleanup fails while an exception is active previously read `mlx.core.clear_cache() failed`, but its `try` now covers the synchronize too, so a synchronize failure would have been misattributed. The message and the bound exception name now cover both calls.

## Validation

```bash
python -m pytest tests/test_mlx_generate.py tests/test_mlx_distributed_loader.py -q
```

Three tests added to `tests/test_mlx_generate.py`, alongside the existing hygiene coverage: both clears drain first, the exit clear still drains when the body raised, and a runtime without `mlx.core.clear_cache` is still rejected before any work — parametrized so that the `mx.metal.clear_cache` shape is refused here too, since this path never accepted it. Each was mutation-checked: removing either synchronize, swapping the order, or re-accepting the `mx.metal` shape fails exactly the test that covers it.