### PR TITLE
perf(mlx): dequantize the KV cache to the fused attention kernel at prefill

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -171,6 +171,12 @@ jobs:
         # trimming, the audio fallback contract, and request validation.
         run: python -m pytest tests/test_mlx_generate.py -v -rs
 
+      - name: tests/test_mlx_attention_metal.py
+        # Quantized-KV attention routed to the fused kernel: the tie against the
+        # runtime's own path, agreement with both runtimes, the transient on a
+        # real cache view, and the installer.
+        run: python -m pytest tests/test_mlx_attention_metal.py -v -rs
+
       - name: tests/test_mlx_generate_metal.py
         # Batched generation on real models: batched-vs-sequential greedy
         # equivalence with aligned sampled-token logprobs, memory-limit

--- a/tests/test_mlx_attention_metal.py
+++ b/tests/test_mlx_attention_metal.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Quantized-KV attention over a dequantized copy, against the runtime's own path, on real Metal."""
 
 from __future__ import annotations

--- a/tests/test_mlx_attention_metal.py
+++ b/tests/test_mlx_attention_metal.py
@@ -69,7 +69,7 @@ def _peak(call):
     (32, 8, 128, 128, 4, mx.bfloat16, 82),
     (32, 8, 128, 128, 8, mx.bfloat16, 98),
     (8, 8, 128, 128, 4, mx.bfloat16, 328),
