### PR TITLE
Guard the disabled-hook eager fallback against checkpointed regions

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -296,6 +296,11 @@ jobs:
         # test_wheel_top_level_packages pins that discovery ships unsloth_zoo and
         # nothing else; collect-only would let the packaging config regress.
         #
+        # test_disabled_hook_checkpoint_guard pins the disabled-hook arm of the
+        # eager fallback: that it still falls back for a first-call refusal, that
+        # it ends the step instead when a compiled pack is outstanding, and that
+        # only its own label latches. CPU-pure, no model weights.
+        #
         # test_loss_normalization_contract pins num_items_in_batch: the grad-accum
         # guard, and the packed / padding-free boundary count. The second one
         # shipped broken for the same reason this comment keeps repeating -- the
@@ -356,6 +361,7 @@ jobs:
             tests/test_missing_parent_package_is_drift.py \
             tests/test_sibling_imports_do_not_go_through_a_tests_package.py \
             tests/test_hip_bf16_offload_dtype.py \
+            tests/test_disabled_hook_checkpoint_guard.py \
             -v
 
       - name: pytest MLX adapter-filter gate (HARD GATE)

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -297,9 +297,8 @@ jobs:
         # nothing else; collect-only would let the packaging config regress.
         #
         # test_disabled_hook_checkpoint_guard pins the disabled-hook arm of the
-        # eager fallback: that it still falls back for a first-call refusal, that
-        # it ends the step instead when a compiled pack is outstanding, and that
-        # only its own label latches. CPU-pure, no model weights.
+        # eager fallback: still falls back on a first-call refusal, ends the step
+        # when a compiled pack is outstanding, latches only its own label. CPU-pure.
         #
         # test_loss_normalization_contract pins num_items_in_batch: the grad-accum
         # guard, and the packed / padding-free boundary count. The second one

--- a/tests/test_checkpoint_compile_mix.py
+++ b/tests/test_checkpoint_compile_mix.py
@@ -443,3 +443,126 @@ def test_the_last_sequential_segment_is_outside_every_region():
     is packed while it executes and eager is safe there even when the earlier
     segments are non-reentrant."""
     assert _sequential_walk(2, False) == [True, True, False, False]
+
+
+# ---- the disabled-hook arm, which used to flip with no question asked -----
+
+def _disabled_hook_error():
+    """Dynamo's refusal to inline a `torch.compiler.disable`d callable."""
+    import torch._dynamo.exc as exc
+    cls = getattr(exc, "Unsupported", None)
+    if cls is None:
+        pytest.skip("this torch has no torch._dynamo.exc.Unsupported")
+    try:
+        return cls(
+            "Skip calling `torch.compiler.disable()`d function\n"
+            "  Explanation: Skip calling function `requires_grad_pre_hook` "
+            "since it was wrapped with `torch.compiler.disable`\n"
+            "  Hint: Remove the `torch.compiler.disable` call"
+        )
+    except Exception:
+        pytest.skip("Unsupported cannot be constructed on this torch")
+
+
+@pytest.fixture
+def hook_label():
+    label = "test_disabled_hook_under_checkpoint"
+    for s in (U._LATCHED_EAGER_LABELS, U._PENDING_EAGER_LABELS,
+              U._RECENT_EAGER_LABELS, U._COMPILED_OK_LABELS):
+        s.discard(label)
+    packed = U._PACKED_COMPILED_IN_CHECKPOINT
+    yield label
+    for s in (U._LATCHED_EAGER_LABELS, U._PENDING_EAGER_LABELS,
+              U._RECENT_EAGER_LABELS, U._COMPILED_OK_LABELS):
+        s.discard(label)
+    U._PACKED_COMPILED_IN_CHECKPOINT = packed
+    U._RAISED_INSIDE_CHECKPOINT = False
+    U._CHECKPOINT_SETTLE_ATTEMPTS = 0
+
+
+@pytest.mark.skipif(
+    U._in_non_reentrant_checkpoint() is None,
+    reason = "torch < 2.8 cannot report whether a checkpoint region is live",
+)
+def test_a_disabled_hook_does_not_flip_a_region_that_packed_compiled(hook_label):
+    """The Gemma4 abort.
+
+    Dynamo only discovers a disabled hook while TRACING, so this arm fires on a
+    recompile -- routinely the backward recompute of a region whose forward
+    already packed compiled. It used to set `state["eager"]` and run eager on
+    the spot, with none of the checkpoint question the other give-up arms ask,
+    and torch reported
+
+        CheckpointError: Recomputed values for the following tensors have
+        different metadata than during the forward pass
+
+    with `_LATCHED_EAGER_LABELS` still empty, because this arm recorded nothing.
+    """
+    calls = {"n": 0}
+
+    def compiled(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "compiled"
+        raise _disabled_hook_error()
+
+    fn = U._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda *a, **k: "eager", hook_label)
+
+    def region(x):
+        # First call packs compiled, so the region owes a compiled recompute.
+        assert fn(x) == "compiled"
+        # A later trace in the same region refuses. Eager here is the abort.
+        return fn(x) * x
+
+    with pytest.raises(Exception) as ei:
+        checkpoint(region, torch.randn(4, 4, requires_grad = True),
+                   use_reentrant = False)
+    message = str(ei.value)
+    assert "torch.compiler.disable" in message, message[:200]
+
+    assert hook_label in U._LATCHED_EAGER_LABELS, "the flip must be recorded"
+    assert hook_label in U._RECENT_EAGER_LABELS, "and as this step's evidence"
+    assert U._RAISED_INSIDE_CHECKPOINT, "the abandoned region must be settled"
+    assert fn._unsloth_fallback_state["eager"], "the retry has to be eager"
+
+    # `ei` roots the traceback, which roots the abandoned generator and leaves
+    # its saved-tensor hooks installed for every later test in the process --
+    # the case `_settle_abandoned_checkpoint_generator` documents.
+    del ei
+    U.apply_pending_eager_fallbacks()
+    assert U._in_non_reentrant_checkpoint() is False, "the region never closed"
+
+
+@pytest.mark.skipif(
+    U._in_non_reentrant_checkpoint() is None,
+    reason = "torch < 2.8 cannot report whether a checkpoint region is live",
+)
+def test_a_disabled_hook_still_falls_back_when_nothing_packed_compiled(hook_label):
+    """The majority case must not regress.
+
+    A refusal on the FIRST call means nothing compiled was packed by this label,
+    so the eager call packs eagerly and the recompute recomputes eagerly. Those
+    agree, and turning that into a dead step would cost users a working run.
+    """
+    def compiled(*args, **kwargs):
+        raise _disabled_hook_error()
+
+    fn = U._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda *a, **k: "eager", hook_label)
+
+    out = checkpoint(lambda x: fn(x) and x * 2,
+                     torch.randn(4, 4, requires_grad = True),
+                     use_reentrant = False)
+    out.sum().backward()
+    assert fn._unsloth_fallback_state["eager"]
+    assert not U._RAISED_INSIDE_CHECKPOINT, "nothing was stranded"
+
+
+def test_a_disabled_hook_outside_any_region_is_unchanged(hook_label):
+    def compiled(*args, **kwargs):
+        raise _disabled_hook_error()
+    fn = U._fall_back_to_eager_on_recompile_limit(
+        compiled, lambda *a, **k: "eager", hook_label)
+    assert fn() == "eager"
+    assert not U._RAISED_INSIDE_CHECKPOINT

