### PR TITLE
fix(mlx): select LoRA targets by role so MLX adapts what CUDA adapts

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -581,6 +581,14 @@ jobs:
 
       # One pytest process per file: tests/mlx_simulation/ replaces
       # sys.modules["mlx.core"] process-wide, disarming whatever runs after it.
+      - name: tests/test_mlx_lora_group_selection.py
+        # Group-flag selection is structural, so real Metal adds nothing to it
+        # and the CPU backend is a full gate.
+        run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_lora_group_selection.py -v -rs
+
+      - name: tests/test_mlx_resume_adapter_mismatch.py
+        run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_resume_adapter_mismatch.py -v -rs
+
       - name: tests/test_mlx_shape_guard.py
         run: .lanes/venv-suites/bin/python -m pytest tests/test_mlx_shape_guard.py -v -rs
 

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -213,6 +213,17 @@ jobs:
       # The three VLM/shape/batching suites, also run on Linux CPU MLX by
       # consolidated-tests-ci.yml. Here they meet real Metal and the mlx-vlm
       # version an Apple Silicon user resolves, which the audio gate is keyed on.
+      - name: tests/test_mlx_lora_group_selection.py
+        # Which linears each group flag adapts. Reads module trees rather than
+        # running kernels, so the Linux CPU lane gates it too; here it meets the
+        # mlx-lm and mlx-vlm versions an Apple Silicon user actually resolves.
+        run: python -m pytest tests/test_mlx_lora_group_selection.py -v -rs
+
+      - name: tests/test_mlx_resume_adapter_mismatch.py
+        # Resume binds with strict=False, so a checkpoint that predates a wider
+        # selection must be reported rather than silently half-loaded.
+        run: python -m pytest tests/test_mlx_resume_adapter_mismatch.py -v -rs
+
       - name: tests/test_mlx_shape_guard.py
         run: python -m pytest tests/test_mlx_shape_guard.py -v -rs
 

--- a/tests/test_mlx_lora_group_selection.py
+++ b/tests/test_mlx_lora_group_selection.py
@@ -402,3 +402,20 @@ def test_a_root_module_sharing_a_layer_local_name_is_left_alone():
     assert _adapters(model) == [
         "model.layers.0.att_proj", "model.layers.0.attn_out",
         "model.layers.0.ff_out", "model.layers.0.ff_proj"]
+
+
+def test_every_container_discovery_yields_can_be_written_back_into():
+    # Selection is only useful if the pass that adapts can replace what it
+    # found, so discovery must not name a container the writer cannot mutate.
+    import mlx.nn as nn
+    from unsloth_zoo.mlx.loader import _named_child_modules, _navigate, _set_child
+    holder = _build({})
+    holder.as_list = [nn.Linear(4, 4)]
+    holder.as_dict = {"vision": nn.Linear(4, 4)}
+    found = [name for name, _ in _named_child_modules(holder)]
+    assert sorted(found) == ["as_dict.vision", "as_list.0"]
+    for path in found:
+        parent_path, _, leaf = path.rpartition(".")
+        parent = _navigate(holder, parent_path)
+        _set_child(parent, leaf, nn.Linear(4, 4))       # must not raise
+        assert _navigate(holder, path) is not None

--- a/tests/test_mlx_lora_group_selection.py
+++ b/tests/test_mlx_lora_group_selection.py
@@ -281,7 +281,8 @@ def test_a_refusal_on_the_defaulted_path_names_no_target_modules():
     model = _vlm(tower=_build({"patch_ln1": {}, "patch_dense": (VISION, HIDDEN)}))
     with pytest.raises(ValueError) as excinfo:
         _peft(model, finetune_vision_layers=True)
-    assert "target_modules" not in str(excinfo.value)
+    # Suggesting one is fine; quoting back a list they never passed is not.
+    assert "target_modules=" not in str(excinfo.value)
     assert "'patch_dense'" in str(excinfo.value)
     # A vocabulary the caller did pass is still worth naming back to them.
     model = _vlm(tower=_tower(merger=_GLM_MERGER))
@@ -305,3 +306,53 @@ def test_a_tower_holding_routed_experts_adapts_them(mixed):
     adapted = _adapters(model, "vision_tower")
     assert "blocks.0.mlp.switch_mlp" in adapted
     assert ("blocks.0.attn.qkv" in adapted) is mixed
+
+
+# `feed_forward` splits into two tokens, so the joined spelling in the MLP table
+# did not reach it and the whole block lost its role.
+@pytest.mark.parametrize("block_name,role", [
+    ("feed_forward", "mlp"), ("feedforward", "mlp"), ("ffn", "mlp"),
+    ("mlp", "mlp"), ("self_attn", "attention")])
+def test_an_enclosing_block_names_its_role_however_it_is_spelled(block_name, role):
+    from unsloth_zoo.mlx.loader import _linear_role
+    assert _linear_role(f"{block_name}.dense_h_to_4h") == role
+
+
+def test_a_block_spelled_feed_forward_is_adapted_by_the_mlp_flag():
+    model = _text_model([{"self_attn": {"q_proj": (HIDDEN, HIDDEN)},
+                          "feed_forward": {"dense_h_to_4h": (HIDDEN, HIDDEN),
+                                           "dense_4h_to_h": (HIDDEN, HIDDEN)}}])
+    _peft(model)
+    assert _adapters(model, "model.layers.0") == [
+        "feed_forward.dense_4h_to_h", "feed_forward.dense_h_to_4h",
+        "self_attn.q_proj"]
+
+
+# A role is read per layer, so the same generic name can be attention beside a
+# qkv and MLP beside an fc1. Unioning the layers wrapped it in both.
+def test_a_role_read_in_one_layer_does_not_reach_another():
+    model = _text_model([{"mixer": {"qkv": (HIDDEN, HIDDEN * 3),
+                                    "proj": (HIDDEN, HIDDEN)}},
+                         {"mixer": {"fc1": (HIDDEN, HIDDEN),
+                                    "proj": (HIDDEN, HIDDEN)}}])
+    _peft(model, finetune_mlp_modules=False)
+    assert _adapters(model, "model.layers.0") == ["mixer.proj", "mixer.qkv"]
+    assert _adapters(model, "model.layers.1") == []
+
+
+def test_a_fused_expert_stack_reports_output_width_not_expert_count():
+    switch_layers = pytest.importorskip("mlx_lm.models.switch_layers")
+    from unsloth_zoo.mlx.loader import _semantic_dims
+    # (experts, out, in): the first axis counts experts, not outputs.
+    assert _semantic_dims(switch_layers.SwitchLinear(HIDDEN, 7, 4)) == (7, HIDDEN)
+    import mlx.nn as nn
+    assert _semantic_dims(nn.Linear(HIDDEN, 7)) == (7, HIDDEN)
+
+
+def test_a_tower_of_roleless_linears_says_so_rather_than_claiming_none_exist():
+    model = _vlm(tower=_build({"patch_ln1": {}, "patch_dense": (VISION, HIDDEN)}))
+    with pytest.raises(ValueError) as excinfo:
+        _peft(model, finetune_vision_layers=True)
+    said = str(excinfo.value)
+    assert "holds no linear layer" not in said
+    assert "read as attention or MLP" in said and "'patch_dense'" in said

--- a/tests/test_mlx_lora_group_selection.py
+++ b/tests/test_mlx_lora_group_selection.py
@@ -24,11 +24,13 @@ pytest.importorskip("mlx.core")
 
 
 @pytest.fixture(autouse=True)
-def _require_real_metal():
+def _require_real_mlx():
+    # Selection reads module trees, never a kernel, so the CPU backend answers
+    # it as well as Metal does. The torch shim cannot: its module classes are
+    # not the ones the selection isinstance-checks against.
     import mlx.core as _mx   # re-import: the shim may have swapped it
-    if not (getattr(_mx, "metal", None) and _mx.metal.is_available()
-            and _mx.default_device() == _mx.gpu):
-        pytest.skip("real Metal required; shim active or no GPU")
+    if "mlx_simulation" in str(getattr(_mx, "__file__", "")):
+        pytest.skip("requires the real MLX runtime; shim active")
 
 
 HIDDEN, VOCAB, VISION = 64, 128, 32

--- a/tests/test_mlx_lora_group_selection.py
+++ b/tests/test_mlx_lora_group_selection.py
@@ -356,3 +356,49 @@ def test_a_tower_of_roleless_linears_says_so_rather_than_claiming_none_exist():
     said = str(excinfo.value)
     assert "holds no linear layer" not in said
     assert "read as attention or MLP" in said and "'patch_dense'" in said
+
+
+# An all-caps prefix runs into the next word, so a tower found only by its class
+# name needs the acronym boundary as well as the camelCase one.
+@pytest.mark.parametrize("name,expected", [
+    ("CLIPVisionModel", {"clip", "vision", "model"}),
+    ("SiglipVisionTransformer", {"siglip", "vision", "transformer"}),
+    ("vision_tower", {"vision", "tower"})])
+def test_a_class_name_splits_on_acronym_boundaries(name, expected):
+    from unsloth_zoo.mlx.loader import _role_tokens
+    assert expected <= _role_tokens(name)
+
+
+def test_a_tower_named_only_by_its_class_still_resolves():
+    import mlx.nn as nn
+    from unsloth_zoo.mlx.loader import _resolve_vision_group
+    # `encoder` says nothing, so only the class name marks this as a tower.
+    tower = _tower()
+    tower.__class__ = type("CLIPVisionModel", (nn.Module,), {})
+    assert _resolve_vision_group(_vlm(tower_attr="encoder", tower=tower))[1] == "encoder"
+
+
+def test_a_module_registered_in_a_mapping_is_reachable():
+    from unsloth_zoo.mlx.loader import _named_child_modules, _navigate
+    model = _vlm(tower_attr="placeholder", tower=_build({"x": (VISION, VISION)}))
+    model.encoders = {"vision": _tower()}
+    assert "encoders.vision" in [name for name, _ in _named_child_modules(model)]
+    assert _navigate(model, "encoders.vision") is not None
+
+
+def test_a_text_side_projection_is_not_the_vision_connector():
+    from unsloth_zoo.mlx.loader import _resolve_vision_group, _resolve_projector_group
+    model = _vlm()
+    model.text_projection = _build({"linear_1": (VISION, HIDDEN)})
+    owner, _, path, tower = _resolve_vision_group(model)
+    assert _resolve_projector_group(model, owner, tower, path) == []
+
+
+def test_a_root_module_sharing_a_layer_local_name_is_left_alone():
+    import mlx.nn as nn
+    model = _text_model([_MOLMO_BLOCK])
+    model.ff_proj = nn.Linear(HIDDEN, HIDDEN)   # an unrelated auxiliary head
+    _peft(model)
+    assert _adapters(model) == [
+        "model.layers.0.att_proj", "model.layers.0.attn_out",
+        "model.layers.0.ff_out", "model.layers.0.ff_proj"]

--- a/tests/test_mlx_lora_group_selection.py
+++ b/tests/test_mlx_lora_group_selection.py
@@ -288,3 +288,20 @@ def test_a_refusal_on_the_defaulted_path_names_no_target_modules():
     with pytest.raises(ValueError) as excinfo:
         _peft(model, finetune_vision_layers=True, target_modules=["q_proj"])
     assert "target_modules=['q_proj']" in str(excinfo.value)
+
+
+# Routed experts are selectable, so the pass that adapts them must know the same
+# module types selection does: a mixed tower silently trained only its ordinary
+# linears, and a tower holding nothing else refused as though it were empty.
+@pytest.mark.parametrize("mixed", [True, False],
+                         ids=["beside ordinary linears", "alone in the tower"])
+def test_a_tower_holding_routed_experts_adapts_them(mixed):
+    switch_layers = pytest.importorskip("mlx_lm.models.switch_layers")
+    block = {"mlp": {"switch_mlp": lambda: switch_layers.SwitchLinear(VISION, VISION, 4)}}
+    if mixed:
+        block["attn"] = {"qkv": (VISION, VISION * 3), "proj": (VISION, VISION)}
+    model = _vlm(tower=_build({"blocks": [block], "patch_embed": {}}))
+    _peft(model, finetune_vision_layers=True)
+    adapted = _adapters(model, "vision_tower")
+    assert "blocks.0.mlp.switch_mlp" in adapted
+    assert ("blocks.0.attn.qkv" in adapted) is mixed

--- a/tests/test_mlx_lora_group_selection.py
+++ b/tests/test_mlx_lora_group_selection.py
@@ -273,3 +273,18 @@ def test_a_nested_connector_is_adapted_whichever_pass_owns_it(
     assert not [name for name, module in model.named_modules()
                 if hasattr(module, "lora_a")
                 and hasattr(getattr(module, "linear", None), "lora_a")]
+
+
+def test_a_refusal_on_the_defaulted_path_names_no_target_modules():
+    # The canonical list is substituted internally, so quoting it back sends
+    # the caller to change an argument they never passed.
+    model = _vlm(tower=_build({"patch_ln1": {}, "patch_dense": (VISION, HIDDEN)}))
+    with pytest.raises(ValueError) as excinfo:
+        _peft(model, finetune_vision_layers=True)
+    assert "target_modules" not in str(excinfo.value)
+    assert "'patch_dense'" in str(excinfo.value)
+    # A vocabulary the caller did pass is still worth naming back to them.
+    model = _vlm(tower=_tower(merger=_GLM_MERGER))
+    with pytest.raises(ValueError) as excinfo:
+        _peft(model, finetune_vision_layers=True, target_modules=["q_proj"])
+    assert "target_modules=['q_proj']" in str(excinfo.value)

--- a/tests/test_mlx_lora_group_selection_metal.py
+++ b/tests/test_mlx_lora_group_selection_metal.py
@@ -55,6 +55,7 @@ _KIMI_BLOCK = {"wqkv": (VISION, VISION * 3), "wo": (VISION, VISION),
                "mlp": {"fc0": (VISION, VISION), "fc1": (VISION, VISION)}}
 _GLM_MERGER = {"proj": (VISION, VISION), "gate_proj": (VISION, HIDDEN),
                "down_proj": (HIDDEN, HIDDEN)}
+_MIXER = {"token_mixer": {"qkv": (VISION, VISION * 3), "proj": (VISION, VISION)}}
 _TEXT_BLOCK = {"self_attn": {"q_proj": (HIDDEN, HIDDEN), "o_proj": (HIDDEN, HIDDEN)},
                "mlp": {"gate_proj": (HIDDEN, HIDDEN), "down_proj": (HIDDEN, HIDDEN)}}
 def _tower(block=_KIMI_BLOCK, merger=None):
@@ -97,8 +98,33 @@ def _adapters(model, prefix=""):
                   if hasattr(module, "lora_a") and name.startswith(prefix))
 
 
