### PR TITLE
Do not report unsloth's own bitsandbytes stub as a test module leak

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,6 +328,22 @@ def _is_module_stub(mod):
     return mod is not None and getattr(mod, "__file__", None) is None
 
 
+def _is_unsloth_bnb_stub(mod):
+    """Whether this is the bitsandbytes stub `import unsloth_zoo` installs for itself.
+
+    `unsloth_zoo/__init__.py` calls `bitsandbytes_stub.inject_into_sys_modules()` when no
+    real bitsandbytes is installed, and `_BnbFinder` then builds each submodule on demand
+    with this spec origin. That is the package behaving as designed on a host without the
+    real one, not a test substituting a module, and unlike the partial substitute this
+    guard was written for it answers every attribute rather than a chosen few.
+
+    The parent `bitsandbytes` already escapes the check below because the stub module has
+    a `__file__` of its own; its submodules are bare ModuleType and do not, which is the
+    only reason the first test to import unsloth_zoo was reported as a leak.
+    """
+    return getattr(getattr(mod, "__spec__", None), "origin", None) == "bitsandbytes_stub"
+
+
 def pytest_runtest_setup(item):
     import sys as _sys
 
@@ -364,10 +380,12 @@ def pytest_runtest_teardown(item, nextitem):
             if _is_from_pytest_tmp(now):
                 leaked.append(name)
             continue
-        if was is None and not _is_module_stub(now):
-            # Nothing was there and the test imported the real thing. That is an
-            # import, not a swap, and flagging it would fail every test that touches
-            # the package.
+        if was is None and (not _is_module_stub(now) or _is_unsloth_bnb_stub(now)):
+            # Nothing was there, and the test either imported the real thing or merely
+            # imported unsloth_zoo, which installs its own bitsandbytes stub. Both are
+            # imports rather than swaps, and flagging either would fail every test that
+            # touches the package. A real module replaced by the stub is still a swap and
+            # still reported, because `was` is not None there.
             continue
         leaked.append(name)
     if leaked:

--- a/tests/test_module_leak_guard.py
+++ b/tests/test_module_leak_guard.py
@@ -1,0 +1,107 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""What the sys.modules leak guard in conftest must and must not report."""
+
+import sys
+from importlib.machinery import ModuleSpec
+from types import ModuleType
+
+import pytest
+
+import conftest
+
+
+class _Item:
+    """The one attribute the hooks read off a pytest item."""
+
+    nodeid = "tests/test_fake.py::test_fake"
+
+
+def _apply(entries):
+    for name, module in entries.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+def _run_guard(before, after):
+    """Run the guard over a test that started with `before` and left `after` behind.
+
+    Both states are set explicitly rather than inherited, because by the time this file
+    runs another test may already have imported unsloth_zoo and put the stub in place.
+    """
+    saved = {name: sys.modules.get(name) for name in conftest._GUARDED_MODULES}
+    item = _Item()
+    try:
+        _apply(before)
+        conftest.pytest_runtest_setup(item)
+        _apply(after)
+        conftest.pytest_runtest_teardown(item, None)
+    finally:
+        _apply(saved)
+
+
+def _unsloth_stub(name):
+    """What `_BnbFinder` builds: a bare module carrying the stub's spec origin."""
+    module = ModuleType(name)
+    module.__spec__ = ModuleSpec(name, None, origin = "bitsandbytes_stub")
+    return module
+
+
+def _partial_stub(name):
+    """The shape that motivated the guard: a bare module carrying one chosen symbol."""
+    module = ModuleType(name)
+    module.dequantize_4bit = lambda *args, **kwargs: None
+    return module
+
+
+def _real_module(name):
+    module = ModuleType(name)
+    module.__file__ = "/somewhere/%s/__init__.py" % name.replace(".", "/")
+    return module
+
+
+@pytest.mark.parametrize("name", ["bitsandbytes.nn", "bitsandbytes.functional"])
+def test_unsloth_bitsandbytes_stub_is_not_a_leak(name):
+    # `import unsloth_zoo` installs this itself on a host with no real bitsandbytes, so
+    # the first test to import the package was reported as having swapped a module out.
+    _run_guard({name: None}, {name: _unsloth_stub(name)})
+
+
+def test_importing_the_real_package_is_not_a_leak():
+    _run_guard({"bitsandbytes.nn": None}, {"bitsandbytes.nn": _real_module("bitsandbytes.nn")})
+
+
+def test_a_partial_substitute_is_still_a_leak():
+    # test_vllm_to_hf_conversion left a bitsandbytes.functional carrying only
+    # dequantize_4bit, and every later `from bitsandbytes.functional import QuantState`
+    # failed. That is the case this guard exists for.
+    with pytest.raises(AssertionError, match = "bitsandbytes.functional"):
+        _run_guard(
+            {"bitsandbytes.functional": None},
+            {"bitsandbytes.functional": _partial_stub("bitsandbytes.functional")},
+        )
+
+
+def test_replacing_a_module_that_was_there_is_still_a_leak():
+    # Even by the unsloth stub: nothing installs it over a real bitsandbytes, so a test
+    # is the only thing that could have.
+    with pytest.raises(AssertionError, match = "bitsandbytes.nn"):
+        _run_guard(
+            {"bitsandbytes.nn": _real_module("bitsandbytes.nn")},
+            {"bitsandbytes.nn": _unsloth_stub("bitsandbytes.nn")},
+        )


