### PR TITLE
Fix text-only loads for MLX VLM architectures mlx_lm cannot build

### DIFF
--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -105,6 +105,23 @@ def test_vlm_detection_requires_a_real_modality(monkeypatch, tmp_path):
     assert not loader._is_vlm({"vision_config": {}, "model_type": "text_only"})
 
 
+class _VLMOnlyClass:
+    """Stands in for a class only mlx-vlm ships; routing never calls it."""
+
+
+def test_text_only_vlm_load_stays_on_vlm_path_when_mlx_lm_has_no_model(monkeypatch):
+    import unsloth_zoo.mlx.loader as loader
+
+    monkeypatch.setattr(loader, "_get_mlx_lm_model_class", lambda _: None)
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: _VLMOnlyClass)
+
+    config = {"model_type": "gemma4_unified", "vision_config": {"hidden_size": 32}}
+    assert loader._prefer_vlm_loader_for_text(config, "gemma4_unified")
+
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: None)
+    assert not loader._prefer_vlm_loader_for_text(config, "unsupported_vlm")
+
+
 def test_apply_mlx_distributed_sharding_modes_and_guards():
     from unsloth_zoo.mlx.loader import (
         _apply_mlx_distributed_sharding,

--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -122,6 +122,36 @@ def test_text_only_vlm_load_stays_on_vlm_path_when_mlx_lm_has_no_model(monkeypat
     assert not loader._prefer_vlm_loader_for_text(config, "unsupported_vlm")
 
 
+def test_a_model_module_that_exits_at_import_is_a_verdict_not_a_dead_process(monkeypatch):
+    """mlx_lm and mlx-vlm both ship modules that call `exit(1)` at import when an
+    optional dependency is missing -- `mlx_lm/models/olmo.py` does it without
+    ai2-olmo, which no install pulls in. `SystemExit` is not an `Exception`, so
+    catching only that let a routing question take the process down with no
+    traceback. Every one of these imports asks a question whose answer, when the
+    module will not import, is simply "this backend cannot build it".
+    """
+    import importlib
+
+    import unsloth_zoo.mlx.loader as loader
+
+    real_import = importlib.import_module
+
+    def exiting_import(name, *args, **kwargs):
+        if name.startswith(("mlx_lm.models.", "mlx_vlm.models.")):
+            print("To run olmo install ai2-olmo: pip install ai2-olmo")
+            raise SystemExit(1)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(loader.importlib, "import_module", exiting_import)
+
+    assert loader._get_mlx_lm_model_class("olmo") is None
+    assert loader._resolve_mlx_vlm_model_class("olmo") is None
+    # Reached on the mlx_lm branch of every text load, for any model_type.
+    loader._ensure_safe_text_wrapper_sanitize("olmo")
+    config = {"model_type": "olmo", "vision_config": {"hidden_size": 32}}
+    assert loader._prefer_vlm_loader_for_text(config, "olmo") is False
+
+
 def test_apply_mlx_distributed_sharding_modes_and_guards():
     from unsloth_zoo.mlx.loader import (
         _apply_mlx_distributed_sharding,

--- a/tests/test_mlx_text_path_contract.py
+++ b/tests/test_mlx_text_path_contract.py
@@ -128,15 +128,6 @@ def test_a_broken_remapping_falls_back_to_the_raw_name(mutils, remapping, hostil
     assert _is_array(out["image_grid_thw"])
 
 
-def test_the_loader_and_the_grid_agree_on_the_same_alias(remapping):
-    """One helper, so the two ends cannot drift apart again."""
-    import unsloth_zoo.mlx.loader as loader
-    import unsloth_zoo.mlx.utils as mutils
-    remapping({"muse-glimmer": "muse_glimmer"})
-    assert loader._mlx_vlm_text_path_is_verified("muse-glimmer") is True
-    assert mutils._mlx_vlm_canonical_model_type("muse-glimmer") == "muse_glimmer"
-
-
 def test_an_empty_model_type_resolves_to_nothing(mutils):
     assert mutils._mlx_vlm_canonical_model_type("") == ""
     assert mutils._mlx_vlm_canonical_model_type(None) == ""

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import re
 
 import numpy as np
@@ -9,6 +10,7 @@ from unittest import mock
 
 
 mx = pytest.importorskip("mlx.core")
+nn = pytest.importorskip("mlx.nn")
 if "mlx_simulation" in str(getattr(mx, "__file__", "")):
     pytest.skip("requires real MLX runtime", allow_module_level=True)
 
@@ -966,15 +968,26 @@ def test_text_only_vlm_wrapper_uses_text_training_path():
 _VLM_CONFIG = {"model_type": "fake_vlm", "vision_config": {"hidden_size": 8}}
 
 
-def _route_text_only(
-    monkeypatch, *, mlx_lm_class, vlm_text_path_verified, config=_VLM_CONFIG,
-):
+def _skip_unless_mlx_vlm_ships(model_type):
+    """Asking the resolver would turn its own regressions into skips."""
+    import pkgutil
+
+    import mlx_vlm.models
+
+    shipped = {module.name for module in pkgutil.iter_modules(mlx_vlm.models.__path__)}
+    if model_type not in shipped:
+        pytest.skip(f"installed mlx-vlm does not ship {model_type}")
+
+
+class _VLMOnlyClass:
+    """Stands in for a class only mlx-vlm ships; routing never calls it."""
+
+
+def _route_text_only(monkeypatch, *, mlx_lm_class, vlm_class, config=_VLM_CONFIG):
     from unsloth_zoo.mlx import loader
 
     monkeypatch.setattr(loader, "_get_mlx_lm_model_class", lambda _t: mlx_lm_class)
-    monkeypatch.setattr(
-        loader, "_mlx_vlm_text_path_is_verified", lambda _t: vlm_text_path_verified,
-    )
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _t: vlm_class)
     return loader._prefer_vlm_loader_for_text(config, config["model_type"])
 
 
@@ -988,27 +1001,31 @@ class _PlainModel:
         return weights
 
 
-def test_vlm_only_architecture_routes_text_only_loads_to_mlx_vlm(monkeypatch):
-    """mlx_lm cannot build it, mlx-vlm can: load the wrapper's text tower."""
-    assert _route_text_only(
-        monkeypatch, mlx_lm_class=None, vlm_text_path_verified=True
-    ) is True
-
-
-@pytest.mark.parametrize("model_type", ["muse_glimmer", "qwen4_exp", "glm5_next"])
-def test_verified_vlm_text_paths_stay_verified(model_type):
-    """Dropping one silently restores the mlx_lm "not supported" load error."""
+@pytest.mark.parametrize(
+    "model_type",
+    ["muse_glimmer", "qwen4_exp", "glm5_next", "lfm2_vl", "mage_vl", "kimi_k3"],
+)
+def test_vlm_only_families_reach_the_text_path_without_being_listed(model_type):
+    """Against the installed packages rather than a monkeypatched resolver."""
     from unsloth_zoo.mlx import loader
 
-    assert loader._mlx_vlm_text_path_is_verified(model_type) is True
-    assert loader._mlx_vlm_text_path_is_verified("qwen3_5") is False
-    assert loader._mlx_vlm_text_path_is_verified("") is False
+    _skip_unless_mlx_vlm_ships(model_type)
+    config = {"model_type": model_type, "vision_config": {"hidden_size": 8}}
+    assert loader._get_mlx_lm_model_class(model_type) is None
+    assert loader._prefer_vlm_loader_for_text(config, model_type) is True
 
 
-def test_architecture_neither_backend_ships_is_not_routed_to_mlx_vlm(monkeypatch):
-    assert _route_text_only(
-        monkeypatch, mlx_lm_class=None, vlm_text_path_verified=False
-    ) is False
+def test_a_capitalised_model_type_routes_like_its_lowercase_spelling():
+    """mlx-vlm lower-cases before it remaps, so a `Muse_Glimmer` config loads."""
+    from unsloth_zoo.mlx import loader
+
+    _skip_unless_mlx_vlm_ships("muse_glimmer")
+
+    def route(model_type):
+        config = {"model_type": model_type, "vision_config": {"hidden_size": 8}}
+        return loader._prefer_vlm_loader_for_text(config, model_type)
+
+    assert route("Muse_Glimmer") is route("muse_glimmer") is True
 
 
 @pytest.mark.parametrize("alias, target", [("qwen2_5_vl", "qwen2_vl"), ("llava", "mistral3")])
@@ -1023,6 +1040,209 @@ def test_an_aliased_model_type_loads_like_the_architecture_it_aliases(alias, tar
         return loader._prefer_vlm_loader_for_text(config, model_type)
 
     assert route(alias) == route(target)
+
+
+def _causal_logits(input_ids, vocab=7):
+    running = mx.cumsum(input_ids.astype(mx.float32), axis=1)
+    return mx.repeat(running[:, :, None], vocab, axis=2)
+
+
+def _sees_everything(values):
+    """What bidirectional attention looks like from outside."""
+    everything = values.astype(mx.float32).sum(axis=1, keepdims=True)
+    return mx.repeat(mx.broadcast_to(everything, values.shape)[:, :, None], 5, axis=2)
+
+
+class _PooledOutput:
+    """Shaped like mlx-vlm's pooled wrappers: no `logits` at all."""
+    text_embeds = "embeddings"
+
+
+@pytest.mark.parametrize(
+    "call, expected",
+    [
+        pytest.param(
+            lambda self, ids: (_ for _ in ()).throw(ValueError("You have to specify pixel_values")),
+            "cannot be fine-tuned on text alone",
+            id="demands pixels it was not given",
+        ),
+        pytest.param(
+            lambda self, ids: mx.zeros((1, ids.shape[1] + 3, 7)),
+            "not a causal language model",
+            id="answers a different sequence length",
+        ),
+        pytest.param(
+            lambda self, ids: _PooledOutput(),
+            "cannot be fine-tuned on text alone",
+            id="returns pooled embeddings",
+        ),
+        pytest.param(
+            lambda self, ids, a, b, c, d: _causal_logits(ids),
+            "cannot be fine-tuned on text alone",
+            id="demands more modalities than the path can invent",
+        ),
+        pytest.param(
+            lambda self, ids: _sees_everything(ids),
+            "attends bidirectionally",
+            id="sees the whole sequence",
+        ),
+        pytest.param(
+            lambda self, ids: _sees_everything(mx.maximum(ids, 4)),
+            "attends bidirectionally",
+            id="sees it only above the ids that share an embedding row",
+        ),
+        pytest.param(
+            lambda self, ids: mx.repeat(
+                mx.broadcast_to(1.0 + ids[:, -1:].astype(mx.float32) * 1e-6, ids.shape)[:, :, None], 5, axis=2),
+            "attends bidirectionally",
+            id="leaks far below any numerical tolerance",
+        ),
+        pytest.param(
+            lambda self, ids: mx.zeros((*ids.shape, 5)),
+            "answered every probe identically",
+            id="no probe can move it",
+        ),
+    ],
+)
+def test_a_wrapper_that_cannot_be_trained_on_text_is_refused_by_name(call, expected):
+    """Only running one tells these apart, and the refusal has to name it."""
+    from unsloth_zoo.mlx import loader
+
+    cls = type("Wrapper", (), {"__call__": call})
+    try:
+        with pytest.raises(ValueError, match=expected) as raised:
+            loader._verify_text_only_wrapper(cls(), "fake_vlm")
+    finally:
+        loader._TEXT_ONLY_CALL_PATCHED.discard(cls)
+    assert "fake_vlm" in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda self, ids: _causal_logits(ids), id="plain causal"),
+        pytest.param(
+            lambda self, ids: _causal_logits(mx.where(ids < 4, ids // 2, ids)),
+            id="two probe pairs cannot move it",
+        ),
+    ],
+)
+def test_a_causal_wrapper_is_accepted_and_left_unpatched(call):
+    """The second ties ids 0/1 and 2/3, so only the wider pairs settle it."""
+    from unsloth_zoo.mlx import loader
+
+    cls = type("Wrapper", (), {"__call__": call})
+    original, model = cls.__call__, cls()
+    loader._mark_text_only_vlm(model, "fake_vlm")
+    assert model._unsloth_text_only_vlm is True
+    assert cls.__call__ is original
+
+
+def test_the_text_only_path_flags_the_model_makes_it_callable_and_checks_it():
+    """Checked but not bound, or bound but not flagged, fails on the first step."""
+    from unsloth_zoo.mlx import loader
+
+    class Wrapper:
+        def __call__(self, input_ids, pixel_values, mask):
+            return _causal_logits(input_ids)
+
+    model = Wrapper()
+    try:
+        loader._mark_text_only_vlm(model, "fake_vlm")
+        assert model._unsloth_text_only_vlm is True
+        assert model(mx.ones((1, 2), dtype=mx.int32)).shape == (1, 2, 7)
+    finally:
+        loader._TEXT_ONLY_CALL_PATCHED.discard(Wrapper)
+
+
+def test_a_refused_wrapper_leaves_the_process_as_it_found_it():
+    """A class patch would outlive the refusal and reach the next load."""
+    from unsloth_zoo.mlx import loader
+
+    class Bidirectional:
+        def __call__(self, input_ids, pixel_values):
+            return _sees_everything(input_ids)
+
+    original, model = Bidirectional.__call__, Bidirectional()
+    try:
+        with pytest.raises(ValueError, match="attends bidirectionally"):
+            loader._mark_text_only_vlm(model, "fake_vlm")
+    finally:
+        loader._TEXT_ONLY_CALL_PATCHED.discard(Bidirectional)
+
+    assert Bidirectional.__call__ is original
+    assert not hasattr(model, "_unsloth_text_only_vlm")
+
+
+def test_a_wrapper_bound_for_text_still_takes_its_modalities_by_name():
+    """The image path names `pixel_values`; that must not become a duplicate."""
+    from unsloth_zoo.mlx import loader
+
+    class Wrapper:
+        def __call__(self, input_ids, pixel_values, mask=None):
+            if pixel_values is None:
+                return _causal_logits(input_ids)
+            return pixel_values, mask
+
+    model = Wrapper()
+    ids = mx.ones((1, 2), dtype=mx.int32)
+    try:
+        loader._mark_text_only_vlm(model, "fake_vlm")
+        assert model(ids).shape == (1, 2, 7)
+        assert model(ids, pixel_values="pixels", mask="mask") == ("pixels", "mask")
+    finally:
+        loader._TEXT_ONLY_CALL_PATCHED.discard(Wrapper)
+
+
+def test_a_wrapper_whose_signature_hides_what_it_demands_is_still_called():
+    """`_install_paligemma_causal_mask` rewrites `__call__` as `(*args, **kwargs)`."""
+    from unsloth_zoo.mlx import loader
+
+    class Wrapper:
+        def _forward(self, input_ids, pixel_values, mask=None):
+            return _causal_logits(input_ids)
+
+        def __call__(self, *args, **kwargs):
+            return self._forward(*args, **kwargs)
+
+    assert str(inspect.signature(Wrapper.__call__)) == "(self, *args, **kwargs)"
+
+    model = Wrapper()
+    try:
+        loader._mark_text_only_vlm(model, "fake_vlm")
+        assert model(mx.ones((1, 2), dtype=mx.int32)).shape == (1, 2, 7)
+    finally:
+        loader._TEXT_ONLY_CALL_PATCHED.discard(Wrapper)
+
+
+def test_the_check_leaves_no_state_behind_for_the_first_training_batch():
+    """qwen2_vl reuses a cached `_position_ids` without checking it still fits."""
+    from unsloth_zoo.mlx import loader
+
+    class Cacher(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = mx.ones((4, 5))
+            self._position_ids = None
+
+        def __call__(self, input_ids):
+            self._position_ids = mx.arange(input_ids.shape[1])
+            return _causal_logits(input_ids, vocab=5)
+
+    class Wrapper(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.language_model = Cacher()
+
+        def __call__(self, input_ids):
+            return self.language_model(input_ids)
+
+    model = Wrapper()
+    weight = model.language_model.weight
+    loader._verify_text_only_wrapper(model, "fake_vlm")
+
+    assert model.language_model._position_ids is None
+    assert model.language_model.weight is weight
 
 
 @pytest.mark.parametrize("model_type", ["lfm2-vl", "lille-130m", "nemotron-nas"])
@@ -1067,10 +1287,10 @@ def test_vlm_generate_prefers_the_processor_over_the_published_tokenizer():
 def test_text_capable_mlx_lm_architecture_still_decides_by_its_sanitize(monkeypatch):
     """An mlx_lm class keeps deciding on whether its sanitize strips towers."""
     assert _route_text_only(
-        monkeypatch, mlx_lm_class=_StripSanitizeModel, vlm_text_path_verified=True
+        monkeypatch, mlx_lm_class=_StripSanitizeModel, vlm_class=_VLMOnlyClass
     ) is True
     assert _route_text_only(
-        monkeypatch, mlx_lm_class=_PlainModel, vlm_text_path_verified=True
+        monkeypatch, mlx_lm_class=_PlainModel, vlm_class=_VLMOnlyClass
     ) is False
 
 
@@ -1078,51 +1298,24 @@ def test_text_only_config_is_never_routed_to_the_vlm_loader(monkeypatch):
     assert _route_text_only(
         monkeypatch,
         mlx_lm_class=None,
-        vlm_text_path_verified=True,
+        vlm_class=_VLMOnlyClass,
         config={"model_type": "fake_text"},
     ) is False
 
 
-def test_text_path_fallback_is_limited_to_validated_architectures():
-    """The fallback claims the whole text path works, and nothing readable
-    before loading establishes that: mlx-vlm's encoder-decoder and diffusion
-    families declare the same output type as the causal ones, and the towers
-    holding `_position_ids` across calls declare nothing about it."""
-    from unsloth_zoo.mlx.loader import _mlx_vlm_text_path_is_verified
-
-    assert _mlx_vlm_text_path_is_verified("muse_glimmer") is True
-
-    unverified = (
-        # Encoder-decoder and masked-diffusion: same declared output type,
-        # bidirectional semantics, so a text run would optimize the wrong thing.
-        "florence2", "diffusion_gemma",
-        # Towers that keep per-call position state a later, wider batch reuses.
-        "qwen2_5_vl", "qwen2_vl", "glm4v", "paddleocr_vl",
-        # Wrappers whose own call requires pixel_values positionally.
-        "aya_vision", "fastvlm", "granite_vision",
-        # Retrieval, encoder, embedding and detector families.
-        "colqwen2_5", "siglip", "bert", "rfdetr", "sam3",
-        # Causal, but never validated on this path.
-        "llava", "gemma3", "qwen3_vl", "phi3_v",
-    )
-    for model_type in unverified:
-        assert _mlx_vlm_text_path_is_verified(model_type) is False, model_type
-
-    assert _mlx_vlm_text_path_is_verified("not_a_real_architecture") is False
-    assert _mlx_vlm_text_path_is_verified("") is False
-
-
 def test_text_path_fallback_resolves_mlx_vlm_model_type_aliases():
-    """mlx-vlm maps several config spellings onto one module, so a validated
-    module name has to match every spelling that reaches it."""
+    """mlx-vlm maps several config spellings onto one module."""
     from unsloth_zoo.mlx import loader
 
-    remapping = {"muse-glimmer": "muse_glimmer", "llava_qwen2": "fastvlm"}
+    _skip_unless_mlx_vlm_ships("fastvlm")
     with mock.patch.dict(
-        "mlx_vlm.utils.MODEL_REMAPPING", remapping, clear = False,
+        "mlx_vlm.utils.MODEL_REMAPPING", {"llava_qwen2": "fastvlm"}, clear = False,
     ):
-        assert loader._mlx_vlm_text_path_is_verified("muse-glimmer") is True
-        assert loader._mlx_vlm_text_path_is_verified("llava_qwen2") is False
+        # Only the remap reaches fastvlm, and only from the lower-cased spelling.
+        fastvlm = loader._resolve_mlx_vlm_model_class("fastvlm")
+        assert loader._resolve_mlx_vlm_model_class("llava_qwen2") is fastvlm
+        assert loader._resolve_mlx_vlm_model_class("LLaVA_Qwen2") is fastvlm
+        assert loader._resolve_mlx_vlm_model_class("not_a_real_arch") is None
 
 
 def test_gemma3_vlm_cce_does_not_forward_outer_product_attention_mask():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1011,6 +1011,28 @@ def test_architecture_neither_backend_ships_is_not_routed_to_mlx_vlm(monkeypatch
     ) is False
 
 
+@pytest.mark.parametrize("alias, target", [("qwen2_5_vl", "qwen2_vl"), ("llava", "mistral3")])
+def test_an_aliased_model_type_loads_like_the_architecture_it_aliases(alias, target):
+    """mlx_lm remaps before it imports, so both spellings must decide alike."""
+    from unsloth_zoo.mlx import loader
+
+    assert loader._get_mlx_lm_model_class(alias) is loader._get_mlx_lm_model_class(target)
+
+    def route(model_type):
+        config = {"model_type": model_type, "vision_config": {"hidden_size": 8}}
+        return loader._prefer_vlm_loader_for_text(config, model_type)
+
+    assert route(alias) == route(target)
+
+
+@pytest.mark.parametrize("model_type", ["lfm2-vl", "lille-130m", "nemotron-nas"])
+def test_a_hyphenated_model_type_keeps_its_hyphens(model_type):
+    """mlx_lm names these modules after the raw config spelling."""
+    from unsloth_zoo.mlx import loader
+
+    assert loader._get_mlx_lm_model_class(model_type) is not None
+
+
 def test_vlm_generate_prefers_the_processor_over_the_published_tokenizer():
     """A text-only multimodal load stays on the vision path but publishes its
     inner tokenizer, which cannot drive mlx-vlm preprocessing."""

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1247,9 +1247,22 @@ def test_the_check_leaves_no_state_behind_for_the_first_training_batch():
 
 @pytest.mark.parametrize("model_type", ["lfm2-vl", "lille-130m", "nemotron-nas"])
 def test_a_hyphenated_model_type_keeps_its_hyphens(model_type):
-    """mlx_lm names these modules after the raw config spelling."""
+    """mlx_lm names these modules after the raw config spelling.
+
+    Asserted on the resolved module name, which is what this change decides.
+    Reaching the class as well needs mlx_lm to import, and it does not everywhere:
+    `mlx_lm/utils.py` imports `resource`, a Unix-only stdlib module, so on Windows
+    -- where mlx now does ship a wheel -- every one of these resolves to None for
+    a reason that has nothing to do with hyphens.
+    """
     from unsloth_zoo.mlx import loader
 
+    assert loader._mlx_lm_module_name(model_type) == model_type
+
+    try:
+        import mlx_lm  # noqa: F401
+    except Exception as error:
+        pytest.skip(f"installed mlx_lm does not import here ({error})")
     assert loader._get_mlx_lm_model_class(model_type) is not None
 
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -59,6 +59,7 @@ _vlm_model_types_cache = None
 _VLM_MODALITY_CONFIG_FIELDS = ("vision_config", "audio_config", "dflash_config")
 _SAFE_TEXT_SANITIZE_PATCHED: set[str] = set()
 _AUDIO_CONV_SANITIZE_PATCHED: set[str] = set()
+_TEXT_ONLY_CALL_PATCHED: set = set()
 _MULTIMODAL_STRIP_KEYS = (
     "vision_tower",
     "audio_tower",
@@ -2642,32 +2643,6 @@ def _get_mlx_lm_model_class(model_type: str):
     return getattr(module, "Model", None)
 
 
-_VLM_TEXT_PATH_MODEL_TYPES = frozenset({
-    "muse_glimmer",
-    # Hybrid linear-attention decoders mlx_lm has no class for. Both reproduce a
-    # fresh model bitwise across a width or batch change, so the position tensor
-    # qwen4_exp caches between calls never leaks into the next text batch.
-    "qwen4_exp",
-    "glm5_next",
-})
-
-
-def _mlx_vlm_text_path_is_verified(model_type: str) -> bool:
-    """Whether mlx-vlm's text path for this architecture is known to train.
-
-    Listed rather than inferred, because nothing readable before loading proves
-    it: mlx-vlm's encoder-decoder and masked-diffusion families declare the same
-    token-logit output as the causal ones, and the Qwen, GLM and Paddle towers
-    holding `_position_ids` across calls declare nothing about it. An unlisted
-    architecture keeps the mlx_lm "Model type ... not supported" it had before.
-    """
-    if not model_type:
-        return False
-    # Shared with utils' vision-grid family set so the two cannot disagree on spelling.
-    from .utils import _mlx_vlm_canonical_model_type
-    return _mlx_vlm_canonical_model_type(model_type) in _VLM_TEXT_PATH_MODEL_TYPES
-
-
 def _prefer_vlm_loader_for_text(config: dict, model_type: str) -> bool:
     """Whether a multimodal wrapper should stay on the VLM load path.
 
@@ -2677,9 +2652,10 @@ def _prefer_vlm_loader_for_text(config: dict, model_type: str) -> bool:
     robust than a per-family sanitizer workaround.
 
     Multimodal architectures also land in mlx-vlm before mlx_lm has them, or
-    without mlx_lm ever gaining them. mlx_lm cannot construct those at all, so
-    a text-only request loads the wrapper and trains its text tower rather than
-    failing with "Model type ... not supported".
+    without mlx_lm ever gaining them. mlx_lm cannot construct those at all, so a
+    text-only request loads the wrapper and trains its text tower rather than
+    failing with "Model type ... not supported". Whether the wrapper answers a
+    text batch is settled after loading, by asking it.
     """
 
     if not _is_vlm(config):
@@ -2687,7 +2663,7 @@ def _prefer_vlm_loader_for_text(config: dict, model_type: str) -> bool:
 
     cls = _get_mlx_lm_model_class(model_type)
     if cls is None:
-        return _mlx_vlm_text_path_is_verified(model_type)
+        return _resolve_mlx_vlm_model_class(model_type) is not None
 
     return _has_multimodal_strip_sanitize(cls)
 
@@ -2741,18 +2717,152 @@ def _ensure_safe_text_wrapper_sanitize(model_type: str) -> None:
     _SAFE_TEXT_SANITIZE_PATCHED.add(module_name)
 
 
+# No installed mlx-vlm wrapper demands more than two.
+_MODALITY_ARGUMENT_LIMIT = 3
+
+# Token pairs differing only in their last position. Two ids sharing an embedding
+# row answer identically, so the next pair is tried; low ids first, because mlx
+# reads past a short table as zeros and ties the pair rather than raising.
+_PROBE_TOKEN_PAIRS = (
+    ((2, 3, 2), (2, 3, 3)),
+    ((0, 1, 0), (0, 1, 1)),
+    ((5, 7, 5), (5, 7, 7)),
+    ((11, 13, 11), (11, 13, 13)),
+)
+
+
+def _call_restoring_module_state(model, call):
+    """Run `call` and put back the state it left on the model's modules: qwen2_vl
+    reuses a cached `_position_ids` without checking it still fits."""
+
+    from .utils import _mlx_module_state_restored
+
+    try:
+        modules = list(model.modules())
+    except Exception:
+        return call()
+
+    with _mlx_module_state_restored(modules):
+        return call()
+
+
+def _bind_text_only_modality_arguments(model, extra: int) -> None:
+    cls = type(model)
+    if extra <= 0 or cls in _TEXT_ONLY_CALL_PATCHED:
+        return
+
+    call = cls.__call__
+
+    def patched_call(self, input_ids, *args, **kwargs):
+        if args:
+            return call(self, input_ids, *args, **kwargs)
+        try:
+            return call(self, input_ids, *(None,) * extra, **kwargs)
+        except TypeError as exc:
+            # The image path names `pixel_values`, so yield to a caller that did.
+            if "multiple values for" not in str(exc):
+                raise
+            return call(self, input_ids, **kwargs)
+
+    cls.__call__ = patched_call
+    _TEXT_ONLY_CALL_PATCHED.add(cls)
+    print(
+        f"Unsloth: Passing {extra} empty modality argument(s) to {cls.__name__} "
+        "so the text-only path can call it."
+    )
+
+
+def _verify_text_only_wrapper(model, model_type: str) -> int:
+    """Establish, by asking, that the wrapper is a causal LM over token ids, and
+    return how many empty modality arguments its call needs. Nothing about the class
+    settles it: these wrappers take token ids and then demand pixels, answer a
+    different length, return no logits, or answer bidirectionally — and
+    `_install_paligemma_causal_mask` rewrites `__call__` as `(*args, **kwargs)`, so
+    even a signature depends on what the process has already loaded."""
+
+    import mlx.core as mx
+    from .utils import _model_logits
+
+    def forward(tokens, extra=0):
+        ids = mx.array([list(tokens)])
+        return _model_logits(model(ids, *((None,) * extra)))
+
+    def refuse(exc):
+        return ValueError(
+            f"Unsloth: mlx-vlm's `{model_type}` cannot be fine-tuned on text alone "
+            f"({type(exc).__name__}: {exc}). Train it with a dataset carrying its "
+            "own modality, or pick a checkpoint whose text tower stands on its own."
+        )
+
+    def discover_arity():
+        for extra in range(_MODALITY_ARGUMENT_LIMIT + 1):
+            try:
+                forward(_PROBE_TOKEN_PAIRS[0][0], extra)
+            except TypeError as exc:
+                if "positional argument" not in str(exc):
+                    raise
+                continue
+            return extra
+        raise TypeError(
+            f"needs more than {_MODALITY_ARGUMENT_LIMIT} modality arguments"
+        )
+
+    try:
+        extra = _call_restoring_module_state(model, discover_arity)
+    except Exception as exc:
+        raise refuse(exc) from exc
+
+    for tokens, perturbed_tokens in _PROBE_TOKEN_PAIRS:
+        try:
+            baseline = _call_restoring_module_state(model, lambda: forward(tokens, extra))
+            perturbed = _call_restoring_module_state(model, lambda: forward(perturbed_tokens, extra))
+            mx.eval(baseline, perturbed)
+            shape = tuple(baseline.shape)
+        except Exception as exc:
+            raise refuse(exc) from exc
+
+        if len(shape) != 3 or shape[:2] != (1, len(tokens)):
+            raise ValueError(
+                f"Unsloth: mlx-vlm's `{model_type}` answered {len(tokens)} tokens with "
+                f"logits shaped {shape}, so it is not a causal language model the text "
+                "path can train."
+            )
+
+        # Nothing moved where the input changed, so this pair says nothing.
+        if mx.array_equal(baseline[:, -1], perturbed[:, -1]).item():
+            continue
+
+        if not mx.array_equal(baseline[:, :-1], perturbed[:, :-1]).item():
+            raise ValueError(
+                f"Unsloth: mlx-vlm's `{model_type}` attends bidirectionally — changing "
+                "the last token moved the logits before it — so a shifted causal "
+                "objective would train it to predict tokens it can already see."
+            )
+        return extra
+
+    raise ValueError(
+        f"Unsloth: mlx-vlm's `{model_type}` answered every probe identically, so "
+        "whether it attends causally could not be established and a text-only "
+        "fine-tune cannot be trusted."
+    )
+
+
+def _mark_text_only_vlm(model, model_type: str) -> None:
+    # A refused load must leave the class unpatched and the model unflagged.
+    extra = _verify_text_only_wrapper(model, model_type)
+    _bind_text_only_modality_arguments(model, extra)
+    model._unsloth_text_only_vlm = True
+
+
 def _resolve_mlx_vlm_model_class(model_type):
     """Resolve the mlx_vlm ``Model`` class for a model_type (honoring remaps)."""
     if not model_type:
         return None
-    module_type = str(model_type).replace("-", "_")
-    try:
-        from mlx_vlm.utils import MODEL_REMAPPING
-        remapped = MODEL_REMAPPING.get(model_type, MODEL_REMAPPING.get(module_type))
-        if remapped:
-            module_type = str(remapped).replace("-", "_")
-    except Exception:
-        pass
+    # Shared with utils' vision-grid resolution: mlx-vlm lower-cases before it remaps.
+    from .utils import _mlx_vlm_canonical_model_type
+    module_type = _mlx_vlm_canonical_model_type(model_type)
+    if not module_type:
+        return None
     for candidate in (
         f"mlx_vlm.models.{module_type}.{module_type}",
         f"mlx_vlm.models.{module_type}",
@@ -7777,7 +7887,7 @@ class FastMLXModel:
                     "Unsloth: text_only=True requested for a multimodal wrapper; "
                     "keeping the model on the mlx-vlm path and returning its tokenizer."
                 )
-                model._unsloth_text_only_vlm = True
+                _mark_text_only_vlm(model, model_type)
             model._is_vlm_model = True
             model._processor = processor
             for fixup in _VLM_MODEL_FIXUPS:

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2619,11 +2619,24 @@ def _has_multimodal_strip_sanitize(model_or_cls) -> bool:
     return any(token in source for token in _MULTIMODAL_STRIP_KEYS)
 
 
-def _get_mlx_lm_model_class(model_type: str):
+def _mlx_lm_module_name(model_type: str) -> str:
+    """The `mlx_lm.models` module mlx_lm itself would import: it remaps the raw
+    config spelling and imports the result verbatim, hyphens included (`lfm2-vl`)."""
     if not model_type:
+        return ""
+    try:
+        from mlx_lm.utils import MODEL_REMAPPING
+        return str(MODEL_REMAPPING.get(model_type, model_type))
+    except Exception:
+        return str(model_type)
+
+
+def _get_mlx_lm_model_class(model_type: str):
+    module_name = _mlx_lm_module_name(model_type)
+    if not module_name:
         return None
     try:
-        module = importlib.import_module(f"mlx_lm.models.{model_type}")
+        module = importlib.import_module(f"mlx_lm.models.{module_name}")
     except Exception:
         return None
     return getattr(module, "Model", None)
@@ -2687,11 +2700,12 @@ def _ensure_safe_text_wrapper_sanitize(model_type: str) -> None:
     one architecture, so any loader with the same assumption is handled.
     """
 
-    if not model_type or model_type in _SAFE_TEXT_SANITIZE_PATCHED:
+    module_name = _mlx_lm_module_name(model_type)
+    if not module_name or module_name in _SAFE_TEXT_SANITIZE_PATCHED:
         return
 
     try:
-        module = importlib.import_module(f"mlx_lm.models.{model_type}")
+        module = importlib.import_module(f"mlx_lm.models.{module_name}")
     except Exception:
         return
 
@@ -2724,7 +2738,7 @@ def _ensure_safe_text_wrapper_sanitize(model_type: str) -> None:
         return dict(tree_flatten(structured))
 
     cls.sanitize = patched_sanitize
-    _SAFE_TEXT_SANITIZE_PATCHED.add(model_type)
+    _SAFE_TEXT_SANITIZE_PATCHED.add(module_name)
 
 
 def _resolve_mlx_vlm_model_class(model_type):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2638,7 +2638,12 @@ def _get_mlx_lm_model_class(model_type: str):
         return None
     try:
         module = importlib.import_module(f"mlx_lm.models.{module_name}")
-    except Exception:
+    except (Exception, SystemExit):
+        # SystemExit, because mlx_lm ships modules that `exit(1)` at import when
+        # an optional dependency is missing (`mlx_lm/models/olmo.py` without
+        # ai2-olmo). It is not an Exception, so catching only that killed the
+        # whole load here, with no traceback, over a question whose answer is
+        # "mlx_lm cannot build this one".
         return None
     return getattr(module, "Model", None)
 
@@ -2682,7 +2687,9 @@ def _ensure_safe_text_wrapper_sanitize(model_type: str) -> None:
 
     try:
         module = importlib.import_module(f"mlx_lm.models.{module_name}")
-    except Exception:
+    except (Exception, SystemExit):
+        # See `_get_mlx_lm_model_class`: an `exit(1)` at import must be a skipped
+        # patch, not a dead process. This runs on every mlx_lm text load.
         return
 
     cls = getattr(module, "Model", None)
@@ -2869,7 +2876,7 @@ def _resolve_mlx_vlm_model_class(model_type):
     ):
         try:
             module = importlib.import_module(candidate)
-        except Exception:
+        except (Exception, SystemExit):
             continue
         cls = getattr(module, "Model", None)
         if cls is not None:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -15165,6 +15165,25 @@ def _mlx_stacked_expert_tensor_names(model, tensor_names):
     return stacked
 
 
+@contextlib.contextmanager
+def _mlx_module_state_restored(modules):
+    """Leave these modules as they were found: an mlx `Module` is a dict of
+    parameters and children plus plain attributes, and both halves are put back.
+    State inside plain objects a module merely references is not reached."""
+    state = [(module, dict(module) if isinstance(module, dict) else None,
+              dict(vars(module))) for module in modules]
+    try:
+        yield
+    finally:
+        for module, items, attributes in state:
+            if items is not None:
+                # Through `dict`: `Module.update` reads a nested parameter tree.
+                dict.clear(module)
+                dict.update(module, items)
+            vars(module).clear()
+            vars(module).update(attributes)
+
+
 class _MlxReplayedSanitizers:
     """Sanitizers replayed in order, leaving no module of the model changed: Gemma 3
     ties its head and drops `lm_head` if handed no `lm_head.weight`."""
@@ -15174,24 +15193,13 @@ class _MlxReplayedSanitizers:
         self.held = tuple(held)
 
     def sanitize(self, weights):
-        # An mlx `Module` is a dict of parameters/children plus plain attributes.
-        state = [(module, dict(module) if isinstance(module, dict) else None,
-                  dict(vars(module))) for module in self.held]
-        try:
+        with _mlx_module_state_restored(self.held):
             for owner in self.owners:
                 weights = owner.sanitize(weights)
                 # A failed replay writes nothing: the export is then what it was without this pass.
                 if not isinstance(weights, Mapping):
                     raise TypeError("sanitize did not return a mapping")
             return weights
-        finally:
-            for module, items, attributes in state:
-                if items is not None:
-                    # Through `dict`: `Module.update` reads a nested parameter tree.
-                    dict.clear(module)
-                    dict.update(module, items)
-                vars(module).clear()
-                vars(module).update(attributes)
 
 
 def _mlx_moe_sanitizers(model):


### PR DESCRIPTION
Two defects made `text_only=True` fail for MLX VLM architectures that mlx-vlm ships and mlx_lm does not. This extends #1096, whose one-line routing change is the first half of the fix; the rest is what that change uncovered when the affected checkpoints were actually loaded and trained.

## The routing allow-list was fail-closed

`_prefer_vlm_loader_for_text` fell back to a hand-maintained set of model types when mlx_lm had no class for the architecture. Any multimodal wrapper only mlx-vlm ships — `lfm2_vl`, `mage_vl` and `kimi_k3` among them — failed a text-only load with `ValueError: Model type ... not supported` instead of training the wrapper's text tower, and a newly supported family stayed unreachable until someone added its name. Because a text dataset always requests `text_only=True`, this made a text-only fine-tune of an unlisted VLM unreachable rather than merely unoptimized.

The load now takes the VLM path whenever mlx-vlm has a wrapper for the architecture. Architectures neither backend ships still fail as before, and an architecture mlx_lm can build still decides by whether its `sanitize` strips modality towers. Resolution goes through the same canonical helper the vision-grid code uses, so a capitalised or aliased spelling such as `Muse_Glimmer` resolves the way mlx-vlm itself resolves it.

## Reaching the wrapper is not the same as being trainable on text

Removing the list makes importability the routing decision, and importability proves nothing about whether a wrapper is a causal LM over token ids. Among the installed wrappers, `nemotron_parse` accepts token ids and then raises `You have to specify pixel_values`, `diffusion_gemma` answers 3 tokens with logits for 5, and the pooled families such as `siglip` return embeddings carrying no logits — each of which previously surfaced as a shape or missing-argument error from inside the loss on the first training step, naming nothing useful. PaliGemma is worse: mlx-vlm defaults its `use_bidirectional_attention` to `True`, so it answers with correctly shaped logits that every position can see the whole sequence through, and a shifted causal objective would quietly train it to predict tokens it was already shown.

Nothing about the class settles any of this, and the class is not even stable — the PaliGemma causal-mask fixup in this package replaces `Model.__call__` with `(*args, **kwargs)`, so what `inspect.signature` reports depends on which models the process has already loaded. So the load asks the model it just built:

- **Arity, by calling.** Twenty-four of the installed wrappers declare `pixel_values` — and sometimes `mask` — with no default, while their `get_input_embeddings` already returns plain text embeddings for `pixel_values=None`. The load calls with one more trailing `None` each time, up to three, treating only a `TypeError` that names a positional argument as "needs another". A caller that passes those arguments itself still reaches the wrapper unchanged, positionally or by name.
- **Causality, by perturbation.** Two three-token forwards differing only in the last token must return token logits of the matching shape whose earlier positions are bitwise unchanged. A pair whose two runs answer identically at the position that changed proves nothing — two ids sharing an embedding row do exactly that — so the next of four pairs drawn from disjoint ids is tried, and a wrapper no pair can move is refused rather than assumed causal. The comparison admits no tolerance, because a faint backwards path leaks the same tokens a large one does.

Nothing is flagged or patched until the wrapper has answered, so a refused load leaves the process as it found it. The probe forwards put back the state they leave on the model's modules — `qwen2_vl` caches `_position_ids` and reuses it without checking the cached sequence still fits, and an unrestored probe would shift the numerics of the first training batch. That snapshot is the same one the replayed-sanitizer export path needs, so both now share one helper.

## `_get_mlx_lm_model_class` skipped mlx_lm's own remap

It imported `mlx_lm.models.<model_type>` from the raw config spelling, but mlx_lm sends that spelling through `MODEL_REMAPPING` first. Aliased families therefore looked unsupported to the loader while mlx_lm loads them fine, and the two spellings of one architecture took different text-only routes: `qwen2_vl` and `mistral3` stayed on the mlx-vlm wrapper because their `sanitize` strips modality towers, while the identical `qwen2_5_vl` and `llava` checkpoints were sent to mlx_lm instead. The module name is now resolved once and reused for the sanitize patch, so an aliased architecture is patched under the module it actually lives in. The remap is the only normalization applied — mlx_lm names several modules after a hyphenated model type (`lfm2-vl`, `lille-130m`, `nemotron-nas`), so folding hyphens would lose them.

## Risks and tradeoffs

- The causality check is fail-closed on an inconclusive probe. Four token pairs drawn from disjoint ids settle every installed architecture tested; a checkpoint contrived to tie all four would be refused with a named error rather than trained, which is the safe direction.
- Module state is restored by snapshotting each module's parameter mapping and attributes. State kept inside plain objects a module merely references — an n-gram embedding cache, an expert store's LRU counters — is not reached, which costs cache contents and counters but no numerics.
- The refusal messages name the architecture and say what to do instead, so an architecture that genuinely cannot be trained on text alone fails at load with an explanation rather than inside the loss.

## Validation

Loaded and trained through the real `from_pretrained` and trainer paths against shrunken-but-real checkpoints for the three architectures reported broken, with no weights downloaded:

| family | before | after |
|---|---|---|
| `lfm2_vl` | `ValueError: Model type lfm2_vl not supported.` | trains, loss 11.46 |
| `mage_vl` | `ValueError: Model type mage_vl not supported.` | trains and saves, 56 LoRA modules wrapped and moved |
| `kimi_k3` | `ValueError: Model type kimi_k3 not supported.` | trains and saves, 86 LoRA modules wrapped and moved |

A real constructed PaliGemma is refused when `use_bidirectional_attention` is left at its default and accepted when it is `False` — the same verdict in a fresh process and after the causal-mask fixup has rewritten `__call__`, which was previously load-order dependent. Three cached quantized checkpoints (`LFM2.5-VL-1.6B-4bit`, `Qwen2-VL-2B-Instruct-4bit`, `InternVL3-1B-4bit`) load and are accepted, with `max|Δ| = 0.0` at the earlier positions on every probe pair while the changed position moves by 6 to 24, so the exact comparison is not tight for real quantized models.

Every added test was mutation-checked: relaxing the comparison to a tolerance, assuming causality when no pair is informative, dropping either group of probe pairs, taking the arity from a signature, moving the flag or the class patch before the check, ignoring keyword callers, and dropping the state restoration each fail exactly the tests that name that behavior.

Tests that read the installed mlx-vlm's architecture inventory skip when the installed version predates a family, so they stay meaningful across the supported range.

One unrelated pre-existing defect is visible while testing this: an `lfm2_vl` text-only run trains correctly and then fails in the final save with `property 'text' of 'NaiveStreamingDetokenizer' object has no setter`. It reproduces without these changes and is not addressed here.