-# What each path reads as. The enclosing block outranks the leaf below it, a bare
-# projection names no role, and a `gate` naming what it projects into is an MLP.
+# What each path reads as: the enclosing block outranks the leaf below it.
+_ROLE_CASES = {
+    "attn_pool.mlp.fc1": "mlp", "mlp.dense_h_to_4h": "mlp",
+    "self_attn.gate_proj": "attention", "linear_attn.in_proj_qkv": "attention",
+    "block_sparse_moe.switch_mlp.gate_up_proj": "mlp",
+}
+
+
+@pytest.mark.parametrize("path,role", _ROLE_CASES.items(), ids=list(_ROLE_CASES))
+def test_what_a_linear_name_reads_as(path, role):
+    from unsloth_zoo.mlx.loader import _linear_role
+    assert _linear_role(path) == role
+
+
+_LOAN_CASES = {
+    "attention, from the one linear beside it": (
+        _MIXER, True, True, ["token_mixer.proj", "token_mixer.qkv"]),
+    "and not when the attention flag is off": (_MIXER, False, True, []),
+}
+
+
+@pytest.mark.parametrize("spec,attention,mlp,expected", _LOAN_CASES.values(),
+                         ids=list(_LOAN_CASES))
+def test_role_selection_borrows_beside_and_excludes_what_decides(
+        spec, attention, mlp, expected):
+    from unsloth_zoo.mlx.loader import _role_selected_paths
+    assert sorted(_role_selected_paths(_build(spec), attention, mlp)) == expected
 
 
 # Selecting nothing must raise, naming the flag and enough of the tree to act on.
