### PR TITLE
fix(mlx): reroute sorted gather_qmm around the defective NAX rhs kernel

### DIFF
--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -21,8 +21,11 @@ except Exception:
 
 if not _METAL:
     print("NOTICE: Metal unavailable; all MLX e2e training tests will be skipped.")
+    _U, _CPU = lambda *s: None, None   # parametrization evaluates before the skip
 
 metal_only = pytest.mark.skipif(not _METAL, reason="requires Apple Silicon Metal")
+_K_REM, _ROW_OVF = "k_remainder", "row_overflow"
+_UNTRANSPOSED = dict(k=192, rows=1, out_width=128, transpose=False, rhs_indices=None)
 
 if _METAL:
     # Module scope: leaked mlx-simulation shims must not hijack test-time imports.
@@ -30,10 +33,12 @@ if _METAL:
     from mlx.utils import tree_flatten, tree_map
     from unsloth_zoo.mlx.loader import FastMLXModel
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+    from unsloth_zoo.mlx import utils as mlx_utils
     from unsloth_zoo.mlx.utils import (
         FiniteTextBatchPlan, _FiniteTextRow, collect_mlx_lora_adapter_tensors,
         make_baseline_loss_fn,
     )
+    _U, _CPU = lambda *s: mx.zeros(s, dtype=mx.uint32), mx.default_stream(mx.cpu)
 
 MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
 
@@ -1322,3 +1327,110 @@ def test_post_head_multiplier_reaches_the_fused_cce_loss(softcap):
 
     assert float(scaled) == pytest.approx(reference, rel=2e-2)
     assert abs(float(scaled) - float(unscaled)) > 1e-3
