### PR TITLE
AMD: ask whether HIP supports bf16 before allocating bf16 offload buffers

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -305,6 +305,12 @@ jobs:
         # here, which masks labels[position_ids == 0] (trl added that in 0.23.1),
         # so this job exercises the regressed regime on every pull request.
         #
+        # test_hip_bf16_offload_dtype pins that the HIP branch ASKS whether bf16 is
+        # supported rather than hardcoding True, which is what kills an RDNA 1/2 card
+        # at step 0. No job here has an AMD runner, so it stubs device_count to 0 and
+        # runs the dtype decision alone on CPU; left to --collect-only it would prove
+        # only that it imports, which is the failure this comment already lists twice.
+        #
         # The last two are here because `--collect-only` is exactly what missed
         # the bug they cover. `tests/` is not a package, so `from tests.x import
         # y` binds to whatever `tests` package is importable; unsloth's CI runs
@@ -348,6 +354,7 @@ jobs:
             tests/test_disabled_hook_graph_break.py \
             tests/test_missing_parent_package_is_drift.py \
             tests/test_sibling_imports_do_not_go_through_a_tests_package.py \
+            tests/test_hip_bf16_offload_dtype.py \
             -v
 
       - name: pytest MLX adapter-filter gate (HARD GATE)

--- a/tests/test_hip_bf16_offload_dtype.py
+++ b/tests/test_hip_bf16_offload_dtype.py
@@ -1,0 +1,164 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The HIP branch of ``initialize_unsloth_gradient_checkpointing`` must ASK.
+
+It used to read ``SUPPORTS_BFLOAT16 = True`` and pin the CPU offload buffers in
+bfloat16 on every AMD host. RDNA 1 and 2 (gfx101x, gfx103x) have no native bf16
+arithmetic: Triton selects ``llvm.amdgcn.fdot2.bf16.bf16``, LLVM cannot lower it
+for the target, and the process dies with no Python exception, which reaches the
+user as "Training process exited unexpectedly" at step 0
+(unslothai/unsloth issue 7922, an RX 6600 XT / gfx1032).
+
+Two things this file has to keep straight, because they pull in opposite
+directions:
+
+* On a stock ROCm install the change is **inert**. ``torch.cuda.is_bf16_supported``
+  returns True for ``torch.version.hip`` before it looks at the architecture at
+  all, so an AMD user without unslothai/unsloth#7682 keeps bfloat16 exactly as
+  before. A test that only proved "float16 now" would be proving a regression
+  for every current AMD user.
+* Once that PR patches the probe process-wide, this line inherits the same
+  answer as every other bf16 decision instead of disagreeing with them.
+
+``DEVICE_TYPE_TORCH`` maps "hip" to "cuda", so the HIP branch can be driven on
+an NVIDIA box by spoofing one module global, and the buffers it allocates are
+real ones.
+"""
+
+import ast
+import inspect
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from unsloth_zoo import gradient_checkpointing as gc
+
+
+def _hip_branch_source():
+    """The body of the `elif DEVICE_TYPE == "hip"` arm, as source."""
+    tree = ast.parse(inspect.getsource(gc.initialize_unsloth_gradient_checkpointing).lstrip())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if (
+            isinstance(test, ast.Compare)
+            and getattr(test.left, "id", None) == "DEVICE_TYPE"
+            and isinstance(test.comparators[0], ast.Constant)
+            and test.comparators[0].value == "hip"
+        ):
+            return node.body
+    raise AssertionError("no `DEVICE_TYPE == \"hip\"` branch; this guard has gone vacuous")
+
+
+def test_the_hip_branch_asks_rather_than_hardcoding_true():
+    """Runs anywhere, including the CPU lane, since it only reads the source."""
+    body = _hip_branch_source()
+
+    assigned = [
+        node.value
+        for node in ast.walk(ast.Module(body = body, type_ignores = []))
+        if isinstance(node, ast.Assign)
+        and any(getattr(t, "id", None) == "SUPPORTS_BFLOAT16" for t in node.targets)
+    ]
+    assert assigned, "the HIP branch no longer sets SUPPORTS_BFLOAT16"
+    assert not any(
+        isinstance(value, ast.Constant) and value.value is True for value in assigned
+    ), (
+        "the HIP branch hardcodes bf16 support again, so an RDNA 1/2 card gets "
+        "bfloat16 offload buffers and dies in the Triton bf16 dot intrinsic"
+    )
+    assert any(isinstance(value, ast.Call) for value in assigned), (
+        "the HIP branch does not call anything, so it cannot be asking"
+    )
+
+
+def test_the_probe_is_called_with_no_arguments():
+    """`unsloth` replaces this probe, and replacements differ in signature.
+
+    `unsloth/_gpu_init.py` installs one wrapper taking `including_emulation` and
+    another taking nothing, choosing by inspecting the original. Calling with no
+    arguments is the only form both accept.
+    """
+    calls = []
+    dtype = _run_hip_branch(lambda *args, **kwargs: calls.append((args, kwargs)) or True)
+    if dtype is None:
+        pytest.skip("needs a device to allocate the buffers")
+    assert calls and calls[0] == ((), {}), f"the probe was called as {calls[:1]}"
+
+
+def _run_hip_branch(probe):
+    """Drive the real initializer down its HIP branch; None if no device."""
+    if not torch.cuda.is_available():
+        return None
+    old_device_type = gc.DEVICE_TYPE
+    old_probe = torch.cuda.is_bf16_supported
+    gc.DEVICE_TYPE = "hip"
+    torch.cuda.is_bf16_supported = probe
+    try:
+        gc.CPU_BUFFERS = []
+        gc.initialize_unsloth_gradient_checkpointing()
+        return gc.CPU_BUFFERS[0].dtype
+    finally:
+        gc.DEVICE_TYPE = old_device_type
+        torch.cuda.is_bf16_supported = old_probe
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "allocates real device buffers")
+def test_a_stock_rocm_host_still_gets_bfloat16():
+    """The inertness claim, which is what makes this safe to merge alone.
+
+    `torch.cuda.is_bf16_supported` short-circuits to True on `torch.version.hip`
+    before any architecture check, so this is what every AMD host sees today.
+    """
+    assert _run_hip_branch(lambda *args, **kwargs: True) is torch.bfloat16, (
+        "an unpatched AMD host no longer gets bfloat16, so this change is not "
+        "inert and it moves the dtype under every current ROCm user"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "allocates real device buffers")
+def test_a_patched_probe_saying_no_gets_float16():
+    """The case the change exists for: gfx101x/gfx103x, once #7682 lands."""
+    assert _run_hip_branch(lambda *args, **kwargs: False) is torch.float16, (
+        "the offload buffers are still bfloat16 on a card that cannot do bf16"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "allocates real device buffers")
+def test_cuda_still_decides_on_compute_capability_not_the_probe():
+    """The other vendors must not move. CUDA reads the capability directly."""
+    old_device_type = gc.DEVICE_TYPE
+    old_probe = torch.cuda.is_bf16_supported
+    gc.DEVICE_TYPE = "cuda"
+    # A probe that would flip the answer if CUDA ever started consulting it.
+    torch.cuda.is_bf16_supported = lambda *args, **kwargs: False
+    try:
+        gc.CPU_BUFFERS = []
+        gc.initialize_unsloth_gradient_checkpointing()
+        got = gc.CPU_BUFFERS[0].dtype
+    finally:
+        gc.DEVICE_TYPE = old_device_type
+        torch.cuda.is_bf16_supported = old_probe
+
+    major, _ = torch.cuda.get_device_capability()
+    expected = torch.bfloat16 if major >= 8 else torch.float16
+    assert got is expected, (
+        f"CUDA picked {got} on a compute-capability {major}.x card; the HIP "
+        "change has leaked into the NVIDIA path"
+    )

