### PR TITLE
Stop the gemma4 probe writing a 3.4 GB cache to a pull request ref

### DIFF
--- a/.github/workflows/gemma4-audio-probe.yml
+++ b/.github/workflows/gemma4-audio-probe.yml
@@ -97,10 +97,12 @@ jobs:
           key: ${{ steps.pip-cache.outputs.key }}
           cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
-      - name: Cache the checkpoint
+      - name: Restore the checkpoint
         # 3.4 GB, and every job wants the same one. Shared key on purpose: the
         # first to finish saves it, the rest log a collision and move on.
-        uses: actions/cache@v6
+        id: hf-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        continue-on-error: true
         with:
           path: ~/.cache/huggingface
           key: hf-gemma4-e2b-4bit-v1
@@ -113,6 +115,30 @@ jobs:
         #
         # The checkpoint arrives through env rather than interpolation: it is
         # the one free-text value here.
+        id: probe
         env:
           MODEL: ${{ inputs.model || 'mlx-community/gemma-4-e2b-it-4bit' }}
         run: python tests/gemma4_audio_version_probe.py --model "$MODEL"
+
+      - name: Save the checkpoint
+        # Split out of the restore above, and on the default branch only, for the
+        # reason pip-cache-save carries at length: `actions/cache` saves from its
+        # own post-step on WHATEVER REF the job ran on. This one triggers on a
+        # label, so a labelled PR wrote 3.4 GB to refs/pull/N/merge that only that
+        # PR's re-runs could ever restore, seven legs racing the one key, against
+        # a 20 GiB budget the repo has already been at 99% of. The janitor could
+        # not clean it up either: the key carries no trailing hash, so generation
+        # ranking skips it and only closing the PR would have freed it.
+        #
+        # After the Probe, not before: the probe is what downloads the checkpoint,
+        # so a save placed where the restore sits would store an empty directory
+        # under the key and every later job would hit it and find nothing.
+        if: >-
+          github.ref == 'refs/heads/main'
+          && steps.hf-cache.outputs.cache-hit != 'true'
+          && steps.probe.outcome == 'success'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        continue-on-error: true
+        with:
+          path: ~/.cache/huggingface
+          key: hf-gemma4-e2b-4bit-v1

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -36,8 +36,8 @@ import yaml
 
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
-# Both extensions: GitHub runs `.yaml` workflows too, and a glob for `.yml` alone would
-# let an unguarded cache writer added in a `.yaml` file bypass every check in this file.
+# Both extensions: GitHub runs `.yaml` workflows too, and a `.yml`-only glob would let a
+# writer added in one bypass every check here.
 WORKFLOWS = sorted(
     p for ext in ("*.yml", "*.yaml") for p in (REPO / ".github" / "workflows").glob(ext)
 )
@@ -195,32 +195,22 @@ def test_save_runs_on_the_default_branch_only():
 
 # --- every cache save, not just the pip pair ------------------------------------------
 #
-# The rule above is enforced on the pip-cache-save action, which is the only thing that
-# was writing PR-scoped entries when it was written. It is not the only thing that CAN.
-# `gemma4-audio-probe.yml` used a bare read-write `actions/cache`, which registers its own
-# post-step and saves on whatever ref the job ran on, exactly like the setup-python form
-# this file exists to keep out. That workflow triggers on a label, so a labelled PR wrote
-# a 3.4 GB checkpoint to refs/pull/N/merge that only that PR's re-runs could restore,
-# seven macOS legs racing the one key.
-#
-# The janitor could not have cleaned it up either: `hf-gemma4-e2b-4bit-v1` carries no
-# trailing dependency hash, so cache-janitor.yml's generation ranking skips it entirely
-# and only closing the PR would ever have freed the bytes.
-#
-# So the check is on the shape, everywhere, rather than on the one action that had the
-# problem first.
+# The rule above covers pip-cache-save, the only PR-scoped writer when it was written but
+# not the only possible one. `gemma4-audio-probe.yml` used a bare read-write
+# `actions/cache`, whose post-step saves on whatever ref ran, so a labelled PR wrote a
+# 3.4 GB checkpoint to refs/pull/N/merge that only its own re-runs could restore. The
+# janitor could not reclaim it either: `hf-gemma4-e2b-4bit-v1` has no trailing dependency
+# hash, so generation ranking skips it. Hence a check on the shape, everywhere.
 
 _CACHE_WRITERS = ("actions/cache@", "actions/cache/save@")
 
 
 def _uses(step):
-    """A step's `uses`, casefolded, because GitHub resolves owner/repo case-insensitively.
+    """A step's `uses`, casefolded: GitHub resolves owner/repo case-insensitively.
 