--- a/tests/test_checkpoint_compile_mix.py
+++ b/tests/test_checkpoint_compile_mix.py
@@ -488,15 +488,11 @@ def test_a_disabled_hook_does_not_flip_a_region_that_packed_compiled(hook_label)
     """The Gemma4 abort.
 
     Dynamo only discovers a disabled hook while TRACING, so this arm fires on a
-    recompile -- routinely the backward recompute of a region whose forward
-    already packed compiled. It used to set `state["eager"]` and run eager on
-    the spot, with none of the checkpoint question the other give-up arms ask,
-    and torch reported
-
-        CheckpointError: Recomputed values for the following tensors have
-        different metadata than during the forward pass
-
-    with `_LATCHED_EAGER_LABELS` still empty, because this arm recorded nothing.
+    recompile, routinely the backward recompute of a region whose forward already
+    packed compiled. It used to set `state["eager"]` and run eager on the spot,
+    with none of the checkpoint question the other give-up arms ask, and torch
+    raised CheckpointError about recomputed tensors having different metadata,
+    with `_LATCHED_EAGER_LABELS` still empty because this arm recorded nothing.
     """
     calls = {"n": 0}
 
@@ -526,9 +522,8 @@ def test_a_disabled_hook_does_not_flip_a_region_that_packed_compiled(hook_label)
     assert U._RAISED_INSIDE_CHECKPOINT, "the abandoned region must be settled"
     assert fn._unsloth_fallback_state["eager"], "the retry has to be eager"
 
-    # `ei` roots the traceback, which roots the abandoned generator and leaves
-    # its saved-tensor hooks installed for every later test in the process --
-    # the case `_settle_abandoned_checkpoint_generator` documents.
+    # `ei` roots the traceback, hence the abandoned generator and its still
+    # installed hooks -- the case `_settle_abandoned_checkpoint_generator` covers.
     del ei
     U.apply_pending_eager_fallbacks()
     assert U._in_non_reentrant_checkpoint() is False, "the region never closed"
@@ -539,12 +534,9 @@ def test_a_disabled_hook_does_not_flip_a_region_that_packed_compiled(hook_label)
     reason = "torch < 2.8 cannot report whether a checkpoint region is live",
 )
 def test_a_disabled_hook_still_falls_back_when_nothing_packed_compiled(hook_label):
-    """The majority case must not regress.
-
-    A refusal on the FIRST call means nothing compiled was packed by this label,
-    so the eager call packs eagerly and the recompute recomputes eagerly. Those
-    agree, and turning that into a dead step would cost users a working run.
-    """
+    """The majority case must not regress: a refusal on the FIRST call means
+    nothing compiled was packed by this label, so eager pack and eager recompute
+    agree. Turning that into a dead step would cost users a working run."""
     def compiled(*args, **kwargs):
         raise _disabled_hook_error()
 

--- a/tests/test_disabled_hook_checkpoint_guard.py
+++ b/tests/test_disabled_hook_checkpoint_guard.py
@@ -21,14 +21,10 @@ through `_give_up_at_compile_time`, the contract `_give_up_on_backend` already
 had. Before, that arm did `state["eager"] = True; return eager_func(...)` and
 never raised, never touched the global label sets, never restored the marker.
 
-That is a behaviour change in shared machinery used by every `fullgraph = True`
-patch in the package plus 14 sites in unsloth core, so the risk is NOT "does the
-new case work" but "does the old case still work". These tests are weighted
-accordingly.
-
-Written as a before/after pair and kept in that shape: each test says what the
-old arm did as well as what the new one does, so the reason for a branch is
-readable rather than inferred.
+That changes shared machinery used by every `fullgraph = True` patch here plus
+14 sites in unsloth core, so the risk is NOT "does the new case work" but "does
+the old case still work", and the tests are weighted accordingly. Each is
+written as a before/after pair so the reason for a branch is readable.
 """
 
 import sys
@@ -100,9 +96,7 @@ def _raiser(msg=DISABLE_MSG):
     return compiled
 
 
-# --------------------------------------------------------------------------
 # R1: the common case must not change. This is the regression that would hurt.
-# --------------------------------------------------------------------------
 
 def test_disabled_hook_outside_any_checkpoint_still_falls_back_to_eager():
     """The overwhelmingly common case: no checkpoint in sight. Both trees must
@@ -111,9 +105,9 @@ def test_disabled_hook_outside_any_checkpoint_still_falls_back_to_eager():
 
 
 def test_first_call_refusal_inside_checkpoint_still_falls_back():
-    """Nothing compiled has been packed by this label, so eager pack + eager
-    recompute agree and there is nothing to protect. Must not raise on either
-    tree, or every first-call user of a checkpointed fullgraph region breaks."""
+    """Nothing compiled was packed by this label, so eager pack + eager
+    recompute agree. Raising here would break every first-call user of a
+    checkpointed fullgraph region."""
     U._PACKED_COMPILED_IN_CHECKPOINT = True   # a region is live
     assert LABEL not in U._COMPILED_OK_LABELS  # but WE never compiled ok
     assert _wrap(_raiser())() == "eager"
@@ -132,17 +126,12 @@ def test_an_unrelated_graph_break_still_raises():
         _wrap(_raiser("Unsupported: something else entirely"))()
 
 
-# --------------------------------------------------------------------------
 # R2: the new behaviour, only on the fix tree.
-# --------------------------------------------------------------------------
 
 def test_refusal_after_compiling_ok_inside_a_live_region():
-    """The bug. This label compiled fine, so a compiled pack is outstanding;
-    flipping to eager mid-region desynchronises pack and recompute.
-
-    main: silently returns eager (corruption).
-    fix:  raises, so the step ends honestly.
-    """
+    """The bug. This label compiled fine, so a compiled pack is outstanding and
+    flipping to eager mid-region desynchronises pack and recompute. main returns
+    eager silently (corruption); fix raises, so the step ends honestly."""
     U._COMPILED_OK_LABELS.add(LABEL)
     U._PACKED_COMPILED_IN_CHECKPOINT = True
     w = _wrap(_raiser())
@@ -167,9 +156,9 @@ def test_fix_records_the_latch_in_the_global_label_sets():
 
 
 def test_a_new_wrapper_with_a_latched_label_starts_eager():
-    """Consequence of recording the latch: a rebuilt wrapper inherits it. That
-    is intended (the codegen arm has always behaved this way) but it means more
-    un-compilation than before, so it is pinned rather than left implicit."""
+    """Consequence of recording the latch: a rebuilt wrapper inherits it, as it
+    always has for the codegen arm. Intended, but more un-compilation than
+    before, so pinned rather than left implicit."""
     _wrap(_raiser())()
     second = _wrap(lambda *a, **k: "compiled-should-not-run")
     if IS_FIX:
@@ -178,13 +167,11 @@ def test_a_new_wrapper_with_a_latched_label_starts_eager():
         assert second() == "compiled-should-not-run"
 
 
