### PR TITLE
MLX: fused Metal kernels for the gated-delta training backward

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -566,6 +566,31 @@ jobs:
 
       - name: tests/test_mlx_batching_and_decay.py
         run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_batching_and_decay.py -v -rs
+
+      # The three gated-delta files ran in no workflow at all: this lane's list
+      # omitted them and the Apple Silicon lane, which is opt-in behind the `mlx`
+      # label, names only test_qwen35_vjp_metal.py. So the ops VJP, the batched
+      # gradient regression from #776 and the consumer-binding sweep shipped
+      # ungated. They need mlx core plus mlx-lm, not Metal, so they belong here;
+      # the Metal-only halves skip and stay the macOS lane's job.
+      - name: tests/test_mlx_gated_delta.py
+        run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_gated_delta.py -v -rs
+
+      - name: tests/test_mlx_gated_delta_vjp.py
+        run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_gated_delta_vjp.py -v -rs
+
+      - name: tests/test_mlx_gated_delta_batch_grad.py
+        # Gradient parity vs plain autodiff at B >= 2. Every test here needs the
+        # real runtime, so under the torch shim the file skips wholesale -- which
+        # is exactly what the gate below refuses to accept as a pass.
+        run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_gated_delta_batch_grad.py -v -rs
+
+      - name: Fail if the gated-delta gradient tests skipped
+        run: |
+          .lanes/venv-suites/bin/python -m pytest tests/test_mlx_gated_delta_batch_grad.py -q -rs | tee gd.txt
+          if ! grep -qiE '[1-9][0-9]* passed' gd.txt; then
+            echo "real mlx is installed but no gated-delta gradient test ran"; exit 1
+          fi
   # Core (HF/TRL/peft) drift matrix. Three cells: HF=4.57.6+TRL<1, HF=latest+TRL=latest,
   # and pyproject defaults.
   #

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -406,6 +406,67 @@ def test_kernel_dispatch_guards_partial_threadgroup_rows():
     assert not gv.gated_delta_kernel_supported(q, g, None, bad_v, q)
 
 
+@pytest.mark.skipif(_HAS_METAL, reason="the off-Metal answer is what is pinned here")
+def test_kernel_support_declines_off_metal_without_touching_the_layout_search():
+    """Off Metal the predicate must answer False, not raise.
+
+    The layout search reads `dtype.size`, which only a real mx.Dtype has, so with
+    it ahead of the device guard a training call under the torch shim died with
+    AttributeError instead of falling back to the ops VJP.
+    """
+    import unsloth_zoo.gated_delta_vjp as gv
+
+    q = mx.zeros((1, 8, 2, 64))
+    k = mx.zeros((1, 8, 2, 64))
+    v = mx.zeros((1, 8, 2, 64))
+    for g in (mx.zeros((1, 8, 2)), mx.zeros((1, 8, 2, 64))):
+        assert gv.gated_delta_kernel_supported(q, g, None, v, k) is False
+
+
+@pytest.mark.skipif(_HAS_METAL, reason="the off-Metal answer is what is pinned here")
+def test_training_call_falls_back_to_ops_vjp_off_metal(monkeypatch):
+    """The whole dispatch, not just the predicate: an open training window off
+    Metal must reach gated_delta_ops_efficient."""
+    import types
+
+    import unsloth_zoo.gated_delta_vjp as gv
+
+    # patch_gated_delta does `from mlx_lm.models import gated_delta`, which reads
+    # the package ATTRIBUTE, so sys.modules alone is not enough to redirect it.
+    package = types.ModuleType("mlx_lm")
+    models = types.ModuleType("mlx_lm.models")
+    module = types.ModuleType("mlx_lm.models.gated_delta")
+    module.gated_delta_update = lambda *args, **kwargs: ("original", None)
+    module.gated_delta_kernel = lambda *args, **kwargs: ("kernel", None)
+    module.compute_g = lambda A_log, a, dt_bias: mx.zeros(a.shape)
+    models.gated_delta = module
+    package.models = models
+    monkeypatch.setitem(sys.modules, "mlx_lm", package)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models", models)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.gated_delta", module)
+
+    reached = []
+    real_ops = gv.gated_delta_ops_efficient
+    monkeypatch.setattr(
+        gv, "gated_delta_ops_efficient",
+        lambda *args, **kwargs: (reached.append(True), real_ops(*args, **kwargs))[1],
+    )
+    gv.patch_gated_delta()
+
+    q = mx.zeros((1, 8, 2, 64))
+    v = mx.zeros((1, 8, 2, 64))
+    a = mx.zeros((1, 8, 2))
+    acquire_mlx_training_patches()
+    try:
+        module.gated_delta_update(
+            q, q, v, a, a, mx.zeros((2,)), mx.zeros((2,)),
+            state=None, mask=None, use_kernel=True,
+        )
+    finally:
+        release_mlx_training_patches()
+    assert reached, "training call off Metal did not reach the ops VJP"
+
+
 # -- training window and index detachment -------------------------------------
 
 @pytest.fixture

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -402,8 +402,8 @@ def test_kernel_dispatch_guards_partial_threadgroup_rows():
     g = mx.zeros((1, 8, 2))
     ok_v = mx.zeros((1, 8, 2, 16))
     bad_v = mx.zeros((1, 8, 2, 30))
-    assert gv.gated_delta_kernel_supported(q, g, None, ok_v)
-    assert not gv.gated_delta_kernel_supported(q, g, None, bad_v)
+    assert gv.gated_delta_kernel_supported(q, g, None, ok_v, q)
+    assert not gv.gated_delta_kernel_supported(q, g, None, bad_v, q)
 
 
 # -- training window and index detachment -------------------------------------

--- a/tests/test_qwen35_vjp_metal.py
+++ b/tests/test_qwen35_vjp_metal.py
@@ -290,13 +290,11 @@ def test_end_to_end_training_step_all_patches():
     assert any(float(mx.abs(g).max()) > 0 for g in flat), "all grads zero"
 
 
-# Two tolerances per output. The global one bounds error against the tensor's
-# largest magnitude; the elementwise one bounds each output against its own
-# magnitude, so a single badly-computed small entry cannot hide behind a large
-# one. bf16 inputs quantize y to ~4e-3 either way; the fp32 state carries no
-# such rounding and is held to fp32 accumulation error.
-_Y_TOL = {mx.bfloat16: 5e-3, mx.float32: 5e-6}
-_Y_ELEM_TOL = {mx.bfloat16: 8e-3, mx.float32: 2e-5}
+# The global tolerance bounds error against the tensor's largest magnitude,
+# the elementwise one against each entry's own, so a small badly computed
+# entry cannot hide behind a large one.
+_Y_TOL = {mx.bfloat16: 5e-3, mx.float16: 5e-4, mx.float32: 5e-6}
+_Y_ELEM_TOL = {mx.bfloat16: 8e-3, mx.float16: 1e-3, mx.float32: 2e-5}
 _STATE_TOL = 1e-6
 _STATE_ELEM_TOL = 2e-5
 
@@ -311,9 +309,14 @@ def _inputs(B, T, Hk, Hv, Dk, Dv, dtype, vectorized, seed=0):
     g = mx.exp(-mx.random.uniform(shape=g_shape).astype(mx.float32) * 0.5)
     beta = mx.random.uniform(shape=(B, T, Hv)).astype(dtype)
     state = mx.random.normal((B, Hv, Dv, Dk)).astype(mx.float32) * 0.1