-    `Actions/Cache/Save@v6` runs the same action as the lowercase spelling, so a
-    case-sensitive match here let a writer skip every guard while still working. Only
-    the owner/repo half is case-insensitive; the ref after `@` is a git ref and is not,
-    but nothing below matches on the ref. Local `./.github/actions/...` paths are real
-    filesystem paths on the runner and stay case-sensitive, so they are compared raw.
+    `Actions/Cache/Save@v6` is the same action, so a case-sensitive match let a writer
+    skip every guard. The ref after `@` is case-sensitive but nothing here matches on
+    it, and local `./.github/actions/...` paths are compared raw.
     """
     return str(step.get("uses", "")).casefold()
 
@@ -311,12 +301,10 @@ def _restricted_to_main(expr):
         # A leaf. `!` anywhere outside a `!=` is a negation we will not reason about.
         if re.search(r"!(?!=)", part):
             return False
-        # The leaf must BE the equality, not merely contain it. Searching inside
-        # accepted every wrapper that inverts it while quoting it: `(... ) == false`
-        # and `... != true` chain a second comparison, and `startsWith(..., 'false')`
-        # is true off main because GitHub casts the inner boolean to the string
-        # 'false' for string functions. A whitelist ends that class rather than
-        # naming its members.
+        # The leaf must BE the equality, not contain it. Searching inside accepted
+        # every wrapper that quotes it and inverts it: `(...) == false`, `... != true`,
+        # and `startsWith(..., 'false')`, which is true off main because GitHub casts
+        # the inner boolean to a string. A whitelist ends the class.
         return bool(_LEAF_MAIN.fullmatch(part))
 
     return restricted(expr)
@@ -372,9 +360,7 @@ def _cache_writer_steps():
         for name, steps in _jobs(path):
             for step in steps:
                 yield f"{path.name}:{name}", step
-    # Both spellings, for the same reason WORKFLOWS takes both: GitHub accepts
-    # `action.yaml` for composite-action metadata, and a scan for `action.yml`
-    # alone would let an unguarded writer live in one unseen.
+    # Both spellings, as WORKFLOWS does: GitHub accepts `action.yaml` too.
     actions_dir = REPO / ".github" / "actions"
     for action in sorted(
         p for ext in ("action.yml", "action.yaml") for p in actions_dir.rglob(ext)
@@ -401,10 +387,9 @@ def test_no_cache_save_reaches_a_pull_request_ref():
 
 
 # (workflow, job, cached path) -> the step id whose success means the directory is
-# populated. Declared rather than inferred: the interval check below narrows WHERE the
-# producer may sit, but any step in that window satisfies it, including a no-op placed
-# there deliberately. Naming the step is the only thing that ties the guard to the work.
-# A new save with no entry here fails, which is the point: adding one is a decision.
+# populated. Declared, not inferred: the interval below narrows where the producer may
+# sit, but any step there satisfies it, including a deliberate no-op. A save with no
+# entry fails, which is the point -- adding one is a decision.
 _EXPECTED_PRODUCER = {
     ("gemma4-audio-probe.yml", "probe", "~/.cache/huggingface"): "probe",
 }
@@ -429,13 +414,10 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                 condition = " ".join(str(step.get("if", "")).split())
                 path_saved = str((step.get("with") or {}).get("path", "")).strip()
 
-                # The producer has to sit strictly BETWEEN the restore of the same
-                # path and this save. Anything looser is satisfiable by the wrong
-                # step: a `.outputs.` reference matched the restore's own
-                # `cache-hit`, and merely "some earlier step's .outcome" matches the
-                # restore too, so a save moved up next to the restore still passed
-                # while the directory was empty. Only a step in that window can be
-                # what filled it.
+                # Strictly BETWEEN the restore of the same path and this save. Looser
+                # forms are satisfied by the wrong step: `.outputs.` matched the
+                # restore's own `cache-hit`, and "some earlier .outcome" matches the
+                # restore, so a save moved up beside it passed on an empty directory.
                 restore_at = max(
                     (
                         j for j, s in enumerate(steps[:i])
@@ -445,9 +427,8 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                     default=None,
                 )
                 # No restore above the save is an offender, not "the top of the job".
-                # Treating it as position -1 accepted a job whose restore sits BELOW
-                # its save, which writes the entry every run and reads it never, so
-                # every leg re-downloads the payload the cache exists to avoid.
+                # Position -1 accepted a restore sitting BELOW its save, which writes
+                # the entry every run and reads it never.
                 if restore_at is None:
                     offenders.append(
                         f"{label} saves {path_saved!r} with no restore of that path "

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -288,6 +288,14 @@ def _restricted_to_main(expr):
         # A leaf. `!` anywhere outside a `!=` is a negation we will not reason about.
         if re.search(r"!(?!=)", part):
             return False
+        # Exactly one comparison, and it must be the main equality. A second one
+        # is how a leaf inverts itself while still containing the equality:
+        # `(github.ref == 'refs/heads/main') == false` is true off main, and
+        # `... != true` is the same trick. Quoted literals are blanked first so a
+        # `==` inside a string is not counted.
+        bare = re.sub(r"'[^']*'|\"[^\"]*\"", "''", part)
+        if len(re.findall(r"[=!]=", bare)) != 1:
+            return False
         return bool(_MAIN_ONLY.search(part))
 
     return restricted(expr)
@@ -313,6 +321,9 @@ def _restricted_to_main(expr):
         ("!(github.ref == 'refs/heads/main')", False),
         # Parenthesised but genuinely restricted, so the fix must not over-reject.
         ("(github.ref == 'refs/heads/main') && always()", True),
+        # Comparing the equality to a boolean inverts it while still containing it.
+        ("(github.ref == 'refs/heads/main') == false", False),
+        ("github.ref == 'refs/heads/main' != true", False),
         ("always() && (github.ref == 'refs/heads/main' && !cancelled())", True),
         # An OR restricts only when every branch does.
         (

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -36,7 +36,11 @@ import yaml
 
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
-WORKFLOWS = sorted((REPO / ".github" / "workflows").glob("*.yml"))
+# Both extensions: GitHub runs `.yaml` workflows too, and a glob for `.yml` alone would
+# let an unguarded cache writer added in a `.yaml` file bypass every check in this file.
+WORKFLOWS = sorted(
+    p for ext in ("*.yml", "*.yaml") for p in (REPO / ".github" / "workflows").glob(ext)
+)
 RESTORE = "./.github/actions/pip-cache-restore"
 SAVE = "./.github/actions/pip-cache-save"
 
@@ -203,8 +207,8 @@ def test_save_runs_on_the_default_branch_only():
 _CACHE_WRITERS = ("actions/cache@", "actions/cache/save@")
 
 
-def _or_alternatives(expr):
-    """``expr`` split on its TOP-LEVEL ``||``, ignoring ``||`` inside parens or quotes."""
+def _split_top(expr, op):
+    """``expr`` split on its TOP-LEVEL ``op``, ignoring occurrences in parens or quotes."""
     parts, depth, quote, buf, i = [], 0, "", [], 0
     while i < len(expr):
         ch = expr[i]
@@ -221,7 +225,7 @@ def _or_alternatives(expr):
         elif ch == ")":
             depth -= 1
             buf.append(ch)
-        elif ch == "|" and depth == 0 and expr[i:i + 2] == "||":
+        elif depth == 0 and expr[i:i + 2] == op:
             parts.append("".join(buf))
             buf = []
             i += 2
@@ -233,6 +237,24 @@ def _or_alternatives(expr):
     return parts
 
 
+def _balanced(expr):
+    """Whether parentheses in ``expr`` are balanced outside quotes."""
+    depth, quote = 0, ""
+    for ch in expr:
+        if quote:
+            if ch == quote:
+                quote = ""
+        elif ch in "'\"":
+            quote = ch
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth < 0:
+                return False
+    return depth == 0
+
+
 # A POSITIVE equality, in either quote style. `!=` must not match: a condition restricting
 # a save to everything EXCEPT main is the exact inversion of the rule, and a substring
 # search for "refs/heads/main" accepts it.
@@ -242,12 +264,33 @@ _MAIN_ONLY = re.compile(r"github\.ref\s*==\s*['\"]refs/heads/main['\"]")
 def _restricted_to_main(expr):
     """Whether ``expr`` can only be true on the default branch.
 