-# --------------------------------------------------------------------------
 # R3: blast radius. Only THIS label may latch.
-# --------------------------------------------------------------------------
 
 def test_only_this_label_latches_not_every_borrower():
-    """Budget exhaustion is process wide and takes other borrowers with it. A
-    compile-time refusal is one region's property, so unrelated labels must keep
+    """Budget exhaustion is process wide and takes other borrowers with it; a
+    compile-time refusal is one region's property, so unrelated labels keep
     their compilation."""
     other = "SimOther"
     for s in (U._LATCHED_EAGER_LABELS, U._RECENT_EAGER_LABELS):
@@ -200,14 +187,12 @@ def test_only_this_label_latches_not_every_borrower():
             s.discard(other)
 
 
-# --------------------------------------------------------------------------
 # R4: the marker must be restored, not leaked.
-# --------------------------------------------------------------------------
 
 def test_marker_is_restored_to_what_it_was():
     """The arm captures the marker before the compiled call and puts it back.
-    Leaving it set would make a later wrapper believe a compiled pack is
-    outstanding and end a step that was fine."""
+    Left set, a later wrapper believes a compiled pack is outstanding and ends
+    a step that was fine."""
     U._PACKED_COMPILED_IN_CHECKPOINT = False
     _wrap(_raiser())()
     assert U._PACKED_COMPILED_IN_CHECKPOINT is False
@@ -220,9 +205,7 @@ def test_marker_true_is_preserved_when_no_raise_happens():
     assert U._PACKED_COMPILED_IN_CHECKPOINT is True
 
 
-# --------------------------------------------------------------------------
 # R5: the codegen arm this now shares a body with must be unchanged.
-# --------------------------------------------------------------------------
 
 def test_backend_refusal_arm_still_behaves():
     """`_give_up_on_backend` was refactored, not redefined. Its own path must
@@ -244,9 +227,7 @@ def test_backend_refusal_arm_still_behaves():
     assert out == "eager"
 
 
-# --------------------------------------------------------------------------
-# Platform: the changed code has no platform branch. Prove it rather than say it.
-# --------------------------------------------------------------------------
+# Platform: the changed code has no platform branch. Prove it, do not say it.
 
 def test_changed_path_has_no_platform_or_device_branch():
     import inspect
@@ -260,17 +241,15 @@ def test_changed_path_has_no_platform_or_device_branch():
 
 
 def test_conservative_when_another_region_packed_compiled_this_step():
-    """Characterises the one place the fix is deliberately pessimistic.
+    """The one place the fix is deliberately pessimistic.
 
-    `_PACKED_COMPILED_IN_CHECKPOINT` is process-global for the step, and
-    `_COMPILED_OK_LABELS` is sticky for the process. So if this label compiled
-    successfully at ANY earlier point, and ANY compiled call packed under a
-    checkpoint this step, the arm raises even though this particular wrapper may
-    have packed nothing in this region.
+    `_PACKED_COMPILED_IN_CHECKPOINT` is global for the step and
+    `_COMPILED_OK_LABELS` sticky for the process, so if this label ever compiled
+    ok and ANY compiled call packed under a checkpoint this step, the arm raises
+    even though this wrapper may have packed nothing in this region.
 
-    That is the same trade `_give_up_on_backend` has always made, not a new one:
-    ending a step that was probably fine is cheap, returning wrong gradients is
-    not. Pinned so the choice is visible rather than discovered later.
+    Same trade `_give_up_on_backend` has always made: ending a probably-fine
+    step is cheap, wrong gradients are not. Pinned so the choice is visible.
     """
     U._COMPILED_OK_LABELS.add(LABEL)          # compiled fine earlier
     U._PACKED_COMPILED_IN_CHECKPOINT = True   # some region packed compiled

--- a/tests/test_disabled_hook_checkpoint_guard.py
+++ b/tests/test_disabled_hook_checkpoint_guard.py
@@ -18,13 +18,12 @@
 
 PR #1145 routes the disabled-hook arm of `_fall_back_to_eager_on_recompile_limit`
 through `_give_up_at_compile_time`, the contract `_give_up_on_backend` already
-had. Before, that arm did `state["eager"] = True; return eager_func(...)` and
-never raised, never touched the global label sets, never restored the marker.
+had. Before, that arm did `state["eager"] = True; return eager_func(...)`: never
+raised, never touched the global label sets, never restored the marker.
 
-That changes shared machinery used by every `fullgraph = True` patch here plus
-14 sites in unsloth core, so the risk is NOT "does the new case work" but "does
-the old case still work", and the tests are weighted accordingly. Each is
-written as a before/after pair so the reason for a branch is readable.
+That is shared machinery (every `fullgraph = True` patch here plus 14 sites in
+unsloth core), so the risk is NOT "does the new case work" but "does the old one
+still work". Each test is a before/after pair, hence the `IS_FIX` branches.
 """
 
 import sys
@@ -57,8 +56,8 @@ OLD_DISABLE_MSG = (
 
 @pytest.fixture(autouse=True)
 def _clean_label_state():
-    """The latch is process-global and keyed by label. Without this the first
-    test to fall back starts every later one already eager."""
+    """The latch is process-global and keyed by label: without this the first
+    fallback starts every later test already eager."""
     sets = (U._LATCHED_EAGER_LABELS, U._PENDING_EAGER_LABELS,
             U._RECENT_EAGER_LABELS, U._COMPILED_OK_LABELS)
     for s in sets:
@@ -99,29 +98,25 @@ def _raiser(msg=DISABLE_MSG):
 # R1: the common case must not change. This is the regression that would hurt.
 
 def test_disabled_hook_outside_any_checkpoint_still_falls_back_to_eager():
-    """The overwhelmingly common case: no checkpoint in sight. Both trees must
-    return eager and must NOT raise."""
+    """The common case: no checkpoint in sight. Both trees return eager, no raise."""
     assert _wrap(_raiser())() == "eager"
 
 
 def test_first_call_refusal_inside_checkpoint_still_falls_back():
-    """Nothing compiled was packed by this label, so eager pack + eager
-    recompute agree. Raising here would break every first-call user of a
-    checkpointed fullgraph region."""
+    """Nothing compiled was packed by this label, so eager pack + eager recompute
+    agree. Raising would break every first-call user of a checkpointed region."""
     U._PACKED_COMPILED_IN_CHECKPOINT = True   # a region is live
     assert LABEL not in U._COMPILED_OK_LABELS  # but WE never compiled ok
     assert _wrap(_raiser())() == "eager"
 
 
 def test_old_torch_message_signature_also_falls_back():
-    """torch < 2.7 phrased the refusal differently. Both spellings must be
-    recognised or the exception escapes as a hard error."""
+    """torch < 2.7 phrased it differently; miss a spelling and it escapes hard."""
     assert _wrap(_raiser(OLD_DISABLE_MSG))() == "eager"
 
 
 def test_an_unrelated_graph_break_still_raises():
-    """The narrow match is the whole safety property of this arm. Over-catching
-    would swallow real bugs."""
+    """The narrow match is this arm's safety property: over-catching hides bugs."""
     with pytest.raises(Exception):
         _wrap(_raiser("Unsupported: something else entirely"))()
 
