### PR TITLE
Bound the gather_qmm guard's chain walk so a permissive mx cannot hang it

### DIFF
--- a/tests/test_mlx_gather_qmm_guard_chain_walk.py
+++ b/tests/test_mlx_gather_qmm_guard_chain_walk.py
@@ -1,0 +1,97 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The gather_qmm guard's chain walk must terminate against a permissive `mx`.
+
+`is_gather_qmm_nax_guard_applied` walks `_unsloth_index_original` until it reads
+None. That terminates for a real mlx function, but a stand-in that answers every
+attribute (the mlx test shim, a Mock) never yields None, and the unbounded walk
+hangs the interpreter rather than failing. This pins the bound.
+"""
+
+import threading
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+
+    simulate_mlx_on_torch()
+
+
+def _utils():
+    """Imported lazily: unsloth_zoo.mlx.utils imports mlx.core at module scope."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    return mlx_utils
+
+
+class _Permissive:
+    """Answers every attribute with a fresh falsy instance, like the mlx shim."""
+
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return _Permissive()
+
+    def __bool__(self):
+        return False
+
+
+def test_guard_chain_walk_terminates_against_a_permissive_mx(monkeypatch):
+    mlx_utils = _utils()
+    monkeypatch.setattr(mlx_utils.mx, "gather_qmm", _Permissive(), raising = False)
+
+    result = {}
+
+    def _run():
+        result["value"] = mlx_utils.is_gather_qmm_nax_guard_applied()
+
+    # Run off-thread: an unbounded walk does not raise, it never returns, so the
+    # only way to report it as a failure instead of a hung job is to stop waiting.
+    worker = threading.Thread(target = _run, daemon = True)
+    worker.start()
+    worker.join(timeout = 10)
+
+    assert not worker.is_alive(), (
+        "is_gather_qmm_nax_guard_applied did not terminate against an mx whose "
+        "attributes never run out: the chain walk needs a bound, not just a None check"
+    )
+    assert result["value"] is False
+
+
+def test_guard_chain_walk_still_finds_a_guard_under_a_wrapper(monkeypatch):
+    """The bound must not cost the real lookup it exists for."""
+
+    def _guarded():
+        pass
+
+    _guarded._unsloth_gather_qmm_guard = True
+
+    def _wrapper():
+        pass
+
+    _wrapper._unsloth_index_original = _guarded
+
+    mlx_utils = _utils()
+    monkeypatch.setattr(mlx_utils.mx, "gather_qmm", _wrapper, raising = False)
+    assert mlx_utils.is_gather_qmm_nax_guard_applied() is True
+
+    mlx_utils = _utils()
+    monkeypatch.setattr(mlx_utils.mx, "gather_qmm", _guarded, raising = False)
+    assert mlx_utils.is_gather_qmm_nax_guard_applied() is True

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -722,7 +722,13 @@ _gather_qmm_guarded._unsloth_gather_qmm_guard = True
 def is_gather_qmm_nax_guard_applied() -> bool:
     """True for the guard anywhere in the chain, index-stop wrapper included."""
     current = mx.gather_qmm
-    while current is not None:
+    # Bounded: the real chain is the guard under at most one index-stop wrapper, but
+    # `getattr(..., None)` only terminates for an object that can be missing an
+    # attribute. A permissive stand-in for mx (the mlx test shim, a Mock) answers every
+    # attribute with a fresh object, so an unbounded walk never reaches None and spins.
+    for _ in range(16):
+        if current is None:
+            break
         if getattr(current, "_unsloth_gather_qmm_guard", False):
             return True
         current = getattr(current, "_unsloth_index_original", None)


### PR DESCRIPTION
## What happens today

`is_gather_qmm_nax_guard_applied` walks the wrapper chain until `getattr` returns `None`:

```python
current = mx.gather_qmm
while current is not None:
    if getattr(current, "_unsloth_gather_qmm_guard", False):
        return True
    current = getattr(current, "_unsloth_index_original", None)
return False
```

That terminates against a real mlx function, but only because a real function eventually lacks the attribute. A stand-in for `mx` that answers every attribute with a fresh object never yields `None`, and the walk never ends.

The mlx test shim is exactly such a stand-in. Its `_Noop.__getattr__` returns a new `_Noop` for any name, and `_Noop.__bool__` is `False`, so the guard check never trips and the next link is never `None`. Any loader path that calls `apply_gather_qmm_nax_guard` under the shim spins forever, building a longer attribute-name string each pass, which is why it degrades into a silent stall rather than a fast spin.

`tests/test_mlx_distributed_loader.py::test_from_pretrained_distributed_vlm_forwards_normalized_override` reaches it through `FastMLXModel.from_pretrained`:

```
loader.py:6976  apply_gather_qmm_nax_guard()
utils.py:739    if is_gather_qmm_nax_guard_applied():
utils.py:726    if getattr(current, "_unsloth_gather_qmm_guard", False):
mlx_stub.py:105 return _Noop(f"{self._name}.{name}")
```

Introduced in #1129, which added the chain walk.

## Why this is not a user-facing bug

Real mlx terminates the walk normally, so the guard behaves as intended on device and #1129's product logic is unaffected. What is wrong is the unbounded walk itself: a lookup over a chain that is at most the guard under one index-stop wrapper should not depend on an unrelated object running out of attributes.

## The fix

Bound the walk to 16 hops.

## Effect

The unsloth CI job that runs this suite has a 35 minute budget. The hang consumed all of it, so the job was killed with no test name and no traceback, and every later step was marked skipped.

| | before | after |
|---|---|---|
| `test_mlx_distributed_loader.py` | hangs indefinitely | 7 passed, 0.16s |
| full MLX group, CI's exact invocation | never completes | 997 passed, 120 skipped, 18.7s |

The three MLX files CI runs separately (`test_mlx_generate.py`, `test_mlx_neftune_quant_map.py`, `test_mlx_gated_delta_vjp.py`) also pass unchanged.

## Regression test

`tests/test_mlx_gather_qmm_guard_chain_walk.py` covers both directions:

- the walk terminates against a permissive `mx`. It runs off-thread and joins with a timeout, because an unbounded walk does not raise, it never returns, so the only way to report it as a failure rather than a hung job is to stop waiting.
- the walk still finds a guard sitting under a wrapper, so the bound does not cost the lookup it exists for.

Mutation checked: with the fix reverted the first test fails and the second still passes.