### PR TITLE
Restore parent package attributes when the mlx shim fixtures put sys.modules back

### DIFF
--- a/tests/mlx_simulation/__init__.py
+++ b/tests/mlx_simulation/__init__.py
@@ -143,3 +143,58 @@ def mlx_is_simulated() -> bool:
         return False
     origin = f"{getattr(module, '__name__', '')} {getattr(module, '__file__', '') or ''}"
     return "mlx_simulation" in origin
+
+
+def snapshot_modules(is_owned):
+    """Record every currently-imported module the caller is about to disturb."""
+    import sys
+
+    return {name: module for name, module in sys.modules.items() if is_owned(name)}
+
+
+def restore_modules(saved, is_owned):
+    """Undo a fixture's sys.modules surgery, PARENT PACKAGE ATTRIBUTES INCLUDED.
+
+    Putting the old entries back in sys.modules is only half of it. Dropping
+    `unsloth_zoo.mlx` and letting it be re-imported makes the import machinery
+    bind `unsloth_zoo.mlx = <the new module>` as an attribute on the parent
+    package, and that binding outlives the sys.modules entry that produced it.
+
+    The two then disagree, because they are read by different things:
+    `import unsloth_zoo.mlx.trainer as t` walks parent attributes, while a
+    `from unsloth_zoo.mlx.trainer import MLXTrainer` inside the code under test
+    resolves through sys.modules. A file that does both is left holding two live
+    copies of one module, and `isinstance(trainer, MLXTrainer)` is False for an
+    object the other copy built. That is not hypothetical: it is what
+    dataset_utils.train_on_responses_only does to decide whether it is looking at
+    an MLXTrainer, and it silently took the Hugging Face branch instead.
+
+    So sys.modules and the parent attributes are put back together, or the next
+    file inherits a split that only shows up under `-n N --dist loadfile`.
+    """
+    import sys
+
+    disturbed = sorted(name for name in sys.modules if is_owned(name))
+    for name in disturbed:
+        sys.modules.pop(name, None)
+    sys.modules.update(saved)
+
+    # Shortest names first so a parent is itself restored before its children are
+    # re-pointed at it.
+    for name in sorted(set(disturbed) | set(saved), key = lambda n: (n.count("."), n)):
+        parent_name, _, child = name.rpartition(".")
+        if not parent_name:
+            continue
+        parent = sys.modules.get(parent_name)
+        if parent is None:
+            continue
+        module = sys.modules.get(name)
+        if module is not None:
+            setattr(parent, child, module)
+        elif hasattr(parent, child):
+            # Imported only while the shim was up, so the attribute is a dangling
+            # reference to a module nothing can reach through sys.modules.
+            try:
+                delattr(parent, child)
+            except AttributeError:
+                pass

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -28,23 +28,23 @@ def _install_shim():
     # op quietly takes the cached path instead of the VJP. Serially that never
     # happens (alphabetical order puts this file last of the pair); under
     # `-n N --dist loadfile` it depends on which worker draws which file.
-    real_modules = {
-        name: module for name, module in sys.modules.items() if _owned(name)
-    }
-    from mlx_simulation import simulate_mlx_on_torch
+    from mlx_simulation import (
+        restore_modules,
+        simulate_mlx_on_torch,
+        snapshot_modules,
+    )
     from mlx_simulation.mlx_stub import _MLXFinder
+
+    real_modules = snapshot_modules(_owned)
     simulate_mlx_on_torch()
     for name in list(sys.modules):
         if name == "unsloth_zoo.mlx" or name.startswith("unsloth_zoo.mlx."):
             sys.modules.pop(name, None)
     yield
-    for name in list(sys.modules):
-        if _owned(name):
-            sys.modules.pop(name, None)
     sys.meta_path[:] = [
         finder for finder in sys.meta_path if not isinstance(finder, _MLXFinder)
     ]
-    sys.modules.update(real_modules)
+    restore_modules(real_modules, _owned)
 
 
 class Tokenizer:

--- a/tests/test_mlx_shim_module_restore.py
+++ b/tests/test_mlx_shim_module_restore.py
@@ -1,0 +1,134 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The mlx shim fixtures must hand the next test file an intact import graph.
+
+test_mlx_preference.py and test_mlx_trainer_internals.py drop every
+unsloth_zoo.mlx.* module so their shim is the one those modules bind against,
+then put the originals back. Restoring sys.modules alone is not enough, and the
+gap is not visible from inside the file that causes it: whoever runs next on the
+same xdist worker pays for it.
+
+#1131 restored sys.modules and stopped there. It fixed the two failures it was
+aimed at and introduced six others -- in test_pr684_review_fixes_a.py,
+test_mlx_text_path_contract.py and test_mlx_distributed_loader.py -- because
+`import unsloth_zoo.mlx.trainer as t` reads parent package attributes while a
+`from unsloth_zoo.mlx.trainer import MLXTrainer` inside the code under test
+reads sys.modules. Nothing asserted the two agreed, so the trade went unnoticed.
+This file asserts it.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+def _owned(name):
+    prefixes = ("mlx", "mlx_lm", "mlx_vlm")
+    return (
+        name == "unsloth_zoo.mlx" or name.startswith("unsloth_zoo.mlx.")
+        or any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
+    )
+
+
+def _walk_parent_attributes(name):
+    """Resolve a dotted module name the way `import a.b.c as x` does."""
+    parts = name.split(".")
+    module = sys.modules.get(parts[0])
+    for part in parts[1:]:
+        if module is None:
+            return None
+        module = getattr(module, part, None)
+    return module
+
+
+def test_restore_puts_parent_attributes_back():
+    """A drop-and-reimport cycle must leave both lookup paths on one module."""
+    from mlx_simulation import restore_modules, snapshot_modules
+
+    import unsloth_zoo.mlx.trainer  # noqa: F401
+    saved = snapshot_modules(_owned)
+    before = sys.modules["unsloth_zoo.mlx.trainer"]
+
+    for name in list(sys.modules):
+        if name == "unsloth_zoo.mlx" or name.startswith("unsloth_zoo.mlx."):
+            sys.modules.pop(name, None)
+    import unsloth_zoo.mlx.trainer  # noqa: F401,F811
+    assert sys.modules["unsloth_zoo.mlx.trainer"] is not before, (
+        "the re-import did not build a new module, so this proves nothing"
+    )
+
+    restore_modules(saved, _owned)
+
+    assert sys.modules["unsloth_zoo.mlx.trainer"] is before
+    assert _walk_parent_attributes("unsloth_zoo.mlx.trainer") is before, (
+        "parent attribute still points at the module built under the shim"
+    )
+    assert _walk_parent_attributes("unsloth_zoo.mlx") is sys.modules["unsloth_zoo.mlx"]
+
+
+def test_restore_drops_attributes_for_modules_it_cannot_restore():
+    """A submodule imported only under the shim leaves no dangling attribute.
+
+    Putting nothing back in sys.modules for it while leaving parent.child bound
+    is the same split in reverse: the attribute walk finds a module that no
+    sys.modules lookup can ever reach.
+    """
+    from mlx_simulation import restore_modules, snapshot_modules
+
+    saved = snapshot_modules(_owned)
+    fresh = [
+        name for name in ("unsloth_zoo.mlx.trainer", "unsloth_zoo.mlx.utils")
+        if name not in saved
+    ]
+    if not fresh:
+        for name in list(sys.modules):
+            if name.startswith("unsloth_zoo.mlx."):
+                sys.modules.pop(name, None)
+                saved.pop(name, None)
+        fresh = ["unsloth_zoo.mlx.trainer"]
+
+    __import__(fresh[0])
+    restore_modules(saved, _owned)
+
+    for name in fresh:
+        assert _walk_parent_attributes(name) is sys.modules.get(name), name
+
+
+def test_the_shim_files_use_the_shared_restore():
+    """Both fixtures must go through restore_modules, not sys.modules.update.
+
+    The bare update is what shipped in #1131. Spelled out here so a future edit
+    that reintroduces it is a failing test rather than six failures in unrelated
+    files one worker over.
+    """
+    from pathlib import Path
+
+    here = Path(__file__).resolve().parent
+    for filename in ("test_mlx_preference.py", "test_mlx_trainer_internals.py"):
+        source = (here / filename).read_text(encoding = "utf-8")
+        assert "restore_modules(" in source, filename
+        assert "sys.modules.update(" not in source, (
+            f"{filename} restores sys.modules without repairing parent attributes"
+        )

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -50,24 +50,24 @@ def _install_shim():
     # op quietly takes the cached path instead of the VJP. Serially that never
     # happens (alphabetical order puts this file after the pair it would break);
     # under `-n N --dist loadfile` it depends on which worker draws which file.