-    Every alternative of a top-level `||` has to carry the check, because `||` is how a
-    condition GAINS refs: `github.ref == 'refs/heads/main' || github.event_name ==
-    'pull_request'` mentions main and still runs on every PR.
+    Evaluated over the whole boolean structure, not just the top level. `||` is how a
+    condition GAINS refs, so an OR restricts only if EVERY branch restricts; `&&` narrows,
+    so an AND restricts if ANY branch does. Parentheses matter: splitting only on
+    top-level `||` accepted `always() && (github.ref == 'refs/heads/main' ||
+    github.event_name == 'pull_request')`, which runs on every PR. Anything negated is
+    refused outright rather than reasoned about, because `!(github.ref ==
+    'refs/heads/main')` contains a positive main equality and is its exact inverse.
     """
-    alternatives = _or_alternatives(expr)
-    return bool(expr.strip()) and all(_MAIN_ONLY.search(a) for a in alternatives)
+    if not expr.strip():
+        return False
+
+    def restricted(part):
+        part = part.strip()
+        while part.startswith("(") and part.endswith(")") and _balanced(part[1:-1]):
+            part = part[1:-1].strip()
+        ors = _split_top(part, "||")
+        if len(ors) > 1:
+            return all(restricted(p) for p in ors)
+        ands = _split_top(part, "&&")
+        if len(ands) > 1:
+            return any(restricted(p) for p in ands)
+        # A leaf. `!` anywhere outside a `!=` is a negation we will not reason about.
+        if re.search(r"!(?!=)", part):
+            return False
+        return bool(_MAIN_ONLY.search(part))
+
+    return restricted(expr)
 
 
 @pytest.mark.parametrize(
@@ -258,6 +301,27 @@ def _restricted_to_main(expr):
         ("github.ref != 'refs/heads/main'", False),
         ("github.ref == 'refs/heads/main' || github.event_name == 'pull_request'", False),
         ("", False),
+        # A `||` inside parens is still a `||`. Splitting only the top level read this
+        # as one alternative containing the main equality and accepted it, while it
+        # actually runs on every pull request.
+        (
+            "always() && (github.ref == 'refs/heads/main' "
+            "|| github.event_name == 'pull_request')",
+            False,
+        ),
+        # Contains a positive main equality and means its exact opposite.
+        ("!(github.ref == 'refs/heads/main')", False),
+        # Parenthesised but genuinely restricted, so the fix must not over-reject.
+        ("(github.ref == 'refs/heads/main') && always()", True),
+        ("always() && (github.ref == 'refs/heads/main' && !cancelled())", True),
+        # An OR restricts only when every branch does.
+        (
+            "(github.ref == 'refs/heads/main' && always()) "
+            "|| (github.ref == 'refs/heads/main' && failure())",
+            True,
+        ),
+        # A `||` inside a string is not a split point.
+        ("github.ref == 'refs/heads/main' && contains(x, 'a||b')", True),
     ],
 )
 def test_the_main_only_check_reads_the_expression(expr, restricted):
@@ -304,15 +368,32 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
     offenders = []
     for path in WORKFLOWS:
         for name, steps in _jobs(path):
-            saves = [
-                i for i, s in enumerate(steps)
-                if "actions/cache/save@" in str(s.get("uses", ""))
-            ]
-            for i in saves:
-                condition = " ".join(str(steps[i].get("if", "")).split())
-                if "outcome ==" not in condition and ".outputs." not in condition:
+            ids = {s.get("id"): i for i, s in enumerate(steps) if s.get("id")}
+            for i, step in enumerate(steps):
+                if "actions/cache/save@" not in str(step.get("uses", "")):
+                    continue
+                label = f"{path.name}:{name}: {step.get('name') or 'save'}"
+                condition = " ".join(str(step.get("if", "")).split())
+                # The producer is the step whose OUTCOME the save is gated on. A
+                # `.outputs.` reference is not one: the checkpoint save reads
+                # `steps.hf-cache.outputs.cache-hit`, which is the RESTORE, and
+                # accepting that let the save sit above the step that fills the
+                # directory and still pass.
+                producers = set(re.findall(r"steps\.([A-Za-z0-9_-]+)\.outcome", condition))
+                if not producers:
                     offenders.append(
-                        f"{path.name}:{name}: {steps[i].get('name') or 'save'} is not "
-                        f"gated on the outcome of the step that produced its contents"
+                        f"{label} is not gated on the outcome of any step, so nothing "
+                        f"establishes that the directory it saves was populated"
+                    )
+                    continue
+                unknown = sorted(p for p in producers if p not in ids)
+                if unknown:
+                    offenders.append(f"{label} references unknown step id(s) {unknown}")
+                    continue
+                late = sorted(p for p in producers if ids[p] > i)
+                if late:
+                    offenders.append(
+                        f"{label} is gated on {late}, which run AFTER it, so it would "
+                        f"save the directory before those steps fill it"
                     )
     assert not offenders, "\n  ".join(offenders)

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -60,19 +60,25 @@ def test_workflows_exist():
     assert WORKFLOWS, "no workflows found; the layout moved and this file is stale"
 
 
-@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
-def test_no_builtin_setup_python_pip_cache(path):
-    for job, steps in _jobs(path):
-        for step in steps:
-            uses = str(step.get("uses", ""))
-            if not uses.startswith("actions/setup-python@"):
-                continue
-            with_ = step.get("with") or {}
-            assert "cache" not in with_, (
-                f"{path.name}:{job} uses setup-python's built-in cache. It saves on "
-                f"the PR ref, where nothing else can read it. Use {RESTORE} plus "
-                f"{SAVE} instead."
-            )
+def test_no_builtin_setup_python_pip_cache():
+    """Every step in the repo, including the ones inside composite actions.
+
+    Scanning only workflows left a hole: a composite action may run setup-python
+    itself, and a PR workflow that calls it gets the same post-step writing a
+    PR-scoped cache. The save guard below does not cover it either, because that one
+    filters on the `actions/cache` spellings.
+    """
+    offenders = [
+        f"{where}: {step.get('name') or step.get('uses')}"
+        for where, step in _cache_writer_steps()
+        if str(step.get("uses", "")).startswith("actions/setup-python@")
+        and "cache" in (step.get("with") or {})
+    ]
+    assert not offenders, (
+        "these steps use setup-python's built-in cache. It saves on the PR ref, where "
+        f"nothing else can read it. Use {RESTORE} plus {SAVE} instead:\n  "
+        + "\n  ".join(offenders)
+    )
 
 
 @pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
@@ -259,6 +265,11 @@ def _balanced(expr):
 # a save to everything EXCEPT main is the exact inversion of the rule, and a substring
 # search for "refs/heads/main" accepts it.
 _MAIN_ONLY = re.compile(r"github\.ref\s*==\s*['\"]refs/heads/main['\"]")
+# A whole leaf that is nothing but the equality, in either operand order.
+_LEAF_MAIN = re.compile(
+    r"github\.ref\s*==\s*['\"]refs/heads/main['\"]"
+    r"|['\"]refs/heads/main['\"]\s*==\s*github\.ref"
+)
 
 
 def _restricted_to_main(expr):
@@ -288,15 +299,13 @@ def _restricted_to_main(expr):
         # A leaf. `!` anywhere outside a `!=` is a negation we will not reason about.
         if re.search(r"!(?!=)", part):
             return False
-        # Exactly one comparison, and it must be the main equality. A second one
-        # is how a leaf inverts itself while still containing the equality:
-        # `(github.ref == 'refs/heads/main') == false` is true off main, and
-        # `... != true` is the same trick. Quoted literals are blanked first so a
-        # `==` inside a string is not counted.
-        bare = re.sub(r"'[^']*'|\"[^\"]*\"", "''", part)
-        if len(re.findall(r"[=!]=", bare)) != 1:
-            return False
-        return bool(_MAIN_ONLY.search(part))
+        # The leaf must BE the equality, not merely contain it. Searching inside
+        # accepted every wrapper that inverts it while quoting it: `(... ) == false`
+        # and `... != true` chain a second comparison, and `startsWith(..., 'false')`
+        # is true off main because GitHub casts the inner boolean to the string
+        # 'false' for string functions. A whitelist ends that class rather than
+        # naming its members.
+        return bool(_LEAF_MAIN.fullmatch(part))
 
     return restricted(expr)
 
@@ -324,6 +333,11 @@ def _restricted_to_main(expr):
         # Comparing the equality to a boolean inverts it while still containing it.
         ("(github.ref == 'refs/heads/main') == false", False),
         ("github.ref == 'refs/heads/main' != true", False),
+        # String functions cast the inner boolean, so these are true only OFF main.
+        ("startsWith(github.ref == 'refs/heads/main', 'false')", False),
+        ("contains(github.ref == 'refs/heads/main', 'false')", False),
+        # The reversed operand order is the same guard and stays accepted.
+        ("'refs/heads/main' == github.ref", True),
         ("always() && (github.ref == 'refs/heads/main' && !cancelled())", True),
         # An OR restricts only when every branch does.
         (
@@ -374,6 +388,16 @@ def test_no_cache_save_reaches_a_pull_request_ref():
     )
 
 
+# (workflow, job, cached path) -> the step id whose success means the directory is
+# populated. Declared rather than inferred: the interval check below narrows WHERE the
+# producer may sit, but any step in that window satisfies it, including a no-op placed
+# there deliberately. Naming the step is the only thing that ties the guard to the work.
+# A new save with no entry here fails, which is the point: adding one is a decision.
+_EXPECTED_PRODUCER = {
+    ("gemma4-audio-probe.yml", "probe", "~/.cache/huggingface"): "probe",
+}
+
+
 def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
     """A save placed where the restore sits stores an empty directory under the key.
 