@@ -107,6 +133,12 @@ _EMPTY_GROUP_CASES = {
     "unresolved tower": (
         lambda: _vlm(tower_attr="itok_upsampler"), {"train_vision": True},
         ["train_vision=True", "'itok_upsampler'"]),
+    # Refuses after the tower walk matched, so an adapting pass would leave
+    # those adapters behind.
+    "a connector with no linear, beside an adaptable tower": (
+        lambda: _vlm(extra=("mm_projector", _build({}))),
+        {"finetune_vision_layers": True, "train_projector": True},
+        ["holds no linear layer to adapt"]),
     # An explicit vocabulary is the caller's, so a tower it misses is theirs.
     "tower matches no requested target": (
         lambda: _vlm(tower=_tower(merger=_GLM_MERGER)),

--- a/tests/test_mlx_lora_group_selection_metal.py
+++ b/tests/test_mlx_lora_group_selection_metal.py
@@ -1,0 +1,169 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Which linears each MLX `get_peft_model` group flag adapts."""
+
+import warnings
+
+import pytest
+
+pytest.importorskip("mlx.core")
+
+
+@pytest.fixture(autouse=True)
+def _require_real_metal():
+    import mlx.core as _mx   # re-import: the shim may have swapped it
+    if not (getattr(_mx, "metal", None) and _mx.metal.is_available()
+            and _mx.default_device() == _mx.gpu):
+        pytest.skip("real Metal required; shim active or no GPU")
+
+
+HIDDEN, VOCAB, VISION = 64, 128, 32
+
+
+def _build(spec):
+    # Module trees as data: a dict is a module, a tuple is `Linear(in, out)`.
+    import mlx.nn as nn
+    if isinstance(spec, nn.Module):
+        return spec
+    if callable(spec):
+        return spec()
+    if isinstance(spec, tuple):
+        return nn.Linear(*spec)
+    if isinstance(spec, list):
+        return [_build(item) for item in spec]
+    module = type("Module", (nn.Module,), {})()
+    for name, child in spec.items():
+        setattr(module, name, _build(child))
+    return module
+
+
+_KIMI_BLOCK = {"wqkv": (VISION, VISION * 3), "wo": (VISION, VISION),
+               "mlp": {"fc0": (VISION, VISION), "fc1": (VISION, VISION)}}
+_GLM_MERGER = {"proj": (VISION, VISION), "gate_proj": (VISION, HIDDEN),
+               "down_proj": (HIDDEN, HIDDEN)}
+_TEXT_BLOCK = {"self_attn": {"q_proj": (HIDDEN, HIDDEN), "o_proj": (HIDDEN, HIDDEN)},
+               "mlp": {"gate_proj": (HIDDEN, HIDDEN), "down_proj": (HIDDEN, HIDDEN)}}
+def _tower(block=_KIMI_BLOCK, merger=None):
+    spec = {"blocks": [block], "patch_embed": {}}
+    if merger is not None:
+        spec["merger"] = merger
+    return _build(spec)
+
+
+def _text_model(blocks=None):
+    import mlx.nn as nn
+    model = _build({"model": {"embed_tokens": lambda: nn.Embedding(VOCAB, HIDDEN),
+                              "layers": blocks or [_TEXT_BLOCK] * 2},
+                    "lm_head": (HIDDEN, VOCAB)})
+    model.config = type("C", (), {})()
+    return model
+
+
+def _vlm(tower_attr="vision_tower", tower=None, extra=None, decoder=None):
+    config, text = type("C", (), {})(), type("C", (), {})()
+    text.hidden_size, config.hidden_size, config.text_config = HIDDEN, HIDDEN, text
+    model, model.config = _build({}), config
+    setattr(model, tower_attr, _tower() if tower is None else tower)
+    for name, child in [extra] if extra else []:
+        setattr(model, name, child)
+    model.language_model = _text_model(decoder)
+    model._is_vlm_model = True
+    return model
+
+
+def _peft(model, **kwargs):
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    return FastMLXModel.get_peft_model(
+        model, **{"r": 4, "use_gradient_checkpointing": False, **kwargs})
+
+
+def _adapters(model, prefix=""):
+    cut = len(prefix) + 1 if prefix else 0
+    return sorted(name[cut:] for name, module in model.named_modules()
+                  if hasattr(module, "lora_a") and name.startswith(prefix))
+
+
+# What each path reads as. The enclosing block outranks the leaf below it, a bare
+# projection names no role, and a `gate` naming what it projects into is an MLP.
+
+
+# Selecting nothing must raise, naming the flag and enough of the tree to act on.
+_EMPTY_GROUP_CASES = {
+    # "sam" occurs inside `itok_upsampler`, so tokens are matched whole.
+    "unresolved tower": (
+        lambda: _vlm(tower_attr="itok_upsampler"), {"train_vision": True},
+        ["train_vision=True", "'itok_upsampler'"]),
+    # An explicit vocabulary is the caller's, so a tower it misses is theirs.
+    "tower matches no requested target": (
+        lambda: _vlm(tower=_tower(merger=_GLM_MERGER)),
+        {"finetune_vision_layers": True, "train_projector": True,
+         "target_modules": ["q_proj"]},
+        ["finetune_vision_layers", "'vision_tower'", "q_proj", "'wqkv'"]),
+    "a tower whose linears read as neither role": (
+        lambda: _vlm(tower=_build({"patch_ln1": {}, "patch_dense": (VISION, HIDDEN)})),
+        {"finetune_vision_layers": True},
+        ["finetune_vision_layers", "'patch_dense'"]),
+}
+
+
+@pytest.mark.parametrize("build,kwargs,expected", _EMPTY_GROUP_CASES.values(),
+                         ids=list(_EMPTY_GROUP_CASES))
+def test_a_group_flag_selecting_nothing_raises_and_changes_nothing(
+        build, kwargs, expected):
+    model = build()
+    model._unsloth_cpt_full_module_weight_keys = "untouched"
+    with pytest.raises(ValueError) as excinfo:
+        _peft(model, **kwargs)
+    assert all(word in str(excinfo.value) for word in expected)
+    assert _adapters(model) == []
+    assert model._unsloth_cpt_full_module_weight_keys == "untouched"
+    _peft(model)                      # the retry the message asks for
+    assert len(_adapters(model, "language_model")) == 8
+    assert _adapters(model, "vision_tower") == []
+
+
+def _text_only_vlm():
+    model = _vlm(tower=_tower(merger=_GLM_MERGER))
+    model._unsloth_text_only_vlm = True
+    return model
+
+
+# A warning is a message, not a decision, so it precedes any modification.
+@pytest.mark.parametrize("build,prefix,adapted", [
+    (_text_only_vlm, "language_model", "vision_tower"),
+    (_text_model, "model", None)],
+    ids=["a vlm the forward pass never reaches", "no vision path at all"])
+@pytest.mark.parametrize("flag", ["finetune_vision_layers", "train_vision",
+                                  "train_projector"])
+def test_a_flag_that_will_not_train_warns_before_the_model_is_touched(
+        build, flag, prefix, adapted):
+    model = build()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        with pytest.raises(UserWarning):
+            _peft(model, **{flag: True})
+    assert _adapters(model) == []
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _peft(model, **{flag: True})
+    said = [str(w.message) for w in caught if "text_only" in str(w.message)]
+    assert len(said) == 1, "the executing pass must not warn as well"
+    assert f"{flag}=True" in said[0]
+    assert ("text_only=True" if adapted else "no vision path") in said[0]
+    assert len(_adapters(model, prefix)) == 8
+    # Warning, not refusing: the tower really is wrapped, just never trained.
+    assert bool(_adapters(model, adapted)) if adapted else True

--- a/tests/test_mlx_lora_group_selection_metal.py
+++ b/tests/test_mlx_lora_group_selection_metal.py
@@ -98,10 +98,12 @@ def _adapters(model, prefix=""):
                   if hasattr(module, "lora_a") and name.startswith(prefix))
 
 
-# What each path reads as: the enclosing block outranks the leaf below it.
+# What each path reads as. The enclosing block outranks the leaf below it,
+# and a bare projection names no role.
 _ROLE_CASES = {
-    "attn_pool.mlp.fc1": "mlp", "mlp.dense_h_to_4h": "mlp",
-    "self_attn.gate_proj": "attention", "linear_attn.in_proj_qkv": "attention",
+    "query_key_value": "attention", "dense": None, "attn_pool.mlp.fc1": "mlp",
+    "mlp.dense_h_to_4h": "mlp", "self_attn.gate_proj": "attention",
+    "q_proj.linear": "attention", "linear_attn.in_proj_qkv": "attention",
     "block_sparse_moe.switch_mlp.gate_up_proj": "mlp",
 }
 
@@ -113,6 +115,9 @@ def test_what_a_linear_name_reads_as(path, role):
 
 
 _LOAN_CASES = {
+    "mlp, from three agreeing siblings": (
+        _GLM_MERGER, True, True, ["down_proj", "gate_proj", "proj"]),
+    "and not when the mlp flag is off": (_GLM_MERGER, True, False, []),
     "attention, from the one linear beside it": (
         _MIXER, True, True, ["token_mixer.proj", "token_mixer.qkv"]),
     "and not when the attention flag is off": (_MIXER, False, True, []),
@@ -125,6 +130,34 @@ def test_role_selection_borrows_beside_and_excludes_what_decides(
         spec, attention, mlp, expected):
     from unsloth_zoo.mlx.loader import _role_selected_paths
     assert sorted(_role_selected_paths(_build(spec), attention, mlp)) == expected
+
+
+_SELECTION_CASES = {
+    "a tower under an unlisted name, by role and by flag": (
+        lambda: _vlm(tower_attr="visual"),
+        {"finetune_vision_layers": True, "finetune_mlp_modules": False},
+        "visual.blocks.0", ["wo", "wqkv"]),
+    # A nested connector reads as MLP, so the tower pass must leave it alone.
+    "a nested connector is adapted once, by its own pass": (
+        lambda: _vlm(tower=_tower(merger=_GLM_MERGER)),
+        {"finetune_vision_layers": True, "train_projector": True},
+        "vision_tower.merger", ["down_proj", "gate_proj", "proj"]),
+    # Each call site must pass the flags on, not merely honour them.
+    "a tower with attention off": (
+        lambda: _vlm(tower_attr="visual"), {"finetune_vision_layers": True,
+        "finetune_attention_modules": False}, "visual.blocks.0", ["mlp.fc0", "mlp.fc1"]),
+}
+
+
+@pytest.mark.parametrize("build,kwargs,prefix,expected", _SELECTION_CASES.values(),
+                         ids=list(_SELECTION_CASES))
+def test_a_group_flag_adapts_exactly_its_own_linears(build, kwargs, prefix,
+                                                     expected):
+    model = build()
+    with warnings.catch_warnings():   # role selection announces nothing
+        warnings.simplefilter("error", UserWarning)
+        _peft(model, **kwargs)
+    assert _adapters(model, prefix) == expected
 
 
 # Selecting nothing must raise, naming the flag and enough of the tree to act on.

--- a/tests/test_mlx_lora_group_selection_metal.py
+++ b/tests/test_mlx_lora_group_selection_metal.py
@@ -58,6 +58,8 @@ _GLM_MERGER = {"proj": (VISION, VISION), "gate_proj": (VISION, HIDDEN),
 _MIXER = {"token_mixer": {"qkv": (VISION, VISION * 3), "proj": (VISION, VISION)}}
 _TEXT_BLOCK = {"self_attn": {"q_proj": (HIDDEN, HIDDEN), "o_proj": (HIDDEN, HIDDEN)},
                "mlp": {"gate_proj": (HIDDEN, HIDDEN), "down_proj": (HIDDEN, HIDDEN)}}
+_MOLMO_BLOCK = {"att_proj": (HIDDEN, HIDDEN), "attn_out": (HIDDEN, HIDDEN),
+                "ff_proj": (HIDDEN, HIDDEN), "ff_out": (HIDDEN, HIDDEN)}
 def _tower(block=_KIMI_BLOCK, merger=None):
     spec = {"blocks": [block], "patch_embed": {}}
     if merger is not None:
@@ -98,13 +100,15 @@ def _adapters(model, prefix=""):
                   if hasattr(module, "lora_a") and name.startswith(prefix))
 
 
-# What each path reads as. The enclosing block outranks the leaf below it,
-# and a bare projection names no role.
+# What each path reads as. The enclosing block outranks the leaf below it, a bare
+# projection names no role, and a `gate` naming what it projects into is an MLP.
 _ROLE_CASES = {
-    "query_key_value": "attention", "dense": None, "attn_pool.mlp.fc1": "mlp",
-    "mlp.dense_h_to_4h": "mlp", "self_attn.gate_proj": "attention",
-    "q_proj.linear": "attention", "linear_attn.in_proj_qkv": "attention",
+    "query_key_value": "attention", "dense": None, "mlp.gate": "gate",
+    "attn_pool.mlp.fc1": "mlp", "mlp.dense_h_to_4h": "mlp", "mlp.gate_1": "gate",
+    "self_attn.gate_proj": "attention", "q_proj.linear": "attention",
+    "linear_attn.in_proj_qkv": "attention", "per_layer_input_gate": "gate",
     "block_sparse_moe.switch_mlp.gate_up_proj": "mlp",
+    "mlp.zaya_block.router.down_proj": "gate",
 }
 
 
@@ -121,6 +125,11 @@ _LOAN_CASES = {
     "attention, from the one linear beside it": (
         _MIXER, True, True, ["token_mixer.proj", "token_mixer.qkv"]),
     "and not when the attention flag is off": (_MIXER, False, True, []),
+    # Exclusion, not borrowing: a gate decides, and one unit is a scale.
+    "and a gate or a one-unit scale is selected by neither flag": (
+        {"mlp": {"up": (HIDDEN, HIDDEN), "gate": (HIDDEN, 4),
+                 "shared_expert_gate": (HIDDEN, 1)},
+         "mlp_res_proj": (HIDDEN, 1)}, True, True, ["mlp.up"]),
 }
 
 
@@ -142,10 +151,22 @@ _SELECTION_CASES = {
         lambda: _vlm(tower=_tower(merger=_GLM_MERGER)),
         {"finetune_vision_layers": True, "train_projector": True},
         "vision_tower.merger", ["down_proj", "gate_proj", "proj"]),
-    # Each call site must pass the flags on, not merely honour them.
+    # Qwen3.5 alternates attention kinds, so reading one layer misses half.
+    "a decoder spelled unlike a canonical one, layer by layer": (
+        lambda: _text_model([_MOLMO_BLOCK, _TEXT_BLOCK]), {}, "model.layers",
+        ["0.att_proj", "0.attn_out", "0.ff_out", "0.ff_proj", "1.mlp.down_proj",
+         "1.mlp.gate_proj", "1.self_attn.o_proj", "1.self_attn.q_proj"]),
+    # Each call site must pass the flags on, and the decoder has two of them.
     "a tower with attention off": (
         lambda: _vlm(tower_attr="visual"), {"finetune_vision_layers": True,
         "finetune_attention_modules": False}, "visual.blocks.0", ["mlp.fc0", "mlp.fc1"]),
+    "a decoder with attention off": (
+        lambda: _text_model([_MOLMO_BLOCK]), {"finetune_attention_modules": False},
+        "model.layers.0", ["ff_out", "ff_proj"]),
+    "a vlm decoder with mlp off": (
+        lambda: _vlm(decoder=[_MOLMO_BLOCK]), {"finetune_vision_layers": False,
+        "finetune_mlp_modules": False}, "language_model.model.layers.0",
+        ["att_proj", "attn_out"]),
 }
 
 

--- a/tests/test_mlx_lora_group_selection_metal.py
+++ b/tests/test_mlx_lora_group_selection_metal.py
@@ -253,3 +253,21 @@ def test_a_flag_that_will_not_train_warns_before_the_model_is_touched(
     assert len(_adapters(model, prefix)) == 8
     # Warning, not refusing: the tower really is wrapped, just never trained.
     assert bool(_adapters(model, adapted)) if adapted else True
+
+
+# A connector nested in the tower is skipped so the projector pass can adapt it
+# once. With that pass switched off there is no second pass, and skipping would
+# drop linears the tower walk used to reach.
+@pytest.mark.parametrize("train_projector,adapted_by", [
+    (False, "the tower pass"), (True, "its own pass")],
+    ids=["projector off", "projector on"])
+def test_a_nested_connector_is_adapted_whichever_pass_owns_it(
+        train_projector, adapted_by):
+    model = _vlm(tower=_tower(merger=_GLM_MERGER))
+    _peft(model, finetune_vision_layers=True, train_projector=train_projector)
+    merger = _adapters(model, "vision_tower.merger")
+    assert merger == ["down_proj", "gate_proj", "proj"], adapted_by
+    # Once, not twice: an adapter stacked on an adapter would show a wrapped base.
+    assert not [name for name, module in model.named_modules()
+                if hasattr(module, "lora_a")
+                and hasattr(getattr(module, "linear", None), "lora_a")]

--- a/tests/test_mlx_resume_adapter_mismatch.py
+++ b/tests/test_mlx_resume_adapter_mismatch.py
@@ -1,0 +1,77 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Resuming from an adapter that does not cover every LoRA module now attached."""
+
+import warnings
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+nn = pytest.importorskip("mlx.nn")
+
+RANK, HIDDEN = 4, 8
+
+
+def _lora_module():
+    module = nn.Linear(HIDDEN, HIDDEN)
+    module.lora_a = mx.zeros((HIDDEN, RANK))
+    module.lora_b = mx.zeros((RANK, HIDDEN))
+    return module
+
+
+def _model(names):
+    model = type("M", (nn.Module,), {})()
+    for name in names:
+        setattr(model, name, _lora_module())
+    return model
+
+
+def _checkpoint(tmp_path, names):
+    path = tmp_path / "adapters.safetensors"
+    mx.save_safetensors(str(path), {
+        f"{name}.{leaf}": mx.zeros((HIDDEN, RANK) if leaf == "lora_a"
+                                   else (RANK, HIDDEN))
+        for name in names for leaf in ("lora_a", "lora_b")})
+    return str(path)
+
+
+def _warn_on(model, path):
+    from unsloth_zoo.mlx.trainer import _warn_resume_adapter_mismatch
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _warn_resume_adapter_mismatch(model, path)
+    return [str(w.message) for w in caught]
+
+
+def test_a_checkpoint_covering_every_module_is_silent(tmp_path):
+    names = ["q_proj", "o_proj"]
+    assert _warn_on(_model(names), _checkpoint(tmp_path, names)) == []
+
+
+def test_a_narrower_checkpoint_names_what_it_does_not_cover(tmp_path):
+    # What an adapter written when selection was narrower looks like on resume.
+    path = _checkpoint(tmp_path, ["q_proj"])
+    said = _warn_on(_model(["q_proj", "in_proj_qkv", "out_proj"]), path)
+    assert len(said) == 1
+    assert "2 of the LoRA modules" in said[0]
+    assert "in_proj_qkv" in said[0] and "out_proj" in said[0]
+    assert "q_proj" not in said[0].split("for example")[1]
+
+
+def test_a_missing_checkpoint_is_not_an_error(tmp_path):
+    # Reporting must never be the thing that stops a resume.
+    assert _warn_on(_model(["q_proj"]), str(tmp_path / "absent.safetensors")) == []

--- a/tests/test_mlx_resume_adapter_mismatch.py
+++ b/tests/test_mlx_resume_adapter_mismatch.py
@@ -26,25 +26,30 @@ nn = pytest.importorskip("mlx.nn")
 RANK, HIDDEN = 4, 8
 
 
-def _lora_module():
+def _lora_module(wrapped=False):
     module = nn.Linear(HIDDEN, HIDDEN)
-    module.lora_a = mx.zeros((HIDDEN, RANK))
-    module.lora_b = mx.zeros((RANK, HIDDEN))
+    if wrapped:                     # adapters held as modules, not arrays
+        module.lora_a = nn.Linear(HIDDEN, RANK)
+        module.lora_b = nn.Linear(RANK, HIDDEN)
+    else:
+        module.lora_a = mx.zeros((HIDDEN, RANK))
+        module.lora_b = mx.zeros((RANK, HIDDEN))
     return module
 
 
-def _model(names):
+def _model(names, wrapped=False):
     model = type("M", (nn.Module,), {})()
     for name in names:
-        setattr(model, name, _lora_module())
+        setattr(model, name, _lora_module(wrapped))
     return model
 
 
-def _checkpoint(tmp_path, names):
+def _checkpoint(tmp_path, names, wrapped=False):
     path = tmp_path / "adapters.safetensors"
+    suffix = ".weight" if wrapped else ""
     mx.save_safetensors(str(path), {
-        f"{name}.{leaf}": mx.zeros((HIDDEN, RANK) if leaf == "lora_a"
-                                   else (RANK, HIDDEN))
+        f"{name}.{leaf}{suffix}": mx.zeros((HIDDEN, RANK) if leaf == "lora_a"
+                                           else (RANK, HIDDEN))
         for name in names for leaf in ("lora_a", "lora_b")})
     return str(path)
 
@@ -57,9 +62,14 @@ def _warn_on(model, path):
     return [str(w.message) for w in caught]
 
 
-def test_a_checkpoint_covering_every_module_is_silent(tmp_path):
+# A wrapper holding its adapters as modules stores them one level down, so the
+# same coverage is spelled `q_proj.lora_a.weight` rather than `q_proj.lora_a`.
+@pytest.mark.parametrize("wrapped", [False, True],
+                         ids=["adapters as arrays", "adapters as modules"])
+def test_a_checkpoint_covering_every_module_is_silent(tmp_path, wrapped):
     names = ["q_proj", "o_proj"]
-    assert _warn_on(_model(names), _checkpoint(tmp_path, names)) == []
+    assert _warn_on(_model(names, wrapped),
+                    _checkpoint(tmp_path, names, wrapped)) == []
 
 
 def test_a_narrower_checkpoint_names_what_it_does_not_cover(tmp_path):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -6801,8 +6801,48 @@ def _raise_projector_unresolved(model, vision_path, vision_module):
     )
 
 
+# The enclosing block names the role even where the leaf does not.
+_ATTENTION_PATH_TOKENS = frozenset(("attn", "attention"))
+_MLP_PATH_TOKENS = frozenset(("mlp", "ffn", "feedforward", "swiglu"))
+_ATTENTION_LEAVES = frozenset((
+    "q", "k", "v", "o", "kv", "qkv", "wq", "wk", "wv", "wo", "wkv", "wqkv",
+    "query", "key", "value", "out", "dense", "proj",
+))
+_MLP_LEAVES = frozenset((
+    "fc", "fc0", "fc1", "fc2", "fc3", "w1", "w2", "w3", "gate", "up", "down",
+    "c_fc", "linear1", "linear2",
+))
+
+
+def _linear_role(path):
+    """``"attention"``, ``"mlp"`` or ``None`` for a linear at ``path``."""
+    segments = str(path).lower().split(".")
+    for segment in reversed(segments):
+        tokens = _role_tokens(segment)
+        if tokens & _ATTENTION_PATH_TOKENS:
+            return "attention"
+        if tokens & _MLP_PATH_TOKENS:
+            return "mlp"
+    leaf = segments[-1] if segments else ""
+    if leaf in _ATTENTION_LEAVES:
+        return "attention"
+    if leaf in _MLP_LEAVES:
+        return "mlp"
+    return None
+
+
 def _under_any(path, prefixes):
     return any(path == p or path.startswith(f"{p}.") for p in prefixes)
+
+
+def _role_selected_paths(module, attention, mlp, skip_subtrees=()):
+    """``module``'s linears by role, one whose role cannot be read left alone."""
+    wanted = {"attention": attention, "mlp": mlp}
+    return [
+        path for path, _ in _subtree_linears(module)
+        if wanted.get(_linear_role(path), False)
+        and not _under_any(path, skip_subtrees)
+    ]
 
 
 def _raise_empty_target_modules():
@@ -6832,7 +6872,9 @@ def _raise_group_empty(flag, role, module_path, module, target_modules=None):
 
 
 def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
-                    train_vision, train_projector, dry_run):
+                    train_vision, train_projector, targets_defaulted,
+                    finetune_attention_modules, finetune_mlp_modules,
+                    dry_run):
     """Adapt the vision tower and connector, returning what each flag selected.
 
     The ``dry_run`` pass is the only source of refusals and warnings: raising
@@ -6886,6 +6928,39 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
             tower_owner, vision_attr, lora_config, target_modules,
             skip_subtrees=nested_projectors, dry_run=dry_run,
         )
+        # The canonical target names are a decoder vocabulary this code
+        # chose, not one the caller asked for, so when a tower speaks a
+        # different one, select its linears by role instead. Only ever
+        # reached where the walk above found nothing, so no tree that
+        # matches today changes, nor the order LoRA init draws randomness.
+        if vision_lora_count == 0 and targets_defaulted:
+            role_paths = _role_selected_paths(
+                vision_module, finetune_attention_modules,
+                finetune_mlp_modules, skip_subtrees=nested_projectors,
+            )
+            if role_paths:
+                vision_lora_count = _lora_walk_module(
+                    tower_owner, vision_attr, lora_config, None,
+                    match_paths=set(role_paths), dry_run=dry_run,
+                )
+                roles = " and ".join(
+                    role for role, wanted in (
+                        ("attention", finetune_attention_modules),
+                        ("MLP", finetune_mlp_modules),
+                    ) if wanted
+                )
+                if dry_run:
+                    warnings.warn(
+                        f"Unsloth: the vision tower at {vision_path!r} has no "
+                        "module named in the default target_modules, so "
+                        f"{vision_flag}=True will adapt its {roles} linears "
+                        "by position instead: "
+                        f"{sorted({_leaf_name(p) for p in role_paths})!r}. "
+                        "Pass target_modules explicitly to choose them yourself.",
+                        # One frame deeper than `get_peft_model`, which is the
+                        # caller worth naming.
+                        stacklevel=3,
+                    )
     projector_lora_count = 0
     for p_owner, p_attr, _, _ in projector_entries:
         projector_lora_count += _lora_walk_module(
@@ -6917,16 +6992,11 @@ def _lora_walk_module(
     *,
     match_all_linear=False,
     skip_subtrees=(),
+    match_paths=None,
     dry_run=False,
 ):
-    """Replace matching Linear/QuantizedLinear under ``owner.attr_name`` with LoRA.
-
-    Used for vision encoders and connectors that don't have the flat `.layers`
-    structure expected by mlx-lm's `linear_to_lora_layers`. ``skip_subtrees``
-    names children left untouched, so a connector nested in the tower is adapted
-    once, by its own pass, rather than wrapped again on top of the tower's.
-    ``dry_run`` counts what would be replaced without replacing it.
-    """
+    """LoRA for encoders and connectors, which lack the flat `.layers` structure
+    mlx-lm's `linear_to_lora_layers` expects."""
     import mlx.nn as nn
     try:
         from mlx_lm.tuner.lora import LoRALinear