--- a/tests/test_hip_bf16_offload_dtype.py
+++ b/tests/test_hip_bf16_offload_dtype.py
@@ -23,6 +23,11 @@ the process dies with no Python exception (unslothai/unsloth issue 7922).
 Inert until unslothai/unsloth#7682 lands, because `is_bf16_supported` returns
 True for `torch.version.hip` BEFORE any architecture check -- so a test proving
 only "float16 now" would prove a regression for every current ROCm user.
+
+Runs on a CPU runner. `device_count` is stubbed to 0, which is what makes that
+possible: the function then allocates no device buffer, no stream and no event,
+so only the dtype decision is left. Skipping on CPU would leave the decision
+unexecuted everywhere, since no job here has an AMD runner.
 """
 import ast
 import inspect
@@ -32,6 +37,8 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from unsloth_zoo import gradient_checkpointing as gc
+
+_MISSING = object()
 
 
 def _hip_branch_source():
@@ -71,66 +78,92 @@ def test_the_hip_branch_asks_rather_than_hardcoding_true():
     )
 
 
-def test_the_probe_is_called_with_no_arguments():
-    """`_gpu_init.py` installs two wrappers; no-args is the only form both accept."""
-    calls = []
-    dtype = _run_hip_branch(lambda *args, **kwargs: calls.append((args, kwargs)) or True)
-    if dtype is None:
-        pytest.skip("needs a device to allocate the buffers")
-    assert calls and calls[0] == ((), {}), f"the probe was called as {calls[:1]}"
+def _globals_the_init_writes():
+    """Read the `global` declarations rather than listing them, so the restore
+    below cannot fall behind a new one."""
+    tree = ast.parse(inspect.getsource(gc.initialize_unsloth_gradient_checkpointing).lstrip())
+    return sorted(
+        {name for node in ast.walk(tree) if isinstance(node, ast.Global) for name in node.names}
+    )
 
 
-def _run_hip_branch(probe):
-    if not torch.cuda.is_available():
-        return None
-    old_device_type = gc.DEVICE_TYPE
-    old_probe = torch.cuda.is_bf16_supported
-    gc.DEVICE_TYPE = "hip"
-    torch.cuda.is_bf16_supported = probe
-    try:
+@pytest.fixture
+def run_init(monkeypatch):
+    """Drive the real function on a CPU box and hand back the buffer dtype.
+
+    `pin_memory = True` needs a CUDA context, so `torch.empty` is unwrapped rather
+    than reimplemented: same call, minus the pin, and the dtype under test is
+    still the module's own choice rather than the test's.
+
+    Every module global the call writes is restored afterwards. The gate runs this
+    file in one process with thirty others, and `USE_UNSLOTH_GC = True` plus 200
+    pinned-buffer stand-ins left behind would follow them.
+    """
+    real_empty = torch.empty
+    saved = {name: getattr(gc, name, _MISSING) for name in _globals_the_init_writes()}
+
+    def empty(*args, **kwargs):
+        kwargs.pop("pin_memory", None)
+        kwargs["device"] = "cpu"
+        return real_empty(*args, **kwargs)
+
+    def run(device_type, probe, capability = (8, 0)):
+        monkeypatch.setenv("UNSLOTH_DISABLE_DOUBLE_BUFFER", "1")
+        monkeypatch.setattr(torch, "empty", empty)
+        monkeypatch.setattr(torch.cuda, "device_count", lambda: 0)
+        monkeypatch.setattr(torch.cuda, "is_bf16_supported", probe)
+        monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: capability)
+        monkeypatch.setattr(gc, "DEVICE_TYPE", device_type)
+        monkeypatch.setattr(gc, "DEVICE_TYPE_TORCH", "cuda")
         gc.CPU_BUFFERS = []
         gc.initialize_unsloth_gradient_checkpointing()
         return gc.CPU_BUFFERS[0].dtype
-    finally:
-        gc.DEVICE_TYPE = old_device_type
-        torch.cuda.is_bf16_supported = old_probe
+
+    yield run
+
+    for name, value in saved.items():
+        if value is _MISSING:
+            delattr(gc, name)
+        else:
+            setattr(gc, name, value)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason = "allocates real device buffers")
-def test_a_stock_rocm_host_still_gets_bfloat16():
+def test_the_probe_is_called_with_no_arguments(run_init):
+    """`_gpu_init.py` installs two wrappers; no-args is the only form both accept."""
+    calls = []
+    run_init("hip", lambda *args, **kwargs: calls.append((args, kwargs)) or True)
+    assert calls and calls[0] == ((), {}), f"the probe was called as {calls[:1]}"
+
+
+def test_a_stock_rocm_host_still_gets_bfloat16(run_init):
     """The inertness claim, which is what makes this safe to merge alone."""
-    assert _run_hip_branch(lambda *args, **kwargs: True) is torch.bfloat16, (
+    assert run_init("hip", lambda *a, **k: True) is torch.bfloat16, (
         "an unpatched AMD host no longer gets bfloat16, so this change is not "
         "inert and it moves the dtype under every current ROCm user"
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason = "allocates real device buffers")
-def test_a_patched_probe_saying_no_gets_float16():
-    assert _run_hip_branch(lambda *args, **kwargs: False) is torch.float16, (
+def test_a_patched_probe_saying_no_gets_float16(run_init):
+    assert run_init("hip", lambda *a, **k: False) is torch.float16, (
         "the offload buffers are still bfloat16 on a card that cannot do bf16"
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason = "allocates real device buffers")
-def test_cuda_still_decides_on_compute_capability_not_the_probe():
-    """The other vendors must not move."""
-    old_device_type = gc.DEVICE_TYPE
-    old_probe = torch.cuda.is_bf16_supported
-    gc.DEVICE_TYPE = "cuda"
-    # A probe that would flip the answer if CUDA ever started consulting it.
-    torch.cuda.is_bf16_supported = lambda *args, **kwargs: False
-    try:
-        gc.CPU_BUFFERS = []
-        gc.initialize_unsloth_gradient_checkpointing()
-        got = gc.CPU_BUFFERS[0].dtype
-    finally:
-        gc.DEVICE_TYPE = old_device_type
-        torch.cuda.is_bf16_supported = old_probe
-
-    major, _ = torch.cuda.get_device_capability()
-    expected = torch.bfloat16 if major >= 8 else torch.float16
+@pytest.mark.parametrize(
+    "capability,expected",
+    [((8, 0), torch.bfloat16), ((7, 5), torch.float16)],
+)
+def test_cuda_still_decides_on_compute_capability_not_the_probe(
+    run_init, capability, expected
+):
+    """The other vendors must not move. The probe answers the opposite of the
+    capability in both rows, so a CUDA branch that started consulting it fails."""
+    got = run_init("cuda", lambda *a, **k: capability[0] < 8, capability = capability)
     assert got is expected, (
-        f"CUDA picked {got} on a compute-capability {major}.x card; the HIP "
-        "change has leaked into the NVIDIA path"
+        f"CUDA picked {got} on a compute-capability {capability[0]}.x card; the "
+        "HIP change has leaked into the NVIDIA path"
     )
+
+
+def test_xpu_is_untouched(run_init):
+    assert run_init("xpu", lambda *a, **k: False) is torch.bfloat16

--- a/tests/test_hip_bf16_offload_dtype.py
+++ b/tests/test_hip_bf16_offload_dtype.py
@@ -16,29 +16,14 @@
 
 """The HIP branch of ``initialize_unsloth_gradient_checkpointing`` must ASK.
 
