### PR TITLE
Fix the two mlx cross-file pollution failures under xdist

### DIFF
--- a/tests/mlx_simulation/__init__.py
+++ b/tests/mlx_simulation/__init__.py
@@ -124,3 +124,22 @@ def _spoof_apple_silicon_platform():
     if not hasattr(platform, "_orig_machine_for_mlx_shim"):
         platform._orig_machine_for_mlx_shim = platform.machine
         platform.machine = _scoped(platform._orig_machine_for_mlx_shim, "arm64")
+
+
+def mlx_is_simulated() -> bool:
+    """True when the ``mlx`` in ``sys.modules`` is this shim rather than a real one.
+
+    ``simulate_mlx_on_torch`` installs process-wide, and one test module calls it
+    while being IMPORTED. Collection imports every module in the session, so a
+    later module's ``import mlx`` can succeed against the shim without that module
+    ever having asked for it -- and whether it does depends on collection order,
+    which under ``-n N --dist loadfile`` is not stable. A test that needs real mlx
+    semantics must ask this, not just whether the import worked.
+    """
+    import sys
+
+    module = sys.modules.get("mlx.core") or sys.modules.get("mlx")
+    if module is None:
+        return False
+    origin = f"{getattr(module, '__name__', '')} {getattr(module, '__file__', '') or ''}"
+    return "mlx_simulation" in origin

--- a/tests/test_mlx_neftune_quant_map.py
+++ b/tests/test_mlx_neftune_quant_map.py
@@ -18,15 +18,24 @@ import pytest
 
 try:
     import mlx.core as mx
-    _MLX = True
-    _METAL = mx.metal.is_available()
+    from mlx_simulation import mlx_is_simulated
+
+    # Not `True` on a successful import: another test module installs the
+    # MLX-on-torch shim into sys.modules while being IMPORTED, and collection
+    # imports every module, so `import mlx` here lands on that shim whenever
+    # collection reaches the other file first. These tests need real mlx --
+    # nn.RMSNorm, Module.train/_set_training_mode, a rewindable RNG key -- none
+    # of which the shim implements, so gating on the import alone made the file
+    # pass or fail on collection order (stable serially, not under xdist).
+    _MLX = not mlx_is_simulated()
+    _METAL = _MLX and mx.metal.is_available()
 except Exception:
     _MLX = _METAL = False
 
 metal_only = pytest.mark.skipif(not _METAL, reason="requires Apple Silicon Metal")
 # Identification, scale resolution and cleanup are pure logic over a synthetic
-# tree: real mlx, no Metal, no downloads, so they gate the Linux job too.
-mlx_only = pytest.mark.skipif(not _MLX, reason="requires the mlx runtime")
+# tree: real mlx, no Metal, no downloads, so they gate any host with mlx installed.
+mlx_only = pytest.mark.skipif(not _MLX, reason="requires the real mlx runtime")
 
 # mlx 0.32 made mx.random.state a sentinel refusing item assignment, so tests
 # rewind through the same reseed pair the production code uses.

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -12,10 +12,24 @@ import pytest
 @pytest.fixture(autouse=True, scope="module")
 def _install_shim():
     prefixes = ("mlx", "mlx_lm", "mlx_vlm")
+
+    def _owned(name):
+        return (
+            name == "unsloth_zoo.mlx" or name.startswith("unsloth_zoo.mlx.")
+            or any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
+        )
+
+    # The unsloth_zoo.mlx.* entries are saved as well as the mlx* ones, because
+    # this fixture drops them and the next importer therefore builds a NEW module
+    # object. Anything that ran earlier in this process and did
+    # `from unsloth_zoo.mlx.utils import ...` at import time keeps the OLD one, so
+    # it and the code under test end up on two copies of the same module globals:
+    # the training window one opens is invisible to the other, and a gated-delta
+    # op quietly takes the cached path instead of the VJP. Serially that never
+    # happens (alphabetical order puts this file last of the pair); under
+    # `-n N --dist loadfile` it depends on which worker draws which file.
     real_modules = {
-        name: module
-        for name, module in sys.modules.items()
-        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
+        name: module for name, module in sys.modules.items() if _owned(name)
     }
     from mlx_simulation import simulate_mlx_on_torch
     from mlx_simulation.mlx_stub import _MLXFinder
@@ -25,10 +39,7 @@ def _install_shim():
             sys.modules.pop(name, None)
     yield
     for name in list(sys.modules):