@@ -409,6 +433,21 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                     default=None,
                 )
                 producers = set(re.findall(r"steps\.([A-Za-z0-9_-]+)\.outcome", condition))
+                want = _EXPECTED_PRODUCER.get((path.name, name, path_saved))
+                if want is None:
+                    offenders.append(
+                        f"{label} saves {path_saved!r} but no producer is declared for "
+                        f"it in _EXPECTED_PRODUCER. Position alone cannot say which "
+                        f"step fills a directory, so each save names its own"
+                    )
+                    continue
+                if want not in producers:
+                    offenders.append(
+                        f"{label} is gated on {sorted(producers)}, not on the declared "
+                        f"producer {want!r}. A no-op step in the right position "
+                        f"satisfies the interval below while filling nothing"
+                    )
+                    continue
                 if not producers:
                     offenders.append(
                         f"{label} is not gated on the outcome of any step, so nothing "

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -71,7 +71,7 @@ def test_no_builtin_setup_python_pip_cache():
     offenders = [
         f"{where}: {step.get('name') or step.get('uses')}"
         for where, step in _cache_writer_steps()
-        if str(step.get("uses", "")).startswith("actions/setup-python@")
+        if _uses(step).startswith("actions/setup-python@")
         and "cache" in (step.get("with") or {})
     ]
     assert not offenders, (
@@ -211,6 +211,18 @@ def test_save_runs_on_the_default_branch_only():
 # problem first.
 
 _CACHE_WRITERS = ("actions/cache@", "actions/cache/save@")
+
+
+def _uses(step):
+    """A step's `uses`, casefolded, because GitHub resolves owner/repo case-insensitively.
+
+    `Actions/Cache/Save@v6` runs the same action as the lowercase spelling, so a
+    case-sensitive match here let a writer skip every guard while still working. Only
+    the owner/repo half is case-insensitive; the ref after `@` is a git ref and is not,
+    but nothing below matches on the ref. Local `./.github/actions/...` paths are real
+    filesystem paths on the runner and stay case-sensitive, so they are compared raw.
+    """
+    return str(step.get("uses", "")).casefold()
 
 
 def _split_top(expr, op):
@@ -375,7 +387,7 @@ def _cache_writer_steps():
 def test_no_cache_save_reaches_a_pull_request_ref():
     offenders = []
     for where, step in _cache_writer_steps():
-        uses = str(step.get("uses", ""))
+        uses = _uses(step)
         # `actions/cache/restore@` is read-only and correct on every ref.
         if not any(w in uses for w in _CACHE_WRITERS):
             continue
@@ -411,7 +423,7 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
         for name, steps in _jobs(path):
             ids = {s.get("id"): i for i, s in enumerate(steps) if s.get("id")}
             for i, step in enumerate(steps):
-                if "actions/cache/save@" not in str(step.get("uses", "")):
+                if "actions/cache/save@" not in _uses(step):
                     continue
                 label = f"{path.name}:{name}: {step.get('name') or 'save'}"
                 condition = " ".join(str(step.get("if", "")).split())
@@ -427,11 +439,22 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                 restore_at = max(
                     (
                         j for j, s in enumerate(steps[:i])
-                        if "actions/cache/restore@" in str(s.get("uses", ""))
+                        if "actions/cache/restore@" in _uses(s)
                         and str((s.get("with") or {}).get("path", "")).strip() == path_saved
                     ),
                     default=None,
                 )
+                # No restore above the save is an offender, not "the top of the job".
+                # Treating it as position -1 accepted a job whose restore sits BELOW
+                # its save, which writes the entry every run and reads it never, so
+                # every leg re-downloads the payload the cache exists to avoid.
+                if restore_at is None:
+                    offenders.append(
+                        f"{label} saves {path_saved!r} with no restore of that path "
+                        f"above it, so the entry is written on every run and read on "
+                        f"none"
+                    )
+                    continue
                 producers = set(re.findall(r"steps\.([A-Za-z0-9_-]+)\.outcome", condition))
                 want = _EXPECTED_PRODUCER.get((path.name, name, path_saved))
                 if want is None:
@@ -458,16 +481,12 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                 if unknown:
                     offenders.append(f"{label} references unknown step id(s) {unknown}")
                     continue
-                lower = -1 if restore_at is None else restore_at
-                between = [p for p in producers if lower < ids[p] < i]
+                between = [p for p in producers if restore_at < ids[p] < i]
                 if not between:
-                    where = (
-                        f"after the restore at step {restore_at}"
-                        if restore_at is not None else "before it"
-                    )
                     offenders.append(
                         f"{label} is gated on {sorted(producers)}, none of which runs "
-                        f"{where} and before the save, so nothing between the restore "
-                        f"and the save is known to have filled {path_saved!r}"
+                        f"after the restore at step {restore_at} and before the save, so "
+                        f"nothing between the restore and the save is known to have "
+                        f"filled {path_saved!r}"
                     )
     assert not offenders, "\n  ".join(offenders)

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -335,7 +335,13 @@ def _cache_writer_steps():
         for name, steps in _jobs(path):
             for step in steps:
                 yield f"{path.name}:{name}", step
-    for action in sorted((REPO / ".github" / "actions").rglob("action.yml")):
+    # Both spellings, for the same reason WORKFLOWS takes both: GitHub accepts
+    # `action.yaml` for composite-action metadata, and a scan for `action.yml`
+    # alone would let an unguarded writer live in one unseen.
+    actions_dir = REPO / ".github" / "actions"
+    for action in sorted(
+        p for ext in ("action.yml", "action.yaml") for p in actions_dir.rglob(ext)
+    ):
         doc = yaml.safe_load(action.read_text()) or {}
         for step in ((doc.get("runs") or {}).get("steps") or []):
             yield f"action {action.parent.name}", step
@@ -374,11 +380,23 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                     continue
                 label = f"{path.name}:{name}: {step.get('name') or 'save'}"
                 condition = " ".join(str(step.get("if", "")).split())
-                # The producer is the step whose OUTCOME the save is gated on. A
-                # `.outputs.` reference is not one: the checkpoint save reads
-                # `steps.hf-cache.outputs.cache-hit`, which is the RESTORE, and
-                # accepting that let the save sit above the step that fills the
-                # directory and still pass.
+                path_saved = str((step.get("with") or {}).get("path", "")).strip()
+
+                # The producer has to sit strictly BETWEEN the restore of the same
+                # path and this save. Anything looser is satisfiable by the wrong
+                # step: a `.outputs.` reference matched the restore's own
+                # `cache-hit`, and merely "some earlier step's .outcome" matches the
+                # restore too, so a save moved up next to the restore still passed
+                # while the directory was empty. Only a step in that window can be
+                # what filled it.
+                restore_at = max(
+                    (
+                        j for j, s in enumerate(steps[:i])
+                        if "actions/cache/restore@" in str(s.get("uses", ""))
+                        and str((s.get("with") or {}).get("path", "")).strip() == path_saved
+                    ),
+                    default=None,
+                )
                 producers = set(re.findall(r"steps\.([A-Za-z0-9_-]+)\.outcome", condition))
                 if not producers:
                     offenders.append(
@@ -390,10 +408,16 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                 if unknown:
                     offenders.append(f"{label} references unknown step id(s) {unknown}")
                     continue
-                late = sorted(p for p in producers if ids[p] > i)
-                if late:
+                lower = -1 if restore_at is None else restore_at
+                between = [p for p in producers if lower < ids[p] < i]
+                if not between:
+                    where = (
+                        f"after the restore at step {restore_at}"
+                        if restore_at is not None else "before it"
+                    )
                     offenders.append(
-                        f"{label} is gated on {late}, which run AFTER it, so it would "
-                        f"save the directory before those steps fill it"
+                        f"{label} is gated on {sorted(producers)}, none of which runs "
+                        f"{where} and before the save, so nothing between the restore "
+                        f"and the save is known to have filled {path_saved!r}"
                     )
     assert not offenders, "\n  ".join(offenders)

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -181,3 +181,138 @@ def test_save_runs_on_the_default_branch_only():
         "copy that only that PR can read, which is the whole defect."
     )
     assert "always()" in condition, "a later step failing must not discard a completed install"
+
+
+# --- every cache save, not just the pip pair ------------------------------------------
+#
+# The rule above is enforced on the pip-cache-save action, which is the only thing that
+# was writing PR-scoped entries when it was written. It is not the only thing that CAN.
+# `gemma4-audio-probe.yml` used a bare read-write `actions/cache`, which registers its own
+# post-step and saves on whatever ref the job ran on, exactly like the setup-python form
+# this file exists to keep out. That workflow triggers on a label, so a labelled PR wrote
+# a 3.4 GB checkpoint to refs/pull/N/merge that only that PR's re-runs could restore,
+# seven macOS legs racing the one key.
+#
+# The janitor could not have cleaned it up either: `hf-gemma4-e2b-4bit-v1` carries no
+# trailing dependency hash, so cache-janitor.yml's generation ranking skips it entirely
+# and only closing the PR would ever have freed the bytes.
+#
+# So the check is on the shape, everywhere, rather than on the one action that had the
+# problem first.
+
+_CACHE_WRITERS = ("actions/cache@", "actions/cache/save@")
+
+
+def _or_alternatives(expr):
+    """``expr`` split on its TOP-LEVEL ``||``, ignoring ``||`` inside parens or quotes."""
+    parts, depth, quote, buf, i = [], 0, "", [], 0
+    while i < len(expr):
+        ch = expr[i]
+        if quote:
+            if ch == quote:
+                quote = ""
+            buf.append(ch)
+        elif ch in "'\"":
+            quote = ch
+            buf.append(ch)
+        elif ch == "(":
+            depth += 1
+            buf.append(ch)
+        elif ch == ")":
+            depth -= 1
+            buf.append(ch)
+        elif ch == "|" and depth == 0 and expr[i:i + 2] == "||":
+            parts.append("".join(buf))
+            buf = []
+            i += 2
+            continue
+        else:
+            buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+# A POSITIVE equality, in either quote style. `!=` must not match: a condition restricting
+# a save to everything EXCEPT main is the exact inversion of the rule, and a substring
+# search for "refs/heads/main" accepts it.
+_MAIN_ONLY = re.compile(r"github\.ref\s*==\s*['\"]refs/heads/main['\"]")
+
+
+def _restricted_to_main(expr):
+    """Whether ``expr`` can only be true on the default branch.
+
+    Every alternative of a top-level `||` has to carry the check, because `||` is how a
+    condition GAINS refs: `github.ref == 'refs/heads/main' || github.event_name ==
+    'pull_request'` mentions main and still runs on every PR.
+    """
+    alternatives = _or_alternatives(expr)
+    return bool(expr.strip()) and all(_MAIN_ONLY.search(a) for a in alternatives)
+
+
+@pytest.mark.parametrize(
+    "expr,restricted",
+    [
+        ("always() && github.ref == 'refs/heads/main'", True),
+        ('github.ref == "refs/heads/main" && steps.x.outcome == \'success\'', True),
+        ("github.ref != 'refs/heads/main'", False),
+        ("github.ref == 'refs/heads/main' || github.event_name == 'pull_request'", False),
+        ("", False),
+    ],
+)
+def test_the_main_only_check_reads_the_expression(expr, restricted):
+    # The guard below is only as good as this predicate, so the predicate is tested too.
+    assert _restricted_to_main(expr) is restricted, expr
+
+
+def _cache_writer_steps():
+    """(where, step) for every step that can write a cache entry, workflows and actions."""
+    for path in WORKFLOWS:
+        for name, steps in _jobs(path):
+            for step in steps:
+                yield f"{path.name}:{name}", step
+    for action in sorted((REPO / ".github" / "actions").rglob("action.yml")):
+        doc = yaml.safe_load(action.read_text()) or {}
+        for step in ((doc.get("runs") or {}).get("steps") or []):
+            yield f"action {action.parent.name}", step
+
+
+def test_no_cache_save_reaches_a_pull_request_ref():
+    offenders = []
+    for where, step in _cache_writer_steps():
+        uses = str(step.get("uses", ""))
+        # `actions/cache/restore@` is read-only and correct on every ref.
+        if not any(w in uses for w in _CACHE_WRITERS):
+            continue
+        if not _restricted_to_main(" ".join(str(step.get("if", "")).split())):
+            offenders.append(f"{where}: {step.get('name') or uses}")
+    assert not offenders, (
+        "these steps save a cache without restricting it to the default branch, so a "
+        "pull request writes an entry only its own re-runs can ever restore while "
+        "competing for the 20 GiB budget:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
+    """A save placed where the restore sits stores an empty directory under the key.
+
+    Splitting a read-write `actions/cache` is exactly where this goes wrong: the
+    read-write form saves from a post-step at the END of the job, so moving to
+    restore/save without also moving the save below the step that fills the directory
+    poisons the key for every later job, which then hits it and finds nothing.
+    """
+    offenders = []
+    for path in WORKFLOWS:
+        for name, steps in _jobs(path):
+            saves = [
+                i for i, s in enumerate(steps)
+                if "actions/cache/save@" in str(s.get("uses", ""))
+            ]
+            for i in saves:
+                condition = " ".join(str(steps[i].get("if", "")).split())
+                if "outcome ==" not in condition and ".outputs." not in condition:
+                    offenders.append(
+                        f"{path.name}:{name}: {steps[i].get('name') or 'save'} is not "
+                        f"gated on the outcome of the step that produced its contents"
+                    )
+    assert not offenders, "\n  ".join(offenders)

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -285,6 +285,16 @@ def _restricted_to_main(expr):
     refused outright rather than reasoned about, because `!(github.ref ==
     'refs/heads/main')` contains a positive main equality and is its exact inverse.
     """
+    return _requires(expr, _LEAF_MAIN)
+
+
+def _requires(expr, leaf):
+    """Whether ``expr`` can only be true when a ``leaf``-shaped condition holds.
+
+    The same reading for every guard: an OR restricts only when every branch does, an
+    AND when any branch does, parens are descended, and a `!` outside a `!=` is a
+    negation we refuse to reason about.
+    """
     if not expr.strip():
         return False
 
@@ -305,7 +315,7 @@ def _restricted_to_main(expr):
         # every wrapper that quotes it and inverts it: `(...) == false`, `... != true`,
         # and `startsWith(..., 'false')`, which is true off main because GitHub casts
         # the inner boolean to a string. A whitelist ends the class.
-        return bool(_LEAF_MAIN.fullmatch(part))
+        return bool(leaf.fullmatch(part))
 
     return restricted(expr)
 
@@ -418,11 +428,16 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                 # forms are satisfied by the wrong step: `.outputs.` matched the
                 # restore's own `cache-hit`, and "some earlier .outcome" matches the
                 # restore, so a save moved up beside it passed on an empty directory.
+                key_saved = str((step.get("with") or {}).get("key", "")).strip()
+                # Same key AND same path. Matching on the path alone accepted a restore
+                # whose key had drifted from the save's, so every run would read one key
+                # and write another and the download would never be reused.
                 restore_at = max(
                     (
                         j for j, s in enumerate(steps[:i])
                         if "actions/cache/restore@" in _uses(s)
                         and str((s.get("with") or {}).get("path", "")).strip() == path_saved
+                        and str((s.get("with") or {}).get("key", "")).strip() == key_saved
                     ),
                     default=None,
                 )
@@ -431,9 +446,9 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                 # the entry every run and reads it never.
                 if restore_at is None:
                     offenders.append(
-                        f"{label} saves {path_saved!r} with no restore of that path "
-                        f"above it, so the entry is written on every run and read on "
-                        f"none"
+                        f"{label} saves {path_saved!r} under {key_saved!r} with no "
+                        f"restore of that same key and path above it, so the entry is "
+                        f"written on every run and read on none"
                     )
                     continue
                 producers = set(re.findall(r"steps\.([A-Za-z0-9_-]+)\.outcome", condition))
@@ -450,6 +465,20 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                         f"{label} is gated on {sorted(producers)}, not on the declared "
                         f"producer {want!r}. A no-op step in the right position "
                         f"satisfies the interval below while filling nothing"
+                    )
+                    continue
+                # Mentioning the producer is not requiring it to have SUCCEEDED.
+                # `steps.probe.outcome != 'success'` and
+                # `(steps.probe.outcome == 'success' || always())` both name it and both
+                # save when it failed, writing a half-downloaded tree under a key that
+                # is immutable once created. Read with the same rigour as the ref guard.
+                success = re.compile(
+                    rf"steps\.{re.escape(want)}\.outcome\s*==\s*['\"]success['\"]"
+                )
+                if not _requires(condition, success):
+                    offenders.append(
+                        f"{label} names {want!r} but does not require it to have "
+                        f"succeeded, so it can save what a failed run left behind"
                     )
                     continue
                 if not producers:


### PR DESCRIPTION
`gemma4-audio-probe.yml:103` was the only unguarded cache writer left in either repo:

```yaml
- name: Cache the checkpoint
  uses: actions/cache@v6          # read-write, saves from its own post-step
  with:
    path: ~/.cache/huggingface
    key: hf-gemma4-e2b-4bit-v1    # static, no trailing hash
```

No `github.ref` gate. That is the same defect as setup-python's built-in `cache: 'pip'`, which #1109 removed everywhere else: the read-write form registers a post-step that saves on whatever ref the job ran on, with no knob to gate it. It was missed because it is not a pip cache and nothing asserted on the shape.

The workflow triggers on `pull_request: [labeled]`, so a labelled PR writes a 3.4 GB checkpoint to `refs/pull/N/merge` that only that PR's own re-runs can ever restore, with seven macOS legs racing the one key, against a budget this repo was measured at 99% of on 2026-08-26.

The janitor could not have recovered it. `hf-gemma4-e2b-4bit-v1` carries no trailing dependency hash, so `cache-janitor.yml`'s pass 2 falls through to `*) continue` and never ranks it. Only closing the PR would have freed the bytes. It is dormant today, which is the only reason nothing has noticed.

## Change

Split into `actions/cache/restore` plus a save gated on the default branch, matching `pip-cache-save`.

Two details that matter:

- **The save goes below the Probe, not where the restore sits.** The probe is what downloads the checkpoint. The read-write form saved from a post-step at the end of the job, so a naive split would store an empty directory under the key, and every later job would hit it and find nothing.
- **It is gated on `steps.probe.outcome == 'success'`**, so a failed run cannot publish a half-downloaded checkpoint under a key that reads as complete.

`actions/cache@v6` also becomes the pinned SHA the rest of the repo uses.

The main-only gate means the entry is now only ever populated by a `workflow_dispatch` on main. That is the same tradeoff every other cache in the repo makes, and it beats 3.4 GB per labelled PR.

## The guard is generalised, not pointed at this file

`test_pip_cache_actions.py` asserted the main-only rule on the `pip-cache-save` action alone, because that was the only thing writing PR-scoped entries when it was written. Two checks now cover the shape instead:

- `test_no_cache_save_reaches_a_pull_request_ref` scans every workflow step and every composite action for `actions/cache@` or `actions/cache/save@` and requires a structural main-only condition. Structural rather than a substring test, because `github.ref != 'refs/heads/main'` and a top-level `||` admitting another event both contain the literal string while still permitting PR saves. The predicate itself is parametrised and tested.
- `test_a_downloaded_artifact_is_saved_after_it_is_downloaded` requires a save to be gated on the outcome of the step that filled its directory, which is the trap in splitting a read-write cache.

Both confirmed non-vacuous: against the previous file the first fails with `gemma4-audio-probe.yml:probe: Cache the checkpoint`.

## Verify

```
pytest tests/test_pip_cache_actions.py
```

47 passed. Then trigger the probe on a labelled test PR and confirm no `refs/pull/*` entry appears in `gh api /repos/unslothai/unsloth-zoo/actions/caches`.

## Not in this PR

The 6.18 GiB of `setup-python-*-pip-*` entries currently on `refs/pull/929/merge` are unrelated to this. They were written on 2026-08-26 between 09:25 and 09:36 by CI runs that had started at 07:38, before #1109 merged at 09:16, so they are the last exhaust of the pre-migration workflow rather than an ongoing leak. PR #929's current merge ref carries main's post-migration workflow and would write nothing today. They expire on the 7-day idle timer.