@@ -6949,7 +7019,10 @@ def _lora_walk_module(
     for name, child in list(root.named_modules()):
         if _under_any(name, skip_subtrees):
             continue
-        if not match_all_linear and not _lora_name_matches_target(name, target_modules):
+        if match_paths is not None:
+            if name not in match_paths:
+                continue
+        elif not match_all_linear and not _lora_name_matches_target(name, target_modules):
             continue
         if not isinstance(child, (nn.Linear, nn.QuantizedLinear)):
             continue
@@ -8513,6 +8586,8 @@ class FastMLXModel:
                 "Install via: pip install unsloth-zoo[mlx]"
             )
 
+        targets_defaulted = target_modules is None
+
         # finetune_vision_layers (None = use train_vision arg; bool overrides it)
         vision_flag = "train_vision"
         if finetune_vision_layers is not None:
@@ -8615,7 +8690,9 @@ class FastMLXModel:
             _vlm_group_lora(
                 model, lora_config, target_modules, vision_flag=vision_flag,
                 train_vision=train_vision, train_projector=train_projector,
-                dry_run=True,
+                targets_defaulted=targets_defaulted,
+                finetune_attention_modules=finetune_attention_modules,
+                finetune_mlp_modules=finetune_mlp_modules, dry_run=True,
             )
 
             # Scopes embedding_learning_rate to exactly these tensors.