### PR DESCRIPTION
Part of unslothai/unsloth#8138, though narrower than that issue: this is a false positive in the leak guard itself, not the shim-vs-real-mlx collision the issue is mainly about.

## What happens

`tests/conftest.py`'s `sys.modules` guard reports a leak against the **first test in a session that imports `unsloth_zoo`**, on any host where bitsandbytes is not installed. On an Apple Silicon checkout that is two tests, and the error tells them to fix something they did not do:

```
ERROR tests/test_mlx_batching_and_decay.py::test_compiler_review_guards_are_present
ERROR tests/test_extended_dep_api_pins.py::test_bnb_functional_dequantize_4bit_present

AssertionError: tests/test_mlx_batching_and_decay.py::test_compiler_review_guards_are_present
replaced ['bitsandbytes.nn'] in sys.modules and did not put it back, so every later test
in this process imports the substitute. Use monkeypatch.setitem(sys.modules, ...), which
restores on teardown.
```

Neither test mentions bitsandbytes. The first one is four `inspect.getsource` assertions; all it does is `import unsloth_zoo.compiler`.

## Why

`unsloth_zoo/__init__.py:191` calls `bitsandbytes_stub.inject_into_sys_modules()` when `real_bitsandbytes_available()` is false, and `_BnbFinder.find_spec` then builds each submodule on demand:

```
bitsandbytes             __file__=.../stubs/bitsandbytes_stub.py  origin=.../bitsandbytes_stub.py
bitsandbytes.nn          __file__=None                            origin=bitsandbytes_stub
bitsandbytes.functional  __file__=None                            origin=bitsandbytes_stub
```

`_is_module_stub` keys on `__file__`, so the parent escapes the check because the stub module is a real file on disk. Its lazily created submodules are bare `ModuleType` and do not, which is the only reason they were reported. The package installing its own stub is the same thing that happens in production on that host, not a test swapping a module out.

It matters beyond the noise: the guard raises in **teardown**, so the test itself passes and the run still reports an error, and whichever test happens to sort first wears it. Move a file and the error moves with it.

## The fix

Exempt the stub by the spec origin `_BnbFinder` sets explicitly, and only when nothing was bound before, so `was is not None` keeps the swap case reported.

This does not weaken what the guard was written for. Its own comment records the motivating case: `test_vllm_to_hf_conversion` left a `bitsandbytes.functional` carrying only `dequantize_4bit`, and every later `from bitsandbytes.functional import QuantState` failed with "(unknown location)". The unsloth stub has the opposite property, a module-level `__getattr__` that answers every name, so it cannot cause that.

## Test

`tests/test_module_leak_guard.py` drives the two hooks directly with explicit before/after `sys.modules` states, so no case depends on whether an earlier test already imported `unsloth_zoo`:

- the unsloth stub appearing where nothing was bound, for `bitsandbytes.nn` and `bitsandbytes.functional`, is not reported
- importing the real package where nothing was bound is not reported
- a partial substitute appearing where nothing was bound is still reported, which is the motivating case above
- a module that was already bound being replaced, **even by the unsloth stub**, is still reported

```
$ pytest tests/test_module_leak_guard.py -q
5 passed

# without the conftest change
FAILED tests/test_module_leak_guard.py::test_unsloth_bitsandbytes_stub_is_not_a_leak[bitsandbytes.nn]
FAILED tests/test_module_leak_guard.py::test_unsloth_bitsandbytes_stub_is_not_a_leak[bitsandbytes.functional]

$ pytest tests/test_mlx_batching_and_decay.py::test_compiler_review_guards_are_present \
         tests/test_extended_dep_api_pins.py::test_bnb_functional_dequantize_4bit_present -q
2 passed                     # before: 2 passed, 2 errors
```

Against the twelve test files that mention bitsandbytes, the failure set is identical to `main` apart from `test_bnb_functional_dequantize_4bit_present`, which stops erroring. Run on macOS arm64, Python 3.11, no bitsandbytes installed, at `52aff0d`.