-    real_mlx_modules = {
-        name: module for name, module in sys.modules.items() if _owned(name)
-    }
-    from mlx_simulation import simulate_mlx_on_torch
+    from mlx_simulation import (
+        restore_modules,
+        simulate_mlx_on_torch,
+        snapshot_modules,
+    )
     from mlx_simulation.mlx_stub import _MLXFinder
+
+    real_mlx_modules = snapshot_modules(_owned)
     simulate_mlx_on_torch()
     for name in list(sys.modules):
         if name == "unsloth_zoo.mlx" or name.startswith("unsloth_zoo.mlx."):
             sys.modules.pop(name, None)
     yield
-    for name in list(sys.modules):
-        if _owned(name):
-            sys.modules.pop(name, None)
     sys.meta_path[:] = [
         finder for finder in sys.meta_path
         if not isinstance(finder, _MLXFinder)
     ]
-    sys.modules.update(real_mlx_modules)
+    restore_modules(real_mlx_modules, _owned)
 
 
 def test_finite_text_batch_plan_materializes_cpu_rows_on_demand():


### PR DESCRIPTION
#1131 was a net regression. It fixed the two failures it was aimed at and introduced six others, and unsloth's `Core` job reports three of them against zoo main today, one per matrix leg depending on which worker draws which file.

### What went wrong

`test_mlx_preference.py` and `test_mlx_trainer_internals.py` drop every `unsloth_zoo.mlx.*` module so their shim is what those modules bind against. #1131 made them save the originals and put them back, which is right as far as it goes and only half the state.

Dropping `unsloth_zoo.mlx` and letting it be re-imported makes the import machinery bind

```python
unsloth_zoo.mlx = <the module built under the shim>
```

as an attribute on the parent package, and that binding outlives the `sys.modules` entry that produced it. Restoring `sys.modules` therefore leaves two lookup paths disagreeing, because they are read by different things:

```python
import unsloth_zoo.mlx.trainer as t              # walks parent attributes
from unsloth_zoo.mlx.trainer import MLXTrainer   # resolves via sys.modules
```

Measured after the fixture runs:

```
import-as module id : 139681420121392
sys.modules entry   : 139700800574768  same=False
t.MLXTrainer        : 616397424
fresh MLXTrainer    : 618847840        SAME=False
```

Any file doing both is left holding two live copies of one module, and an `isinstance` against a class from one is False for an object the other built. That is exactly what `dataset_utils.train_on_responses_only` does to decide whether it has an `MLXTrainer`, so it silently took the Hugging Face branch and called a non-callable tokenizer wrapper.

### The fix

Both fixtures now go through `mlx_simulation.restore_modules`, which puts `sys.modules` and the parent attributes back together. It also drops the attribute outright for a submodule that was imported only while the shim was up, since leaving that bound is the same split in reverse: an attribute walk reaching a module no `sys.modules` lookup can.

### Confirmation

Each is a deterministic two-file repro, run as `pytest A B`:

| paired with `test_mlx_preference.py` | before #1131 | at #1131 | here |
| --- | --- | --- | --- |
| `test_pr684_review_fixes_a.py` | 97 passed | 1 failed | 97 passed |
| `test_mlx_text_path_contract.py` | 98 passed | 1 failed | 98 passed |
| `test_mlx_distributed_loader.py` | 87 passed | 4 failed | 87 passed |

What #1131 fixed still holds: `test_mlx_preference` + `test_mlx_gated_delta_vjp`, `test_mlx_gated_delta_vjp` + `test_mlx_neftune_quant_map`, and `test_mlx_trainer_internals` + `test_mlx_gated_delta_vjp` all pass, as do both polluters on their own.

Whole suite as `Core` runs it (`-n 4 --dist loadfile`, same ignores and deselects): **11 failures before, 5 after**, and the 5 are the local-environment ones this box produces with or without these changes and that CI does not report (`test_rl_replacements_compile_disable`, which fails here even in isolation, and `test_moe_lora_grouped_mm_capability`).

### Why nothing caught it

Nothing asserted that the two lookup paths agreed, which is how #1131 traded two failures for six without it showing up. `tests/test_mlx_shim_module_restore.py` now asserts it, and also pins both fixtures to the shared helper so a future edit that goes back to a bare `sys.modules.update` is a failing test rather than six failures in unrelated files one worker over. Removing the parent repair fails two of its three tests.
