### PR TITLE
Isolate the compiled-source directory per CI lane, and handle TokenError from inspect.getsource

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -786,6 +786,7 @@ jobs:
                   tests/test_upstream_source_patterns.py \
                   tests/test_compiler_rewriter_exhaustive.py \
                   tests/test_compiler_dynamic_exec.py \
+                  tests/test_compiler_getsource_tokenerror.py \
                   tests/test_temporary_patches_exhaustive.py \
                   tests/test_mxfp4_load_path_layout.py \
                   tests/test_missing_parent_package_is_drift.py \

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -137,6 +137,13 @@ jobs:
             venv=".lanes/venv-$version"
             log=".lanes/$version.log"
             (
+              # Per-lane generated-source directory, for the reason spelled out
+              # on the core-drift job below: four lanes, one checkout, and a
+              # default that is the relative `unsloth_compiled_cache`. Here the
+              # lanes are four INTERPRETERS, so sharing it would also mean
+              # 3.10 importing a cache 3.13 wrote.
+              export UNSLOTH_COMPILE_LOCATION="$PWD/.lanes/compiled-$version"
+              mkdir -p "$UNSLOTH_COMPILE_LOCATION"
               rc=0
               {
                 "$interpreter" -m venv "$venv" &&
@@ -703,6 +710,25 @@ jobs:
             id="$1"; shift
             venv=".lanes/venv-$id"; log=".lanes/$id.log"
             (
+              # One generated-source directory per lane. The three lanes run
+              # concurrently out of ONE checkout, and unsloth_zoo defaults this
+              # to the RELATIVE `unsloth_compiled_cache`, so by default all
+              # three resolve it to the same directory and write each other's
+              # files: unsloth_compiled_module_<model>.py, and the torch.nn
+              # forwards (LayerNorm.py, Conv1d.py, ...) that compiler.py
+              # installs and then reads back with inspect.getsource. The
+              # contents genuinely differ per lane -- that is the point of the
+              # job, three different transformers/TRL pins -- so every lane
+              # rewrites what the others just wrote, and a getsource that lands
+              # between a truncate and its write reads a prefix and dies in
+              # tokenize. That is what made test_compiler_dynamic_exec pass in
+              # two lanes and fail in the third on the same commit.
+              #
+              # Absolute, not relative like the venv paths above: compiler.py
+              # puts this value straight on sys.path, where a relative entry is
+              # re-resolved against whatever the cwd happens to be.
+              export UNSLOTH_COMPILE_LOCATION="$PWD/.lanes/compiled-$id"
+              mkdir -p "$UNSLOTH_COMPILE_LOCATION"
               rc=0
               {
                 set -x &&

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -137,9 +137,7 @@ jobs:
             venv=".lanes/venv-$version"
             log=".lanes/$version.log"
             (
-              # Per-lane generated-source directory, as on the core-drift job
-              # below. Here the lanes are four interpreters, so sharing the
-              # default would also mean 3.10 importing a cache 3.13 wrote.
+              # Per-lane generated-source dir: else 3.10 imports a cache 3.13 wrote.
               export UNSLOTH_COMPILE_LOCATION="$PWD/.lanes/compiled-$version"
               mkdir -p "$UNSLOTH_COMPILE_LOCATION"
               rc=0
@@ -708,16 +706,8 @@ jobs:
             id="$1"; shift
             venv=".lanes/venv-$id"; log=".lanes/$id.log"
             (
-              # One generated-source directory per lane. The three lanes run
-              # concurrently out of ONE checkout and unsloth_zoo defaults to the
-              # relative `unsloth_compiled_cache`, so they would share it and
-              # rewrite each other's generated files, whose contents differ per
-              # lane (three transformers/TRL pins). A getsource landing
-              # mid-rewrite then dies in tokenize, which is what made
-              # test_compiler_dynamic_exec fail in only one of the three lanes.
-              #
-              # Absolute, not relative: compiler.py puts this straight on
-              # sys.path, where a relative entry follows the cwd.
+              # Per-lane generated-source dir, absolute (compiler.py puts it on sys.path):
+              # concurrent lanes sharing one checkout rewrite the default cache under a reader.
               export UNSLOTH_COMPILE_LOCATION="$PWD/.lanes/compiled-$id"
               mkdir -p "$UNSLOTH_COMPILE_LOCATION"
               rc=0

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -137,11 +137,9 @@ jobs:
             venv=".lanes/venv-$version"
             log=".lanes/$version.log"
             (
-              # Per-lane generated-source directory, for the reason spelled out
-              # on the core-drift job below: four lanes, one checkout, and a
-              # default that is the relative `unsloth_compiled_cache`. Here the
-              # lanes are four INTERPRETERS, so sharing it would also mean
-              # 3.10 importing a cache 3.13 wrote.
+              # Per-lane generated-source directory, as on the core-drift job
+              # below. Here the lanes are four interpreters, so sharing the
+              # default would also mean 3.10 importing a cache 3.13 wrote.
               export UNSLOTH_COMPILE_LOCATION="$PWD/.lanes/compiled-$version"
               mkdir -p "$UNSLOTH_COMPILE_LOCATION"
               rc=0
@@ -711,22 +709,15 @@ jobs:
             venv=".lanes/venv-$id"; log=".lanes/$id.log"
             (
               # One generated-source directory per lane. The three lanes run
-              # concurrently out of ONE checkout, and unsloth_zoo defaults this
-              # to the RELATIVE `unsloth_compiled_cache`, so by default all
-              # three resolve it to the same directory and write each other's
-              # files: unsloth_compiled_module_<model>.py, and the torch.nn
-              # forwards (LayerNorm.py, Conv1d.py, ...) that compiler.py
-              # installs and then reads back with inspect.getsource. The
-              # contents genuinely differ per lane -- that is the point of the
-              # job, three different transformers/TRL pins -- so every lane
-              # rewrites what the others just wrote, and a getsource that lands
-              # between a truncate and its write reads a prefix and dies in
-              # tokenize. That is what made test_compiler_dynamic_exec pass in
-              # two lanes and fail in the third on the same commit.
+              # concurrently out of ONE checkout and unsloth_zoo defaults to the
+              # relative `unsloth_compiled_cache`, so they would share it and
+              # rewrite each other's generated files, whose contents differ per
+              # lane (three transformers/TRL pins). A getsource landing
+              # mid-rewrite then dies in tokenize, which is what made
+              # test_compiler_dynamic_exec fail in only one of the three lanes.
               #
-              # Absolute, not relative like the venv paths above: compiler.py
-              # puts this value straight on sys.path, where a relative entry is
-              # re-resolved against whatever the cwd happens to be.
+              # Absolute, not relative: compiler.py puts this straight on
+              # sys.path, where a relative entry follows the cwd.
               export UNSLOTH_COMPILE_LOCATION="$PWD/.lanes/compiled-$id"
               mkdir -p "$UNSLOTH_COMPILE_LOCATION"
               rc=0

--- a/tests/test_compiler_getsource_tokenerror.py
+++ b/tests/test_compiler_getsource_tokenerror.py
@@ -16,30 +16,21 @@
 
 """`inspect.getsource` raising `tokenize.TokenError` must not fail a load.
 
-`unsloth_compile_transformers` reads source in two places that already accept
-not getting any: the whole-module read that drives source-level feature
-detection (`unsloth_zoo/compiler.py`, the `full_source` read), and the torch.nn
-forward that `_patch_torch_dtype_modules` is about to add a dtype cast to. Both
-degrade gracefully on `OSError`/`TypeError`.
+`unsloth_compile_transformers` reads source in two places that already degrade
+on `OSError`/`TypeError`: the whole-module `full_source` read, and the torch.nn
+forward `_patch_torch_dtype_modules` adds a dtype cast to. `TokenError` means
+the same thing but subclasses `Exception` directly, so it used to escape both
+and fail `FastModel.from_pretrained` over source only wanted for speed.
 
-`tokenize.TokenError` reaches the same two calls and means the same thing, but
-subclasses `Exception` directly, so it used to escape both handlers and
-propagate out of `FastModel.from_pretrained` -- failing the LOAD over source
-that was only wanted in order to make the model faster.
+It is real: after the first model type, `torch.nn.LayerNorm.forward` and its
+siblings live in generated compile-folder files that later runs rewrite, and a
+read landing mid-rewrite gets a prefix that `inspect.getblock` rejects. Two
+processes sharing one compile folder is all it takes, which is what three CI
+lanes out of one checkout were doing.
 
-It is not hypothetical. After the first model type, `torch.nn.LayerNorm.forward`
-and its siblings are functions this package GENERATED: their `co_filename` is a
-file under the compile folder, and later runs truncate and rewrite that same
-path. A `getsource` that reads one between the truncate and the write gets a
-valid prefix that stops inside a docstring or a bracket, and `inspect.getblock`
-turns that into a `TokenError`. Two processes sharing one compile folder is all
-it takes, which is what three CI lanes running out of one checkout were doing.
-
-Subprocesses, for two reasons. `unsloth_compile_transformers` mutates
-`torch.nn` process-wide, so an in-process version would depend on which tests
-ran before it. And `UNSLOTH_COMPILE_LOCATION` is read once, at compiler import,
-into a module global -- `monkeypatch.setenv` after that point does nothing, and
-the probe would silently write to the shared default instead of its own folder.
+Subprocesses because `unsloth_compile_transformers` mutates `torch.nn`
+process-wide, and because `UNSLOTH_COMPILE_LOCATION` is read once at compiler
+import, so a later `monkeypatch.setenv` would leave the probe on the default.
 """
 
 from __future__ import annotations
@@ -113,8 +104,7 @@ def _result(proc, what: str):
 
 
 def test_tokenerror_is_not_an_oserror_or_typeerror():
-    """Why `except (OSError, TypeError)` was not enough. If this ever stops
-    holding, the widened handlers become redundant rather than wrong."""
+    """Why `except (OSError, TypeError)` was not enough."""
     assert not issubclass(tokenize.TokenError, OSError)
     assert not issubclass(tokenize.TokenError, TypeError)
 
@@ -144,14 +134,12 @@ def test_compile_transformers_survives_tokenerror_from_getsource(tmp_path):
     )
     out = _result(proc, "all-getsource-raises")
 
-    # Guard against a vacuous pass: an early return that never reads source
-    # would also "not raise".
+    # Guard against a vacuous pass: an early return would also "not raise".
     assert out["calls"] > 0, (
         "inspect.getsource was never called, so the probe proved nothing "
         "about the TokenError handlers"
     )
-    # The unreadable-source branch must say so rather than leave SDPA selected
-    # for a model that never claimed it.
+    # Must not leave SDPA selected for a model that never claimed it.
     assert out["supports_sdpa"] is False, (
         f"the unreadable-source branch must set __UNSLOTH_SUPPORTS_SDPA__ "
         f"False, got {out['supports_sdpa']!r}"
@@ -159,12 +147,9 @@ def test_compile_transformers_survives_tokenerror_from_getsource(tmp_path):
 
 
 def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
-    """Narrowed to the site that actually reads a file this package generated
-    and later rewrites: the torch.nn forward in the dtype patcher.
-
-    The whole-module read is left working, so the pipeline reaches the dtype
-    patcher down its normal path rather than down the early return.
-    """
+    """Only the site that reads a generated-then-rewritten file raises: the
+    torch.nn forward in the dtype patcher. The whole-module read is left
+    working so the pipeline gets there normally, not via the early return."""
     proc = _run(
         """
         import torch

--- a/tests/test_compiler_getsource_tokenerror.py
+++ b/tests/test_compiler_getsource_tokenerror.py
@@ -14,23 +14,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""`inspect.getsource` raising `tokenize.TokenError` must not fail a load.
-
-`unsloth_compile_transformers` reads source in two places that already degrade
-on `OSError`/`TypeError`: the whole-module `full_source` read, and the torch.nn
-forward `_patch_torch_dtype_modules` adds a dtype cast to. `TokenError` means
-the same thing but subclasses `Exception` directly, so it used to escape both
-and fail `FastModel.from_pretrained` over source only wanted for speed.
-
-It is real: after the first model type, `torch.nn.LayerNorm.forward` and its
-siblings live in generated compile-folder files that later runs rewrite, and a
-read landing mid-rewrite gets a prefix that `inspect.getblock` rejects. Two
-processes sharing one compile folder is all it takes, which is what three CI
-lanes out of one checkout were doing.
-
-Subprocesses because `unsloth_compile_transformers` mutates `torch.nn`
-process-wide, and because `UNSLOTH_COMPILE_LOCATION` is read once at compiler
-import, so a later `monkeypatch.setenv` would leave the probe on the default.
+"""`inspect.getsource` raising `tokenize.TokenError` must not fail a model load.
+TokenError subclasses Exception directly, so it escaped the OSError/TypeError catches;
+it fires when a generated compile-folder file is read mid-rewrite. Subprocesses: the
+compiler mutates torch.nn process-wide and reads UNSLOTH_COMPILE_LOCATION at import.
 """
 
 from __future__ import annotations
@@ -104,14 +91,13 @@ def _result(proc, what: str):
 
 
 def test_tokenerror_is_not_an_oserror_or_typeerror():
-    """Why `except (OSError, TypeError)` was not enough."""
+    """The catch must name TokenError explicitly: it subclasses neither."""
     assert not issubclass(tokenize.TokenError, OSError)
     assert not issubclass(tokenize.TokenError, TypeError)
 
 
 def test_compile_transformers_survives_tokenerror_from_getsource(tmp_path):
-    """Every `inspect.getsource` raises `TokenError`. The pipeline must return
-    anyway, exactly as it does when the source is missing outright."""
+    """Every getsource raises; the pipeline must still return."""
     proc = _run(
         """
         calls = []
@@ -134,12 +120,10 @@ def test_compile_transformers_survives_tokenerror_from_getsource(tmp_path):
     )
     out = _result(proc, "all-getsource-raises")
 
-    # Guard against a vacuous pass: an early return would also "not raise".
     assert out["calls"] > 0, (
         "inspect.getsource was never called, so the probe proved nothing "
         "about the TokenError handlers"
     )
-    # Must not leave SDPA selected for a model that never claimed it.
     assert out["supports_sdpa"] is False, (
         f"the unreadable-source branch must set __UNSLOTH_SUPPORTS_SDPA__ "
         f"False, got {out['supports_sdpa']!r}"
@@ -147,9 +131,7 @@ def test_compile_transformers_survives_tokenerror_from_getsource(tmp_path):
 
 
 def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
-    """Only the site that reads a generated-then-rewritten file raises: the
-    torch.nn forward in the dtype patcher. The whole-module read is left
-    working so the pipeline gets there normally, not via the early return."""
+    """Raises only on the generated forward, so the pipeline reaches the dtype patcher."""
     proc = _run(
         """
         import torch

--- a/tests/test_compiler_getsource_tokenerror.py
+++ b/tests/test_compiler_getsource_tokenerror.py
@@ -1,0 +1,214 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""`inspect.getsource` raising `tokenize.TokenError` must not fail a load.
+
+`unsloth_compile_transformers` reads source in two places that already accept
+not getting any: the whole-module read that drives source-level feature
+detection (`unsloth_zoo/compiler.py`, the `full_source` read), and the torch.nn
+forward that `_patch_torch_dtype_modules` is about to add a dtype cast to. Both
+degrade gracefully on `OSError`/`TypeError`.
+
+`tokenize.TokenError` reaches the same two calls and means the same thing, but
+subclasses `Exception` directly, so it used to escape both handlers and
+propagate out of `FastModel.from_pretrained` -- failing the LOAD over source
+that was only wanted in order to make the model faster.
+
+It is not hypothetical. After the first model type, `torch.nn.LayerNorm.forward`
+and its siblings are functions this package GENERATED: their `co_filename` is a
+file under the compile folder, and later runs truncate and rewrite that same
+path. A `getsource` that reads one between the truncate and the write gets a
+valid prefix that stops inside a docstring or a bracket, and `inspect.getblock`
+turns that into a `TokenError`. Two processes sharing one compile folder is all
+it takes, which is what three CI lanes running out of one checkout were doing.
+
+Subprocesses, for two reasons. `unsloth_compile_transformers` mutates
+`torch.nn` process-wide, so an in-process version would depend on which tests
+ran before it. And `UNSLOTH_COMPILE_LOCATION` is read once, at compiler import,
+into a module global -- `monkeypatch.setenv` after that point does nothing, and
+the probe would silently write to the shared default instead of its own folder.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import tokenize
+from pathlib import Path
+
+import pytest
+
+
+pytest.importorskip("transformers")
+pytest.importorskip("unsloth_zoo.compiler")
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(body: str, cache_dir: Path, timeout: int = 900):
+    script = textwrap.dedent(
+        f"""
+        import importlib, json, os, sys, tokenize
+        sys.path.insert(0, {str(ROOT)!r})
+        import unsloth_zoo.compiler as compiler
+
+        CACHE = os.environ["UNSLOTH_COMPILE_LOCATION"]
+
+        def fresh_llama():
+            mod = importlib.import_module(
+                "transformers.models.llama.modeling_llama",
+            )
+            if hasattr(mod, "__UNSLOTH_PATCHED__"):
+                delattr(mod, "__UNSLOTH_PATCHED__")
+            return mod
+
+        # Warm-up on real source. This is what replaces the torch.nn forwards
+        # with generated ones, i.e. what puts the compile folder on the far end
+        # of a later inspect.getsource.
+        fresh_llama()
+        compiler.unsloth_compile_transformers("llama", disable=True)
+        """
+    ) + textwrap.dedent(body)
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    env["UNSLOTH_COMPILE_LOCATION"] = str(cache_dir)
+    env["UNSLOTH_COMPILE_DISABLE"] = "1"
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True, text=True, timeout=timeout, env=env,
+    )
+
+
+def _result(proc, what: str):
+    if proc.returncode != 0:
+        pytest.fail(
+            f"{what}: the probe died, so tokenize.TokenError escaped "
+            f"unsloth_compile_transformers instead of being handled.\n"
+            f"STDOUT:\n{proc.stdout[-2500:]}\nSTDERR:\n{proc.stderr[-3000:]}"
+        )
+    line = [l for l in proc.stdout.splitlines() if l.startswith("RESULT ")]
+    if not line:
+        pytest.fail(
+            f"{what}: probe produced no RESULT line.\n"
+            f"STDOUT:\n{proc.stdout[-2500:]}\nSTDERR:\n{proc.stderr[-3000:]}"
+        )
+    return json.loads(line[-1][len("RESULT "):])
+
+
+def test_tokenerror_is_not_an_oserror_or_typeerror():
+    """Why `except (OSError, TypeError)` was not enough. If this ever stops
+    holding, the widened handlers become redundant rather than wrong."""
+    assert not issubclass(tokenize.TokenError, OSError)
+    assert not issubclass(tokenize.TokenError, TypeError)
+
+
+def test_compile_transformers_survives_tokenerror_from_getsource(tmp_path):
+    """Every `inspect.getsource` raises `TokenError`. The pipeline must return
+    anyway, exactly as it does when the source is missing outright."""
+    proc = _run(
+        """
+        calls = []
+
+        def raise_tokenerror(obj, *args, **kwargs):
+            calls.append(getattr(obj, "__name__", repr(obj)))
+            raise tokenize.TokenError("EOF in multi-line string", (1, 0))
+
+        compiler.inspect.getsource = raise_tokenerror
+
+        mod = fresh_llama()
+        compiler.unsloth_compile_transformers("llama", disable=True)
+
+        print("RESULT " + json.dumps({
+            "calls": len(calls),
+            "supports_sdpa": getattr(mod, "__UNSLOTH_SUPPORTS_SDPA__", None),
+        }))
+        """,
+        tmp_path / "cache_all",
+    )
+    out = _result(proc, "all-getsource-raises")
+
+    # Guard against a vacuous pass: an early return that never reads source
+    # would also "not raise".
+    assert out["calls"] > 0, (
+        "inspect.getsource was never called, so the probe proved nothing "
+        "about the TokenError handlers"
+    )
+    # The unreadable-source branch must say so rather than leave SDPA selected
+    # for a model that never claimed it.
+    assert out["supports_sdpa"] is False, (
+        f"the unreadable-source branch must set __UNSLOTH_SUPPORTS_SDPA__ "
+        f"False, got {out['supports_sdpa']!r}"
+    )
+
+
+def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
+    """Narrowed to the site that actually reads a file this package generated
+    and later rewrites: the torch.nn forward in the dtype patcher.
+
+    The whole-module read is left working, so the pipeline reaches the dtype
+    patcher down its normal path rather than down the early return.
+    """
+    proc = _run(
+        """
+        import torch
+
+        generated = sorted({
+            code.co_filename
+            for code in (
+                getattr(getattr(torch.nn, name).forward, "__code__", None)
+                for name in compiler._patch_functions
+                if hasattr(torch.nn, name)
+            )
+            if code is not None and code.co_filename.startswith(CACHE)
+        })
+
+        real_getsource = compiler.inspect.getsource
+        hits = []
+
+        def raise_on_generated(obj, *args, **kwargs):
+            code = getattr(obj, "__code__", None)
+            if code is not None and code.co_filename.startswith(CACHE):
+                hits.append(code.co_filename)
+                raise tokenize.TokenError("EOF in multi-line statement", (1, 0))
+            return real_getsource(obj, *args, **kwargs)
+
+        compiler.inspect.getsource = raise_on_generated
+
+        fresh_llama()
+        compiler.unsloth_compile_transformers("llama", disable=True)
+
+        print("RESULT " + json.dumps({
+            "generated": len(generated),
+            "hits": len(hits),
+        }))
+        """,
+        tmp_path / "cache_generated",
+    )
+    out = _result(proc, "generated-forward-getsource-raises")
+
+    assert out["generated"] > 0, (
+        "no torch.nn forward was served out of the compile folder after a "
+        "warm-up compile, so this probe does not cover the concurrent-rewrite "
+        "case it exists for"
+    )
+    assert out["hits"] > 0, (
+        "no getsource call resolved into the compile folder, so the dtype "
+        "patcher's TokenError handler was never exercised"
+    )

--- a/tests/test_compiler_getsource_tokenerror.py
+++ b/tests/test_compiler_getsource_tokenerror.py
@@ -68,6 +68,13 @@ def _run(body: str, cache_dir: Path, timeout: int = 900):
     env = dict(os.environ)
     env["UNSLOTH_COMPILE_LOCATION"] = str(cache_dir)
     env["UNSLOTH_COMPILE_DISABLE"] = "1"
+    # On a CPU-only runner the zoo's get_device_type raises "Unsloth cannot find
+    # any torch accelerator" during the child's import, before either TokenError
+    # handler is reached. It does not today, but only because tests/conftest.py
+    # does os.environ.setdefault("UNSLOTH_ALLOW_CPU", "1") at import and this
+    # copy of os.environ carries it. Measured: neuter that one conftest line and
+    # all three tests here die on the import. That is too far away to rely on.
+    env.setdefault("UNSLOTH_ALLOW_CPU", "1")
     return subprocess.run(
         [sys.executable, "-c", script],
         capture_output=True, text=True, timeout=timeout, env=env,
@@ -178,4 +185,26 @@ def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
     assert out["hits"] > 0, (
         "no getsource call resolved into the compile folder, so the dtype "
         "patcher's TokenError handler was never exercised"
+    )
+
+
+def test_the_probe_sets_cpu_mode_itself_rather_than_inheriting_it():
+    """The subprocess must not depend on conftest for its own importability.
+
+    A fresh interpreter inherits none of pytest's setup. These probes ran on a
+    CPU-only runner only because tests/conftest.py sets UNSLOTH_ALLOW_CPU at
+    import time and dict(os.environ) happened to carry it into the child;
+    neutering that single line makes every test in this file die inside the
+    child's `import unsloth_zoo.compiler`, before the handlers under test.
+
+    The checkout pin is already handled: the generated script starts with
+    sys.path.insert(0, ROOT), so the child imports this tree and not an
+    installed copy. Only the CPU flag was missing.
+    """
+    source = Path(__file__).read_text(encoding="utf-8")
+    setup = source[source.index("env = dict(os.environ)"):source.index("return subprocess.run(")]
+    assert 'env.setdefault("UNSLOTH_ALLOW_CPU", "1")' in setup
+    assert "sys.path.insert(0, {str(ROOT)!r})" in source, (
+        "the child must keep pinning this checkout, or it validates a "
+        "different compiler.py than the one under review"
     )

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -4190,12 +4190,8 @@ def _patch_torch_dtype_modules(
                 # to patch a dtype cast. `get_compiler_config` above only covers
                 # torch.compile wrappers.
                 #
-                # TokenError: by now `function.forward` is usually OUR generated
-                # forward, living in a compile-folder file we rewrite at runtime.
-                # A getsource landing mid-rewrite reads a truncated prefix, which
-                # inspect.getblock turns into TokenError. It subclasses Exception
-                # directly, so OSError/TypeError did not catch it. Truncated
-                # source is the same "no usable source" case handled here.
+                # TokenError subclasses Exception directly, so neither catch above sees it: getsource
+                # can read our generated forward mid-rewrite. linecache.checkcache() is NOT the fix (findsource calls it).
                 #
                 # The precondition is not fully characterised: two plain Qwen
                 # loads do not trigger it, and after such a load no torch.nn
@@ -4492,9 +4488,7 @@ def unsloth_compile_transformers(
         # FastModel.from_pretrained and the model fails to LOAD, over a file we
         # only wanted in order to make it faster.
         #
-        # TokenError is listed for symmetry with _patch_torch_dtype_modules,
-        # which provably needed it. It cannot fire here today: for a module
-        # inspect.getsourcelines skips getblock, so nothing tokenizes.
+        # TokenError is dead here (module: getsourcelines never calls getblock), kept for symmetry.
         #
         # Return rather than continue with an empty string: checks of the form
         # `"_supports_sdpa = False" not in full_source` are TRUE on empty and

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -4190,20 +4190,12 @@ def _patch_torch_dtype_modules(
                 # to patch a dtype cast. `get_compiler_config` above only covers
                 # torch.compile wrappers.
                 #
-                # tokenize.TokenError is in the tuple because by this point
-                # `function.forward` is usually OUR generated forward, not
-                # torch's: the create_new_function() call at the bottom of this
-                # loop installs it, so its co_filename is a file under the
-                # compile folder that we rewrite at runtime. inspect.getsource
-                # reads that file through linecache, and a read that lands while
-                # another process is between the truncate and the write of the
-                # same path returns a prefix -- valid so far, but ending inside
-                # a docstring or a bracket, which is a TokenError out of
-                # inspect.getblock. It subclasses Exception directly, so neither
-                # OSError nor TypeError covered it and it escaped all the way
-                # out of unsloth_compile_transformers. Truncated source is
-                # exactly the "no usable source" case this handler already
-                # degrades for.
+                # TokenError: by now `function.forward` is usually OUR generated
+                # forward, living in a compile-folder file we rewrite at runtime.
+                # A getsource landing mid-rewrite reads a truncated prefix, which
+                # inspect.getblock turns into TokenError. It subclasses Exception
+                # directly, so OSError/TypeError did not catch it. Truncated
+                # source is the same "no usable source" case handled here.
                 #
                 # The precondition is not fully characterised: two plain Qwen
                 # loads do not trigger it, and after such a load no torch.nn
@@ -4500,14 +4492,9 @@ def unsloth_compile_transformers(
         # FastModel.from_pretrained and the model fails to LOAD, over a file we
         # only wanted in order to make it faster.
         #
-        # tokenize.TokenError is in the tuple for symmetry with the getsource in
-        # _patch_torch_dtype_modules, which is the one that provably needed it.
-        # It cannot fire HERE today: the argument is a module, and for a module
-        # inspect.getsourcelines returns every line without going through
-        # getblock, so the tokenizer never runs and only OSError is reachable.
-        # It is listed anyway because the two handlers answer the same question
-        # -- can this source be read -- and a reader who widens one and not the
-        # other has to rediscover that asymmetry to find out why.
+        # TokenError is listed for symmetry with _patch_torch_dtype_modules,
+        # which provably needed it. It cannot fire here today: for a module
+        # inspect.getsourcelines skips getblock, so nothing tokenizes.
         #
         # Return rather than continue with an empty string: checks of the form
         # `"_supports_sdpa = False" not in full_source` are TRUE on empty and

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -4183,12 +4183,27 @@ def _patch_torch_dtype_modules(
 
             try:
                 source = inspect.getsource(function.forward).rstrip()
-            except (OSError, TypeError):
+            except (OSError, TypeError, tokenize.TokenError):
                 # A forward built by exec, or one whose file has gone. Unguarded
                 # the OSError propagates out of FastModel.from_pretrained and
                 # the model does not load, over source we only wanted in order
                 # to patch a dtype cast. `get_compiler_config` above only covers
                 # torch.compile wrappers.
+                #
+                # tokenize.TokenError is in the tuple because by this point
+                # `function.forward` is usually OUR generated forward, not
+                # torch's: the create_new_function() call at the bottom of this
+                # loop installs it, so its co_filename is a file under the
+                # compile folder that we rewrite at runtime. inspect.getsource
+                # reads that file through linecache, and a read that lands while
+                # another process is between the truncate and the write of the
+                # same path returns a prefix -- valid so far, but ending inside
+                # a docstring or a bracket, which is a TokenError out of
+                # inspect.getblock. It subclasses Exception directly, so neither
+                # OSError nor TypeError covered it and it escaped all the way
+                # out of unsloth_compile_transformers. Truncated source is
+                # exactly the "no usable source" case this handler already
+                # degrades for.
                 #
                 # The precondition is not fully characterised: two plain Qwen
                 # loads do not trigger it, and after such a load no torch.nn
@@ -4479,11 +4494,20 @@ def unsloth_compile_transformers(
     functions = dir(modeling_file)
     try:
         full_source = inspect.getsource(modeling_file)
-    except (OSError, TypeError) as exception:
+    except (OSError, TypeError, tokenize.TokenError) as exception:
         # Everything below is source-level feature detection, so with no source
         # there is nothing to do. Unguarded the OSError propagates out of
         # FastModel.from_pretrained and the model fails to LOAD, over a file we
         # only wanted in order to make it faster.
+        #
+        # tokenize.TokenError is in the tuple for symmetry with the getsource in
+        # _patch_torch_dtype_modules, which is the one that provably needed it.
+        # It cannot fire HERE today: the argument is a module, and for a module
+        # inspect.getsourcelines returns every line without going through
+        # getblock, so the tokenizer never runs and only OSError is reachable.
+        # It is listed anyway because the two handlers answer the same question
+        # -- can this source be read -- and a reader who widens one and not the
+        # other has to rediscover that asymmetry to find out why.
         #
         # Return rather than continue with an empty string: checks of the form
         # `"_supports_sdpa = False" not in full_source` are TRUE on empty and


### PR DESCRIPTION
## The failure

`tests/test_compiler_dynamic_exec.py::test_unsloth_compile_transformers_emits_parseable_cache[olmo2]` fails intermittently in the "Core drift (3 upstream pins)" job with a `tokenize.TokenError` out of `inspect.getsource`.

It is not a code defect. On one run, on one commit, the same test passed in two lanes and failed in the third. It also passes locally, alone and as the whole file in one session.

## Mechanism

The three lanes of `core-upstream-matrix` are backgrounded with `&` and joined with `wait`, out of a single checkout, and no lane sets `UNSLOTH_COMPILE_LOCATION`. `unsloth_zoo/compiler.py` defaults it to the relative `unsloth_compiled_cache`, so all three lanes resolve it against the same cwd and share one directory. The lanes pin conflicting transformers and TRL versions on purpose, so the generated contents always differ and every lane rewrites what the others just wrote.

The file being torn is not the combined per-model module. `_patch_torch_dtype_modules` calls `create_new_function` for each entry in `_patch_functions` and installs the result on the class, so from the second call onward `torch.nn.LayerNorm.forward.__code__.co_filename` is a path inside that shared directory:

```
BEFORE  LayerNorm  .../site-packages/torch/nn/modules/normalization.py
AFTER   LayerNorm  .../unsloth_compiled_cache/LayerNorm.py
```

The next call reads it back with `inspect.getsource(function.forward)`. `create_new_function` writes with `open(path, "wb")`, which truncates first, under a `FileLock` the reader never takes. A read landing inside that window returns a valid prefix that stops mid docstring or mid bracket, and `inspect.getblock` turns it into `tokenize.TokenError`. `TokenError` subclasses `Exception` directly, so `except (OSError, TypeError)` did not cover it and it propagated out of `unsloth_compile_transformers`.

## The changes

They are independent, and either one alone makes the reproduction green.

**1. Isolation, in the workflow.** Each lane of `core-upstream-matrix` and of `python-version-collect` exports its own `UNSLOTH_COMPILE_LOCATION`. This is the root cause.

The variable is read once, at compiler import, into a module global (`compiler.py`, `UNSLOTH_COMPILE_LOCATION = os.environ.get(...)`), so exporting it before the interpreter starts is the mechanism that works; setting it from inside a process after import has no effect. The path is absolute because `compiler.py` puts that value straight on `sys.path`, where a relative entry is re-resolved against whatever the cwd happens to be.

`python-version-collect` is included because `pytest --collect-only` is not inert: on a clean directory it writes `moe_utils.py` into the compile folder, and that job's four lanes are four different interpreters sharing one checkout.

**2. Brittleness, in `compiler.py`.** The two `inspect.getsource` sites that already degrade on `OSError` / `TypeError` now also accept `tokenize.TokenError`. Source that is present but unreadable deserves the same answer as source that is absent, and that holds regardless of how CI is laid out.

The site in `_patch_torch_dtype_modules` is the one that provably needed it, and is the site in the CI traceback. The whole-module read cannot raise `TokenError` today, because for a module `inspect.getsourcelines` returns every line without going through `getblock`, so the tokenizer never runs. It is widened anyway for symmetry, and the comment there says so rather than implying a live path.

**3. A regression test**, `tests/test_compiler_getsource_tokenerror.py`. Subprocess probes, because `unsloth_compile_transformers` mutates `torch.nn` process-wide and because `UNSLOTH_COMPILE_LOCATION` only takes effect through the environment.

- One probe raises `TokenError` from every `getsource` and asserts the pipeline still returns, with the unreadable-source branch setting `__UNSLOTH_SUPPORTS_SDPA__` to `False`.
- One raises it only for functions whose `co_filename` is inside the compile folder, which is the site that actually reads a file we generate and later rewrite.
- Both assert they were exercised (a non-zero call count, a non-zero hit count), so neither can pass vacuously.
- A third test guards the harness itself: the probes must set `UNSLOTH_ALLOW_CPU` and pin `sys.path` to this checkout rather than inheriting either from `conftest.py`, since a fresh interpreter inherits none of pytest's setup and would otherwise die on import, before the handlers under test.

The new file is added to the executing "Core drift (3 upstream pins)" gate in `consolidated-tests-ci.yml`.

## Verification

The race was reproduced deterministically enough to measure: three concurrent processes running the affected test file against one compiled-source directory, each stamping a different version into the generated header so every lane rewrites the others' files, 25 rounds per lane. Measured against the `compiler.py` change as it stands in this PR:

| code | compile dir | rounds | TokenError | failed |
| --- | --- | --- | --- | --- |
| `main` | shared | 75 | 3 | 1 |
| `main` | per lane | 75 | 0 | 0 |
| this PR | shared | 75 | 0 | 0 |

The failure on `main` reproduces the CI signature exactly:

```
unsloth_zoo/compiler.py:5587: in unsloth_compile_transformers
    _patch_torch_dtype_modules(
unsloth_zoo/compiler.py:4185: in _patch_torch_dtype_modules
    source = inspect.getsource(function.forward).rstrip()
/usr/lib/python3.13/inspect.py:1224: in getblock
    for _token in tokens:
tokenize.TokenError: ('unexpected EOF in multi-line statement', (131, 0))
```

Which parametrization loses is whichever one is running when a sibling truncates, which is why CI named `olmo2` and the local reproduction named `paligemma`.

## On linecache and inspect.getsource

Worth stating explicitly, because "the file is generated and rewritten at runtime, so invalidate the cache" is the intuitive fix and it is the wrong one.

`inspect.findsource` already calls `linecache.checkcache(file)` unconditionally as its first statement, so an added `linecache.checkcache()` is a no-op. Measured against a truncating writer, `linecache.clearcache()` and reading the file directly instead of through the cache both make things worse, not better, because they force a fresh read of the torn bytes: direct reads raised `TokenError` on 2.9 percent of calls against 0.06 percent through `linecache`. In the one configuration where a rewrite preserved size and mtime, so `checkcache` did not invalidate, the stale cache was what let the read succeed at all.

A torn read cannot be repaired on the reader side. The two things that work are not sharing the path, and tolerating the exception. That is what this PR does, and it is why the widened `except` is described above as a backstop rather than as the fix.

## Deliberately not in this PR

Two things surfaced while measuring, both worth their own change:

- `create_new_function` writes in place after truncating. A temp file plus `os.replace()` would make the write atomic and close this class of torn read for every consumer, not just CI. An atomic writer produced no `TokenError` and no `OSError` across the same reader loop that showed a steady rate against the truncating writer.
- `_patch_torch_dtype_modules` re-reads its own generated output and re-applies the dtype prologue each time, so the file grows by one copy per call and the casts stack: after five calls `LayerNorm.py` ends in `.to(original_dtype)` five times over. That is a correctness bug independent of any race, and it is also what makes the files churn on every call.

Neither is needed to fix the reported flake, and both change a hot path, so they are left separate.