-        if (
-            name == "unsloth_zoo.mlx" or name.startswith("unsloth_zoo.mlx.")
-            or any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
-        ):
+        if _owned(name):
             sys.modules.pop(name, None)
     sys.meta_path[:] = [
         finder for finder in sys.meta_path if not isinstance(finder, _MLXFinder)

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -35,10 +35,23 @@ import torch
 def _install_shim():
     import sys
     shim_prefixes = ("mlx", "mlx_lm", "mlx_vlm")
+    def _owned(name):
+        return (
+            name == "unsloth_zoo.mlx" or name.startswith("unsloth_zoo.mlx.")
+            or any(name == prefix or name.startswith(f"{prefix}.") for prefix in shim_prefixes)
+        )
+
+    # The unsloth_zoo.mlx.* entries are saved as well as the mlx* ones, because
+    # this fixture drops them and the next importer therefore builds a NEW module
+    # object. Anything that ran earlier in this process and did
+    # `from unsloth_zoo.mlx.utils import ...` at import time keeps the OLD one, so
+    # it and the code under test end up on two copies of the same module globals:
+    # the training window one opens is invisible to the other, and a gated-delta
+    # op quietly takes the cached path instead of the VJP. Serially that never
+    # happens (alphabetical order puts this file after the pair it would break);
+    # under `-n N --dist loadfile` it depends on which worker draws which file.
     real_mlx_modules = {
-        name: module
-        for name, module in sys.modules.items()
-        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in shim_prefixes)
+        name: module for name, module in sys.modules.items() if _owned(name)
     }
     from mlx_simulation import simulate_mlx_on_torch
     from mlx_simulation.mlx_stub import _MLXFinder
@@ -48,10 +61,7 @@ def _install_shim():
             sys.modules.pop(name, None)
     yield
     for name in list(sys.modules):
-        if (
-            name == "unsloth_zoo.mlx" or name.startswith("unsloth_zoo.mlx.")
-            or any(name == prefix or name.startswith(f"{prefix}.") for prefix in shim_prefixes)
-        ):
+        if _owned(name):
             sys.modules.pop(name, None)
     sys.meta_path[:] = [
         finder for finder in sys.meta_path


### PR DESCRIPTION
These are the 11 failures `unslothai/unsloth`'s Core job reports against zoo main, on every open PR there. Both are ordering bugs: invisible serially, because alphabetical order happens to hide each one, and live under `-n 4 --dist loadfile`, where worker assignment decides.

This is the cross-file pollution the unsloth workflow already documents and mitigates for three other files by giving them their own process. These two are fixed at the source instead.

### 1. `test_mlx_neftune_quant_map.py`, 9 failures

The file gates its tests on `import mlx.core` succeeding. `test_mlx_gated_delta_vjp.py` calls `simulate_mlx_on_torch()` while being **imported**, and collection imports every module in the session, so when collection reaches that file first the gate lands on the shim rather than on mlx.

These tests need real mlx: `nn.RMSNorm`, `Module.train` / `_set_training_mode`, and a rewindable RNG key, none of which the shim implements. The file says so itself, in `test_probe_survives_the_backends_own_random_state`:

```
assert key is not None, "this mlx exposes no rewindable key; the probe cannot be checked"
```

So the answer is to skip, not to grow the shim to fake a runtime these tests are written against.

Adds `mlx_simulation.mlx_is_simulated()` and gates on real mlx. The file now behaves the same whatever ran before it, which is what it already does when run on its own.

Repro, deterministic:

```
pytest tests/test_mlx_gated_delta_vjp.py tests/test_mlx_neftune_quant_map.py
```

### 2. `test_shared_patch_rebinds_consumers_and_forwards_lower_bound`, 2 failures

`test_mlx_preference.py` and `test_mlx_trainer_internals.py` both pop every `unsloth_zoo.mlx.*` module out of `sys.modules`. Unlike the `mlx*` ones, which they save into `real_modules` and restore, these are never put back. The next importer therefore builds a **new** module object, and any file that ran earlier and did `from unsloth_zoo.mlx.utils import ...` at import time is left holding the old one.

`gated_delta_vjp._is_training_call` resolves `mlx_training_patches_active` through `sys.modules` on every call, which is deliberate:

```python
# Lazy: this runs once per layer per decode step, so a pure-inference process
# should not import `unsloth_zoo.mlx.utils` until a call site is ambiguous.
from unsloth_zoo.mlx.utils import mlx_training_patches_active
```

So the test and the code under test end up on two copies of the same module globals, each with its own `_MLX_TRAINING_ACTIVE_DEPTH` ContextVar. The training window the test opens is invisible to the code, and the op quietly takes the cached path instead of the VJP:

```
E  AssertionError: assert ('cached', None) == 'vjp'
```

Confirmed directly: at the failing assertion the test's own `mlx_training_patches_active()` reports `True` while a freshly imported one reports `False`, and the two functions' `__globals__` are different dicts.

Both fixtures now save and restore `unsloth_zoo.mlx.*` alongside `mlx*`, which is what their existing `real_modules` handling already does for the other half.

Repro, deterministic:

```
pytest tests/test_mlx_preference.py tests/test_mlx_gated_delta_vjp.py
pytest tests/test_mlx_trainer_internals.py tests/test_mlx_gated_delta_vjp.py
```

### Verification

Run as unsloth's Core job runs it, `-n 4 --dist loadfile` with the same ignores and deselects: **14 failures before, 5 after**. All 11 mlx failures are gone.

The remaining 5 (`test_moe_lora_grouped_mm_capability`, 4 in `test_rl_replacements_compile_disable`) fail on this box with or without these changes and are not in the set CI reports. They come from the local torch / trl versions and a visible GPU, not from anything here.