@@ -8668,7 +8745,9 @@ class FastMLXModel:
             (vision_lora_count, projector_lora_count) = _vlm_group_lora(
                 model, lora_config, target_modules, vision_flag=vision_flag,
                 train_vision=train_vision, train_projector=train_projector,
-                dry_run=False,
+                targets_defaulted=targets_defaulted,
+                finetune_attention_modules=finetune_attention_modules,
+                finetune_mlp_modules=finetune_mlp_modules, dry_run=False,
             )
 
             if (

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -6998,7 +6998,9 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
             _raise_empty_target_modules()
         _raise_group_empty(
             vision_flag, "vision tower", vision_path, vision_module,
-            target_modules,
+            # Naming a list the caller never passed sends them to fix the wrong
+            # thing; on the defaulted path the tower itself is the whole story.
+            None if targets_defaulted else target_modules,
         )
     if train_projector and projector_lora_count == 0:
         _raise_group_empty(

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -6521,24 +6521,423 @@ def _patch_mlx_saving(model, tokenizer):
     model.save_lora_adapters     = types.MethodType(_mlx_save_lora_adapters, model)
 
 
+# Searched first, so a tree that resolves today keeps resolving the same way.
+_VISION_GROUP_ATTRS = ("vision_tower", "vision_model", "vision_encoder")
+_PROJECTOR_GROUP_ATTRS = (
+    "multi_modal_projector", "mm_projector", "connector", "aligner",
+    "embed_vision",
+)
+_VISION_ROLE_TOKENS = frozenset((
+    "vision", "visual", "vit", "image", "img", "pixel", "siglip", "clip", "sam",
+))
+_PROJECTOR_ROLE_TOKENS = frozenset((
+    "projector", "projection", "proj", "connector", "aligner", "align",
+    "merger", "merge", "resampler", "mlp1",
+))
+# The subset naming the role outright; "proj", "merge" and "align" also occur
+# on modules that are not connectors.
+_STRONG_PROJECTOR_TOKENS = frozenset((
+    "projector", "projection", "connector", "aligner", "merger", "resampler",
+    "mlp1",
+))
+# `audio_projection` is shaped exactly like a vision connector, so only the
+# modality in the name separates them.
+_OTHER_MODALITY_TOKENS = frozenset((
+    "audio", "sound", "speech", "voice", "wav", "mel", "talker",
+))
+_NON_VISION_ROLE_TOKENS = _OTHER_MODALITY_TOKENS | frozenset(("language", "text"))
+# Whole words, not substrings: "sam" occurs inside `itok_upsampler`.
+_ROLE_TOKEN_SPLIT = re.compile(r"[^A-Za-z0-9]+|(?<=[a-z0-9])(?=[A-Z])")
+
+
+def _role_tokens(name):
+    tokens = set()
+    for token in _ROLE_TOKEN_SPLIT.split(str(name)):
+        if not token:
+            continue
+        token = token.lower()
+        tokens.add(token)
+        # A plural names the same role: `layerwise_projectors`.
+        if len(token) > 3 and token.endswith("s"):
+            tokens.add(token[:-1])
+    return frozenset(tokens)
+
+
+def _has_role_token(name, tokens):
+    return bool(_role_tokens(name) & tokens)
+
+
+def _reads_as(name, module, tokens):
+    return (_has_role_token(name, tokens)
+            or _has_role_token(type(module).__name__, tokens))
+
+
+def _named_child_modules(module):
+    # A list-valued attribute is flattened to `attr.i`.
+    import mlx.nn as nn
+    try:
+        children = module.children()
+    except Exception:
+        return []
+    found = []
+    for name, child in children.items():
+        if isinstance(child, nn.Module):
+            found.append((name, child))
+        elif isinstance(child, list):
+            found.extend(
+                (f"{name}.{index}", item)
+                for index, item in enumerate(child)
+                if isinstance(item, nn.Module)
+            )
+    return found
+
+
+def _child_names(module):
+    return sorted({name.rpartition(".")[0] or name
+                   for name, _ in _named_child_modules(module)})
+
+
+def _navigate(owner, path):
+    node = owner
+    for segment in str(path).split("."):
+        if node is None:
+            return None
+        try:
+            node = node[int(segment)]
+        except (ValueError, TypeError):
+            node = getattr(node, segment, None)
+        except (IndexError, KeyError):
+            return None
+    return node
+
+
+def _set_child(parent, leaf, value):
+    try:
+        parent[int(leaf)] = value
+    except (ValueError, TypeError):
+        setattr(parent, leaf, value)
+
+
+def _subtree_linears(module):
+    """``(path, module)`` for every Linear-like leaf in ``module``."""
+    import mlx.nn as nn
+    return [
+        (name, child) for name, child in module.named_modules()
+        if isinstance(child, (nn.Linear, nn.QuantizedLinear))
+    ]
+
+
+def _leaf_name(path):
+    for token in reversed(str(path).split(".")):
+        if token and not token.isdigit():
+            return token
+    return str(path)
+
+
+def _subtree_linear_leaf_names(module):
+    return sorted({_leaf_name(path) for path, _ in _subtree_linears(module)})
+
+
+def _holds_text_decoder(module):
+    # Anchored on `embed_tokens`, not the type: towers carry position embeddings.
+    return any(
+        hasattr(child, "embed_tokens") for _, child in module.named_modules()
+    )
+
+
+def _config_hidden_size(config, depth):
+    if config is None:
+        return None
+    if depth > 1:
+        for field in ("text_config", "thinker_config", "language_config"):
+            size = _config_hidden_size(getattr(config, field, None), depth - 1)
+            if size:
+                return size
+    for field in ("hidden_size", "d_model"):
+        size = getattr(config, field, None)
+        if isinstance(size, int) and size > 0:
+            return size
+    return None
+
+
+def _text_hidden_size(model):
+    # The embedding carries the width whatever the config calls the field.
+    import mlx.nn as nn
+    from .utils import _embedding_dims
+    for _, child in model.named_modules():
+        embed = getattr(child, "embed_tokens", None)
+        if isinstance(embed, (nn.Embedding, nn.QuantizedEmbedding)):
+            return _embedding_dims(embed)[1]
+    return _config_hidden_size(getattr(model, "config", None), 3)
+
+
+def _feeds_text_width(name, module, text_hidden_size):
+    """Whether ``module`` hands its output to the decoder.
+
+    A head merely running at that width fits too, so a weakly named candidate
+    must change width somewhere.
+    """
+    if not text_hidden_size:
+        return False
+    text_hidden_size = int(text_hidden_size)
+    reaches = changes = False
+    from .utils import _linear_semantic_dims
+    for _, linear in _subtree_linears(module):
+        out_dim, in_dim = _linear_semantic_dims(linear)
+        reaches = reaches or out_dim == text_hidden_size
+        changes = changes or in_dim != text_hidden_size
+    if not reaches:
+        return False
+    return changes or _reads_as(name, module, _STRONG_PROJECTOR_TOKENS)
+
+
+def _resolve_vision_group(model):
+    import mlx.nn as nn
+    from .utils import _get_text_model
+
+    for attr in _VISION_GROUP_ATTRS:
+        module = getattr(model, attr, None)
+        if isinstance(module, nn.Module):
+            return model, attr, attr, module
+    return _search_vision_group(model, "", _get_text_model(model), 2)
+
+
+def _search_vision_group(owner, owner_path, text_model, depth):
+    """Image encoder below ``owner``, by the role its name or class reads as."""
+    found, containers = [], []
+    for name, child in _named_child_modules(owner):
+        if child is text_model or _has_role_token(name, _NON_VISION_ROLE_TOKENS):
+            continue
+        path = f"{owner_path}.{name}" if owner_path else name
+        # A child holding the decoder is a container, not a tower.
+        if _holds_text_decoder(child):
+            containers.append((child, path))
+        elif _reads_as(name, child, _VISION_ROLE_TOKENS):
+            found.append((owner, name, path, child))
+    if found:
+        return found[0]
+    if depth > 1:
+        for child, path in containers:
+            found = _search_vision_group(child, path, text_model, depth - 1)
+            if found[0] is not None:
+                return found
+    return None, None, None, None
+
+
+def _projector_candidates(owner, owner_path, skip, text_hidden_size):
+    found = []
+    for name, child in _named_child_modules(owner):
+        if any(child is s for s in skip):
+            continue
+        if not _reads_as(name, child, _PROJECTOR_ROLE_TOKENS):
+            continue
+        if _reads_as(name, child, _OTHER_MODALITY_TOKENS):
+            continue
+        # The decoder is what a connector feeds, not something it holds.
+        if _holds_text_decoder(child):
+            continue
+        if not _feeds_text_width(name, child, text_hidden_size):
+            continue
+        path = f"{owner_path}.{name}" if owner_path else name
+        found.append((owner, name, path, child))
+    return found
+
+
+def _resolve_projector_group(model, vision_owner=None, vision_module=None,
+                             vision_path=None):
+    """``(owner, attr, path, module)`` entries for the vision-to-text connector.
+
+    Not always one module, so every candidate at the first root that has any is
+    returned, one level deep so per-block output projections are not among them.
+    """
+    import mlx.nn as nn
+    from .utils import _get_text_model
+
+    for attr in _PROJECTOR_GROUP_ATTRS:
+        module = getattr(model, attr, None)
+        if isinstance(module, nn.Module):
+            # Alone: joining it with others would adapt more than today.
+            return [(model, attr, attr, module)]
+
+    text_hidden_size = _text_hidden_size(model)
+    skip = (_get_text_model(model), vision_module)
+    roots = [(model, "")]
+    if vision_owner is not None and vision_owner is not model:
+        roots.append((vision_owner, vision_path.rsplit(".", 1)[0]))
+    if vision_module is not None:
+        roots.append((vision_module, vision_path))
+    for root, root_path in roots:
+        candidates = _projector_candidates(root, root_path, skip, text_hidden_size)
+        if candidates:
+            return candidates
+    return []
+
+
+def _raise_vision_unresolved(flag, model):
+    raise ValueError(
+        f"Unsloth: {flag}=True, but no vision tower was found. Looked for a "
+        f"module named one of {list(_VISION_GROUP_ATTRS)!r}, then any module "
+        f"beside or below them whose name or class reads as an image encoder. "
+        f"This model's top-level modules are "
+        f"{_child_names(model)!r}. If one of "
+        f"those is the vision tower, please report the architecture; otherwise "
+        f"set {flag}=False."
+    )
+
+
+def _raise_projector_unresolved(model, vision_path, vision_module):
+    searched = _child_names(model)
+    if vision_module is not None:
+        searched += [f"{vision_path}.{name}"
+                    for name in _child_names(vision_module)]
+    raise ValueError(
+        "Unsloth: train_projector=True, but no vision-to-text projector was "
+        f"found. Looked for a module named one of {list(_PROJECTOR_GROUP_ATTRS)!r}, "
+        "then any module beside or below the vision tower whose name or class "
+        "reads as a connector and that projects to the decoder's hidden size. "
+        f"The modules searched were {searched!r}. If one of those is the "
+        "projector, please report the architecture; otherwise set "
+        "train_projector=False."
+    )
+
+
+def _under_any(path, prefixes):
+    return any(path == p or path.startswith(f"{p}.") for p in prefixes)
+
+
+def _raise_empty_target_modules():
+    raise ValueError(
+        "Unsloth: target_modules became empty after filtering by "
+        "finetune_attention_modules / finetune_mlp_modules. Enable at least one "
+        "of these flags."
+    )
+
+
+def _raise_group_empty(flag, role, module_path, module, target_modules=None):
+    leaf_names = _subtree_linear_leaf_names(module)
+    if target_modules is None or not leaf_names:
+        raise ValueError(
+            f"Unsloth: {flag}=True, but the {role} at {module_path!r} holds no "
+            f"linear layer to adapt. Its modules are "
+            f"{_child_names(module)!r}. Set "
+            f"{flag}=False."
+        )
+    raise ValueError(
+        f"Unsloth: {flag}=True selected no LoRA target inside the {role} at "
+        f"{module_path!r}. target_modules={list(target_modules)!r} matched none "
+        f"of its linear layers, which are named {leaf_names!r}. Pass "
+        f"target_modules with names from that list to train the {role}, or set "
+        f"{flag}=False."
+    )
+
+
+def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
+                    train_vision, train_projector, dry_run):
+    """Adapt the vision tower and connector, returning what each flag selected.
+
+    The ``dry_run`` pass is the only source of refusals and warnings: raising
+    later would leave adapters for the retry to stack on.
+    """
+    # The tower of a wrapper loaded text-only still resolves and adapts, but the
+    # text forward returns before reaching it, so those adapters never train.
+    if dry_run and getattr(model, "_unsloth_text_only_vlm", False):
+        for flag, requested in (
+            (vision_flag, train_vision),
+            ("train_projector", train_projector),
+        ):
+            if requested:
+                warnings.warn(
+                    f"Unsloth: {flag}=True, but this model was loaded with "
+                    "text_only=True. Its vision tower is still attached, so "
+                    "the flag will wrap adapters that the text-only forward "
+                    "pass never reaches and never trains. Reload with "
+                    f"text_only=False to train the vision path, or set "
+                    f"{flag}=False.",
+                    stacklevel=3,   # name `get_peft_model`'s caller
+                )
+    (vision_owner, vision_attr, vision_path,
+     vision_module) = _resolve_vision_group(model)
+    projector_entries = []
+    projector_path = None
+    if train_vision and vision_module is None:
+        _raise_vision_unresolved(vision_flag, model)
+    if train_projector:
+        projector_entries = _resolve_projector_group(
+            model, vision_owner, vision_module, vision_path,
+        )
+        if not projector_entries:
+            _raise_projector_unresolved(model, vision_path, vision_module)
+        projector_path = projector_entries[0][2]
+        if len(projector_entries) > 1:
+            projector_path = projector_path.rpartition(".")[0]
+
+    # A connector nested in the tower belongs to whichever pass will
+    # claim it, never to both: adapting it twice would stack a second
+    # adapter on the first one's base.
+    nested_projectors = [
+        attr for owner, attr, _, _ in projector_entries
+        if train_vision and owner is vision_module
+    ]
+
+    vision_lora_count = 0
+    if train_vision:
+        tower_owner = model if vision_owner is None else vision_owner
+        vision_lora_count = _lora_walk_module(
+            tower_owner, vision_attr, lora_config, target_modules,
+            skip_subtrees=nested_projectors, dry_run=dry_run,
+        )
+    projector_lora_count = 0
+    for p_owner, p_attr, _, _ in projector_entries:
+        projector_lora_count += _lora_walk_module(
+            p_owner, p_attr, lora_config,
+            target_modules=(), match_all_linear=True, dry_run=dry_run,
+        )
+
+    # Not a no-op: the run looks healthy while the decoder trains alone.
+    if train_vision and vision_lora_count == 0:
+        if isinstance(target_modules, list) and len(target_modules) == 0:
+            _raise_empty_target_modules()
+        _raise_group_empty(
+            vision_flag, "vision tower", vision_path, vision_module,
+            target_modules,
+        )
+    if train_projector and projector_lora_count == 0:
+        _raise_group_empty(
+            "train_projector", "projector", projector_path,
+            projector_entries[0][3],
+        )
+    return vision_lora_count, projector_lora_count
+
+
 def _lora_walk_module(
-    model,
+    owner,
+    attr_name,
     lora_config,
     target_modules,
-    attr_names,
     *,
     match_all_linear=False,
+    skip_subtrees=(),
+    dry_run=False,
 ):
-    """Walk a module tree and replace matching Linear/QuantizedLinear with LoRA.
+    """Replace matching Linear/QuantizedLinear under ``owner.attr_name`` with LoRA.
 
-    Used for vision encoders that don't have the flat `.layers` structure
-    expected by mlx-lm's `linear_to_lora_layers`.
+    Used for vision encoders and connectors that don't have the flat `.layers`
+    structure expected by mlx-lm's `linear_to_lora_layers`. ``skip_subtrees``
+    names children left untouched, so a connector nested in the tower is adapted
+    once, by its own pass, rather than wrapped again on top of the tower's.
+    ``dry_run`` counts what would be replaced without replacing it.
     """
     import mlx.nn as nn
     try:
         from mlx_lm.tuner.lora import LoRALinear
     except ImportError:
-        return
+        return 0
+
+    root = _navigate(owner, attr_name) if attr_name else None
+    if root is None:
+        return 0
+    root_base, _, root_leaf = str(attr_name).rpartition(".")
+    root_parent = _navigate(owner, root_base) if root_base else owner
 
     if target_modules is None:
         match_all_linear = True
@@ -6547,46 +6946,31 @@ def _lora_walk_module(
         target_modules = set(target_modules or ())
 
     replacements = 0
-
-    for attr_name in attr_names:
-        root = getattr(model, attr_name, None)
-        if root is None:
+    for name, child in list(root.named_modules()):
+        if _under_any(name, skip_subtrees):
             continue
-
-        def _walk(module):
-            nonlocal replacements
-            for name, child in list(module.named_modules()):
-                if not match_all_linear and not _lora_name_matches_target(name, target_modules):
-                    continue
-                if isinstance(child, (nn.Linear, nn.QuantizedLinear)):
-                    lora_layer = _lora_from_base_compat(
-                        LoRALinear,
-                        child,
-                        rank=lora_config["rank"],
-                        scale=lora_config["scale"],
-                        dropout=lora_config.get("dropout", 0.0),
-                    )
-                    replacements += 1
-                    if name == "":
-                        setattr(model, attr_name, lora_layer)
-                        continue
-                    # The final segment can be a numeric string (list index)
-                    # for some VLM trees like Qwen2.5-VL's vision merger.
-                    parts = name.split(".")
-                    parent = root
-                    for p in parts[:-1]:
-                        try:
-                            parent = parent[int(p)]
-                        except (ValueError, TypeError):
-                            parent = getattr(parent, p)
-                    leaf = parts[-1]
-                    try:
-                        parent[int(leaf)] = lora_layer
-                    except (ValueError, TypeError):
-                        setattr(parent, leaf, lora_layer)
-
-        _walk(root)
-        break  # These are alternative names for the same component — stop after first hit
+        if not match_all_linear and not _lora_name_matches_target(name, target_modules):
+            continue
+        if not isinstance(child, (nn.Linear, nn.QuantizedLinear)):
+            continue
+        if dry_run:
+            # Building it would draw from the executing pass's RNG.
+            replacements += 1
+            continue
+        lora_layer = _lora_from_base_compat(
+            LoRALinear,
+            child,
+            rank=lora_config["rank"],
+            scale=lora_config["scale"],
+            dropout=lora_config.get("dropout", 0.0),
+        )
+        replacements += 1
+        if name == "":
+            _set_child(root_parent, root_leaf, lora_layer)
+            continue
+        parent_path, _, leaf = name.rpartition(".")
+        parent = _navigate(root, parent_path) if parent_path else root
+        _set_child(parent, leaf, lora_layer)
     return replacements
 
 
@@ -8130,8 +8514,10 @@ class FastMLXModel:
             )
 
         # finetune_vision_layers (None = use train_vision arg; bool overrides it)
+        vision_flag = "train_vision"
         if finetune_vision_layers is not None:
             train_vision = bool(finetune_vision_layers)
+            vision_flag = "finetune_vision_layers"
 
 
         # "all-linear" means every nn.Linear (fused QKV, MoE routers/experts,
@@ -8215,13 +8601,6 @@ class FastMLXModel:
         _cpt_lm_head_keys = (
             {_cpt_lm_head_lora_path} if _cpt_lm_head_lora_path else set()
         )
-        # Record the registered full-module weight keys so the trainer scopes
-        # embedding_learning_rate to exactly these tensors, whatever the layout.
-        model._unsloth_cpt_full_module_weight_keys = (
-            _full_module_weight_keys(model, _cpt_full_specs)
-            if _cpt_full_specs else set()
-        )
-
         lora_config = {
             "rank": r,
             "alpha": lora_alpha,
@@ -8232,6 +8611,20 @@ class FastMLXModel:
         is_vlm = getattr(model, "_is_vlm_model", False)
 
         if is_vlm:
+            # Decide, and refuse, before anything is modified.
+            _vlm_group_lora(
+                model, lora_config, target_modules, vision_flag=vision_flag,
+                train_vision=train_vision, train_projector=train_projector,
+                dry_run=True,
+            )
+
+            # Scopes embedding_learning_rate to exactly these tensors.
+            model._unsloth_cpt_full_module_weight_keys = (
+                _full_module_weight_keys(model, _cpt_full_specs)
+                if _cpt_full_specs else set()
+            )
+
+            # Freeze everything, then apply LoRA selectively.
             _fix_missing_no_grad(model)
             _fix_gemma4_kv_sharing(model)
             model.freeze()
@@ -8270,32 +8663,13 @@ class FastMLXModel:
                         config={**lora_config, "keys": language_lora_keys},
                     )
 
-            vision_lora_count = 0
-            if train_vision:
-                vision_lora_count = _lora_walk_module(
-                    model,
-                    lora_config,
-                    target_modules,
-                    attr_names=("vision_tower", "vision_model", "vision_encoder"),
-                )
-
             # LoRA beats unfreezing raw weights since many projectors are
             # QuantizedLinear and MLX can't backprop into quantized weights.
-            projector_lora_count = 0
-            if train_projector:
-                projector_lora_count = _lora_walk_module(
-                    model,
-                    lora_config,
-                    target_modules=(),
-                    attr_names=(
-                        "multi_modal_projector",
-                        "mm_projector",
-                        "connector",
-                        "aligner",
-                        "embed_vision",
-                    ),
-                    match_all_linear=True,
-                )
+            (vision_lora_count, projector_lora_count) = _vlm_group_lora(
+                model, lora_config, target_modules, vision_flag=vision_flag,
+                train_vision=train_vision, train_projector=train_projector,
+                dry_run=False,
+            )
 
             if (
                 language_lora_count == 0
@@ -8313,18 +8687,33 @@ class FastMLXModel:
                         "finetune_attention_modules=False, finetune_mlp_modules=True."
                     )
                 if isinstance(target_modules, list) and len(target_modules) == 0:
-                    raise ValueError(
-                        "Unsloth: target_modules became empty after filtering by "
-                        "finetune_attention_modules / finetune_mlp_modules. Enable "
-                        "at least one of these flags."
-                    )
+                    _raise_empty_target_modules()
                 _raise_no_lora_targets(target_modules)
 
             model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
             _unfreeze_full_modules(_cpt_full_specs)
         else:
-            # Text-only path. _fix_missing_no_grad handles modules using
-            # __new__ without __init__ (e.g. Gemma4 AudioRelativePosition...).
+            # No tower to adapt, and nothing to name in an error either.
+            for flag, requested in (
+                (vision_flag, train_vision), ("train_projector", train_projector),
+            ):
+                if requested:
+                    warnings.warn(
+                        f"Unsloth: {flag}=True, but this model has no vision "
+                        "path — it was loaded as text-only, so there is no "
+                        f"vision tower or projector to adapt. Set {flag}=False, "
+                        "or load the model with text_only=False if it is a VLM.",
+                        stacklevel=2,
+                    )
+
+            # Scopes embedding_learning_rate to exactly these tensors.
+            model._unsloth_cpt_full_module_weight_keys = (
+                _full_module_weight_keys(model, _cpt_full_specs)
+                if _cpt_full_specs else set()
+            )
+
+            # _fix_missing_no_grad handles modules using __new__ without
+            # __init__ (e.g. Gemma4 AudioRelativePosition...).
             _fix_missing_no_grad(model)
 
             num_layers = len(_mlx_language_layers(model))

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -6804,18 +6804,26 @@ def _raise_projector_unresolved(model, vision_path, vision_module):
 # The enclosing block names the role even where the leaf does not.
 _ATTENTION_PATH_TOKENS = frozenset(("attn", "attention"))
 _MLP_PATH_TOKENS = frozenset(("mlp", "ffn", "feedforward", "swiglu"))
+# Neither table lists `proj` or `dense`, which say that a linear projects
+# without saying what it projects.
 _ATTENTION_LEAVES = frozenset((
     "q", "k", "v", "o", "kv", "qkv", "wq", "wk", "wv", "wo", "wkv", "wqkv",
-    "query", "key", "value", "out", "dense", "proj",
+    "query", "key", "value", "out",
 ))
 _MLP_LEAVES = frozenset((
     "fc", "fc0", "fc1", "fc2", "fc3", "w1", "w2", "w3", "gate", "up", "down",
     "c_fc", "linear1", "linear2",
 ))
 
-
 def _linear_role(path):
-    """``"attention"``, ``"mlp"`` or ``None`` for a linear at ``path``."""
+    """``"attention"``, ``"mlp"`` or ``None`` for a linear at ``path``.
+
+    An enclosing block outranks every name below it: afmoe's attention holds a
+    `gate_proj`, which names the MLP anywhere else. Only where nothing encloses
+    the linear does its own name decide, read outwards — a fused
+    `query_key_value` says its role itself, while a clipped `q_proj.linear`
+    leaves it to the module wrapping it.
+    """
     segments = str(path).lower().split(".")
     for segment in reversed(segments):
         tokens = _role_tokens(segment)
@@ -6823,11 +6831,12 @@ def _linear_role(path):
             return "attention"
         if tokens & _MLP_PATH_TOKENS:
             return "mlp"
-    leaf = segments[-1] if segments else ""
-    if leaf in _ATTENTION_LEAVES:
-        return "attention"
-    if leaf in _MLP_LEAVES:
-        return "mlp"
+    for segment in reversed(segments):
+        names = _role_tokens(segment)
+        if names & _ATTENTION_LEAVES:
+            return "attention"
+        if names & _MLP_LEAVES:
+            return "mlp"
     return None
 
 
@@ -6838,11 +6847,21 @@ def _under_any(path, prefixes):
 def _role_selected_paths(module, attention, mlp, skip_subtrees=()):
     """``module``'s linears by role, one whose role cannot be read left alone."""
     wanted = {"attention": attention, "mlp": mlp}
-    return [
-        path for path, _ in _subtree_linears(module)
-        if wanted.get(_linear_role(path), False)
-        and not _under_any(path, skip_subtrees)
-    ]
+    paths = [path for path, _ in _subtree_linears(module)
+             if not _under_any(path, skip_subtrees)]
+    roles = {path: _linear_role(path) for path in paths}
+    # A projection naming no role takes the role of the linears beside it, where
+    # those agree; a patch embedding sits alone, so nothing lends it one.
+    for path, role in list(roles.items()):
+        if role:
+            continue
+        parent = path.rpartition(".")[0]
+        beside = {roles[other] for other in paths
+                  if other != path and other.rpartition(".")[0] == parent}
+        beside.discard(None)
+        if len(beside) == 1:
+            roles[path] = beside.pop()
+    return [path for path in paths if wanted.get(roles[path], False)]
 
 
 def _raise_empty_target_modules():
@@ -6899,41 +6918,33 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
                 )
     (vision_owner, vision_attr, vision_path,
      vision_module) = _resolve_vision_group(model)
