### PR TITLE
Make test_mlx_gated_delta_vjp's real-mlx gate reject the torch shim

### DIFF
--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -33,9 +33,22 @@ import types
 
 import pytest
 
-_HAS_REAL_MLX = importlib.util.find_spec("mlx") is not None
-if not _HAS_REAL_MLX:
-    from mlx_simulation import simulate_mlx_on_torch
+from mlx_simulation import mlx_is_simulated, simulate_mlx_on_torch  # noqa: E402
+
+# Not "the import worked": several test modules install the MLX-on-torch shim into
+# sys.modules while being IMPORTED, and collection imports every module, so `mlx`
+# can already BE that shim by the time this file is reached. Gating on find_spec
+# alone then reads the shim as real, and the cases marked requires_real_mlx run
+# against it -- they need mx.checkpoint, a vjp that differentiates integer arrays,
+# and mlx_vlm's glm5_next, none of which the shim implements. That made the file
+# pass or fail on collection order: stable serially, where alphabetical order puts
+# no installer first, and not under `-n N --dist loadfile`, where worker assignment
+# decides. Same gate, and same reason, as test_mlx_neftune_quant_map.py.
+_SHIM_ALREADY_INSTALLED = mlx_is_simulated()
+_HAS_REAL_MLX = (
+    importlib.util.find_spec("mlx") is not None and not _SHIM_ALREADY_INSTALLED
+)
+if not _HAS_REAL_MLX and not _SHIM_ALREADY_INSTALLED:
     simulate_mlx_on_torch()
 
 import mlx.core as mx  # noqa: E402  (real, or the torch shim on CI)

--- a/tests/test_mlx_real_mlx_gates_reject_the_shim.py
+++ b/tests/test_mlx_real_mlx_gates_reject_the_shim.py
@@ -1,0 +1,129 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Every "needs real MLX" gate in the suite must reject the torch shim.
+
+Several test modules call ``simulate_mlx_on_torch()`` while being IMPORTED, and
+pytest's collection imports every module in the session. So by the time a module
+that wants REAL mlx is imported, ``import mlx`` may already resolve to the shim,
+and a gate that only asks whether the import worked reads the shim as real. The
+tests behind it then run against a stub that implements neither ``mx.checkpoint``
+nor a vjp over integer arrays, and fail.
+
+Which module is imported first is alphabetical serially -- where no installer
+happens to come first -- and worker assignment under ``-n N --dist loadfile``,
+which is how unsloth's Core job runs this suite. That is why the same tests pass
+locally and fail in CI: not flakiness, an ordering the local run never produces.
+
+The fix in each module is to gate on ``mlx_is_simulated()`` rather than on the
+import. This file is the standing check that no module loses that gate again, and
+that a new one does not arrive without it. Each case runs in a SUBPROCESS with the
+shim installed first, because the point is what a module decides at import time and
+this session has already made those decisions.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+# module -> the module-level flag holding "a REAL mlx is importable". Every module
+# whose tests need real MLX semantics is here; the flag names differ because the
+# modules were written apart.
+REAL_MLX_GATES = {
+    "test_mlx_gated_delta_vjp": "_HAS_REAL_MLX",
+    "test_mlx_gated_delta_batch_grad": "_HAS_MLX",
+    "test_mlx_neftune_quant_map": "_MLX",
+}
+
+_PROBE = textwrap.dedent(
+    """
+    import sys
+    sys.path.insert(0, {tests_dir!r})
+
+    # Exactly what a sibling module does to this process during collection.
+    from mlx_simulation import simulate_mlx_on_torch, mlx_is_simulated
+    simulate_mlx_on_torch()
+    assert mlx_is_simulated(), "the shim did not install; the probe proves nothing"
+
+    import importlib
+    module = importlib.import_module({module!r})
+    print("GATE:", bool(getattr(module, {flag!r})))
+    """
+)
+
+
+@pytest.mark.parametrize("module, flag", sorted(REAL_MLX_GATES.items()))
+def test_a_real_mlx_gate_is_false_under_the_shim(module, flag):
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE.format(tests_dir=str(TESTS_DIR), module=module, flag=flag)],
+        capture_output=True,
+        text=True,
+        cwd=str(TESTS_DIR.parent),
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"{module} did not import with the MLX shim installed:\n{result.stderr}"
+    )
+    gate = [ln for ln in result.stdout.splitlines() if ln.startswith("GATE:")]
+    assert gate, f"probe printed no verdict for {module}:\n{result.stdout}\n{result.stderr}"
+    assert gate[-1] == "GATE: False", (
+        f"{module}.{flag} is True while `mlx` in sys.modules is the torch shim, so the "
+        f"cases it guards will run against the shim whenever another module installed it "
+        f"first. Gate on mlx_simulation.mlx_is_simulated(), not on the import succeeding."
+    )
+
+
+def _module_level_names(source: str) -> set:
+    """Names assigned at module level, including inside a module-level try/if.
+
+    Both shapes are in use: one module assigns its gate at top level, another inside
+    `try: import mlx.core`. Walking the whole tree would also count names bound inside
+    functions, which is not what "module-level flag" means.
+    """
+    tree = ast.parse(source)
+    names, queue = set(), list(tree.body)
+    while queue:
+        node = queue.pop()
+        if isinstance(node, ast.Assign):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        elif isinstance(node, (ast.AnnAssign,)) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+        elif isinstance(node, (ast.Try, ast.If)):
+            queue.extend(node.body + node.orelse + getattr(node, "finalbody", []))
+            for handler in getattr(node, "handlers", []):
+                queue.extend(handler.body)
+    return names
+
+
+def test_the_gate_names_still_exist():
+    """Non-vacuity: a renamed flag would make getattr raise, but a DELETED module or a
+    gate that stopped being module-level would quietly leave this file testing nothing."""
+    for module, flag in REAL_MLX_GATES.items():
+        path = TESTS_DIR / f"{module}.py"
+        assert path.exists(), f"{module} is gone; update REAL_MLX_GATES."
+        assert flag in _module_level_names(path.read_text()), (
+            f"{module} no longer defines a module-level {flag}; update REAL_MLX_GATES so "
+            f"this file keeps guarding a gate that exists."
+        )