-    if Hv > Hk:
-        q, k = mx.repeat(q, Hv // Hk, -2), mx.repeat(k, Hv // Hk, -2)
     return q, k, v, g, beta, state
+
+
+def _gqa_repeated(args):
+    # q/k as the kernels see them; the drivers repeat before dispatching.
+    q, k, v, g, beta, state = args
+    r = v.shape[-2] // q.shape[-2]
+    return (mx.repeat(q, r, -2), mx.repeat(k, r, -2), v, g, beta, state) if r > 1 else args
 
 
 def _reference(q, k, v, g, beta, state):
@@ -328,44 +331,50 @@ def _reference(q, k, v, g, beta, state):
     return mx.stack(ys, axis=1), s
 
 
+def _grads_of(fn, args, w, ws):
+    def inner(q, k, v, g, beta, state):
+        y, s = fn(q, k, v, g, beta, state)
+        return (y.astype(mx.float32) * w).sum() + (s.astype(mx.float32) * ws).sum()
+    return mx.value_and_grad(inner, argnums=(0, 1, 2, 3, 4, 5))(*args)
+
+
 def _rel(a, b):
     return float(mx.max(mx.abs(a.astype(mx.float32) - b)) / mx.max(mx.abs(b)))
 
 
 def _elem_rel(a, b, floor=0.01):
-    """Worst deviation relative to each element's own magnitude.
-
-    The denominator carries a floor of ``floor`` x the tensor's scale so that
-    outputs that are near zero by construction do not divide by ~0.
-    """
-    d = mx.abs(a.astype(mx.float32) - b)
-    return float(mx.max(d / (mx.abs(b) + floor * mx.max(mx.abs(b)))))
+    """Deviation per entry, floored at ``floor`` x the tensor's scale."""
+    return float(mx.max(mx.abs(a.astype(mx.float32) - b)
+                        / (mx.abs(b) + floor * mx.max(mx.abs(b)))))
 
 
-# (B, T, Hk, Hv, Dk, Dv, dtype, vectorized) -- one case per P the layout can
-# derive (2, 4, 8, 16, 32, so every step of the shuffle reduction runs), the
-# segment widths that are not 16 (W=20, 24, 28), both gating shapes, both input
-# dtypes, threadgroups that do and do not fill a simdgroup, and a T that is not
-# a multiple of the time block.
+# (B, T, Hk, Hv, Dk, Dv, dtype, vectorized). Between them the layout derives
+# every thread prefix (1 to 32) and segment width (4 to 32) it can produce, for
+# both gating shapes, all three input dtypes, one to eight simdgroups per
+# threadgroup, GQA ratios 1 to 4, and a T that is not a multiple of the block.
 _CASES = [
     (1, 64, 16, 32, 128, 128, mx.bfloat16, False),
     (2, 77, 16, 32, 128, 128, mx.bfloat16, False),
     (1, 64, 32, 32, 128, 128, mx.float32, False),
     (1, 33, 4, 8, 64, 64, mx.bfloat16, False),
-    (1, 40, 2, 4, 96, 128, mx.bfloat16, False),
+    (1, 40, 2, 4, 96, 128, mx.bfloat16, False),   # W=24 forward, W=12 backward
     (1, 64, 8, 16, 128, 128, mx.bfloat16, True),
-    (1, 20, 2, 4, 32, 128, mx.float32, False),   # P=2, DB=128
-    (1, 20, 2, 4, 160, 128, mx.float32, False),  # W=20, Dk not a power of two
-    (1, 20, 2, 4, 256, 128, mx.float32, False),  # P=16, TB=8
-    (1, 20, 2, 4, 128, 3, mx.float32, False),    # 24 threads: partial simdgroup
-    (1, 20, 2, 4, 32, 6, mx.float32, True),      # 12 threads, per-column gating
-    (1, 20, 2, 4, 224, 128, mx.float32, False),  # W=28
-    (1, 20, 2, 4, 512, 128, mx.bfloat16, False), # P=32: the off=16 shuffle step
+    (1, 20, 2, 4, 32, 128, mx.float32, False),    # P=1 forward, P=2 backward
+    (1, 20, 2, 4, 160, 128, mx.float32, False),   # W=20, Dk not a power of two
+    (1, 20, 2, 4, 256, 128, mx.float32, False),   # P=16 backward
+    (1, 20, 2, 4, 128, 4, mx.float32, False),     # 32 threads, one simdgroup
+    (1, 20, 2, 4, 128, 40, mx.float32, False),    # Dv not a multiple of the cap
+    (1, 20, 2, 4, 224, 128, mx.float32, False),
+    (1, 20, 2, 4, 64, 128, mx.float32, True),     # per-column gating, P=2/P=4
+    (1, 20, 2, 4, 128, 2, mx.float32, False),
+    (1, 20, 2, 4, 128, 1, mx.float32, True),      # P=32, W=4: the off=16 shuffle
+    (1, 20, 2, 8, 128, 128, mx.bfloat16, False),
+    (1, 20, 2, 4, 128, 128, mx.float16, False),
 ]
 
 
 def _case_id(c):
-    return f"B{c[0]}T{c[1]}_Dk{c[4]}Dv{c[5]}_{'vec' if c[7] else 'scalar'}_{str(c[6])[10:]}"
+    return f"B{c[0]}T{c[1]}_Dk{c[4]}Dv{c[5]}_{'vec' if c[7] else 'scalar'}_{str(c[6])[9:]}"
 
 
 @metal_only
@@ -373,7 +382,7 @@ def _case_id(c):
 def test_blocked_forward_matches_fp32_reference(case):
     from unsloth_zoo.gated_delta_vjp import gated_delta_blocked_forward
 
-    q, k, v, g, beta, state = _inputs(*case)
+    q, k, v, g, beta, state = _gqa_repeated(_inputs(*case))
     out = gated_delta_blocked_forward(q, k, v, g, beta, state)
     assert out is not None, "layout should be supported for this shape"
     y, s_out = out
@@ -386,56 +395,158 @@ def test_blocked_forward_matches_fp32_reference(case):
 
 
 @metal_only
-def test_blocked_forward_is_causal_per_step_and_independent_per_v_row():
-    """Perturb a late timestep and a non-zero v row; check both directions."""
-    from unsloth_zoo.gated_delta_vjp import gated_delta_blocked_forward
-
-    q, k, v, g, beta, state = _inputs(1, 40, 4, 8, 128, 128, mx.float32, False)
-    y0, _ = gated_delta_blocked_forward(q, k, v, g, beta, state)
-
-    t_p, dv_p = 37, 71  # deliberately not step 0 and not row 0
-    v2 = mx.array(v)
-    v2[0, t_p, 5, dv_p] = v2[0, t_p, 5, dv_p] + 1.0
-    y1, _ = gated_delta_blocked_forward(q, k, v2, g, beta, state)
-    d = mx.abs(y1 - y0)
-    assert float(mx.max(d[:, :t_p])) == 0.0, "a step must not affect earlier steps"
-    assert float(mx.max(d[:, t_p:, 5, dv_p])) > 0.0, "later steps of the row must move"
-    assert float(mx.max(d[:, :, 4])) == 0.0, "other v heads must not move"
-    other = mx.concatenate([d[:, :, 5, :dv_p], d[:, :, 5, dv_p + 1:]], axis=-1)
-    assert float(mx.max(other)) == 0.0, "other rows of the same head must not move"
-
-
-@metal_only
-def test_unsupported_layout_falls_back_to_the_stock_kernel():
+def test_only_calls_the_kernels_can_answer_for_are_admitted():
     from unsloth_zoo.gated_delta_vjp import (
-        _blocked_layout, gated_delta_blocked_forward, gated_delta_kernel_efficient,
+        _blocked_layouts, gated_delta_blocked_backward, gated_delta_blocked_forward,
+        gated_delta_kernel_supported,
     )
 
-    assert _blocked_layout(40, 128, mx.bfloat16, False) is None  # Dk % 16 != 0
-    assert _blocked_layout(128, 40, mx.bfloat16, False) is None  # Dv % DB != 0
-    assert _blocked_layout(128, 128, mx.bfloat16, False)[:2] == (8, 16)
-    # Dv=40 satisfies gated_delta_kernel_supported but derives no blocked
-    # layout, so the whole path has to run on the stock forward.
-    q, k, v, g, beta, state = _inputs(1, 40, 2, 4, 128, 40, mx.float32, False)
+    q, k, v, g, beta, state = _inputs(1, 8, 1, 1, 288, 128, mx.float32, False)
+    assert _blocked_layouts(q, g, v) is None   # Dk=288 passes every other rule
+    assert not gated_delta_kernel_supported(q, g, None, v, k)
     assert gated_delta_blocked_forward(q, k, v, g, beta, state) is None
-    y, s = gated_delta_kernel_efficient(q, k, v, g, beta, state)
-    y_ref, s_ref = _reference(q, k, v, g, beta, state)
-    assert _rel(y, y_ref) < _Y_TOL[mx.float32] and _rel(s, s_ref) < _STATE_TOL
+
+    ok_q, ok_k, ok_v, ok_g, _, _ = _inputs(1, 8, 1, 1, 128, 128, mx.float32, False)
+    bf_q, bf_k, bf_v, bf_g = (x.astype(mx.bfloat16) for x in (ok_q, ok_k, ok_v, ok_g))
+    assert gated_delta_kernel_supported(ok_q, ok_g, None, ok_v, ok_k)
+    assert gated_delta_kernel_supported(bf_q, bf_g, None, bf_v, bf_k)
+    for partial in ((ok_q, ok_g, None), (ok_q, ok_g, None, ok_v), (q, g, None)):
+        assert not gated_delta_kernel_supported(*partial)
+    # One element type behind all three, same-width mixes included.
+    for mix in ((ok_q, ok_g, ok_v, bf_k), (ok_q, ok_g, bf_v, ok_k),
+                (bf_q, bf_g, bf_v, bf_k.astype(mx.float16))):
+        assert not gated_delta_kernel_supported(mix[0], mix[1], None, *mix[2:])
+    fwd, bwd = gated_delta_blocked_forward, gated_delta_blocked_backward
+    args = list(_inputs(1, 16, 4, 4, 128, 128, mx.float32, False))
+    dy, d_state = mx.random.normal((1, 16, 4, 128)), mx.zeros_like(args[5])
+    assert fwd(*args) is not None and bwd(*args, dy, d_state) is not None
+    for i in (1, 2):
+        mixed = list(args)
+        mixed[i] = mixed[i].astype(mx.bfloat16)
+        assert fwd(*mixed) is None and bwd(*mixed, dy, d_state) is None
+    assert bwd(*args, dy.astype(mx.bfloat16), d_state) is None
 
 
 @metal_only
-def test_kernel_efficient_forward_uses_the_blocked_kernel():
+@pytest.mark.parametrize("dtypes", [(mx.float32, mx.float32), (mx.float32, mx.bfloat16),
+                                    (mx.bfloat16, mx.bfloat16)])
+def test_every_output_keeps_the_dtype_its_primal_came_in(dtypes):
+    """g, beta and the state can arrive in a dtype no in-tree caller uses."""
     import unsloth_zoo.gated_delta_vjp as gdv
 
-    q, k, v, g, beta, state = _inputs(1, 96, 32, 32, 128, 128, mx.float32, False)
-    calls, real = [], gdv.gated_delta_blocked_forward
-    gdv.gated_delta_blocked_forward = lambda *a: (calls.append(1), real(*a))[1]
+    in_dtype, rest_dtype = dtypes
+    q, k, v, *rest = _inputs(1, 100, 4, 4, 128, 128, in_dtype, False)
+    g, beta, state = (x.astype(rest_dtype) for x in rest)
+    ref = _reference(q, k, v, g, beta, state.astype(mx.float32))[1]
+    for out in (gdv.gated_delta_blocked_forward(q, k, v, g, beta, state)[1],
+                gdv.gated_delta_kernel_efficient(q, k, v, g, beta, state)[1]):
+        mx.eval(out)
+        assert out.dtype == rest_dtype and out.shape == state.shape
+        assert _rel(out, ref) < (_STATE_TOL if rest_dtype == mx.float32 else 5e-3)
+
+    mx.random.seed(13)
+    w, ws = mx.random.normal((1, 100, 4, 128)), mx.random.normal((1, 4, 128, 128))
+    primals = (q, k, v, g, beta, state)
+    # Not elementwise: a bf16 operand leaves three decimal digits, and
+    # cancellation then dominates the small entries.
+    gtol = 2e-6 if in_dtype == rest_dtype == mx.float32 else 1e-2
+    got = _grads_of(gdv.gated_delta_kernel_efficient, primals, w, ws)[1]
+    want = _grads_of(gdv.gated_delta_ops_efficient, primals, w, ws)[1]
+    for name, a, b, primal in zip("q k v g beta state".split(), got, want, primals):
+        assert a.dtype == primal.dtype and a.shape == primal.shape, name
+        assert _rel(a, b) < gtol, name
+
+
+@metal_only
+@pytest.mark.parametrize("case", _CASES, ids=_case_id)
+def test_gradients_match_autodiff_over_the_same_recurrence(case):
+    """Different accumulation orders, so the elementwise bound exposes a misroute."""
+    import unsloth_zoo.gated_delta_vjp as gdv
+
+    args = _inputs(*case)
+    B, T, Hk, Hv, Dk, Dv, dtype, _ = case
+    mx.random.seed(11)
+    w = mx.random.normal((B, T, Hv, Dv))
+    ws = mx.random.normal((B, Hv, Dv, Dk))
+    tol, elem_tol = (2e-6, 2e-5) if dtype == mx.float32 else (5e-3, 2e-2)
+    l_k, g_k = _grads_of(gdv.gated_delta_kernel_efficient, args, w, ws)
+    l_o, g_o = _grads_of(gdv.gated_delta_ops_efficient, args, w, ws)
+    assert abs(float(l_k) - float(l_o)) <= tol * max(abs(float(l_o)), 1.0)
+    for name, a, b, primal in zip("q k v g beta state".split(), g_k, g_o, args):
+        assert a.shape == b.shape and a.dtype == primal.dtype, name
+        assert _rel(a, b) < tol, name
+        assert _elem_rel(a, b) < elem_tol, name
+
+
+@metal_only
+def test_backward_is_causal_and_reaches_non_first_positions():
+    """Perturbing dy at one late step must move the gradients at and before it
+    and leave the rest at a noise floor the atomic reductions make nonzero."""
+    import unsloth_zoo.gated_delta_vjp as gdv
+
+    q, k, v, g, beta, state = _inputs(1, 40, 4, 8, 128, 128, mx.float32, False)
+    t_p, hv_p, dv_p = 31, 5, 97   # deliberately none of them index 0
+    hq_p = hv_p // (8 // 4)       # d_q is folded back to the 4 key heads
+
+    def grads(dy):
+        def inner(q, k, v, g, beta, state):
+            y, _ = gdv.gated_delta_kernel_efficient(q, k, v, g, beta, state)
+            return (y.astype(mx.float32) * dy).sum()
+        return mx.grad(inner, argnums=(0, 2))(q, k, v, g, beta, state)
+
+    mx.random.seed(7)
+    dy0 = mx.random.normal((1, 40, 8, 128))
+    dy1 = mx.array(dy0)
+    dy1[0, t_p, hv_p, dv_p] += 1.0
+    (dq0, dv0), (dq1, dv1) = grads(dy0), grads(dy1)
+    repeats = [grads(dy0) for _ in range(4)]
+    floor = 8 * max([1e-12] + [float(mx.max(mx.abs(a - b)))
+                               for r in repeats for a, b in zip(r, (dq0, dv0))])
+    d_q, d_v = mx.abs(dq1 - dq0), mx.abs(dv1 - dv0)
+
+    # d_q[t] contracts dy[t] with the state at t: only t_p, only its head.
+    assert float(mx.max(d_q[:, :t_p])) <= floor, "d_q must not move before t_p"
+    assert float(mx.max(d_q[:, t_p + 1:])) <= floor, "d_q must not move after t_p"
+    assert float(mx.max(d_q[:, t_p, :hq_p])) <= floor
+    assert float(mx.max(d_q[:, t_p, hq_p + 1:])) <= floor
+    assert float(mx.max(d_q[:, t_p, hq_p])) > 1e3 * floor
+    # d_v never looks ahead, and its trail runs the whole way back rather than
+    # stopping near the step the reverse scan entered on. v enters its own
+    # state row only, so every other row is untouched exactly.
+    assert float(mx.max(d_v[:, t_p + 1:])) <= floor, "d_v cannot look ahead"
+    assert float(d_v[0, t_p, hv_p, dv_p]) > 1e3 * floor
+    assert float(mx.min(d_v[0, :t_p + 1, hv_p, dv_p])) > 10 * floor
+    other = mx.concatenate([d_v[:, :, hv_p, :dv_p], d_v[:, :, hv_p, dv_p + 1:]], axis=-1)
+    assert float(mx.max(other)) == 0.0, "d_v must stay in the perturbed state row"
+    assert float(mx.max(d_v[:, :, :hv_p])) == 0.0
+    assert float(mx.max(d_v[:, :, hv_p + 1:])) == 0.0
+
+
+@metal_only
+@pytest.mark.parametrize("T", [8, 64, 100, 128])
+def test_backward_checkpoints_block_boundaries_not_steps(T):
+    """One state per boundary between time blocks, not one per step; a
+    single-block chunk keeps one unwritten slot, which is the T=8 case."""
+    import unsloth_zoo.gated_delta_vjp as gdv
+
+    B, Hv, Dk, Dv = 1, 32, 128, 128
+    q, k, v, g, beta, state = _inputs(B, T, Hv, Hv, Dk, Dv, mx.bfloat16, False)
+    dy = mx.random.normal((B, T, Hv, Dv)).astype(mx.bfloat16)
+    TB = gdv._blocked_layouts(q, g, v)[1][3]
+    gdv._get_blocked_kernels(False)   # the spy replaces a built kernel triple
+    shapes, real = [], gdv._GD_BLOCKED[False]
+
+    def spy(**kwargs):
+        shapes.append(kwargs["output_shapes"])
+        return real[1](**kwargs)
+
+    gdv._GD_BLOCKED[False] = (real[0], spy, real[2])
     try:
-        y, s = gdv.gated_delta_kernel_efficient(q, k, v, g, beta, state)
+        mx.eval(gdv.gated_delta_blocked_backward(
+            q, k, v, g, beta, state, dy, mx.zeros_like(state)))
     finally:
-        gdv.gated_delta_blocked_forward = real
-    assert calls, "the chunked forward must dispatch the blocked kernel"
-    y_ref, s_ref = _reference(q, k, v, g, beta, state)
-    assert _rel(y, y_ref) < _Y_TOL[mx.float32]
-    assert _elem_rel(y, y_ref) < _Y_ELEM_TOL[mx.float32]
-    assert _rel(s, s_ref) < _STATE_TOL
+        gdv._GD_BLOCKED[False] = real
+
+    (ckpt_shape, kv_shape), = shapes
+    assert ckpt_shape == (B, Hv, max(1, -(-T // TB) - 1), Dv, Dk)
+    assert kv_shape == (B, Hv, T, Dv)

--- a/tests/test_qwen35_vjp_metal.py
+++ b/tests/test_qwen35_vjp_metal.py
@@ -290,9 +290,8 @@ def test_end_to_end_training_step_all_patches():
     assert any(float(mx.abs(g).max()) > 0 for g in flat), "all grads zero"
 
 
-# The global tolerance bounds error against the tensor's largest magnitude,
-# the elementwise one against each entry's own, so a small badly computed
-# entry cannot hide behind a large one.
+# The elementwise bound divides by each entry's own magnitude plus 1% of the
+# tensor's largest, so a small bad entry cannot hide behind a large one.
 _Y_TOL = {mx.bfloat16: 5e-3, mx.float16: 5e-4, mx.float32: 5e-6}
 _Y_ELEM_TOL = {mx.bfloat16: 8e-3, mx.float16: 1e-3, mx.float32: 2e-5}
 _STATE_TOL = 1e-6
@@ -313,7 +312,6 @@ def _inputs(B, T, Hk, Hv, Dk, Dv, dtype, vectorized, seed=0):
 
 
 def _gqa_repeated(args):
-    # q/k as the kernels see them; the drivers repeat before dispatching.
     q, k, v, g, beta, state = args
     r = v.shape[-2] // q.shape[-2]
     return (mx.repeat(q, r, -2), mx.repeat(k, r, -2), v, g, beta, state) if r > 1 else args
@@ -343,15 +341,12 @@ def _rel(a, b):
 
 
 def _elem_rel(a, b, floor=0.01):
-    """Deviation per entry, floored at ``floor`` x the tensor's scale."""
     return float(mx.max(mx.abs(a.astype(mx.float32) - b)
                         / (mx.abs(b) + floor * mx.max(mx.abs(b)))))
 
 
-# (B, T, Hk, Hv, Dk, Dv, dtype, vectorized). Between them the layout derives
-# every thread prefix (1 to 32) and segment width (4 to 32) it can produce, for
-# both gating shapes, all three input dtypes, one to eight simdgroups per
-# threadgroup, GQA ratios 1 to 4, and a T that is not a multiple of the block.
+# (B, T, Hk, Hv, Dk, Dv, dtype, vectorized). Together they exercise every thread
+# prefix and segment width the layout derives, both gatings, all dtypes, a ragged T.
 _CASES = [
     (1, 64, 16, 32, 128, 128, mx.bfloat16, False),
     (2, 77, 16, 32, 128, 128, mx.bfloat16, False),
@@ -412,7 +407,6 @@ def test_only_calls_the_kernels_can_answer_for_are_admitted():
     assert gated_delta_kernel_supported(bf_q, bf_g, None, bf_v, bf_k)
     for partial in ((ok_q, ok_g, None), (ok_q, ok_g, None, ok_v), (q, g, None)):
         assert not gated_delta_kernel_supported(*partial)
-    # One element type behind all three, same-width mixes included.
     for mix in ((ok_q, ok_g, ok_v, bf_k), (ok_q, ok_g, bf_v, ok_k),
                 (bf_q, bf_g, bf_v, bf_k.astype(mx.float16))):
         assert not gated_delta_kernel_supported(mix[0], mix[1], None, *mix[2:])
@@ -428,33 +422,26 @@ def test_only_calls_the_kernels_can_answer_for_are_admitted():
 
 
 @metal_only
-@pytest.mark.parametrize("dtypes", [(mx.float32, mx.float32), (mx.float32, mx.bfloat16),
-                                    (mx.bfloat16, mx.bfloat16)])
-def test_every_output_keeps_the_dtype_its_primal_came_in(dtypes):
-    """g, beta and the state can arrive in a dtype no in-tree caller uses."""
+@pytest.mark.parametrize("rest_dtype", [mx.float32, mx.bfloat16])
+def test_every_output_keeps_the_dtype_its_primal_came_in(rest_dtype):
     import unsloth_zoo.gated_delta_vjp as gdv
 
-    in_dtype, rest_dtype = dtypes
-    q, k, v, *rest = _inputs(1, 100, 4, 4, 128, 128, in_dtype, False)
+    q, k, v, *rest = _inputs(1, 100, 4, 4, 128, 128, mx.bfloat16, False)
     g, beta, state = (x.astype(rest_dtype) for x in rest)
-    ref = _reference(q, k, v, g, beta, state.astype(mx.float32))[1]
-    for out in (gdv.gated_delta_blocked_forward(q, k, v, g, beta, state)[1],
-                gdv.gated_delta_kernel_efficient(q, k, v, g, beta, state)[1]):
-        mx.eval(out)
-        assert out.dtype == rest_dtype and out.shape == state.shape
-        assert _rel(out, ref) < (_STATE_TOL if rest_dtype == mx.float32 else 5e-3)
-
+    primals = (q, k, v, g, beta, state)
     mx.random.seed(13)
     w, ws = mx.random.normal((1, 100, 4, 128)), mx.random.normal((1, 4, 128, 128))
-    primals = (q, k, v, g, beta, state)
-    # Not elementwise: a bf16 operand leaves three decimal digits, and
-    # cancellation then dominates the small entries.
-    gtol = 2e-6 if in_dtype == rest_dtype == mx.float32 else 1e-2
-    got = _grads_of(gdv.gated_delta_kernel_efficient, primals, w, ws)[1]
-    want = _grads_of(gdv.gated_delta_ops_efficient, primals, w, ws)[1]
-    for name, a, b, primal in zip("q k v g beta state".split(), got, want, primals):
+    ref = _reference(q, k, v, g, beta, state.astype(mx.float32))[1]
+    for out in (gdv.gated_delta_kernel_efficient(q, k, v, g, beta, state)[1],
+                gdv.gated_delta_blocked_forward(q, k, v, g, beta, state)[1]):
+        assert out.dtype == rest_dtype and _rel(out, ref) < 5e-3
+    # Not elementwise: bf16 leaves three digits, so cancellation dominates.
+    for name, a, b, primal in zip(
+            "q k v g beta state".split(),
+            _grads_of(gdv.gated_delta_kernel_efficient, primals, w, ws)[1],
+            _grads_of(gdv.gated_delta_ops_efficient, primals, w, ws)[1], primals):
         assert a.dtype == primal.dtype and a.shape == primal.shape, name
-        assert _rel(a, b) < gtol, name
+        assert _rel(a, b) < 1e-2, name
 
 
 @metal_only
@@ -480,8 +467,8 @@ def test_gradients_match_autodiff_over_the_same_recurrence(case):
 
 @metal_only
 def test_backward_is_causal_and_reaches_non_first_positions():
-    """Perturbing dy at one late step must move the gradients at and before it
-    and leave the rest at a noise floor the atomic reductions make nonzero."""
+    """Perturbing dy at one late step moves d_q only at that step and head, and d_v
+    all the way back from it; the rest sits at the atomic reductions' noise floor."""
     import unsloth_zoo.gated_delta_vjp as gdv
 
     q, k, v, g, beta, state = _inputs(1, 40, 4, 8, 128, 128, mx.float32, False)
@@ -504,37 +491,60 @@ def test_backward_is_causal_and_reaches_non_first_positions():
                                for r in repeats for a, b in zip(r, (dq0, dv0))])
     d_q, d_v = mx.abs(dq1 - dq0), mx.abs(dv1 - dv0)
 
-    # d_q[t] contracts dy[t] with the state at t: only t_p, only its head.
-    assert float(mx.max(d_q[:, :t_p])) <= floor, "d_q must not move before t_p"
-    assert float(mx.max(d_q[:, t_p + 1:])) <= floor, "d_q must not move after t_p"
-    assert float(mx.max(d_q[:, t_p, :hq_p])) <= floor
-    assert float(mx.max(d_q[:, t_p, hq_p + 1:])) <= floor
+    assert max(float(mx.max(d_q[:, :t_p])), float(mx.max(d_q[:, t_p + 1:]))) <= floor
+    assert max(float(mx.max(d_q[:, t_p, :hq_p])), float(mx.max(d_q[:, t_p, hq_p+1:]))) <= floor
     assert float(mx.max(d_q[:, t_p, hq_p])) > 1e3 * floor
-    # d_v never looks ahead, and its trail runs the whole way back rather than
-    # stopping near the step the reverse scan entered on. v enters its own
-    # state row only, so every other row is untouched exactly.
+    # d_v's trail runs the whole way back, not just to the step the scan entered on.
     assert float(mx.max(d_v[:, t_p + 1:])) <= floor, "d_v cannot look ahead"
     assert float(d_v[0, t_p, hv_p, dv_p]) > 1e3 * floor
     assert float(mx.min(d_v[0, :t_p + 1, hv_p, dv_p])) > 10 * floor
     other = mx.concatenate([d_v[:, :, hv_p, :dv_p], d_v[:, :, hv_p, dv_p + 1:]], axis=-1)
-    assert float(mx.max(other)) == 0.0, "d_v must stay in the perturbed state row"
-    assert float(mx.max(d_v[:, :, :hv_p])) == 0.0
-    assert float(mx.max(d_v[:, :, hv_p + 1:])) == 0.0
+    assert float(mx.max(other)) == 0.0, "d_v must stay in its own state row"
+    assert float(mx.max(d_v[:, :, :hv_p]) + mx.max(d_v[:, :, hv_p + 1:])) == 0.0
+
+
+@metal_only
+def test_the_chunk_length_is_the_longest_affordable_and_never_visible():
+    """A memory decision, so 64 and 512 agree bit for bit; the only seam coverage."""
+    import unsloth_zoo.gated_delta_vjp as gdv
+
+    bill = lambda B, Hv, Dk, Dv, n: B * Hv * Dv * Dk * 4 * max(0, n - 1)
+    for B, Hv, Dk, Dv, TB in ((1, 32, 128, 128, 8), (8, 32, 128, 64, 8),
+                              (64, 32, 128, 128, 4), (1, 32, 256, 256, 8)):
+        chunk = gdv._kernel_chunk_size(B, Hv, Dk, Dv, TB)
+        assert chunk % TB == 0 and gdv._KERNEL_CHUNK_MIN <= chunk <= gdv._KERNEL_CHUNK_MAX
+        if chunk > gdv._KERNEL_CHUNK_MIN:
+            assert bill(B, Hv, Dk, Dv, chunk // TB) <= gdv._KERNEL_CHECKPOINT_BUDGET
+        if chunk < gdv._KERNEL_CHUNK_MAX:
+            assert bill(B, Hv, Dk, Dv, chunk // TB + 1) > gdv._KERNEL_CHECKPOINT_BUDGET
+    assert gdv._kernel_chunk_size(1, 0, 128, 128, 8) == gdv._KERNEL_CHUNK_MAX
+
+    q, k, v, g, beta, state = _inputs(1, 300, 4, 4, 128, 128, mx.float32, False)
+    state, out, chunks = state.astype(mx.bfloat16), [], []
+    real, fwd = gdv._kernel_chunk_size, gdv.gated_delta_blocked_forward
+    gdv.gated_delta_blocked_forward = lambda *a: (chunks.append(a[0].shape[1]), fwd(*a))[1]
+    try:
+        for length in (64, 512):
+            gdv._kernel_chunk_size = lambda *a, n=length: n
+            out.append(gdv.gated_delta_kernel_efficient(q, k, v, g, beta, state))
+    finally:
+        gdv._kernel_chunk_size, gdv.gated_delta_blocked_forward = real, fwd
+    assert chunks == [64, 64, 64, 64, 44, 300], "the loop has to use the length"
+
+    assert (out[0][0] == out[1][0]).all() and (out[0][1] == out[1][1]).all()
+    assert out[0][1].dtype == mx.bfloat16 and out[0][1].shape == state.shape
 
 
 @metal_only
 @pytest.mark.parametrize("T", [8, 64, 100, 128])
 def test_backward_checkpoints_block_boundaries_not_steps(T):
-    """One state per boundary between time blocks, not one per step; a
-    single-block chunk keeps one unwritten slot, which is the T=8 case."""
     import unsloth_zoo.gated_delta_vjp as gdv
 
     B, Hv, Dk, Dv = 1, 32, 128, 128
     q, k, v, g, beta, state = _inputs(B, T, Hv, Hv, Dk, Dv, mx.bfloat16, False)
     dy = mx.random.normal((B, T, Hv, Dv)).astype(mx.bfloat16)
     TB = gdv._blocked_layouts(q, g, v)[1][3]
-    gdv._get_blocked_kernels(False)   # the spy replaces a built kernel triple
-    shapes, real = [], gdv._GD_BLOCKED[False]
+    shapes, real = [], gdv._get_blocked_kernels(False)
 
     def spy(**kwargs):
         shapes.append(kwargs["output_shapes"])

--- a/tests/test_qwen35_vjp_metal.py
+++ b/tests/test_qwen35_vjp_metal.py
@@ -10,18 +10,15 @@ These bugs ONLY manifest on Metal (``mx.metal.is_available()`` and the default
 device is the GPU). On CPU, mlx-vlm already falls back to differentiable ops, so
 every test here is skipped on non-Metal machines with a loud notice.
 
-Run on an Apple Silicon machine (CI installs unsloth-zoo with ``pip install -e .``):
-
-    pytest tests/test_pr738_qwen35_vjp_metal.py -v
-
 Target runtime: well under ~2 minutes on an M1.
 """
 
 import pytest
 
+mx = pytest.importorskip("mlx.core", reason="MLX is not installed.")
+import mlx.nn as nn
+
 try:
-    import mlx.core as mx
-    import mlx.nn as nn
     _HAS_METAL = mx.metal.is_available() and mx.default_device() == mx.gpu
 except Exception:
     _HAS_METAL = False
@@ -291,3 +288,154 @@ def test_end_to_end_training_step_all_patches():
     assert flat, "no gradients produced"
     assert all(bool(mx.all(mx.isfinite(g))) for g in flat), "non-finite grads"
     assert any(float(mx.abs(g).max()) > 0 for g in flat), "all grads zero"
+
+
+# Two tolerances per output. The global one bounds error against the tensor's
+# largest magnitude; the elementwise one bounds each output against its own
+# magnitude, so a single badly-computed small entry cannot hide behind a large
+# one. bf16 inputs quantize y to ~4e-3 either way; the fp32 state carries no
+# such rounding and is held to fp32 accumulation error.
+_Y_TOL = {mx.bfloat16: 5e-3, mx.float32: 5e-6}
+_Y_ELEM_TOL = {mx.bfloat16: 8e-3, mx.float32: 2e-5}
+_STATE_TOL = 1e-6
+_STATE_ELEM_TOL = 2e-5
+
+
+def _inputs(B, T, Hk, Hv, Dk, Dv, dtype, vectorized, seed=0):
+    mx.random.seed(seed)
+    q = mx.random.normal((B, T, Hk, Dk)).astype(dtype)
+    k = mx.random.normal((B, T, Hk, Dk)).astype(dtype)
+    k = k / mx.linalg.norm(k.astype(mx.float32), axis=-1, keepdims=True).astype(dtype)
+    v = mx.random.normal((B, T, Hv, Dv)).astype(dtype)
+    g_shape = (B, T, Hv, Dk) if vectorized else (B, T, Hv)
+    g = mx.exp(-mx.random.uniform(shape=g_shape).astype(mx.float32) * 0.5)
+    beta = mx.random.uniform(shape=(B, T, Hv)).astype(dtype)
+    state = mx.random.normal((B, Hv, Dv, Dk)).astype(mx.float32) * 0.1
+    if Hv > Hk:
+        q, k = mx.repeat(q, Hv // Hk, -2), mx.repeat(k, Hv // Hk, -2)
+    return q, k, v, g, beta, state
+
+
+def _reference(q, k, v, g, beta, state):
+    q, k, v = (x.astype(mx.float32) for x in (q, k, v))
+    beta = beta.astype(mx.float32)
+    s, ys = state, []
+    for t in range(q.shape[1]):
+        s = s * (g[:, t][..., None, None] if g.ndim == 3 else g[:, t][..., None, :])
+        delta = (v[:, t] - (s * k[:, t][..., None, :]).sum(-1)) * beta[:, t][..., None]
+        s = s + k[:, t][..., None, :] * delta[..., None]
+        ys.append((s * q[:, t][..., None, :]).sum(-1))
+    return mx.stack(ys, axis=1), s
+
+
+def _rel(a, b):
+    return float(mx.max(mx.abs(a.astype(mx.float32) - b)) / mx.max(mx.abs(b)))
+
+
+def _elem_rel(a, b, floor=0.01):
+    """Worst deviation relative to each element's own magnitude.
+
+    The denominator carries a floor of ``floor`` x the tensor's scale so that
+    outputs that are near zero by construction do not divide by ~0.
+    """
+    d = mx.abs(a.astype(mx.float32) - b)
+    return float(mx.max(d / (mx.abs(b) + floor * mx.max(mx.abs(b)))))
+
+
+# (B, T, Hk, Hv, Dk, Dv, dtype, vectorized) -- one case per P the layout can
+# derive (2, 4, 8, 16, 32, so every step of the shuffle reduction runs), the
+# segment widths that are not 16 (W=20, 24, 28), both gating shapes, both input
+# dtypes, threadgroups that do and do not fill a simdgroup, and a T that is not
+# a multiple of the time block.
+_CASES = [
+    (1, 64, 16, 32, 128, 128, mx.bfloat16, False),
+    (2, 77, 16, 32, 128, 128, mx.bfloat16, False),
+    (1, 64, 32, 32, 128, 128, mx.float32, False),
+    (1, 33, 4, 8, 64, 64, mx.bfloat16, False),
+    (1, 40, 2, 4, 96, 128, mx.bfloat16, False),
+    (1, 64, 8, 16, 128, 128, mx.bfloat16, True),
+    (1, 20, 2, 4, 32, 128, mx.float32, False),   # P=2, DB=128
+    (1, 20, 2, 4, 160, 128, mx.float32, False),  # W=20, Dk not a power of two
+    (1, 20, 2, 4, 256, 128, mx.float32, False),  # P=16, TB=8
+    (1, 20, 2, 4, 128, 3, mx.float32, False),    # 24 threads: partial simdgroup
+    (1, 20, 2, 4, 32, 6, mx.float32, True),      # 12 threads, per-column gating
+    (1, 20, 2, 4, 224, 128, mx.float32, False),  # W=28
+    (1, 20, 2, 4, 512, 128, mx.bfloat16, False), # P=32: the off=16 shuffle step
+]
+
+
+def _case_id(c):
+    return f"B{c[0]}T{c[1]}_Dk{c[4]}Dv{c[5]}_{'vec' if c[7] else 'scalar'}_{str(c[6])[10:]}"
+
+
+@metal_only
+@pytest.mark.parametrize("case", _CASES, ids=_case_id)
+def test_blocked_forward_matches_fp32_reference(case):
+    from unsloth_zoo.gated_delta_vjp import gated_delta_blocked_forward
+
+    q, k, v, g, beta, state = _inputs(*case)
+    out = gated_delta_blocked_forward(q, k, v, g, beta, state)
+    assert out is not None, "layout should be supported for this shape"
+    y, s_out = out
+    assert (y.dtype, s_out.dtype) == (q.dtype, state.dtype)
+    y_ref, s_ref = _reference(q, k, v, g, beta, state)
+    assert _rel(y, y_ref) < _Y_TOL[case[6]]
+    assert _elem_rel(y, y_ref) < _Y_ELEM_TOL[case[6]]
+    assert _rel(s_out, s_ref) < _STATE_TOL
+    assert _elem_rel(s_out, s_ref) < _STATE_ELEM_TOL
+
+
+@metal_only
+def test_blocked_forward_is_causal_per_step_and_independent_per_v_row():
+    """Perturb a late timestep and a non-zero v row; check both directions."""
+    from unsloth_zoo.gated_delta_vjp import gated_delta_blocked_forward
+
+    q, k, v, g, beta, state = _inputs(1, 40, 4, 8, 128, 128, mx.float32, False)
+    y0, _ = gated_delta_blocked_forward(q, k, v, g, beta, state)
+
+    t_p, dv_p = 37, 71  # deliberately not step 0 and not row 0
+    v2 = mx.array(v)
+    v2[0, t_p, 5, dv_p] = v2[0, t_p, 5, dv_p] + 1.0
+    y1, _ = gated_delta_blocked_forward(q, k, v2, g, beta, state)
+    d = mx.abs(y1 - y0)
+    assert float(mx.max(d[:, :t_p])) == 0.0, "a step must not affect earlier steps"
+    assert float(mx.max(d[:, t_p:, 5, dv_p])) > 0.0, "later steps of the row must move"
+    assert float(mx.max(d[:, :, 4])) == 0.0, "other v heads must not move"
+    other = mx.concatenate([d[:, :, 5, :dv_p], d[:, :, 5, dv_p + 1:]], axis=-1)
+    assert float(mx.max(other)) == 0.0, "other rows of the same head must not move"
+
+
+@metal_only
+def test_unsupported_layout_falls_back_to_the_stock_kernel():
+    from unsloth_zoo.gated_delta_vjp import (
+        _blocked_layout, gated_delta_blocked_forward, gated_delta_kernel_efficient,
+    )
+
+    assert _blocked_layout(40, 128, mx.bfloat16, False) is None  # Dk % 16 != 0
+    assert _blocked_layout(128, 40, mx.bfloat16, False) is None  # Dv % DB != 0
+    assert _blocked_layout(128, 128, mx.bfloat16, False)[:2] == (8, 16)
+    # Dv=40 satisfies gated_delta_kernel_supported but derives no blocked
+    # layout, so the whole path has to run on the stock forward.
+    q, k, v, g, beta, state = _inputs(1, 40, 2, 4, 128, 40, mx.float32, False)
+    assert gated_delta_blocked_forward(q, k, v, g, beta, state) is None
+    y, s = gated_delta_kernel_efficient(q, k, v, g, beta, state)
+    y_ref, s_ref = _reference(q, k, v, g, beta, state)
+    assert _rel(y, y_ref) < _Y_TOL[mx.float32] and _rel(s, s_ref) < _STATE_TOL
+
+
+@metal_only
+def test_kernel_efficient_forward_uses_the_blocked_kernel():
+    import unsloth_zoo.gated_delta_vjp as gdv
+
+    q, k, v, g, beta, state = _inputs(1, 96, 32, 32, 128, 128, mx.float32, False)
+    calls, real = [], gdv.gated_delta_blocked_forward
+    gdv.gated_delta_blocked_forward = lambda *a: (calls.append(1), real(*a))[1]
+    try:
+        y, s = gdv.gated_delta_kernel_efficient(q, k, v, g, beta, state)
+    finally:
+        gdv.gated_delta_blocked_forward = real
+    assert calls, "the chunked forward must dispatch the blocked kernel"
+    y_ref, s_ref = _reference(q, k, v, g, beta, state)
+    assert _rel(y, y_ref) < _Y_TOL[mx.float32]
+    assert _elem_rel(y, y_ref) < _Y_ELEM_TOL[mx.float32]
+    assert _rel(s, s_ref) < _STATE_TOL

--- a/tests/test_qwen35_vjp_metal.py
+++ b/tests/test_qwen35_vjp_metal.py
@@ -360,6 +360,7 @@ _CASES = [
     (1, 20, 2, 4, 128, 4, mx.float32, False),     # 32 threads, one simdgroup
     (1, 20, 2, 4, 128, 40, mx.float32, False),    # Dv not a multiple of the cap
     (1, 20, 2, 4, 224, 128, mx.float32, False),
+    (1, 20, 2, 4, 256, 128, mx.float32, True),    # backward needs a narrowed threadgroup
     (1, 20, 2, 4, 64, 128, mx.float32, True),     # per-column gating, P=2/P=4
     (1, 20, 2, 4, 128, 2, mx.float32, False),
     (1, 20, 2, 4, 128, 1, mx.float32, True),      # P=32, W=4: the off=16 shuffle

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -1133,17 +1133,22 @@ def gated_delta_kernel_supported(q, g, mask, v=None, k=None) -> bool:
     """Whether the fused-kernel VJP path can handle this call.
 
     A caller omitting `v` or `k` gets False, not a yes the dispatch would refuse.
+
+    Device first: _blocked_layouts reads `dtype.size`, which only a real mx.Dtype
+    has, so off Metal this has to answer False before reaching it rather than
+    raise. tests/mlx_simulation hands out torch dtypes, so a training call under
+    the shim died in the layout search instead of falling back to the ops VJP.
     """
     return (
-        mask is None
+        mx.metal.is_available()
+        and mx.default_device() == mx.gpu
+        and mask is None
         and v is not None
         and k is not None
         and _blocked_shares_q_dtype(q, k, v)
         and g.ndim in (3, 4)
         and q.shape[-1] % 32 == 0
         and _blocked_layouts(q, g, v) is not None
-        and mx.default_device() == mx.gpu
-        and mx.metal.is_available()
     )
 
 

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -26,7 +26,8 @@ Usage:
     patch_gated_delta()  # monkey-patches mlx_lm's gated_delta module
 """
 
-from typing import Optional, Tuple
+from functools import lru_cache
+from typing import NamedTuple, Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 
@@ -305,7 +306,7 @@ def patch_gated_delta():
 
             # Training: prefer the fused-kernel VJP, ops VJP otherwise.
             if is_training_call:
-                if gated_delta_kernel_supported(q, g, mask, v):
+                if gated_delta_kernel_supported(q, g, mask, v, k):
                     return gated_delta_kernel_efficient(
                         q, k, v, g, beta, state, mask,
                     )
@@ -425,7 +426,7 @@ def patch_gated_delta_vlm():
         B, _, Hk, Dk = q.shape
         Hv, Dv = v.shape[-2:]
         state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
-        if gated_delta_kernel_supported(q, g, mask, v):
+        if gated_delta_kernel_supported(q, g, mask, v, k):
             return gated_delta_kernel_efficient(q, k, v, g, beta, state, mask)
         return gated_delta_ops_efficient(q, k, v, g, beta, state, mask)
 
@@ -465,7 +466,7 @@ def patch_gated_delta_vlm_shared():
         B, Dk = q.shape[0], q.shape[-1]
         Hv, Dv = v.shape[-2:]
         state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
-        if gated_delta_kernel_supported(q, g, mask, v):
+        if gated_delta_kernel_supported(q, g, mask, v, k):
             return gated_delta_kernel_efficient(q, k, v, g, beta, state, mask)
         return gated_delta_ops_efficient(q, k, v, g, beta, state, mask)
 
@@ -488,12 +489,8 @@ def patch_gated_delta_vlm_shared():
 #
 # The ops VJP above is memory-correct but dispatch-bound (~T*12 lazy
 # primitives per layer per step, unfusable by mx.compile). These kernels work
-# at chunk granularity: forward runs the blocked-sequential kernel below (or
-# mlx-lm's gated_delta_kernel for shapes it does not cover); backward replays
-# chunk states (K1) and reverse-scans with atomic grad accumulation (K2).
-# Eligible on Metal GPU, mask=None, Dk % 32 == 0, for both
-# scalar (qwen3_5/qwen3_next) and vectorized (kimi_linear) gating; else falls
-# back to the ops VJP. Atomic accumulation leaves low-order gradient bits
+# at chunk granularity: a blocked-sequential forward, and a backward that
+# checkpoints block boundaries and reverse-scans with atomics, leaving low bits
 # nondeterministic, as elsewhere on Metal.
 #
 # Must stay BELOW patch_gated_delta: the pinned-symbol suite (commit 46866ce)
@@ -503,11 +500,9 @@ def patch_gated_delta_vlm_shared():
 # --------------------------------------------------------------------------
 
 _KERNEL_CHUNK_SIZE = 64
-_KERNEL_THREADGROUP_X = 32
-_KERNEL_THREADGROUP_Y = 4
 
 
-# Blocked-sequential layout for the forward kernel below.
+# Blocked-sequential thread layout, shared by the three kernels below.
 #
 # mlx-lm's kernel gives every state row its own simdgroup: 32 lanes hold Dk/32
 # state columns each, every contraction costs a full simd_sum, and each of the
@@ -517,36 +512,66 @@ _KERNEL_THREADGROUP_Y = 4
 # threadgroup stages a TB-step time block of k/q/v/g/beta into threadgroup
 # memory once instead of re-reading it per row.
 
-_BLOCKED_TB_CHOICES = (32, 16, 8)
 _BLOCKED_TG_MEMORY = 32768   # Metal threadgroup-memory limit
 _BLOCKED_TG_THREADS = 256
 _BLOCKED_PAD = 8             # row padding, keeps threadgroup rows bank- and 8-byte-aligned
 
+class _BlockedCfg(NamedTuple):
+    """What a kernel needs from a thread layout.
 
-def _blocked_layout(Dk, Dv, in_dtype, vectorized):
-    """Derive (P, W, DB, TB, threads) for these dimensions, or None if none fits.
-
-    None means the caller keeps the 32-lanes-per-row kernel, so widening the
-    support predicate is never required to add this path.
+    `dk_rows`, `dv_rows` and `dv_f32_rows` count the Dk-wide, DB-wide and
+    DB-wide fp32 threadgroup arrays it stages per time step; `red_arrays`
+    counts its Dk-wide cross-row reduction rows, one per simdgroup. Together
+    they decide how long a time block fits in threadgroup memory.
     """
-    if Dk % 16 != 0 or Dv <= 0:
+    dk_rows: int
+    dv_rows: int
+    dv_f32_rows: int
+    red_arrays: int
+    max_segment: int
+    tb_choices: tuple
+
+
+# Wide segments give the forward more rows per threadgroup and fewer redundant
+# k/q reads; the backward carries three state fragments per thread and replays
+# blocks, so it prefers narrow. First fit wins; forcing agreement costs 1.9x.
+_BLOCKED_FORWARD_CFGS = (_BlockedCfg(2, 1, 0, 0, 32, (16, 8, 4)),)
+_BLOCKED_BACKWARD_CFGS = (_BlockedCfg(2, 2, 1, 2, 16, (8, 4)),
+                          _BlockedCfg(2, 2, 1, 2, 32, (8, 4)))
+
+
+def _blocked_dv_block(Dv, cap, rows_per_simd):
+    for DB in range(min(cap, Dv), 0, -1):
+        if Dv % DB == 0 and DB % rows_per_simd == 0:
+            return DB
+    return None
+
+
+@lru_cache(maxsize=None)
+def _blocked_layout(Dk, Dv, in_dtype, vectorized, cfg):
+    dk_rows, dv_rows, dv_f32_rows, red_arrays, max_segment, tb_choices = cfg
+    if red_arrays and vectorized:
+        red_arrays += 1        # per-column d_g reduces the same way d_k does
+    if Dk <= 0 or Dv <= 0:
         return None
     P = 1
-    while P * 2 <= min(32, Dk // 16):
+    while P <= 32:
+        W = Dk // P
+        # Whole simdgroups only: the backward reduces d_q/d_k across the 32 / P
+        # state rows a simdgroup holds, and a partial one would read idle lanes.
+        DB = (None if Dk % P or W % 4 or W > max_segment else
+              _blocked_dv_block(Dv, min(Dv, _BLOCKED_TG_THREADS // P), 32 // P))
+        if DB is not None:
+            # Cross-row reduction scratch: one Dk-wide row per simdgroup.
+            fixed = red_arrays * (P * DB // 32) * Dk * 4
+            for TB in tb_choices:
+                used = TB * (
+                    in_dtype.size * (dk_rows * (Dk + _BLOCKED_PAD) + dv_rows * (DB + _BLOCKED_PAD))
+                    + 4 * dv_f32_rows * (DB + _BLOCKED_PAD)
+                    + 4 * (1 + (Dk + _BLOCKED_PAD if vectorized else 1)))
+                if used + fixed <= _BLOCKED_TG_MEMORY:
+                    return P, W, DB, TB, P * DB
         P *= 2
-    W = Dk // P
-    if W % 4 != 0 or 32 % P != 0:
-        return None
-    DB = min(Dv, _BLOCKED_TG_THREADS // P)
-    if DB == 0 or Dv % DB != 0:
-        return None
-    threads = P * DB
-    isz = in_dtype.size
-    for TB in _BLOCKED_TB_CHOICES:
-        used = 2 * TB * (Dk + _BLOCKED_PAD) * isz + TB * (DB + _BLOCKED_PAD) * isz
-        used += TB * 4 * (1 + (Dk + _BLOCKED_PAD if vectorized else 1))
-        if used <= _BLOCKED_TG_MEMORY:
-            return P, W, DB, TB, threads
     return None
 
 
@@ -567,6 +592,8 @@ _BLOCKED_PREAMBLE = """
         const int seg = tid % P;
         const int d0  = seg * W;
         const int row_lane = (tid % 32) / P * P;
+        const int simd = tid / 32;
+        constexpr int NSIMD = TG / 32;
 
         const size_t krow = (size_t)Hk * Dk;
         const size_t vrow = (size_t)Hv * Dv;
@@ -654,17 +681,283 @@ _BLOCKED_FORWARD_SRC = """
         {{
           auto s_out = state_out + (((size_t)b * Hv + hv) * Dv + dv0 + dv) * Dk + d0;
           for (int i = 0; i < NV; ++i) {{
-            s_out[4 * i + 0] = st[i].x;
-            s_out[4 * i + 1] = st[i].y;
-            s_out[4 * i + 2] = st[i].z;
-            s_out[4 * i + 3] = st[i].w;
+            s_out[4 * i + 0] = static_cast<StT>(st[i].x);
+            s_out[4 * i + 1] = static_cast<StT>(st[i].y);
+            s_out[4 * i + 2] = static_cast<StT>(st[i].z);
+            s_out[4 * i + 3] = static_cast<StT>(st[i].w);
+          }}
+        }}
+"""
+
+
+_BLOCKED_CHECKPOINT_SRC = """
+        threadgroup InT k_s[TB][Dk + PAD];
+        threadgroup InT v_s[TB][DB + PAD];
+        threadgroup float b_s[TB];
+        {g_decl}
+
+        const device InT* k_base = k + ((size_t)b * T * Hk + hk) * Dk;
+        auto v_base = v + ((size_t)b * T * Hv + hv) * Dv + dv0;
+
+        // ckpt [B, Hv, NB, Dv, Dk]: state per boundary. kv [B, Hv, T, Dv]: k.state.
+        constexpr size_t cstride = (size_t)Dv * Dk;
+        const int NB = metal::max(1, (T + TB - 1) / TB - 1);
+        auto ck_base = ckpt + ((size_t)b * Hv + hv) * NB * cstride
+                     + (size_t)(dv0 + dv) * Dk + d0;
+        auto kv_base = kv + ((size_t)b * Hv + hv) * (size_t)T * Dv + dv0 + dv;
+
+        float4 st[NV];
+        {{
+          auto s_in = state_in + (((size_t)b * Hv + hv) * Dv + dv0 + dv) * Dk + d0;
+          for (int i = 0; i < NV; ++i) {{
+            st[i] = float4(static_cast<float>(s_in[4 * i + 0]),
+                           static_cast<float>(s_in[4 * i + 1]),
+                           static_cast<float>(s_in[4 * i + 2]),
+                           static_cast<float>(s_in[4 * i + 3]));
+          }}
+        }}
+
+        for (int t0 = 0; t0 < T; t0 += TB) {{
+          const int tt = (TB < T - t0) ? TB : (int)(T - t0);
+          for (int p = tid; p < tt * Dk; p += TG) {{
+            const int r = p / Dk, d = p % Dk;
+            k_s[r][d] = static_cast<InT>(k_base[(size_t)(t0 + r) * krow + d]);
+          }}
+          for (int p = tid; p < tt * DB; p += TG) {{
+            const int r = p / DB, d = p % DB;
+            v_s[r][d] = static_cast<InT>(v_base[(size_t)(t0 + r) * vrow + d]);
+          }}
+          for (int p = tid; p < tt; p += TG) {{
+            b_s[p] = static_cast<float>(beta[((size_t)b * T + t0 + p) * Hv + hv]);
+          }}
+          {g_stage}
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+
+          for (int t = 0; t < tt; ++t) {{
+            const float bt = b_s[t];
+            {g_load}
+            const threadgroup vec<InT, 4>* k4 =
+                (const threadgroup vec<InT, 4>*)&k_s[t][d0];
+
+            float4 kf[NV];
+            float4 acc = 0.0f;
+            for (int i = 0; i < NV; ++i) {{
+              kf[i] = float4(k4[i]);
+              st[i] *= {g_decay};
+              acc += st[i] * kf[i];
+            }}
+            float kv_mem = acc.x + acc.y + acc.z + acc.w;
+            for (int off = P / 2; off > 0; off >>= 1) {{
+              kv_mem += simd_shuffle_down(kv_mem, off);
+            }}
+            kv_mem = simd_shuffle(kv_mem, row_lane);
+            if (seg == 0) {{
+              kv_base[(size_t)(t0 + t) * Dv] = kv_mem;
+            }}
+            const float delta = (static_cast<float>(v_s[t][dv]) - kv_mem) * bt;
+            for (int i = 0; i < NV; ++i) {{
+              st[i] += kf[i] * delta;
+            }}
+          }}
+          if (t0 + TB < T) {{
+            device float4* out = (device float4*)(ck_base + (size_t)(t0 / TB) * cstride);
+            for (int i = 0; i < NV; ++i) {{
+              out[i] = st[i];
+            }}
+          }}
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        }}
+"""
+
+
+_BLOCKED_BACKWARD_SRC = """
+        threadgroup InT k_s[TB][Dk + PAD];
+        threadgroup InT q_s[TB][Dk + PAD];
+        threadgroup InT v_s[TB][DB + PAD];
+        threadgroup InT dy_s[TB][DB + PAD];
+        threadgroup float kv_s[TB][DB + PAD];
+        threadgroup float b_s[TB];
+        threadgroup float red_q[NSIMD][Dk];
+        threadgroup float red_k[NSIMD][Dk];
+        {d_g_scratch}
+        {g_decl}
+
+        const device InT* k_base = k + ((size_t)b * T * Hk + hk) * Dk;
+        const device InT* q_base = q + ((size_t)b * T * Hk + hk) * Dk;
+        auto v_base  = v  + ((size_t)b * T * Hv + hv) * Dv + dv0;
+        auto dy_base = dy + ((size_t)b * T * Hv + hv) * Dv + dv0;
+
+        constexpr size_t cstride = (size_t)Dv * Dk;
+        const int NB = metal::max(1, (T + TB - 1) / TB - 1);
+        auto ck_base = ckpt + ((size_t)b * Hv + hv) * NB * cstride
+                     + (size_t)(dv0 + dv) * Dk + d0;
+        auto kv_base = kv + ((size_t)b * Hv + hv) * (size_t)T * Dv + dv0 + dv;
+        auto s_in = state_in + (((size_t)b * Hv + hv) * Dv + dv0 + dv) * Dk + d0;
+        const int lane = tid % 32;
+
+        float4 d_state[NV];
+        {{
+          auto ds = d_state_out + (((size_t)b * Hv + hv) * Dv + dv0 + dv) * Dk + d0;
+          for (int i = 0; i < NV; ++i) {{
+            d_state[i] = float4(static_cast<float>(ds[4 * i + 0]),
+                                static_cast<float>(ds[4 * i + 1]),
+                                static_cast<float>(ds[4 * i + 2]),
+                                static_cast<float>(ds[4 * i + 3]));
+          }}
+        }}
+
+        float4 entry[NV];
+        float4 sp[NV];
+
+        for (int t0 = ((T - 1) / TB) * TB; t0 >= 0; t0 -= TB) {{
+          const int tt = (TB < T - t0) ? TB : (int)(T - t0);
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          for (int p = tid; p < tt * Dk; p += TG) {{
+            const int r = p / Dk, d = p % Dk;
+            k_s[r][d] = static_cast<InT>(k_base[(size_t)(t0 + r) * krow + d]);
+            q_s[r][d] = static_cast<InT>(q_base[(size_t)(t0 + r) * krow + d]);
+          }}
+          for (int p = tid; p < tt * DB; p += TG) {{
+            const int r = p / DB, d = p % DB;
+            v_s[r][d]  = static_cast<InT>(v_base[(size_t)(t0 + r) * vrow + d]);
+            dy_s[r][d] = static_cast<InT>(dy_base[(size_t)(t0 + r) * vrow + d]);
+            kv_s[r][d] = kv[((size_t)b * Hv + hv) * (size_t)T * Dv
+                            + (size_t)(t0 + r) * Dv + dv0 + d];
+          }}
+          for (int p = tid; p < tt; p += TG) {{
+            b_s[p] = static_cast<float>(beta[((size_t)b * T + t0 + p) * Hv + hv]);
+          }}
+          {g_stage}
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+
+          if (t0 > 0) {{
+            const device float4* ck =
+                (const device float4*)(ck_base + (size_t)(t0 / TB - 1) * cstride);
+            for (int i = 0; i < NV; ++i) {{
+              entry[i] = ck[i];
+            }}
+          }} else {{
+            for (int i = 0; i < NV; ++i) {{
+              entry[i] = float4(static_cast<float>(s_in[4 * i + 0]),
+                                static_cast<float>(s_in[4 * i + 1]),
+                                static_cast<float>(s_in[4 * i + 2]),
+                                static_cast<float>(s_in[4 * i + 3]));
+            }}
+          }}
+
+          for (int t = tt - 1; t >= 0; --t) {{
+            const int ts = t0 + t;
+            const float bt = b_s[t];
+            const float v_t = static_cast<float>(v_s[t][dv]);
+            const float dy_t = static_cast<float>(dy_s[t][dv]);
+            const float kv_mem = kv_s[t][dv];
+            const float delta = (v_t - kv_mem) * bt;
+
+            // Replay to t-1 in the checkpoint pass's fma order, so it reproduces it.
+            for (int i = 0; i < NV; ++i) {{
+              sp[i] = entry[i];
+            }}
+            for (int u = 0; u < t; ++u) {{
+              const threadgroup vec<InT, 4>* ku =
+                  (const threadgroup vec<InT, 4>*)&k_s[u][d0];
+              {g_load_u}
+              const float du = (static_cast<float>(v_s[u][dv]) - kv_s[u][dv]) * b_s[u];
+              for (int i = 0; i < NV; ++i) {{
+                sp[i] *= {g_decay_u};
+                sp[i] += float4(ku[i]) * du;
+              }}
+            }}
+
+            {g_load}
+            const threadgroup vec<InT, 4>* k4 =
+                (const threadgroup vec<InT, 4>*)&k_s[t][d0];
+            const threadgroup vec<InT, 4>* q4 =
+                (const threadgroup vec<InT, 4>*)&q_s[t][d0];
+
+            float4 acc_d = 0.0f;
+            for (int i = 0; i < NV; ++i) {{
+              const float4 kf = float4(k4[i]);
+              acc_d += (d_state[i] + dy_t * float4(q4[i])) * kf;
+              float4 dq = dy_t * (sp[i] * {g_decay} + kf * delta);
+              for (int off = P; off < 32; off <<= 1) {{
+                dq += simd_shuffle_down(dq, off);
+              }}
+              if (lane < P) {{
+                threadgroup float* r = &red_q[simd][d0 + 4 * i];
+                r[0] = dq.x; r[1] = dq.y; r[2] = dq.z; r[3] = dq.w;
+              }}
+            }}
+            float d_delta = acc_d.x + acc_d.y + acc_d.z + acc_d.w;
+            for (int off = P / 2; off > 0; off >>= 1) {{
+              d_delta += simd_shuffle_down(d_delta, off);
+            }}
+            d_delta = simd_shuffle(d_delta, row_lane);
+            const float d_kv = -d_delta * bt;
+
+            {d_g_decl}
+            for (int i = 0; i < NV; ++i) {{
+              const float4 kf = float4(k4[i]);
+              const float4 dS = d_state[i] + dy_t * float4(q4[i]);
+              const float4 sd = sp[i] * {g_decay};
+              const float4 d_sd = dS + d_kv * kf;
+              float4 dkc = dS * delta + d_kv * sd;
+              for (int off = P; off < 32; off <<= 1) {{
+                dkc += simd_shuffle_down(dkc, off);
+              }}
+              if (lane < P) {{
+                threadgroup float* r = &red_k[simd][d0 + 4 * i];
+                r[0] = dkc.x; r[1] = dkc.y; r[2] = dkc.z; r[3] = dkc.w;
+              }}
+              {d_g_accum}
+              d_state[i] = d_sd * {g_decay};
+            }}
+            {d_g_finalize}
+
+            auto d_q_ = d_q + ((size_t)b * T + ts) * Hk * Dk + (size_t)hk * Dk;
+            auto d_k_ = d_k + ((size_t)b * T + ts) * Hk * Dk + (size_t)hk * Dk;
+            {d_g_setup}
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            for (int c = tid; c < Dk; c += TG) {{
+              float sq = 0.0f, sk = 0.0f;
+              {d_g_reduce_decl}
+              for (int m = 0; m < NSIMD; ++m) {{
+                sq += red_q[m][c];
+                sk += red_k[m][c];
+                {d_g_reduce_accum}
+              }}
+              atomic_fetch_add_explicit(&d_q_[c], sq, memory_order_relaxed);
+              atomic_fetch_add_explicit(&d_k_[c], sk, memory_order_relaxed);
+              {d_g_reduce_store}
+            }}
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            if (seg == 0) {{
+              auto d_v_ = d_v + ((size_t)b * T + ts) * Hv * Dv + (size_t)hv * Dv;
+              atomic_fetch_add_explicit(&d_v_[dv0 + dv], d_delta * bt,
+                                        memory_order_relaxed);
+            }}
+            float d_beta_part = (seg == 0) ? d_delta * (v_t - kv_mem) : 0.0f;
+            d_beta_part = simd_sum(d_beta_part);
+            if (lane == 0) {{
+              atomic_fetch_add_explicit(&d_beta[((size_t)b * T + ts) * Hv + hv],
+                                        d_beta_part, memory_order_relaxed);
+            }}
+          }}
+        }}
+
+        {{
+          auto dsi = d_state_in + (((size_t)b * Hv + hv) * Dv + dv0 + dv) * Dk + d0;
+          for (int i = 0; i < NV; ++i) {{
+            atomic_fetch_add_explicit(&dsi[4 * i + 0], d_state[i].x, memory_order_relaxed);
+            atomic_fetch_add_explicit(&dsi[4 * i + 1], d_state[i].y, memory_order_relaxed);
+            atomic_fetch_add_explicit(&dsi[4 * i + 2], d_state[i].z, memory_order_relaxed);
+            atomic_fetch_add_explicit(&dsi[4 * i + 3], d_state[i].w, memory_order_relaxed);
           }}
         }}
 """
 
 
 def _blocked_gating(vectorized):
-    """Threadgroup staging and per-step decay for scalar vs per-column gating."""
     if vectorized:
         return {
             "g_decl": "threadgroup float g_s[TB][Dk + PAD];",
@@ -675,6 +968,23 @@ def _blocked_gating(vectorized):
           }""",
             "g_load": "const threadgroup float4* g4 = (const threadgroup float4*)&g_s[t][d0];",
             "g_decay": "g4[i]",
+            "g_load_u": "const threadgroup float4* gu = (const threadgroup float4*)&g_s[u][d0];",
+            "g_decay_u": "gu[i]",
+            "d_g_scratch": "threadgroup float red_g[NSIMD][Dk];",
+            "d_g_setup": "auto d_g_ = d_g + (((size_t)b * T + ts) * Hv + hv) * Dk;",
+            "d_g_decl": "",
+            "d_g_accum": """float4 dgc = d_sd * sp[i];
+              for (int off = P; off < 32; off <<= 1) {
+                dgc += simd_shuffle_down(dgc, off);
+              }
+              if (lane < P) {
+                threadgroup float* rg = &red_g[simd][d0 + 4 * i];
+                rg[0] = dgc.x; rg[1] = dgc.y; rg[2] = dgc.z; rg[3] = dgc.w;
+              }""",
+            "d_g_finalize": "",
+            "d_g_reduce_decl": "float sg = 0.0f;",
+            "d_g_reduce_accum": "sg += red_g[m][c];",
+            "d_g_reduce_store": "atomic_fetch_add_explicit(&d_g_[c], sg, memory_order_relaxed);",
         }
     return {
         "g_decl": "threadgroup float g_s[TB];",
@@ -683,13 +993,24 @@ def _blocked_gating(vectorized):
           }""",
         "g_load": "const float gt = g_s[t];",
         "g_decay": "gt",
+        "g_load_u": "const float gu = g_s[u];",
+        "g_decay_u": "gu",
+        "d_g_scratch": "",
+        "d_g_setup": "",
+        "d_g_decl": "float d_g_part = 0.0f;",
+        "d_g_reduce_decl": "",
+        "d_g_reduce_accum": "",
+        "d_g_reduce_store": "",
+        "d_g_accum": "d_g_part += dot(d_sd, sp[i]);",
+        "d_g_finalize": """d_g_part = simd_sum(d_g_part);
+            if (lane == 0) {
+              atomic_fetch_add_explicit(&d_g[((size_t)b * T + ts) * Hv + hv],
+                                        d_g_part, memory_order_relaxed);
+            }""",
     }
 
 
 def _make_gd_blocked_forward_kernel(vectorized=False):
-    """Blocked-sequential GDN forward: same recurrence, restructured access."""
-    if not mx.metal.is_available():
-        return None
     source = _BLOCKED_PREAMBLE + _BLOCKED_FORWARD_SRC.format(**_blocked_gating(vectorized))
     return mx.fast.metal_kernel(
         name=f"unsloth_gd_blocked_fwd{'_vec' if vectorized else ''}",
@@ -699,311 +1020,22 @@ def _make_gd_blocked_forward_kernel(vectorized=False):
     )
 
 
-_GD_BLOCKED_FWD: dict = {}
-
-
-def _get_blocked_forward(vectorized=False):
-    if vectorized not in _GD_BLOCKED_FWD:
-        _GD_BLOCKED_FWD[vectorized] = _make_gd_blocked_forward_kernel(vectorized)
-    return _GD_BLOCKED_FWD[vectorized]
-
-
-def gated_delta_blocked_forward(q, k, v, g, beta, state):
-    """Forward half of the fused path; None when the layout does not fit.
-
-    Contract matches mlx_lm.models.gated_delta.gated_delta_kernel for the
-    unmasked case: returns (y [B, T, Hv, Dv] in q.dtype, state_out in
-    state.dtype).
-    """
-    B, T, Hk, Dk = k.shape
-    Hv, Dv = v.shape[2:]
-    vectorized = g.ndim == 4
-    layout = _blocked_layout(Dk, Dv, q.dtype, vectorized)
-    kernel = _get_blocked_forward(vectorized)
-    if layout is None or kernel is None:
-        return None
-    P, W, DB, TB, threads = layout
-    return kernel(
-        inputs=[q, k, v, g, beta, state, T],
-        template=[
-            ("InT", q.dtype), ("Dk", Dk), ("Dv", Dv), ("Hk", Hk), ("Hv", Hv),
-            ("TB", TB), ("P", P), ("W", W), ("DB", DB),
-        ],
-        grid=(threads * (Dv // DB), Hv, B),
-        threadgroup=(threads, 1, 1),
-        output_shapes=[(B, T, Hv, Dv), state.shape],
-        output_dtypes=[q.dtype, state.dtype],
-    )
-
-
-def _make_gd_chunk_states_kernel(vectorized=False):
-    """K1: replay the chunk forward, storing every post-step state.
-
-    Thread layout mirrors mlx-lm's gated_delta_step kernel: grid z = B*Hv,
-    grid y = Dv (one state row per simdgroup), 32 lanes each owning
-    Dk/32 contiguous state columns held in registers. `vectorized` selects
-    per-column gating (g: [B, T, Hv, Dk], kimi_linear) over per-head
-    scalar gating (g: [B, T, Hv]).
-    """
-    if not mx.metal.is_available():
-        return None
-    if vectorized:
-        g_setup = "auto g_ = g + (b_idx * T * Hv + hv_idx) * Dk;"
-        g_decay = "g_[s_idx]"
-        g_advance = "g_ += Hv * Dk;"
-    else:
-        g_setup = "auto g_ = g + b_idx * T * Hv;"
-        g_decay = "g_[hv_idx]"
-        g_advance = "g_ += Hv;"
-    source = f"""
-        auto n = thread_position_in_grid.z;
-        auto b_idx = n / Hv;
-        auto hv_idx = n % Hv;
-        constexpr int n_per_t = Dk / 32;
-
-        // q unused in the state replay; k: [B, T, Hv, Dk] (post GQA-repeat)
-        auto k_ = k + b_idx * T * Hv * Dk + hv_idx * Dk;
-        // v: [B, T, Hv, Dv]
-        auto v_ = v + b_idx * T * Hv * Dv + hv_idx * Dv;
-
-        auto dk_idx = thread_position_in_threadgroup.x;
-        auto dv_idx = thread_position_in_grid.y;
-
-        // state_in: [B, Hv, Dv, Dk]
-        auto i_state = state_in + (n * Dv + dv_idx) * Dk;
-        // states: [B, Hv, T, Dv, Dk] -- post-update state for each step
-        auto states_ = states + ((n * T) * Dv + dv_idx) * Dk;
-
-        float state[n_per_t];
-        for (int i = 0; i < n_per_t; ++i) {{
-          auto s_idx = n_per_t * dk_idx + i;
-          state[i] = static_cast<float>(i_state[s_idx]);
-        }}
-
-        {g_setup}
-        auto beta_ = beta + b_idx * T * Hv;
-
-        for (int t = 0; t < T; ++t) {{
-          float kv_mem = 0.0f;
-          for (int i = 0; i < n_per_t; ++i) {{
-            auto s_idx = n_per_t * dk_idx + i;
-            state[i] = state[i] * {g_decay};
-            kv_mem += state[i] * k_[s_idx];
-          }}
-          kv_mem = simd_sum(kv_mem);
-
-          auto delta = (static_cast<float>(v_[dv_idx]) - kv_mem)
-              * static_cast<float>(beta_[hv_idx]);
-
-          for (int i = 0; i < n_per_t; ++i) {{
-            auto s_idx = n_per_t * dk_idx + i;
-            state[i] = state[i] + static_cast<float>(k_[s_idx]) * delta;
-            states_[s_idx] = state[i];
-          }}
-
-          k_ += Hv * Dk;
-          v_ += Hv * Dv;
-          {g_advance}
-          beta_ += Hv;
-          states_ += Dv * Dk;
-        }}
-    """
-    suffix = "_vec" if vectorized else ""
+def _make_gd_blocked_checkpoint_kernel(vectorized=False):
+    source = _BLOCKED_PREAMBLE + _BLOCKED_CHECKPOINT_SRC.format(**_blocked_gating(vectorized))
     return mx.fast.metal_kernel(
-        name=f"unsloth_gd_chunk_states{suffix}",
+        name=f"unsloth_gd_blocked_ckpt{'_vec' if vectorized else ''}",
         input_names=["k", "v", "g", "beta", "state_in", "T"],
-        output_names=["states"],
+        output_names=["ckpt", "kv"],
         source=source,
     )
 
 
-def _make_gd_chunk_backward_kernel(vectorized=False):
-    """K2: reverse-time scan over one chunk, accumulating input gradients.
-
-    Same thread layout as K1. The per-row d_state slice lives in registers;
-    cross-row reductions (d_q, d_k, d_g, d_beta) go through atomic float
-    adds into zero-initialized outputs. With vectorized gating d_g is
-    per-column ([B, T, Hv, Dk]) and needs no simdgroup reduction.
-    """
-    if not mx.metal.is_available():
-        return None
-    if vectorized:
-        g_setup = "auto g_ = g + ((b_idx * T + (T - 1)) * Hv + hv_idx) * Dk;"
-        d_g_setup = "auto d_g_ = d_g + ((b_idx * T + (T - 1)) * Hv + hv_idx) * Dk;"
-        g_step_decl = "float gcol[n_per_t];"
-        g_load = "gcol[i] = static_cast<float>(g_[s_idx]);"
-        g_col = "gcol[i]"
-        d_g_accum = """atomic_fetch_add_explicit(&d_g_[s_idx], d_sd * s_prev[i],
-                                      memory_order_relaxed);"""
-        d_g_finalize = ""
-        g_retreat = "g_ -= Hv * Dk;"
-        d_g_retreat = "d_g_ -= Hv * Dk;"
-    else:
-        g_setup = "auto g_ = g + (b_idx * T + (T - 1)) * Hv;"
-        d_g_setup = "auto d_g_ = d_g + (b_idx * T + (T - 1)) * Hv;"
-        g_step_decl = "float g_t = 0.0f;"
-        g_load = "g_t = static_cast<float>(g_[hv_idx]);"
-        g_col = "g_t"
-        d_g_accum = "d_g_partial += d_sd * s_prev[i];"
-        d_g_finalize = """d_g_partial = simd_sum(d_g_partial);
-          if (thread_index_in_simdgroup == 0) {
-            atomic_fetch_add_explicit(&d_g_[hv_idx], d_g_partial,
-                                      memory_order_relaxed);
-          }"""
-        g_retreat = "g_ -= Hv;"
-        d_g_retreat = "d_g_ -= Hv;"
-    source = f"""
-        auto n = thread_position_in_grid.z;
-        auto b_idx = n / Hv;
-        auto hv_idx = n % Hv;
-        constexpr int n_per_t = Dk / 32;
-
-        auto dk_idx = thread_position_in_threadgroup.x;
-        auto dv_idx = thread_position_in_grid.y;
-
-        // Start every per-timestep pointer at t = T-1.
-        auto q_ = q + (b_idx * T + (T - 1)) * Hv * Dk + hv_idx * Dk;
-        auto k_ = k + (b_idx * T + (T - 1)) * Hv * Dk + hv_idx * Dk;
-        auto v_ = v + (b_idx * T + (T - 1)) * Hv * Dv + hv_idx * Dv;
-        {g_setup}
-        auto beta_ = beta + (b_idx * T + (T - 1)) * Hv;
-        auto dy_ = dy + (b_idx * T + (T - 1)) * Hv * Dv + hv_idx * Dv;
-
-        auto d_q_ = d_q + (b_idx * T + (T - 1)) * Hv * Dk + hv_idx * Dk;
-        auto d_k_ = d_k + (b_idx * T + (T - 1)) * Hv * Dk + hv_idx * Dk;
-        auto d_v_ = d_v + (b_idx * T + (T - 1)) * Hv * Dv + hv_idx * Dv;
-        {d_g_setup}
-        auto d_beta_ = d_beta + (b_idx * T + (T - 1)) * Hv;
-
-        auto i_state = state_in + (n * Dv + dv_idx) * Dk;
-        auto states_ = states + ((n * T) * Dv + dv_idx) * Dk;
-        auto d_state_out_ = d_state_out + (n * Dv + dv_idx) * Dk;
-        auto d_state_in_ = d_state_in + (n * Dv + dv_idx) * Dk;
-
-        // d_state: cotangent w.r.t. the state RETURNED by step t.
-        float d_state[n_per_t];
-        float s_prev[n_per_t];
-        float s_cur[n_per_t];
-        // Reduce threadgroup-local Dv rows before the global d_q/d_k atomics.
-        threadgroup float tg_dq[TG_ROWS * 32];
-        threadgroup float tg_dk[TG_ROWS * 32];
-        {g_step_decl}
-        auto tg_y = thread_position_in_threadgroup.y;
-        auto tg_lane = thread_index_in_simdgroup;
-        auto tg_idx = tg_y * 32 + tg_lane;
-        for (int i = 0; i < n_per_t; ++i) {{
-          auto s_idx = n_per_t * dk_idx + i;
-          d_state[i] = static_cast<float>(d_state_out_[s_idx]);
-        }}
-
-        for (int t = T - 1; t >= 0; --t) {{
-          auto cur_row = states_ + t * Dv * Dk;
-          float beta_t = static_cast<float>(beta_[hv_idx]);
-          float v_t = static_cast<float>(v_[dv_idx]);
-          float dy_t = static_cast<float>(dy_[dv_idx]);
-
-          // Recompute Sd = S_prev * g, kv, delta from the stored states.
-          float kv_mem = 0.0f;
-          for (int i = 0; i < n_per_t; ++i) {{
-            auto s_idx = n_per_t * dk_idx + i;
-            {g_load}
-            if (t > 0) {{
-              auto prev_row = states_ + (t - 1) * Dv * Dk;
-              s_prev[i] = static_cast<float>(prev_row[s_idx]);
-            }} else {{
-              s_prev[i] = static_cast<float>(i_state[s_idx]);
-            }}
-            s_cur[i] = cur_row[s_idx];
-            kv_mem += s_prev[i] * {g_col} * static_cast<float>(k_[s_idx]);
-          }}
-          kv_mem = simd_sum(kv_mem);
-          float delta = (v_t - kv_mem) * beta_t;
-
-          // y = (S_t * q).sum(-1): dy contributes to d_state and d_q.
-          float d_delta_partial = 0.0f;
-          for (int i = 0; i < n_per_t; ++i) {{
-            auto s_idx = n_per_t * dk_idx + i;
-            float k_c = static_cast<float>(k_[s_idx]);
-            float q_c = static_cast<float>(q_[s_idx]);
-            float dS_tot = d_state[i] + dy_t * q_c;
-
-            tg_dq[tg_idx] = dy_t * s_cur[i];
-            threadgroup_barrier(mem_flags::mem_threadgroup);
-            if (tg_y == 0) {{
-              float d_q_group = 0.0f;
-              for (int yy = 0; yy < TG_ROWS; ++yy) {{
-                d_q_group += tg_dq[yy * 32 + tg_lane];
-              }}
-              atomic_fetch_add_explicit(&d_q_[s_idx], d_q_group,
-                                        memory_order_relaxed);
-            }}
-            threadgroup_barrier(mem_flags::mem_threadgroup);
-            d_delta_partial += dS_tot * k_c;
-            // Stash dS_tot for the second pass below.
-            s_cur[i] = dS_tot;
-          }}
-          float d_delta = simd_sum(d_delta_partial);
-
-          float d_kv = -d_delta * beta_t;
-          float d_g_partial = 0.0f;
-          (void)d_g_partial;
-          for (int i = 0; i < n_per_t; ++i) {{
-            auto s_idx = n_per_t * dk_idx + i;
-            float k_c = static_cast<float>(k_[s_idx]);
-            float dS_tot = s_cur[i];
-            float sd = s_prev[i] * {g_col};
-            float d_sd = dS_tot + d_kv * k_c;
-
-            tg_dk[tg_idx] = dS_tot * delta + d_kv * sd;
-            threadgroup_barrier(mem_flags::mem_threadgroup);
-            if (tg_y == 0) {{
-              float d_k_group = 0.0f;
-              for (int yy = 0; yy < TG_ROWS; ++yy) {{
-                d_k_group += tg_dk[yy * 32 + tg_lane];
-              }}
-              atomic_fetch_add_explicit(&d_k_[s_idx], d_k_group,
-                                        memory_order_relaxed);
-            }}
-            threadgroup_barrier(mem_flags::mem_threadgroup);
-            {d_g_accum}
-            d_state[i] = d_sd * {g_col};
-          }}
-          {d_g_finalize}
-
-          if (thread_index_in_simdgroup == 0) {{
-            atomic_fetch_add_explicit(&d_v_[dv_idx], d_delta * beta_t,
-                                      memory_order_relaxed);
-            atomic_fetch_add_explicit(&d_beta_[hv_idx],
-                                      d_delta * (v_t - kv_mem),
-                                      memory_order_relaxed);
-          }}
-
-          if (t > 0) {{
-            q_ -= Hv * Dk;
-            k_ -= Hv * Dk;
-            v_ -= Hv * Dv;
-            {g_retreat}
-            beta_ -= Hv;
-            dy_ -= Hv * Dv;
-            d_q_ -= Hv * Dk;
-            d_k_ -= Hv * Dk;
-            d_v_ -= Hv * Dv;
-            {d_g_retreat}
-            d_beta_ -= Hv;
-          }}
-        }}
-
-        for (int i = 0; i < n_per_t; ++i) {{
-          auto s_idx = n_per_t * dk_idx + i;
-          atomic_fetch_add_explicit(&d_state_in_[s_idx], d_state[i],
-                                    memory_order_relaxed);
-        }}
-    """
-    suffix = "_vec" if vectorized else ""
+def _make_gd_blocked_backward_kernel(vectorized=False):
+    source = _BLOCKED_PREAMBLE + _BLOCKED_BACKWARD_SRC.format(**_blocked_gating(vectorized))
     return mx.fast.metal_kernel(
-        name=f"unsloth_gd_chunk_backward{suffix}",
+        name=f"unsloth_gd_blocked_backward{'_vec' if vectorized else ''}",
         input_names=[
-            "q", "k", "v", "g", "beta", "state_in", "states",
+            "q", "k", "v", "g", "beta", "state_in", "ckpt", "kv",
             "dy", "d_state_out", "T",
         ],
         output_names=["d_q", "d_k", "d_v", "d_g", "d_beta", "d_state_in"],
@@ -1012,30 +1044,110 @@ def _make_gd_chunk_backward_kernel(vectorized=False):
     )
 
 
-_GD_KERNELS: dict = {}
+_GD_BLOCKED: dict = {}
 
 
-def _get_kernels(vectorized=False):
-    if vectorized not in _GD_KERNELS:
-        _GD_KERNELS[vectorized] = (
-            _make_gd_chunk_states_kernel(vectorized=vectorized),
-            _make_gd_chunk_backward_kernel(vectorized=vectorized),
+def _get_blocked_kernels(vectorized=False):
+    if vectorized not in _GD_BLOCKED:
+        _GD_BLOCKED[vectorized] = (None, None, None) if not mx.metal.is_available() else (
+            _make_gd_blocked_forward_kernel(vectorized),
+            _make_gd_blocked_checkpoint_kernel(vectorized),
+            _make_gd_blocked_backward_kernel(vectorized),
         )
-    return _GD_KERNELS[vectorized]
+    return _GD_BLOCKED[vectorized]
 
 
-def gated_delta_kernel_supported(q, g, mask, v=None) -> bool:
+def _blocked_layouts(q, g, v):
+    """(forward, backward) layouts, or None if either does not fit -- the backward
+    replays the forward, so a shape needs both. The checkpoint kernel shares the
+    backward's: TB is what its checkpoint boundaries count in."""
+    Dk, Dv, vec = q.shape[-1], v.shape[-1], g.ndim == 4
+    out = tuple(
+        next((lay for cfg in cfgs
+              if (lay := _blocked_layout(Dk, Dv, q.dtype, vec, cfg)) is not None), None)
+        for cfgs in (_BLOCKED_FORWARD_CFGS, _BLOCKED_BACKWARD_CFGS)
+    )
+    return None if any(x is None for x in out) else out
+
+
+def _blocked_shares_q_dtype(q, *others):
+    """One Metal template element type stages them all, so another dtype misreads."""
+    return all(x.dtype == q.dtype for x in others)
+
+
+def gated_delta_blocked_forward(q, k, v, g, beta, state):
+    """Forward half, or None when it does not apply. gated_delta_kernel's unmasked
+    contract: (y [B, T, Hv, Dv] in q.dtype, state_out shaped and typed like state)."""
+    B, T, Hk, Dk = k.shape
+    Hv, Dv = v.shape[2:]
+    layouts = _blocked_layouts(q, g, v)
+    kernel = _get_blocked_kernels(g.ndim == 4)[0]
+    if layouts is None or kernel is None or not _blocked_shares_q_dtype(q, k, v):
+        return None
+    P, W, DB, TB, threads = layouts[0]
+    return kernel(
+        inputs=[q, k, v, g, beta, state, T],
+        template=[
+            ("InT", q.dtype), ("StT", state.dtype), ("Dk", Dk), ("Dv", Dv),
+            ("Hk", Hk), ("Hv", Hv), ("TB", TB), ("P", P), ("W", W), ("DB", DB),
+        ],
+        grid=(threads * (Dv // DB), Hv, B),
+        threadgroup=(threads, 1, 1),
+        output_shapes=[(B, T, Hv, Dv), state.shape],
+        output_dtypes=[q.dtype, state.dtype],
+    )
+
+
+def gated_delta_blocked_backward(q, k, v, g, beta, state, dy, d_state_out):
+    """Backward half, or None when it does not apply: six fp32 gradients in primal order."""
+    B, T, Hk, Dk = k.shape
+    Hv, Dv = v.shape[2:]
+    vectorized = g.ndim == 4
+    layouts = _blocked_layouts(q, g, v)
+    _, ckpt_kernel, backward_kernel = _get_blocked_kernels(vectorized)
+    if (layouts is None or ckpt_kernel is None
+            or not _blocked_shares_q_dtype(q, k, v, dy)):
+        return None
+    P, W, DB, TB, threads = layouts[1]
+    template = [
+        ("InT", q.dtype), ("Dk", Dk), ("Dv", Dv), ("Hk", Hk), ("Hv", Hv),
+        ("TB", TB), ("P", P), ("W", W), ("DB", DB),
+    ]
+    grid, threadgroup = (threads * (Dv // DB), Hv, B), (threads, 1, 1)
+    # A single-block chunk would pass an empty input, which arrives as `constant`.
+    boundaries = max(1, -(-T // TB) - 1)
+
+    ckpt, kv = ckpt_kernel(
+        inputs=[k, v, g, beta, state, T],
+        template=template, grid=grid, threadgroup=threadgroup,
+        output_shapes=[(B, Hv, boundaries, Dv, Dk), (B, Hv, T, Dv)],
+        output_dtypes=[mx.float32, mx.float32],
+    )
+    return backward_kernel(
+        inputs=[q, k, v, g, beta, state, ckpt, kv, dy, d_state_out, T],
+        template=template, grid=grid, threadgroup=threadgroup,
+        output_shapes=[
+            (B, T, Hk, Dk), (B, T, Hk, Dk), (B, T, Hv, Dv),
+            (B, T, Hv, Dk) if vectorized else (B, T, Hv), (B, T, Hv), state.shape,
+        ],
+        output_dtypes=[mx.float32] * 6,
+        init_value=0,
+    )
+
+
+def gated_delta_kernel_supported(q, g, mask, v=None, k=None) -> bool:
     """Whether the fused-kernel VJP path can handle this call.
 
-    Dv must divide evenly into threadgroup rows: the backward kernel's
-    shared-memory pre-reduction reads every row slot in a threadgroup, and
-    a partial trailing group would read uninitialized slots.
+    A caller omitting `v` or `k` gets False, not a yes the dispatch would refuse.
     """
     return (
         mask is None
+        and v is not None
+        and k is not None
+        and _blocked_shares_q_dtype(q, k, v)
         and g.ndim in (3, 4)
         and q.shape[-1] % 32 == 0
-        and (v is None or v.shape[-1] % _KERNEL_THREADGROUP_Y == 0)
+        and _blocked_layouts(q, g, v) is not None
         and mx.default_device() == mx.gpu
         and mx.metal.is_available()
     )
@@ -1055,14 +1167,14 @@ def gated_delta_kernel_efficient(
     Same contract as gated_delta_ops_efficient, restricted to the
     kernel-eligible case (see gated_delta_kernel_supported).
     """
-    if not gated_delta_kernel_supported(q, g, mask, v):
+    if not gated_delta_kernel_supported(q, g, mask, v, k):
         raise ValueError(
             "gated_delta_kernel_efficient called outside kernel support "
-            "(requires a Metal GPU, mask=None, Dk % 32 == 0, and Dv divisible "
-            "by the threadgroup rows); use gated_delta_ops_efficient instead."
+            "(requires a Metal GPU, mask=None, Dk % 32 == 0, one dtype shared "
+            "by q, k and v, and a thread layout for this (Dk, Dv) -- see "
+            "gated_delta_kernel_supported); use gated_delta_ops_efficient "
+            "instead."
         )
-    from mlx_lm.models.gated_delta import gated_delta_kernel
-
     B, T, Hk, Dk = q.shape
     Hv, Dv = v.shape[-2:]
     if state is None:
@@ -1074,54 +1186,16 @@ def gated_delta_kernel_efficient(
         q = mx.repeat(q, repeat_factor, -2)
         k = mx.repeat(k, repeat_factor, -2)
 
-    vectorized = g.ndim == 4
-    states_kernel, backward_kernel = _get_kernels(vectorized=vectorized)
-    d_g_shape = (lambda b, t: (b, t, Hv, Dk)) if vectorized else (lambda b, t: (b, t, Hv))
-
     @mx.custom_function
     def _chunk(q_c, k_c, v_c, g_c, beta_c, state_in):
-        out = gated_delta_blocked_forward(q_c, k_c, v_c, g_c, beta_c, state_in)
-        if out is None:
-            return gated_delta_kernel(q_c, k_c, v_c, g_c, beta_c, state_in)
-        return out
+        return gated_delta_blocked_forward(q_c, k_c, v_c, g_c, beta_c, state_in)
 
     @_chunk.vjp
     def _chunk_vjp(primals, cotangents, outputs):
         q_c, k_c, v_c, g_c, beta_c, state_in = primals
         dy, d_state_out = cotangents
-        Bc, Tc = q_c.shape[:2]
-
-        (states,) = states_kernel(
-            inputs=[k_c, v_c, g_c, beta_c, state_in, Tc],
-            template=[("Dk", Dk), ("Dv", Dv), ("Hv", Hv)],
-            grid=(32, Dv, Bc * Hv),
-            threadgroup=(_KERNEL_THREADGROUP_X, _KERNEL_THREADGROUP_Y, 1),
-            output_shapes=[(Bc, Hv, Tc, Dv, Dk)],
-            output_dtypes=[mx.float32],
-        )
-        d_q, d_k, d_v, d_g, d_beta, d_state_in = backward_kernel(
-            inputs=[
-                q_c, k_c, v_c, g_c, beta_c, state_in, states,
-                dy, d_state_out, Tc,
-            ],
-            template=[
-                ("Dk", Dk),
-                ("Dv", Dv),
-                ("Hv", Hv),
-                ("TG_ROWS", _KERNEL_THREADGROUP_Y),
-            ],
-            grid=(32, Dv, Bc * Hv),
-            threadgroup=(_KERNEL_THREADGROUP_X, _KERNEL_THREADGROUP_Y, 1),
-            output_shapes=[
-                (Bc, Tc, Hv, Dk),
-                (Bc, Tc, Hv, Dk),
-                (Bc, Tc, Hv, Dv),
-                d_g_shape(Bc, Tc),
-                (Bc, Tc, Hv),
-                (Bc, Hv, Dv, Dk),
-            ],
-            output_dtypes=[mx.float32] * 6,
-            init_value=0,
+        d_q, d_k, d_v, d_g, d_beta, d_state_in = gated_delta_blocked_backward(
+            q_c, k_c, v_c, g_c, beta_c, state_in, dy, d_state_out,
         )
         return (
             d_q.astype(q_c.dtype),

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -499,31 +499,21 @@ def patch_gated_delta_vlm_shared():
 # order is semantically irrelevant.
 # --------------------------------------------------------------------------
 
-_KERNEL_CHUNK_SIZE = 64
+# BPTT chunk length, derived per call: longer amortizes the launch and the replay.
+_KERNEL_CHUNK_MIN = 64
+_KERNEL_CHUNK_MAX = 512
+_KERNEL_CHECKPOINT_BUDGET = 128 << 20
 
 
-# Blocked-sequential thread layout, shared by the three kernels below.
-#
-# mlx-lm's kernel gives every state row its own simdgroup: 32 lanes hold Dk/32
-# state columns each, every contraction costs a full simd_sum, and each of the
-# Dv rows re-reads the same k/q row from device memory. Here a thread owns a
-# W-wide segment of one row, P = Dk/W threads cover a row inside one simdgroup
-# (so a contraction is log2(P) shuffles), DB rows share a threadgroup, and each
-# threadgroup stages a TB-step time block of k/q/v/g/beta into threadgroup
-# memory once instead of re-reading it per row.
+# Blocked-sequential thread layout, shared by the three kernels below. mlx-lm
+# gives each state row its own simdgroup; here P = Dk/W threads cover a row
+# inside one, DB rows share a threadgroup, which stages a TB-step block once.
 
 _BLOCKED_TG_MEMORY = 32768   # Metal threadgroup-memory limit
 _BLOCKED_TG_THREADS = 256
 _BLOCKED_PAD = 8             # row padding, keeps threadgroup rows bank- and 8-byte-aligned
 
 class _BlockedCfg(NamedTuple):
-    """What a kernel needs from a thread layout.
-
-    `dk_rows`, `dv_rows` and `dv_f32_rows` count the Dk-wide, DB-wide and
-    DB-wide fp32 threadgroup arrays it stages per time step; `red_arrays`
-    counts its Dk-wide cross-row reduction rows, one per simdgroup. Together
-    they decide how long a time block fits in threadgroup memory.
-    """
     dk_rows: int
     dv_rows: int
     dv_f32_rows: int
@@ -1153,6 +1143,13 @@ def gated_delta_kernel_supported(q, g, mask, v=None, k=None) -> bool:
     )
 
 
+def _kernel_chunk_size(B, Hv, Dk, Dv, TB):
+    """Longest chunk whose checkpoints fit the budget, clamped to the length bounds
+    and so overridden by either; n blocks hold n - 1 states."""
+    states = _KERNEL_CHECKPOINT_BUDGET // max(1, B * Hv * Dv * Dk * 4)
+    return min(_KERNEL_CHUNK_MAX, max(_KERNEL_CHUNK_MIN, (states + 1) * TB))
+
+
 def gated_delta_kernel_efficient(
     q: mx.array,
     k: mx.array,
@@ -1179,6 +1176,7 @@ def gated_delta_kernel_efficient(
     Hv, Dv = v.shape[-2:]
     if state is None:
         state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+    chunk = _kernel_chunk_size(B, Hv, Dk, Dv, _blocked_layouts(q, g, v)[1][3])
 
     if (repeat_factor := Hv // Hk) > 1:
         # Repeat outside custom_function so autodiff folds the per-group
@@ -1207,9 +1205,10 @@ def gated_delta_kernel_efficient(
         )
 
     all_ys = []
-    s = state
-    for t_start in range(0, T, _KERNEL_CHUNK_SIZE):
-        t_end = min(t_start + _KERNEL_CHUNK_SIZE, T)
+    # fp32 across chunks: rounding per chunk makes the length observable in y.
+    s = state if T <= chunk else state.astype(mx.float32)
+    for t_start in range(0, T, chunk):
+        t_end = min(t_start + chunk, T)
         chunk_y, s = _chunk(
             q[:, t_start:t_end],
             k[:, t_start:t_end],
@@ -1221,4 +1220,4 @@ def gated_delta_kernel_efficient(
         all_ys.append(chunk_y)
 
     y = mx.concatenate(all_ys, axis=1) if len(all_ys) > 1 else all_ys[0]
-    return y, s
+    return y, s.astype(state.dtype)

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -488,9 +488,10 @@ def patch_gated_delta_vlm_shared():
 #
 # The ops VJP above is memory-correct but dispatch-bound (~T*12 lazy
 # primitives per layer per step, unfusable by mx.compile). These kernels work
-# at chunk granularity: forward reuses mlx-lm's gated_delta_kernel per chunk;
-# backward replays chunk states (K1) and reverse-scans with atomic grad
-# accumulation (K2). Eligible on Metal GPU, mask=None, Dk % 32 == 0, for both
+# at chunk granularity: forward runs the blocked-sequential kernel below (or
+# mlx-lm's gated_delta_kernel for shapes it does not cover); backward replays
+# chunk states (K1) and reverse-scans with atomic grad accumulation (K2).
+# Eligible on Metal GPU, mask=None, Dk % 32 == 0, for both
 # scalar (qwen3_5/qwen3_next) and vectorized (kimi_linear) gating; else falls
 # back to the ops VJP. Atomic accumulation leaves low-order gradient bits
 # nondeterministic, as elsewhere on Metal.
@@ -504,6 +505,235 @@ def patch_gated_delta_vlm_shared():
 _KERNEL_CHUNK_SIZE = 64
 _KERNEL_THREADGROUP_X = 32
 _KERNEL_THREADGROUP_Y = 4
+
+
+# Blocked-sequential layout for the forward kernel below.
+#
+# mlx-lm's kernel gives every state row its own simdgroup: 32 lanes hold Dk/32
+# state columns each, every contraction costs a full simd_sum, and each of the
+# Dv rows re-reads the same k/q row from device memory. Here a thread owns a
+# W-wide segment of one row, P = Dk/W threads cover a row inside one simdgroup
+# (so a contraction is log2(P) shuffles), DB rows share a threadgroup, and each
+# threadgroup stages a TB-step time block of k/q/v/g/beta into threadgroup
+# memory once instead of re-reading it per row.
+
+_BLOCKED_TB_CHOICES = (32, 16, 8)
+_BLOCKED_TG_MEMORY = 32768   # Metal threadgroup-memory limit
+_BLOCKED_TG_THREADS = 256
+_BLOCKED_PAD = 8             # row padding, keeps threadgroup rows bank- and 8-byte-aligned
+
+
+def _blocked_layout(Dk, Dv, in_dtype, vectorized):
+    """Derive (P, W, DB, TB, threads) for these dimensions, or None if none fits.
+
+    None means the caller keeps the 32-lanes-per-row kernel, so widening the
+    support predicate is never required to add this path.
+    """
+    if Dk % 16 != 0 or Dv <= 0:
+        return None
+    P = 1
+    while P * 2 <= min(32, Dk // 16):
+        P *= 2
+    W = Dk // P
+    if W % 4 != 0 or 32 % P != 0:
+        return None
+    DB = min(Dv, _BLOCKED_TG_THREADS // P)
+    if DB == 0 or Dv % DB != 0:
+        return None
+    threads = P * DB
+    isz = in_dtype.size
+    for TB in _BLOCKED_TB_CHOICES:
+        used = 2 * TB * (Dk + _BLOCKED_PAD) * isz + TB * (DB + _BLOCKED_PAD) * isz
+        used += TB * 4 * (1 + (Dk + _BLOCKED_PAD if vectorized else 1))
+        if used <= _BLOCKED_TG_MEMORY:
+            return P, W, DB, TB, threads
+    return None
+
+
+_BLOCKED_PREAMBLE = """
+        constexpr int NV = W / 4;
+        constexpr int TG = P * DB;
+        constexpr int PAD = 8;
+
+        const int tid = thread_position_in_threadgroup.x;
+        const int blk = threadgroup_position_in_grid.x;
+        const int hv  = threadgroup_position_in_grid.y;
+        const int b   = threadgroup_position_in_grid.z;
+        const int hk  = hv / (Hv / Hk);
+        const int dv0 = blk * DB;
+
+        // thread -> (row in the dv block, W-wide segment of Dk)
+        const int dv  = tid / P;
+        const int seg = tid % P;
+        const int d0  = seg * W;
+        const int row_lane = (tid % 32) / P * P;
+
+        const size_t krow = (size_t)Hk * Dk;
+        const size_t vrow = (size_t)Hv * Dv;
+"""
+
+_BLOCKED_FORWARD_SRC = """
+        threadgroup InT k_s[TB][Dk + PAD];
+        threadgroup InT q_s[TB][Dk + PAD];
+        threadgroup InT v_s[TB][DB + PAD];
+        threadgroup float b_s[TB];
+        {g_decl}
+
+        const device InT* k_base = k + ((size_t)b * T * Hk + hk) * Dk;
+        const device InT* q_base = q + ((size_t)b * T * Hk + hk) * Dk;
+        auto v_base = v + ((size_t)b * T * Hv + hv) * Dv + dv0;
+        auto y_base = y + ((size_t)b * T * Hv + hv) * Dv + dv0;
+
+        float4 st[NV];
+        {{
+          auto s_in = state_in + (((size_t)b * Hv + hv) * Dv + dv0 + dv) * Dk + d0;
+          for (int i = 0; i < NV; ++i) {{
+            st[i] = float4(static_cast<float>(s_in[4 * i + 0]),
+                           static_cast<float>(s_in[4 * i + 1]),
+                           static_cast<float>(s_in[4 * i + 2]),
+                           static_cast<float>(s_in[4 * i + 3]));
+          }}
+        }}
+
+        for (int t0 = 0; t0 < T; t0 += TB) {{
+          const int tt = (TB < T - t0) ? TB : (int)(T - t0);
+          for (int p = tid; p < tt * Dk; p += TG) {{
+            const int r = p / Dk, d = p % Dk;
+            k_s[r][d] = static_cast<InT>(k_base[(size_t)(t0 + r) * krow + d]);
+            q_s[r][d] = static_cast<InT>(q_base[(size_t)(t0 + r) * krow + d]);
+          }}
+          for (int p = tid; p < tt * DB; p += TG) {{
+            const int r = p / DB, d = p % DB;
+            v_s[r][d] = static_cast<InT>(v_base[(size_t)(t0 + r) * vrow + d]);
+          }}
+          for (int p = tid; p < tt; p += TG) {{
+            b_s[p] = static_cast<float>(beta[((size_t)b * T + t0 + p) * Hv + hv]);
+          }}
+          {g_stage}
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+
+          for (int t = 0; t < tt; ++t) {{
+            const float bt = b_s[t];
+            {g_load}
+            const threadgroup vec<InT, 4>* k4 =
+                (const threadgroup vec<InT, 4>*)&k_s[t][d0];
+            const threadgroup vec<InT, 4>* q4 =
+                (const threadgroup vec<InT, 4>*)&q_s[t][d0];
+
+            float4 kf[NV];
+            float part4 = 0.0f;
+            float4 acc = 0.0f;
+            for (int i = 0; i < NV; ++i) {{
+              kf[i] = float4(k4[i]);
+              st[i] *= {g_decay};
+              acc += st[i] * kf[i];
+            }}
+            part4 = acc.x + acc.y + acc.z + acc.w;
+            for (int off = P / 2; off > 0; off >>= 1) {{
+              part4 += simd_shuffle_down(part4, off);
+            }}
+            const float kv_mem = simd_shuffle(part4, row_lane);
+            const float delta = (static_cast<float>(v_s[t][dv]) - kv_mem) * bt;
+
+            float4 o4 = 0.0f;
+            for (int i = 0; i < NV; ++i) {{
+              st[i] += kf[i] * delta;
+              o4 += st[i] * float4(q4[i]);
+            }}
+            float out = o4.x + o4.y + o4.z + o4.w;
+            for (int off = P / 2; off > 0; off >>= 1) {{
+              out += simd_shuffle_down(out, off);
+            }}
+            if (seg == 0) {{
+              y_base[(size_t)(t0 + t) * vrow + dv] = static_cast<InT>(out);
+            }}
+          }}
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        }}
+
+        {{
+          auto s_out = state_out + (((size_t)b * Hv + hv) * Dv + dv0 + dv) * Dk + d0;
+          for (int i = 0; i < NV; ++i) {{
+            s_out[4 * i + 0] = st[i].x;
+            s_out[4 * i + 1] = st[i].y;
+            s_out[4 * i + 2] = st[i].z;
+            s_out[4 * i + 3] = st[i].w;
+          }}
+        }}
+"""
+
+
+def _blocked_gating(vectorized):
+    """Threadgroup staging and per-step decay for scalar vs per-column gating."""
+    if vectorized:
+        return {
+            "g_decl": "threadgroup float g_s[TB][Dk + PAD];",
+            "g_stage": """for (int p = tid; p < tt * Dk; p += TG) {
+            const int r = p / Dk, d = p % Dk;
+            g_s[r][d] = static_cast<float>(
+                g[(((size_t)b * T + t0 + r) * Hv + hv) * Dk + d]);
+          }""",
+            "g_load": "const threadgroup float4* g4 = (const threadgroup float4*)&g_s[t][d0];",
+            "g_decay": "g4[i]",
+        }
+    return {
+        "g_decl": "threadgroup float g_s[TB];",
+        "g_stage": """for (int p = tid; p < tt; p += TG) {
+            g_s[p] = static_cast<float>(g[((size_t)b * T + t0 + p) * Hv + hv]);
+          }""",
+        "g_load": "const float gt = g_s[t];",
+        "g_decay": "gt",
+    }
+
+
+def _make_gd_blocked_forward_kernel(vectorized=False):
+    """Blocked-sequential GDN forward: same recurrence, restructured access."""
+    if not mx.metal.is_available():
+        return None
+    source = _BLOCKED_PREAMBLE + _BLOCKED_FORWARD_SRC.format(**_blocked_gating(vectorized))
+    return mx.fast.metal_kernel(
+        name=f"unsloth_gd_blocked_fwd{'_vec' if vectorized else ''}",
+        input_names=["q", "k", "v", "g", "beta", "state_in", "T"],
+        output_names=["y", "state_out"],
+        source=source,
+    )
+
+
+_GD_BLOCKED_FWD: dict = {}
+
+
+def _get_blocked_forward(vectorized=False):
+    if vectorized not in _GD_BLOCKED_FWD:
+        _GD_BLOCKED_FWD[vectorized] = _make_gd_blocked_forward_kernel(vectorized)
+    return _GD_BLOCKED_FWD[vectorized]
+
+
+def gated_delta_blocked_forward(q, k, v, g, beta, state):
+    """Forward half of the fused path; None when the layout does not fit.
+
+    Contract matches mlx_lm.models.gated_delta.gated_delta_kernel for the
+    unmasked case: returns (y [B, T, Hv, Dv] in q.dtype, state_out in
+    state.dtype).
+    """
+    B, T, Hk, Dk = k.shape
+    Hv, Dv = v.shape[2:]
+    vectorized = g.ndim == 4
+    layout = _blocked_layout(Dk, Dv, q.dtype, vectorized)
+    kernel = _get_blocked_forward(vectorized)
+    if layout is None or kernel is None:
+        return None
+    P, W, DB, TB, threads = layout
+    return kernel(
+        inputs=[q, k, v, g, beta, state, T],
+        template=[
+            ("InT", q.dtype), ("Dk", Dk), ("Dv", Dv), ("Hk", Hk), ("Hv", Hv),
+            ("TB", TB), ("P", P), ("W", W), ("DB", DB),
+        ],
+        grid=(threads * (Dv // DB), Hv, B),
+        threadgroup=(threads, 1, 1),
+        output_shapes=[(B, T, Hv, Dv), state.shape],
+        output_dtypes=[q.dtype, state.dtype],
+    )
 
 
 def _make_gd_chunk_states_kernel(vectorized=False):
@@ -850,7 +1080,10 @@ def gated_delta_kernel_efficient(
 
     @mx.custom_function
     def _chunk(q_c, k_c, v_c, g_c, beta_c, state_in):
-        return gated_delta_kernel(q_c, k_c, v_c, g_c, beta_c, state_in)
+        out = gated_delta_blocked_forward(q_c, k_c, v_c, g_c, beta_c, state_in)
+        if out is None:
+            return gated_delta_kernel(q_c, k_c, v_c, g_c, beta_c, state_in)
+        return out
 
     @_chunk.vjp
     def _chunk_vjp(primals, cotangents, outputs):

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -544,24 +544,28 @@ def _blocked_layout(Dk, Dv, in_dtype, vectorized, cfg):
         red_arrays += 1        # per-column d_g reduces the same way d_k does
     if Dk <= 0 or Dv <= 0:
         return None
-    P = 1
-    while P <= 32:
-        W = Dk // P
-        # Whole simdgroups only: the backward reduces d_q/d_k across the 32 / P
-        # state rows a simdgroup holds, and a partial one would read idle lanes.
-        DB = (None if Dk % P or W % 4 or W > max_segment else
-              _blocked_dv_block(Dv, min(Dv, _BLOCKED_TG_THREADS // P), 32 // P))
-        if DB is not None:
-            # Cross-row reduction scratch: one Dk-wide row per simdgroup.
-            fixed = red_arrays * (P * DB // 32) * Dk * 4
-            for TB in tb_choices:
-                used = TB * (
-                    in_dtype.size * (dk_rows * (Dk + _BLOCKED_PAD) + dv_rows * (DB + _BLOCKED_PAD))
-                    + 4 * dv_f32_rows * (DB + _BLOCKED_PAD)
-                    + 4 * (1 + (Dk + _BLOCKED_PAD if vectorized else 1)))
-                if used + fixed <= _BLOCKED_TG_MEMORY:
-                    return P, W, DB, TB, P * DB
-        P *= 2
+    # Halving the threadgroup costs far less than losing the fused path entirely.
+    threads_cap = _BLOCKED_TG_THREADS
+    while threads_cap >= 32:
+        P = 1
+        while P <= 32:
+            W = Dk // P
+            # Whole simdgroups: the backward reduces across the 32/P rows one holds.
+            DB = (None if Dk % P or W % 4 or W > max_segment else
+                  _blocked_dv_block(Dv, min(Dv, threads_cap // P), 32 // P))
+            if DB is not None:
+                # Cross-row reduction scratch: one Dk-wide row per simdgroup.
+                fixed = red_arrays * (P * DB // 32) * Dk * 4
+                for TB in tb_choices:
+                    used = TB * (
+                        in_dtype.size * (dk_rows * (Dk + _BLOCKED_PAD)
+                                         + dv_rows * (DB + _BLOCKED_PAD))
+                        + 4 * dv_f32_rows * (DB + _BLOCKED_PAD)
+                        + 4 * (1 + (Dk + _BLOCKED_PAD if vectorized else 1)))
+                    if used + fixed <= _BLOCKED_TG_MEMORY:
+                        return P, W, DB, TB, P * DB
+            P *= 2
+        threads_cap //= 2
     return None
 
 


### PR DESCRIPTION
## What this changes

Training on MLX with a gated-delta model (Qwen3.5, Qwen3-Next, Kimi Linear) currently takes an ops VJP through the recurrence. It is memory-correct but dispatch-bound: roughly `T * 12` lazy primitives per layer per step, which `mx.compile` cannot fuse. This adds fused Metal kernels for the training forward and backward and routes eligible calls to them.

Gated-delta forward+backward gets **2.3-2.9x** faster, which is worth **1.08-1.25x** on a whole training step. Numerics are unchanged to within accumulation-order noise, and peak memory is unchanged.

Nothing else about the path changes: shapes the kernels cannot place still take the ops VJP in both directions, inference is untouched, and `gated_delta_kernel_supported` is the single predicate deciding eligibility.

## How it works

Three kernels share one blocked-sequential thread layout. Where mlx-lm's kernel gives each state row its own simdgroup — so every contraction costs a full `simd_sum` and each of the `Dv` rows re-reads the same `k`/`q` from device memory — here `P = Dk/W` threads cover a row inside a single simdgroup, `DB` rows share a threadgroup, and the threadgroup stages a `TB`-step time block of `k`/`q`/`v`/`g`/`beta` once.

- **Forward** runs the recurrence in that layout.
- **Checkpoint** replays the chunk keeping only the state at each time-block boundary, plus every step's `k · state` contraction.
- **Backward** reverse-scans, replaying each block from its entry checkpoint, so no per-step state buffer is needed and the per-row state cotangent stays in registers.

The BPTT chunk length is derived per call rather than fixed. Longer chunks amortize the launch and the block replay — 1.9x on the backward between 64 and 512 steps — but hold more block checkpoints, so the length is chosen against a checkpoint memory budget and clamped to a 64-512 range.

The forward and backward want different layouts: the forward prefers wide segments (more rows per threadgroup, fewer redundant `k`/`q` reads), the backward prefers narrow ones because it carries three state fragments per thread and replays blocks. They are therefore selected independently. Forcing them to agree costs 1.9x on the backward.

The last commit fixes a placement gap found while benchmarking: at `Dk >= 256` the reduction scratch crowded out every time block at full threadgroup width, so no layout was found and those shapes silently fell back to the ops VJP. The layout search now retries at half threadgroup width, which halves the reduction scratch while costing the time block far less.

## Results

Apple M3 Max, batch 1, bfloat16, measured against this branch's merge base. Every figure is min-of-N wall time with the arms interleaved, and a duplicate baseline arm runs in every measurement so the spread between its two timings shows how much of a difference is the machine. All cells below are under 3% control spread.

Gated-delta layer, at the head configurations the Qwen3.5 checkpoints actually run:

| model | T | forward | forward+backward |
|---|---:|---:|---:|
| 0.8B / 2B | 512 | 1.61x | **2.37x** |
| 0.8B / 2B | 1024 | 1.49x | **2.35x** |
| 0.8B / 2B | 2048 | 1.53x | **2.62x** |
| 4B | 512 | 1.63x | **2.33x** |
| 4B | 1024 | 1.72x | **2.44x** |
| 4B | 2048 | 1.82x | **2.87x** |

Whole training step — gradient checkpointing, chunked cross-entropy and `mx.compile` all on, which is what the MLX trainer runs:

| model | T | full-parameter tok/s | LoRA tok/s | full-parameter | LoRA |
|---|---:|---:|---:|---:|---:|
| Qwen3.5-0.8B | 512 | 989 → 1,072 | 1,362 → 1,619 | 1.096x | 1.188x |
| Qwen3.5-0.8B | 1024 | 924 → 1,093 | 1,344 → 1,616 | 1.199x | 1.200x |
| Qwen3.5-0.8B | 2048 | 887 → 1,079 | 1,295 → 1,616 | 1.227x | 1.245x |
| Qwen3.5-2B | 512 | 510 → 546 | 739 → 820 | 1.079x | 1.110x |
| Qwen3.5-2B | 1024 | 503 → 543 | 763 → 822 | 1.088x | 1.082x |
| Qwen3.5-2B | 2048 | 517 → 596 | 765 → 870 | 1.165x | 1.152x |
| Qwen3.5-4B | 512 | 225 → 247 | 334 → 371 | 1.104x | 1.114x |
| Qwen3.5-4B | 1024 | 268 → 299 | 349 → 389 | 1.114x | 1.118x |
| Qwen3.5-4B | 2048 | 191 → 222 | 307 → 354 | 1.156x | 1.152x |

LoRA is r=16, alpha=32 on every linear in both mixer kinds and the MLP.

The end-to-end figure is much smaller than the layer figure because gated delta is a shrinking share of a step that also runs MLPs, full attention every fourth layer, and a cross-entropy over a 248k vocabulary. The gain rises with sequence length and falls with model width, and it is the same whether training full-parameter or with LoRA.

## Correctness

Losses on a real training step agree with the current path to at most **1.1e-4** relative across all eighteen model-level measurements. Gradients are checked in the test suite against autodiff over a step-by-step fp32 reference, elementwise rather than globally so a small misrouted entry cannot hide behind a large one.

Atomic accumulation in the backward leaves low-order gradient bits nondeterministic, as elsewhere on Metal. The forward and backward use different layouts, so the backward replays states differing from the forward's in the low bits: at most 2.4e-7 relative per gradient over a T=512 fp32 chunk, against up to 1.9e-7 between two runs of the same backward, which already disagree through the atomics.

## Risks and tradeoffs

- **No memory win.** Isolated, the fused backward cuts layer peak memory 8.6-11x. At model scale that saving is already taken by gradient checkpointing, which recomputes exactly the activations the fused backward avoids storing. Measured end to end, peak memory moves by at most 136 MB in either direction. This is a speed change, not a memory change.
- **Single-machine calibration.** The layout search and the chunk-length budget were tuned on one Apple GPU. `mx.device_info()` does not expose a core count, so the thresholds cannot scale themselves to the device. They are conservative rather than tight.
- **Absolute throughput is machine-state dependent.** The same configuration measured 415.8 ms and 517.6 ms on an idle versus a loaded machine. The ratios held across both; read the tok/s figures as relative, not as a specification.

## Validation

```bash
python -m pytest tests/test_qwen35_vjp_metal.py -q        # 49 passed
python -m pytest tests/test_mlx_gated_delta_vjp.py -q     # 36 passed
```

Run the two files separately. A pre-existing failure occurs when both run in one process, and it reproduces on the merge base.

The tests cover both gating shapes, all three dtypes, thread prefixes 1 to 32, segment widths 4 to 32, GQA ratios 1 to 4, sequence lengths that are not a multiple of the time block, and the chunk seam. A dispatch check confirms the fused kernels are actually reached at every benchmarked shape, with blocked-forward call counts matching the expected chunk counts, so the measured gains are attributable to the kernels rather than to a dispatch that quietly declined.