-    projector_entries = []
     projector_path = None
     if train_vision and vision_module is None:
         _raise_vision_unresolved(vision_flag, model)
+    # Also resolved when nothing will adapt it, so the tower pass can skip it.
+    projector_entries = (
+        _resolve_projector_group(model, vision_owner, vision_module, vision_path)
+        if train_projector or (train_vision and targets_defaulted) else []
+    )
     if train_projector:
-        projector_entries = _resolve_projector_group(
-            model, vision_owner, vision_module, vision_path,
-        )
         if not projector_entries:
             _raise_projector_unresolved(model, vision_path, vision_module)
         projector_path = projector_entries[0][2]
         if len(projector_entries) > 1:
             projector_path = projector_path.rpartition(".")[0]
 
-    # A connector nested in the tower belongs to whichever pass will
-    # claim it, never to both: adapting it twice would stack a second
-    # adapter on the first one's base.
+    # Adapting a nested connector here would stack on the projector pass's base.
     nested_projectors = [
         attr for owner, attr, _, _ in projector_entries
-        if train_vision and owner is vision_module
+        if owner is vision_module
     ]
 
     vision_lora_count = 0
     if train_vision:
         tower_owner = model if vision_owner is None else vision_owner
-        vision_lora_count = _lora_walk_module(
-            tower_owner, vision_attr, lora_config, target_modules,
-            skip_subtrees=nested_projectors, dry_run=dry_run,
-        )
-        # The canonical target names are a decoder vocabulary this code
-        # chose, not one the caller asked for, so when a tower speaks a
-        # different one, select its linears by role instead. Only ever
-        # reached where the walk above found nothing, so no tree that
-        # matches today changes, nor the order LoRA init draws randomness.
-        if vision_lora_count == 0 and targets_defaulted:
+        if targets_defaulted:
+            # The canonical names are a decoder vocabulary this code chose
+            # rather than one the caller asked for, and a tower rarely speaks it.
             role_paths = _role_selected_paths(
                 vision_module, finetune_attention_modules,
                 finetune_mlp_modules, skip_subtrees=nested_projectors,
@@ -6943,30 +6954,20 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
                     tower_owner, vision_attr, lora_config, None,
                     match_paths=set(role_paths), dry_run=dry_run,
                 )
-                roles = " and ".join(
-                    role for role, wanted in (
-                        ("attention", finetune_attention_modules),
-                        ("MLP", finetune_mlp_modules),
-                    ) if wanted
-                )
-                if dry_run:
-                    warnings.warn(
-                        f"Unsloth: the vision tower at {vision_path!r} has no "
-                        "module named in the default target_modules, so "
-                        f"{vision_flag}=True will adapt its {roles} linears "
-                        "by position instead: "
-                        f"{sorted({_leaf_name(p) for p in role_paths})!r}. "
-                        "Pass target_modules explicitly to choose them yourself.",
-                        # One frame deeper than `get_peft_model`, which is the
-                        # caller worth naming.
-                        stacklevel=3,
-                    )
+        else:
+            # The caller named these, so they decide inside a nested connector
+            # too, unless the projector pass is the one adapting it.
+            vision_lora_count = _lora_walk_module(
+                tower_owner, vision_attr, lora_config, target_modules,
+                skip_subtrees=nested_projectors, dry_run=dry_run,
+            )
     projector_lora_count = 0
-    for p_owner, p_attr, _, _ in projector_entries:
-        projector_lora_count += _lora_walk_module(
-            p_owner, p_attr, lora_config,
-            target_modules=(), match_all_linear=True, dry_run=dry_run,
-        )
+    if train_projector:
+        for p_owner, p_attr, _, _ in projector_entries:
+            projector_lora_count += _lora_walk_module(
+                p_owner, p_attr, lora_config,
+                target_modules=(), match_all_linear=True, dry_run=dry_run,
+            )
 
     # Not a no-op: the run looks healthy while the decoder trains alone.
     if train_vision and vision_lora_count == 0:

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -309,9 +309,8 @@ def linear_to_lora_layers(model, num_layers, config):
     layers = _mlx_language_layers(model)
     type_specs = _mlx_lora_type_specs()
     keys = set(config.get("keys") or ())
-    # Roles are read per layer, so one generic name can be attention beside a
-    # qkv and MLP beside an fc1. Applying the union everywhere would wrap it in
-    # both. Keys the caller added on top of the selection are not layer-local.
+    # A generic name is attention beside a qkv and MLP beside an fc1, so the
+    # union cannot be applied layer-wide; caller keys are not layer-local.
     layer_keys = config.get("layer_keys")
     if layer_keys is not None and len(layer_keys) != len(layers):
         layer_keys = None
@@ -340,8 +339,7 @@ def linear_to_lora_layers(model, num_layers, config):
 
     # Root-module pass: a head named in `keys` sits beside the layers, so the
     # layer walk above never reaches it.