-    (16, 2, 64, 64, 4, mx.bfloat16, 41),     # the narrowest head dim with a fused kernel
+    (16, 2, 64, 64, 4, mx.bfloat16, 20),     # the narrowest head dim with a fused kernel
     (32, 8, 128, 128, 4, mx.float16, 73),    # both sides at float32, with the result
 ])
 def test_the_query_count_against_the_cache_geometry_decides_the_route(HQ, HKV, D, Dv, bits,
@@ -110,9 +110,10 @@ def test_a_geometry_with_no_fused_kernel_never_leaves_the_runtime(D, Dv, group_s
     for L in (16, 1024, 65536):
         queries = _queries(1, 32, L, D)
         assert fused_kernel_exists(queries, *cache, group_size) is False, L
-        assert dequantizing_is_smaller(queries, *cache, group_size) is True, L
         mx.eval(wrapped(queries, *cache, D ** -0.5, "causal", group_size=group_size, bits=4))
-    assert taken == [16, 1024, 65536], "the cost said yes; only the missing kernel declined it"
+    assert taken == [16, 1024, 65536]
+    # and the guard is what declined it: on bytes alone the deepest call would have dequantized.
+    assert dequantizing_is_smaller(_queries(1, 32, 65536, D), *cache, group_size) is True
 
 
 @pytest.mark.parametrize("bits,group_size,last", [(4, 64, 82), (8, 64, 98), (2, 32, 76)])

--- a/tests/test_mlx_attention_metal.py
+++ b/tests/test_mlx_attention_metal.py
@@ -14,6 +14,7 @@ from unsloth_zoo.mlx.attention import (
     _PATCH_TARGETS,
     dequantized_sdpa,
     dequantizing_is_smaller,
+    fused_kernel_exists,
     install_quantized_attention,
     quantized_sdpa_over,
 )
@@ -68,7 +69,7 @@ def _peak(call):
     (32, 8, 128, 128, 4, mx.bfloat16, 82),
     (32, 8, 128, 128, 8, mx.bfloat16, 98),
     (8, 8, 128, 128, 4, mx.bfloat16, 328),
-    (16, 1, 192, 128, 4, mx.bfloat16, 25),   # MLA-shaped: a latent wider than the values
+    (16, 2, 64, 64, 4, mx.bfloat16, 41),     # the narrowest head dim with a fused kernel
     (32, 8, 128, 128, 4, mx.float16, 73),    # both sides at float32, with the result
 ])
 def test_the_query_count_against_the_cache_geometry_decides_the_route(HQ, HKV, D, Dv, bits,
@@ -83,9 +84,35 @@ def test_the_query_count_against_the_cache_geometry_decides_the_route(HQ, HKV, D
     wrapped = quantized_sdpa_over(unfused)
     for L in (1, last, last + 1):
         queries = _queries(1, HQ, L, D, dtype=query_dtype)
-        assert dequantizing_is_smaller(queries, *cache, GS) is (L > last), L
+        assert (dequantizing_is_smaller(queries, *cache, GS)
+                and fused_kernel_exists(queries, *cache, GS)) is (L > last), L
         mx.eval(wrapped(queries, *cache, D ** -0.5, mask="causal", group_size=GS, bits=bits))
     assert taken == [1, last]
+
+
+@pytest.mark.parametrize("D,Dv,group_size", [
+    (256, 256, 64),   # Gemma-2 and Gemma-3: no full kernel at head_dim 256
+    (192, 128, 64),   # MLA-shaped: a latent wider than the values
+    (160, 160, 32),   # not a supported head dim at all
+    (128, 64, 64),    # values narrower than the keys
+])
+def test_a_geometry_with_no_fused_kernel_never_leaves_the_runtime(D, Dv, group_size):
+    """Past 8 queries mlx has a full kernel only at head_dim 64/72/80/96/128 with D == Dv; anywhere
+    else it materializes the same scores, so dequantizing on top of them is strictly worse."""
+    cache = _cache(1, 8, 512, D, 4, group_size, Dv=Dv)
+    taken = []
+
+    def unfused(queries, q_keys, q_values, scale, mask, group_size=64, bits=8):
+        taken.append(queries.shape[-2])
+        return mx.zeros((1, 32, queries.shape[-2], Dv))
+
+    wrapped = quantized_sdpa_over(unfused)
+    for L in (16, 1024, 65536):
+        queries = _queries(1, 32, L, D)
+        assert fused_kernel_exists(queries, *cache, group_size) is False, L
+        assert dequantizing_is_smaller(queries, *cache, group_size) is True, L
+        mx.eval(wrapped(queries, *cache, D ** -0.5, "causal", group_size=group_size, bits=4))
+    assert taken == [16, 1024, 65536], "the cost said yes; only the missing kernel declined it"
 
 
 @pytest.mark.parametrize("bits,group_size,last", [(4, 64, 82), (8, 64, 98), (2, 32, 76)])
@@ -93,7 +120,13 @@ def test_the_query_count_against_the_cache_geometry_decides_the_route(HQ, HKV, D
 @pytest.mark.parametrize("runtime", ["mlx_lm", "mlx_vlm"])
 def test_matches_the_runtime_path_on_both_sides_of_the_threshold(runtime, mask, bits, group_size,
                                                                  last):
-    """mlx-vlm runs batched, as its array masks are; those masks also drop every seventh key."""
+    """mlx-vlm runs batched, as its array masks are; those masks also drop every seventh key.
+
+    Both array masks carry a leading 1: `mlx_vlm<0.6.5` -- which is what `mlx-vlm<0.7.0` against
+    this repo's `transformers` cap resolves to -- broadcasts a `[B, 1, L, S]` mask against its own
+    5-D grouped scores only when B is 1. A per-row batched mask above the tie is covered by
+    `test_a_batched_mask_the_pinned_runtime_cannot_broadcast` below.
+    """
     unfused = _runtime(runtime)
     B, HQ, HKV, S, D = (2 if runtime == "mlx_vlm" else 1), 32, 8, 640, 128
     cache = _cache(B, HKV, S, D, bits, group_size)
@@ -105,7 +138,7 @@ def test_matches_the_runtime_path_on_both_sides_of_the_threshold(runtime, mask, 
         else:
             keep = mx.arange(S - L, S)[:, None] >= mx.arange(S)[None]
             keep = keep & (mx.arange(S)[None] % 7 != 3)
-            m = (mx.broadcast_to(keep, (B, 1, L, S)) if mask == "bool"
+            m = (keep[None, None] if mask == "bool"
                  else mx.where(keep, 0.0, -mx.inf).astype(queries.dtype)[None, None])
         call = dict(scale=D ** -0.5, mask=m, group_size=group_size, bits=bits)
         expected = unfused(mx.array(queries), *cache, **call)
@@ -116,6 +149,33 @@ def test_matches_the_runtime_path_on_both_sides_of_the_threshold(runtime, mask, 
             assert mx.array_equal(actual, expected).item(), L
         else:
             assert _divergence(expected, actual) < MAX_DIVERGENCE, L
+
+
+@pytest.mark.parametrize("runtime", ["mlx_lm", "mlx_vlm"])
+def test_a_batched_mask_the_pinned_runtime_cannot_broadcast(runtime):
+    """A per-row `[B, 1, L, S]` mask over grouped heads, which above the tie no longer reaches the
+    runtime. `mlx_lm` 0.31.3 and `mlx_vlm` 0.6.4 both raise on it; the fused kernel takes it as
+    given, so gate on a float32 reference rather than on their answer."""
+    unfused = _runtime(runtime)
+    B, HQ, HKV, S, L, D, bits = 2, 32, 8, 640, 256, 128, 4
+    cache = _cache(B, HKV, S, D, bits)
+    queries = _queries(B, HQ, L, D)
+    keep = mx.arange(S - L, S)[:, None] >= mx.arange(S)[None]
+    rows = mx.arange(B)[:, None, None, None] == 0
+    m = mx.broadcast_to(keep, (B, 1, L, S)) & (rows | (mx.arange(S)[None] % 7 != 3))
+    call = dict(scale=D ** -0.5, mask=m, group_size=GS, bits=bits)
+
+    assert dequantizing_is_smaller(queries, *cache, GS) is True
+    keys = mx.dequantize(*cache[0], group_size=GS, bits=bits).astype(mx.float32)
+    values = mx.dequantize(*cache[1], group_size=GS, bits=bits).astype(mx.float32)
+    keys, values = mx.repeat(keys, HQ // HKV, 1), mx.repeat(values, HQ // HKV, 1)
+    scores = (queries.astype(mx.float32) @ mx.swapaxes(keys, -1, -2)) * D ** -0.5
+    expected = mx.softmax(mx.where(m, scores, mx.finfo(mx.float32).min), axis=-1,
+                          precise=True) @ values
+    actual = quantized_sdpa_over(unfused)(mx.array(queries), *cache, **call)
+    mx.eval(expected, actual)
+    assert actual.shape == expected.shape
+    assert _divergence(expected, actual) < MAX_DIVERGENCE
 
 
 def test_the_transient_is_one_dequantized_cache_not_the_scores():
@@ -156,6 +216,42 @@ def test_the_result_dtype_is_the_one_the_runtime_returns(query_dtype, key_dtype,
     actual = dequantized_sdpa(queries, *cache, **call)
     assert actual.dtype == expected.dtype
     assert _divergence(expected, actual) < MAX_DIVERGENCE
+
+
+@pytest.mark.parametrize("mask_dtype", [mx.bfloat16, mx.float16, mx.float32])
+def test_an_additive_mask_the_fused_kernel_would_reject_stays_on_the_runtime(mask_dtype):
+    """`scores += mask` widens the runtime's result, where the fused kernel refuses any mask that
+    does not promote to its output. Whichever it is, the caller must get the runtime's answer."""
+    unfused = _runtime("mlx_lm")
+    B, HQ, HKV, S, L, D, bits = 1, 32, 8, 256, 128, 128, 4
+    cache = _cache(B, HKV, S, D, bits)
+    queries = _queries(B, HQ, L, D)
+    keep = mx.arange(S - L, S)[:, None] >= mx.arange(S)[None]
+    m = mx.where(keep, 0.0, -mx.inf).astype(mask_dtype)
+    call = dict(scale=D ** -0.5, mask=m, group_size=GS, bits=bits)
+    promotes = mask_dtype == mx.bfloat16
+    assert fused_kernel_exists(queries, *cache, GS, m) is promotes
+    expected = unfused(mx.array(queries), *cache, **call)
+    actual = quantized_sdpa_over(unfused)(mx.array(queries), *cache, **call)
+    mx.eval(expected, actual)
+    assert actual.dtype == expected.dtype, mask_dtype
+    assert _divergence(expected, actual) < MAX_DIVERGENCE
+
+
+def test_an_argument_the_wrapper_predates_goes_to_the_runtime():
+    """A future `sinks=` has no fused equivalent, so it must delegate, not be dropped."""
+    seen = []
+
+    def unfused(queries, q_keys, q_values, scale, mask=None, group_size=64, bits=8, sinks=None):
+        seen.append(sinks)
+        return mx.zeros((1, 32, queries.shape[-2], 128), dtype=queries.dtype)
+
+    cache = _cache(1, 8, 512, 128, 4)
+    wrapped = quantized_sdpa_over(unfused)
+    over_the_tie = _queries(1, 32, 4096, 128)
+    assert dequantizing_is_smaller(over_the_tie, *cache, GS) is True
+    mx.eval(wrapped(over_the_tie, *cache, 128 ** -0.5, "causal", group_size=GS, bits=4, sinks="S"))
+    assert seen == ["S"], "an unknown argument must send the call to the runtime"
 
 
 def test_installing_the_patch_redirects_both_runtimes():

--- a/tests/test_mlx_attention_metal.py
+++ b/tests/test_mlx_attention_metal.py
@@ -1,0 +1,226 @@
+"""Quantized-KV attention over a dequantized copy, against the runtime's own path, on real Metal."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytest.importorskip("mlx_lm")
+
+from unsloth_zoo.mlx.attention import (
+    _PATCH_FLAG,
+    _PATCH_TARGETS,
+    dequantized_sdpa,
+    dequantizing_is_smaller,
+    install_quantized_attention,
+    quantized_sdpa_over,
+)
+
+GS = 64
+# bf16 rounding in a different order meets at ~1.5e-2; a wrong operand, scale or mask at 1e-1.
+MAX_DIVERGENCE = 3e-2
+
+
+def _quant(shape, bits, group_size=GS, dtype=mx.bfloat16, seed=0):
+    mx.random.seed(seed)
+    return mx.quantize(mx.random.normal(shape).astype(dtype), group_size, bits)
+
+
+def _cache(B, HKV, S, D, bits, group_size=GS, dtype=mx.bfloat16, Dv=None, value_dtype=None):
+    q = (_quant((B, HKV, S, D), bits, group_size, dtype),
+         _quant((B, HKV, S, Dv or D), bits, group_size, value_dtype or dtype, seed=100))
+    mx.eval(q)
+    return q
+
+
+def _queries(B, HQ, L, D, dtype=mx.bfloat16, seed=1):
+    mx.random.seed(seed)
+    return mx.random.normal((B, HQ, L, D)).astype(dtype)
+
+
+def _divergence(a, b):
+    a, b = a.astype(mx.float32), b.astype(mx.float32)
+    return (mx.max(mx.abs(a - b)) / mx.maximum(mx.max(mx.abs(a)), 1e-6)).item()
+
+
+def _runtime(name):
+    return pytest.importorskip(f"{name}.models.base").quantized_scaled_dot_product_attention
+
+
+def _peak(call):
+    mx.synchronize()
+    mx.clear_cache()
+    base = mx.get_active_memory()
+    mx.reset_peak_memory()
+    out = call()
+    mx.eval(out)
+    peak = mx.get_peak_memory() - base
+    del out
+    mx.synchronize()
+    mx.clear_cache()
+    return peak
+
+
+# `last`: the last query count on the runtime's path; a row costs its bf16 width plus packing.
+@pytest.mark.parametrize("HQ,HKV,D,Dv,bits,query_dtype,last", [
+    (32, 8, 128, 128, 4, mx.bfloat16, 82),
+    (32, 8, 128, 128, 8, mx.bfloat16, 98),
+    (8, 8, 128, 128, 4, mx.bfloat16, 328),
+    (16, 1, 192, 128, 4, mx.bfloat16, 25),   # MLA-shaped: a latent wider than the values
+    (32, 8, 128, 128, 4, mx.float16, 73),    # both sides at float32, with the result
+])
+def test_the_query_count_against_the_cache_geometry_decides_the_route(HQ, HKV, D, Dv, bits,
+                                                                      query_dtype, last):
+    cache = _cache(1, HKV, 512, D, bits, Dv=Dv)
+    taken = []
+
+    def unfused(queries, q_keys, q_values, scale, mask, group_size=64, bits=8):
+        taken.append(queries.shape[-2])
+        return mx.zeros((1, HQ, queries.shape[-2], Dv))
+
+    wrapped = quantized_sdpa_over(unfused)
+    for L in (1, last, last + 1):
+        queries = _queries(1, HQ, L, D, dtype=query_dtype)
+        assert dequantizing_is_smaller(queries, *cache, GS) is (L > last), L
+        mx.eval(wrapped(queries, *cache, D ** -0.5, mask="causal", group_size=GS, bits=bits))
+    assert taken == [1, last]
+
+
+@pytest.mark.parametrize("bits,group_size,last", [(4, 64, 82), (8, 64, 98), (2, 32, 76)])
+@pytest.mark.parametrize("mask", ["causal", "bool", "additive"])
+@pytest.mark.parametrize("runtime", ["mlx_lm", "mlx_vlm"])
+def test_matches_the_runtime_path_on_both_sides_of_the_threshold(runtime, mask, bits, group_size,
+                                                                 last):
+    """mlx-vlm runs batched, as its array masks are; those masks also drop every seventh key."""
+    unfused = _runtime(runtime)
+    B, HQ, HKV, S, D = (2 if runtime == "mlx_vlm" else 1), 32, 8, 640, 128
+    cache = _cache(B, HKV, S, D, bits, group_size)
+    wrapped = quantized_sdpa_over(unfused)
+    for L, exact in ((last, True), (last + 1, False)):
+        queries = _queries(B, HQ, L, D)
+        if mask == "causal":
+            m = "causal"
+        else:
+            keep = mx.arange(S - L, S)[:, None] >= mx.arange(S)[None]
+            keep = keep & (mx.arange(S)[None] % 7 != 3)
+            m = (mx.broadcast_to(keep, (B, 1, L, S)) if mask == "bool"
+                 else mx.where(keep, 0.0, -mx.inf).astype(queries.dtype)[None, None])
+        call = dict(scale=D ** -0.5, mask=m, group_size=group_size, bits=bits)
+        expected = unfused(mx.array(queries), *cache, **call)
+        actual = wrapped(mx.array(queries), *cache, **call)
+        mx.eval(expected, actual)
+        assert actual.shape == expected.shape and actual.dtype == expected.dtype, L
+        if exact:
+            assert mx.array_equal(actual, expected).item(), L
+        else:
+            assert _divergence(expected, actual) < MAX_DIVERGENCE, L
+
+
+def test_the_transient_is_one_dequantized_cache_not_the_scores():
+    """On the prefix view a real cache hands over, which is compacted first."""
+    from mlx_lm.models.cache import QuantizedKVCache
+
+    B, HQ, HKV, S, L, D, bits = 1, 32, 8, 32768 - 100, 2048, 128, 4
+    cache = QuantizedKVCache(group_size=GS, bits=bits)
+    mx.random.seed(0)
+    q_keys, q_values = cache.update_and_fetch(
+        mx.random.normal((B, HKV, S, D)).astype(mx.bfloat16),
+        mx.random.normal((B, HKV, S, D)).astype(mx.bfloat16))
+    queries = _queries(B, HQ, L, D)
+    mx.eval(q_keys, q_values, queries)
+    assert q_keys[0].shape[2] == S < cache.keys[0].shape[2]
+
+    peak = _peak(lambda: dequantized_sdpa(queries, q_keys, q_values, D ** -0.5, mask="causal",
+                                          group_size=GS, bits=bits))
+    dequantized = 2 * B * HKV * S * D * 2
+    scores = B * HQ * L * S * 2
+    assert dequantized < peak < 2 * dequantized < scores, (peak, dequantized, scores)
+
+
+@pytest.mark.parametrize("query_dtype,key_dtype,value_dtype", [
+    (mx.bfloat16, mx.bfloat16, mx.bfloat16),
+    (mx.float16, mx.float16, mx.float16),
+    (mx.float16, mx.bfloat16, mx.bfloat16),
+    (mx.bfloat16, mx.float32, mx.float32),
+    (mx.float16, mx.float16, mx.bfloat16),
+])
+def test_the_result_dtype_is_the_one_the_runtime_returns(query_dtype, key_dtype, value_dtype):
+    unfused = _runtime("mlx_lm")
+    B, HQ, HKV, S, L, D, bits = 1, 32, 8, 256, 128, 128, 4
+    cache = _cache(B, HKV, S, D, bits, dtype=key_dtype, value_dtype=value_dtype)
+    queries = _queries(B, HQ, L, D, dtype=query_dtype)
+    call = dict(scale=D ** -0.5, mask="causal", group_size=GS, bits=bits)
+    expected = unfused(mx.array(queries), *cache, **call)
+    actual = dequantized_sdpa(queries, *cache, **call)
+    assert actual.dtype == expected.dtype
+    assert _divergence(expected, actual) < MAX_DIVERGENCE
+
+
+def test_installing_the_patch_redirects_both_runtimes():
+    pytest.importorskip("mlx_vlm.models.base")
+    assert _PATCH_TARGETS == ("mlx_lm.models.base", "mlx_vlm.models.base")
+    modules = [sys.modules[path] for path in _PATCH_TARGETS]
+    saved = [(m, m.quantized_scaled_dot_product_attention, getattr(m, _PATCH_FLAG, False))
+             for m in modules]
+    try:
+        originals = []
+        for module, function, flagged in saved:
+            if flagged:
+                delattr(module, _PATCH_FLAG)
+                function = module.quantized_scaled_dot_product_attention = function.__wrapped__
+            originals.append(function)
+        assert install_quantized_attention() == _PATCH_TARGETS
+        for module, original in zip(modules, originals):
+            assert module.quantized_scaled_dot_product_attention.__wrapped__ is original
+        assert install_quantized_attention() == ()
+        for module, original in zip(modules, originals):
+            assert module.quantized_scaled_dot_product_attention.__wrapped__ is original
+    finally:
+        for module, function, flagged in saved:
+            module.quantized_scaled_dot_product_attention = function
+            if flagged:
+                setattr(module, _PATCH_FLAG, True)
+            elif hasattr(module, _PATCH_FLAG):
+                delattr(module, _PATCH_FLAG)
+
+
+def test_every_model_load_path_installs_the_patch():
+    """Checked as a shape: every model-returning `return` in `from_pretrained` goes through
+    `_finish_load`, since reaching each branch needs repositories this suite lacks."""
+    import ast
+    import inspect
+
+    from unsloth_zoo.mlx import loader
+
+    tree = ast.parse(inspect.getsource(loader))
+    entry = next(n for n in ast.walk(tree)
+                 if isinstance(n, ast.FunctionDef) and n.name == "from_pretrained")
+
+    def own_returns(node):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue
+            if isinstance(child, ast.Return) and child.value is not None:
+                yield child
+            yield from own_returns(child)
+
+    def funnelled(stmt):
+        return (isinstance(stmt.value, ast.Call) and isinstance(stmt.value.func, ast.Name)
+                and stmt.value.func.id == "_finish_load")
+
+    returns = list(own_returns(entry))
+    bypassing = [n.lineno for n in returns if not funnelled(n)]
+    assert not bypassing, f"value returned without _finish_load at lines {bypassing}"
+    assert len(returns) >= 4, f"loader return paths changed shape ({len(returns)} found)"
+
+    helper = next(n for n in ast.walk(tree)
+                  if isinstance(n, ast.FunctionDef) and n.name == "_finish_load")
+    shape = [type(n).__name__ for n in helper.body]
+    assert shape == ["Expr", "Expr", "Return"], f"_finish_load is no longer straight-line: {shape}"
+    assert isinstance(helper.body[0].value, ast.Constant), "expected a docstring first"
+    install = helper.body[1].value
+    assert (isinstance(install, ast.Call) and isinstance(install.func, ast.Name)
+            and install.func.id == "install_quantized_attention"), \
+        "_finish_load does not install the patch before returning"

--- a/unsloth_zoo/mlx/attention.py
+++ b/unsloth_zoo/mlx/attention.py
@@ -28,8 +28,8 @@ def _result_dtype(queries, q_keys, q_values):
 
 
 def _row_bytes(q_cache, group_size, dtype):
-    # Dequantized plus packed: a prefix view is compacted before it is read. Charged always,
-    # since contiguity is not visible from the arrays and views are the common case.
+    # Dequantized plus packed: a prefix view is compacted first, and contiguity is not visible
+    # from the arrays, so the compaction is charged always.
     packed = sum(part.shape[-1] * part.dtype.size for part in q_cache)
     return q_cache[1].shape[-1] * group_size * dtype.size + packed
 
@@ -44,11 +44,8 @@ def dequantizing_is_smaller(queries, q_keys, q_values, group_size):
     return scores > copy
 
 
-# The head dims mlx actually has a kernel for, transcribed from
-# `ScaledDotProductAttention::use_fallback` (mlx/backend/metal/scaled_dot_product_attention.cpp)
-# against the `mlx==0.32.1` pin. Anywhere else `mx.fast.scaled_dot_product_attention` takes its own
-# fallback, which builds the very `[B, HQ, L, S]` scores this module exists to avoid -- so
-# dequantizing there would pay for the copy on top of them rather than instead of them.
+# Elsewhere mlx falls back and builds the scores anyway, so the copy would cost extra rather
+# than instead. ScaledDotProductAttention::use_fallback, mlx 0.32.1.
 _FUSED_FULL_HEAD_DIMS = frozenset((64, 72, 80, 96, 128))
 _FUSED_VECTOR_HEAD_DIMS = frozenset((64, 96, 128, 256))
 
@@ -56,8 +53,7 @@ _FUSED_VECTOR_HEAD_DIMS = frozenset((64, 96, 128, 256))
 def fused_kernel_exists(queries, q_keys, q_values, group_size, mask=None):
     """Whether mlx will really fuse this call. Reachable today at `head_dim` 256 (Qwen3-Next)."""
     if isinstance(mask, mx.array) and mx.issubdtype(mask.dtype, mx.floating):
-        # An additive mask that does not promote to the result is rejected outright by the fused
-        # kernel, where the runtime's `scores += mask` widens the scores to it and carries on.
+        # The fused kernel rejects such a mask; the runtime widens the scores instead.
         dtype = _result_dtype(queries, q_keys, q_values)
         if mx.result_type(mask.dtype, dtype) != dtype:
             return False
@@ -72,8 +68,8 @@ def fused_kernel_exists(queries, q_keys, q_values, group_size, mask=None):
 
 
 def dequantized_sdpa(queries, q_keys, q_values, scale, mask=None, group_size=64, bits=8):
-    """The fused kernel over one dequantized copy. A row the mask empties gets the same average
-    the unfused path gives it: mlx masks with a finite minimum, not with -inf."""
+    """The fused kernel over one dequantized copy. An emptied row averages, as the unfused path
+    does: mlx masks with a finite minimum, not -inf."""
     dtype = _result_dtype(queries, q_keys, q_values)
     keys = mx.dequantize(*q_keys, group_size=group_size, bits=bits).astype(dtype)
     values = mx.dequantize(*q_values, group_size=group_size, bits=bits).astype(dtype)
@@ -85,8 +81,7 @@ def quantized_sdpa_over(unfused):
     @functools.wraps(unfused)
     def quantized_sdpa(queries, q_keys, q_values, scale, mask=None, group_size=64, bits=8,
                        **kwargs):
-        # An argument this wrapper predates (a future `sinks=`) has no fused equivalent here, so
-        # the runtime's own function takes the call rather than the argument being dropped.
+        # An argument this wrapper predates has no fused equivalent: delegate, never drop it.
         if (not kwargs
                 and fused_kernel_exists(queries, q_keys, q_values, group_size, mask)
                 and dequantizing_is_smaller(queries, q_keys, q_values, group_size)):

--- a/unsloth_zoo/mlx/attention.py
+++ b/unsloth_zoo/mlx/attention.py
@@ -44,9 +44,36 @@ def dequantizing_is_smaller(queries, q_keys, q_values, group_size):
     return scores > copy
 
 
+# The head dims mlx actually has a kernel for, transcribed from
+# `ScaledDotProductAttention::use_fallback` (mlx/backend/metal/scaled_dot_product_attention.cpp)
+# against the `mlx==0.32.1` pin. Anywhere else `mx.fast.scaled_dot_product_attention` takes its own
+# fallback, which builds the very `[B, HQ, L, S]` scores this module exists to avoid -- so
+# dequantizing there would pay for the copy on top of them rather than instead of them.
+_FUSED_FULL_HEAD_DIMS = frozenset((64, 72, 80, 96, 128))
+_FUSED_VECTOR_HEAD_DIMS = frozenset((64, 96, 128, 256))
+
+
+def fused_kernel_exists(queries, q_keys, q_values, group_size, mask=None):
+    """Whether mlx will really fuse this call. Reachable today at `head_dim` 256 (Qwen3-Next)."""
+    if isinstance(mask, mx.array) and mx.issubdtype(mask.dtype, mx.floating):
+        # An additive mask that does not promote to the result is rejected outright by the fused
+        # kernel, where the runtime's `scores += mask` widens the scores to it and carries on.
+        dtype = _result_dtype(queries, q_keys, q_values)
+        if mx.result_type(mask.dtype, dtype) != dtype:
+            return False
+    head_dim = q_keys[1].shape[-1] * group_size
+    value_dim = q_values[1].shape[-1] * group_size
+    L = queries.shape[-2]
+    if L > 8:
+        return head_dim == value_dim and head_dim in _FUSED_FULL_HEAD_DIMS
+    return (L * (queries.shape[-3] // q_keys[0].shape[-3]) <= 32
+            and ((head_dim == value_dim and head_dim in _FUSED_VECTOR_HEAD_DIMS)
+                 or (head_dim == 192 and value_dim == 128)))
+
+
 def dequantized_sdpa(queries, q_keys, q_values, scale, mask=None, group_size=64, bits=8):
-    """The fused kernel over one dequantized copy. A row the mask empties gets its answer, not
-    the unfused path's average; the runtimes build such rows only as padding they discard."""
+    """The fused kernel over one dequantized copy. A row the mask empties gets the same average
+    the unfused path gives it: mlx masks with a finite minimum, not with -inf."""
     dtype = _result_dtype(queries, q_keys, q_values)
     keys = mx.dequantize(*q_keys, group_size=group_size, bits=bits).astype(dtype)
     values = mx.dequantize(*q_values, group_size=group_size, bits=bits).astype(dtype)
@@ -56,11 +83,17 @@ def dequantized_sdpa(queries, q_keys, q_values, scale, mask=None, group_size=64,
 def quantized_sdpa_over(unfused):
     """Wrap a runtime's `quantized_scaled_dot_product_attention`; it still answers below the tie."""
     @functools.wraps(unfused)
-    def quantized_sdpa(queries, q_keys, q_values, scale, mask=None, group_size=64, bits=8):
-        if dequantizing_is_smaller(queries, q_keys, q_values, group_size):
+    def quantized_sdpa(queries, q_keys, q_values, scale, mask=None, group_size=64, bits=8,
+                       **kwargs):
+        # An argument this wrapper predates (a future `sinks=`) has no fused equivalent here, so
+        # the runtime's own function takes the call rather than the argument being dropped.
+        if (not kwargs
+                and fused_kernel_exists(queries, q_keys, q_values, group_size, mask)
+                and dequantizing_is_smaller(queries, q_keys, q_values, group_size)):
             return dequantized_sdpa(queries, q_keys, q_values, scale, mask,
                                     group_size=group_size, bits=bits)
-        return unfused(queries, q_keys, q_values, scale, mask, group_size=group_size, bits=bits)
+        return unfused(queries, q_keys, q_values, scale, mask, group_size=group_size, bits=bits,
+                       **kwargs)
     return quantized_sdpa
 
 

--- a/unsloth_zoo/mlx/attention.py
+++ b/unsloth_zoo/mlx/attention.py
@@ -1,0 +1,90 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Quantized-KV attention through `mx.fast.scaled_dot_product_attention` over a dequantized copy,
+once the `[B, HQ, L, S]` scores the runtimes materialize would cost more than the copy."""
+import functools
+
+import mlx.core as mx
+
+
+def _result_dtype(queries, q_keys, q_values):
+    # `mx.quantized_matmul` widens to float32 when either cache disagrees with the queries.
+    same = queries.dtype == q_keys[1].dtype == q_values[1].dtype
+    return queries.dtype if same else mx.float32
+
+
+def _row_bytes(q_cache, group_size, dtype):
+    # Dequantized plus packed: a prefix view is compacted before it is read. Charged always,
+    # since contiguity is not visible from the arrays and views are the common case.
+    packed = sum(part.shape[-1] * part.dtype.size for part in q_cache)
+    return q_cache[1].shape[-1] * group_size * dtype.size + packed
+
+
+def dequantizing_is_smaller(queries, q_keys, q_values, group_size):
+    """Scores cost `HQ * L` per cached token, the copy `HKV` rows; the depth cancels."""
+    dtype = _result_dtype(queries, q_keys, q_values)
+    HQ, L = queries.shape[-3], queries.shape[-2]
+    HKV = q_keys[0].shape[-3]
+    scores = HQ * L * dtype.size
+    copy = HKV * (_row_bytes(q_keys, group_size, dtype) + _row_bytes(q_values, group_size, dtype))
+    return scores > copy
+
+
+def dequantized_sdpa(queries, q_keys, q_values, scale, mask=None, group_size=64, bits=8):
+    """The fused kernel over one dequantized copy. A row the mask empties gets its answer, not
+    the unfused path's average; the runtimes build such rows only as padding they discard."""
+    dtype = _result_dtype(queries, q_keys, q_values)
+    keys = mx.dequantize(*q_keys, group_size=group_size, bits=bits).astype(dtype)
+    values = mx.dequantize(*q_values, group_size=group_size, bits=bits).astype(dtype)
+    return mx.fast.scaled_dot_product_attention(queries, keys, values, scale=scale, mask=mask)
+
+
+def quantized_sdpa_over(unfused):
+    """Wrap a runtime's `quantized_scaled_dot_product_attention`; it still answers below the tie."""
+    @functools.wraps(unfused)
+    def quantized_sdpa(queries, q_keys, q_values, scale, mask=None, group_size=64, bits=8):
+        if dequantizing_is_smaller(queries, q_keys, q_values, group_size):
+            return dequantized_sdpa(queries, q_keys, q_values, scale, mask,
+                                    group_size=group_size, bits=bits)
+        return unfused(queries, q_keys, q_values, scale, mask, group_size=group_size, bits=bits)
+    return quantized_sdpa
+
+
+_PATCH_FLAG = "_unsloth_quantized_attention_patch"
+
+_PATCH_TARGETS = ("mlx_lm.models.base", "mlx_vlm.models.base")
+
+
+def install_quantized_attention():
+    """Wrap the imported runtimes' quantized attention, idempotently; returns the paths patched."""
+    import sys
+
+    if hasattr(mx.fast, "quantized_scaled_dot_product_attention"):
+        return ()
+
+    patched = []
+    for module_path in _PATCH_TARGETS:
+        module = sys.modules.get(module_path)
+        if module is None or getattr(module, _PATCH_FLAG, False):
+            continue
+        unfused = getattr(module, "quantized_scaled_dot_product_attention", None)
+        if unfused is None:
+            continue
+        module.quantized_scaled_dot_product_attention = quantized_sdpa_over(unfused)
+        setattr(module, _PATCH_FLAG, True)
+        patched.append(module_path)
+    return tuple(patched)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -54,6 +54,7 @@ from .compile import (
     normalize_mlx_patch_mode,
     trace_compile_application,
 )
+from .attention import install_quantized_attention
 
 _vlm_model_types_cache = None
 _VLM_MODALITY_CONFIG_FIELDS = ("vision_config", "audio_config", "dflash_config")
@@ -6819,6 +6820,12 @@ def _coerce_list_extra_special_tokens():
     PreTrainedTokenizerBase.__init__ = patched_init
 
 
+def _finish_load(model, tokenizer):
+    """The single exit from a load, so the patch installs after the runtimes the load imports."""
+    install_quantized_attention()
+    return model, tokenizer
+
+
 class FastMLXModel:
     """MLX model loader for Apple Silicon.
 
@@ -7181,7 +7188,7 @@ class FastMLXModel:
             model._src_path = local_path
             model._unsloth_base_revision = revision
             model._unsloth_base_commit_hash = _infer_snapshot_commit(local_path)
-            return model, tokenizer
+            return _finish_load(model, tokenizer)
 
         # Reject full_finetuning on a pre-quantized repo: int4/int8 weights
         # aren't trainable (our CCE backward zeros the quantized weight grad),
@@ -7524,7 +7531,7 @@ class FastMLXModel:
                             "base_quantized_source"
                         )
                     _patch_mlx_saving(model, tokenizer)
-                    return model, tokenizer
+                    return _finish_load(model, tokenizer)
             except Exception as e:
                 # Preserve Unsloth-tagged Value/Import/RuntimeError so
                 # adapter-config failures aren't swallowed into a base-model
@@ -7827,7 +7834,7 @@ class FastMLXModel:
             _run_with_vlm_config_view(_patch_mlx_saving, model, public_target)
             if vlm_config_view_owner is not None:
                 vlm_config_view_owner.transfer_to(model)
-            return model, public_target
+            return _finish_load(model, public_target)
         else:
             # Text path via mlx-lm (original behavior)
             quant_state = _ensure_quantization_compatible(
@@ -7932,7 +7939,7 @@ class FastMLXModel:
             _patch_mixed_precision_set_dtype(model)
 
             _patch_mlx_saving(model, tokenizer)
-            return model, tokenizer
+            return _finish_load(model, tokenizer)
 
     @staticmethod
     def get_peft_model(


### PR DESCRIPTION
## What this fixes

**Quantizing the KV cache on MLX today costs context length instead of buying it.**

An unquantized cache goes to `mx.fast.scaled_dot_product_attention`, which is fused and materializes no scores. There is no fused equivalent for a quantized cache, so `mlx_lm` and `mlx_vlm` fall back to a Python `quantized_scaled_dot_product_attention` that dequantizes the cache into a materialized `[B, HQ, L, S]` score matrix. At a fixed prefill chunk that matrix grows with cache depth -- about 130 MB per layer per 1024 tokens, against the 2.9 MB per 1024 tokens that quantizing saves -- and it dwarfs the cache the quantization shrank.

The effect a caller actually sees, on `mlx-community/Qwen3-4B-4bit` (36 layers) through `mlx_lm` at its default 2048-token prefill chunk. Peak is above the 2160 MB of weights, so it is the cache plus everything attention allocates to process the prompt:

| prompt | KV cache in bf16 | 4-bit KV cache, today | 4-bit KV cache, this PR |
|---|---|---|---|
| 8192 | 2267 MB | 3337 MB — **1.47x worse** | **1582 MB** |
| 16384 | 3388 MB | 5734 MB — **1.69x worse** | **1902 MB** |
| 32768 | 5670 MB | 9967 MB — **1.76x worse** | **2613 MB** |

So quantizing the cache to fit a longer context gives a *shorter* one: it raises peak memory by half to three quarters, and the machine runs out during prompt processing sooner than it would have with no quantization at all. With this PR quantizing does what it was meant to do -- 1.4x to 2.2x below bf16, and 2.1x to 3.8x below what quantizing costs today.

## How it works

The fix is the one `mlx_vlm` already uses for its TurboQuant caches: dequantize the cache and hand the fused kernel the copy.

`quantized_sdpa_over` wraps each runtime's own `quantized_scaled_dot_product_attention`. The wrapper compares the two transients per cached token -- `HQ * L` score elements against `HKV` rows of keys and values, counted at both widths because the prefix view a `QuantizedKVCache` hands over is compacted before it is dequantized -- and once the scores would cost more, it dequantizes and calls `mx.fast.scaled_dot_product_attention` over the copy. The depth cancels, so the query count alone decides: 82 queries for 32 heads over 8 at 128 wide and 4 bits, moving with the packing (98 at 8 bits, 76 at 2 bits / group 32). Below that the runtime's own function answers, unchanged, so every decode step returns its own bits.

The transient is then one bf16 copy of the cache, 4 MB per 1024 tokens of depth per layer, and only one layer's copy is live at a time. That is the whole-model effect in the table above.

`install_quantized_attention()` wraps the function in `mlx_lm.models.base` and `mlx_vlm.models.base`, whichever the load has already imported, and is idempotent. `FastMLXModel.from_pretrained` returns through a single helper that calls it after the load's own imports, so no load path can return a model still bound to the unwrapped function. If MLX ever ships `mx.fast.quantized_scaled_dot_product_attention`, the installer patches nothing and the runtimes keep their own.

## Memory and performance

Apple M3 Max, mlx 0.32.2, mlx-lm 0.31.3. Llama-3-8B attention shape: 32 query heads over 8 key/value heads, 128 wide, 4-bit cache at group size 64, `mask="causal"`. Peak is the transient above the settled baseline; both paths are timed in alternating rounds so drift falls on both equally, medians of nine.

Per layer, per call:

| queries | cache depth | peak, today | peak, this PR | | time, today | time, this PR | |
|---|---|---|---|---|---|---|---|
| 2048 | 8192 | 1072.0 MB | **64.0 MB** | 16.8x less | 39.2 ms | **22.8 ms** | 1.72x faster |
| 2048 | 32768 | 4192.1 MB | **160.0 MB** | 26.2x less | 206.5 ms | **129.9 ms** | 1.59x faster |
| 512 | 32768 | 1048.1 MB | **136.0 MB** | 7.7x less | 38.5 ms | **26.2 ms** | 1.47x faster |
| 512 | 131072 | 4168.5 MB | **520.0 MB** | 8.0x less | 224.0 ms | **114.5 ms** | 1.96x faster |

On a real cache prefix view add the packed cache once more (36 MB at 32K), for the compaction the dequantization does first. Decode is unchanged: below the threshold it is the runtime's own function.

Whole model, `mlx-community/Qwen3-4B-4bit`, 32 generated tokens, 2048-token prefill chunks, 4-bit cache at group size 64. Single runs on a laptop, so treat the times as indicative; the peaks are deterministic:

| prompt | prefill, bf16 cache | prefill, today | prefill, this PR | peak, today | peak, this PR |
|---|---|---|---|---|---|
| 8192 | 7.8 s | 9.7 s | **7.6 s** | 3337 MB | **1582 MB** |
| 16384 | 20.7 s | 26.2 s | **18.9 s** | 5734 MB | **1902 MB** |
| 32768 | 58.0 s | 111.2 s | **58.5 s** | 9967 MB | **2613 MB** |

Prefill runs at the speed of the bf16 cache and faster than the replaced path at every depth -- at 32K the replaced path's 10 GB peak puts the machine under memory pressure and it takes twice as long. `mx.fast.scaled_dot_product_attention` is a fused kernel; the replaced path is a dequantizing matmul, a masked softmax and a second matmul over a score matrix that does not fit in any cache.

## Accuracy

Agreement with the runtime's own function above the threshold: worst relative divergence 1.5e-2 over 18 cases (both runtimes, three mask forms, three bit widths), which is bf16 rounding in a different order. Below the threshold the result is the runtime's own, exactly.

## Deliberate divergences

The wrapper is a drop-in replacement -- same argument names, shapes and result dtypes, including the float32 the replaced path widens to when the queries and either cache disagree -- with two differences above the threshold, both inherited from the fused kernel and both the behaviour the same runtime already has for an unquantized cache:

1. **A query row whose mask admits no key gets the fused kernel's answer**, not the replaced path's average over every cached value (boolean mask) or NaN (additive). The runtimes build such rows only as batch padding, which they discard.
2. **The caller's queries survive the call.** The replaced path does `queries *= scale` in place; the fused kernel takes `scale` as an argument.

The mask goes to the fused kernel as given, which accepts every form the runtimes build (`"causal"`, boolean and additive arrays at `[L, S]`, `[B, 1, L, S]` and `[B, HQ, L, S]`). `mlx_vlm`'s own quantized function aligns `[B, 1, L, S]` masks against its 5-D grouped scores; the fused kernel needs no alignment, so a batched mask is handed over unchanged.

## History

An earlier revision of this PR shipped an `mx.fast.metal_kernel` flash-attention kernel that read the quantized cache in place, holding the transient flat at 113.5 MB whatever the depth. Measured whole-model it was both slower and larger than dequantizing to the fused kernel (1727 / 1954 / 2669 MB and 10.5 / 52.2 / 100.5 s at the three prompts above), because only one layer's transient is live at a time, so the flatness bought nothing a caller could see while the kernel's prefill ran 1.1x-1.3x slower than stock. Replaced by the ~90-line module here.

## Validation

```bash
python -m pytest tests/test_mlx_attention_metal.py -q
# 31 passed
```

Covers the routing tie at four head geometries (grouped, ungrouped, MLA-shaped, mixed dtype) and three packings; agreement with both runtimes' own functions on either side of the threshold under `"causal"`, boolean and additive masks, batched for `mlx_vlm`; the transient on a real `QuantizedKVCache` prefix view; result dtype against the runtime's for matched and mismatched query, key and value dtypes; the installer on both runtimes, twice; and that every return path of `from_pretrained` installs. A mutation sweep of 19 mutations of the module and the loader kills all 19.
