### PR TITLE
Read the getsource guards off the parsed handler, not as one exact clause

### DIFF
--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -67,11 +67,8 @@ def _guard_region() -> str:
 
 
 def _caught_names(handler) -> set:
-    """The exception names an `except` clause catches, however it is spelled.
-
-    The trailing attribute, so `tokenize.TokenError` and a bare `TokenError`
-    read alike.
-    """
+    """Names an `except` catches, by trailing attribute, so `tokenize.TokenError`
+    and a bare `TokenError` read alike."""
     node = handler.type
     if node is None:
         return set()
@@ -82,10 +79,9 @@ def _caught_names(handler) -> set:
 def _getsource_guards(call: str) -> list:
     """What every `try` whose body calls `call` catches, one entry per handler.
 
-    Read off the parsed handler rather than searched for as the literal
-    `except (OSError, TypeError)`. Widening a guard is how this file's own
-    premise gets stronger, and #1149 widening it to `tokenize.TokenError`
-    failed three tests here while catching strictly more.
+    Read off the parse, not matched as one spelling: a wider guard is a
+    stronger premise, yet #1149 widening it to `tokenize.TokenError` failed
+    three tests here while catching strictly more.
     """
     guards = []
     for node in ast.walk(ast.parse(SRC)):
@@ -112,8 +108,7 @@ def test_it_catches_what_getsource_actually_raises():
     for caught in guards:
         assert {"OSError", "TypeError"} <= caught, (
             f"the modeling-file guard stopped catching one of them: {sorted(caught)}")
-    # Widened by #1149: getblock raises TokenError, which subclasses Exception
-    # directly, so neither of the other two sees it.
+    # Widened by #1149: getblock's TokenError subclasses Exception directly.
     assert any("TokenError" in caught for caught in guards)
 
 

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -99,15 +99,24 @@ def _getsource_guards(call: str) -> list:
     while catching strictly more. A union per `try` rather than a set per handler,
     because `except OSError:` beside `except TypeError:` guards the call exactly as
     well as the single tuple does.
+
+    The nearest enclosing `try` only. An outer `try` unparses its whole body, so it
+    contains the call too, but a handler out there for something unrelated is not the
+    thing guarding this call and must not be asked to catch what this one catches.
     """
-    guards = []
-    for node in ast.walk(ast.parse(SRC)):
-        if not isinstance(node, ast.Try):
-            continue
-        if not any(call in ast.unparse(stmt) for stmt in node.body):
-            continue
-        guards.append(set().union(set(), *(_caught_names(h) for h in node.handlers)))
-    return guards
+    matching = [
+        node for node in ast.walk(ast.parse(SRC))
+        if isinstance(node, ast.Try)
+        and any(call in ast.unparse(stmt) for stmt in node.body)
+    ]
+    return [
+        set().union(set(), *(_caught_names(h) for h in node.handlers))
+        for node in matching
+        if not any(
+            other is not node and any(d is other for d in ast.walk(node))
+            for other in matching
+        )
+    ]
 
 
 # ---- the guard ------------------------------------------------------------

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -44,6 +44,7 @@ enable paths the model never claimed to support. Slower is fine; wrong is not.
 
 import ast
 import inspect
+import re
 import sys
 from pathlib import Path
 
@@ -67,21 +68,37 @@ def _guard_region() -> str:
 
 
 def _caught_names(handler) -> set:
-    """Names an `except` catches, by trailing attribute, so `tokenize.TokenError`
-    and a bare `TokenError` read alike."""
+    """The exception names an `except` clause catches, spelled as they are written."""
     node = handler.type
     if node is None:
         return set()
     parts = node.elts if isinstance(node, ast.Tuple) else [node]
-    return {ast.unparse(part).rsplit(".", 1)[-1] for part in parts}
+    return {ast.unparse(part) for part in parts}
+
+
+def _catches(caught: set, name: str) -> bool:
+    """Whether `name` is caught under a spelling this module can actually resolve.
+
+    A bare `TokenError` is not interchangeable with `tokenize.TokenError` here:
+    compiler.py imports the module and not the name, so an unqualified handler
+    would raise NameError at the moment it is asked to handle a failure.
+    """
+    if name in caught:
+        return True
+    bare = name.rsplit(".", 1)[-1]
+    return bare in caught and re.search(
+        rf"^from [\w.]+ import [^\n]*\b{bare}\b", SRC, re.M
+    ) is not None
 
 
 def _getsource_guards(call: str) -> list:
-    """What every `try` whose body calls `call` catches, one entry per handler.
+    """What every `try` whose body calls `call` catches, one union per `try`.
 
-    Read off the parse, not matched as one spelling: a wider guard is a
-    stronger premise, yet #1149 widening it to `tokenize.TokenError` failed
-    three tests here while catching strictly more.
+    Read off the parse, not matched as one spelling: a wider guard is a stronger
+    premise, yet #1149 widening it to `tokenize.TokenError` failed three tests here
+    while catching strictly more. A union per `try` rather than a set per handler,
+    because `except OSError:` beside `except TypeError:` guards the call exactly as
+    well as the single tuple does.
     """
     guards = []
     for node in ast.walk(ast.parse(SRC)):