-    # `shared` rather than `keys`: a layer-local path like `ff_proj` can name an
-    # unrelated root module too, and only the caller's own keys belong here.
+    # `shared`, not `keys`: a layer-local `ff_proj` can name a root module too.
     root_replacements = [
         (name, _mlx_lora_from_base(module, config, specs=type_specs))
         for name, module in model.named_modules()
@@ -6545,14 +6543,12 @@ _PROJECTOR_ROLE_TOKENS = frozenset((
     "projector", "projection", "proj", "connector", "aligner", "align",
     "merger", "merge", "resampler", "mlp1",
 ))
-# The subset naming the role outright; "proj", "merge" and "align" also occur
-# on modules that are not connectors.
+# Names the role outright; "proj", "merge" and "align" also occur elsewhere.
 _STRONG_PROJECTOR_TOKENS = frozenset((
     "projector", "projection", "connector", "aligner", "merger", "resampler",
     "mlp1",
 ))
-# `audio_projection` is shaped exactly like a vision connector, so only the
-# modality in the name separates them.
+# `audio_projection` is shaped like a vision connector; only the name differs.
 _OTHER_MODALITY_TOKENS = frozenset((
     "audio", "sound", "speech", "voice", "wav", "mel", "talker",
 ))
@@ -6595,8 +6591,7 @@ def _named_child_modules(module):
     for name, child in children.items():
         if isinstance(child, nn.Module):
             found.append((name, child))
-        # Lists and mappings only: mlx does not register a tuple as a container,
-        # and a tuple could not be written back into if it did.
+        # Lists and mappings only: mlx registers no tuple, and none is writable.
         elif isinstance(child, list):
             found.extend(
                 (f"{name}.{index}", item)
@@ -6622,8 +6617,7 @@ def _navigate(owner, path):
     for segment in str(path).split("."):
         if node is None:
             return None
-        # A plain dict is keyed by the segment itself; a Module is a dict too,
-        # so ask for the attribute there rather than reading its own mapping.
+        # A Module is a dict too, so reach its children by attribute, not key.
         if isinstance(node, dict) and not hasattr(node, "named_modules"):
             node = node.get(segment)
             continue
@@ -6641,8 +6635,7 @@ def _set_child(parent, leaf, value):
         parent[leaf] = value
         return
     try:
-        # A Module is a dict, so `parent[0]` would insert an int key beside the
-        # attribute named "0" rather than replacing it.
+        # A Module is a dict: `parent[0]` inserts an int key beside "0".
         if not isinstance(parent, (list, tuple)):
             raise TypeError
         parent[int(leaf)] = value
@@ -6761,8 +6754,8 @@ def _projector_candidates(owner, owner_path, skip, text_hidden_size):
             continue
         if not _reads_as(name, child, _PROJECTOR_ROLE_TOKENS):
             continue
-        # `text_projection` reads as a strong connector and feeds the decoder
-        # width, but it is the text side of the model, not the bridge to it.
+        # `text_projection` reads as a connector but is the text side, not the
+        # bridge to it.
         if _reads_as(name, child, _NON_VISION_ROLE_TOKENS):
             continue
         # The decoder is what a connector feeds, not something it holds.
@@ -6836,8 +6829,7 @@ def _raise_projector_unresolved(model, vision_path, vision_module):
 # The enclosing block names the role even where the leaf does not.
 _ATTENTION_PATH_TOKENS = frozenset(("attn", "attention", "att"))
 _MLP_PATH_TOKENS = frozenset(("mlp", "ffn", "feedforward", "swiglu", "ff"))
-# Neither table lists `proj` or `dense`, which say that a linear projects
-# without saying what it projects.
+# Neither lists `proj` or `dense`: they say a linear projects, not into what.
 _ATTENTION_LEAVES = frozenset((
     "q", "k", "v", "o", "kv", "qkv", "wq", "wk", "wv", "wo", "wkv", "wqkv",
     "query", "key", "value", "out",
@@ -6873,8 +6865,7 @@ def _linear_role(path):
         tokens = _role_tokens(segment)
         if tokens & _ATTENTION_PATH_TOKENS:
             return "attention"
-        # `feed_forward` splits into two tokens, so the compound needs naming
-        # as well as the joined `feedforward` spelling.
+        # `feed_forward` splits in two, so name it beside `feedforward`.
         if tokens & _MLP_PATH_TOKENS or {"feed", "forward"} <= tokens:
             return "mlp"
     for segment in reversed(segments):
@@ -6981,8 +6972,8 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
     The ``dry_run`` pass is the only source of refusals and warnings: raising
     later would leave adapters for the retry to stack on.
     """
-    # The tower of a wrapper loaded text-only still resolves and adapts, but the
-    # text forward returns before reaching it, so those adapters never train.
+    # A text-only wrapper's tower still adapts, but its forward never reaches
+    # those adapters, so they never train.
     if dry_run and getattr(model, "_unsloth_text_only_vlm", False):
         for flag, requested in (
             (vision_flag, train_vision),
@@ -7014,9 +7005,8 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
         if len(projector_entries) > 1:
             projector_path = projector_path.rpartition(".")[0]
 
-    # Adapting a nested connector here would stack on the projector pass's base.
-    # Only that pass earns the skip: with `train_projector` off there is no
-    # second pass, and skipping would drop a connector the tower pass reached.
+    # Skipping a nested connector avoids stacking on the projector pass's base,
+    # so only that pass earns it: with it off, the connector would go unadapted.
     nested_projectors = [
         attr for owner, attr, _, _ in projector_entries
         if owner is vision_module
@@ -7026,8 +7016,8 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
     if train_vision:
         tower_owner = model if vision_owner is None else vision_owner
         if targets_defaulted:
-            # The canonical names are a decoder vocabulary this code chose
-            # rather than one the caller asked for, and a tower rarely speaks it.
+            # The canonical names are this code's own vocabulary, not the
+            # caller's, and a tower rarely speaks it.
             role_paths = _role_selected_paths(
                 vision_module, finetune_attention_modules,
                 finetune_mlp_modules, skip_subtrees=nested_projectors,
@@ -7039,7 +7029,7 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
                 )
         else:
             # The caller named these, so they decide inside a nested connector
-            # too, unless the projector pass is the one adapting it.
+            # too, unless the projector pass adapts it.
             vision_lora_count = _lora_walk_module(
                 tower_owner, vision_attr, lora_config, target_modules,
                 skip_subtrees=nested_projectors, dry_run=dry_run,
@@ -7058,8 +7048,7 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
             _raise_empty_target_modules()
         _raise_group_empty(
             vision_flag, "vision tower", vision_path, vision_module,
-            # Naming a list the caller never passed sends them to fix the wrong
-            # thing; on the defaulted path the tower itself is the whole story.
+            # Quoting a list they never passed sends them to fix the wrong thing.
             None if targets_defaulted else target_modules,
         )
     if train_projector and projector_lora_count == 0:
@@ -7084,8 +7073,7 @@ def _lora_walk_module(
     """LoRA for encoders and connectors, which lack the flat `.layers` structure
     mlx-lm's `linear_to_lora_layers` expects."""
     try:
-        # The same specs selection reads, so the walk adapts every type
-        # `_role_selected_paths` can hand it, routed experts included.
+        # The specs selection reads, so the walk adapts all it is handed.
         specs = _mlx_lora_type_specs()
     except ImportError:
         return 0
@@ -8809,7 +8797,6 @@ class FastMLXModel:
                 if _cpt_full_specs else set()
             )
 
-            # Freeze everything, then apply LoRA selectively.
             _fix_missing_no_grad(model)
             _fix_gemma4_kv_sharing(model)
             model.freeze()

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -309,13 +309,22 @@ def linear_to_lora_layers(model, num_layers, config):
     layers = _mlx_language_layers(model)
     type_specs = _mlx_lora_type_specs()
     keys = set(config.get("keys") or ())
+    # Roles are read per layer, so one generic name can be attention beside a
+    # qkv and MLP beside an fc1. Applying the union everywhere would wrap it in
+    # both. Keys the caller added on top of the selection are not layer-local.
+    layer_keys = config.get("layer_keys")
+    if layer_keys is not None and len(layer_keys) != len(layers):
+        layer_keys = None
+    shared = keys - {k for ks in layer_keys for k in ks} if layer_keys else keys
 
     limit = max(int(num_layers), 0)
     attached = 0
-    for layer in layers[max(len(layers) - limit, 0):]:
+    offset = max(len(layers) - limit, 0)
+    for index, layer in enumerate(layers[offset:], start=offset):
+        wanted = (set(layer_keys[index]) | shared) if layer_keys else keys
         replacements = []
         for name, module in layer.named_modules():
-            if name not in keys:
+            if name not in wanted:
                 continue
             replacements.append((
                 name,
@@ -6680,9 +6689,8 @@ def _feeds_text_width(name, module, text_hidden_size):
         return False
     text_hidden_size = int(text_hidden_size)
     reaches = changes = False
-    from .utils import _linear_semantic_dims
     for _, linear in _subtree_linears(module):
-        out_dim, in_dim = _linear_semantic_dims(linear)
+        out_dim, in_dim = _semantic_dims(linear)
         reaches = reaches or out_dim == text_hidden_size
         changes = changes or in_dim != text_hidden_size
     if not reaches:
@@ -6840,7 +6848,9 @@ def _linear_role(path):
         tokens = _role_tokens(segment)
         if tokens & _ATTENTION_PATH_TOKENS:
             return "attention"
-        if tokens & _MLP_PATH_TOKENS:
+        # `feed_forward` splits into two tokens, so the compound needs naming
+        # as well as the joined `feedforward` spelling.
+        if tokens & _MLP_PATH_TOKENS or {"feed", "forward"} <= tokens:
             return "mlp"
     for segment in reversed(segments):
         names = _role_tokens(segment)
@@ -6853,6 +6863,23 @@ def _linear_role(path):
 
 def _under_any(path, prefixes):
     return any(path == p or path.startswith(f"{p}.") for p in prefixes)
+
+
+def _semantic_dims(linear):
+    """Output and input width, reading the axes `_projects` reads.
+
+    `_linear_semantic_dims` takes the first two axes, which for a fused expert
+    stack are the expert count and the output width rather than output and
+    input.
+    """
+    from .utils import _linear_semantic_dims
+    if len(linear.weight.shape) <= 2:
+        return _linear_semantic_dims(linear)
+    out_dim, in_dim = int(linear.weight.shape[-2]), int(linear.weight.shape[-1])
+    bits = getattr(linear, "bits", None)
+    if isinstance(bits, int) and bits > 0 and hasattr(linear, "scales"):
+        in_dim = in_dim * 32 // bits
+    return out_dim, in_dim
 
 
 def _projects(linear):
@@ -6896,12 +6923,20 @@ def _raise_empty_target_modules():
 
 def _raise_group_empty(flag, role, module_path, module, target_modules=None):
     leaf_names = _subtree_linear_leaf_names(module)
-    if target_modules is None or not leaf_names:
+    if not leaf_names:
         raise ValueError(
             f"Unsloth: {flag}=True, but the {role} at {module_path!r} holds no "
             f"linear layer to adapt. Its modules are "
             f"{_child_names(module)!r}. Set "
             f"{flag}=False."
+        )
+    if target_modules is None:
+        raise ValueError(
+            f"Unsloth: {flag}=True, but none of the linear layers in the {role} "
+            f"at {module_path!r} read as attention or MLP, so the group flags "
+            f"select none of them. They are named {leaf_names!r}. Pass "
+            f"target_modules with names from that list to train the {role} "
+            f"anyway, or set {flag}=False."
         )
     raise ValueError(
         f"Unsloth: {flag}=True selected no LoRA target inside the {role} at "
@@ -7101,10 +7136,16 @@ def _language_lora_keys(model, target_modules, targets_defaulted,
     """
     if targets_defaulted:
         keys = set()
-        for root in _mlx_language_layers(model):
-            keys.update(_role_selected_paths(root, attention, mlp))
+        for selected in _language_layer_keys(model, attention, mlp):
+            keys.update(selected)
         return keys
     return _resolve_lora_keys(model, target_modules)
+
+
+def _language_layer_keys(model, attention, mlp):
+    """Each decoder layer's own role selection, in layer order."""
+    return [set(_role_selected_paths(root, attention, mlp))
+            for root in _mlx_language_layers(model)]
 
 
 def _raise_no_lora_targets(target_modules):
@@ -8768,6 +8809,11 @@ class FastMLXModel:
                         finetune_attention_modules, finetune_mlp_modules)
                     if finetune_language_layers else None
                 )
+                language_layer_keys = (
+                    _language_layer_keys(lm, finetune_attention_modules,
+                                         finetune_mlp_modules)
+                    if targets_defaulted and finetune_language_layers else None
+                )
                 language_lora_keys = set(language_lora_keys or set()) | _vlm_lm_head_keys
                 if len(language_lora_keys) > 0:
                     # Compat patch (older mlx-lm rejects scale=/dropout= on
@@ -8781,7 +8827,8 @@ class FastMLXModel:
                     language_lora_count = linear_to_lora_layers(
                         lm,
                         num_layers=num_layers,
-                        config={**lora_config, "keys": language_lora_keys},
+                        config={**lora_config, "keys": language_lora_keys,
+                                "layer_keys": language_layer_keys},
                     )
 
             # LoRA beats unfreezing raw weights since many projectors are
@@ -8849,6 +8896,11 @@ class FastMLXModel:
                     finetune_attention_modules, finetune_mlp_modules)
                 if finetune_language_layers else None
             )
+            language_layer_keys = (
+                _language_layer_keys(model, finetune_attention_modules,
+                                     finetune_mlp_modules)
+                if targets_defaulted and finetune_language_layers else None
+            )
             if _cpt_lm_head_keys or _cpt_full_specs:
                 # Empty layer targets are valid here (full modules / an lm_head
                 # adapter still train); never fall through to auto-discovery.
@@ -8874,7 +8926,8 @@ class FastMLXModel:
                 language_lora_count = linear_to_lora_layers(
                     model,
                     num_layers=num_layers,
-                    config={**lora_config, "keys": language_lora_keys},
+                    config={**lora_config, "keys": language_lora_keys,
+                            "layer_keys": language_layer_keys},
                 )
                 if language_lora_count == 0:
                     _raise_no_lora_targets(target_modules)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -340,10 +340,12 @@ def linear_to_lora_layers(model, num_layers, config):
 
     # Root-module pass: a head named in `keys` sits beside the layers, so the
     # layer walk above never reaches it.
+    # `shared` rather than `keys`: a layer-local path like `ff_proj` can name an
+    # unrelated root module too, and only the caller's own keys belong here.
     root_replacements = [
         (name, _mlx_lora_from_base(module, config, specs=type_specs))
         for name, module in model.named_modules()
-        if name in keys
+        if name in shared
     ]
     if root_replacements:
         model.update_modules(tree_unflatten(root_replacements))
@@ -6556,7 +6558,8 @@ _OTHER_MODALITY_TOKENS = frozenset((
 ))
 _NON_VISION_ROLE_TOKENS = _OTHER_MODALITY_TOKENS | frozenset(("language", "text"))
 # Whole words, not substrings: "sam" occurs inside `itok_upsampler`.
-_ROLE_TOKEN_SPLIT = re.compile(r"[^A-Za-z0-9]+|(?<=[a-z0-9])(?=[A-Z])")
+_ROLE_TOKEN_SPLIT = re.compile(
+    r"[^A-Za-z0-9]+|(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
 
 
 def _role_tokens(name):
@@ -6592,10 +6595,16 @@ def _named_child_modules(module):
     for name, child in children.items():
         if isinstance(child, nn.Module):
             found.append((name, child))
-        elif isinstance(child, list):
+        elif isinstance(child, (list, tuple)):
             found.extend(
                 (f"{name}.{index}", item)
                 for index, item in enumerate(child)
+                if isinstance(item, nn.Module)
+            )
+        elif isinstance(child, dict):
+            found.extend(
+                (f"{name}.{key}", item)
+                for key, item in child.items()
                 if isinstance(item, nn.Module)
             )
     return found
@@ -6611,6 +6620,11 @@ def _navigate(owner, path):
     for segment in str(path).split("."):
         if node is None:
             return None
+        # A plain dict is keyed by the segment itself; a Module is a dict too,
+        # so ask for the attribute there rather than reading its own mapping.
+        if isinstance(node, dict) and not hasattr(node, "named_modules"):
+            node = node.get(segment)
+            continue
         try:
             node = node[int(segment)]
         except (ValueError, TypeError):
@@ -6621,7 +6635,14 @@ def _navigate(owner, path):
 
 
 def _set_child(parent, leaf, value):
+    if isinstance(parent, dict) and not hasattr(parent, "named_modules"):
+        parent[leaf] = value
+        return
     try:
+        # A Module is a dict, so `parent[0]` would insert an int key beside the
+        # attribute named "0" rather than replacing it.
+        if not isinstance(parent, (list, tuple)):
+            raise TypeError
         parent[int(leaf)] = value
     except (ValueError, TypeError):
         setattr(parent, leaf, value)
@@ -6738,7 +6759,9 @@ def _projector_candidates(owner, owner_path, skip, text_hidden_size):
             continue
         if not _reads_as(name, child, _PROJECTOR_ROLE_TOKENS):
             continue
-        if _reads_as(name, child, _OTHER_MODALITY_TOKENS):
+        # `text_projection` reads as a strong connector and feeds the decoder
+        # width, but it is the text side of the model, not the bridge to it.
+        if _reads_as(name, child, _NON_VISION_ROLE_TOKENS):
             continue
         # The decoder is what a connector feeds, not something it holds.
         if _holds_text_decoder(child):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -6943,10 +6943,9 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
     projector_path = None
     if train_vision and vision_module is None:
         _raise_vision_unresolved(vision_flag, model)
-    # Also resolved when nothing will adapt it, so the tower pass can skip it.
     projector_entries = (
         _resolve_projector_group(model, vision_owner, vision_module, vision_path)
-        if train_projector or (train_vision and targets_defaulted) else []
+        if train_projector else []
     )
     if train_projector:
         if not projector_entries:
@@ -6956,6 +6955,8 @@ def _vlm_group_lora(model, lora_config, target_modules, *, vision_flag,
             projector_path = projector_path.rpartition(".")[0]
 
     # Adapting a nested connector here would stack on the projector pass's base.
+    # Only that pass earns the skip: with `train_projector` off there is no
+    # second pass, and skipping would drop a connector the tower pass reached.
     nested_projectors = [
         attr for owner, attr, _, _ in projector_entries
         if owner is vision_module

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -6595,7 +6595,9 @@ def _named_child_modules(module):
     for name, child in children.items():
         if isinstance(child, nn.Module):
             found.append((name, child))
-        elif isinstance(child, (list, tuple)):
+        # Lists and mappings only: mlx does not register a tuple as a container,
+        # and a tuple could not be written back into if it did.
+        elif isinstance(child, list):
             found.extend(
                 (f"{name}.{index}", item)
                 for index, item in enumerate(child)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -7023,9 +7023,10 @@ def _lora_walk_module(
 ):
     """LoRA for encoders and connectors, which lack the flat `.layers` structure
     mlx-lm's `linear_to_lora_layers` expects."""
-    import mlx.nn as nn
     try:
-        from mlx_lm.tuner.lora import LoRALinear
+        # The same specs selection reads, so the walk adapts every type
+        # `_role_selected_paths` can hand it, routed experts included.
+        specs = _mlx_lora_type_specs()
     except ImportError:
         return 0
 
@@ -7050,14 +7051,15 @@ def _lora_walk_module(
                 continue
         elif not match_all_linear and not _lora_name_matches_target(name, target_modules):
             continue
-        if not isinstance(child, (nn.Linear, nn.QuantizedLinear)):
+        spec = _mlx_lora_spec_for_module(child, specs)
+        if spec is None:
             continue
         if dry_run:
             # Building it would draw from the executing pass's RNG.
             replacements += 1
             continue
         lora_layer = _lora_from_base_compat(
-            LoRALinear,
+            spec.wrapper_type,
             child,
             rank=lora_config["rank"],
             scale=lora_config["scale"],

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -6619,11 +6619,10 @@ def _set_child(parent, leaf, value):
 
 
 def _subtree_linears(module):
-    """``(path, module)`` for every Linear-like leaf in ``module``."""
-    import mlx.nn as nn
+    types = _mlx_lora_base_types()
     return [
         (name, child) for name, child in module.named_modules()
-        if isinstance(child, (nn.Linear, nn.QuantizedLinear))
+        if isinstance(child, types)
     ]
 
 
@@ -6802,8 +6801,8 @@ def _raise_projector_unresolved(model, vision_path, vision_module):
 
 
 # The enclosing block names the role even where the leaf does not.
-_ATTENTION_PATH_TOKENS = frozenset(("attn", "attention"))
-_MLP_PATH_TOKENS = frozenset(("mlp", "ffn", "feedforward", "swiglu"))
+_ATTENTION_PATH_TOKENS = frozenset(("attn", "attention", "att"))
+_MLP_PATH_TOKENS = frozenset(("mlp", "ffn", "feedforward", "swiglu", "ff"))
 # Neither table lists `proj` or `dense`, which say that a linear projects
 # without saying what it projects.
 _ATTENTION_LEAVES = frozenset((
@@ -6815,16 +6814,28 @@ _MLP_LEAVES = frozenset((
     "c_fc", "linear1", "linear2",
 ))
 
-def _linear_role(path):
-    """``"attention"``, ``"mlp"`` or ``None`` for a linear at ``path``.
+def _decides(segment):
+    """Whether ``segment`` names a gate or a router rather than a projection.
 
-    An enclosing block outranks every name below it: afmoe's attention holds a
-    `gate_proj`, which names the MLP anywhere else. Only where nothing encloses
-    the linear does its own name decide, read outwards — a fused
-    `query_key_value` says its role itself, while a clipped `q_proj.linear`
-    leaves it to the module wrapping it.
+    `gate_proj` says what it projects into; `shared_expert_gate` does not.
+    """
+    tokens = _role_tokens(segment)
+    if not tokens & {"gate", "router"}:
+        return False
+    return not (tokens - {"gate", "router"}) & (_MLP_LEAVES | {"proj"})
+
+
+def _linear_role(path):
+    """``"attention"``, ``"mlp"``, ``"gate"`` or ``None`` for ``path``.
+
+    An enclosing block outranks the names below it — afmoe's attention holds a
+    `gate_proj` — and a gate outranks the block.
     """
     segments = str(path).lower().split(".")
+    # A gate outranks its enclosing block and reaches the subtree below it:
+    # ZAYA's router is a small MLP, and adapting it trains the routing decision.
+    if any(_decides(segment) for segment in segments):
+        return "gate"
     for segment in reversed(segments):
         tokens = _role_tokens(segment)
         if tokens & _ATTENTION_PATH_TOKENS:
@@ -6844,11 +6855,22 @@ def _under_any(path, prefixes):
     return any(path == p or path.startswith(f"{p}.") for p in prefixes)
 
 
+def _projects(linear):
+    """Whether ``linear`` emits more than one number per token.
+
+    A single unit is a scale, a gate or a head rather than a projection, and Kimi
+    K3 reads that weight directly rather than calling the layer. The output axis
+    is second from last for a plain linear and for a fused expert stack alike,
+    the stack counting its experts along the first.
+    """
+    return int(linear.weight.shape[-2]) > 1
+
+
 def _role_selected_paths(module, attention, mlp, skip_subtrees=()):
     """``module``'s linears by role, one whose role cannot be read left alone."""
     wanted = {"attention": attention, "mlp": mlp}
-    paths = [path for path, _ in _subtree_linears(module)
-             if not _under_any(path, skip_subtrees)]
+    paths = [path for path, linear in _subtree_linears(module)
+             if not _under_any(path, skip_subtrees) and _projects(linear)]
     roles = {path: _linear_role(path) for path in paths}
     # A projection naming no role takes the role of the linears beside it, where
     # those agree; a patch embedding sits alone, so nothing lends it one.
@@ -6858,7 +6880,7 @@ def _role_selected_paths(module, attention, mlp, skip_subtrees=()):
         parent = path.rpartition(".")[0]
         beside = {roles[other] for other in paths
                   if other != path and other.rpartition(".")[0] == parent}
-        beside.discard(None)
+        beside &= wanted.keys()
         if len(beside) == 1:
             roles[path] = beside.pop()
     return [path for path in paths if wanted.get(roles[path], False)]
@@ -7064,6 +7086,20 @@ def _resolve_lora_keys(model, target_modules):
                 keys.add(name)
 
     return keys
+
+
+def _language_lora_keys(model, target_modules, targets_defaulted,
+                        attention, mlp):
+    """Layer-local mlx-lm LoRA keys for the decoder.
+
+    Read the way the tower is, where the names are this code's own.
+    """
+    if targets_defaulted:
+        keys = set()
+        for root in _mlx_language_layers(model):
+            keys.update(_role_selected_paths(root, attention, mlp))
+        return keys
+    return _resolve_lora_keys(model, target_modules)
 
 
 def _raise_no_lora_targets(target_modules):
@@ -8722,7 +8758,9 @@ class FastMLXModel:
                 if finetune_last_n_layers is not None and num_layers > 0:
                     num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
                 language_lora_keys = (
-                    _resolve_lora_keys(lm, target_modules)
+                    _language_lora_keys(
+                        lm, target_modules, targets_defaulted,
+                        finetune_attention_modules, finetune_mlp_modules)
                     if finetune_language_layers else None
                 )
                 language_lora_keys = set(language_lora_keys or set()) | _vlm_lm_head_keys
@@ -8801,7 +8839,9 @@ class FastMLXModel:
                 num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
             # Layer LoRA keys plus the lm_head key (a root module, not a layer).
             language_lora_keys = (
-                _resolve_lora_keys(model, target_modules)
+                _language_lora_keys(
+                    model, target_modules, targets_defaulted,
+                    finetune_attention_modules, finetune_mlp_modules)
                 if finetune_language_layers else None
             )
             if _cpt_lm_head_keys or _cpt_full_specs:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1987,6 +1987,40 @@ def _resolve_training_steps(args, batches, batch_iter, *, includes_epochs=False)
     raise ValueError("max_steps must be > 0 when using streaming mode.")
 
 
+def _warn_resume_adapter_mismatch(model, adapter_file):
+    """Say so when a checkpoint does not cover the LoRA modules now wrapped.
+
+    Resume binds with ``strict=False``, so an adapter saved when selection was
+    narrower loads without complaint and leaves the modules it does not name at
+    their initialisation. They train from scratch while the optimizer state
+    restored beside them describes the older, smaller parameter tree.
+    """
+    import warnings
+    if not os.path.exists(adapter_file):
+        return
+    try:
+        saved = set(mx.load(adapter_file).keys())
+        live = {f"{name}.{leaf}"
+                for name, _ in iter_mlx_lora_modules(model)
+                for leaf in ("lora_a", "lora_b")}
+    except Exception:
+        return                              # never block a resume to report on it
+    uncovered = sorted(name.rpartition(".")[0] for name in live - saved
+                       if name.endswith(".lora_a"))
+    if not uncovered:
+        return
+    warnings.warn(
+        f"Unsloth: resuming from {adapter_file!r}, which has no weights for "
+        f"{len(uncovered)} of the LoRA modules now attached "
+        f"(for example {uncovered[:3]!r}). Those modules restart from their "
+        "initialisation while the restored optimizer state describes the "
+        "checkpoint's own module set. This happens when the checkpoint was "
+        "written by a version that selected fewer modules. Pass the same "
+        "target_modules the checkpoint was trained with to resume exactly.",
+        stacklevel=2,
+    )
+
+
 class MLXTrainer:
     """MLX-native trainer for Apple Silicon, mirroring SFTTrainer's constructor API."""
 
@@ -5285,6 +5319,9 @@ class MLXTrainer:
                 #    already has LoRA wrappers applied (Unsloth pipeline does
                 #    get_peft_model before training); strict=False ensures
                 #    only the LoRA params match and base weights are untouched.
+                _warn_resume_adapter_mismatch(
+                    model, f"{_resume_from}/adapters.safetensors",
+                )
                 model.load_weights(
                     f"{_resume_from}/adapters.safetensors", strict=False,
                 )

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2000,13 +2000,19 @@ def _warn_resume_adapter_mismatch(model, adapter_file):
         return
     try:
         saved = set(mx.load(adapter_file).keys())
-        live = {f"{name}.{leaf}"
-                for name, _ in iter_mlx_lora_modules(model)
-                for leaf in ("lora_a", "lora_b")}
+        live = [name for name, _ in iter_mlx_lora_modules(model)]
     except Exception:
         return                              # never block a resume to report on it
-    uncovered = sorted(name.rpartition(".")[0] for name in live - saved
-                       if name.endswith(".lora_a"))
+
+    # An adapter held as a module rather than an array is stored one level down,
+    # so both spellings name the same weights; collect_mlx_lora_adapter_tensors
+    # writes whichever the wrapper uses.
+    def covered(name, leaf):
+        return (f"{name}.{leaf}" in saved
+                or f"{name}.{leaf}.weight" in saved)
+
+    uncovered = sorted(name for name in live
+                       if not (covered(name, "lora_a") and covered(name, "lora_b")))
     if not uncovered:
         return
     warnings.warn(


### PR DESCRIPTION
## The bug

When the caller passes no `target_modules`, the MLX LoRA path adapts a fixed list of seven decoder names — `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj`. Any model that names its linears otherwise is adapted partially, and silently: no warning, no error, just a run that trains fewer modules than the same call trains on CUDA.

Measured on Qwen3.5-0.8B (CUDA on an RTX 4070 SUPER against the real checkpoint; MLX against a shrunken checkpoint carrying the real depths so module counts line up):

| | CUDA | MLX before |
|---|---|---|
| vision tower | 48 — block attention and block MLP | 24 — block attention only |
| language decoder | 186 | 114 |

Across other architectures the gap is wider, and on one it is total:

| architecture | linears | before | after |
|---|---|---|---|
| Qwen3.5-0.8B | 236 | 96 | 234 |
| Kimi-K3 | 37 | 8 | 30 |
| granite-vision | 33 | 20 | 29 |
| gemma-4-31B | 30 | 14 | 28 |
| Molmo | 133 | 0 | 46 |

Molmo trains nothing today. `get_peft_model` returns successfully and the run proceeds.

## Root cause

CUDA does not use a fixed list. `get_peft_regex` derives the target set from the model: every leaf `Linear` name occurring more than once — singletons being heads and projections — then keeps only paths that read as attention or MLP under a vision or language part. MLX hardcoded the canonical decoder vocabulary instead, so the selection is only correct for models that happen to speak it.

Two related failures came from the same place. A group flag that selected nothing returned quietly rather than saying so, and a vision tower was located by a fixed attribute-name list, so a tower under an unlisted name was skipped entirely.

## What changed

Selection is now derived from the model, by role rather than by name. A linear's role is read from the names around it: an enclosing block outranks the leaf below it, a leaf with no role borrows one from its siblings when they agree, and anything that decides rather than computes — a router, a gate — is excluded regardless of what encloses it. A linear emitting one number per token is a scale, a gate or a head, not a projection, and is never adapted.

Groups are resolved structurally instead of by name list: the vision tower is found by what holds the decoder and what feeds it, and a connector nested inside a tower is adapted once, by its own pass, rather than wrapped twice.

A group flag that selects nothing now raises, naming the flag and enough of the tree to act on, before anything is modified. A flag that cannot train — `finetune_vision_layers` on a model loaded text-only — warns before the model is touched, so the message arrives whether or not the caller turns warnings into errors.

`target_modules=[...]` is untouched. An explicit vocabulary is the caller's decision and this change does not overrule it.

The four commits are separable and each stands alone:

| | |
|---|---|
| `resolve VLM LoRA groups by structure and refuse an empty group` | group resolution, refusals, warnings |
| `adapt a vision tower whose linears are named unlike a decoder's` | explicit targets reach a non-canonical tower |
| `select vision tower LoRA targets by role, not by decoder names` | role selection inside the tower |
| `select decoder LoRA targets by role, not by canonical names` | role selection in the decoder |

## Deliberate divergence from CUDA: MoE routers

CUDA's frequency rule makes a router a target — a router bound once per layer is "frequent" — so `get_peft_regex` selects `mlp.gate`. Nothing in that path decides a router should be adapted; frequency cannot tell a router from a projection. Measured on a real Klear decoder by running the shipped `get_peft_regex` against a torch model carrying the MLX module names:

| linear | CUDA | MLX before | MLX after |
|---|---|---|---|
| `mlp.gate` (the router) | yes | no | no |
| `mlp.coefficient` (routed vs shared mix) | yes | no | yes |
| `mlp.experts.*`, `mlp.shared_experts.*` | no | yes | yes |
| `self_attn.*` | yes | yes | yes |

This branch does not drop a router MLX was adapting — a bare `gate` was never a canonical name — it declines to add one, and closes the `coefficient` gap in the same pass. The reason to keep the divergence is that no group flag names a router: `finetune_mlp_modules` asks for the MLP, and a router decides which MLP runs. Adapting it trains the routing decision, the one part of an MoE where a small perturbation redistributes every expert's gradient.

The rule is honest about what it cannot see. `mlp.coefficient` is a two-way gate whose own name says nothing, so it takes the role of the enclosing `mlp` block and is adapted, as it is on CUDA. A gate that names itself is excluded; a gate that does not is indistinguishable from a projection, and no structural signal available at selection time separates them.

## Risks and what is not covered

- **Selection widens.** On every architecture measured the new selection is a strict superset of the old one, so no architecture loses a module — but runs will now train more parameters than before on the same call, which changes memory and step time.
- **Gemma's flat vision projections** remain unadapted. CUDA reaches `vision_embedder.patch_dense` and `vision_tower.patch_embedder.input_proj` through a Gemma-family-gated name list. Closing that needs either the same name list or a structural rule for a tower containing neither role anywhere — which would reverse the deliberate decision here that such a tower is a configuration error rather than a licence to adapt whatever is present. Worth doing separately.
- **Audio towers** are still unreachable: MLX's `get_peft_model` has no audio parameter at all. This is a missing group rather than a naming problem, and CUDA has no parity target to copy — its audio branches are Gemma-family-gated. Role selection is the right filler once the group exists, but the conformer shapes need surveying first.

## Validation

```bash
python -m pytest tests/test_mlx_lora_group_selection_metal.py
# 33 passed
```

The suite runs only on real Metal and skips otherwise. Beyond it:

- **Selection parity per architecture** was compared against CUDA numbers captured on a Linux host, per the tables above.
- **A 2016-path inventory** of every linear path in `mlx-lm` and `mlx-vlm` was used to decide which shapes the rule must handle, and which reported edge cases no real model reaches. Role counts across that corpus: 913 attention, 605 MLP, 83 gate, 415 no role.
- **Mutation testing** covers the selection rules: 38 mutations, each breaking one behaviour. 26 are caught by the suite; 9 more are caught only outside it, covering duplicate shapes whose mechanism a retained case already exercises through a different input; 3 are unkilled, and are each distinguishable only by a shape that does not occur in the surveyed corpus.
- **The full `-k mlx` failure set is unchanged against `main`** — the pre-existing shim failures, none in the files this branch touches.
