### PR TITLE
Keep the transformers vision_utils grid helpers eager

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -760,6 +760,8 @@ jobs:
                   tests/test_upstream_source_patterns.py \
                   tests/test_compiler_rewriter_exhaustive.py \
                   tests/test_compiler_dynamic_exec.py \
+                  tests/test_vision_utils_grid_helpers_eager.py \
+                  tests/test_disable_compile_functions_reach_imported_helpers.py \
                   tests/test_temporary_patches_exhaustive.py \
                   tests/test_mxfp4_load_path_layout.py \
                   tests/test_missing_parent_package_is_drift.py \

--- a/tests/test_disable_compile_functions_reach_imported_helpers.py
+++ b/tests/test_disable_compile_functions_reach_imported_helpers.py
@@ -15,27 +15,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Listing a helper in DISABLE_COMPILE_FUNCTIONS must reach its CALLERS too.
-
-`unsloth_compile_transformers` builds `called_functions` only from names the modeling
-file both calls AND defines, so a file that merely *imports* a helper reaches neither
-`disable_compile_functions` branch and `create_new_function` imports the raw upstream
-function into the generated module. transformers >= 5.9 moved the vision grid helpers
-into `transformers/vision_utils.py`, and at 5.16.1 47 of the 61 (modeling file,
-helper) import pairs are imported-only. Two land inside a `fullgraph = True` region::
-
-    MiniMaxM3VL3DRotaryEmbedding.forward       -> get_vision_position_ids
-    Kimi_K25VisionPositionEmbeddings.forward   -> get_vision_interpolation_indices_and_weights
-
-which on torch < 2.10 ends the first vision forward with "Backend compiler inductor
-failed with aten._local_scalar_dense.default ... grid_thw.tolist()".
-
-The fix demotes any caller of a listed helper to `fullgraph = False`. Re-emitting the
-helper as `@torch.compiler.disable` instead would not do: a disabled callee is itself
-a graph break, which under `fullgraph = True` is the same hard error.
-
-The first two tests are source inspection and run anywhere; the last drives the real
-rewriter and is skipped below transformers 5.9.
-"""
+`called_functions` holds only names the modeling file both calls AND defines, so an
+imported-only helper is imported raw for Dynamo to inline. The fix demotes the CALLER;
+`@torch.compiler.disable` on the helper would not do, a disabled callee is itself a
+graph break and that is the same hard error under fullgraph."""
 
 import inspect
 import os