+
+
+def _gather_qmm_call(k=96, rows=64, m=1, out_width=64, pack_bits=4, **overrides):
+    """One sorted call; an untransposed one is judged on `out_width`."""
+    kw = {"rhs_indices": _U(rows), "transpose": True, "sorted_indices": True,
+          "bits": 4, **overrides}
+    w = ((8, 64, k * pack_bits // 32) if kw["transpose"]
+         else (8, k, out_width * pack_bits // 32))
+    return mx.zeros((rows, m, k), dtype=mx.bfloat16), _U(*w), kw
+
+
+@pytest.fixture
+def raw_gather_qmm(monkeypatch):
+    raw = mlx_utils._MLX_GATHER_QMM_ORIGINAL or mx.gather_qmm
+    monkeypatch.setattr(mx, "gather_qmm", raw)
+    monkeypatch.setattr(mlx_utils, "_MLX_GATHER_QMM_ORIGINAL", raw)
+    monkeypatch.setattr(mlx_utils, "_MLX_GATHER_QMM_CANARIES", {})
+    return raw
+
+
+@metal_only
+@pytest.mark.parametrize("case, expected", [
+    (dict(k=96), (_K_REM,)),                               # K % 64 != 0
+    (dict(k=64, rows=32769), (_ROW_OVF,)),                 # one row past the bound
+    (dict(k=96, rows=32769), (_K_REM, _ROW_OVF)),          # cheaper probe reported first
+    (dict(k=96, sorted_indices=False), ()),                # the flag selects the kernel
+    (dict(k=96, lhs_indices=_U(64, 1)), ()),               # both sides: mlx drops it
+    (dict(k=96, rhs_indices=None, lhs_indices=_U(64, 1)), ()),   # lhs-only, transposed
+    (dict(k=96, m=2), ()),                                 # dispatcher needs M == 1
+    (dict(k=96, stream=_CPU), ()),                         # no Metal kernel from a CPU
+    (dict(k=192, out_width=96, transpose=False), (_K_REM,)),     # the gradient's width
+    (dict(k=192, out_width=96, pack_bits=8, bits=None, mode="mxfp8", transpose=False),
+     (_K_REM,)),
+    ({**_UNTRANSPOSED, "rows": 32769, "rhs_indices": _U(1)}, (_ROW_OVF,)),
+    ({**_UNTRANSPOSED, "lhs_indices": _U(4097, 1)}, (_ROW_OVF,)),
+    ({**_UNTRANSPOSED, "lhs_indices": _U(4096, 8)}, ()),
+])
+def test_gather_qmm_guard_predicate(case, expected):
+    """Bounds spelled out, not derived from the constant they pin. The gradient cases
+    broadcast against indices mlx implies from the other operand: 4097 lhs over 8
+    experts is 32776 rows, and 4096 x 8 overlapping axes is 32768, not 262144."""
+    assert (mlx_utils._MLX_MAX_SORTED_ROWS, mlx_utils._MLX_K_REMAINDER) == (32768, _K_REM)
+    x, w, kw = _gather_qmm_call(**case)
+    assert mlx_utils._gather_qmm_conditions(x, w, (), kw) == expected
+
+
+@metal_only
+@pytest.mark.parametrize("mode, group_size",
+                         [("affine", 32), ("mxfp4", 32), ("mxfp8", 32), ("nvfp4", 16)])
+def test_gather_qmm_canary_probes_the_real_kernel(mode, group_size, monkeypatch, raw_gather_qmm):
+    """Magnitude is no oracle alone -- affine, or the unsorted path, measures just as
+    small here -- and a probe widened to an aligned K never fires at all. `bits` stays
+    omitted as callers omit it; mlx resolves mxfp8 to 8 bits where the rest are 4."""
+    probe_k, rows = mlx_utils._gather_qmm_probe_k, mlx_utils._MLX_PROBE_ROWS
+    k, row_k = probe_k(_K_REM, group_size), probe_k(_ROW_OVF, group_size)
+    assert k % 64 and k % group_size == 0 and k >= 96 and probe_k(_K_REM, 64) is None
+    assert row_k % 64 == 0 and rows[_ROW_OVF] % 2 and rows[_ROW_OVF] > 32768
+    seen = {}
+    monkeypatch.setattr(mlx_utils, "_MLX_GATHER_QMM_ORIGINAL",
+                        lambda *a, **kw: seen.update(kw) or raw_gather_qmm(*a, **kw))
+    dev = mx.default_device()
+    error = mlx_utils._gather_qmm_canary_error(_K_REM, group_size, None, mode, dev)
+    assert (seen["mode"], seen["bits"], seen["sorted_indices"]) == (mode, None, True)
+    assert mx.array_equal(seen["rhs_indices"], mx.sort(seen["rhs_indices"])).item()
+    assert (error < 0.25 or error > 4.0) and mlx_utils._MLX_CANARY_ERROR_LIMIT == 1.0
+    # NaN reads as corrupt, and the verdict is this mode's and this device's alone.
+    monkeypatch.setattr(mlx_utils, "_gather_qmm_canary_error", lambda *a: float("nan"))
+    assert mlx_utils._gather_qmm_canary_defective(_K_REM, group_size, None, mode, dev)
+    assert [*mlx_utils._MLX_GATHER_QMM_CANARIES] == [(_K_REM, group_size, None, mode, str(dev))]
+
+
+@metal_only
+@pytest.mark.parametrize("defective", [False, True])
+def test_gather_qmm_reroutes_only_when_defective(defective, monkeypatch, raw_gather_qmm):
+    """Injects the verdict, not corruption, which would test the threshold on a fiction."""
+    seen = {}
+    monkeypatch.setattr(mlx_utils, "_MLX_GATHER_QMM_ORIGINAL", lambda *a, **kw: seen.update(kw))
+    # Both trip, only the row probe fires: consulting the first alone keeps the flag.
+    monkeypatch.setattr(mlx_utils, "_gather_qmm_canary_error",
+                        lambda c, *a: 99.0 if defective and c == _ROW_OVF else 0.0)
+    scales = mx.zeros((8, 64, 3), dtype=mx.bfloat16)
+    x, w, kw = _gather_qmm_call(k=96, rows=32769)
+    mlx_utils._gather_qmm_guarded(x, w, scales, None, group_size=32, **kw)
+    assert seen["sorted_indices"] is not defective
+    monkeypatch.setattr(mlx_utils, "_gather_qmm_quantization", lambda *a: pytest.fail("probed"))
+    x, w, kw = _gather_qmm_call(k=64)
+    mlx_utils._gather_qmm_guarded(x, w, scales, None, group_size=32, **kw)
+    assert seen["sorted_indices"] is True
+
+
+@metal_only
+def test_gather_qmm_guard_install(monkeypatch, raw_gather_qmm):
+    """The index-stop wrapper removes itself by inspecting whatever sits on `mx`, so the
+    guard must end up beneath it even when a model loads mid-training."""
+    monkeypatch.setenv("UNSLOTH_MLX_GATHER_QMM_GUARD", "0")
+    assert mlx_utils.apply_gather_qmm_nax_guard() is False
+    monkeypatch.delenv("UNSLOTH_MLX_GATHER_QMM_GUARD")
+    mlx_utils.acquire_mlx_training_patches()
+    try:
+        assert mlx_utils.apply_gather_qmm_nax_guard() is True
+        assert mlx_utils.apply_gather_qmm_nax_guard() is False   # idempotent
+        assert mx.gather_qmm._unsloth_index_original._unsloth_gather_qmm_guard
+    finally:
+        mlx_utils.release_mlx_training_patches()
+    assert mx.gather_qmm._unsloth_gather_qmm_guard
+    import inspect   # the only production install site
+    assert "apply_gather_qmm_nax_guard()" in inspect.getsource(FastMLXModel.from_pretrained)

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -1349,15 +1349,15 @@ def raw_gather_qmm(monkeypatch):
 
 @metal_only
 @pytest.mark.parametrize("case, expected", [
-    (dict(k=96), (_K_REM,)),                               # K % 64 != 0
-    (dict(k=64, rows=32769), (_ROW_OVF,)),                 # one row past the bound
-    (dict(k=96, rows=32769), (_K_REM, _ROW_OVF)),          # cheaper probe reported first
-    (dict(k=96, sorted_indices=False), ()),                # the flag selects the kernel
-    (dict(k=96, lhs_indices=_U(64, 1)), ()),               # both sides: mlx drops it
-    (dict(k=96, rhs_indices=None, lhs_indices=_U(64, 1)), ()),   # lhs-only, transposed
-    (dict(k=96, m=2), ()),                                 # dispatcher needs M == 1
-    (dict(k=96, stream=_CPU), ()),                         # no Metal kernel from a CPU
-    (dict(k=192, out_width=96, transpose=False), (_K_REM,)),     # the gradient's width
+    (dict(k=96), (_K_REM,)),
+    (dict(k=64, rows=32769), (_ROW_OVF,)),
+    (dict(k=96, rows=32769), (_K_REM, _ROW_OVF)),
+    (dict(k=96, sorted_indices=False), ()),
+    (dict(k=96, lhs_indices=_U(64, 1)), ()),
+    (dict(k=96, rhs_indices=None, lhs_indices=_U(64, 1)), ()),
+    (dict(k=96, m=2), ()),
+    (dict(k=96, stream=_CPU), ()),
+    (dict(k=192, out_width=96, transpose=False), (_K_REM,)),
     (dict(k=192, out_width=96, pack_bits=8, bits=None, mode="mxfp8", transpose=False),
      (_K_REM,)),
     ({**_UNTRANSPOSED, "rows": 32769, "rhs_indices": _U(1)}, (_ROW_OVF,)),
@@ -1365,9 +1365,7 @@ def raw_gather_qmm(monkeypatch):
     ({**_UNTRANSPOSED, "lhs_indices": _U(4096, 8)}, ()),
 ])
 def test_gather_qmm_guard_predicate(case, expected):
-    """Bounds spelled out, not derived from the constant they pin. The gradient cases
-    broadcast against indices mlx implies from the other operand: 4097 lhs over 8
-    experts is 32776 rows, and 4096 x 8 overlapping axes is 32768, not 262144."""
+    """4097 lhs indices over 8 experts broadcast to 32776 rows; 4096 x 8 is 32768."""
     assert (mlx_utils._MLX_MAX_SORTED_ROWS, mlx_utils._MLX_K_REMAINDER) == (32768, _K_REM)
     x, w, kw = _gather_qmm_call(**case)
     assert mlx_utils._gather_qmm_conditions(x, w, (), kw) == expected
@@ -1377,9 +1375,7 @@ def test_gather_qmm_guard_predicate(case, expected):
 @pytest.mark.parametrize("mode, group_size",
                          [("affine", 32), ("mxfp4", 32), ("mxfp8", 32), ("nvfp4", 16)])
 def test_gather_qmm_canary_probes_the_real_kernel(mode, group_size, monkeypatch, raw_gather_qmm):
-    """Magnitude is no oracle alone -- affine, or the unsorted path, measures just as
-    small here -- and a probe widened to an aligned K never fires at all. `bits` stays
-    omitted as callers omit it; mlx resolves mxfp8 to 8 bits where the rest are 4."""
+    """Magnitude alone is no oracle: the unsorted path measures just as small."""
     probe_k, rows = mlx_utils._gather_qmm_probe_k, mlx_utils._MLX_PROBE_ROWS
     k, row_k = probe_k(_K_REM, group_size), probe_k(_ROW_OVF, group_size)
     assert k % 64 and k % group_size == 0 and k >= 96 and probe_k(_K_REM, 64) is None
@@ -1392,7 +1388,6 @@ def test_gather_qmm_canary_probes_the_real_kernel(mode, group_size, monkeypatch,
     assert (seen["mode"], seen["bits"], seen["sorted_indices"]) == (mode, None, True)
     assert mx.array_equal(seen["rhs_indices"], mx.sort(seen["rhs_indices"])).item()
     assert (error < 0.25 or error > 4.0) and mlx_utils._MLX_CANARY_ERROR_LIMIT == 1.0
-    # NaN reads as corrupt, and the verdict is this mode's and this device's alone.
     monkeypatch.setattr(mlx_utils, "_gather_qmm_canary_error", lambda *a: float("nan"))
     assert mlx_utils._gather_qmm_canary_defective(_K_REM, group_size, None, mode, dev)
     assert [*mlx_utils._MLX_GATHER_QMM_CANARIES] == [(_K_REM, group_size, None, mode, str(dev))]
@@ -1401,10 +1396,9 @@ def test_gather_qmm_canary_probes_the_real_kernel(mode, group_size, monkeypatch,
 @metal_only
 @pytest.mark.parametrize("defective", [False, True])
 def test_gather_qmm_reroutes_only_when_defective(defective, monkeypatch, raw_gather_qmm):
-    """Injects the verdict, not corruption, which would test the threshold on a fiction."""
+    """Injects the verdict, not corruption."""
     seen = {}
     monkeypatch.setattr(mlx_utils, "_MLX_GATHER_QMM_ORIGINAL", lambda *a, **kw: seen.update(kw))
-    # Both trip, only the row probe fires: consulting the first alone keeps the flag.
     monkeypatch.setattr(mlx_utils, "_gather_qmm_canary_error",
                         lambda c, *a: 99.0 if defective and c == _ROW_OVF else 0.0)
     scales = mx.zeros((8, 64, 3), dtype=mx.bfloat16)
@@ -1419,15 +1413,14 @@ def test_gather_qmm_reroutes_only_when_defective(defective, monkeypatch, raw_gat
 
 @metal_only
 def test_gather_qmm_guard_install(monkeypatch, raw_gather_qmm):
-    """The index-stop wrapper removes itself by inspecting whatever sits on `mx`, so the
-    guard must end up beneath it even when a model loads mid-training."""
+    """The guard must end up beneath the index-stop wrapper, even mid-training."""
     monkeypatch.setenv("UNSLOTH_MLX_GATHER_QMM_GUARD", "0")
     assert mlx_utils.apply_gather_qmm_nax_guard() is False
     monkeypatch.delenv("UNSLOTH_MLX_GATHER_QMM_GUARD")
     mlx_utils.acquire_mlx_training_patches()
     try:
         assert mlx_utils.apply_gather_qmm_nax_guard() is True
-        assert mlx_utils.apply_gather_qmm_nax_guard() is False   # idempotent
+        assert mlx_utils.apply_gather_qmm_nax_guard() is False
         assert mx.gather_qmm._unsloth_index_original._unsloth_gather_qmm_guard
     finally:
         mlx_utils.release_mlx_training_patches()
@@ -1442,16 +1435,7 @@ def test_gather_qmm_guard_install(monkeypatch, raw_gather_qmm):
                                      "_gather_qmm_target_device"])
 def test_gather_qmm_guard_never_breaks_a_working_call(failing, monkeypatch,
                                                       raw_gather_qmm):
-    """Reading a call is not worth failing it.
-
-    This wrapper stands on a core mlx op, so anything the predicate raises would break
-    calls plain mlx handles. The reachable cause is an mlx older than the signatures the
-    predicate asks for: `mx.quantize(bits=None, mode=...)` needs 0.29.4, while `.[core]`
-    floors mlx at 0.22.0, so `pip install -U unsloth_zoo --no-deps` over an older mlx
-    reaches the untransposed branch and raises TypeError out of `mx.gather_qmm` itself.
-    Those versions also predate the NAX kernels entirely, so declining to guard there
-    costs no protection.
-    """
+    """Not worth failing a call: the mlx that raises here predates the NAX kernels."""
     monkeypatch.setattr(mlx_utils, "_MLX_GATHER_QMM_UNREADABLE", False)
     seen = {}
     monkeypatch.setattr(mlx_utils, "_MLX_GATHER_QMM_ORIGINAL",
@@ -1465,6 +1449,5 @@ def test_gather_qmm_guard_never_breaks_a_working_call(failing, monkeypatch,
     assert mlx_utils._gather_qmm_guarded(
         x, w, mx.zeros((8, 64, 3), dtype=mx.bfloat16), None, group_size=32,
         **kw) == "result"
-    # Untouched, not rerouted: an unreadable call is passed through exactly as given.
     assert seen["sorted_indices"] is True
     assert mlx_utils._MLX_GATHER_QMM_UNREADABLE is True   # warns once, not per call

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -1434,3 +1434,37 @@ def test_gather_qmm_guard_install(monkeypatch, raw_gather_qmm):
     assert mx.gather_qmm._unsloth_gather_qmm_guard
     import inspect   # the only production install site
     assert "apply_gather_qmm_nax_guard()" in inspect.getsource(FastMLXModel.from_pretrained)
+
+
+@metal_only
+@pytest.mark.parametrize("failing", ["_gather_qmm_conditions",
+                                     "_gather_qmm_quantization",
+                                     "_gather_qmm_target_device"])
+def test_gather_qmm_guard_never_breaks_a_working_call(failing, monkeypatch,
+                                                      raw_gather_qmm):
+    """Reading a call is not worth failing it.
+
+    This wrapper stands on a core mlx op, so anything the predicate raises would break
+    calls plain mlx handles. The reachable cause is an mlx older than the signatures the
+    predicate asks for: `mx.quantize(bits=None, mode=...)` needs 0.29.4, while `.[core]`
+    floors mlx at 0.22.0, so `pip install -U unsloth_zoo --no-deps` over an older mlx
+    reaches the untransposed branch and raises TypeError out of `mx.gather_qmm` itself.
+    Those versions also predate the NAX kernels entirely, so declining to guard there
+    costs no protection.
+    """
+    monkeypatch.setattr(mlx_utils, "_MLX_GATHER_QMM_UNREADABLE", False)
+    seen = {}
+    monkeypatch.setattr(mlx_utils, "_MLX_GATHER_QMM_ORIGINAL",
+                        lambda *a, **kw: seen.update(kw) or "result")
+
+    def boom(*args, **kwargs):
+        raise TypeError("quantize(): incompatible function arguments")
+
+    monkeypatch.setattr(mlx_utils, failing, boom)
+    x, w, kw = _gather_qmm_call(k=96)
+    assert mlx_utils._gather_qmm_guarded(
+        x, w, mx.zeros((8, 64, 3), dtype=mx.bfloat16), None, group_size=32,
+        **kw) == "result"
+    # Untouched, not rerouted: an unreadable call is passed through exactly as given.
+    assert seen["sorted_indices"] is True
+    assert mlx_utils._MLX_GATHER_QMM_UNREADABLE is True   # warns once, not per call

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -6972,6 +6972,9 @@ class FastMLXModel:
                 "Install via: pip install unsloth-zoo[mlx]"
             )
 
+        from .utils import apply_gather_qmm_nax_guard
+        apply_gather_qmm_nax_guard()
+
         chat_template = kwargs.pop("chat_template", None)
         patch_mode = normalize_mlx_patch_mode(kwargs.pop("patch_mode", patch_mode))
         q_bits = kwargs.pop("q_bits", None)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -534,6 +534,266 @@ def mlx_training_patches_active() -> bool:
     return _MLX_TRAINING_ACTIVE_DEPTH.get() > 0
 
 
+# Sorted right-hand-side `gather_qmm` -- the MoE expert projection, entered every
+# training step through SwitchGLU -- dispatches on neural-accelerator Metal GPUs to
+# `*_gather_qmm_rhs_nax`, which corrupts its output without raising: the unaligned-K
+# tail bounds the activation tile by the block size rather than the K remainder
+# (ml-explore/mlx#3887, open), and rows past 32768 wrap negative through a `short`
+# narrowing and are never written (ml-explore/mlx#3856, fixed by #3922 on main).
+# `sorted_indices` only selects that kernel, so it is dropped for calls a probe has
+# measured as affected: healthy machines keep the fast path, and the guard retires
+# itself once mlx ships fixed kernels. Kill switch: UNSLOTH_MLX_GATHER_QMM_GUARD=0.
+_MLX_MAX_SORTED_ROWS = 32768
+# Healthy bf16 rounding measures ~0.06; corruption lands at output magnitude.
+_MLX_CANARY_ERROR_LIMIT = 1.0
+_MLX_K_REMAINDER = "k_remainder"
+_MLX_ROW_OVERFLOW = "row_overflow"
+# Both clear the kernel's own selection rule (one output row per matmul, >= 16 rows,
+# >= 4 per expert); the overflow count is unaligned, which is what reaches the cast.
+_MLX_PROBE_ROWS = {_MLX_K_REMAINDER: 64, _MLX_ROW_OVERFLOW: _MLX_MAX_SORTED_ROWS + 1}
+_MLX_PROBE_EXPERTS = 8
+_MLX_PROBE_OUT_DIM = 64
+# One degenerate group, where mlx's sorted nvfp4 path is already wrong without a
+# neural accelerator; probing there would arm healthy machines.
+_MLX_MIN_PROBE_K = 96
+_MLX_GATHER_QMM_ORIGINAL = None
+_MLX_GATHER_QMM_CANARIES = {}
+_MLX_GATHER_QMM_DEFAULTS = {}
+
+
+def _gather_qmm_probe_k(condition, group_size):
+    """Probe width for `condition`, or None when it is out of reach.
+
+    K is a whole number of groups, so a group size that is itself a multiple of 64
+    leaves no K remainder -- for the probe or for any real call. The overflow probe
+    needs the opposite, an aligned K, to isolate the row bound.
+    """
+    if condition == _MLX_ROW_OVERFLOW:
+        return math.lcm(group_size, 64)
+    if group_size % 64 == 0:
+        return None
+    k = group_size
+    while k < _MLX_MIN_PROBE_K or k % 64 == 0:
+        k += group_size
+    return k
+
+
+def _gather_qmm_canary_error(condition, group_size, bits, mode, device) -> float:
+    """`gather_mm` is the float32 reference: its NAX kernel bounds both tiles by the K
+    remainder and takes its row minimum in `int`, carrying neither defect. Gathering
+    rather than materializing `weights[indices]` keeps it small at 32769 rows."""
+    with mx.stream(mx.default_stream(device)):
+        rows = _MLX_PROBE_ROWS[condition]
+        k = _gather_qmm_probe_k(condition, group_size)
+        keys = mx.random.split(mx.random.key(0x3887), 3)
+        w = mx.random.normal(
+            (_MLX_PROBE_EXPERTS, _MLX_PROBE_OUT_DIM, k), key=keys[0]).astype(mx.bfloat16)
+        quantized = mx.quantize(w, group_size=group_size, bits=bits, mode=mode)
+        wq, scales = quantized[0], quantized[1]
+        biases = quantized[2] if len(quantized) > 2 else None  # float formats have none
+        x = (mx.random.normal((rows, 1, k), key=keys[1]) * 0.5).astype(mx.bfloat16)
+        indices = mx.sort(mx.random.randint(
+            0, _MLX_PROBE_EXPERTS, (rows,), key=keys[2]).astype(mx.uint32))
+        reference = mx.gather_mm(
+            x.astype(mx.float32),
+            mx.dequantize(wq, scales, biases, group_size=group_size, bits=bits,
+                          mode=mode).astype(mx.float32).swapaxes(-1, -2),
+            rhs_indices=indices, sorted_indices=False)
+        out = _MLX_GATHER_QMM_ORIGINAL(
+            x, wq, scales, biases, rhs_indices=indices, transpose=True,
+            group_size=group_size, bits=bits, mode=mode, sorted_indices=True)
+        return mx.abs(out.astype(mx.float32) - reference).max().item()
+
+
+def _gather_qmm_canary_defective(condition, group_size, bits, mode, device) -> bool:
+    """Affine and the float formats compile to different kernels carrying different
+    defects, and a verdict measured on one device says nothing about another, so each
+    is probed once. Keyed by device name: mlx devices hash by identity, not value."""
+    if _gather_qmm_probe_k(condition, group_size) is None:
+        return False
+    key = (condition, group_size, bits, mode, str(device))
+    cached = _MLX_GATHER_QMM_CANARIES.get(key)
+    if cached is not None:
+        return cached
+    if not mx.metal.is_available():
+        _MLX_GATHER_QMM_CANARIES[key] = False
+        return False
+    try:
+        max_error = _gather_qmm_canary_error(condition, group_size, bits, mode, device)
+    except Exception as error:
+        # Uncached and answered defensively: an unusable probe proves nothing, and
+        # rerouting a healthy call costs throughput where admitting a corrupt one
+        # costs gradients. A later call re-probes.
+        print(f"Unsloth: sorted gather_qmm {condition} probe failed ({error}); "
+              f"rerouting this call.")
+        return True
+    defective = not (max_error < _MLX_CANARY_ERROR_LIMIT)   # NaN reads as corrupt
+    _MLX_GATHER_QMM_CANARIES[key] = defective
+    if defective:
+        print(f"Unsloth: sorted gather_qmm is corrupt on this machine ({condition} "
+              f"probe, {mode}, max error {max_error:.3g}); rerouting affected calls.")
+    return defective
+
+
+def _gather_qmm_resolved_quantization(bits, mode):
+    """The group size and bit width mlx picks when the caller names neither. Asked of
+    mlx, not inferred: quantization groups along the last axis, so a scales tensor
+    reveals the group size only for transposed weights, and both defaults vary by
+    mode (mxfp8 is 8 bits, the rest 4)."""
+    cached = _MLX_GATHER_QMM_DEFAULTS.get((bits, mode))
+    if cached is not None:
+        return cached
+    probe = mx.zeros((1, 256), dtype=mx.bfloat16)
+    packed, scales = mx.quantize(probe, bits=bits, mode=mode)[:2]
+    resolved = (probe.shape[-1] // scales.shape[-1],
+                bits if bits is not None else 32 * packed.shape[-1] // probe.shape[-1])
+    _MLX_GATHER_QMM_DEFAULTS[(bits, mode)] = resolved
+    return resolved
+
+
+def _gather_qmm_quantization(args, kwargs):
+    group_size = args[5] if len(args) > 5 else kwargs.get("group_size")
+    bits = args[6] if len(args) > 6 else kwargs.get("bits")
+    mode = args[7] if len(args) > 7 else kwargs.get("mode", "affine")
+    if group_size is None:
+        group_size = _gather_qmm_resolved_quantization(bits, mode)[0]
+    return group_size, bits, mode
+
+
+def _gather_qmm_target_device(kwargs):
+    """Where the call runs: mlx takes a stream, device or device type, and falls back
+    to the default device, which need not be where this call was sent."""
+    stream = kwargs.get("stream")
+    if stream is None:
+        return mx.default_device()
+    device = getattr(stream, "device", stream)
+    return device if isinstance(device, mx.Device) else mx.default_stream(device).device
+
+
+def _gather_qmm_gradient_rows(x, w, lhs_indices, rhs_indices):
+    """The gradient's input is the forward's output, whose batch axes mlx builds by
+    broadcasting the two index arrays, filling an absent one in from the batch axes of
+    whichever operand it would have indexed. Asked of mlx so its rules decide here."""
+    left = lhs_indices.shape if lhs_indices is not None else x.shape[:-2]
+    right = rhs_indices.shape if rhs_indices is not None else w.shape[:-2]
+    batch = mx.broadcast_shapes(tuple(left), tuple(right))
+    return math.prod(batch) * x.shape[-2]
+
+
+def _gather_qmm_conditions(x, w, args, kwargs):
+    """Defects this call is exposed to, empty when it misses the kernel.
+
+    Positional layout after the positional-only `(x, w)`: scales, biases, lhs_indices,
+    rhs_indices, transpose, group_size, bits, mode. `sorted_indices` is keyword-only.
+
+    The answer is per-geometry, so it has to be re-derived per geometry. Under
+    `mx.compile` it is: a changed shape misses the trace cache and runs this again.
+    A `shapeless=True` trace would not, and would freeze one call's answer onto every
+    later one -- the sorted flag is baked into the traced primitive.
+    """
+    if not kwargs.get("sorted_indices"):
+        return ()
+    if _gather_qmm_target_device(kwargs).type != mx.gpu:
+        return ()
+    lhs_indices = args[2] if len(args) > 2 else kwargs.get("lhs_indices")
+    rhs_indices = args[3] if len(args) > 3 else kwargs.get("rhs_indices")
+    transpose = args[4] if len(args) > 4 else kwargs.get("transpose", True)
+    # mlx records the sorted flag only when exactly one index side is given.
+    if (lhs_indices is None) == (rhs_indices is None):
+        return ()
+    # The dispatcher takes this kernel at one output row per matmul, and the gradient
+    # inherits that count, so a wider -- prefill-shaped -- call reaches it from neither
+    # direction. The two batch heuristics beside it are marked for retuning upstream
+    # and are deliberately not mirrored; this one is structural.
+    if x.shape[-2] != 1:
+        return ()
+    conditions = []
+    if transpose:
+        # The forward reaches the kernel only as an rhs-indexed gather; an lhs-indexed
+        # one misses it and its gradient arrives untransposed. mlx passes the kernel
+        # `x.size() / K` from the caller's own x, before broadcasting.
+        if rhs_indices is None:
+            return ()
+        k, rows = x.shape[-1], x.size // x.shape[-1]
+    else:
+        # The forward misses, but the VJP re-issues it transposed, rhs-indexed and
+        # still sorted, whichever side the caller indexed. It contracts over the
+        # forward's output width, which mlx derives from the packed weight.
+        bits = args[6] if len(args) > 6 else kwargs.get("bits")
+        mode = args[7] if len(args) > 7 else kwargs.get("mode", "affine")
+        k = w.shape[-1] * 32 // _gather_qmm_resolved_quantization(bits, mode)[1]
+        rows = _gather_qmm_gradient_rows(x, w, lhs_indices, rhs_indices)
+    if k % 64:
+        conditions.append(_MLX_K_REMAINDER)
+    if rows > _MLX_MAX_SORTED_ROWS:
+        conditions.append(_MLX_ROW_OVERFLOW)
+    return tuple(conditions)
+
+
+def _gather_qmm_guarded(x, w, *args, **kwargs):
+    conditions = _gather_qmm_conditions(x, w, args, kwargs)
+    if conditions:
+        group_size, bits, mode = _gather_qmm_quantization(args, kwargs)
+        device = _gather_qmm_target_device(kwargs)
+        # Either defect alone corrupts the result; the cheaper probe is tried first.
+        if any(_gather_qmm_canary_defective(condition, group_size, bits, mode, device)
+               for condition in conditions):
+            kwargs = dict(kwargs, sorted_indices=False)
+    return _MLX_GATHER_QMM_ORIGINAL(x, w, *args, **kwargs)
+
+
+# Set directly, not through `wraps`: that copies __dict__, and the index-stop wrapper
+# identifies its own wrappers by attribute, so inherited markers would make its
+# removal restore the wrong callable.
+_gather_qmm_guarded._unsloth_gather_qmm_guard = True
+
+
+def is_gather_qmm_nax_guard_applied() -> bool:
+    """True when the guard is anywhere in the chain, index-stop wrapper included."""
+    current = mx.gather_qmm
+    while current is not None:
+        if getattr(current, "_unsloth_gather_qmm_guard", False):
+            return True
+        current = getattr(current, "_unsloth_index_original", None)
+    return False
+
+
+def apply_gather_qmm_nax_guard() -> bool:
+    """Install the reroute on `mx.gather_qmm`. Idempotent and thread-safe.
+
+    The guard must end up UNDER the index-stop wrapper, which removes itself by
+    inspecting whatever sits on `mx`; installed on top it would bury that wrapper's
+    marker and strand it for the process.
+    """
+    global _MLX_GATHER_QMM_ORIGINAL
+    if os.environ.get("UNSLOTH_MLX_GATHER_QMM_GUARD", "1") == "0":
+        return False
+    with _MLX_INDEX_GRADIENT_LOCK:
+        if is_gather_qmm_nax_guard_applied():
+            return False
+        current = mx.gather_qmm
+        if (_MLX_GATHER_QMM_ORIGINAL is not None
+                and current is not _MLX_GATHER_QMM_ORIGINAL
+                and getattr(current, "_unsloth_index_original", None)
+                is not _MLX_GATHER_QMM_ORIGINAL):
+            # Capturing an opaque wrapper would make the guard reachable from its own
+            # original, and every call would recurse until the stack ran out.
+            print("Unsloth: mx.gather_qmm was replaced by an unrecognized wrapper; "
+                  "leaving the NAX guard as it stands.")
+            return False
+        if getattr(current, "_unsloth_index_stop_gradient", False):
+            # One assignment. Taking the index stop down and putting it back would
+            # unwrap every index op process-wide, and ordinary calls hold no lock, so
+            # a concurrent trainer could execute a raw one in that window.
+            _MLX_GATHER_QMM_ORIGINAL = current._unsloth_index_original
+            mx.gather_qmm = _wrap_mlx_index_op("gather_qmm", _gather_qmm_guarded)
+        else:
+            _MLX_GATHER_QMM_ORIGINAL = current
+            mx.gather_qmm = _gather_qmm_guarded
+        return True
+
+
+
 def _get_transformer_layers(model):
     """Find transformer layers, unwrapping VLM wrappers if needed.
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -559,6 +559,8 @@ _MLX_MIN_PROBE_K = 96
 _MLX_GATHER_QMM_ORIGINAL = None
 _MLX_GATHER_QMM_CANARIES = {}
 _MLX_GATHER_QMM_DEFAULTS = {}
+# Set once if reading a call ever fails, so the warning does not repeat per call.
+_MLX_GATHER_QMM_UNREADABLE = False
 
 
 def _gather_qmm_probe_k(condition, group_size):
@@ -731,14 +733,29 @@ def _gather_qmm_conditions(x, w, args, kwargs):
 
 
 def _gather_qmm_guarded(x, w, *args, **kwargs):
-    conditions = _gather_qmm_conditions(x, w, args, kwargs)
-    if conditions:
-        group_size, bits, mode = _gather_qmm_quantization(args, kwargs)
-        device = _gather_qmm_target_device(kwargs)
-        # Either defect alone corrupts the result; the cheaper probe is tried first.
-        if any(_gather_qmm_canary_defective(condition, group_size, bits, mode, device)
-               for condition in conditions):
-            kwargs = dict(kwargs, sorted_indices=False)
+    global _MLX_GATHER_QMM_UNREADABLE
+    try:
+        conditions = _gather_qmm_conditions(x, w, args, kwargs)
+        if conditions:
+            group_size, bits, mode = _gather_qmm_quantization(args, kwargs)
+            device = _gather_qmm_target_device(kwargs)
+            # Either defect alone corrupts the result; the cheaper probe is tried first.
+            if any(_gather_qmm_canary_defective(condition, group_size, bits, mode,
+                                                device)
+                   for condition in conditions):
+                kwargs = dict(kwargs, sorted_indices=False)
+    except Exception as error:
+        # Failing to READ a call is not a reason to fail the call. This wrapper stands
+        # on a core mlx op, so an exception here breaks calls plain mlx handles fine.
+        # The reachable cause is an mlx older than the signatures the predicate asks
+        # for -- `quantize(bits=None, mode=...)` needs 0.29.4, and `.[core]` floors mlx
+        # at 0.22.0 -- which is also an mlx generations older than the NAX kernels, so
+        # there is nothing there to guard. Warn once, then behave as the unpatched op.
+        if not _MLX_GATHER_QMM_UNREADABLE:
+            _MLX_GATHER_QMM_UNREADABLE = True
+            print(f"Unsloth: could not inspect this gather_qmm call "
+                  f"({type(error).__name__}: {error}); the sorted NAX guard is "
+                  f"inactive for this process.")
     return _MLX_GATHER_QMM_ORIGINAL(x, w, *args, **kwargs)
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -534,42 +534,27 @@ def mlx_training_patches_active() -> bool:
     return _MLX_TRAINING_ACTIVE_DEPTH.get() > 0
 
 
-# Sorted right-hand-side `gather_qmm` -- the MoE expert projection, entered every
-# training step through SwitchGLU -- dispatches on neural-accelerator Metal GPUs to
-# `*_gather_qmm_rhs_nax`, which corrupts its output without raising: the unaligned-K
-# tail bounds the activation tile by the block size rather than the K remainder
-# (ml-explore/mlx#3887, open), and rows past 32768 wrap negative through a `short`
-# narrowing and are never written (ml-explore/mlx#3856, fixed by #3922 on main).
-# `sorted_indices` only selects that kernel, so it is dropped for calls a probe has
-# measured as affected: healthy machines keep the fast path, and the guard retires
-# itself once mlx ships fixed kernels. Kill switch: UNSLOTH_MLX_GATHER_QMM_GUARD=0.
+# Sorted `gather_qmm` silently corrupts its output on neural-accelerator Metal GPUs:
+# unaligned K (ml-explore/mlx#3887, open) and rows past 32768 (ml-explore/mlx#3856,
+# fixed by #3922). `sorted_indices` is only a dispatch hint, so dropping it where a
+# probe measures corruption is safe. Kill switch: UNSLOTH_MLX_GATHER_QMM_GUARD=0.
 _MLX_MAX_SORTED_ROWS = 32768
-# Healthy bf16 rounding measures ~0.06; corruption lands at output magnitude.
 _MLX_CANARY_ERROR_LIMIT = 1.0
 _MLX_K_REMAINDER = "k_remainder"
 _MLX_ROW_OVERFLOW = "row_overflow"
-# Both clear the kernel's own selection rule (one output row per matmul, >= 16 rows,
-# >= 4 per expert); the overflow count is unaligned, which is what reaches the cast.
 _MLX_PROBE_ROWS = {_MLX_K_REMAINDER: 64, _MLX_ROW_OVERFLOW: _MLX_MAX_SORTED_ROWS + 1}
 _MLX_PROBE_EXPERTS = 8
 _MLX_PROBE_OUT_DIM = 64
-# One degenerate group, where mlx's sorted nvfp4 path is already wrong without a
-# neural accelerator; probing there would arm healthy machines.
+# Below this, nvfp4 degenerates to one group that mlx gets wrong even without a NAX.
 _MLX_MIN_PROBE_K = 96
 _MLX_GATHER_QMM_ORIGINAL = None
 _MLX_GATHER_QMM_CANARIES = {}
 _MLX_GATHER_QMM_DEFAULTS = {}
-# Set once if reading a call ever fails, so the warning does not repeat per call.
 _MLX_GATHER_QMM_UNREADABLE = False
 
 
 def _gather_qmm_probe_k(condition, group_size):
-    """Probe width for `condition`, or None when it is out of reach.
-
-    K is a whole number of groups, so a group size that is itself a multiple of 64
-    leaves no K remainder -- for the probe or for any real call. The overflow probe
-    needs the opposite, an aligned K, to isolate the row bound.
-    """
+    """Probe width, or None: a 64-multiple group size leaves no K remainder to probe."""
     if condition == _MLX_ROW_OVERFLOW:
         return math.lcm(group_size, 64)
     if group_size % 64 == 0:
@@ -581,9 +566,7 @@ def _gather_qmm_probe_k(condition, group_size):
 
 
 def _gather_qmm_canary_error(condition, group_size, bits, mode, device) -> float:
-    """`gather_mm` is the float32 reference: its NAX kernel bounds both tiles by the K
-    remainder and takes its row minimum in `int`, carrying neither defect. Gathering
-    rather than materializing `weights[indices]` keeps it small at 32769 rows."""
+    """`gather_mm` is the reference: its NAX kernel carries neither defect."""
     with mx.stream(mx.default_stream(device)):
         rows = _MLX_PROBE_ROWS[condition]
         k = _gather_qmm_probe_k(condition, group_size)
@@ -592,7 +575,7 @@ def _gather_qmm_canary_error(condition, group_size, bits, mode, device) -> float
             (_MLX_PROBE_EXPERTS, _MLX_PROBE_OUT_DIM, k), key=keys[0]).astype(mx.bfloat16)
         quantized = mx.quantize(w, group_size=group_size, bits=bits, mode=mode)
         wq, scales = quantized[0], quantized[1]
-        biases = quantized[2] if len(quantized) > 2 else None  # float formats have none
+        biases = quantized[2] if len(quantized) > 2 else None
         x = (mx.random.normal((rows, 1, k), key=keys[1]) * 0.5).astype(mx.bfloat16)
         indices = mx.sort(mx.random.randint(
             0, _MLX_PROBE_EXPERTS, (rows,), key=keys[2]).astype(mx.uint32))
@@ -608,9 +591,7 @@ def _gather_qmm_canary_error(condition, group_size, bits, mode, device) -> float
 
 
 def _gather_qmm_canary_defective(condition, group_size, bits, mode, device) -> bool:
-    """Affine and the float formats compile to different kernels carrying different
-    defects, and a verdict measured on one device says nothing about another, so each
-    is probed once. Keyed by device name: mlx devices hash by identity, not value."""
+    """Keyed by device name: mlx devices hash by identity, not value."""
     if _gather_qmm_probe_k(condition, group_size) is None:
         return False
     key = (condition, group_size, bits, mode, str(device))
@@ -623,9 +604,10 @@ def _gather_qmm_canary_defective(condition, group_size, bits, mode, device) -> b
     try:
         max_error = _gather_qmm_canary_error(condition, group_size, bits, mode, device)
     except Exception as error:
-        # Uncached and answered defensively: an unusable probe proves nothing, and
-        # rerouting a healthy call costs throughput where admitting a corrupt one
-        # costs gradients. A later call re-probes.
+        # Fails CLOSED, unlike the pass-through in `_gather_qmm_guarded`: an unusable
+        # probe proves nothing, and rerouting a healthy call only costs throughput
+        # where admitting a corrupt one costs gradients. Uncached, so a later call
+        # re-probes.
         print(f"Unsloth: sorted gather_qmm {condition} probe failed ({error}); "
               f"rerouting this call.")
         return True
@@ -638,10 +620,7 @@ def _gather_qmm_canary_defective(condition, group_size, bits, mode, device) -> b
 
 
 def _gather_qmm_resolved_quantization(bits, mode):
-    """The group size and bit width mlx picks when the caller names neither. Asked of
-    mlx, not inferred: quantization groups along the last axis, so a scales tensor
-    reveals the group size only for transposed weights, and both defaults vary by
-    mode (mxfp8 is 8 bits, the rest 4)."""
+    """Asked of mlx: scales reveal the group size only for transposed weights."""
     cached = _MLX_GATHER_QMM_DEFAULTS.get((bits, mode))
     if cached is not None:
         return cached
@@ -663,8 +642,7 @@ def _gather_qmm_quantization(args, kwargs):
 
 
 def _gather_qmm_target_device(kwargs):
-    """Where the call runs: mlx takes a stream, device or device type, and falls back
-    to the default device, which need not be where this call was sent."""
+    """mlx takes a stream, device or device type here."""
     stream = kwargs.get("stream")
     if stream is None:
         return mx.default_device()
@@ -673,9 +651,7 @@ def _gather_qmm_target_device(kwargs):
 
 
 def _gather_qmm_gradient_rows(x, w, lhs_indices, rhs_indices):
-    """The gradient's input is the forward's output, whose batch axes mlx builds by
-    broadcasting the two index arrays, filling an absent one in from the batch axes of
-    whichever operand it would have indexed. Asked of mlx so its rules decide here."""
+    """mlx fills an absent index side in from the operand it would have indexed."""
     left = lhs_indices.shape if lhs_indices is not None else x.shape[:-2]
     right = rhs_indices.shape if rhs_indices is not None else w.shape[:-2]
     batch = mx.broadcast_shapes(tuple(left), tuple(right))
@@ -683,16 +659,9 @@ def _gather_qmm_gradient_rows(x, w, lhs_indices, rhs_indices):
 
 
 def _gather_qmm_conditions(x, w, args, kwargs):
-    """Defects this call is exposed to, empty when it misses the kernel.
-
-    Positional layout after the positional-only `(x, w)`: scales, biases, lhs_indices,
-    rhs_indices, transpose, group_size, bits, mode. `sorted_indices` is keyword-only.
-
-    The answer is per-geometry, so it has to be re-derived per geometry. Under
-    `mx.compile` it is: a changed shape misses the trace cache and runs this again.
-    A `shapeless=True` trace would not, and would freeze one call's answer onto every
-    later one -- the sorted flag is baked into the traced primitive.
-    """
+    """Defects this call is exposed to, empty when it misses the kernel. Re-derived
+    per geometry: a `shapeless=True` trace would instead freeze one call's answer onto
+    every later one, since the sorted flag is baked into the traced primitive."""
     if not kwargs.get("sorted_indices"):
         return ()
     if _gather_qmm_target_device(kwargs).type != mx.gpu:
@@ -703,24 +672,16 @@ def _gather_qmm_conditions(x, w, args, kwargs):
     # mlx records the sorted flag only when exactly one index side is given.
     if (lhs_indices is None) == (rhs_indices is None):
         return ()
-    # The dispatcher takes this kernel at one output row per matmul, and the gradient
-    # inherits that count, so a wider -- prefill-shaped -- call reaches it from neither
-    # direction. The two batch heuristics beside it are marked for retuning upstream
-    # and are deliberately not mirrored; this one is structural.
+    # The kernel is dispatched at one output row per matmul; the gradient inherits it.
     if x.shape[-2] != 1:
         return ()
     conditions = []
     if transpose:
-        # The forward reaches the kernel only as an rhs-indexed gather; an lhs-indexed
-        # one misses it and its gradient arrives untransposed. mlx passes the kernel
-        # `x.size() / K` from the caller's own x, before broadcasting.
         if rhs_indices is None:
             return ()
         k, rows = x.shape[-1], x.size // x.shape[-1]
     else:
-        # The forward misses, but the VJP re-issues it transposed, rhs-indexed and
-        # still sorted, whichever side the caller indexed. It contracts over the
-        # forward's output width, which mlx derives from the packed weight.
+        # The forward misses, but the VJP re-issues it transposed, rhs-indexed, sorted.
         bits = args[6] if len(args) > 6 else kwargs.get("bits")
         mode = args[7] if len(args) > 7 else kwargs.get("mode", "affine")
         k = w.shape[-1] * 32 // _gather_qmm_resolved_quantization(bits, mode)[1]
@@ -739,18 +700,13 @@ def _gather_qmm_guarded(x, w, *args, **kwargs):
         if conditions:
             group_size, bits, mode = _gather_qmm_quantization(args, kwargs)
             device = _gather_qmm_target_device(kwargs)
-            # Either defect alone corrupts the result; the cheaper probe is tried first.
             if any(_gather_qmm_canary_defective(condition, group_size, bits, mode,
                                                 device)
                    for condition in conditions):
                 kwargs = dict(kwargs, sorted_indices=False)
     except Exception as error:
-        # Failing to READ a call is not a reason to fail the call. This wrapper stands
-        # on a core mlx op, so an exception here breaks calls plain mlx handles fine.
-        # The reachable cause is an mlx older than the signatures the predicate asks
-        # for -- `quantize(bits=None, mode=...)` needs 0.29.4, and `.[core]` floors mlx
-        # at 0.22.0 -- which is also an mlx generations older than the NAX kernels, so
-        # there is nothing there to guard. Warn once, then behave as the unpatched op.
+        # Failing to READ a call is not a reason to fail it: this stands on a core mlx
+        # op, and the reachable cause is an mlx predating the NAX kernels. Pass through.
         if not _MLX_GATHER_QMM_UNREADABLE:
             _MLX_GATHER_QMM_UNREADABLE = True
             print(f"Unsloth: could not inspect this gather_qmm call "
@@ -759,14 +715,12 @@ def _gather_qmm_guarded(x, w, *args, **kwargs):
     return _MLX_GATHER_QMM_ORIGINAL(x, w, *args, **kwargs)
 
 
-# Set directly, not through `wraps`: that copies __dict__, and the index-stop wrapper
-# identifies its own wrappers by attribute, so inherited markers would make its
-# removal restore the wrong callable.
+# Not `wraps`: copied __dict__ markers make the index-stop removal restore the wrong callable.
 _gather_qmm_guarded._unsloth_gather_qmm_guard = True
 
 
 def is_gather_qmm_nax_guard_applied() -> bool:
-    """True when the guard is anywhere in the chain, index-stop wrapper included."""
+    """True for the guard anywhere in the chain, index-stop wrapper included."""
     current = mx.gather_qmm
     while current is not None:
         if getattr(current, "_unsloth_gather_qmm_guard", False):
@@ -776,12 +730,8 @@ def is_gather_qmm_nax_guard_applied() -> bool:
 
 
 def apply_gather_qmm_nax_guard() -> bool:
-    """Install the reroute on `mx.gather_qmm`. Idempotent and thread-safe.
-
-    The guard must end up UNDER the index-stop wrapper, which removes itself by
-    inspecting whatever sits on `mx`; installed on top it would bury that wrapper's
-    marker and strand it for the process.
-    """
+    """Idempotent, thread-safe, and installed UNDER the index-stop wrapper, which
+    removes itself by inspecting `mx` and would be stranded by anything on top."""
     global _MLX_GATHER_QMM_ORIGINAL
     if os.environ.get("UNSLOTH_MLX_GATHER_QMM_GUARD", "1") == "0":
         return False
@@ -793,15 +743,12 @@ def apply_gather_qmm_nax_guard() -> bool:
                 and current is not _MLX_GATHER_QMM_ORIGINAL
                 and getattr(current, "_unsloth_index_original", None)
                 is not _MLX_GATHER_QMM_ORIGINAL):
-            # Capturing an opaque wrapper would make the guard reachable from its own
-            # original, and every call would recurse until the stack ran out.
+            # Capturing an opaque wrapper makes the guard reachable from its original.
             print("Unsloth: mx.gather_qmm was replaced by an unrecognized wrapper; "
                   "leaving the NAX guard as it stands.")
             return False
         if getattr(current, "_unsloth_index_stop_gradient", False):
-            # One assignment. Taking the index stop down and putting it back would
-            # unwrap every index op process-wide, and ordinary calls hold no lock, so
-            # a concurrent trainer could execute a raw one in that window.
+            # One assignment: removing the index stop would unwrap every index op.
             _MLX_GATHER_QMM_ORIGINAL = current._unsloth_index_original
             mx.gather_qmm = _wrap_mlx_index_op("gather_qmm", _gather_qmm_guarded)
         else:


### PR DESCRIPTION
## The bug

On Metal GPUs with a neural accelerator, sorted right-hand-side `gather_qmm` — the MoE expert projection, entered on every training step through `SwitchGLU` — dispatches to `*_gather_qmm_rhs_nax`, which can corrupt its output without raising. Training does not crash and does not warn. It converges on wrong gradients.

Two upstream defects, both in the RHS NAX kernel:

- **Unaligned K.** The dispatcher enters the kernel with no `K % 64 == 0` guard, and the `!align_K` tail bounds the *activation* tile by the block size rather than by the K remainder, so it multiplies stale threadgroup weights by out-of-bounds reads. Upstream: ml-explore/mlx#3887, open — the bound is identical in 0.32.1, 0.32.2 and `main`. Affects affine and mxfp4 alike.
- **Row count above 32768.** The edge-tile row bound casts `M - (y_row + tm)` to `short` before taking its minimum, so a tile sitting more than 32767 rows from the end wraps negative, the A-tile is zeroed and those output rows are never written — they read back whatever the recycled Metal buffer last held. Upstream: ml-explore/mlx#3856, fixed by ml-explore/mlx#3922 on `main` and still live in 0.32.1 and 0.32.2. The upstream trigger is `rows > 32768 && rows % 64 != 0`; a 4096-token top-8 step crosses it.

## What changed

`sorted_indices` only *selects* that kernel — it is a dispatch hint, not a semantic requirement — so the wrapper drops it for calls that would land there, and mlx takes an unaffected path instead.

The guard self-arms. A call matching one of the two conditions triggers a probe that compares the sorted quantized kernel against a float32 `gather_mm` reference at the same geometry; the reroute applies only if that probe actually measures corruption. `gather_mm` is a valid reference because its own NAX kernel bounds both tiles by the K remainder and takes its row minimum in `int`, carrying neither defect. Verdicts are cached per condition, quantization mode and device, so healthy machines pay one probe per distinct call shape and then nothing — and the guard retires itself automatically once mlx ships fixed kernels, with no version pin to maintain.

Kill switch: `UNSLOTH_MLX_GATHER_QMM_GUARD=0`.

### Which calls are considered exposed

Three cases, all gated on `sorted_indices`, a GPU target device, and `x.shape[-2] == 1` (the dispatcher's `M == 1`):

1. **transposed + rhs-only indices** — the forward reaches the kernel. K is `x.shape[-1]`; the row count is `x.size // K`, which is what mlx passes, before broadcasting.
2. **untransposed, either index side** — the forward misses, but `GatherQMM::vjp` re-issues the call transposed, rhs-indexed and still sorted. K is the forward's output width, derived from the packed weight and mlx's own resolved bit width. Rows come from broadcasting the two index arrays through `mx.broadcast_shapes`, filling an absent side in from the batch axes of the operand it would have indexed.
3. **transposed + lhs-only** — exposed from neither direction.

## Tradeoffs worth a reviewer's attention

- **The row condition ignores `align_M`.** Upstream needs `rows % 64 != 0` as well as `rows > 32768`, because an aligned row count short-circuits the cast. This guard checks only the row count, so it probes a superset of the affected calls rather than replicating a block-size heuristic that upstream is free to retune.
- **The two batch heuristics beside the `M == 1` gate are deliberately not mirrored.** `B >= 16` and `B / E >= 4` carry an upstream `// TODO: Tune 16 and 4 here a bit better`, so mirroring them would rot against retuning. The consequence is that some calls are probed which cannot reach the kernel — a bounded, one-off cost, in the direction that keeps protection rather than losing it.
- **The float32/TF32 dispatch gate is not mirrored either.** mlx caches `MLX_ENABLE_TF32` in a function-local `static`, so a Python-side read can disagree with what the dispatcher actually used, and the disagreement falls in the direction that loses protection.
- **The predicate is per-geometry and needs a shape-aware trace.** Under `mx.compile` it gets one: a changed shape misses the trace cache and the predicate runs again. A `shapeless=True` trace would freeze one call's answer onto every later one, because the sorted flag is baked into the traced primitive. Nothing in this repository uses `shapeless`, and the finite-shape planning in `shape_guard.py` pushes the same way, but the constraint is now stated in the code so it is not rediscovered the hard way.
- **A failed probe reroutes rather than proceeding.** An unusable probe proves nothing, and rerouting a healthy call costs throughput where admitting a corrupt one costs gradients. The failure is not cached, so a later call re-probes.

## Validation

Provoking the corruption requires neural-accelerator hardware, which was not available. **Nothing here asserts that a probe catches real corruption**, and no test fakes corruption either — a fabricated defect would pass against a broken implementation and prove nothing. What is tested is the decision logic: the predicate's boundaries in both directions, the probe's geometry, that the canary measures the call it stands in for, that the reroute follows the verdict rather than the condition, that an unaffected call pays nothing, and the install layering.

```bash
python -m pytest tests/test_mlx_training_e2e_metal.py -k gather_qmm
```

- 53/53 in that file on mlx 0.32.2, and on a separate environment pinned to the 0.32.1 in `pyproject.toml`.
- 53 skipped with no collection error when Metal is unavailable.
- Probe margins on healthy hardware against a threshold of 1.0: affine 0.0593, mxfp4 0.0606, mxfp8 0.0622, nvfp4 0.0570 for the unaligned-K condition, affine 0.0623 for the row-count condition — roughly sixteen times below the threshold, and well below output magnitude.
- Sorted-versus-unsorted input gradients differ by 0.125 against a magnitude of 34.25 (0.37%), consistent with bfloat16 accumulation order rather than corruption.
- Mutation-checked: 54 mutations of the guard, 43 killed. The survivors are the probe's fail-open path, its device targeting, and quantization-default resolution; three more are masked by the unrecognized-wrapper refusal branch, which also returns `False`, and one is an equivalent mutant behind the `M == 1` gate.
