### PR TITLE
Pin the getsource guards on the TokenError-widened clause

### DIFF
--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -55,12 +55,17 @@ sys.path.insert(0, str(ROOT))
 COMPILER = ROOT / "unsloth_zoo" / "compiler.py"
 SRC = COMPILER.read_text(encoding="utf-8")
 
+# The clause both guards must carry. tokenize.TokenError subclasses Exception directly, so
+# OSError/TypeError alone let it through (#1149); the pin names the full tuple so a guard
+# that quietly drops a member fails here rather than at model load.
+GUARD = "except (OSError, TypeError, tokenize.TokenError)"
+
 
 def _guard_region() -> str:
     """The modeling-file guard and its handler.
 
-    Anchored on the call, not on "except (OSError, TypeError)": the torch
-    forward guard uses the same clause and is defined earlier in the file.
+    Anchored on the call, not on GUARD: the torch forward guard uses the same
+    clause and is defined earlier in the file.
     """
     i = SRC.index("full_source = inspect.getsource(modeling_file)")
     return SRC[max(0, i - 400):i + 2200]
@@ -75,9 +80,10 @@ def test_getsource_is_wrapped():
 
 
 def test_it_catches_what_getsource_actually_raises():
-    """OSError for unreadable source, TypeError for a built-in or C module."""
+    """OSError for unreadable source, TypeError for a built-in or C module,
+    TokenError for a generated forward read mid-rewrite."""
     region = _guard_region()
-    assert "except (OSError, TypeError)" in region
+    assert GUARD in region
 
 
 def test_the_real_exception_type_is_oserror():
@@ -172,7 +178,7 @@ def test_the_nn_forward_patch_loop_is_guarded():
     """
     region = _nn_patch_region()
     assert "try:" in region
-    assert "except (OSError, TypeError)" in region
+    assert GUARD in region
 
 
 def test_an_unreadable_forward_is_skipped_not_fatal():
@@ -217,7 +223,7 @@ def test_the_compiler_config_check_is_kept():
 def test_both_getsource_guards_are_present():
     """Two distinct sites, two distinct failures. Fixing only the first one
     just moves the crash later, which is exactly what happened."""
-    assert SRC.count("except (OSError, TypeError)") >= 2
+    assert SRC.count(GUARD) >= 2
 
 
 # ---- what the fallback must still do -------------------------------------


### PR DESCRIPTION
## What

#1149 (08f7e157d) widened both `inspect.getsource` guards in `unsloth_zoo/compiler.py` to `except (OSError, TypeError, tokenize.TokenError)`, but the source pins in `tests/test_unreadable_modeling_source.py` still grep the two-member tuple. Three of them fail on main since that merge:

- `test_it_catches_what_getsource_actually_raises`
- `test_the_nn_forward_patch_loop_is_guarded`
- `test_both_getsource_guards_are_present` (`SRC.count("except (OSError, TypeError)") >= 2` now counts 0)

This also reds every `Core (HF=…)` leg of unsloth's CI, which installs this package from git and runs this suite: unsloth main's Core runs at 1e8eda349 and 2b9c4bf64 fail these three (their jobs started after 09:13Z), while the run at cc33ff215 (started before) passed. Same three on every unsloth PR run since.

## How

The three assertions share one `GUARD` constant naming the full tuple, so what is pinned is the property the tests exist for — both sites carry the same complete clause — and a guard that quietly drops a member (including `TokenError`, which subclasses `Exception` directly and is the reason #1149 existed) fails here rather than at model load. The docstrings say why `TokenError` is in the clause. No production code touched.

## Verification

- `tests/test_unreadable_modeling_source.py` against 08f7e157d unpatched: 3 failed, 28 passed. With this change: 31 passed.
- `test_the_logger_name_exists_in_this_module` errors locally in a torch-less venv on the `bitsandbytes.nn` stub-leak check from `conftest.py`, identically before and after this change (it is what #1133 addresses); it is unrelated to this pin and passes in CI where the real package is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DRiTpjxAymRtv9p8Xr2kd