@@ -52,18 +35,13 @@ from unsloth_zoo.compiler import (
 
 
 def test_bare_calls_are_detected_and_attribute_calls_are_not():
-    """The detector has to see an imported helper and ignore a same-named method.
-
-    qwen3_vl, glm4v, qwen2_5_vl and paddleocr_vl all define a METHOD called
-    `get_vision_position_ids`, so matching the bare name would demote modules that
-    never touch the helper.
-    """
+    """qwen3_vl, glm4v, qwen2_5_vl and paddleocr_vl each define a METHOD of the same
+    name, so a bare-name match would demote modules that never touch the helper."""
     listed = DISABLE_COMPILE_FUNCTIONS[0]
 
     assert calls_disable_compile_function(
         f"    x = {listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
     ) == [listed]
-    # whitespace between name and paren
     assert calls_disable_compile_function(
         f"    x = {listed} (grid_thw)\n", DISABLE_COMPILE_FUNCTIONS
     ) == [listed]
@@ -74,23 +52,17 @@ def test_bare_calls_are_detected_and_attribute_calls_are_not():
     assert calls_disable_compile_function(
         f"    x = vision_utils.{listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
     ) == []
-    # a longer name ending with a listed one must not match
     assert calls_disable_compile_function(
         f"    x = wrapped_{listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
     ) == []
-    # a mention that is not a call must not match
     assert calls_disable_compile_function(
         f'    """See {listed} for details."""\n', DISABLE_COMPILE_FUNCTIONS
     ) == []
 
 
 def test_every_fullgraph_emit_site_consults_the_detector():
-    """All three places that can stamp fullgraph = True have to ask.
-
-    The module scan (`no_fullgraph_modules`) plus both generated-source emit sites.
-    Miss one and an imported helper is inlined into a fullgraph region again, which
-    the tests here cannot see since they do not go through the rewriter.
-    """
+    """Miss one of the three emit sites and an imported helper is inlined into a
+    fullgraph region again, unseen by tests that do not go through the rewriter."""
     source = inspect.getsource(compiler_module)
     assert source.count("calls_disable_compile_function(") == 4, (
         "expected one definition plus three call sites (module scan + the two "
@@ -109,8 +81,7 @@ except Exception:
     pass
 
 
-# Its own interpreter: the rewriter sets `__UNSLOTH_PATCHED__` on the modeling
-# module and writes a cache directory.
+# Its own interpreter: the rewriter sets `__UNSLOTH_PATCHED__` on the modeling module.
 _CHILD = r'''
 import os, sys, json, importlib, io, contextlib
 os.environ["UNSLOTH_COMPILE_LOCATION"] = "unsloth_compiled_cache"
@@ -159,27 +130,18 @@ print("@@@" + json.dumps({
     reason = "needs transformers >= 5.9 (shared vision_utils) with minimax_m3_vl",
 )
 def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
-    """The regression itself, end to end through the real rewriter.
-
-    minimax_m3_vl only imports `get_vision_position_ids`, so it is never in
-    `called_functions` and the generated module calls the raw upstream helper. The
-    forward must therefore be emitted `fullgraph = False`, and calling it must give
-    position embeddings rather than a Dynamo error.
-    """
-    # conftest's GPU-free harness does not reach a subprocess, and importing
-    # unsloth_zoo on a GPU-less runner would otherwise go looking for one.
+    # conftest's GPU-free harness does not reach a subprocess.
     env = dict(os.environ)
     env["UNSLOTH_ALLOW_CPU"] = "1"
     env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
-    # Pin the child to THIS checkout, else it imports the site-packages unsloth_zoo
-    # and reports on a different copy of compiler.py.
+    # Pin the child to THIS checkout, else it imports the site-packages unsloth_zoo and
+    # reports on a different compiler.py (a false green).
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     env["PYTHONPATH"] = os.pathsep.join(
         [repo_root] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
     )
-    # The core-drift job sets UNSLOTH_COMPILE_DISABLE=1 job-wide; inheriting it forces
-    # disable=True, so the forward is emitted @torch.compiler.disable rather than the
-    # torch_compile_with_fallback this test is about.
+    # Inheriting the core-drift job's UNSLOTH_COMPILE_DISABLE=1 forces disable=True, so
+    # the forward is emitted @torch.compiler.disable, not torch_compile_with_fallback.
     env.pop("UNSLOTH_COMPILE_DISABLE", None)
     result = subprocess.run(
         [sys.executable, "-c", _CHILD],
@@ -199,7 +161,6 @@ def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
     assert payload is not None, result.stdout[-4000:]
 
     generated = payload["generated"]
-    # The premise: the helper is imported raw rather than re-emitted.
     assert "def get_vision_position_ids(" not in generated, (
         "minimax_m3_vl now defines the helper itself; pick another model type "
         "that only imports it, or this test proves nothing."
@@ -215,11 +176,8 @@ def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
         + decorators[-400:]
     )
 
-    # The decorator asserted above IS the regression guard, and it runs everywhere.
-    # Actually calling the forward is a bonus that also needs a working inductor
-    # toolchain, which a bare Triton-less CI runner may not have, so tolerate exactly
-    # that failure. The regression surfaces as torch._dynamo.exc.Unsupported instead,
-    # so it is still caught.
+    # Bonus check; a bare CI runner may lack a working inductor, and the regression
+    # itself surfaces as a different exception type.
     if payload.get("error_type") == "BackendCompilerFailed":
         pytest.skip(f"inductor cannot compile here ({payload['error']}); decorator asserted above")
     assert payload["error"] is None, payload["error"]

--- a/tests/test_disable_compile_functions_reach_imported_helpers.py
+++ b/tests/test_disable_compile_functions_reach_imported_helpers.py
@@ -147,19 +147,22 @@ generated = open(
 ).read()
 
 error = None
+error_type = None
+shapes = None
 try:
     rope = mf.MiniMaxM3VL3DRotaryEmbedding(head_dim = 80, spatial_merge_size = 2)
     cos, sin = rope(torch.tensor([[1, 24, 32]], dtype = torch.long),
                     torch.device("cpu"), torch.float32)
     shapes = [tuple(cos.shape), tuple(sin.shape)]
 except Exception as exception:
-    error = f"{type(exception).__name__}: {str(exception).strip().splitlines()[0]}"
-    shapes = None
+    error_type = type(exception).__name__
+    error = f"{error_type}: {str(exception).strip().splitlines()[0]}"
 
 print("@@@" + json.dumps({
-    "generated" : generated,
-    "error"     : error,
-    "shapes"    : shapes,
+    "generated"   : generated,
+    "error"       : error,
+    "error_type"  : error_type,
+    "shapes"      : shapes,
 }))
 '''
 
@@ -228,5 +231,15 @@ def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
         + decorators[-400:]
     )
 
+    # The decorator asserted above IS the regression guard: emitting this forward
+    # fullgraph = True is precisely the bug, and that check is deterministic and
+    # runs everywhere. Actually calling the forward is a bonus end-to-end check
+    # that additionally needs a working inductor toolchain. A bare CI runner has
+    # no Triton and its inductor CPU backend can fail outright, which says nothing
+    # about this change, so tolerate exactly that and nothing else. The regression
+    # this test exists for surfaces as torch._dynamo.exc.Unsupported, a different
+    # type, so it is still caught here.
+    if payload.get("error_type") == "BackendCompilerFailed":
+        pytest.skip(f"inductor cannot compile here ({payload['error']}); decorator asserted above")
     assert payload["error"] is None, payload["error"]
     assert payload["shapes"] == [[768, 78], [768, 78]], payload["shapes"]

--- a/tests/test_disable_compile_functions_reach_imported_helpers.py
+++ b/tests/test_disable_compile_functions_reach_imported_helpers.py
@@ -188,6 +188,12 @@ def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
     env["PYTHONPATH"] = os.pathsep.join(
         [repo_root] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
     )
+    # The core-drift job sets UNSLOTH_COMPILE_DISABLE=1 at job level, and this
+    # copies the whole environment. Inheriting it makes unsloth_compile_transformers
+    # force disable=True, so the forward is emitted @torch.compiler.disable instead
+    # of the torch_compile_with_fallback this test is about, and the assertion below
+    # fails for a reason unrelated to the regression. Drop it for the child.
+    env.pop("UNSLOTH_COMPILE_DISABLE", None)
     result = subprocess.run(
         [sys.executable, "-c", _CHILD],
         cwd = str(tmp_path),

--- a/tests/test_disable_compile_functions_reach_imported_helpers.py
+++ b/tests/test_disable_compile_functions_reach_imported_helpers.py
@@ -16,9 +16,7 @@
 
 """Listing a helper in DISABLE_COMPILE_FUNCTIONS must reach its CALLERS too.
 `called_functions` holds only names the modeling file both calls AND defines, so an
-imported-only helper is imported raw for Dynamo to inline. The fix demotes the CALLER;
-`@torch.compiler.disable` on the helper would not do, a disabled callee is itself a
-graph break and that is the same hard error under fullgraph."""
+imported-only helper is imported raw for Dynamo to inline, and the CALLER is demoted."""
 
 import inspect
 import os
@@ -35,8 +33,8 @@ from unsloth_zoo.compiler import (
 
 
 def test_bare_calls_are_detected_and_attribute_calls_are_not():
-    """qwen3_vl, glm4v, qwen2_5_vl and paddleocr_vl each define a METHOD of the same
-    name, so a bare-name match would demote modules that never touch the helper."""
+    """Several VL files define a METHOD of the same name, so matching those would demote
+    modules that never touch the helper."""
     listed = DISABLE_COMPILE_FUNCTIONS[0]
 
     assert calls_disable_compile_function(
@@ -61,8 +59,7 @@ def test_bare_calls_are_detected_and_attribute_calls_are_not():
 
 
 def test_every_fullgraph_emit_site_consults_the_detector():
-    """Miss one of the three emit sites and an imported helper is inlined into a
-    fullgraph region again, unseen by tests that do not go through the rewriter."""
+    """Miss one emit site and an imported helper is inlined into a fullgraph region again."""
     source = inspect.getsource(compiler_module)
     assert source.count("calls_disable_compile_function(") == 4, (
         "expected one definition plus three call sites (module scan + the two "
@@ -134,14 +131,12 @@ def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
     env = dict(os.environ)
     env["UNSLOTH_ALLOW_CPU"] = "1"
     env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
-    # Pin the child to THIS checkout, else it imports the site-packages unsloth_zoo and
-    # reports on a different compiler.py (a false green).
+    # Pin the child to THIS checkout, else it reports on the site-packages compiler.py.
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     env["PYTHONPATH"] = os.pathsep.join(
         [repo_root] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
     )
-    # Inheriting the core-drift job's UNSLOTH_COMPILE_DISABLE=1 forces disable=True, so
-    # the forward is emitted @torch.compiler.disable, not torch_compile_with_fallback.
+    # An inherited UNSLOTH_COMPILE_DISABLE=1 forces disable=True and emits the wrong decorator.
     env.pop("UNSLOTH_COMPILE_DISABLE", None)
     result = subprocess.run(
         [sys.executable, "-c", _CHILD],
@@ -176,8 +171,8 @@ def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
         + decorators[-400:]
     )
 
-    # Bonus check; a bare CI runner may lack a working inductor, and the regression
-    # itself surfaces as a different exception type.
+    # Bonus check: a bare CI runner may lack a working inductor, and the regression itself
+    # surfaces as a different exception type.
     if payload.get("error_type") == "BackendCompilerFailed":
         pytest.skip(f"inductor cannot compile here ({payload['error']}); decorator asserted above")
     assert payload["error"] is None, payload["error"]

--- a/tests/test_disable_compile_functions_reach_imported_helpers.py
+++ b/tests/test_disable_compile_functions_reach_imported_helpers.py
@@ -16,37 +16,25 @@
 
 """Listing a helper in DISABLE_COMPILE_FUNCTIONS must reach its CALLERS too.
 
-`unsloth_compile_transformers` builds `called_functions` from names that the
-modeling file both calls AND defines::
-
-    defined = re.findall(r"\\bdef[\\s]{1,}" + re.escape(function), full_source, ...)
-    called  = re.findall(r"[\\s]{1,}" + re.escape(function) + r"\\(.+?\\)", full_source, ...)
-    if len(defined) != 0 and len(called) != 0:
-
-so a modeling file that only *imports* a helper never reaches either
-`disable_compile_functions` branch, and `create_new_function` imports the raw
-upstream function into the generated module. transformers >= 5.9 moved the
-vision grid helpers into `transformers/vision_utils.py`, and at 5.16.1 47 of the
-61 (modeling file, helper) import pairs are imported-only. Two of those land
-inside a `fullgraph = True` region::
+`unsloth_compile_transformers` builds `called_functions` only from names the modeling
+file both calls AND defines, so a file that merely *imports* a helper reaches neither
+`disable_compile_functions` branch and `create_new_function` imports the raw upstream
+function into the generated module. transformers >= 5.9 moved the vision grid helpers
+into `transformers/vision_utils.py`, and at 5.16.1 47 of the 61 (modeling file,
+helper) import pairs are imported-only. Two land inside a `fullgraph = True` region::
 
     MiniMaxM3VL3DRotaryEmbedding.forward       -> get_vision_position_ids
     Kimi_K25VisionPositionEmbeddings.forward   -> get_vision_interpolation_indices_and_weights
 
-which on torch < 2.10 ends the first vision forward with
+which on torch < 2.10 ends the first vision forward with "Backend compiler inductor
+failed with aten._local_scalar_dense.default ... grid_thw.tolist()".
 
-    torch._dynamo.exc.Unsupported: Backend compiler exception
-    Backend compiler `inductor` failed with aten._local_scalar_dense.default
-      ... in get_vision_position_ids: grid_thw.tolist()
+The fix demotes any caller of a listed helper to `fullgraph = False`. Re-emitting the
+helper as `@torch.compiler.disable` instead would not do: a disabled callee is itself
+a graph break, which under `fullgraph = True` is the same hard error.
 
-The fix demotes any caller of a listed helper to `fullgraph = False`. Demoting the
-caller, rather than only re-emitting the helper as `@torch.compiler.disable`, is
-deliberate: a disabled callee is itself a graph break, and a graph break under
-`fullgraph = True` is a hard error, so disabling alone swaps one crash for another.
-
-The first two tests are pure source inspection and run anywhere. The last one
-drives the real rewriter and is skipped below transformers 5.9, where the shared
-vision_utils does not exist.
+The first two tests are source inspection and run anywhere; the last drives the real
+rewriter and is skipped below transformers 5.9.
 """
 
 import inspect
@@ -67,15 +55,15 @@ def test_bare_calls_are_detected_and_attribute_calls_are_not():
     """The detector has to see an imported helper and ignore a same-named method.
 
     qwen3_vl, glm4v, qwen2_5_vl and paddleocr_vl all define a METHOD called
-    `get_vision_position_ids` next to the module-level import, so matching the
-    bare name would demote modules that never touch the helper.
+    `get_vision_position_ids`, so matching the bare name would demote modules that
+    never touch the helper.
     """
     listed = DISABLE_COMPILE_FUNCTIONS[0]
 
     assert calls_disable_compile_function(
         f"    x = {listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
     ) == [listed]
-    # whitespace between name and paren, and a call as the very first token
+    # whitespace between name and paren
     assert calls_disable_compile_function(
         f"    x = {listed} (grid_thw)\n", DISABLE_COMPILE_FUNCTIONS
     ) == [listed]
@@ -86,11 +74,11 @@ def test_bare_calls_are_detected_and_attribute_calls_are_not():
     assert calls_disable_compile_function(
         f"    x = vision_utils.{listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
     ) == []
-    # a longer name that merely ends with a listed one must not match
+    # a longer name ending with a listed one must not match
     assert calls_disable_compile_function(
         f"    x = wrapped_{listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
     ) == []
-    # a mention that is not a call (a docstring, an export list) must not match
+    # a mention that is not a call must not match
     assert calls_disable_compile_function(
         f'    """See {listed} for details."""\n', DISABLE_COMPILE_FUNCTIONS
     ) == []
@@ -99,10 +87,9 @@ def test_bare_calls_are_detected_and_attribute_calls_are_not():
 def test_every_fullgraph_emit_site_consults_the_detector():
     """All three places that can stamp fullgraph = True have to ask.
 
-    The module scan (`no_fullgraph_modules`) plus both generated-source emit
-    sites in `compile_function_calls`. Miss one and an imported helper is
-    inlined into a fullgraph region again, which the runtime tests here cannot
-    see because they do not go through the rewriter.
+    The module scan (`no_fullgraph_modules`) plus both generated-source emit sites.
+    Miss one and an imported helper is inlined into a fullgraph region again, which
+    the tests here cannot see since they do not go through the rewriter.
     """
     source = inspect.getsource(compiler_module)
     assert source.count("calls_disable_compile_function(") == 4, (
@@ -122,8 +109,8 @@ except Exception:
     pass
 
 
-# Runs the rewriter for real, so it goes in its own interpreter: it sets
-# `__UNSLOTH_PATCHED__` on the modeling module and writes a cache directory.
+# Its own interpreter: the rewriter sets `__UNSLOTH_PATCHED__` on the modeling
+# module and writes a cache directory.
 _CHILD = r'''
 import os, sys, json, importlib, io, contextlib
 os.environ["UNSLOTH_COMPILE_LOCATION"] = "unsloth_compiled_cache"
@@ -175,27 +162,24 @@ def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
     """The regression itself, end to end through the real rewriter.
 
     minimax_m3_vl only imports `get_vision_position_ids`, so it is never in
-    `called_functions` and the generated module calls the raw upstream helper.
-    The forward that calls it must therefore be emitted `fullgraph = False`, and
-    calling it must produce position embeddings rather than a Dynamo error.
+    `called_functions` and the generated module calls the raw upstream helper. The
+    forward must therefore be emitted `fullgraph = False`, and calling it must give
+    position embeddings rather than a Dynamo error.
     """
     # conftest's GPU-free harness does not reach a subprocess, and importing
     # unsloth_zoo on a GPU-less runner would otherwise go looking for one.
     env = dict(os.environ)
     env["UNSLOTH_ALLOW_CPU"] = "1"
     env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
-    # Pin the child to THIS checkout. Without it the subprocess imports whatever
-    # unsloth_zoo is installed in site-packages, so the test silently reports on
-    # a different copy of compiler.py than the one under review.
+    # Pin the child to THIS checkout, else it imports the site-packages unsloth_zoo
+    # and reports on a different copy of compiler.py.
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     env["PYTHONPATH"] = os.pathsep.join(
         [repo_root] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
     )
-    # The core-drift job sets UNSLOTH_COMPILE_DISABLE=1 at job level, and this
-    # copies the whole environment. Inheriting it makes unsloth_compile_transformers
-    # force disable=True, so the forward is emitted @torch.compiler.disable instead
-    # of the torch_compile_with_fallback this test is about, and the assertion below
-    # fails for a reason unrelated to the regression. Drop it for the child.
+    # The core-drift job sets UNSLOTH_COMPILE_DISABLE=1 job-wide; inheriting it forces
+    # disable=True, so the forward is emitted @torch.compiler.disable rather than the
+    # torch_compile_with_fallback this test is about.
     env.pop("UNSLOTH_COMPILE_DISABLE", None)
     result = subprocess.run(
         [sys.executable, "-c", _CHILD],
@@ -215,7 +199,7 @@ def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
     assert payload is not None, result.stdout[-4000:]
 
     generated = payload["generated"]
-    # The premise: the helper really is imported raw rather than re-emitted.
+    # The premise: the helper is imported raw rather than re-emitted.
     assert "def get_vision_position_ids(" not in generated, (
         "minimax_m3_vl now defines the helper itself; pick another model type "
         "that only imports it, or this test proves nothing."
@@ -231,14 +215,11 @@ def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
         + decorators[-400:]
     )
 
-    # The decorator asserted above IS the regression guard: emitting this forward
-    # fullgraph = True is precisely the bug, and that check is deterministic and
-    # runs everywhere. Actually calling the forward is a bonus end-to-end check
-    # that additionally needs a working inductor toolchain. A bare CI runner has
-    # no Triton and its inductor CPU backend can fail outright, which says nothing
-    # about this change, so tolerate exactly that and nothing else. The regression
-    # this test exists for surfaces as torch._dynamo.exc.Unsupported, a different
-    # type, so it is still caught here.
+    # The decorator asserted above IS the regression guard, and it runs everywhere.
+    # Actually calling the forward is a bonus that also needs a working inductor
+    # toolchain, which a bare Triton-less CI runner may not have, so tolerate exactly
+    # that failure. The regression surfaces as torch._dynamo.exc.Unsupported instead,
+    # so it is still caught.
     if payload.get("error_type") == "BackendCompilerFailed":
         pytest.skip(f"inductor cannot compile here ({payload['error']}); decorator asserted above")
     assert payload["error"] is None, payload["error"]

--- a/tests/test_disable_compile_functions_reach_imported_helpers.py
+++ b/tests/test_disable_compile_functions_reach_imported_helpers.py
@@ -1,0 +1,226 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Listing a helper in DISABLE_COMPILE_FUNCTIONS must reach its CALLERS too.
+
+`unsloth_compile_transformers` builds `called_functions` from names that the
+modeling file both calls AND defines::
+
+    defined = re.findall(r"\\bdef[\\s]{1,}" + re.escape(function), full_source, ...)
+    called  = re.findall(r"[\\s]{1,}" + re.escape(function) + r"\\(.+?\\)", full_source, ...)
+    if len(defined) != 0 and len(called) != 0:
+
+so a modeling file that only *imports* a helper never reaches either
+`disable_compile_functions` branch, and `create_new_function` imports the raw
+upstream function into the generated module. transformers >= 5.9 moved the
+vision grid helpers into `transformers/vision_utils.py`, and at 5.16.1 47 of the
+61 (modeling file, helper) import pairs are imported-only. Two of those land
+inside a `fullgraph = True` region::
+
+    MiniMaxM3VL3DRotaryEmbedding.forward       -> get_vision_position_ids
+    Kimi_K25VisionPositionEmbeddings.forward   -> get_vision_interpolation_indices_and_weights
+
+which on torch < 2.10 ends the first vision forward with
+
+    torch._dynamo.exc.Unsupported: Backend compiler exception
+    Backend compiler `inductor` failed with aten._local_scalar_dense.default
+      ... in get_vision_position_ids: grid_thw.tolist()
+
+The fix demotes any caller of a listed helper to `fullgraph = False`. Demoting the
+caller, rather than only re-emitting the helper as `@torch.compiler.disable`, is
+deliberate: a disabled callee is itself a graph break, and a graph break under
+`fullgraph = True` is a hard error, so disabling alone swaps one crash for another.
+
+The first two tests are pure source inspection and run anywhere. The last one
+drives the real rewriter and is skipped below transformers 5.9, where the shared
+vision_utils does not exist.
+"""
+
+import inspect
+import os
+import subprocess
+import sys
+
+import pytest
+
+from unsloth_zoo import compiler as compiler_module
+from unsloth_zoo.compiler import (
+    DISABLE_COMPILE_FUNCTIONS,
+    calls_disable_compile_function,
+)
+
+
+def test_bare_calls_are_detected_and_attribute_calls_are_not():
+    """The detector has to see an imported helper and ignore a same-named method.
+
+    qwen3_vl, glm4v, qwen2_5_vl and paddleocr_vl all define a METHOD called
+    `get_vision_position_ids` next to the module-level import, so matching the
+    bare name would demote modules that never touch the helper.
+    """
+    listed = DISABLE_COMPILE_FUNCTIONS[0]
+
+    assert calls_disable_compile_function(
+        f"    x = {listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
+    ) == [listed]
+    # whitespace between name and paren, and a call as the very first token
+    assert calls_disable_compile_function(
+        f"    x = {listed} (grid_thw)\n", DISABLE_COMPILE_FUNCTIONS
+    ) == [listed]
+
+    assert calls_disable_compile_function(
+        f"    x = self.{listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
+    ) == []
+    assert calls_disable_compile_function(
+        f"    x = vision_utils.{listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
+    ) == []
+    # a longer name that merely ends with a listed one must not match
+    assert calls_disable_compile_function(
+        f"    x = wrapped_{listed}(grid_thw, 2)\n", DISABLE_COMPILE_FUNCTIONS
+    ) == []
+    # a mention that is not a call (a docstring, an export list) must not match
+    assert calls_disable_compile_function(
+        f'    """See {listed} for details."""\n', DISABLE_COMPILE_FUNCTIONS
+    ) == []
+
+
+def test_every_fullgraph_emit_site_consults_the_detector():
+    """All three places that can stamp fullgraph = True have to ask.
+
+    The module scan (`no_fullgraph_modules`) plus both generated-source emit
+    sites in `compile_function_calls`. Miss one and an imported helper is
+    inlined into a fullgraph region again, which the runtime tests here cannot
+    see because they do not go through the rewriter.
+    """
+    source = inspect.getsource(compiler_module)
+    assert source.count("calls_disable_compile_function(") == 4, (
+        "expected one definition plus three call sites (module scan + the two "
+        "generated-source emit sites); a fullgraph = True emit no longer "
+        "consults DISABLE_COMPILE_FUNCTIONS membership of the CALLEE."
+    )
+
+
+_HAS_VISION_UTILS = False
+try:
+    import transformers.vision_utils  # noqa: F401
+    import transformers.models.minimax_m3_vl  # noqa: F401
+
+    _HAS_VISION_UTILS = True
+except Exception:
+    pass
+
+
+# Runs the rewriter for real, so it goes in its own interpreter: it sets
+# `__UNSLOTH_PATCHED__` on the modeling module and writes a cache directory.
+_CHILD = r'''
+import os, sys, json, importlib, io, contextlib
+os.environ["UNSLOTH_COMPILE_LOCATION"] = "unsloth_compiled_cache"
+import torch
+from unsloth_zoo.compiler import unsloth_compile_transformers
+
+MT = "minimax_m3_vl"
+loc = f"transformers.models.{MT}.modeling_{MT}"
+mf = importlib.import_module(loc)
+
+buf = io.StringIO()
+with contextlib.redirect_stdout(buf):
+    unsloth_compile_transformers(
+        model_type = MT, fast_lora_forwards = False, fullgraph = True,
+        import_from_cache = False, disable = False, supports_sdpa = [None],
+    )
+
+generated = open(
+    os.path.join("unsloth_compiled_cache", f"unsloth_compiled_module_{MT}.py"),
+    encoding = "utf-8",
+).read()
+
+error = None
+try:
+    rope = mf.MiniMaxM3VL3DRotaryEmbedding(head_dim = 80, spatial_merge_size = 2)
+    cos, sin = rope(torch.tensor([[1, 24, 32]], dtype = torch.long),
+                    torch.device("cpu"), torch.float32)
+    shapes = [tuple(cos.shape), tuple(sin.shape)]
+except Exception as exception:
+    error = f"{type(exception).__name__}: {str(exception).strip().splitlines()[0]}"
+    shapes = None
+
+print("@@@" + json.dumps({
+    "generated" : generated,
+    "error"     : error,
+    "shapes"    : shapes,
+}))
+'''
+
+
+@pytest.mark.skipif(
+    not _HAS_VISION_UTILS,
+    reason = "needs transformers >= 5.9 (shared vision_utils) with minimax_m3_vl",
+)
+def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
+    """The regression itself, end to end through the real rewriter.
+
+    minimax_m3_vl only imports `get_vision_position_ids`, so it is never in
+    `called_functions` and the generated module calls the raw upstream helper.
+    The forward that calls it must therefore be emitted `fullgraph = False`, and
+    calling it must produce position embeddings rather than a Dynamo error.
+    """
+    # conftest's GPU-free harness does not reach a subprocess, and importing
+    # unsloth_zoo on a GPU-less runner would otherwise go looking for one.
+    env = dict(os.environ)
+    env["UNSLOTH_ALLOW_CPU"] = "1"
+    env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
+    # Pin the child to THIS checkout. Without it the subprocess imports whatever
+    # unsloth_zoo is installed in site-packages, so the test silently reports on
+    # a different copy of compiler.py than the one under review.
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env["PYTHONPATH"] = os.pathsep.join(
+        [repo_root] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", _CHILD],
+        cwd = str(tmp_path),
+        env = env,
+        capture_output = True,
+        text = True,
+        timeout = 1800,
+    )
+    assert result.returncode == 0, result.stdout[-4000:] + result.stderr[-4000:]
+    payload = None
+    for line in result.stdout.splitlines():
+        if line.startswith("@@@"):
+            import json
+
+            payload = json.loads(line[3:])
+    assert payload is not None, result.stdout[-4000:]
+
+    generated = payload["generated"]
+    # The premise: the helper really is imported raw rather than re-emitted.
+    assert "def get_vision_position_ids(" not in generated, (
+        "minimax_m3_vl now defines the helper itself; pick another model type "
+        "that only imports it, or this test proves nothing."
+    )
+    where = generated.find("def MiniMaxM3VL3DRotaryEmbedding_forward")
+    assert where != -1, "MiniMaxM3VL3DRotaryEmbedding_forward is no longer generated"
+    decorators = generated[:where]
+    assert "fullgraph = False" in decorators.rsplit("\n@", 1)[-1], (
+        "MiniMaxM3VL3DRotaryEmbedding_forward calls the raw upstream "
+        "get_vision_position_ids, whose first line is grid_thw.tolist(); "
+        "emitting it fullgraph = True kills the first vision forward with "
+        "`Backend compiler exception ... aten._local_scalar_dense.default`.\n"
+        + decorators[-400:]
+    )
+
+    assert payload["error"] is None, payload["error"]
+    assert payload["shapes"] == [[768, 78], [768, 78]], payload["shapes"]

--- a/tests/test_vision_utils_grid_helpers_eager.py
+++ b/tests/test_vision_utils_grid_helpers_eager.py
@@ -16,43 +16,24 @@
 
 """The transformers/vision_utils.py grid helpers must never be compiled fullgraph.
 
-transformers 5.9 pulled the per-image grid helpers every VL tower calls out of the
-individual modeling files and into a shared `transformers/vision_utils.py`. The
-modeling files import them by name, so the rewriter in compiler.py sees them as
-called functions and used to stamp
+transformers 5.9 moved the per-image grid helpers every VL tower calls into a shared
+`transformers/vision_utils.py`, and compiler.py's rewriter used to stamp
+fullgraph = True on them. Each opens by reading the grid off the device with
+`grid_thw.tolist()`, so the shapes built from those unbacked SymInts are not
+guardable (`UserError: Could not guard on data-dependent expression Eq((u2//u3), 0)`
+out of `reshape((h // merge, merge, w // merge, merge))`). Under fullgraph = True
+that is a hard error rather than a graph break, so every Qwen3.5 / Qwen3-VL /
+GLM-4V / PaddleOCR-VL run died on the first vision forward. fullgraph = False alone
+is not enough either, since the `.tolist()` sync breaks the graph on line 1, so the
+helpers are listed in `DISABLE_COMPILE_FUNCTIONS` and emitted eager.
 
-    @torch_compile_with_fallback(fullgraph = True, dynamic = True, ...)
+Which helpers trip is torch dependent (pytorch#162354 made the guards non-throwing
+in 2.10), so `test_uncompilable_grid_helpers_are_listed` probes upstream and asserts
+an implication rather than a fixed list of names: it passes on both sides of that
+boundary and picks up new helpers without an edit here, which is how 5.16's
+`get_vision_interpolation_indices_and_weights` was caught.
 
-on them. Each one opens by reading the image grid off the device with
-`grid_thw.tolist()`, which Dynamo turns into unbacked SymInts, and the shapes built
-from those ints are not guardable, e.g.
-
-    hpos_ids.reshape((h // merge_size, merge_size, w // merge_size, merge_size))
-    torch._dynamo.exc.UserError: Could not guard on data-dependent expression
-    Eq((u2//u3), 0)
-
-Under fullgraph = True that is a hard error rather than a graph break, so every
-Qwen3.5 / Qwen3-VL / GLM-4V / PaddleOCR-VL run died on the first vision forward.
-`fullgraph = False` was never enough on its own either: the `.tolist()` is a
-mandatory device-to-host sync on the first line, so the break lands there and the
-compiled region is only the item() prologue. The helpers are listed in
-`DISABLE_COMPILE_FUNCTIONS` so they are emitted eager instead.
-
-Which helpers actually trip is torch dependent: pytorch 48dbd60df482
-(pytorch#162354, in v2.10.0 but not v2.9.x) made the guards in
-`are_strides_like_channels_last` non-throwing, so on torch >= 2.10 several of these
-trace cleanly again. That is precisely why the test below is written as an
-implication rather than a fixed list of names, and why it passes on both sides of
-that boundary.
-
-The interesting test here is `test_uncompilable_grid_helpers_are_listed`: it probes
-upstream directly rather than hard-coding today's names, so a helper added to
-`vision_utils.py` by a later transformers, or one of these becoming compilable
-upstream, is picked up without editing this file. That is not hypothetical:
-transformers 5.16 deprecated `get_vision_bilinear_indices_and_weights` in favour of
-`get_vision_interpolation_indices_and_weights`, and the probe caught the new name.
-
-Runs on CPU. The failure is in the meta/shape layer, so no GPU is needed.
+CPU only: the failure is in the meta/shape layer.
 """
 
 import inspect
@@ -69,15 +50,15 @@ vision_utils = pytest.importorskip(
 )
 
 
-# A grid whose height and width are both multiples of every merge size below, so the
-# helpers have real work to do and eager execution is meaningful.
+# Height and width are multiples of every merge size below, so the helpers have real
+# work to do.
 GRID_THW = torch.tensor([[1, 24, 32]], dtype=torch.long)
 
-# Filled in by name so a signature reordering upstream (5.16 inserts `include_temporal`
-# into get_vision_position_ids, for instance) does not silently pass the wrong value.
-# `config` is only read to decide whether flash attention is requested; a default
-# PreTrainedConfig answers no, which is the path get_vision_attention_seqlens takes for
-# every non-flash run. Without it that helper would be skipped by the probe below.
+# Filled in by name so an upstream signature reordering (5.16 inserts
+# `include_temporal` into get_vision_position_ids) cannot silently pass the wrong
+# value. `config` only decides whether flash attention is requested; a default one
+# answers no, the path get_vision_attention_seqlens takes for every non-flash run,
+# and without it the probe below would skip that helper.
 _ARGS = {
     "grid_thw": GRID_THW,
     "spatial_merge_size": 2,
@@ -91,9 +72,9 @@ _ARGS = {
 def _grid_helpers():
     """Every public vision_utils helper the modeling files call with an image grid.
 
-    Deliberately not filtered on `.tolist()`: get_vision_cu_seqlens reaches the same
-    unbacked shapes through `repeat_interleave` instead, and it is the "cannot be
-    traced fullgraph" property below that matters, not how it got there.
+    Not filtered on `.tolist()`: get_vision_cu_seqlens reaches the same unbacked
+    shapes via `repeat_interleave`, and only the "cannot be traced fullgraph"
+    property below matters, not how it got there.
     """
     found = {}
     for name in dir(vision_utils):
@@ -110,8 +91,7 @@ def _grid_helpers():
             for p, spec in params.items()
             if spec.default is inspect.Parameter.empty
         ):
-            # A required argument this test does not know how to build. Better to
-            # leave it out than to guess and report a bogus failure.
+            # A required argument this test cannot build; skip rather than guess.
             continue
         found[name] = (fn, {p: _ARGS[p] for p in params if p in _ARGS})
     return found
@@ -131,9 +111,8 @@ def test_grid_helpers_are_discoverable():
 def test_uncompilable_grid_helpers_are_listed(name):
     """Anything Dynamo cannot capture fullgraph must be in DISABLE_COMPILE_FUNCTIONS.
 
-    Stated as an implication rather than a flat "these four names are listed" so it
-    stays correct in both directions: upstream making a helper compilable does not
-    fail the test, and a new uncompilable helper does.
+    An implication rather than a flat list of names, so upstream making a helper
+    compilable does not fail, while a new uncompilable helper does.
     """
     fn, kwargs = _grid_helpers()[name]
 
@@ -155,10 +134,9 @@ def test_uncompilable_grid_helpers_are_listed(name):
     finally:
         torch._dynamo.reset()
 
-    # Whether or not it compiles, eager has to produce something usable, otherwise
-    # the probe above proved nothing about the real call path. `None` is allowed:
-    # get_vision_attention_seqlens documents a None max_seqlen when flash attention
-    # is not requested, which is exactly the config this test builds.
+    # Eager has to produce something usable either way, else the probe above proved
+    # nothing about the real call path. `None` is allowed: get_vision_attention_seqlens
+    # documents a None max_seqlen without flash attention, the config built here.
     outputs = eager if isinstance(eager, tuple) else (eager,)
     assert any(o is not None for o in outputs)
     assert all(
@@ -169,9 +147,9 @@ def test_uncompilable_grid_helpers_are_listed(name):
 def test_get_vision_position_ids_eager_result_is_the_block_major_layout():
     """The layout the disabled path has to keep producing.
 
-    Cheap oracle so "we stopped compiling it" cannot quietly turn into "we stopped
-    computing it correctly": for a single t=1 image the (row, col) pairs are the
-    h*w grid walked in spatial-merge-block order.
+    Cheap oracle so "we stopped compiling it" cannot become "we stopped computing
+    it correctly": for a t=1 image the (row, col) pairs are the h*w grid walked in
+    spatial-merge-block order.
     """
     merge_size = 2
     _, height, width = GRID_THW[0].tolist()
@@ -202,9 +180,9 @@ def test_get_vision_position_ids_eager_result_is_the_block_major_layout():
 def test_disable_compile_functions_selects_the_disable_decorator():
     """The list only works because both emit sites consult it before compiling.
 
-    Membership is checked ahead of the `torch_compile_with_fallback` branch in
-    compiler.py. If that ordering is ever inverted the names above go back to being
-    compiled and the runtime tests here would still pass, so pin the wiring too.
+    Membership is checked ahead of the `torch_compile_with_fallback` branch. Invert
+    that ordering and the names go back to being compiled while the runtime tests
+    above still pass, so pin the wiring too.
     """
     source = inspect.getsource(
         __import__("unsloth_zoo.compiler", fromlist=["compiler"])

--- a/tests/test_vision_utils_grid_helpers_eager.py
+++ b/tests/test_vision_utils_grid_helpers_eager.py
@@ -1,0 +1,209 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The transformers/vision_utils.py grid helpers must never be compiled fullgraph.
+
+transformers 5.9 pulled the per-image grid helpers every VL tower calls out of the
+individual modeling files and into a shared `transformers/vision_utils.py`. The
+modeling files import them by name, so the rewriter in compiler.py sees them as
+called functions and used to stamp
+
+    @torch_compile_with_fallback(fullgraph = True, dynamic = True, ...)
+
+on them. Each one opens by reading the image grid off the device with
+`grid_thw.tolist()`, which Dynamo turns into unbacked SymInts, and the shapes built
+from those ints are not guardable, e.g.
+
+    hpos_ids.reshape((h // merge_size, merge_size, w // merge_size, merge_size))
+    torch._dynamo.exc.UserError: Could not guard on data-dependent expression
+    Eq((u2//u3), 0)
+
+Under fullgraph = True that is a hard error rather than a graph break, so every
+Qwen3.5 / Qwen3-VL / GLM-4V / PaddleOCR-VL run died on the first vision forward.
+`fullgraph = False` was never enough on its own either: the `.tolist()` is a
+mandatory device-to-host sync on the first line, so the break lands there and the
+compiled region is only the item() prologue. The helpers are listed in
+`DISABLE_COMPILE_FUNCTIONS` so they are emitted eager instead.
+
+The interesting test here is `test_uncompilable_grid_helpers_are_listed`: it probes
+upstream directly rather than hard-coding today's four names, so a helper added to
+`vision_utils.py` by a later transformers, or one of these becoming compilable
+upstream, is picked up without editing this file.
+
+Runs on CPU. The failure is in the meta/shape layer, so no GPU is needed.
+"""
+
+import inspect
+
+import pytest
+import torch
+
+from unsloth_zoo.compiler import DISABLE_COMPILE_FUNCTIONS
+
+vision_utils = pytest.importorskip(
+    "transformers.vision_utils",
+    reason="transformers < 5.9 has no shared vision_utils module",
+)
+
+
+# A grid whose height and width are both multiples of every merge size below, so the
+# helpers have real work to do and eager execution is meaningful.
+GRID_THW = torch.tensor([[1, 24, 32]], dtype=torch.long)
+
+# Filled in by name so a signature reordering upstream (5.16 inserts `include_temporal`
+# into get_vision_position_ids, for instance) does not silently pass the wrong value.
+_ARGS = {
+    "grid_thw": GRID_THW,
+    "spatial_merge_size": 2,
+    "window_size": 112,
+    "patch_size": 14,
+    "num_grid_per_side": 32,
+}
+
+
+def _grid_helpers():
+    """Every public vision_utils helper the modeling files call with an image grid.
+
+    Deliberately not filtered on `.tolist()`: get_vision_cu_seqlens reaches the same
+    unbacked shapes through `repeat_interleave` instead, and it is the "cannot be
+    traced fullgraph" property below that matters, not how it got there.
+    """
+    found = {}
+    for name in dir(vision_utils):
+        if not name.startswith("get_vision_"):
+            continue
+        fn = getattr(vision_utils, name)
+        if not inspect.isfunction(fn):
+            continue
+        params = inspect.signature(fn).parameters
+        if "grid_thw" not in params:
+            continue
+        if any(
+            p not in _ARGS
+            for p, spec in params.items()
+            if spec.default is inspect.Parameter.empty
+        ):
+            # A required argument this test does not know how to build. Better to
+            # leave it out than to guess and report a bogus failure.
+            continue
+        found[name] = (fn, {p: _ARGS[p] for p in params if p in _ARGS})
+    return found
+
+
+def test_grid_helpers_are_discoverable():
+    """Guard the probe itself: if this finds nothing the tests below are vacuous."""
+    helpers = _grid_helpers()
+    assert "get_vision_position_ids" in helpers, (
+        "transformers.vision_utils no longer exposes a get_vision_position_ids taking "
+        f"grid_thw; found {sorted(helpers)}. Re-check what the modeling files import "
+        "before trusting the rest of this file."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(_grid_helpers()))
+def test_uncompilable_grid_helpers_are_listed(name):
+    """Anything Dynamo cannot capture fullgraph must be in DISABLE_COMPILE_FUNCTIONS.
+
+    Stated as an implication rather than a flat "these four names are listed" so it
+    stays correct in both directions: upstream making a helper compilable does not
+    fail the test, and a new uncompilable helper does.
+    """
+    fn, kwargs = _grid_helpers()[name]
+
+    eager = fn(**kwargs)
+
+    torch._dynamo.reset()
+    compiled = torch.compile(fn, fullgraph=True, dynamic=True)
+    try:
+        compiled(**kwargs)
+    except Exception as exception:
+        assert name in DISABLE_COMPILE_FUNCTIONS, (
+            f"transformers.vision_utils.{name} cannot be traced with fullgraph = True "
+            f"({type(exception).__name__}: "
+            f"{str(exception).strip().splitlines()[0][:200]}), but it is not in "
+            "compiler.py's DISABLE_COMPILE_FUNCTIONS, so the rewriter will stamp "
+            "@torch_compile_with_fallback(fullgraph = True, ...) on it and every VL "
+            "model importing it dies on the first vision forward. Add it to the list."
+        )
+    finally:
+        torch._dynamo.reset()
+
+    # Whether or not it compiles, eager has to produce something usable, otherwise
+    # the probe above proved nothing about the real call path.
+    outputs = eager if isinstance(eager, tuple) else (eager,)
+    assert all(isinstance(o, torch.Tensor) and o.numel() > 0 for o in outputs)
+
+
+def test_get_vision_position_ids_eager_result_is_the_block_major_layout():
+    """The layout the disabled path has to keep producing.
+
+    Cheap oracle so "we stopped compiling it" cannot quietly turn into "we stopped
+    computing it correctly": for a single t=1 image the (row, col) pairs are the
+    h*w grid walked in spatial-merge-block order.
+    """
+    merge_size = 2
+    _, height, width = GRID_THW[0].tolist()
+
+    position_ids = vision_utils.get_vision_position_ids(GRID_THW, merge_size)
+
+    assert position_ids.shape == (height * width, 2)
+
+    expected_rows, expected_cols = torch.meshgrid(
+        torch.arange(height), torch.arange(width), indexing="ij"
+    )
+    block_shape = (
+        height // merge_size,
+        merge_size,
+        width // merge_size,
+        merge_size,
+    )
+    expected = torch.stack(
+        [
+            expected_rows.reshape(block_shape).transpose(1, 2).flatten(),
+            expected_cols.reshape(block_shape).transpose(1, 2).flatten(),
+        ],
+        dim=-1,
+    )
+    assert torch.equal(position_ids.cpu(), expected)
+
+
+def test_disable_compile_functions_selects_the_disable_decorator():
+    """The list only works because both emit sites consult it before compiling.
+
+    Membership is checked ahead of the `torch_compile_with_fallback` branch in
+    compiler.py. If that ordering is ever inverted the names above go back to being
+    compiled and the runtime tests here would still pass, so pin the wiring too.
+    """
+    source = inspect.getsource(
+        __import__("unsloth_zoo.compiler", fromlist=["compiler"])
+    )
+
+    assert source.count("if module in disable_compile_functions:") == 2, (
+        "compiler.py no longer gates both generated-source emit sites on "
+        "disable_compile_functions; DISABLE_COMPILE_FUNCTIONS entries may no "
+        "longer take effect."
+    )
+    for name in (
+        "get_vision_position_ids",
+        "get_vision_cu_seqlens",
+        "get_vision_window_index",
+        "get_vision_bilinear_indices_and_weights",
+    ):
+        assert f'"{name}"' in source, (
+            f"compiler.py's DISABLE_COMPILE_FUNCTIONS no longer lists {name}; "
+            "transformers 5.9+ VL models will crash with "
+            "'Could not guard on data-dependent expression' on the first vision forward."
+        )

--- a/tests/test_vision_utils_grid_helpers_eager.py
+++ b/tests/test_vision_utils_grid_helpers_eager.py
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Grid helpers in transformers/vision_utils.py must never be compiled fullgraph:
-`grid_thw.tolist()` builds unguardable shapes from unbacked SymInts, a hard UserError
-on the first vision forward for Qwen3-VL / GLM-4V / PaddleOCR-VL. The probe below
-enumerates vision_utils rather than hard-coding today's names."""
+`grid_thw.tolist()` builds unguardable shapes from unbacked SymInts, a hard UserError on
+the first vision forward. The probe below enumerates vision_utils rather than hard-coding
+today's names."""
 
 import inspect
 
@@ -35,8 +35,8 @@ vision_utils = pytest.importorskip(
 
 GRID_THW = torch.tensor([[1, 24, 32]], dtype=torch.long)
 
-# Keyed by name so an upstream signature reorder cannot pass the wrong value; without
-# a default (non-flash) `config` the probe below skips get_vision_attention_seqlens.
+# Keyed by name so an upstream signature reorder cannot pass the wrong value; without a
+# default `config` the probe below skips get_vision_attention_seqlens.
 _ARGS = {
     "grid_thw": GRID_THW,
     "spatial_merge_size": 2,
@@ -81,9 +81,8 @@ def test_grid_helpers_are_discoverable():
 
 @pytest.mark.parametrize("name", sorted(_grid_helpers()))
 def test_uncompilable_grid_helpers_are_listed(name):
-    """Anything Dynamo cannot capture fullgraph must be in DISABLE_COMPILE_FUNCTIONS.
-    One-directional on purpose: the assert fires only inside `except`, so a helper
-    becoming traceable upstream cannot fail it while a new uncompilable one does."""
+    """Anything Dynamo cannot capture fullgraph must be in DISABLE_COMPILE_FUNCTIONS. The
+    assert fires only inside `except`, so a helper turning traceable upstream cannot fail it."""
     fn, kwargs = _grid_helpers()[name]
 
     eager = fn(**kwargs)
@@ -140,8 +139,8 @@ def test_get_vision_position_ids_eager_result_is_the_block_major_layout():
 
 
 def test_disable_compile_functions_selects_the_disable_decorator():
-    """Membership is checked ahead of the `torch_compile_with_fallback` branch; invert
-    that and these names compile again while the runtime tests above still pass."""
+    """Membership is checked ahead of the `torch_compile_with_fallback` branch; invert that
+    and these names compile again while the runtime tests above still pass."""
     source = inspect.getsource(
         __import__("unsloth_zoo.compiler", fromlist=["compiler"])
     )

--- a/tests/test_vision_utils_grid_helpers_eager.py
+++ b/tests/test_vision_utils_grid_helpers_eager.py
@@ -38,10 +38,19 @@ mandatory device-to-host sync on the first line, so the break lands there and th
 compiled region is only the item() prologue. The helpers are listed in
 `DISABLE_COMPILE_FUNCTIONS` so they are emitted eager instead.
 
+Which helpers actually trip is torch dependent: pytorch 48dbd60df482
+(pytorch#162354, in v2.10.0 but not v2.9.x) made the guards in
+`are_strides_like_channels_last` non-throwing, so on torch >= 2.10 several of these
+trace cleanly again. That is precisely why the test below is written as an
+implication rather than a fixed list of names, and why it passes on both sides of
+that boundary.
+
 The interesting test here is `test_uncompilable_grid_helpers_are_listed`: it probes
-upstream directly rather than hard-coding today's four names, so a helper added to
+upstream directly rather than hard-coding today's names, so a helper added to
 `vision_utils.py` by a later transformers, or one of these becoming compilable
-upstream, is picked up without editing this file.
+upstream, is picked up without editing this file. That is not hypothetical:
+transformers 5.16 deprecated `get_vision_bilinear_indices_and_weights` in favour of
+`get_vision_interpolation_indices_and_weights`, and the probe caught the new name.
 
 Runs on CPU. The failure is in the meta/shape layer, so no GPU is needed.
 """
@@ -50,6 +59,7 @@ import inspect
 
 import pytest
 import torch
+import transformers
 
 from unsloth_zoo.compiler import DISABLE_COMPILE_FUNCTIONS
 
@@ -65,12 +75,16 @@ GRID_THW = torch.tensor([[1, 24, 32]], dtype=torch.long)
 
 # Filled in by name so a signature reordering upstream (5.16 inserts `include_temporal`
 # into get_vision_position_ids, for instance) does not silently pass the wrong value.
+# `config` is only read to decide whether flash attention is requested; a default
+# PreTrainedConfig answers no, which is the path get_vision_attention_seqlens takes for
+# every non-flash run. Without it that helper would be skipped by the probe below.
 _ARGS = {
     "grid_thw": GRID_THW,
     "spatial_merge_size": 2,
     "window_size": 112,
     "patch_size": 14,
     "num_grid_per_side": 32,
+    "config": transformers.PreTrainedConfig(),
 }
 
 
@@ -142,9 +156,14 @@ def test_uncompilable_grid_helpers_are_listed(name):
         torch._dynamo.reset()
 
     # Whether or not it compiles, eager has to produce something usable, otherwise
-    # the probe above proved nothing about the real call path.
+    # the probe above proved nothing about the real call path. `None` is allowed:
+    # get_vision_attention_seqlens documents a None max_seqlen when flash attention
+    # is not requested, which is exactly the config this test builds.
     outputs = eager if isinstance(eager, tuple) else (eager,)
-    assert all(isinstance(o, torch.Tensor) and o.numel() > 0 for o in outputs)
+    assert any(o is not None for o in outputs)
+    assert all(
+        isinstance(o, torch.Tensor) and o.numel() > 0 for o in outputs if o is not None
+    )
 
 
 def test_get_vision_position_ids_eager_result_is_the_block_major_layout():
@@ -199,7 +218,9 @@ def test_disable_compile_functions_selects_the_disable_decorator():
     for name in (
         "get_vision_position_ids",
         "get_vision_cu_seqlens",
+        "get_vision_attention_seqlens",
         "get_vision_window_index",
+        "get_vision_interpolation_indices_and_weights",
         "get_vision_bilinear_indices_and_weights",
     ):
         assert f'"{name}"' in source, (

--- a/tests/test_vision_utils_grid_helpers_eager.py
+++ b/tests/test_vision_utils_grid_helpers_eager.py
@@ -14,27 +14,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""The transformers/vision_utils.py grid helpers must never be compiled fullgraph.
-
-transformers 5.9 moved the per-image grid helpers every VL tower calls into a shared
-`transformers/vision_utils.py`, and compiler.py's rewriter used to stamp
-fullgraph = True on them. Each opens by reading the grid off the device with
-`grid_thw.tolist()`, so the shapes built from those unbacked SymInts are not
-guardable (`UserError: Could not guard on data-dependent expression Eq((u2//u3), 0)`
-out of `reshape((h // merge, merge, w // merge, merge))`). Under fullgraph = True
-that is a hard error rather than a graph break, so every Qwen3.5 / Qwen3-VL /
-GLM-4V / PaddleOCR-VL run died on the first vision forward. fullgraph = False alone
-is not enough either, since the `.tolist()` sync breaks the graph on line 1, so the
-helpers are listed in `DISABLE_COMPILE_FUNCTIONS` and emitted eager.
-
-Which helpers trip is torch dependent (pytorch#162354 made the guards non-throwing
-in 2.10), so `test_uncompilable_grid_helpers_are_listed` probes upstream and asserts
-an implication rather than a fixed list of names: it passes on both sides of that
-boundary and picks up new helpers without an edit here, which is how 5.16's
-`get_vision_interpolation_indices_and_weights` was caught.
-
-CPU only: the failure is in the meta/shape layer.
-"""
+"""Grid helpers in transformers/vision_utils.py must never be compiled fullgraph:
+`grid_thw.tolist()` builds unguardable shapes from unbacked SymInts, a hard UserError
+on the first vision forward for Qwen3-VL / GLM-4V / PaddleOCR-VL. The probe below
+enumerates vision_utils rather than hard-coding today's names."""
 
 import inspect
 
@@ -50,15 +33,10 @@ vision_utils = pytest.importorskip(
 )
 
 
-# Height and width are multiples of every merge size below, so the helpers have real
-# work to do.
 GRID_THW = torch.tensor([[1, 24, 32]], dtype=torch.long)
 
-# Filled in by name so an upstream signature reordering (5.16 inserts
-# `include_temporal` into get_vision_position_ids) cannot silently pass the wrong
-# value. `config` only decides whether flash attention is requested; a default one
-# answers no, the path get_vision_attention_seqlens takes for every non-flash run,
-# and without it the probe below would skip that helper.
+# Keyed by name so an upstream signature reorder cannot pass the wrong value; without
+# a default (non-flash) `config` the probe below skips get_vision_attention_seqlens.
 _ARGS = {
     "grid_thw": GRID_THW,
     "spatial_merge_size": 2,
@@ -70,12 +48,8 @@ _ARGS = {
 
 
 def _grid_helpers():
-    """Every public vision_utils helper the modeling files call with an image grid.
-
-    Not filtered on `.tolist()`: get_vision_cu_seqlens reaches the same unbacked
-    shapes via `repeat_interleave`, and only the "cannot be traced fullgraph"
-    property below matters, not how it got there.
-    """
+    """Public vision_utils helpers taking an image grid. Not filtered on `.tolist()`:
+    get_vision_cu_seqlens reaches the same unbacked shapes via `repeat_interleave`."""
     found = {}
     for name in dir(vision_utils):
         if not name.startswith("get_vision_"):
@@ -91,14 +65,12 @@ def _grid_helpers():
             for p, spec in params.items()
             if spec.default is inspect.Parameter.empty
         ):
-            # A required argument this test cannot build; skip rather than guess.
             continue
         found[name] = (fn, {p: _ARGS[p] for p in params if p in _ARGS})
     return found
 
 
 def test_grid_helpers_are_discoverable():
-    """Guard the probe itself: if this finds nothing the tests below are vacuous."""
     helpers = _grid_helpers()
     assert "get_vision_position_ids" in helpers, (
         "transformers.vision_utils no longer exposes a get_vision_position_ids taking "
@@ -110,10 +82,8 @@ def test_grid_helpers_are_discoverable():
 @pytest.mark.parametrize("name", sorted(_grid_helpers()))
 def test_uncompilable_grid_helpers_are_listed(name):
     """Anything Dynamo cannot capture fullgraph must be in DISABLE_COMPILE_FUNCTIONS.
-
-    An implication rather than a flat list of names, so upstream making a helper
-    compilable does not fail, while a new uncompilable helper does.
-    """
+    One-directional on purpose: the assert fires only inside `except`, so a helper
+    becoming traceable upstream cannot fail it while a new uncompilable one does."""
     fn, kwargs = _grid_helpers()[name]
 
     eager = fn(**kwargs)
@@ -134,9 +104,7 @@ def test_uncompilable_grid_helpers_are_listed(name):
     finally:
         torch._dynamo.reset()
 
-    # Eager has to produce something usable either way, else the probe above proved
-    # nothing about the real call path. `None` is allowed: get_vision_attention_seqlens
-    # documents a None max_seqlen without flash attention, the config built here.
+    # `None` is documented for get_vision_attention_seqlens without flash attention.
     outputs = eager if isinstance(eager, tuple) else (eager,)
     assert any(o is not None for o in outputs)
     assert all(
@@ -145,12 +113,6 @@ def test_uncompilable_grid_helpers_are_listed(name):
 
 
 def test_get_vision_position_ids_eager_result_is_the_block_major_layout():
-    """The layout the disabled path has to keep producing.
-
-    Cheap oracle so "we stopped compiling it" cannot become "we stopped computing
-    it correctly": for a t=1 image the (row, col) pairs are the h*w grid walked in
-    spatial-merge-block order.
-    """
     merge_size = 2
     _, height, width = GRID_THW[0].tolist()
 
@@ -178,12 +140,8 @@ def test_get_vision_position_ids_eager_result_is_the_block_major_layout():
 
 
 def test_disable_compile_functions_selects_the_disable_decorator():
-    """The list only works because both emit sites consult it before compiling.
-
-    Membership is checked ahead of the `torch_compile_with_fallback` branch. Invert
-    that ordering and the names go back to being compiled while the runtime tests
-    above still pass, so pin the wiring too.
-    """
+    """Membership is checked ahead of the `torch_compile_with_fallback` branch; invert
+    that and these names compile again while the runtime tests above still pass."""
     source = inspect.getsource(
         __import__("unsloth_zoo.compiler", fromlist=["compiler"])
     )

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -153,12 +153,21 @@ DISABLE_COMPILE_FUNCTIONS = [
     # way transformers 5.2 does for chunk_gated_delta_rule, stays uncompiled.
     "recurrent_gated_delta_rule",
 
-    # transformers 5.9+ VL files import these; their `grid_thw.tolist()` builds shapes
-    # from unbacked SymInts, so fullgraph = True is a hard UserError on the first vision
-    # forward. Needs transformers >= 5.9 AND torch < 2.10 (pytorch 48dbd60df48,
-    # pytorch#162354, swapped guard_size_oblivious for guard_or_true), and we support
-    # torch well below 2.10. bilinear_indices, deprecated at 5.16 and imported by no
-    # modeling file today, is listed so a model going back to it stays uncompiled.
+    # transformers 5.9+ VL files import these; `grid_thw.tolist()` builds shapes from
+    # unbacked SymInts, so fullgraph = True is a hard error on the first vision forward.
+    # Deliberately NOT gated on torch version. pytorch 48dbd60df48 (pytorch#162354)
+    # swapped guard_size_oblivious for guard_or_true and does make four of them
+    # traceable, but measured on torch 2.9.1 / 2.10.0 / 2.11.0 against transformers
+    # 5.16.1, window_index still dies on GuardOnDataDependentSymNode at
+    # `cu_window_seqlens.extend(cu_seqlens_tmp.tolist())` and bilinear_indices on its
+    # deprecation warning; on transformers 5.14.1, attention_seqlens and
+    # interpolation_indices break on torch 2.11 too. A `torch < 2.10` gate would put the
+    # crash back for qwen2_5_vl and qwen2_5_omni on the default install. Listing the
+    # traceable ones anyway costs one demoted caller across 10 VL model types
+    # (minimax_m3_vl's 3DRotaryEmbedding), because every VL vision forward is already
+    # off fullgraph through an earlier tier. bilinear_indices, deprecated at 5.16 and
+    # imported by no modeling file today, is listed so a model going back to it stays
+    # uncompiled.
     "get_vision_position_ids",
     "get_vision_cu_seqlens",
     "get_vision_attention_seqlens",

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -156,28 +156,35 @@ DISABLE_COMPILE_FUNCTIONS = [
     # transformers 5.9 moved the vision grid helpers every VL tower calls into the
     # shared transformers/vision_utils.py, and the modeling files now import them by
     # name, so the rewriter picks them up as called functions and stamps
-    # fullgraph = True on them. Every one of them starts by reading the image grid
-    # off the GPU with `grid_thw.tolist()`, which Dynamo turns into unbacked
-    # SymInts, and the shapes built from those ints are then unguardable:
-    #   get_vision_position_ids               reshape((h//m, m, w//m, m))
-    #                                         -> Eq((u2//u3), 0)
-    #   get_vision_window_index               -> Eq(((u1//2) - PythonMod(...))//4 + 1, 0)
-    #   get_vision_bilinear_indices_and_weights
-    #                                         -> could not extract specialized integer u1
-    #   get_vision_cu_seqlens                 repeat_interleave -> Dynamic shape operator
-    # fullgraph = True turns those into a hard UserError, so Qwen3.5 / Qwen3-VL /
-    # GLM-4V / PaddleOCR-VL and friends died at the first vision forward. There is
-    # nothing to win by compiling them anyway: the `.tolist()` is a mandatory D2H
-    # sync on the first line, so a graph break lands there and the "compiled"
-    # region is only the item() prologue. Measured on a single 24x32 grid these run
-    # 125 us eager against 133 us under torch.compile, so eager is the faster half
-    # as well as the working one.
+    # fullgraph = True on them. They read the image grid off the GPU with
+    # `grid_thw.tolist()` / `repeat_interleave`, which Dynamo turns into unbacked
+    # SymInts, and the shapes built from those are then unguardable, e.g.
+    # get_vision_position_ids' reshape((h//m, m, w//m, m)) -> Eq((u2//u3), 0).
+    # fullgraph = True makes that a hard UserError rather than a graph break, so
+    # Qwen3.5 / Qwen3-VL / GLM-4V / PaddleOCR-VL died at the first vision forward.
+    #
+    # The trigger is transformers >= 5.9 AND torch < 2.10, not transformers alone.
+    # pytorch 48dbd60df482 (pytorch#162354, in v2.10.0, not in v2.9.x) rewrote the
+    # guard_size_oblivious calls in are_strides_like_channels_last as guard_or_true,
+    # which never raises. Probed at transformers 5.16.1 on torch 2.9.1 vs 2.10.0:
+    # position_ids, cu_seqlens, attention_seqlens and interpolation_indices fail on
+    # 2.9.1 and trace fine on 2.10.0, while window_index (data-dependent guard) and
+    # bilinear_indices (logger.warning_once) still fail on both. We support torch
+    # well below 2.10, so every one of them stays listed.
+    #
+    # Nothing is won by compiling them anyway: the `.tolist()` is a mandatory D2H
+    # sync on the first line, so a graph break lands there and the "compiled" region
+    # is only the item() prologue. Measured on a single 24x32 grid these run 125 us
+    # eager against 133 us under torch.compile.
     # Matching is by name, so on transformers < 5.9, where these names are not in
     # the modeling source, none of these entries match and the generated module is
-    # unchanged.
+    # unchanged. Names no modeling file imports today (bilinear_indices, deprecated
+    # at 5.16 in favour of interpolation_indices) are kept for the same reason.
     "get_vision_position_ids",
     "get_vision_cu_seqlens",
+    "get_vision_attention_seqlens",
     "get_vision_window_index",
+    "get_vision_interpolation_indices_and_weights",
     "get_vision_bilinear_indices_and_weights",
 ]
 

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -188,6 +188,30 @@ DISABLE_COMPILE_FUNCTIONS = [
     "get_vision_bilinear_indices_and_weights",
 ]
 
+
+def calls_disable_compile_function(source, disable_compile_functions):
+    """Names from `DISABLE_COMPILE_FUNCTIONS` that `source` CALLS.
+
+    Listing a name only helps where the rewriter re-emits its `def`, which needs
+    `def <name>` in the modeling file's own source. A modeling file that merely
+    imports the helper (every transformers >= 5.9 VL tower, since the vision grid
+    helpers moved to transformers/vision_utils.py) keeps calling the raw upstream
+    function, so the caller must not be compiled `fullgraph = True` or Dynamo
+    inlines the `.tolist()` and the region dies. Answering that question is what
+    this is for; it is a deliberate superset of the `called_functions` membership
+    test one level up.
+
+    `[^\\w.]` excludes attribute calls: qwen3_vl, glm4v and qwen2_5_vl all define
+    a METHOD named `get_vision_position_ids`, and `self.get_vision_position_ids(...)`
+    is not the module-level helper.
+    """
+    return sorted(
+        name
+        for name in disable_compile_functions
+        if re.search(r"[^\w.]" + re.escape(name) + r"[\s]{0,}\(", source)
+    )
+
+
 # Re-exported from .model_lists so callers can keep using
 # `from unsloth_zoo.compiler import FORCE_FLOAT32`.
 from .model_lists import FORCE_FLOAT32  # noqa: E402,F401
@@ -4957,6 +4981,39 @@ def unsloth_compile_transformers(
             bad_torch_modules.add(module)
         pass
 
+        # Tier 3: the data-dependent op is one call level down, inside a helper
+        # this file only IMPORTS. `called_functions` below needs `def <name>` in
+        # the modeling file's own source, so a DISABLE_COMPILE_FUNCTIONS entry
+        # for an imported-only helper never reaches either disable branch and
+        # `create_new_function` imports the raw upstream function into the
+        # generated module, where Dynamo inlines it. transformers >= 5.9 moved
+        # the vision grid helpers into transformers/vision_utils.py, and 47 of
+        # the 61 (modeling file, helper) import pairs in 5.16.1 are
+        # imported-only. Two of them land in a fullgraph = True region:
+        #   MiniMaxM3VL3DRotaryEmbedding.forward  -> get_vision_position_ids
+        #   Kimi_K25VisionPositionEmbeddings.forward
+        #                        -> get_vision_interpolation_indices_and_weights
+        # and both died on the first vision forward with
+        #   torch._dynamo.exc.Unsupported: Backend compiler exception
+        #   Backend compiler `inductor` failed with aten._local_scalar_dense.default
+        #   ... in get_vision_position_ids: grid_thw.tolist()
+        # fullgraph = False rather than bad_torch_modules: the break lands at the
+        # helper's `.tolist()` and the rest of the forward still compiles. Making
+        # the helper itself `@torch.compiler.disable` is NOT an alternative here,
+        # it is the same crash with a different message - a disabled callee is
+        # a graph break, and a graph break under fullgraph = True raises
+        # `Unsupported: Skip inlining torch.compiler.disable()d function`.
+        called_disabled = calls_disable_compile_function(
+            source, disable_compile_functions
+        )
+        if fullgraph and len(called_disabled) != 0:
+            print(
+                f"Unsloth: Will compile {module} without fullgraph since it calls "
+                f"{', '.join(called_disabled)}, which cannot be traced."
+            )
+            no_fullgraph_modules.add(module)
+        pass
+
         if (
             fullgraph
             and len(output_capture_target_names) > 0
@@ -5492,7 +5549,13 @@ def unsloth_compile_transformers(
                     + parameters
                 )
             elif not disable:
-                parameters = f"@torch_compile_with_fallback(fullgraph = {UNSLOTH_FULLGRAPH}, dynamic = True, options = torch_compile_options)\n{parameters}"
+                # Same reason as the `no_fullgraph_modules` demotion above: a
+                # helper we have declared untraceable is untraceable from here
+                # too, whether it is re-emitted or imported raw.
+                _fullgraph = UNSLOTH_FULLGRAPH and not calls_disable_compile_function(
+                    parameters, disable_compile_functions
+                )
+                parameters = f"@torch_compile_with_fallback(fullgraph = {_fullgraph}, dynamic = True, options = torch_compile_options)\n{parameters}"
             all_standalone_classes[module] = parameters
         pass
 
@@ -5556,7 +5619,10 @@ def unsloth_compile_transformers(
                     if "@torch.compiler.disable(recursive = False)\n" not in source:
                         source = "@torch.compiler.disable(recursive = False)\n" + source
                 elif not disable:
-                    source = f"@torch_compile_with_fallback(fullgraph = {UNSLOTH_FULLGRAPH}, dynamic = True, options = torch_compile_options)\n{source}"
+                    _fullgraph = UNSLOTH_FULLGRAPH and not calls_disable_compile_function(
+                        source, disable_compile_functions
+                    )
+                    source = f"@torch_compile_with_fallback(fullgraph = {_fullgraph}, dynamic = True, options = torch_compile_options)\n{source}"
                 print(f"Unsloth: Compiled function {module}.")
             else:
                 print(

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -153,20 +153,12 @@ DISABLE_COMPILE_FUNCTIONS = [
     # way transformers 5.2 does for chunk_gated_delta_rule, stays uncompiled.
     "recurrent_gated_delta_rule",
 
-    # transformers 5.9 moved the vision grid helpers every VL tower calls into the
-    # shared transformers/vision_utils.py. Each reads the grid off the GPU with
-    # `grid_thw.tolist()` / `repeat_interleave`, so Dynamo builds shapes out of
-    # unbacked SymInts and cannot guard them, e.g. get_vision_position_ids'
-    # reshape((h//m, m, w//m, m)) -> Eq((u2//u3), 0). Under fullgraph = True that is
-    # a hard UserError rather than a graph break, killing Qwen3.5 / Qwen3-VL /
-    # GLM-4V / PaddleOCR-VL on the first vision forward. torch >= 2.10
-    # (pytorch#162354) makes some trace again, but window_index and
-    # bilinear_indices still fail there, and we support torch well below 2.10, so
-    # all of them stay listed. Compiling them wins nothing anyway: the `.tolist()`
-    # is a mandatory D2H sync on line 1, so the break lands there and a 24x32 grid
-    # measures 125 us eager against 133 us compiled. Matching is by name, so on
-    # transformers < 5.9, and for names nothing imports today (bilinear_indices,
-    # deprecated at 5.16), no entry matches and the generated module is unchanged.
+    # transformers 5.9+ VL files import these; their `grid_thw.tolist()` builds shapes
+    # from unbacked SymInts, so fullgraph = True is a hard UserError on the first vision
+    # forward. Needs transformers >= 5.9 AND torch < 2.10 (pytorch 48dbd60df48,
+    # pytorch#162354, swapped guard_size_oblivious for guard_or_true), and we support
+    # torch well below 2.10. bilinear_indices, deprecated at 5.16 and imported by no
+    # modeling file today, is listed so a model going back to it stays uncompiled.
     "get_vision_position_ids",
     "get_vision_cu_seqlens",
     "get_vision_attention_seqlens",
@@ -177,17 +169,10 @@ DISABLE_COMPILE_FUNCTIONS = [
 
 
 def calls_disable_compile_function(source, disable_compile_functions):
-    """Names from `DISABLE_COMPILE_FUNCTIONS` that `source` CALLS.
-
-    A modeling file that only imports a helper (every transformers >= 5.9 VL
-    tower) keeps calling the raw upstream function, so the caller must not be
-    compiled `fullgraph = True` or Dynamo inlines the `.tolist()` and the region
-    dies. Deliberately a superset of the `called_functions` test one level up,
-    which also requires `def <name>` in the modeling file's own source.
-
-    `[^\\w.]` excludes attribute calls: qwen3_vl, glm4v and qwen2_5_vl all define
-    a METHOD named `get_vision_position_ids`, which is not this helper.
-    """
+    """Names from `DISABLE_COMPILE_FUNCTIONS` that `source` CALLS: deliberately a
+    superset of the `called_functions` test one level up, which also requires
+    `def <name>` locally and so misses every imported-only helper. `[^\\w.]` excludes
+    attribute calls; qwen3_vl, glm4v and qwen2_5_vl define a METHOD of the same name."""
     return sorted(
         name
         for name in disable_compile_functions
@@ -4964,21 +4949,10 @@ def unsloth_compile_transformers(
             bad_torch_modules.add(module)
         pass
 
-        # Tier 3: the data-dependent op is one call level down, inside a helper
-        # this file only IMPORTS. `called_functions` below needs `def <name>` in
-        # the modeling file's own source, so a DISABLE_COMPILE_FUNCTIONS entry for
-        # an imported-only helper reaches neither disable branch and
-        # `create_new_function` imports the raw upstream function for Dynamo to
-        # inline. At transformers 5.16.1 47 of the 61 (modeling file, helper)
-        # import pairs are imported-only, and two sit in a fullgraph = True region
-        # (MiniMaxM3VL3DRotaryEmbedding.forward -> get_vision_position_ids,
-        # Kimi_K25VisionPositionEmbeddings.forward -> ..._interpolation_indices...),
-        # both dying on the first vision forward with `inductor failed with
-        # aten._local_scalar_dense.default ... grid_thw.tolist()`. Demote to
-        # fullgraph = False rather than bad_torch_modules so only the `.tolist()`
-        # breaks and the rest of the forward still compiles. Marking the helper
-        # `@torch.compiler.disable` is not an alternative: a disabled callee is a
-        # graph break, which under fullgraph = True is the same hard error.
+        # Tier 3: an imported-only callee is never in `called_functions`, so the raw
+        # upstream helper is imported for Dynamo to inline. Demote the CALLER; marking
+        # the helper `@torch.compiler.disable` is not an alternative, a disabled callee
+        # is itself a graph break and that is the same hard error under fullgraph.
         called_disabled = calls_disable_compile_function(
             source, disable_compile_functions
         )
@@ -5525,8 +5499,6 @@ def unsloth_compile_transformers(
                     + parameters
                 )
             elif not disable:
-                # As with the `no_fullgraph_modules` demotion above: a helper we
-                # declared untraceable is untraceable from here too.
                 _fullgraph = UNSLOTH_FULLGRAPH and not calls_disable_compile_function(
                     parameters, disable_compile_functions
                 )

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -152,6 +152,33 @@ DISABLE_COMPILE_FUNCTIONS = [
     # nothing today; it is here so one that goes back to importing it by name, the
     # way transformers 5.2 does for chunk_gated_delta_rule, stays uncompiled.
     "recurrent_gated_delta_rule",
+
+    # transformers 5.9 moved the vision grid helpers every VL tower calls into the
+    # shared transformers/vision_utils.py, and the modeling files now import them by
+    # name, so the rewriter picks them up as called functions and stamps
+    # fullgraph = True on them. Every one of them starts by reading the image grid
+    # off the GPU with `grid_thw.tolist()`, which Dynamo turns into unbacked
+    # SymInts, and the shapes built from those ints are then unguardable:
+    #   get_vision_position_ids               reshape((h//m, m, w//m, m))
+    #                                         -> Eq((u2//u3), 0)
+    #   get_vision_window_index               -> Eq(((u1//2) - PythonMod(...))//4 + 1, 0)
+    #   get_vision_bilinear_indices_and_weights
+    #                                         -> could not extract specialized integer u1
+    #   get_vision_cu_seqlens                 repeat_interleave -> Dynamic shape operator
+    # fullgraph = True turns those into a hard UserError, so Qwen3.5 / Qwen3-VL /
+    # GLM-4V / PaddleOCR-VL and friends died at the first vision forward. There is
+    # nothing to win by compiling them anyway: the `.tolist()` is a mandatory D2H
+    # sync on the first line, so a graph break lands there and the "compiled"
+    # region is only the item() prologue. Measured on a single 24x32 grid these run
+    # 125 us eager against 133 us under torch.compile, so eager is the faster half
+    # as well as the working one.
+    # Matching is by name, so on transformers < 5.9, where these names are not in
+    # the modeling source, none of these entries match and the generated module is
+    # unchanged.
+    "get_vision_position_ids",
+    "get_vision_cu_seqlens",
+    "get_vision_window_index",
+    "get_vision_bilinear_indices_and_weights",
 ]
 
 # Re-exported from .model_lists so callers can keep using

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -154,32 +154,19 @@ DISABLE_COMPILE_FUNCTIONS = [
     "recurrent_gated_delta_rule",
 
     # transformers 5.9 moved the vision grid helpers every VL tower calls into the
-    # shared transformers/vision_utils.py, and the modeling files now import them by
-    # name, so the rewriter picks them up as called functions and stamps
-    # fullgraph = True on them. They read the image grid off the GPU with
-    # `grid_thw.tolist()` / `repeat_interleave`, which Dynamo turns into unbacked
-    # SymInts, and the shapes built from those are then unguardable, e.g.
-    # get_vision_position_ids' reshape((h//m, m, w//m, m)) -> Eq((u2//u3), 0).
-    # fullgraph = True makes that a hard UserError rather than a graph break, so
-    # Qwen3.5 / Qwen3-VL / GLM-4V / PaddleOCR-VL died at the first vision forward.
-    #
-    # The trigger is transformers >= 5.9 AND torch < 2.10, not transformers alone.
-    # pytorch 48dbd60df482 (pytorch#162354, in v2.10.0, not in v2.9.x) rewrote the
-    # guard_size_oblivious calls in are_strides_like_channels_last as guard_or_true,
-    # which never raises. Probed at transformers 5.16.1 on torch 2.9.1 vs 2.10.0:
-    # position_ids, cu_seqlens, attention_seqlens and interpolation_indices fail on
-    # 2.9.1 and trace fine on 2.10.0, while window_index (data-dependent guard) and
-    # bilinear_indices (logger.warning_once) still fail on both. We support torch
-    # well below 2.10, so every one of them stays listed.
-    #
-    # Nothing is won by compiling them anyway: the `.tolist()` is a mandatory D2H
-    # sync on the first line, so a graph break lands there and the "compiled" region
-    # is only the item() prologue. Measured on a single 24x32 grid these run 125 us
-    # eager against 133 us under torch.compile.
-    # Matching is by name, so on transformers < 5.9, where these names are not in
-    # the modeling source, none of these entries match and the generated module is
-    # unchanged. Names no modeling file imports today (bilinear_indices, deprecated
-    # at 5.16 in favour of interpolation_indices) are kept for the same reason.
+    # shared transformers/vision_utils.py. Each reads the grid off the GPU with
+    # `grid_thw.tolist()` / `repeat_interleave`, so Dynamo builds shapes out of
+    # unbacked SymInts and cannot guard them, e.g. get_vision_position_ids'
+    # reshape((h//m, m, w//m, m)) -> Eq((u2//u3), 0). Under fullgraph = True that is
+    # a hard UserError rather than a graph break, killing Qwen3.5 / Qwen3-VL /
+    # GLM-4V / PaddleOCR-VL on the first vision forward. torch >= 2.10
+    # (pytorch#162354) makes some trace again, but window_index and
+    # bilinear_indices still fail there, and we support torch well below 2.10, so
+    # all of them stay listed. Compiling them wins nothing anyway: the `.tolist()`
+    # is a mandatory D2H sync on line 1, so the break lands there and a 24x32 grid
+    # measures 125 us eager against 133 us compiled. Matching is by name, so on
+    # transformers < 5.9, and for names nothing imports today (bilinear_indices,
+    # deprecated at 5.16), no entry matches and the generated module is unchanged.
     "get_vision_position_ids",
     "get_vision_cu_seqlens",
     "get_vision_attention_seqlens",
@@ -192,18 +179,14 @@ DISABLE_COMPILE_FUNCTIONS = [
 def calls_disable_compile_function(source, disable_compile_functions):
     """Names from `DISABLE_COMPILE_FUNCTIONS` that `source` CALLS.
 
-    Listing a name only helps where the rewriter re-emits its `def`, which needs
-    `def <name>` in the modeling file's own source. A modeling file that merely
-    imports the helper (every transformers >= 5.9 VL tower, since the vision grid
-    helpers moved to transformers/vision_utils.py) keeps calling the raw upstream
-    function, so the caller must not be compiled `fullgraph = True` or Dynamo
-    inlines the `.tolist()` and the region dies. Answering that question is what
-    this is for; it is a deliberate superset of the `called_functions` membership
-    test one level up.
+    A modeling file that only imports a helper (every transformers >= 5.9 VL
+    tower) keeps calling the raw upstream function, so the caller must not be
+    compiled `fullgraph = True` or Dynamo inlines the `.tolist()` and the region
+    dies. Deliberately a superset of the `called_functions` test one level up,
+    which also requires `def <name>` in the modeling file's own source.
 
     `[^\\w.]` excludes attribute calls: qwen3_vl, glm4v and qwen2_5_vl all define
-    a METHOD named `get_vision_position_ids`, and `self.get_vision_position_ids(...)`
-    is not the module-level helper.
+    a METHOD named `get_vision_position_ids`, which is not this helper.
     """
     return sorted(
         name
@@ -4983,26 +4966,19 @@ def unsloth_compile_transformers(
 
         # Tier 3: the data-dependent op is one call level down, inside a helper
         # this file only IMPORTS. `called_functions` below needs `def <name>` in
-        # the modeling file's own source, so a DISABLE_COMPILE_FUNCTIONS entry
-        # for an imported-only helper never reaches either disable branch and
-        # `create_new_function` imports the raw upstream function into the
-        # generated module, where Dynamo inlines it. transformers >= 5.9 moved
-        # the vision grid helpers into transformers/vision_utils.py, and 47 of
-        # the 61 (modeling file, helper) import pairs in 5.16.1 are
-        # imported-only. Two of them land in a fullgraph = True region:
-        #   MiniMaxM3VL3DRotaryEmbedding.forward  -> get_vision_position_ids
-        #   Kimi_K25VisionPositionEmbeddings.forward
-        #                        -> get_vision_interpolation_indices_and_weights
-        # and both died on the first vision forward with
-        #   torch._dynamo.exc.Unsupported: Backend compiler exception
-        #   Backend compiler `inductor` failed with aten._local_scalar_dense.default
-        #   ... in get_vision_position_ids: grid_thw.tolist()
-        # fullgraph = False rather than bad_torch_modules: the break lands at the
-        # helper's `.tolist()` and the rest of the forward still compiles. Making
-        # the helper itself `@torch.compiler.disable` is NOT an alternative here,
-        # it is the same crash with a different message - a disabled callee is
-        # a graph break, and a graph break under fullgraph = True raises
-        # `Unsupported: Skip inlining torch.compiler.disable()d function`.
+        # the modeling file's own source, so a DISABLE_COMPILE_FUNCTIONS entry for
+        # an imported-only helper reaches neither disable branch and
+        # `create_new_function` imports the raw upstream function for Dynamo to
+        # inline. At transformers 5.16.1 47 of the 61 (modeling file, helper)
+        # import pairs are imported-only, and two sit in a fullgraph = True region
+        # (MiniMaxM3VL3DRotaryEmbedding.forward -> get_vision_position_ids,
+        # Kimi_K25VisionPositionEmbeddings.forward -> ..._interpolation_indices...),
+        # both dying on the first vision forward with `inductor failed with
+        # aten._local_scalar_dense.default ... grid_thw.tolist()`. Demote to
+        # fullgraph = False rather than bad_torch_modules so only the `.tolist()`
+        # breaks and the rest of the forward still compiles. Marking the helper
+        # `@torch.compiler.disable` is not an alternative: a disabled callee is a
+        # graph break, which under fullgraph = True is the same hard error.
         called_disabled = calls_disable_compile_function(
             source, disable_compile_functions
         )
@@ -5549,9 +5525,8 @@ def unsloth_compile_transformers(
                     + parameters
                 )
             elif not disable:
-                # Same reason as the `no_fullgraph_modules` demotion above: a
-                # helper we have declared untraceable is untraceable from here
-                # too, whether it is re-emitted or imported raw.
+                # As with the `no_fullgraph_modules` demotion above: a helper we
+                # declared untraceable is untraceable from here too.
                 _fullgraph = UNSLOTH_FULLGRAPH and not calls_disable_compile_function(
                     parameters, disable_compile_functions
                 )

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -155,19 +155,14 @@ DISABLE_COMPILE_FUNCTIONS = [
 
     # transformers 5.9+ VL files import these; `grid_thw.tolist()` builds shapes from
     # unbacked SymInts, so fullgraph = True is a hard error on the first vision forward.
-    # Deliberately NOT gated on torch version. pytorch 48dbd60df48 (pytorch#162354)
-    # swapped guard_size_oblivious for guard_or_true and does make four of them
-    # traceable, but measured on torch 2.9.1 / 2.10.0 / 2.11.0 against transformers
-    # 5.16.1, window_index still dies on GuardOnDataDependentSymNode at
-    # `cu_window_seqlens.extend(cu_seqlens_tmp.tolist())` and bilinear_indices on its
-    # deprecation warning; on transformers 5.14.1, attention_seqlens and
-    # interpolation_indices break on torch 2.11 too. A `torch < 2.10` gate would put the
-    # crash back for qwen2_5_vl and qwen2_5_omni on the default install. Listing the
-    # traceable ones anyway costs one demoted caller across 10 VL model types
-    # (minimax_m3_vl's 3DRotaryEmbedding), because every VL vision forward is already
-    # off fullgraph through an earlier tier. bilinear_indices, deprecated at 5.16 and
-    # imported by no modeling file today, is listed so a model going back to it stays
-    # uncompiled.
+    # Deliberately NOT gated on torch version: pytorch#162354 does make four of them
+    # traceable, but on torch 2.9.1 / 2.10.0 / 2.11.0 window_index still dies on
+    # GuardOnDataDependentSymNode and bilinear_indices on its deprecation warning, and a
+    # `torch < 2.10` gate would put the crash back for qwen2_5_vl and qwen2_5_omni on the
+    # default install. Listing the traceable ones anyway costs one demoted caller across
+    # 10 VL model types, since every VL vision forward is already off fullgraph through an
+    # earlier tier. bilinear_indices, deprecated at 5.16 and imported by no modeling file
+    # today, is listed so a model going back to it stays uncompiled.
     "get_vision_position_ids",
     "get_vision_cu_seqlens",
     "get_vision_attention_seqlens",
@@ -178,10 +173,10 @@ DISABLE_COMPILE_FUNCTIONS = [
 
 
 def calls_disable_compile_function(source, disable_compile_functions):
-    """Names from `DISABLE_COMPILE_FUNCTIONS` that `source` CALLS: deliberately a
-    superset of the `called_functions` test one level up, which also requires
-    `def <name>` locally and so misses every imported-only helper. `[^\\w.]` excludes
-    attribute calls; qwen3_vl, glm4v and qwen2_5_vl define a METHOD of the same name."""
+    """Names from `DISABLE_COMPILE_FUNCTIONS` that `source` CALLS: a superset of the
+    `called_functions` test above, which also wants `def <name>` locally and so misses
+    imported-only helpers. `[^\\w.]` excludes attribute calls: qwen3_vl, glm4v and
+    qwen2_5_vl define a method of the same name."""
     return sorted(
         name
         for name in disable_compile_functions
@@ -4963,10 +4958,9 @@ def unsloth_compile_transformers(
             bad_torch_modules.add(module)
         pass
 
-        # Tier 3: an imported-only callee is never in `called_functions`, so the raw
-        # upstream helper is imported for Dynamo to inline. Demote the CALLER; marking
-        # the helper `@torch.compiler.disable` is not an alternative, a disabled callee
-        # is itself a graph break and that is the same hard error under fullgraph.
+        # Tier 3: an imported-only callee is never in `called_functions`, so Dynamo inlines
+        # the raw upstream helper. Demote the CALLER; `@torch.compiler.disable` on the
+        # helper is no alternative, a disabled callee is itself a fullgraph break.
         called_disabled = calls_disable_compile_function(
             source, disable_compile_functions
         )


### PR DESCRIPTION
## The problem

transformers 5.9 pulled the per-image grid helpers every VL tower calls out of the individual modeling files and into a shared `transformers/vision_utils.py` (huggingface/transformers#45396, commit `f00940ef`, merged 2026-05-13). The modeling files now import them by name, so the rewriter sees ordinary called functions: it copies their source into the generated module and stamps `@torch_compile_with_fallback(fullgraph = True, dynamic = True, ...)` on it.

Each helper reads the image grid off the device with `grid_thw.tolist()` or `repeat_interleave`. Dynamo turns those into unbacked SymInts, and the shapes built from them are not guardable, so the first vision forward dies:

```
torch._dynamo.exc.UserError: Could not guard on data-dependent expression Eq((u2//u3), 0)
  (unhinted: Eq((u2//u3), 0)). (Size-like symbols: u2, u3)
Caused by: hpos_ids = hpos_ids.reshape(block_shape).transpose(1, 2).flatten()
  # unsloth_compiled_cache/unsloth_compiled_module_qwen3_5.py in get_vision_position_ids
```

Upstream says the same thing in the module docstring of `vision_utils.py`: these exist "for pre-computing very dynamic and data-dependent tensors that can break model graph capturing" and "use untraceable ops (`repeat_interleave`, `.tolist()`, `nonzero()`, loops)".

### Scope

The guard error above needs **transformers >= 5.9.0 and torch < 2.10**. pytorch commit [`48dbd60df482`](https://github.com/pytorch/pytorch/commit/48dbd60df482fd884d211a800c5e82c648780a98) (pytorch#162354, "are_strides_like_channels_last_or_false") replaced the `guard_size_oblivious(shape[d] == 0)` calls in `torch/_prims_common/__init__.py` with `guard_or_true`, which never throws. `shape[d]` there is `FloorDiv(u2, u3)`, and size-oblivious reasoning only special-cases atomic size-like symbols, so before that commit the compound expression raised. Confirmed by tag containment: the commit is not an ancestor of `v2.9.1` and is an ancestor of `v2.10.0`. We support torch well below 2.10, and the Qwen3.5 vision notebooks avoid the failure today only because their install cell pins `transformers==5.2.0`.

The second half of this PR is not version-gated. Listing a name only reaches the copy the rewriter generates. A modeling file that *imports* a helper rather than defining it never puts it in `called_functions`, so the raw upstream function is imported for Dynamo to inline into whichever generated forward calls it, and that forward is still emitted `fullgraph = True`.

## What this changes

Two parts, both in `unsloth_zoo/compiler.py`.

**1. List the six grid helpers in `DISABLE_COMPILE_FUNCTIONS`.** Where the rewriter does copy one into the generated module, it now emits `@torch.compiler.disable(recursive = False)` instead of the fullgraph decorator.

**2. Reach the callers.** New `calls_disable_compile_function(source, disable_compile_functions)` returns the listed names a body calls. `unsloth_compile_transformers` consults it in three places: the module scan adds a caller to `no_fullgraph_modules`, and both generated-source emit sites compute `fullgraph = UNSLOTH_FULLGRAPH and not calls_disable_compile_function(...)`. Marking only the helper is not an alternative here: a disabled callee is itself a graph break, which is the same hard error under `fullgraph = True`.

Matching is on a bare name (`[^\w.]<name>\s*(`), so attribute calls are excluded on purpose. qwen3_vl, glm4v, qwen2_5_vl and paddleocr_vl each define a *method* of the same name, and `self.get_vision_position_ids(...)` must not demote a module that never touches the shared helper.

### Which names

The listed six are exactly the `get_vision_*` functions in `vision_utils` that take an image grid. Measured against transformers 5.16.1, by number of model families whose modeling or modular file imports the name:

| helper | model families importing it at 5.16.1 |
|---|---|
| `get_vision_position_ids` | 25 |
| `get_vision_attention_seqlens` | 22 |
| `get_vision_interpolation_indices_and_weights` | 10 |
| `get_vision_window_index` | 5 |
| `get_vision_cu_seqlens` | 1 (`muse_glimmer`) |
| `get_vision_bilinear_indices_and_weights` | 0 |

`get_vision_interpolation_indices_and_weights` is the live helper: transformers 5.16 deprecated `get_vision_bilinear_indices_and_weights` in favour of it, with removal announced for 5.17, and at 5.16.1 the deprecated name is imported by no modeling file. `get_vision_attention_seqlens` is the wrapper those models now call instead of `get_vision_cu_seqlens` directly, and listing only the inner function does not help, because the inner call is inlined into the stamped outer frame. The deprecated name is kept on the list for the same reason `recurrent_gated_delta_rule` is: it costs nothing and covers a model going back to it.

The other two `get_vision_*` functions at 5.16.1, `get_vision_merged_shape` and `get_vision_nearest_position_ids`, take `target_sizes` rather than a grid and are not in scope here.

### Compatibility

Matching is by function name, so on transformers 5.2 through 5.8, where these names are absent from the modeling source, nothing matches and neither the disable decorator nor the caller demotion fires. There is no version gate and nothing to update when the supported range moves.

## Why not keep them compiled

`.tolist()` is a mandatory device-to-host sync on the first line of the helper, so even a `fullgraph = False` compile breaks the graph right there and the compiled region is only the `item()` prologue. There is no fusion to lose.

Two alternatives were tried and rejected during the investigation:

- `torch._check` / `torch._check_is_size` on `h`, `w`, `t`, `merge_size` and both quotients. The guard is not lifted; the expression is a quotient of unbacked symbols, not an atomic size-like one.
- Keeping `merge_size` a Python int rather than letting upstream launder the static `config.spatial_merge_size` through `torch.tensor([spatial_merge_size]).expand(...)` and back with `.tolist()`. It fails on a different guard, it would mean carrying a patched copy of an upstream body and rebinding it into every modeling module, and it covers only one of the helpers.

## Tests

`tests/test_vision_utils_grid_helpers_eager.py`, CPU only (the failure is in the meta/shape layer) and skipped below transformers 5.9:

- The main test enumerates `transformers.vision_utils` at run time instead of hard coding today's names, and asserts the implication "if Dynamo cannot trace it with `fullgraph = True`, it must be in `DISABLE_COMPILE_FUNCTIONS`". Stating it as an implication is what keeps it torch independent: a helper that becomes traceable on a newer torch does not fail it, and a helper that is untraceable on an older one does. The runtime enumeration is what caught `get_vision_interpolation_indices_and_weights` after 5.16 renamed the bilinear helper out from under the original list.
- A block-major layout oracle on `get_vision_position_ids`, so "we stopped compiling it" cannot drift into "we stopped computing it correctly".
- A wiring check that both generated-source emit sites still consult `disable_compile_functions` before the compile branch.

`tests/test_disable_compile_functions_reach_imported_helpers.py`:

- Detector unit checks: bare calls match; `self.<name>(`, `vision_utils.<name>(`, `wrapped_<name>(` and a docstring mention do not.
- A count check that every fullgraph emit site consults the detector, so a fourth site cannot be added without one.
- An end-to-end probe in its own interpreter over `minimax_m3_vl`, which imports `get_vision_position_ids` without defining it. It runs the rewriter, asserts the generated module does not define the helper (otherwise the probe proves nothing), asserts the generated `MiniMaxM3VL3DRotaryEmbedding_forward` is emitted `fullgraph = False`, and checks the rope forward returns the expected shapes. It pins the child to this checkout via `PYTHONPATH` and clears an inherited `UNSLOTH_COMPILE_DISABLE`, either of which would otherwise make it green against the wrong code.

Both files are added to the executing "Core drift (3 upstream pins)" gate in `consolidated-tests-ci.yml`.
