### PR TITLE
Read the transformers.models module list once instead of on every call

### DIFF
--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import functools
 import os
 import tempfile
 import shutil
@@ -104,6 +105,29 @@ def _normalize_dict_dtypes(obj):
     return _dtype_stringify(obj)
 
 
+
+@functools.lru_cache(maxsize = 1)
+def _transformers_model_module_names() -> tuple:
+    """Names of every module under `transformers.models`, read once per process.
+
+    `dir()` on the lazy `transformers.models` module walks its whole import structure:
+    about 64ms for roughly 5400 names on transformers 4.57. `get_transformers_model_type`
+    is on the model-load path and called it on every invocation, so each call paid that
+    cost to answer a question whose answer cannot change once transformers is imported.
+
+    Order is preserved because the caller below takes the first name whose normalized
+    form matches, and a set would make that choice arbitrary.
+    """
+    import transformers.models
+    return tuple(dir(transformers.models))
+
+
+@functools.lru_cache(maxsize = 1)
+def _transformers_model_module_name_set() -> frozenset:
+    """Membership form of the above: the two lookups below were linear scans."""
+    return frozenset(_transformers_model_module_names())
+
+
 def get_transformers_model_type(config, trust_remote_code=False):
     """ Gets model_type from config file - can be PEFT or normal HF """
     if config is None:
@@ -144,8 +168,7 @@ def get_transformers_model_type(config, trust_remote_code=False):
                 model_type = str(model_type)
                 model_type = model_type.rsplit("For", 1)[0].lower()
                 # Find exact modeling-path name
-                import transformers.models
-                supported_model_types = dir(transformers.models)
+                supported_model_types = _transformers_model_module_names()
                 for modeling_file in supported_model_types:
                     if model_type == modeling_file.lower().replace("_", "").replace(".", "_").replace("-", "_"):
                         model_types = [modeling_file]
@@ -231,8 +254,7 @@ def get_transformers_model_type(config, trust_remote_code=False):
 
     # Check if model type is correct
     # Gemma-3 270M has `gemma3_text` which is wrong
-    import transformers.models
-    all_model_types = dir(transformers.models)
+    all_model_types = _transformers_model_module_name_set()
     # Models with trust_remote_code that are NOT in transformers.models
     # but should be kept as-is (not truncated).
     _REMOTE_CODE_MODEL_TYPES = {"nemotron_h", "nemotronh_nano_vl_v2",}


### PR DESCRIPTION
## What is slow

`get_transformers_model_type` calls `dir(transformers.models)` on every invocation:

```python
import transformers.models
all_model_types = dir(transformers.models)
```

On the lazy `transformers.models` module that walk goes through the whole import structure. Measured on transformers 4.57.6:

```
dir(transformers.models): 63.8 ms per call, 5392 entries
```

The result cannot change once transformers is imported, so every call paid full price for a constant. The function is on the model load path, and the two lookups against the result (`model_type not in all_model_types`, `current_model_type in all_model_types`) were linear scans over all 5392 entries.

## Where it shows up

`tests/security/test_model_type_import_guard.py::test_every_shipped_model_type_accepted` calls the function once per shipped model type, which is 5468 names. That works out to 349 seconds of `dir()` alone, against a measured test time of 353 seconds, so 99 percent of the test was rebuilding the same list.

It was the slowest test in the repo by a wide margin: 353s of a 418s wall clock run under `-n 4 --dist loadfile`, with no other test above 48s. It also got slower on its own over time, since the name list grows with every model transformers adds. That is visible in unsloth CI, where the `HF=latest + TRL=latest` leg spends 21.4 min in this suite against 14.8 min for `HF=default` on identical code.

## Change

Read it once, in two shapes, because the two call sites want different things:

- an ordered tuple where the caller takes the first name whose normalized form matches, since a set would make that choice arbitrary
- a frozenset for the two membership tests

## Result

| | before | after |
|---|---|---|
| `test_every_shipped_model_type_accepted` | 362.94s | 0.12s |
| `tests/security/test_model_type_import_guard.py` | 363.41s | 0.25s |

16 passed in that file, unchanged. No behaviour change: same names, and the same order where order is used.

This is not only a test win. Every model load was paying about 64 ms plus two linear scans for a value that is fixed for the life of the process.

## Note on the test itself

Worth recording separately, since this PR does not change it. The test iterates 5468 names, of which 421 are real model types from `CONFIG_MAPPING_NAMES`. The other 5047 come from `dir(transformers.models)` and are class and symbol names such as `ASTForAudioClassification`, `Aimv2Model` and `AdaptiveEmbedding`, which can never appear as a `model_type` in a config.json. The guarantee the test exists for, that no legitimate model type is falsely rejected, is carried by the 421. Narrowing the iteration set would be reasonable cleanup, but with this fix the test is fast either way, so it is left alone here.