-It used to read ``SUPPORTS_BFLOAT16 = True`` and pin the CPU offload buffers in
-bfloat16 on every AMD host. RDNA 1 and 2 (gfx101x, gfx103x) have no native bf16
-arithmetic: Triton selects ``llvm.amdgcn.fdot2.bf16.bf16``, LLVM cannot lower it
-for the target, and the process dies with no Python exception, which reaches the
-user as "Training process exited unexpectedly" at step 0
-(unslothai/unsloth issue 7922, an RX 6600 XT / gfx1032).
+Hardcoded True pins the offload buffers to bfloat16 on every AMD host, and RDNA
+1/2 have no native bf16: LLVM cannot lower the dot intrinsic Triton picks and
+the process dies with no Python exception (unslothai/unsloth issue 7922).
 
-Two things this file has to keep straight, because they pull in opposite
-directions:
-
-* On a stock ROCm install the change is **inert**. ``torch.cuda.is_bf16_supported``
-  returns True for ``torch.version.hip`` before it looks at the architecture at
-  all, so an AMD user without unslothai/unsloth#7682 keeps bfloat16 exactly as
-  before. A test that only proved "float16 now" would be proving a regression
-  for every current AMD user.
-* Once that PR patches the probe process-wide, this line inherits the same
-  answer as every other bf16 decision instead of disagreeing with them.
-
-``DEVICE_TYPE_TORCH`` maps "hip" to "cuda", so the HIP branch can be driven on
-an NVIDIA box by spoofing one module global, and the buffers it allocates are
-real ones.
+Inert until unslothai/unsloth#7682 lands, because `is_bf16_supported` returns
+True for `torch.version.hip` BEFORE any architecture check -- so a test proving
+only "float16 now" would prove a regression for every current ROCm user.
 """
-
 import ast
 import inspect
 
@@ -50,7 +35,6 @@ from unsloth_zoo import gradient_checkpointing as gc
 
 
 def _hip_branch_source():
-    """The body of the `elif DEVICE_TYPE == "hip"` arm, as source."""
     tree = ast.parse(inspect.getsource(gc.initialize_unsloth_gradient_checkpointing).lstrip())
     for node in ast.walk(tree):
         if not isinstance(node, ast.If):
@@ -67,7 +51,6 @@ def _hip_branch_source():
 
 
 def test_the_hip_branch_asks_rather_than_hardcoding_true():
-    """Runs anywhere, including the CPU lane, since it only reads the source."""
     body = _hip_branch_source()
 
     assigned = [
@@ -89,12 +72,7 @@ def test_the_hip_branch_asks_rather_than_hardcoding_true():
 
 
 def test_the_probe_is_called_with_no_arguments():
-    """`unsloth` replaces this probe, and replacements differ in signature.
-
-    `unsloth/_gpu_init.py` installs one wrapper taking `including_emulation` and
-    another taking nothing, choosing by inspecting the original. Calling with no
-    arguments is the only form both accept.
-    """
+    """`_gpu_init.py` installs two wrappers; no-args is the only form both accept."""
     calls = []
     dtype = _run_hip_branch(lambda *args, **kwargs: calls.append((args, kwargs)) or True)
     if dtype is None:
@@ -103,7 +81,6 @@ def test_the_probe_is_called_with_no_arguments():
 
 
 def _run_hip_branch(probe):
-    """Drive the real initializer down its HIP branch; None if no device."""
     if not torch.cuda.is_available():
         return None
     old_device_type = gc.DEVICE_TYPE
@@ -121,11 +98,7 @@ def _run_hip_branch(probe):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "allocates real device buffers")
 def test_a_stock_rocm_host_still_gets_bfloat16():
-    """The inertness claim, which is what makes this safe to merge alone.
-
-    `torch.cuda.is_bf16_supported` short-circuits to True on `torch.version.hip`
-    before any architecture check, so this is what every AMD host sees today.
-    """
+    """The inertness claim, which is what makes this safe to merge alone."""
     assert _run_hip_branch(lambda *args, **kwargs: True) is torch.bfloat16, (
         "an unpatched AMD host no longer gets bfloat16, so this change is not "
         "inert and it moves the dtype under every current ROCm user"
@@ -134,7 +107,6 @@ def test_a_stock_rocm_host_still_gets_bfloat16():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "allocates real device buffers")
 def test_a_patched_probe_saying_no_gets_float16():
-    """The case the change exists for: gfx101x/gfx103x, once #7682 lands."""
     assert _run_hip_branch(lambda *args, **kwargs: False) is torch.float16, (
         "the offload buffers are still bfloat16 on a card that cannot do bf16"
     )