### PR DESCRIPTION
The five failures unsloth's `Core` job reports against zoo `main`, all in `tests/test_mlx_gated_delta_vjp.py`:

```
test_checkpointed_layer_detaches_integer_arguments        AttributeError: 'bool' object has no attribute 'item'
test_router_gradient_matches_detached_reference           mlx-shim: 'mlx.core.argpartition' is not implemented
test_index_derived_graphs_stay_differentiable[_sparse_mask_loss-shape1]
                                                          mlx-shim: 'mlx.core.put_along_axis' is not implemented
test_only_the_index_argument_is_detached                  only Tensors of floating point dtype can require gradients
test_unfused_projection_matches_the_fused_one             mlx-shim: 'mlx_vlm.models.glm5_next.config.TextConfig' is not implemented
```

## Why

The file gates on `importlib.util.find_spec("mlx") is not None`. `find_spec` consults `sys.modules` first, and several sibling modules call `simulate_mlx_on_torch()` while being IMPORTED. Collection imports every module in the session, so once it has reached one of those the gate reads the shim as a real mlx. The `requires_real_mlx` cases then run against a stub that has no `mx.argpartition`, no `put_along_axis` and no `mlx_vlm.models.glm5_next`, and that returns a Python `bool` where mlx returns an array. Those are the five messages above, one for one.

Whether an installer is imported first is alphabetical serially, where none is, and worker assignment under `-n 4 --dist loadfile`, which is how the `Core` job runs this suite. That is the whole reason the file passes locally and fails in CI.

Deterministic two-file repro, five failures before this change and none after:

```
pytest tests/test_mlx_arrays_cache_advance.py tests/test_mlx_gated_delta_vjp.py
```

This is the same gate, and the same reason, as `test_mlx_neftune_quant_map.py` in #1131, which added `mlx_simulation.mlx_is_simulated()` for exactly this. That change did not reach this file. Its note that the remaining five were local-environment failures CI does not report was wrong: they are these, and CI reports them on every run.

## Why skip rather than grow the shim

The alternative is implementing `argpartition`, `put_along_axis` and a `glm5_next` config in the stub. These cases assert mlx autodiff semantics, so checking them against a torch stub tests the stub; and the `glm5_next` case needs a real `mlx_vlm` module, which cannot be stubbed into a meaningful assertion. #1131 settled the same question the same way.

The tests themselves are right about what they check. #1120 added them with the intent that they need real MLX; only the gate is wrong.

## Coverage

None moves on Apple Silicon. Every `simulate_mlx_on_torch()` call in the suite is conditional on a real mlx being absent, verified by AST over all 36 callers, so where a real mlx exists the shim is never installed and the gate evaluates exactly as before. On Linux CI these five skip, which is what they already do when the file runs on its own.

## Standing check

`tests/test_mlx_real_mlx_gates_reject_the_shim.py` imports each of the three modules holding a real-mlx gate in a subprocess with the shim installed first, and fails if the gate comes back `True`. Verified non-vacuous: it fails on the pre-fix file and passes after. It also asserts each gate is still a module-level name, so a rename cannot leave it guarding nothing.

## Verification

Suite as the `Core` job runs it (`-n 4 --dist loadfile`, same ignores and deselects): `5 failed, 5383 passed`. The five above are gone. The five that remain are this box's pre-existing ones, unrelated to MLX: four in `test_rl_replacements_compile_disable.py` reproduce on an unmodified checkout, and `test_moe_lora_grouped_mm_capability.py::test_no_grad_decoding_retains_nothing` passes in isolation on both trees. CI reports none of them.

Two files, `test_mlx_distributed_loader.py` and `test_mlx_save_export_regressions.py`, were excluded from that local run: they spin at 100% CPU indefinitely on this host, on an unmodified checkout as well, and pass in CI.