@@ -145,8 +140,8 @@ def test_refusal_after_compiling_ok_inside_a_live_region():
 
 
 def test_fix_records_the_latch_in_the_global_label_sets():
-    """main records nothing, which is why a captured state can show an empty
-    latched list after this arm fired. fix records it in both sets."""
+    """main records nothing, hence the empty latched list in captures taken after
+    this arm fired. fix records it in both sets."""
     _wrap(_raiser())()
     if IS_FIX:
         assert LABEL in U._LATCHED_EAGER_LABELS
@@ -156,9 +151,8 @@ def test_fix_records_the_latch_in_the_global_label_sets():
 
 
 def test_a_new_wrapper_with_a_latched_label_starts_eager():
-    """Consequence of recording the latch: a rebuilt wrapper inherits it, as it
-    always has for the codegen arm. Intended, but more un-compilation than
-    before, so pinned rather than left implicit."""
+    """Consequence of recording the latch: a rebuilt wrapper inherits it, as for
+    the codegen arm. Intended, but more un-compilation than before, so pinned."""
     _wrap(_raiser())()
     second = _wrap(lambda *a, **k: "compiled-should-not-run")
     if IS_FIX:
@@ -171,8 +165,7 @@ def test_a_new_wrapper_with_a_latched_label_starts_eager():
 
 def test_only_this_label_latches_not_every_borrower():
     """Budget exhaustion is process wide and takes other borrowers with it; a
-    compile-time refusal is one region's property, so unrelated labels keep
-    their compilation."""
+    compile-time refusal is one region's, so unrelated labels keep compiling."""
     other = "SimOther"
     for s in (U._LATCHED_EAGER_LABELS, U._RECENT_EAGER_LABELS):
         s.discard(other)
@@ -190,9 +183,8 @@ def test_only_this_label_latches_not_every_borrower():
 # R4: the marker must be restored, not leaked.
 
 def test_marker_is_restored_to_what_it_was():
-    """The arm captures the marker before the compiled call and puts it back.
-    Left set, a later wrapper believes a compiled pack is outstanding and ends
-    a step that was fine."""
+    """The arm captures the marker before the compiled call and puts it back; left
+    set, a later wrapper reads a compiled pack outstanding and ends a fine step."""
     U._PACKED_COMPILED_IN_CHECKPOINT = False
     _wrap(_raiser())()
     assert U._PACKED_COMPILED_IN_CHECKPOINT is False
@@ -208,8 +200,7 @@ def test_marker_true_is_preserved_when_no_raise_happens():
 # R5: the codegen arm this now shares a body with must be unchanged.
 
 def test_backend_refusal_arm_still_behaves():
-    """`_give_up_on_backend` was refactored, not redefined. Its own path must
-    still fall back to eager when nothing compiled was packed."""
+    """`_give_up_on_backend` was refactored, not redefined: still falls back."""
     import torch
 
     class _BackendFail(Exception):
@@ -244,12 +235,10 @@ def test_conservative_when_another_region_packed_compiled_this_step():
     """The one place the fix is deliberately pessimistic.
 
     `_PACKED_COMPILED_IN_CHECKPOINT` is global for the step and
-    `_COMPILED_OK_LABELS` sticky for the process, so if this label ever compiled
-    ok and ANY compiled call packed under a checkpoint this step, the arm raises
-    even though this wrapper may have packed nothing in this region.
-
-    Same trade `_give_up_on_backend` has always made: ending a probably-fine
-    step is cheap, wrong gradients are not. Pinned so the choice is visible.
+    `_COMPILED_OK_LABELS` sticky for the process, so this label compiling ok plus
+    ANY compiled pack under a checkpoint this step makes the arm raise, even if
+    this wrapper packed nothing here. Same trade `_give_up_on_backend` has always
+    made: ending a probably-fine step is cheap, wrong gradients are not.
     """
     U._COMPILED_OK_LABELS.add(LABEL)          # compiled fine earlier
     U._PACKED_COMPILED_IN_CHECKPOINT = True   # some region packed compiled