@@ -142,7 +114,7 @@ def test_a_patched_probe_saying_no_gets_float16():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "allocates real device buffers")
 def test_cuda_still_decides_on_compute_capability_not_the_probe():
-    """The other vendors must not move. CUDA reads the capability directly."""
+    """The other vendors must not move."""
     old_device_type = gc.DEVICE_TYPE
     old_probe = torch.cuda.is_bf16_supported
     gc.DEVICE_TYPE = "cuda"

--- a/tests/test_hip_bf16_offload_dtype.py
+++ b/tests/test_hip_bf16_offload_dtype.py
@@ -24,10 +24,9 @@ Inert until unslothai/unsloth#7682 lands, because `is_bf16_supported` returns
 True for `torch.version.hip` BEFORE any architecture check -- so a test proving
 only "float16 now" would prove a regression for every current ROCm user.
 
-Runs on a CPU runner. `device_count` is stubbed to 0, which is what makes that
-possible: the function then allocates no device buffer, no stream and no event,
-so only the dtype decision is left. Skipping on CPU would leave the decision
-unexecuted everywhere, since no job here has an AMD runner.
+Runs on a CPU runner, since no job here has an AMD one and skipping would leave
+the decision unexecuted everywhere. Stubbing `device_count` to 0 is what makes
+that work: no device buffer, no stream and no event, so only the dtype is left.
 """
 import ast
 import inspect
@@ -79,8 +78,7 @@ def test_the_hip_branch_asks_rather_than_hardcoding_true():
 
 
 def _globals_the_init_writes():
-    """Read the `global` declarations rather than listing them, so the restore
-    below cannot fall behind a new one."""
+    """Read rather than list them, so the restore cannot fall behind a new one."""
     tree = ast.parse(inspect.getsource(gc.initialize_unsloth_gradient_checkpointing).lstrip())
     return sorted(
         {name for node in ast.walk(tree) if isinstance(node, ast.Global) for name in node.names}
@@ -91,13 +89,10 @@ def _globals_the_init_writes():
 def run_init(monkeypatch):
     """Drive the real function on a CPU box and hand back the buffer dtype.
 