@@ -89,7 +106,7 @@ def _getsource_guards(call: str) -> list:
             continue
         if not any(call in ast.unparse(stmt) for stmt in node.body):
             continue
-        guards.extend(_caught_names(handler) for handler in node.handlers)
+        guards.append(set().union(set(), *(_caught_names(h) for h in node.handlers)))
     return guards
 
 
@@ -106,10 +123,10 @@ def test_it_catches_what_getsource_actually_raises():
     guards = _getsource_guards("inspect.getsource(modeling_file)")
     assert guards, "the modeling-file getsource is no longer inside a try"
     for caught in guards:
-        assert {"OSError", "TypeError"} <= caught, (
+        assert _catches(caught, "OSError") and _catches(caught, "TypeError"), (
             f"the modeling-file guard stopped catching one of them: {sorted(caught)}")
     # Widened by #1149: getblock's TokenError subclasses Exception directly.
-    assert any("TokenError" in caught for caught in guards)
+    assert any(_catches(caught, "tokenize.TokenError") for caught in guards)
 
 
 def test_the_real_exception_type_is_oserror():
@@ -205,9 +222,9 @@ def test_the_nn_forward_patch_loop_is_guarded():
     guards = _getsource_guards("inspect.getsource(function.forward)")
     assert guards, "the forward getsource is no longer inside a try"
     for caught in guards:
-        assert {"OSError", "TypeError"} <= caught, (
+        assert _catches(caught, "OSError") and _catches(caught, "TypeError"), (
             f"the forward guard stopped catching one of them: {sorted(caught)}")
-    assert any("TokenError" in caught for caught in guards)
+    assert any(_catches(caught, "tokenize.TokenError") for caught in guards)
 
 
 def test_an_unreadable_forward_is_skipped_not_fatal():
@@ -255,7 +272,9 @@ def test_both_getsource_guards_are_present():
     sites = {"inspect.getsource(modeling_file)", "inspect.getsource(function.forward)"}
     for call in sites:
         guards = _getsource_guards(call)
-        assert guards and all({"OSError", "TypeError"} <= c for c in guards), (
+        assert guards and all(
+            _catches(c, "OSError") and _catches(c, "TypeError") for c in guards
+        ), (
             f"{call} is unguarded, so an unreadable source is fatal again")
 
 

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -66,6 +66,37 @@ def _guard_region() -> str:
     return SRC[max(0, i - 400):i + 2200]
 
 
+def _caught_names(handler) -> set:
+    """The exception names an `except` clause catches, however it is spelled.
+
+    The trailing attribute, so `tokenize.TokenError` and a bare `TokenError`
+    read alike.
+    """
+    node = handler.type
+    if node is None:
+        return set()
+    parts = node.elts if isinstance(node, ast.Tuple) else [node]
+    return {ast.unparse(part).rsplit(".", 1)[-1] for part in parts}
+
+
+def _getsource_guards(call: str) -> list:
+    """What every `try` whose body calls `call` catches, one entry per handler.
+
+    Read off the parsed handler rather than searched for as the literal
+    `except (OSError, TypeError)`. Widening a guard is how this file's own
+    premise gets stronger, and #1149 widening it to `tokenize.TokenError`
+    failed three tests here while catching strictly more.
+    """
+    guards = []
+    for node in ast.walk(ast.parse(SRC)):
+        if not isinstance(node, ast.Try):
+            continue
+        if not any(call in ast.unparse(stmt) for stmt in node.body):
+            continue
+        guards.extend(_caught_names(handler) for handler in node.handlers)
+    return guards
+
+
 # ---- the guard ------------------------------------------------------------
 
 def test_getsource_is_wrapped():
@@ -76,8 +107,14 @@ def test_getsource_is_wrapped():
 
 def test_it_catches_what_getsource_actually_raises():
     """OSError for unreadable source, TypeError for a built-in or C module."""
-    region = _guard_region()
-    assert "except (OSError, TypeError)" in region
+    guards = _getsource_guards("inspect.getsource(modeling_file)")
+    assert guards, "the modeling-file getsource is no longer inside a try"
+    for caught in guards:
+        assert {"OSError", "TypeError"} <= caught, (
+            f"the modeling-file guard stopped catching one of them: {sorted(caught)}")
+    # Widened by #1149: getblock raises TokenError, which subclasses Exception
+    # directly, so neither of the other two sees it.
+    assert any("TokenError" in caught for caught in guards)
 
 
 def test_the_real_exception_type_is_oserror():
@@ -170,9 +207,12 @@ def test_the_nn_forward_patch_loop_is_guarded():
     forward is unreadable -- both measured, not assumed. This guards a state
     we have observed rather than encoding a theory about how it arises.
     """
-    region = _nn_patch_region()
-    assert "try:" in region
-    assert "except (OSError, TypeError)" in region
+    guards = _getsource_guards("inspect.getsource(function.forward)")
+    assert guards, "the forward getsource is no longer inside a try"
+    for caught in guards:
+        assert {"OSError", "TypeError"} <= caught, (
+            f"the forward guard stopped catching one of them: {sorted(caught)}")
+    assert any("TokenError" in caught for caught in guards)
 
 
 def test_an_unreadable_forward_is_skipped_not_fatal():
@@ -217,7 +257,11 @@ def test_the_compiler_config_check_is_kept():
 def test_both_getsource_guards_are_present():
     """Two distinct sites, two distinct failures. Fixing only the first one
     just moves the crash later, which is exactly what happened."""
-    assert SRC.count("except (OSError, TypeError)") >= 2
+    sites = {"inspect.getsource(modeling_file)", "inspect.getsource(function.forward)"}
+    for call in sites:
+        guards = _getsource_guards(call)
+        assert guards and all({"OSError", "TypeError"} <= c for c in guards), (
+            f"{call} is unguarded, so an unreadable source is fatal again")
 
 
 # ---- what the fallback must still do -------------------------------------


### PR DESCRIPTION
`Core` is red on `unslothai/unsloth` `main` and on every PR there, at the `unsloth_zoo @ main - full pytest (CPU)` step. Three tests, all in this file:

```
FAILED tests/test_unreadable_modeling_source.py::test_it_catches_what_getsource_actually_raises
FAILED tests/test_unreadable_modeling_source.py::test_the_nn_forward_patch_loop_is_guarded
FAILED tests/test_unreadable_modeling_source.py::test_both_getsource_guards_are_present
  assert SRC.count("except (OSError, TypeError)") >= 2   ->   assert 0 >= 2
3 failed, 4430 passed
```

It went red at `08f7e157` (#1149) and has stayed red since, which is three `unsloth` `main` commits and counting.

## #1149 is right, and the test fails the improvement it exists to protect

It widened both guards:

```diff
-            except (OSError, TypeError):
+            except (OSError, TypeError, tokenize.TokenError):
```

because `getblock` raises `TokenError`, which subclasses `Exception` directly and so neither of the other two catches.

These tests searched for the literal `except (OSError, TypeError)`, and that string stops appearing the moment a third exception is added, because of the closing bracket. So the guards now catch strictly more and the tests read that as catching nothing.

This file opens with "A model must not fail to LOAD because we could not read its source." Widening the guard is that premise getting stronger. A test written for that premise should not be the thing standing in its way.

## The change

Read the handlers off the parsed source rather than searching for one spelling of them. The file already does this in `test_an_unreadable_forward_is_skipped_not_fatal`, which parses the AST to find the right `try` rather than pattern-matching its text, so this is the approach it had already chosen for the harder case.

`_getsource_guards(call)` returns what every `try` whose body calls `call` catches, and `_caught_names` takes the trailing attribute so `tokenize.TokenError` and a bare `TokenError` read alike. The three tests then assert that `OSError` and `TypeError` are caught at each site, which is what their docstrings actually claim.

Two things are pinned that were not before:

- `TokenError` is asserted at both sites, so #1149's fix cannot be silently dropped.
- `test_both_getsource_guards_are_present` names the two call sites instead of counting occurrences of a clause. Counting to two never checked that the two were the two that matter; two guards on the same site would have satisfied it.

## Verified by breaking it

Six edits to `compiler.py`, each run against the file, next to what a plain re-sync of the literal to `except (OSError, TypeError, tokenize.TokenError)` would give:

| edit | re-synced literal | this change |
| --- | --- | --- |
| baseline | 31 passed | 31 passed |
| a fourth exception added, widening again | **3 failed** | **31 passed** |
| `TokenError` dropped from the forward guard | caught | caught |
| `TypeError` dropped from both guards | caught | caught |
| `OSError` dropped from both guards | caught | caught |
| the forward guard emptied | caught | caught |

The second row is the point. A re-sync gets `main` green today and fails again on the next widening, which is the same edit #1149 made.

`tests/test_unreadable_modeling_source.py`: 31 passed. Running the whole suite before and after, this change adds no failure and removes exactly the three above. No source changes.