--- a/tests/test_disabled_hook_checkpoint_guard.py
+++ b/tests/test_disabled_hook_checkpoint_guard.py
@@ -1,0 +1,282 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Simulation suite for unsloth-zoo PR #1145.
+
+PR #1145 routes the disabled-hook arm of `_fall_back_to_eager_on_recompile_limit`
+through `_give_up_at_compile_time`, the contract `_give_up_on_backend` already
+had. Before, that arm did `state["eager"] = True; return eager_func(...)` and
+never raised, never touched the global label sets, never restored the marker.
+
+That is a behaviour change in shared machinery used by every `fullgraph = True`
+patch in the package plus 14 sites in unsloth core, so the risk is NOT "does the
+new case work" but "does the old case still work". These tests are weighted
+accordingly.
+
+Written as a before/after pair and kept in that shape: each test says what the
+old arm did as well as what the new one does, so the reason for a branch is
+readable rather than inferred.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+IS_FIX = True
+
+from unsloth_zoo.temporary_patches import utils as U  # noqa: E402
+
+LABEL = "SimMod"
+
+DISABLE_MSG = (
+    "Skip calling `torch.compiler.disable()`d function\n"
+    "  Explanation: Skip calling function "
+    "`<function requires_grad_for_gradient_checkpointing.<locals>."
+    "requires_grad_pre_hook at 0x7f00>` since it was wrapped with "
+    "`torch.compiler.disable` (reason: None)\n"
+    "  Hint: Remove the `torch.compiler.disable` call"
+)
+OLD_DISABLE_MSG = (
+    "call torch._dynamo.disable() wrapped function "
+    "<function requires_grad_pre_hook at 0x7f00>"
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_label_state():
+    """The latch is process-global and keyed by label. Without this the first
+    test to fall back starts every later one already eager."""
+    sets = (U._LATCHED_EAGER_LABELS, U._PENDING_EAGER_LABELS,
+            U._RECENT_EAGER_LABELS, U._COMPILED_OK_LABELS)
+    for s in sets:
+        s.discard(LABEL)
+    packed = U._PACKED_COMPILED_IN_CHECKPOINT
+    raised = getattr(U, "_RAISED_INSIDE_CHECKPOINT", False)
+    U._PACKED_COMPILED_IN_CHECKPOINT = False
+    U._RAISED_INSIDE_CHECKPOINT = False
+    yield
+    for s in sets:
+        s.discard(LABEL)
+    U._PACKED_COMPILED_IN_CHECKPOINT = packed
+    U._RAISED_INSIDE_CHECKPOINT = raised
+
+
+def _unsupported(msg):
+    import torch._dynamo.exc as exc
+    cls = getattr(exc, "Unsupported", None)
+    if cls is None:
+        pytest.skip("this torch has no torch._dynamo.exc.Unsupported")
+    try:
+        return cls(msg)
+    except Exception:
+        pytest.skip("Unsupported cannot be constructed on this torch")
+
+
+def _wrap(compiled, eager=None, label=LABEL):
+    eager = eager or (lambda *a, **k: "eager")
+    return U._fall_back_to_eager_on_recompile_limit(compiled, eager, label)
+
+
+def _raiser(msg=DISABLE_MSG):
+    def compiled(*a, **k):
+        raise _unsupported(msg)
+    return compiled
+
+
+# --------------------------------------------------------------------------
+# R1: the common case must not change. This is the regression that would hurt.
+# --------------------------------------------------------------------------
+
+def test_disabled_hook_outside_any_checkpoint_still_falls_back_to_eager():
+    """The overwhelmingly common case: no checkpoint in sight. Both trees must
+    return eager and must NOT raise."""
+    assert _wrap(_raiser())() == "eager"
+
+
+def test_first_call_refusal_inside_checkpoint_still_falls_back():
+    """Nothing compiled has been packed by this label, so eager pack + eager
+    recompute agree and there is nothing to protect. Must not raise on either
+    tree, or every first-call user of a checkpointed fullgraph region breaks."""
+    U._PACKED_COMPILED_IN_CHECKPOINT = True   # a region is live
+    assert LABEL not in U._COMPILED_OK_LABELS  # but WE never compiled ok
+    assert _wrap(_raiser())() == "eager"
+
+
+def test_old_torch_message_signature_also_falls_back():
+    """torch < 2.7 phrased the refusal differently. Both spellings must be
+    recognised or the exception escapes as a hard error."""
+    assert _wrap(_raiser(OLD_DISABLE_MSG))() == "eager"
+
+
+def test_an_unrelated_graph_break_still_raises():
+    """The narrow match is the whole safety property of this arm. Over-catching
+    would swallow real bugs."""
+    with pytest.raises(Exception):
+        _wrap(_raiser("Unsupported: something else entirely"))()
+
+
+# --------------------------------------------------------------------------
+# R2: the new behaviour, only on the fix tree.
+# --------------------------------------------------------------------------
+
+def test_refusal_after_compiling_ok_inside_a_live_region():
+    """The bug. This label compiled fine, so a compiled pack is outstanding;
+    flipping to eager mid-region desynchronises pack and recompute.
+
+    main: silently returns eager (corruption).
+    fix:  raises, so the step ends honestly.
+    """
+    U._COMPILED_OK_LABELS.add(LABEL)
+    U._PACKED_COMPILED_IN_CHECKPOINT = True
+    w = _wrap(_raiser())
+    if IS_FIX:
+        with pytest.raises(Exception):
+            w()
+        assert U._RAISED_INSIDE_CHECKPOINT is True
+    else:
+        assert w() == "eager"
+        assert U._RAISED_INSIDE_CHECKPOINT is False
+
+
+def test_fix_records_the_latch_in_the_global_label_sets():
+    """main records nothing, which is why a captured state can show an empty
+    latched list after this arm fired. fix records it in both sets."""
+    _wrap(_raiser())()
+    if IS_FIX:
+        assert LABEL in U._LATCHED_EAGER_LABELS
+        assert LABEL in U._RECENT_EAGER_LABELS
+    else:
+        assert LABEL not in U._LATCHED_EAGER_LABELS
+
+
+def test_a_new_wrapper_with_a_latched_label_starts_eager():
+    """Consequence of recording the latch: a rebuilt wrapper inherits it. That
+    is intended (the codegen arm has always behaved this way) but it means more
+    un-compilation than before, so it is pinned rather than left implicit."""
+    _wrap(_raiser())()
+    second = _wrap(lambda *a, **k: "compiled-should-not-run")
+    if IS_FIX:
+        assert second() == "eager"
+    else:
+        assert second() == "compiled-should-not-run"
+
+
+# --------------------------------------------------------------------------
+# R3: blast radius. Only THIS label may latch.
+# --------------------------------------------------------------------------
+
+def test_only_this_label_latches_not_every_borrower():
+    """Budget exhaustion is process wide and takes other borrowers with it. A
+    compile-time refusal is one region's property, so unrelated labels must keep
+    their compilation."""
+    other = "SimOther"
+    for s in (U._LATCHED_EAGER_LABELS, U._RECENT_EAGER_LABELS):
+        s.discard(other)
+    try:
+        other_wrapper = _wrap(lambda *a, **k: "compiled", label=other)
+        _wrap(_raiser())()
+        assert other not in U._LATCHED_EAGER_LABELS
+        assert other_wrapper() == "compiled"
+    finally:
+        for s in (U._LATCHED_EAGER_LABELS, U._RECENT_EAGER_LABELS,
+                  U._COMPILED_OK_LABELS):
+            s.discard(other)
+
+
+# --------------------------------------------------------------------------
+# R4: the marker must be restored, not leaked.
+# --------------------------------------------------------------------------
+
+def test_marker_is_restored_to_what_it_was():
+    """The arm captures the marker before the compiled call and puts it back.
+    Leaving it set would make a later wrapper believe a compiled pack is
+    outstanding and end a step that was fine."""
+    U._PACKED_COMPILED_IN_CHECKPOINT = False
+    _wrap(_raiser())()
+    assert U._PACKED_COMPILED_IN_CHECKPOINT is False
+
+
+def test_marker_true_is_preserved_when_no_raise_happens():
+    U._PACKED_COMPILED_IN_CHECKPOINT = True
+    # label not in _COMPILED_OK_LABELS, so no raise; marker must survive.
+    _wrap(_raiser())()
+    assert U._PACKED_COMPILED_IN_CHECKPOINT is True
+
+
+# --------------------------------------------------------------------------
+# R5: the codegen arm this now shares a body with must be unchanged.
+# --------------------------------------------------------------------------
+
+def test_backend_refusal_arm_still_behaves():
+    """`_give_up_on_backend` was refactored, not redefined. Its own path must
+    still fall back to eager when nothing compiled was packed."""
+    import torch
+
+    class _BackendFail(Exception):
+        pass
+
+    def compiled(*a, **k):
+        raise torch._dynamo.exc.BackendCompilerFailed(
+            lambda: None, _BackendFail("inductor said no")
+        ) if hasattr(torch._dynamo.exc, "BackendCompilerFailed") else _BackendFail("no")
+
+    try:
+        out = _wrap(compiled)()
+    except Exception:
+        pytest.skip("this torch does not expose the backend failure shape used here")
+    assert out == "eager"
+
+
+# --------------------------------------------------------------------------
+# Platform: the changed code has no platform branch. Prove it rather than say it.
+# --------------------------------------------------------------------------
+
+def test_changed_path_has_no_platform_or_device_branch():
+    import inspect
+    src = inspect.getsource(U._fall_back_to_eager_on_recompile_limit)
+    start = src.find("def _give_up_at_compile_time")
+    if start == -1:
+        pytest.skip("main tree has no _give_up_at_compile_time")
+    body = src[start:src.find("def _is_backend_refusal_we_handle", start)]
+    for token in ("sys.platform", "platform.system", "cuda", "hip", "mps", "darwin", "win32"):
+        assert token not in body, f"{token} appeared in the shared give-up path"
+
+
+def test_conservative_when_another_region_packed_compiled_this_step():
+    """Characterises the one place the fix is deliberately pessimistic.
+
+    `_PACKED_COMPILED_IN_CHECKPOINT` is process-global for the step, and
+    `_COMPILED_OK_LABELS` is sticky for the process. So if this label compiled
+    successfully at ANY earlier point, and ANY compiled call packed under a
+    checkpoint this step, the arm raises even though this particular wrapper may
+    have packed nothing in this region.
+
+    That is the same trade `_give_up_on_backend` has always made, not a new one:
+    ending a step that was probably fine is cheap, returning wrong gradients is
+    not. Pinned so the choice is visible rather than discovered later.
+    """
+    U._COMPILED_OK_LABELS.add(LABEL)          # compiled fine earlier
+    U._PACKED_COMPILED_IN_CHECKPOINT = True   # some region packed compiled
+    w = _wrap(_raiser())
+    if IS_FIX:
+        with pytest.raises(Exception):
+            w()
+    else:
+        assert w() == "eager"

--- a/tests/test_disabled_hook_graph_break.py
+++ b/tests/test_disabled_hook_graph_break.py
@@ -42,6 +42,30 @@ sys.path.insert(0, str(ROOT))
 
 from unsloth_zoo.temporary_patches import utils as U  # noqa: E402
 
+
+@pytest.fixture(autouse = True)
+def _clear_latches():
+    """The latch is process-global and keyed by label, so tests must not leak.
+
+    Every `_wrap` below reuses "TestMod", and the disabled-hook arm now records
+    its latch by label the way the codegen arm always has, so without this the
+    first test to fall back starts every later one already eager.
+    """
+    for _s in (U._LATCHED_EAGER_LABELS, U._PENDING_EAGER_LABELS,
+               U._RECENT_EAGER_LABELS, U._COMPILED_OK_LABELS):
+        _s.discard("TestMod")
+    # Process-global and set by any earlier test file that ran a compiled call
+    # under a checkpoint. Left set, the give-up arms here read "a compiled pack
+    # is outstanding" and end the step instead of falling back.
+    _packed = U._PACKED_COMPILED_IN_CHECKPOINT
+    U._PACKED_COMPILED_IN_CHECKPOINT = False
+    yield
+    for _s in (U._LATCHED_EAGER_LABELS, U._PENDING_EAGER_LABELS,
+               U._RECENT_EAGER_LABELS, U._COMPILED_OK_LABELS):
+        _s.discard("TestMod")
+    U._PACKED_COMPILED_IN_CHECKPOINT = _packed
+
+
 DISABLE_MSG = (
     "Skip calling `torch.compiler.disable()`d function\n"
     "  Explanation: Skip calling function "

--- a/tests/test_disabled_hook_graph_break.py
+++ b/tests/test_disabled_hook_graph_break.py
@@ -45,18 +45,13 @@ from unsloth_zoo.temporary_patches import utils as U  # noqa: E402
 
 @pytest.fixture(autouse = True)
 def _clear_latches():
-    """The latch is process-global and keyed by label, so tests must not leak.
-
-    Every `_wrap` below reuses "TestMod", and the disabled-hook arm now records
-    its latch by label the way the codegen arm always has, so without this the
-    first test to fall back starts every later one already eager.
-    """
+    """The latch is process-global and keyed by label, and every `_wrap` below
+    reuses "TestMod", so the first fallback would leak into every later test."""
     for _s in (U._LATCHED_EAGER_LABELS, U._PENDING_EAGER_LABELS,
                U._RECENT_EAGER_LABELS, U._COMPILED_OK_LABELS):
         _s.discard("TestMod")
-    # Process-global and set by any earlier test file that ran a compiled call
-    # under a checkpoint. Left set, the give-up arms here read "a compiled pack
-    # is outstanding" and end the step instead of falling back.
+    # Left set by an earlier test file, the give-up arms here read "a compiled
+    # pack is outstanding" and end the step instead of falling back.
     _packed = U._PACKED_COMPILED_IN_CHECKPOINT
     U._PACKED_COMPILED_IN_CHECKPOINT = False
     yield

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1663,17 +1663,16 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     def _give_up_at_compile_time(e, args, kwargs, marker_before, warning):
         """The compiler refused this region while TRACING it. Run eager, and stay.
 
-        Shared by the two refusals that are decided before any compiled code
-        runs -- Inductor declining to generate code, and Dynamo declining to
-        inline one of Unsloth's own `torch.compiler.disable`d hooks under
-        `fullgraph = True`. Both are deterministic properties of one region's
-        graph, so neither gets a budget retry: the same graph regenerates the
-        same refusal, and retrying only pays the compile twice.
+        Shared by both refusals decided before any compiled code runs: Inductor
+        declining to generate code, and Dynamo declining to inline one of
+        Unsloth's own `torch.compiler.disable`d hooks under `fullgraph = True`.
+        Both are deterministic properties of one region's graph, so neither gets
+        a budget retry -- the same graph regenerates the same refusal.
 
         Only THIS label latches, unlike `_give_up`. Exhaustion is process-wide
-        and takes the other borrowers with it; a compile-time refusal is a
-        property of one region's graph, so knocking unrelated regions eager
-        would cost their compilation for nothing.
+        and takes the other borrowers with it; a compile-time refusal is one
+        region's property, so latching others would cost their compilation for
+        nothing.
 
         The checkpoint rule from `_give_up` applies, but only when THIS wrapper
         has actually run compiled at some point in this step. That extra
@@ -1682,23 +1681,21 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         `_give_up` has to assume the worst because it latches every borrower,
         including regions that did pack activations compiled. This path latches
         one label, so the only pack/recompute pair that can desynchronise is
-        this function's own. Both refusals happen at compile time, so a
-        first-call refusal means this region has packed nothing compiled: the
-        eager call below packs eagerly and the backward recomputes eagerly,
-        which agree.
+        this function's own. Both refuse at compile time, so a first-call
+        refusal means this region packed nothing compiled: the eager call below
+        packs eagerly and the backward recomputes eagerly, which agree.
 
-        The case that does need the raise is a later compile, for a new dynamic
-        shape or a newly reachable branch, after an earlier one already compiled
-        and packed. Then the pack was compiled and the recompute would be eager,
-        which either aborts or returns wrong gradients, so end the step instead.
+        The raise is needed on a LATER compile -- new dynamic shape, newly
+        reachable branch -- after an earlier one already compiled and packed:
+        a compiled pack against an eager recompute either aborts or returns
+        wrong gradients, so end the step instead.
 
-        That later compile can be the RECOMPUTE ITSELF. Dynamo only discovers a
-        disabled hook while tracing, and a `dynamic = True` region first traces a
-        recompute-only path during the backward, after the forward packed
-        compiled. Flipping there desynchronises the pair: for an RMSNorm the
-        compiled forward packs 3 tensors and the eager one 6, and `early_stop`
-        truncates the recompute to the forward's count, so the counts agree and
-        torch reports differing metadata rather than a differing count.
+        That later compile can be the RECOMPUTE ITSELF: Dynamo only discovers a
+        disabled hook while tracing, and a `dynamic = True` region can first
+        trace a recompute-only path in the backward, after the forward packed
+        compiled. RMSNorm packs 3 tensors compiled and 6 eager, but `early_stop`
+        truncates to the forward's count, so torch reports differing metadata
+        rather than a differing count.
         """
         global _PACKED_COMPILED_IN_CHECKPOINT
         packed = (
@@ -1746,8 +1743,8 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         """Dynamo refused to inline one of our own `torch.compiler.disable`d hooks.
 
         Was a bare `state["eager"] = True; return eager_func(...)`: the one arm
-        of this wrapper that changed compile mode with no checkpoint question
-        asked, no deferral, and no record in either label set.
+        that flipped compile mode with no checkpoint question, no deferral, and
+        no label record.
         """
         return _give_up_at_compile_time(
             e, args, kwargs, marker_before,

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1660,18 +1660,20 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             raise e
         return eager_func(*args, **kwargs)
 
-    def _give_up_on_backend(e, args, kwargs, marker_before):
-        """Inductor refused to generate code. Run eager, and stay there.
+    def _give_up_at_compile_time(e, args, kwargs, marker_before, warning):
+        """The compiler refused this region while TRACING it. Run eager, and stay.
 
-        No budget retry: cache exhaustion is a resource problem that more
-        budget can genuinely fix, but a codegen refusal is deterministic. The
-        same graph regenerates the same failure, so retrying only pays the
-        compile twice before landing here anyway.
+        Shared by the two refusals that are decided before any compiled code
+        runs -- Inductor declining to generate code, and Dynamo declining to
+        inline one of Unsloth's own `torch.compiler.disable`d hooks under
+        `fullgraph = True`. Both are deterministic properties of one region's
+        graph, so neither gets a budget retry: the same graph regenerates the
+        same refusal, and retrying only pays the compile twice.
 
         Only THIS label latches, unlike `_give_up`. Exhaustion is process-wide
-        and takes the other borrowers with it; a codegen refusal is a property
-        of one region's graph, so knocking unrelated regions eager would cost
-        their compilation for nothing.
+        and takes the other borrowers with it; a compile-time refusal is a
+        property of one region's graph, so knocking unrelated regions eager
+        would cost their compilation for nothing.
 
         The checkpoint rule from `_give_up` applies, but only when THIS wrapper
         has actually run compiled at some point in this step. That extra
@@ -1680,14 +1682,23 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         `_give_up` has to assume the worst because it latches every borrower,
         including regions that did pack activations compiled. This path latches
         one label, so the only pack/recompute pair that can desynchronise is
-        this function's own. Inductor refuses at compile time, so a first-call
-        refusal means this region has packed nothing compiled: the eager call
-        below packs eagerly and the backward recomputes eagerly, which agree.
+        this function's own. Both refusals happen at compile time, so a
+        first-call refusal means this region has packed nothing compiled: the
+        eager call below packs eagerly and the backward recomputes eagerly,
+        which agree.
 
-        The case that does need the raise is a later compile for a new dynamic
-        shape, after an earlier shape already compiled and packed. Then the pack
-        was compiled and the recompute would be eager, which either aborts or
-        returns wrong gradients, so end the step instead.
+        The case that does need the raise is a later compile, for a new dynamic
+        shape or a newly reachable branch, after an earlier one already compiled
+        and packed. Then the pack was compiled and the recompute would be eager,
+        which either aborts or returns wrong gradients, so end the step instead.
+
+        That later compile can be the RECOMPUTE ITSELF. Dynamo only discovers a
+        disabled hook while tracing, and a `dynamic = True` region first traces a
+        recompute-only path during the backward, after the forward packed
+        compiled. Flipping there desynchronises the pair: for an RMSNorm the
+        compiled forward packs 3 tensors and the eager one 6, and `early_stop`
+        truncates the recompute to the forward's count, so the counts agree and
+        torch reports differing metadata rather than a differing count.
         """
         global _PACKED_COMPILED_IN_CHECKPOINT
         packed = (
@@ -1714,17 +1725,37 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         # compile-mode flip happened" and re-raises the very failure it was
         # asked to retry past.
         _RECENT_EAGER_LABELS.add(label)
-        _warn(
-            f"Unsloth: torch.compile could not generate code for {label}; "
-            f"running it eagerly from here. Training is unaffected apart from "
-            f"speed. ({type(e).__name__})"
-        )
+        _warn(warning)
         if packed:
             global _RAISED_INSIDE_CHECKPOINT, _CHECKPOINT_SETTLE_ATTEMPTS
             _RAISED_INSIDE_CHECKPOINT = True
             _CHECKPOINT_SETTLE_ATTEMPTS = 0
             raise e
         return eager_func(*args, **kwargs)
+
+    def _give_up_on_backend(e, args, kwargs, marker_before):
+        """Inductor refused to generate code for this region."""
+        return _give_up_at_compile_time(
+            e, args, kwargs, marker_before,
+            f"Unsloth: torch.compile could not generate code for {label}; "
+            f"running it eagerly from here. Training is unaffected apart from "
+            f"speed. ({type(e).__name__})",
+        )
+
+    def _give_up_on_disabled_hook(e, args, kwargs, marker_before):
+        """Dynamo refused to inline one of our own `torch.compiler.disable`d hooks.
+
+        Was a bare `state["eager"] = True; return eager_func(...)`: the one arm
+        of this wrapper that changed compile mode with no checkpoint question
+        asked, no deferral, and no record in either label set.
+        """
+        return _give_up_at_compile_time(
+            e, args, kwargs, marker_before,
+            f"Unsloth: torch.compile hit one of Unsloth's own "
+            f"`torch.compiler.disable`d gradient-checkpointing hooks inside "
+            f"{label}; running it eagerly from here. Training is unaffected "
+            f"apart from speed.",
+        )
 
     def _is_backend_refusal_we_handle(e):
         """The gate the wrapper's own backend arm applies, in one place."""
@@ -1893,14 +1924,7 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
                 return _give_up(e, args, kwargs)
             if not _is_our_own_disabled_hook(e):
                 raise
-            state["eager"] = True
-            _warn(
-                f"Unsloth: torch.compile hit one of Unsloth's own "
-                f"`torch.compiler.disable`d gradient-checkpointing hooks "
-                f"inside {label}; running it eagerly from here. Training is "
-                f"unaffected apart from speed."
-            )
-            return eager_func(*args, **kwargs)
+            return _give_up_on_disabled_hook(e, args, kwargs, marker_before)
         else:
             # The compiled callable returned, so anything it packed under a
             # checkpoint is packed compiled. Only `_give_up_on_backend` reads

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1663,16 +1663,14 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     def _give_up_at_compile_time(e, args, kwargs, marker_before, warning):
         """The compiler refused this region while TRACING it. Run eager, and stay.
 
-        Shared by both refusals decided before any compiled code runs: Inductor
-        declining to generate code, and Dynamo declining to inline one of
+        Shared by the two refusals decided before any compiled code runs:
+        Inductor declining codegen, and Dynamo declining to inline one of
         Unsloth's own `torch.compiler.disable`d hooks under `fullgraph = True`.
-        Both are deterministic properties of one region's graph, so neither gets
-        a budget retry -- the same graph regenerates the same refusal.
+        Neither gets a budget retry: the same graph regenerates the same refusal.
 
         Only THIS label latches, unlike `_give_up`. Exhaustion is process-wide
-        and takes the other borrowers with it; a compile-time refusal is one
-        region's property, so latching others would cost their compilation for
-        nothing.
+        and takes the other borrowers with it; a compile-time refusal belongs to
+        one region, so latching others would cost their compilation for nothing.
 
         The checkpoint rule from `_give_up` applies, but only when THIS wrapper
         has actually run compiled at some point in this step. That extra
@@ -1682,20 +1680,18 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         including regions that did pack activations compiled. This path latches
         one label, so the only pack/recompute pair that can desynchronise is
         this function's own. Both refuse at compile time, so a first-call
-        refusal means this region packed nothing compiled: the eager call below
-        packs eagerly and the backward recomputes eagerly, which agree.
+        refusal means this region packed nothing compiled: eager pack and eager
+        recompute agree.
 
-        The raise is needed on a LATER compile -- new dynamic shape, newly
-        reachable branch -- after an earlier one already compiled and packed:
-        a compiled pack against an eager recompute either aborts or returns
-        wrong gradients, so end the step instead.
+        The raise is needed on a LATER compile -- new shape, new branch -- after
+        an earlier one already compiled and packed: a compiled pack against an
+        eager recompute aborts or corrupts gradients, so end the step instead.
 
         That later compile can be the RECOMPUTE ITSELF: Dynamo only discovers a
         disabled hook while tracing, and a `dynamic = True` region can first
-        trace a recompute-only path in the backward, after the forward packed
-        compiled. RMSNorm packs 3 tensors compiled and 6 eager, but `early_stop`
-        truncates to the forward's count, so torch reports differing metadata
-        rather than a differing count.
+        trace a recompute-only path after the forward packed compiled. RMSNorm
+        packs 3 tensors compiled and 6 eager, but `early_stop` truncates to the
+        forward's count, so torch reports differing metadata, not a count.
         """
         global _PACKED_COMPILED_IN_CHECKPOINT
         packed = (
@@ -1742,9 +1738,7 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     def _give_up_on_disabled_hook(e, args, kwargs, marker_before):
         """Dynamo refused to inline one of our own `torch.compiler.disable`d hooks.
 
-        Was a bare `state["eager"] = True; return eager_func(...)`: the one arm
-        that flipped compile mode with no checkpoint question, no deferral, and
-        no label record.
+        Was a bare eager flip: no checkpoint question, no deferral, no record.
         """
         return _give_up_at_compile_time(
             e, args, kwargs, marker_before,


### PR DESCRIPTION
## What this changes

`_fall_back_to_eager_on_recompile_limit` in `unsloth_zoo/temporary_patches/utils.py` has four arms that can move a wrapper from compiled to eager. Three of them ask `_in_non_reentrant_checkpoint()` / `_PACKED_COMPILED_IN_CHECKPOINT` before changing mode, and either defer to the step boundary or end the step.

The fourth did not. The arm that catches Dynamo refusing to inline one of our own `torch.compiler.disable`d gradient checkpointing hooks was:

```python
if not _is_our_own_disabled_hook(e):
    raise
state["eager"] = True
_warn(...)
return eager_func(*args, **kwargs)
```

It flipped on the spot, with no checkpoint question asked, no deferral, and no entry in either `_LATCHED_EAGER_LABELS` or `_RECENT_EAGER_LABELS`.

## Why it matters

Dynamo only discovers a disabled hook while tracing. Under `@torch_compile_with_fallback(fullgraph = True, dynamic = True)` the first trace of a recompute-only path therefore happens during the backward, after the forward already packed compiled activations. Flipping to eager there desynchronises the pack and the recompute of a live checkpointed region.

The failure that comes out of it is a metadata error rather than a count error, which is worth spelling out because it looks confusing in a log. For an RMSNorm, measured on this branch:

| mode | tensors packed |
|---|---|
| eager | 6 |
| compiled (static or dynamic, identical) | 3 |

The forward packs 3, the eager recompute wants 6, and `early_stop` raises `_StopRecomputationError` at exactly 3. So `len(weak_holders) == recomp_counter`, torch falls through to the per-index comparison, and you get:

```
CheckpointError: Recomputed values for the following tensors have different
metadata than during the forward pass
```

## The fix

`_give_up_on_backend` already had the right contract for a refusal decided at compile time, so the two now share it. Its body becomes `_give_up_at_compile_time(e, args, kwargs, marker_before, warning)`, and the disabled-hook arm reaches it through `_give_up_on_disabled_hook`.

The arm now restores `marker_before`, records the latch in both label sets, and when `(_in_non_reentrant_checkpoint() or _PACKED_COMPILED_IN_CHECKPOINT) and label in _COMPILED_OK_LABELS` it sets `_RAISED_INSIDE_CHECKPOINT` and re-raises instead of running eager mid-region. Silent backward corruption becomes a well defined "end this step, everything is latched eager, the retry is consistent".

Two deliberate limits on the blast radius:

- A first-call refusal, where nothing compiled has been packed by this label, still falls back to eager exactly as before. The common case does not change.
- Only this label latches, not every borrower. Budget exhaustion is process wide and takes the other borrowers with it; a compile-time refusal is a property of one region's graph, so knocking unrelated regions eager would cost their compilation for nothing.

## Tests

`test_a_disabled_hook_does_not_flip_a_region_that_packed_compiled` in `tests/test_checkpoint_compile_mix.py` fails on `main` and passes here, so it discriminates rather than decorates. Verified by running the new file against the unmodified `main` source, not just against its own branch. Two further tests are non-regression guards and pass on both.

`tests/test_disabled_hook_graph_break.py` gets an autouse fixture that resets label and marker state, because every `_wrap` in that file reuses the label `"TestMod"` and this arm now records by label the way the codegen arm always has.

Across the 24 test files touching the compile and fallback machinery, torch 2.9.1+cu128 and transformers 5.5.0:

| tree | result |
|---|---|
| `main` | 805 passed, 19 skipped |
| this branch | 808 passed, 19 skipped |

Also green on transformers 4.57.6 with torch 2.9.1+cpu.

## What this does not do

**This does not close the Gemma 4 gradient checkpointing report, and should not be merged as though it does.** The state captured on that run was:

```
latched:         []
pending:         ["Gemma4RMSNorm.forward (scaled)"]
packed_compiled: true
```

with the warning "ran out of recompilation cache ... switching to eager at the next step". This arm never touches `_PENDING_EAGER_LABELS` and emits different text, so it cannot produce that state. That report is the budget path in `_retry_with_more_budget`, where the retry recompiles inside the recompute and produces a different variant than the one the forward packed. Tracked separately.

So this is a real inconsistency found while investigating that bug, fixed on its own merits, rather than a fix for it.

## Scope

One file changed under `unsloth_zoo/`, plus two test files. No new torch APIs: it reuses `_in_non_reentrant_checkpoint`, `_COMPILED_OK_LABELS` and `_RAISED_INSIDE_CHECKPOINT`, all already version guarded, so the portability profile is the same as `_give_up_on_backend`'s. Parses under the 3.9 grammar floor declared in pyproject.

Only torch 2.9.1+cu128 was available to test on, so the behaviour is unverified on 2.6 through 2.13 and on Mac and Windows.