-    `pin_memory = True` needs a CUDA context, so `torch.empty` is unwrapped rather
-    than reimplemented: same call, minus the pin, and the dtype under test is
-    still the module's own choice rather than the test's.
-
-    Every module global the call writes is restored afterwards. The gate runs this
-    file in one process with thirty others, and `USE_UNSLOTH_GC = True` plus 200
-    pinned-buffer stand-ins left behind would follow them.
+    `torch.empty` is unwrapped, not reimplemented -- same call minus the pin,
+    which needs a CUDA context -- so the dtype is still the module's own choice.
+    Every global the call writes is restored: the gate runs this file in one
+    process with thirty others, and `USE_UNSLOTH_GC = True` would follow them.
     """
     real_empty = torch.empty
     saved = {name: getattr(gc, name, _MISSING) for name in _globals_the_init_writes()}
@@ -156,8 +151,8 @@ def test_a_patched_probe_saying_no_gets_float16(run_init):
 def test_cuda_still_decides_on_compute_capability_not_the_probe(
     run_init, capability, expected
 ):
-    """The other vendors must not move. The probe answers the opposite of the
-    capability in both rows, so a CUDA branch that started consulting it fails."""
+    """The probe answers the opposite of the capability in both rows, so a CUDA
+    branch that started consulting it fails."""
     got = run_init("cuda", lambda *a, **k: capability[0] < 8, capability = capability)
     assert got is expected, (
         f"CUDA picked {got} on a compute-capability {capability[0]}.x card; the "

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -628,7 +628,13 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
             major_version, minor_version = torch.cuda.get_device_capability()
             SUPPORTS_BFLOAT16 = (major_version >= 8)
         elif DEVICE_TYPE == "hip":
-            SUPPORTS_BFLOAT16 = True
+            # Ask rather than assume. RDNA 1 and 2 (gfx101x, gfx103x) have no native
+            # bf16 arithmetic, and Triton then selects a bf16 dot intrinsic LLVM cannot
+            # lower for the target, killing the process with no Python exception (see
+            # unslothai/unsloth issue 7922). Unsloth patches this probe on HIP so every
+            # caller gets one answer; unpatched, ROCm still answers True here, which is
+            # exactly the behaviour this line had before.
+            SUPPORTS_BFLOAT16 = torch.cuda.is_bf16_supported()
         elif DEVICE_TYPE == "xpu":
             SUPPORTS_BFLOAT16 = True
         dtype = torch.bfloat16 if SUPPORTS_BFLOAT16 else torch.float16

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -628,12 +628,10 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
             major_version, minor_version = torch.cuda.get_device_capability()
             SUPPORTS_BFLOAT16 = (major_version >= 8)
         elif DEVICE_TYPE == "hip":
-            # Ask rather than assume. RDNA 1 and 2 (gfx101x, gfx103x) have no native
-            # bf16 arithmetic, and Triton then selects a bf16 dot intrinsic LLVM cannot
-            # lower for the target, killing the process with no Python exception (see
-            # unslothai/unsloth issue 7922). Unsloth patches this probe on HIP so every
-            # caller gets one answer; unpatched, ROCm still answers True here, which is
-            # exactly the behaviour this line had before.
+            # Ask rather than assume: RDNA 1/2 (gfx101x, gfx103x) have no native bf16,
+            # so Triton picks a dot intrinsic LLVM cannot lower and the process dies
+            # with no Python exception (unslothai/unsloth issue 7922). Unpatched ROCm
+            # still answers True here, so this is inert until unsloth patches the probe.
             SUPPORTS_BFLOAT16 = torch.cuda.is_bf16_supported()
         elif DEVICE_TYPE == "xpu":
             SUPPORTS_BFLOAT16 = True


### PR DESCRIPTION
Companion to unslothai/unsloth#7682, which is incomplete without it.

## Problem

`gradient_checkpointing.py` hardcodes `SUPPORTS_BFLOAT16 = True` on HIP and pins its CPU offload buffers in bfloat16 on every AMD host:

```python
elif DEVICE_TYPE == "hip":
    SUPPORTS_BFLOAT16 = True
...
dtype = torch.bfloat16 if SUPPORTS_BFLOAT16 else torch.float16
```

RDNA 1 and 2 (gfx101x, gfx103x) have no native bf16 arithmetic. Triton selects `llvm.amdgcn.fdot2.bf16.bf16`, LLVM cannot lower it for the target, and the process dies before Python sees an exception. The user gets "Training process exited unexpectedly" at step 0. Reported in unslothai/unsloth#7922 on an RX 6600 XT (gfx1032).

unslothai/unsloth#7682 fixes the model dtype selection by reading `gcnArchName` and patching `torch.cuda.is_bf16_supported()` on HIP. It does not reach this line, because this one never asks. I found it while validating that PR on a real AMD gfx1151 runner, and grepping both repos afterwards this was the last place still deciding bf16 for AMD without asking.

## Fix

```python
SUPPORTS_BFLOAT16 = torch.cuda.is_bf16_supported()
```

## Compatibility

Deliberately the smallest possible change, and inert on its own.

- On ROCm, `torch.cuda.is_bf16_supported()` answers `True` regardless of arch, so with this commit alone every AMD host behaves exactly as it does today. Nothing regresses if #7682 never lands.
- It matters once #7682 does land, because that PR patches this probe process-wide, so this line then inherits the same answer as every other bf16 decision instead of disagreeing with them.
- Used standalone without unsloth, unchanged.
- The CUDA and XPU branches are untouched.

## Scope

One line plus a comment. I left the CUDA branch on its `get_device_capability()` check rather than unifying the three, since that is a bigger change than this needs and is not what the crash is about.
