### PR TITLE
Batched MLX generation: per-row sampling, per-row streaming, and a batch replies can join

### DIFF
--- a/tests/mlx_simulation/mlx_vlm_stub.py
+++ b/tests/mlx_simulation/mlx_vlm_stub.py
@@ -27,6 +27,8 @@ PR-B uses `mlx_vlm.stream_generate` directly.
 
 from __future__ import annotations
 
+import dataclasses
+import math
 import sys
 import types
 
@@ -84,6 +86,101 @@ prompt_utils_module = _pkg("mlx_vlm.prompt_utils")
 models_module = _pkg("mlx_vlm.models")
 chat_module = _pkg("mlx_vlm.chat")
 generate_module = _pkg("mlx_vlm.generate")
+
+# The batched vision path introspects the INSTALLED mlx-vlm: it reads
+# BatchGenerator.__init__'s signature to decide which KV-quantization controls are
+# forwarded, and calls turboquant_enabled to classify the scheme. The module-level
+# __getattr__ below answers any name with a _Noop, so without concrete definitions
+# those probes resolve to something signature-less and every control is reported
+# refused. Shapes copied from mlx-vlm 0.6.4, the newest release this repo's
+# transformers<=5.5.0 cap resolves.
+generate_ar_module = _pkg("mlx_vlm.generate.ar")
+
+
+@dataclasses.dataclass
+class _BatchResponse:
+    uid: int
+    token: int
+    token_logprob: float
+    finish_reason: object = None
+    top_logprobs: object = None
+
+
+class _BatchGenerator:
+    Response = _BatchResponse
+
+    def __init__(self, model, processor, max_tokens=256, stop_tokens=None,
+                 sampler=None, completion_batch_size=32, prefill_batch_size=8,
+                 prefill_step_size=512, prompt_cache=None, kv_bits=None,
+                 kv_group_size=64, kv_quant_scheme=None, quantized_kv_start=0,
+                 compute_logprobs=False, top_logprobs_k=0, logits_processors=None,
+                 stream=None, apc_manager=None, draft_model=None, draft_kind=None,
+                 draft_block_size=None, greedy_sampling=False):
+        self.kwargs = {
+            "kv_bits": kv_bits, "kv_group_size": kv_group_size,
+            "kv_quant_scheme": kv_quant_scheme,
+            "quantized_kv_start": quantized_kv_start,
+        }
+
+    def insert(self, prompts, max_tokens=None, prompt_kwargs=None,
+               logits_processors=None, thinking_budget_criteria=None):
+        raise NotImplementedError("mlx-shim: BatchGenerator.insert not implemented")
+
+    def next(self):
+        raise NotImplementedError("mlx-shim: BatchGenerator.next not implemented")
+
+    def remove(self, uid):
+        raise NotImplementedError("mlx-shim: BatchGenerator.remove not implemented")
+
+    def close(self):
+        pass
+
+
+def turboquant_enabled(bits, scheme=None):
+    if bits is None:
+        return False
+    if scheme == "turboquant":
+        return True
+    bits = float(bits)
+    return not math.isclose(bits, round(bits), abs_tol=1e-6)
+
+
+# The engine rebinds to the module BatchGenerator is DEFINED in, "where the private
+# helpers live", so these must name the module they are published from rather than
+# this one, or the rebind lands back here and finds none of them.
+_BatchGenerator.__module__ = "mlx_vlm.generate.ar"
+turboquant_enabled.__module__ = "mlx_vlm.generate.ar"
+
+generate_ar_module.BatchGenerator = _BatchGenerator
+generate_ar_module.turboquant_enabled = turboquant_enabled
+generate_module.BatchGenerator = _BatchGenerator
+generate_module.turboquant_enabled = turboquant_enabled
+
+# mlx_vlm.kv_quant only exists from 0.6.12, so it stays absent here: the engine's
+# own fallback names the two schemes, and this shim tracks the pinned release.
+turboquant_module = _pkg("mlx_vlm.turboquant")
+turboquant_module.turboquant_enabled = turboquant_enabled
+
+# models.cache has to be concrete for one absence. should_quantize_kv_layer arrived in
+# 0.6.6; at the pinned 0.6.4 the engine must fall back to the policy ar.py applies
+# inline. Left to the permissive finder the name would resolve to a _Noop that imports
+# fine and then raises when called, which is neither release's behaviour.
+# Deliberately NOT _pkg: with a __path__ the finder treats the absent name as a
+# submodule to auto-create, so `from ... import should_quantize_kv_layer` would
+# succeed with a module object instead of raising.
+models_cache_module = types.ModuleType("mlx_vlm.models.cache")
+_CACHE_ABSENT_BEFORE_0_6_6 = ("should_quantize_kv_layer",)
+
+
+def _models_cache_getattr(name):
+    from .mlx_stub import _Noop
+    if name in _CACHE_ABSENT_BEFORE_0_6_6 or (
+            name.startswith("__") and name.endswith("__")):
+        raise AttributeError(name)
+    return _Noop(f"mlx_vlm.models.cache.{name}")
+
+
+models_cache_module.__getattr__ = _models_cache_getattr
 server_module = _pkg("mlx_vlm.server")
 evals_module = _pkg("mlx_vlm.evals")
 evals_utils_module = _pkg("mlx_vlm.evals.utils")
@@ -92,9 +189,16 @@ evals_utils_module = _pkg("mlx_vlm.evals.utils")
 __path__ = []
 
 
+# Absent at the pinned 0.6.4. kv_quant arrived in 0.6.12; answering it with a _Noop
+# would make `from mlx_vlm import kv_quant` succeed and hand back _Noop sentinels
+# where the engine expects the scheme name strings, so every scheme looks unknown.
+_ABSENT_BEFORE_0_6_12 = ("kv_quant",)
+
+
 def __getattr__(name):
     from .mlx_stub import _Noop
-    if name.startswith("__") and name.endswith("__"):
+    if name in _ABSENT_BEFORE_0_6_12 or (
+            name.startswith("__") and name.endswith("__")):
         raise AttributeError(name)
     return _Noop(f"mlx_vlm.{name}")
 
@@ -108,7 +212,10 @@ def inject_into_sys_modules():
     this.generate = generate_module
     this.server = server_module
     this.evals = evals_module
+    this.turboquant = turboquant_module
+    models_module.cache = models_cache_module
     evals_module.utils = evals_utils_module
+    generate_module.ar = generate_ar_module
     sys.modules.update({
         "mlx_vlm": this,
         "mlx_vlm.utils": utils_module,
@@ -116,6 +223,11 @@ def inject_into_sys_modules():
         "mlx_vlm.models": models_module,
         "mlx_vlm.chat": chat_module,
         "mlx_vlm.generate": generate_module,
+        "mlx_vlm.generate.ar": generate_ar_module,
+        "mlx_vlm.turboquant": turboquant_module,
+        "mlx_vlm.models.cache": models_cache_module,
+        # None makes the import raise ImportError instead of the finder inventing it.
+        "mlx_vlm.kv_quant": None,
         "mlx_vlm.server": server_module,
         "mlx_vlm.evals": evals_module,
         "mlx_vlm.evals.utils": evals_utils_module,

--- a/tests/test_mlx_arrays_cache_advance.py
+++ b/tests/test_mlx_arrays_cache_advance.py
@@ -302,9 +302,15 @@ def test_generate_batch_installs_before_it_generates(monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
-        def generate(self, requests):
-            order.append("generate")
-            return []
+        def stream(self, requests):
+            order.append("stream")
+            for index in range(len(requests)):
+                yield engine.GenerationEvent(
+                    index = index,
+                    result = engine.GenerationResult(
+                        token_ids = [], text = "", logprobs = [], finish_reason = "stop",
+                    ),
+                )
 
     import contextlib
 
@@ -322,4 +328,4 @@ def test_generate_batch_installs_before_it_generates(monkeypatch):
         defaults=engine.GenerationDefaults(),
     )
 
-    assert order == ["install", "generate"]
+    assert order == ["install", "stream"]

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1509,6 +1509,15 @@ def test_stream_batch_checks_the_defaults_type_before_reading_stop_strings():
                      defaults = GenerationDefaults(stop_strings = ("X",)))
 
 
+def test_kv_quant_controls_and_processor_rows_are_refused_before_they_reach_a_cache():
+    assert [type(pytest.raises((TypeError, ValueError), GenerationDefaults, **kw).value) for kw in ({"kv_bits": True}, {"kv_bits": float("nan")}, {"kv_bits": float("inf")}, {"kv_group_size": True}, {"kv_group_size": -1}, {"kv_quant_scheme": 3}, {"quantized_kv_start": -1})] == [TypeError, ValueError, ValueError, TypeError, ValueError, TypeError, ValueError] and GenerationDefaults(kv_bits = 4.5, kv_group_size = 32, kv_quant_scheme = "turboquant", quantized_kv_start = 0).kv_bits == 4.5  # noqa: E501
+    with contextlib.closing(_vlm_session()) as session:
+        session.adapter.row_logits_processors = False
+        with pytest.raises(ValueError, match = "cannot carry") as refusal:
+            session.add(GenerationRequest(prompt = "p", logits_processors = [lambda tokens, logits: logits]))
+        assert type(refusal.value).__name__ == "BatchRowRefused" and session.usable and session.add(GenerationRequest(prompt = "p")) == 0  # noqa: E501
+
+
 def test_the_preflight_refuses_defaults_every_add_would():
     from unsloth_zoo.mlx.generate import stream_unavailable_reason
     assert all(m in stream_unavailable_reason(types.SimpleNamespace(**model), object(), defaults = GenerationDefaults(**kw)) for model, kw, m in (({}, {"kv_bits": 8}, "not forwarded"), ({"_is_vlm_model": True, "language_model": object()}, {"max_kv_size": 64}, "max_kv_size"), ({"_is_vlm_model": True, "language_model": object()}, {"prefill_batch_size": 4, "completion_batch_size": 2}, "must not exceed")))  # noqa: E501

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -5,6 +5,7 @@ import importlib.util
 import inspect
 import pathlib
 import sys
+import threading
 import types
 import warnings
 from dataclasses import make_dataclass
@@ -1320,14 +1321,18 @@ def test_a_cancelled_row_leaves_the_batch_and_its_neighbour_runs_on(monkeypatch)
     stream = _open_stream(monkeypatch, max_tokens=8)
     try:
         stream.add(GenerationRequest(prompt_token_ids=[9], max_tokens=8))
-        stream.add(GenerationRequest(prompt_token_ids=[9], max_tokens=8))
+        stream.add(GenerationRequest(prompt_token_ids=[9, 9, 9], max_tokens=8))
         assert [event.index for event in stream.step()] == [0, 1]
         generator = stream._session.generator
-        assert stream.cancel(1) is True
+        managed = stream.withdraw(1)
+        assert managed is not None and managed.finish_reason == "stop"
+        assert managed.prompt_token_count == 3
+        assert managed.text and len(managed.token_ids) == len(managed.logprobs) > 0
         assert generator.removed == [102]
         assert [event.index for event in stream.step()] == [0]
         assert stream.rows_in_flight == 1
-        assert stream.cancel(1) is False and stream.cancel(7) is False
+        assert stream.withdraw(1) is None and stream.withdraw(7) is None
+        assert stream.cancel(1) is False, "and the older answer is the same answer"
     finally:
         stream.close()
 

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -21,7 +21,7 @@ from unsloth_zoo.mlx.generate import (  # noqa: E402
     _StopStringScanner, _TextBatchAdapter,
     _eos_stop_tokens, _new_detokenizer, _probe_sampler_api, _probe_text_api,
     _generation_cache_hygiene, _restore_training_flags,
-    _validate_text_requests, generate_batch, generation_mode,
+    _validate_text_requests, generate_batch, generation_mode, stream_batch,
 )
 
 class _CharDetokenizer:
@@ -1116,3 +1116,122 @@ def test_a_row_is_reported_as_it_goes_and_its_deltas_rebuild_its_text():
     for index in (7, 9):
         row = [event for event in events if event.index == index]
         assert "".join(event.delta for event in row) == row[-1].result.text
+
+class _OpenBatchGenerator:
+    """A BatchGenerator that reports one token per row per step, for as long as"""
+
+    def __init__(self, *_args, **_kwargs):
+        self.rows: dict[int, int] = {}
+        self.removed: list[int] = []
+        self.closed = False
+        self.steps = 0
+        self._next_uid = 100
+
+    def insert(self, prompts, max_tokens=None, samplers=None, logits_processors=None):
+        uids = []
+        for index in range(len(prompts)):
+            self._next_uid += 1
+            budget = (max_tokens or [1])[index]
+            self.rows[self._next_uid] = int(budget)
+            uids.append(self._next_uid)
+        return uids
+
+    def next_generated(self):
+        self.steps += 1
+        events = []
+        for uid in list(self.rows):
+            self.rows[uid] -= 1
+            events.append(types.SimpleNamespace(
+                uid=uid, token=1, logprobs=[-9.0, -0.1, -0.2, -0.3],
+                finish_reason="length" if self.rows[uid] <= 0 else None,
+            ))
+            if self.rows[uid] <= 0:
+                del self.rows[uid]
+        return events
+
+    def remove(self, uids):
+        self.removed.extend(uids)
+        for uid in uids:
+            self.rows.pop(uid, None)
+
+    def close(self):
+        self.closed = True
+
+
+def _stub_generation_mode(monkeypatch, generator_type=_OpenBatchGenerator):
+    """A model that can enter generation mode, decoding through a fake generator."""
+    import unsloth_zoo.mlx.generate as module
+
+    def adapter(model, tok, defaults_):
+        built = object.__new__(_TextBatchAdapter)
+        built.model, built.tokenizer, built.defaults = model, tok, defaults_
+        built.batch_generator_type = generator_type
+        built.make_sampler = lambda **_kwargs: None
+        built.sample_utils = None
+        return built
+
+    monkeypatch.setattr(module, "_TextBatchAdapter", adapter)
+    monkeypatch.setattr(module, "_generation_cache_hygiene", contextlib.nullcontext)
+    monkeypatch.setattr(module, "_snapshot_metal_limits", dict)
+    monkeypatch.setattr(module, "_restore_metal_limits", lambda _snapshot: None)
+    model = types.SimpleNamespace(training=False, eval=lambda: None)
+    model.named_modules = lambda: [("", model)]
+    return model
+
+
+def _open_stream(monkeypatch, generator_type=_OpenBatchGenerator, **defaults):
+    """A BatchStream over a fake generator, with the generation lock stubbed out."""
+    from unsloth_zoo.mlx.generate import BatchStream
+
+    tokenizer = _CharTokenizer()
+    tokenizer.eos_token_ids = ()
+    model = _stub_generation_mode(monkeypatch, generator_type=generator_type)
+    return BatchStream(model, tokenizer, defaults=GenerationDefaults(**defaults))
+
+
+def test_a_batch_left_open_patches_the_cache_before_it_decodes(monkeypatch):
+    """mlx-lm's ArraysCache.advance strands a Metal buffer per token until it is
+    replaced, and a batch left open decodes for as long as the session lasts."""
+    from unsloth_zoo.mlx import generate as engine
+
+    installed = []
+    monkeypatch.setattr(
+        engine, "_install_arrays_cache_advance_fix", lambda: installed.append(True))
+    stream = _open_stream(monkeypatch, max_tokens=2)
+    try:
+        assert installed == [True]
+    finally:
+        stream.close()
+
+
+def test_a_row_added_mid_batch_decodes_with_the_rows_already_running(monkeypatch):
+    """A request that arrived later joins the batch already running: serving"""
+    stream = _open_stream(monkeypatch, max_tokens=6)
+    try:
+        first = stream.add(GenerationRequest(prompt_token_ids=[9], max_tokens=6))
+        early = [event.index for _ in range(2) for event in stream.step()]
+        second = stream.add(GenerationRequest(prompt_token_ids=[9, 9], max_tokens=3))
+        together = [event.index for _ in range(2) for event in stream.step()]
+    finally:
+        stream.close()
+
+    assert (first, second) == (0, 1)
+    assert early == [0, 0]
+    assert together == [0, 1, 0, 1]
+
+
+def test_a_cancelled_row_leaves_the_batch_and_its_neighbour_runs_on(monkeypatch):
+    stream = _open_stream(monkeypatch, max_tokens=8)
+    try:
+        stream.add(GenerationRequest(prompt_token_ids=[9], max_tokens=8))
+        stream.add(GenerationRequest(prompt_token_ids=[9], max_tokens=8))
+        assert [event.index for event in stream.step()] == [0, 1]
+        generator = stream._session.generator
+        assert stream.cancel(1) is True
+        assert generator.removed == [102]
+        assert [event.index for event in stream.step()] == [0]
+        assert stream.rows_in_flight == 1
+        assert stream.cancel(1) is False and stream.cancel(7) is False
+    finally:
+        stream.close()
+

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1468,4 +1468,9 @@ def test_a_text_row_carries_its_own_logits_processors_into_the_batch(monkeypatch
     assert seen[1 - carrying] == [[]]
     assert [_shows(processor, [4, 5, 6]) for processor in seen[carrying][0]] == [7]
 
-
+def test_stream_batch_checks_the_defaults_type_before_reading_stop_strings():
+    with pytest.raises(TypeError, match="must be GenerationDefaults"):
+        stream_batch(object(), object(), [], defaults = {"stop_strings": ()})
+    with pytest.raises(ValueError, match="cannot apply stop_strings"):
+        stream_batch(object(), object(), [],
+                     defaults = GenerationDefaults(stop_strings = ("X",)))

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -5,6 +5,7 @@ import inspect
 import pathlib
 import sys
 import types
+import warnings
 from dataclasses import make_dataclass
 import pytest
 
@@ -15,7 +16,7 @@ if importlib.util.find_spec("mlx") is None:
     simulate_mlx_on_torch()
 
 from unsloth_zoo.mlx.generate import (  # noqa: E402
-    GenerationDefaults, GenerationRequest, SamplingParams,
+    GenerationDefaults, GenerationEvent, GenerationRequest, SamplingParams,
     _GENERATION_MODE_LOCK, _PendingResult, _PerRowSeededSampler,
     _StopStringScanner, _TextBatchAdapter,
     _eos_stop_tokens, _new_detokenizer, _probe_sampler_api, _probe_text_api,
@@ -339,19 +340,19 @@ def test_adapter_removes_stop_matches_and_closes_on_failure():
     adapter.defaults = GenerationDefaults(stop_strings=("<STOP>",), prefill_batch_size=2, completion_batch_size=3, max_kv_size=16)
     adapter.batch_generator_type = Generator
     adapter.make_sampler = lambda **_kwargs: None
-    result = adapter.generate([GenerationRequest(prompt_token_ids=[9])])[0]
+    result = _results(adapter.stream([GenerationRequest(prompt_token_ids=[9])]))[0]
     assert result.token_ids == [1] and Generator.instances[-1].removed == [7]
     assert tuple(Generator.instances[-1].kwargs[name] for name in ("prefill_batch_size", "completion_batch_size", "max_kv_size")) == (2, 3, 16)
     assert Generator.instances[-1].closed is True
     Generator.eos = True
-    eos = adapter.generate([GenerationRequest(prompt_token_ids=[9])])[0]
+    eos = _results(adapter.stream([GenerationRequest(prompt_token_ids=[9])]))[0]
     assert eos.token_ids == [1] and eos.finish_reason == "stop"
     Generator.eos = False
     Generator.fail = True
     Generator.close_fail = True
     with pytest.warns(RuntimeWarning, match=r"close\(\) failed"):
         with pytest.raises(RuntimeError, match="event failure"):
-            adapter.generate([GenerationRequest(prompt_token_ids=[9])])
+            _results(adapter.stream([GenerationRequest(prompt_token_ids=[9])]))
     assert Generator.instances[-1].closed is True
 
 def test_generation_mode_releases_lock_when_limit_restore_raises(monkeypatch):
@@ -534,7 +535,7 @@ def test_vlm_adapter_drives_both_upstream_protocols(per_row):
     adapter.per_row_prompt_kwargs = per_row
     adapter.defaults = GenerationDefaults()
     adapter.processor = _CharTokenizer()
-    results = adapter._drive(generator, [0], {})
+    results = _results(adapter._drive(generator, [0], [0], {}))
     assert ([r.token_ids for r in results], results[0].finish_reason) == ([[1]], "stop")
 
 
@@ -555,7 +556,7 @@ def test_vlm_adapter_isolates_detokenizers_and_reads_scalar_logprobs():
     generator = _vlm_stub(True, events=[
         [(0, 1, None), (1, 4, None)], [(0, 3, "stop"), (1, 3, "stop")]])(
         object(), object())
-    results = adapter._drive(generator, [0, 1], {})
+    results = _results(adapter._drive(generator, [0, 1], [0, 1], {}))
     # Distinct buffers: a shared one concatenates both sequences into the first.
     assert [(r.token_ids, r.text) for r in results] == [
         ([1], "hello "), ([4], "tailSTOPsuffix")] and results[0].logprobs == [-0.5]
@@ -569,11 +570,12 @@ def test_vlm_chunking_respects_release_capabilities():
     chunks = []
     adapter._group_key = lambda request: "same"
     adapter._run_chunk = lambda requests, indices: (
-        chunks.append(list(indices)) or [object() for _ in indices])
+        chunks.append(list(indices))
+        or [GenerationEvent(index = index, result = object()) for index in indices])
     requests = [GenerationRequest(prompt="p") for _ in range(5)]
     for per_row, expected in ((True, [[0, 1, 2, 3, 4]]), (False, [[0, 1], [2, 3], [4]])):
         chunks.clear(); adapter.per_row_prompt_kwargs = per_row  # noqa: E702
-        adapter.generate(requests)
+        _results(adapter.stream(requests))
         assert chunks == expected
 
 
@@ -589,7 +591,10 @@ def test_vlm_run_chunk_builds_the_generator_after_embeddings():
     adapter.constructor_params = {"prefill_batch_size", "completion_batch_size", "sampler", "stop_tokens"}  # noqa: E501
     adapter.prepare_inputs = lambda *a, **k: {"input_ids": ids, "extra": "D", "position_ids": "P"}  # noqa: E501
     adapter.make_sampler = lambda **k: object()
-    adapter._add_special_tokens, adapter._drive = (lambda: True), (lambda *a: ["ok"] * 2)
+    adapter._add_special_tokens = lambda: True
+    adapter._drive = lambda *a: iter(
+        [GenerationEvent(index = row, result = "ok") for row in a[2]]
+    )
     adapter._split_prompt_kwargs = lambda kw, n: (seen.update(kwargs=kw), [{}] * n)[1]
     # Recording on ENTRY proves embeddings run inside the wired-limit context.
     adapter._wired_limit = lambda: _entry_ctx(order)  # records on ENTRY
@@ -600,7 +605,8 @@ def test_vlm_run_chunk_builds_the_generator_after_embeddings():
         get_input_embeddings=lambda *a, **k: (order.append("embed"), embeds)[1])
     adapter.generator_type = lambda *a, **k: (order.append("construct"),
         seen.update(ctor=k), _vlm_stub(True, events=[[(0, 1, "stop")]])(*a[:2]))[2]
-    assert adapter._run_chunk([GenerationRequest(prompt="p")] * 2, [0, 1]) == ["ok", "ok"]
+    assert [event.result for event in
+            adapter._run_chunk([GenerationRequest(prompt = "p")] * 2, [0, 1])] == ["ok", "ok"]
     assert order == ["wired", "embed", "policy", "construct"]
     assert seen["policy"]["prefill_kwargs"]["inputs_embeds"] == "E"
     assert seen["kwargs"]["extra"] == "D"
@@ -651,11 +657,12 @@ def test_vlm_images_are_decoded_once_and_flow_to_preprocessing():
     adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
     adapter.process_image = lambda src, shape, proc: loads.append(src) or decoded
     adapter._run_chunk = lambda requests, indices: (
-        seen.update(image=requests[indices[0]].image), [object()])[1]
-    adapter.generate([GenerationRequest(prompt="p", image="/tmp/one-use.png")])
+        seen.update(image=requests[indices[0]].image),
+        [GenerationEvent(index=indices[0], result=object())])[1]
+    _results(adapter.stream([GenerationRequest(prompt="p", image="/tmp/one-use.png")]))
     assert loads == ["/tmp/one-use.png"] and seen["image"] is decoded
     with pytest.raises(ValueError, match="raw bytes"):
-        adapter.generate([GenerationRequest(prompt="p", image=b"\x89PNG")])
+        _results(adapter.stream([GenerationRequest(prompt="p", image=b"\x89PNG")]))
 
 
 def test_vlm_adapter_initializes_against_newer_module_layout(monkeypatch):
@@ -734,7 +741,9 @@ def test_vlm_drive_raises_on_true_stall_and_survives_long_prefill():
                     self._prompt_batch, self._generation_batch = None, [1]
                 return ([], [])
             return super().next(**kwargs)
-    assert adapter._drive(LongPrefill(object(), object()), [0], {})[0].finish_reason == "stop"
+    assert _results(
+        adapter._drive(LongPrefill(object(), object()), [0], [0], {})
+    )[0].finish_reason == "stop"
     class Stalled(base):
         def __init__(self, *a, **k):
             super().__init__(*a, **k)
@@ -744,7 +753,7 @@ def test_vlm_drive_raises_on_true_stall_and_survives_long_prefill():
         def next(self, **kwargs):
             return ([], [])
     with pytest.raises(RuntimeError, match="admitted no prompt"):
-        adapter._drive(Stalled(object(), object()), [0], {})
+        _results(adapter._drive(Stalled(object(), object()), [0], [0], {}))
 
 
 def test_vlm_requests_group_by_sampling_params():
@@ -755,17 +764,20 @@ def test_vlm_requests_group_by_sampling_params():
     adapter.process_image = None
     chunks = []
     adapter._run_chunk = lambda requests, indices: (
-        chunks.append(list(indices)) or [object() for _ in indices])
+        chunks.append(list(indices))
+        or [GenerationEvent(index = index, result = object()) for index in indices])
     hot = SamplingParams(temperature=0.9)
     adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
-    adapter.generate([GenerationRequest(prompt="a"), GenerationRequest(prompt="b", sampling=hot),
-                      GenerationRequest(prompt="c")])
+    _results(adapter.stream([GenerationRequest(prompt="a"),
+                             GenerationRequest(prompt="b", sampling=hot),
+                             GenerationRequest(prompt="c")]))
     assert sorted(chunks) == [[0, 2], [1]]
     # Preprocessing stacks a group without padding, so differing prompt lengths
     # must not share a chunk; upstream raises when they do.
     chunks.clear()
-    adapter.generate([GenerationRequest(prompt="a"), GenerationRequest(prompt="bb"),
-                      GenerationRequest(prompt="c")])
+    _results(adapter.stream([GenerationRequest(prompt="a"),
+                             GenerationRequest(prompt="bb"),
+                             GenerationRequest(prompt="c")]))
     assert sorted(chunks) == [[0, 2], [1]]
 
 
@@ -784,7 +796,7 @@ def test_vlm_stop_strings_trim_and_cancel_in_the_release_form(plural):
     adapter.per_row_prompt_kwargs = True
     adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
     adapter.cancel = _resolve_cancel(Generator)
-    result = adapter._drive(Generator(object(), object()), [0], {})[0]
+    result = _results(adapter._drive(Generator(object(), object()), [0], [0], {}))[0]
     # "<ST" + "OP>" completes the stop string: trimmed back to the boundary.
     assert (result.token_ids, result.finish_reason, result.stop_match) == ([], "stop_string", "STOP")
     assert cancelled == [[0]]
@@ -804,7 +816,8 @@ def test_vlm_stop_strings_drop_later_events_when_the_release_cannot_cancel():
     adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
     adapter.cancel = _resolve_cancel(Generator)
     assert adapter.cancel is None  # no cancellation on this release
-    stopped, sibling = adapter._drive(Generator(object(), object()), [0, 1], {})
+    stopped, sibling = _results(
+        adapter._drive(Generator(object(), object()), [0, 1], [0, 1], {}))
     assert (stopped.token_ids, stopped.finish_reason, stopped.stop_match) == (
         [], "stop_string", "STOP")
     assert (sibling.token_ids, sibling.finish_reason) == ([1, 1, 1], "length")
@@ -879,6 +892,15 @@ def _sample_utils():
         apply_top_k=lambda x, k: x,
     )
 
+def _results(events):
+    """Row-ordered results from a streaming driver, as generate_batch collects them."""
+    out = {}
+    for event in events:
+        if event.result is not None:
+            out[event.index] = event.result
+    return [out[index] for index in sorted(out)]
+
+
 def _audio_events(*specs):
     """Sequential events; `finish` omitted models releases carrying no reason.
 
@@ -905,11 +927,19 @@ def _audio_adapter(events, tokenizer=None, stops=()):
     adapter.sample_utils = _sample_utils()
     adapter._wired_limit = contextlib.nullcontext
     adapter.stream_calls = []
+    adapter.audio_warn_stacklevel = 3
     def stream(*args, **kwargs):
         adapter.stream_calls.append((args, kwargs))
         return iter(events)
     adapter.stream_module = types.SimpleNamespace(stream_generate=stream)
     return adapter
+
+
+def _audio_row(adapter, request):
+    """The one row an audio request produces, and the deltas it streamed."""
+    events = list(adapter._stream_sequentially(0, request))
+    assert all(event.index == 0 for event in events)
+    return events[-1].result, "".join(event.delta for event in events)
 
 
 class _CriteriaTokenizer(_CharTokenizer):
@@ -934,9 +964,11 @@ class _CriteriaTokenizer(_CharTokenizer):
     (((None, "length"),), None, ([], "length")),
 ])
 def test_audio_fallback_keeps_the_batched_result_contract(specs, tokenizer, expected):
-    result = _audio_adapter(_audio_events(*specs), tokenizer)._generate_sequentially(
+    result, streamed = _audio_row(
+        _audio_adapter(_audio_events(*specs), tokenizer),
         GenerationRequest(prompt="p", audio="a.wav"))
     assert (result.token_ids, result.finish_reason) == expected
+    assert streamed == result.text
     # Logprobs must belong to the tokens they sit beside, not to their successors.
     assert result.logprobs == [-0.5 - n for n in range(len(result.token_ids))]
     assert result.text == "".join(_CharTokenizer.pieces[t] for t in result.token_ids)
@@ -945,16 +977,17 @@ def test_audio_fallback_keeps_the_batched_result_contract(specs, tokenizer, expe
 def test_audio_terminal_event_flushes_text_held_back_during_streaming():
     # Cleanup withholds a trailing space until finalize; losing it truncates.
     tokenizer = _TableTokenizer({(1,): "a ", (1, 2): "a b "}, clean=True)
-    result = _audio_adapter(_audio_events((1, None), (2, None), (2, None)),
-                            tokenizer)._generate_sequentially(
+    result, streamed = _audio_row(
+        _audio_adapter(_audio_events((1, None), (2, None), (2, None)), tokenizer),
         GenerationRequest(prompt="p", audio="a.wav"))
     assert (result.token_ids, result.text) == ([1, 2], "a b ")
+    assert streamed == result.text
 
 
 def test_audio_fallback_forwards_the_request_to_the_stream():
     # A dropped audio payload or ignored control shows up in the stream call.
     adapter = _audio_adapter(_audio_events((1, None), (2, "length")))
-    adapter._generate_sequentially(GenerationRequest(
+    _audio_row(adapter, GenerationRequest(
         prompt="p", audio="a.wav", max_tokens=9,
         sampling=SamplingParams(temperature=0.25, top_k=7)))
     args, kwargs = adapter.stream_calls[0]
@@ -967,8 +1000,9 @@ def test_audio_fallback_forwards_the_request_to_the_stream():
 
 def test_audio_fallback_honours_stop_strings():
     # Audio reaches the same scanner: "<ST" + "OP>" completes the stop string.
-    result = _audio_adapter(_audio_events((2, None), (3, None), (3, "length")),
-                            stops=("STOP",))._generate_sequentially(
+    result, _streamed = _audio_row(
+        _audio_adapter(_audio_events((2, None), (3, None), (3, "length")),
+                       stops=("STOP",)),
         GenerationRequest(prompt="p", audio="a.wav"))
     assert (result.token_ids, result.finish_reason, result.stop_match) == (
         [], "stop_string", "STOP")
@@ -979,17 +1013,22 @@ def test_audio_requests_reach_the_fallback_through_the_public_entry_point(monkey
     # old blanket audio rejection came back.
     from unsloth_zoo.mlx import generate as engine
     seen = []
-    monkeypatch.setattr(engine._VLMBatchAdapter, "__init__",
-                        lambda self, *a: setattr(self, "per_row_prompt_kwargs", True))
     monkeypatch.setattr(engine._VLMBatchAdapter, "_decode_image", lambda self, r: r)
-    monkeypatch.setattr(engine._VLMBatchAdapter, "_generate_sequentially",
-                        lambda self, request: seen.append(request.audio) or "audio")
+    monkeypatch.setattr(
+        engine._VLMBatchAdapter, "_stream_sequentially",
+        lambda self, index, request: iter(
+            [GenerationEvent(index=index,
+                             result=seen.append(request.audio) or "audio")]))
     model = types.SimpleNamespace(_is_vlm_model=True, training=False, eval=lambda: None)
     model.named_modules = lambda: [("", model)]
-    with pytest.warns(RuntimeWarning, match="decode one at a time"):
-        results = engine.generate_batch(
-            model, object(), [GenerationRequest(prompt="p", audio="a.wav")])
+    request = [GenerationRequest(prompt="p", audio="a.wav")]
+    with pytest.warns(RuntimeWarning, match="decode one at a time") as collected:
+        results = engine.generate_batch(model, object(), request)
     assert (results, seen) == (["audio"], ["a.wav"])
+    assert collected[0].filename == __file__
+    with pytest.warns(RuntimeWarning, match="decode one at a time") as collected:
+        _results(engine.stream_batch(model, object(), request))
+    assert collected[0].filename == __file__
     # The at-most-one-media invariant has to survive audio becoming supported.
     with pytest.raises(ValueError, match="both an image and audio"):
         engine.generate_batch(model, object(),
@@ -1005,11 +1044,12 @@ def test_audio_requests_decode_alone_while_the_rest_of_the_batch_still_batches()
     adapter._group_key = lambda request: "g"
     adapter.per_row_prompt_kwargs = True
     adapter._run_chunk = lambda chunk, indices: (
-        batched.append(list(indices)), ["batched"] * len(chunk))[1]
+        batched.append(list(indices)),
+        [GenerationEvent(index = index, result = "batched") for index in indices])[1]
     requests = [GenerationRequest(prompt="a"), GenerationRequest(prompt="b", audio="a.wav"),
                 GenerationRequest(prompt="c")]
     with pytest.warns(RuntimeWarning, match="decode one at a time"):
-        results = _VLMBatchAdapter.generate(adapter, requests)
+        results = _results(_VLMBatchAdapter.stream(adapter, requests))
     assert batched == [[0, 2]]  # the audio row never reached the batched path
     assert [results[0], results[2]] == ["batched", "batched"]
     assert results[1].token_ids == [1]
@@ -1022,8 +1062,9 @@ def test_vision_generation_resolves_the_saved_processor(monkeypatch):
     from unsloth_zoo.mlx import generate as engine
     seen = {}
     class _Adapter:
-        def __init__(self, model, tok, defaults): seen["tok"] = tok
-        def generate(self, requests): return ["ok"]
+        def __init__(self, model, tok, defaults, **kwargs): seen["tok"] = tok
+        def stream(self, requests):
+            return iter([GenerationEvent(index=0, result="ok")])
     monkeypatch.setattr(engine, "_VLMBatchAdapter", _Adapter)
     monkeypatch.setattr(engine, "generation_mode", lambda model: contextlib.nullcontext())
     processor = object()
@@ -1042,3 +1083,30 @@ def test_seed_is_reduced_onto_the_random_key_domain():
         with pytest.raises(TypeError):
             SamplingParams(seed = bad)
 
+
+def test_a_row_is_reported_as_it_goes_and_its_deltas_rebuild_its_text():
+    """The streaming contract: deltas as they settle, then the result once."""
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.per_row_prompt_kwargs = True
+    adapter.defaults = GenerationDefaults()
+    adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
+    adapter.cancel = None
+    generator = _vlm_stub(True, events=[
+        [(0, 1, None), (1, 1, None)],
+        [(0, 2, "length"), (1, 1, None)],
+        [(1, 2, "length")],
+    ])(object(), object())
+    events = list(adapter._drive(generator, [0, 1], [7, 9], {}))
+
+    assert {event.index for event in events} == {7, 9}
+    finished = [index for index, event in enumerate(events) if event.result is not None]
+    assert events[finished[0]].index == 7
+    nine = [index for index, event in enumerate(events) if event.index == 9]
+    assert any(index < finished[0] for index in nine)
+    assert any(index > finished[0] for index in nine)
+
+    for index in (7, 9):
+        row = [event for event in events if event.index == index]
+        assert "".join(event.delta for event in row) == row[-1].result.text

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import contextlib
+import importlib
 import importlib.util
 import inspect
 import pathlib
@@ -418,6 +419,16 @@ def test_fast_generate_binds_text_and_vision_models_and_maps_shared_controls(mon
 def _entry_ctx(order):
     order.append("wired")
     yield
+
+
+@contextlib.contextmanager
+def _wired_ctx(order):
+    """Records both ends, so holding it for a session is observable."""
+    order.append("held")
+    try:
+        yield
+    finally:
+        order.append("released")
 
 
 def _vlm_stub(per_row, *, events):
@@ -1319,4 +1330,223 @@ def test_a_cancelled_row_leaves_the_batch_and_its_neighbour_runs_on(monkeypatch)
         assert stream.cancel(1) is False and stream.cancel(7) is False
     finally:
         stream.close()
+
+
+class _OpenVLMGenerator:
+    """mlx-vlm's open-batch surface: insert answers with uids, next reports."""
+
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+        self.inserted = []
+        self.removed = []
+        self.closed = False
+        self.events = []
+        self._next_uid = 0
+        self._prompt_batch = None
+        self._generation_batch = types.SimpleNamespace(uids = [])
+        self._unprocessed_sequences = []
+
+    def insert(self, prompts, max_tokens, **kwargs):
+        self.inserted.append((list(prompts), list(max_tokens), kwargs))
+        uids = list(range(self._next_uid, self._next_uid + len(prompts)))
+        self._next_uid += len(prompts)
+        self._generation_batch.uids.extend(uids)
+        return uids
+
+    @property
+    def has_work(self):
+        return bool(self.events)
+
+    def next(self):
+        return [], self.events.pop(0) if self.events else []
+
+    def remove(self, uids):
+        self.removed.append(list(uids))
+
+    def close(self):
+        self.closed = True
+
+
+def _vlm_adapter(generator_type = None):
+    """The release surface a vision session actually uses, over fakes."""
+    def embeddings(input_ids, *a, **k):
+        width = len(input_ids.tolist()[0])
+        embeds = types.SimpleNamespace(shape = (1, width, 4), width = width)
+        return types.SimpleNamespace(to_dict = lambda: {"inputs_embeds": embeds})
+
+    def keeps_nothing(input_ids, *a, **k):
+        return embeddings(input_ids, *a, **k)
+
+    adapter = types.SimpleNamespace(
+        defaults = GenerationDefaults(max_tokens = 5),
+        processor = types.SimpleNamespace(tokenizer = _CharTokenizer()),
+        sample_utils = types.SimpleNamespace(),
+        make_sampler = lambda **knobs: (lambda logprobs: logprobs),
+        constructor_params = {"prefill_batch_size", "completion_batch_size",
+                              "sampler", "compute_logprobs", "prefill_step_size"},
+        per_row_prompt_kwargs = True,
+        batches_observable = True,
+        padded_prompt_kwargs = frozenset({"inputs_embeds", "position_ids"}),
+        cancel = lambda generator, uid: generator.remove([uid]),
+        model = types.SimpleNamespace(
+            config = types.SimpleNamespace(image_token_index = None),
+            language_model = object(),
+            get_input_embeddings = keeps_nothing,
+        ),
+        prepare_inputs = lambda processor, **k: {
+            "input_ids": types.SimpleNamespace(
+                tolist = lambda: [[1] * len(k["prompts"][0])]),
+        },
+        generator_type = generator_type or _OpenVLMGenerator,
+    )
+    adapter.wired = []
+    adapter._wired_limit = lambda: _wired_ctx(adapter.wired)
+    adapter._decode_image = lambda request: request
+    adapter._add_special_tokens = lambda: True
+    adapter._split_prompt_kwargs = lambda kwargs, n: [dict(kwargs)] * n
+    adapter._admission_stalled = lambda generator: False
+    adapter._stall_error = lambda: RuntimeError("stalled")
+    return adapter
+
+
+def _vlm_session(generator_type = None):
+    from unsloth_zoo.mlx.generate import _VLMBatchSession
+
+    return _VLMBatchSession(_vlm_adapter(generator_type))
+
+
+def test_a_model_keeping_state_one_call_down_is_still_seen_to_keep_it():
+    """Several models do the assignment in a helper rather than in
+    get_input_embeddings itself, where reading that method alone misses it."""
+    from unsloth_zoo.mlx.generate import _keeps_what_it_prepared
+
+    class Clean:
+        def _measure(self, ids):
+            return len(ids)
+
+        def get_input_embeddings(self, ids):
+            return self._measure(ids)
+
+    class Deep:
+        def _remember(self, ids):
+            self.language_model._position_ids = ids
+
+        def _prepare(self, ids):
+            self._remember(ids)
+
+        def get_input_embeddings(self, ids):
+            self._prepare(ids)
+
+    class Circular:
+        def _left(self, ids):
+            return self._right(ids)
+
+        def _right(self, ids):
+            return self._left(ids)
+
+        def get_input_embeddings(self, ids):
+            return self._left(ids)
+
+    class Submodule:
+        def __call__(self, pixels):
+            return pixels
+
+    class Tower:
+        """Every vision model runs its tower as ``self.<submodule>(...)``."""
+
+        def __init__(self):
+            self.vision_tower = Submodule()
+
+        def get_input_embeddings(self, ids, pixels):
+            return self.vision_tower(pixels)
+
+    class Opaque:
+        get_input_embeddings = Submodule()
+
+    assert _keeps_what_it_prepared(Clean()) is False
+    assert _keeps_what_it_prepared(Deep()) is True
+    assert _keeps_what_it_prepared(Circular()) is False
+    assert _keeps_what_it_prepared(Tower()) is False
+    assert _keeps_what_it_prepared(Opaque()) is True
+
+
+def test_a_shipped_vision_model_is_not_refused_for_running_its_tower():
+    """A tower is run as ``self.<submodule>(...)``, which has no body to read.
+    Reading that as retained state refuses every vision model mlx-vlm ships."""
+    pytest.importorskip("mlx_vlm")
+    from unsloth_zoo.mlx.generate import _keeps_what_it_prepared
+
+    checked = {}
+    for name in ("gemma3", "llava", "qwen2_vl", "smolvlm", "idefics3"):
+        try:
+            module = importlib.import_module(f"mlx_vlm.models.{name}.{name}")
+        except ImportError:
+            continue
+        model = module.Model
+        checked[name] = _keeps_what_it_prepared(model.__new__(model))
+
+    assert len(checked) >= 3, checked
+    assert not any(checked.values()), checked
+
+
+def test_a_release_settling_its_prefill_before_any_prompt_keeps_no_batch_open():
+    """A batch left open is built first and admits prompts after, so a release
+    deciding how to prefill at construction would chunk a prompt whose model
+    needs one pass. The releases that re-decide per prompt are the ones exposing
+    the policy helper."""
+    from unsloth_zoo.mlx.generate import _require_streamable_vlm
+
+    adapter = _vlm_adapter()
+    adapter.batch_module = types.SimpleNamespace()
+    with pytest.raises(ValueError, match = "settles how to prefill"):
+        _require_streamable_vlm(adapter)
+    adapter.batch_module = types.SimpleNamespace(
+        _chunked_prefill_enabled = lambda model, **kwargs: True)
+    assert _require_streamable_vlm(adapter) is None
+
+
+def test_a_vision_request_preparing_unlike_the_batch_s_others_cannot_join():
+    """A key only some rows carry leaves the merged batch with fewer of it than"""
+    session = _vlm_session()
+    plain = session.adapter.model.get_input_embeddings
+    assert session.add(GenerationRequest(prompt = "abc")) == 0
+    def with_positions(input_ids, *a, **k):
+        out = plain(input_ids, *a, **k).to_dict()
+        return types.SimpleNamespace(
+            to_dict = lambda: {**out, "position_ids": "P"})
+    session.adapter.model.get_input_embeddings = with_positions
+    with pytest.raises(ValueError, match = "unlike the batch's other requests"):
+        session.add(GenerationRequest(prompt = "de"))
+    assert (session.rows_in_flight, len(session.generator.inserted)) == (1, 1)
+    session.adapter.model.get_input_embeddings = plain
+    assert session.add(GenerationRequest(prompt = "fg")) == 1
+
+
+def _vlm_event(uid, token, finish_reason):
+    return types.SimpleNamespace(
+        uid = uid, token = token, finish_reason = finish_reason, token_logprob = -0.5,
+    )
+
+
+def test_a_vision_batch_reports_each_row_and_polls_quietly_through_a_prefill():
+    """A poll with nothing in it is ordinary here: a long prompt prefills over"""
+    session = _vlm_session()
+    session.add(GenerationRequest(prompt = "ab"))
+    session.add(GenerationRequest(prompt = "cd"))
+    session.generator.events = [
+        [],                                          # prefill still running
+        [_vlm_event(0, 1, None), _vlm_event(1, 4, None)],
+        [_vlm_event(0, 1, "stop")],
+        [_vlm_event(1, 1, None)],
+    ]
+    quiet = list(session.step())
+    assert (quiet, session.rows_in_flight) == ([], 2)
+    assert [(event.index, event.delta) for event in session.step()] == [
+        (0, "hello "), (1, "tailSTOPsuffix"),
+    ]
+    finished = list(session.step())
+    assert [event.index for event in finished] == [0]
+    assert finished[-1].result.finish_reason == "stop"
+    assert session.rows_in_flight == 1
+    assert [(event.index, event.delta) for event in session.step()] == [(1, "hello ")]
 

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -556,10 +556,11 @@ def test_vlm_adapter_isolates_detokenizers_and_reads_scalar_logprobs():
     generator = _vlm_stub(True, events=[
         [(0, 1, None), (1, 4, None)], [(0, 3, "stop"), (1, 3, "stop")]])(
         object(), object())
-    results = _results(adapter._drive(generator, [0, 1], [0, 1], {}))
+    results = _results(adapter._drive(generator, [0, 1], [0, 1], {}, prompt_token_count=37))
     # Distinct buffers: a shared one concatenates both sequences into the first.
     assert [(r.token_ids, r.text) for r in results] == [
         ([1], "hello "), ([4], "tailSTOPsuffix")] and results[0].logprobs == [-0.5]
+    assert [r.prompt_token_count for r in results] == [37, 37]
 
 
 def test_vlm_chunking_respects_release_capabilities():
@@ -592,8 +593,8 @@ def test_vlm_run_chunk_builds_the_generator_after_embeddings():
     adapter.prepare_inputs = lambda *a, **k: {"input_ids": ids, "extra": "D", "position_ids": "P"}  # noqa: E501
     adapter.make_sampler = lambda **k: object()
     adapter._add_special_tokens = lambda: True
-    adapter._drive = lambda *a: iter(
-        [GenerationEvent(index = row, result = "ok") for row in a[2]]
+    adapter._drive = lambda *a, **k: iter(
+        [GenerationEvent(index = row, result = k["prompt_token_count"]) for row in a[2]]
     )
     adapter._split_prompt_kwargs = lambda kw, n: (seen.update(kwargs=kw), [{}] * n)[1]
     # Recording on ENTRY proves embeddings run inside the wired-limit context.
@@ -606,7 +607,7 @@ def test_vlm_run_chunk_builds_the_generator_after_embeddings():
     adapter.generator_type = lambda *a, **k: (order.append("construct"),
         seen.update(ctor=k), _vlm_stub(True, events=[[(0, 1, "stop")]])(*a[:2]))[2]
     assert [event.result for event in
-            adapter._run_chunk([GenerationRequest(prompt = "p")] * 2, [0, 1])] == ["ok", "ok"]
+            adapter._run_chunk([GenerationRequest(prompt = "p")] * 2, [0, 1])] == [1, 1]
     assert order == ["wired", "embed", "policy", "construct"]
     assert seen["policy"]["prefill_kwargs"]["inputs_embeds"] == "E"
     assert seen["kwargs"]["extra"] == "D"
@@ -909,7 +910,11 @@ def _audio_events(*specs):
     """
     made = []
     for position, (token, finish) in enumerate(specs):
-        fields = {"token": token, "logprobs": {token: -0.5 - position}}
+        fields = {
+            "token": token,
+            "logprobs": {token: -0.5 - position},
+            "prompt_tokens": 40,
+        }
         if finish is not None:
             fields["finish_reason"] = finish
         made.append(types.SimpleNamespace(**fields))
@@ -987,9 +992,10 @@ def test_audio_terminal_event_flushes_text_held_back_during_streaming():
 def test_audio_fallback_forwards_the_request_to_the_stream():
     # A dropped audio payload or ignored control shows up in the stream call.
     adapter = _audio_adapter(_audio_events((1, None), (2, "length")))
-    _audio_row(adapter, GenerationRequest(
+    result, _ = _audio_row(adapter, GenerationRequest(
         prompt="p", audio="a.wav", max_tokens=9,
         sampling=SamplingParams(temperature=0.25, top_k=7)))
+    assert result.prompt_token_count == 40
     args, kwargs = adapter.stream_calls[0]
     assert args[2] == "p"  # the rendered prompt, after model and processor
     assert (kwargs["audio"], kwargs["max_tokens"]) == ("a.wav", 9)

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1509,6 +1509,11 @@ def test_stream_batch_checks_the_defaults_type_before_reading_stop_strings():
                      defaults = GenerationDefaults(stop_strings = ("X",)))
 
 
+def test_the_preflight_refuses_defaults_every_add_would():
+    from unsloth_zoo.mlx.generate import stream_unavailable_reason
+    assert all(m in stream_unavailable_reason(types.SimpleNamespace(**model), object(), defaults = GenerationDefaults(**kw)) for model, kw, m in (({}, {"kv_bits": 8}, "not forwarded"), ({"_is_vlm_model": True, "language_model": object()}, {"max_kv_size": 64}, "max_kv_size"), ({"_is_vlm_model": True, "language_model": object()}, {"prefill_batch_size": 4, "completion_batch_size": 2}, "must not exceed")))  # noqa: E501
+
+
 def test_a_cache_with_model_specific_state_refuses_a_quantized_batch_before_it_starts():
     from unsloth_zoo.mlx.generate import stream_unavailable_reason
 

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -424,7 +424,6 @@ def _entry_ctx(order):
 
 @contextlib.contextmanager
 def _wired_ctx(order):
-    """Records both ends, so holding it for a session is observable."""
     order.append("held")
     try:
         yield
@@ -715,6 +714,9 @@ def test_vlm_adapter_initializes_against_newer_module_layout(monkeypatch):
     assert adapter._split_prompt_kwargs({}, 3) == [{}, {}, {}]  # upstream splitter chosen
     assert adapter._chunked_prefill_kwargs(input_ids=None, prefill_kwargs={}) == {}
     assert policy_calls  # the policy helper was consulted, not bypassed
+    ar._chunked_prefill_enabled = lambda model, **kwargs: False
+    assert adapter._chunked_prefill_kwargs(
+        input_ids=None, prefill_kwargs={}) == {"prefill_step_size": None}
     # The probed capability must reach the adapter, not merely exist on the module.
     assert adapter.cancel is not None
 
@@ -883,7 +885,6 @@ def _sample_utils():
     )
 
 def _results(events):
-    """Row-ordered results from a streaming driver, as generate_batch collects them."""
     out = {}
     for event in events:
         if event.result is not None:
@@ -978,6 +979,21 @@ def test_audio_terminal_event_flushes_text_held_back_during_streaming():
     assert streamed == result.text
 
 
+def _shows(processor, ids):
+    import mlx.core as mx
+
+    return processor(mx.array(ids), None)
+
+
+def _pin(token_id, shown = None):
+    """A processor with a visible effect, recording the history it was shown."""
+    def _processor(tokens, logits):
+        if shown is not None:
+            shown.append(tokens.tolist())
+        return token_id
+    return _processor
+
+
 def test_audio_fallback_forwards_the_request_to_the_stream():
     # A dropped audio payload or ignored control shows up in the stream call.
     adapter = _audio_adapter(_audio_events((1, None), (2, "length")))
@@ -991,6 +1007,15 @@ def test_audio_fallback_forwards_the_request_to_the_stream():
     assert kwargs["sampler"] is adapter.sampler
     # Per-request sampling, not the batch-wide default.
     assert (adapter.sampler_kwargs["temp"], adapter.sampler_kwargs["top_k"]) == (0.25, 7)
+    assert kwargs["logits_processors"] == []
+    # Decoding alone is not a reason to drop what the request asked for.
+    shown = []
+    _result, _ = _audio_row(adapter, GenerationRequest(
+        prompt="p", audio="a.wav", logits_processors=[_pin(7, shown)]))
+    audio = adapter.stream_calls[1][1]["logits_processors"]
+    assert [_shows(f, [4, 5, 6]) for f in audio] == [7]
+    # An audio row starts its history where every other row does.
+    assert shown == [[6]]
 
 
 def test_audio_fallback_honours_stop_strings():
@@ -1069,48 +1094,7 @@ def test_vision_generation_resolves_the_saved_processor(monkeypatch):
     assert seen["tok"] is processor
 
 
-def test_seed_is_reduced_onto_the_random_key_domain():
-    """Any int is accepted; mx.random.key rejects negatives and >= 2**64."""
-    assert SamplingParams().seed is None
-    assert SamplingParams(seed = 0).seed == 0
-    assert SamplingParams(seed = -1).seed == 2**64 - 1
-    assert SamplingParams(seed = 2**64 + 5).seed == 5
-    for bad in (True, 1.5, "7"):
-        with pytest.raises(TypeError):
-            SamplingParams(seed = bad)
-
-
-def _rows(width):
-    return types.SimpleNamespace(shape = (width,))
-
-
-def _row_sampler(params):
-    return _PerRowSampler(
-        params,
-        sample_utils_module = types.SimpleNamespace(),
-        make_sampler = lambda **knobs: (lambda logprobs: logprobs),
-    )
-
-
-def test_a_per_row_sampler_refuses_a_batch_it_cannot_match_to_rows():
-    """Silence here would cross two requests' draws."""
-    sampler = _row_sampler(
-        [SamplingParams(temperature = 0.9, seed = 11),
-         SamplingParams(temperature = 0.9, seed = 22)],
-    )
-    sampler.bind_uids([4, 9])
-    assert sampler.row_uids == [4, 9]
-    with pytest.raises(RuntimeError, match = "cannot be matched to rows"):
-        sampler(_rows(3))
-    with pytest.raises(RuntimeError, match = "cannot be matched to rows"):
-        sampler(_rows(1))
-
-    with pytest.raises(RuntimeError, match = "cannot be matched to rows"):
-        sampler.bind_uids([1, 2, 3])
-
-
 def _knob_sampler(**knobs):
-    """A sampler that reports every knob it was built for."""
     import mlx.core as mx
     token = (int(round(knobs["temp"] * 10)) + 10 * int(round(knobs["top_p"] * 10))
              + 100 * knobs["top_k"] + 1000 * int(round(knobs["min_p"] * 10)))
@@ -1118,24 +1102,19 @@ def _knob_sampler(**knobs):
 
 
 def _batched_generator(prompt_uids = None, generation_uids = None):
-    return types.SimpleNamespace(
-        _prompt_batch = (
-            None if prompt_uids is None
-            else types.SimpleNamespace(uids = list(prompt_uids))
-        ),
-        _generation_batch = (
-            None if generation_uids is None
-            else types.SimpleNamespace(uids = list(generation_uids))
-        ),
-    )
+    def batch(uids):
+        return None if uids is None else types.SimpleNamespace(uids = list(uids))
+
+    return types.SimpleNamespace(_prompt_batch = batch(prompt_uids),
+                                 _generation_batch = batch(generation_uids))
 
 
 def _warm(temps):
     return [SamplingParams(temperature = temp) for temp in temps]
 
 
-def test_a_per_row_sampler_places_rows_by_the_batch_that_is_drawing():
-    """The batch's own row order decides, not the order this adapter inferred."""
+def test_a_per_row_sampler_places_each_row_by_the_batch_and_builds_its_own_knobs():
+    """The batch's own row order decides placement, and every knob reaches its row."""
     import mlx.core as mx
     sampler = _PerRowSampler(
         _warm([0.1, 0.2, 0.3]),
@@ -1156,28 +1135,16 @@ def test_a_per_row_sampler_places_rows_by_the_batch_that_is_drawing():
     assert sampler.sample_target(mx.zeros((2, 4)), row_ids = [0] * 2,
                                  positions = [7, 8]).tolist() == [3, 2]
 
-
-def test_a_per_row_sampler_builds_each_row_every_knob_it_asked_for():
-    """Temperature is the obvious one, and the filters are the easy ones to drop."""
-    import mlx.core as mx
-    rows = [
-        SamplingParams(temperature = 0.5),
-        SamplingParams(temperature = 0.5, top_p = 0.8),
-        SamplingParams(temperature = 0.5, top_k = 3),
-        SamplingParams(temperature = 0.5, min_p = 0.2),
-    ]
-    sampler = _PerRowSampler(
-        rows,
-        sample_utils_module = types.SimpleNamespace(),
-        make_sampler = _knob_sampler,
+    knobs = _PerRowSampler(
+        [SamplingParams(temperature = 0.5), SamplingParams(temperature = 0.5, top_p = 0.8),
+         SamplingParams(temperature = 0.5, top_k = 3),
+         SamplingParams(temperature = 0.5, min_p = 0.2)],
+        sample_utils_module = types.SimpleNamespace(), make_sampler = _knob_sampler,
     )
-    sampler.bind_uids([10, 20, 30, 40])
-    sampler.bind_generator(_batched_generator(generation_uids = [10, 20, 30, 40]))
-    drawn = sampler.sample_target(
-        mx.zeros((4, 4)), row_ids = [0] * 4, positions = [1, 2, 3, 4],
-    ).tolist()
-    assert len(set(drawn)) == 4
-    assert drawn == [5, 85, 305, 2005]
+    knobs.bind_uids([10, 20, 30, 40])
+    knobs.bind_generator(_batched_generator(generation_uids = [10, 20, 30, 40]))
+    assert knobs.sample_target(mx.zeros((4, 4)), row_ids = [0] * 4,
+                               positions = [1, 2, 3, 4]).tolist() == [5, 85, 305, 2005]
 
 
 _UNREADABLE: dict = {}
@@ -1187,49 +1154,50 @@ exec(compile(
     "<generated>", "exec"), _UNREADABLE)
 
 
-def test_a_row_is_reported_as_it_goes_and_its_deltas_rebuild_its_text():
-    """The streaming contract: deltas as they settle, then the result once."""
+def test_a_row_is_reported_as_it_goes_and_says_what_it_consumed_and_produced():
+    """Deltas as they settle then the result once, with running counts on every event."""
     from unsloth_zoo.mlx.generate import _VLMBatchAdapter
 
     adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
-    adapter.per_row_prompt_kwargs = True
+    adapter.per_row_prompt_kwargs, adapter.cancel = True, None
     adapter.defaults = GenerationDefaults()
     adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
-    adapter.cancel = None
     generator = _vlm_stub(True, events=[
         [(0, 1, None), (1, 1, None)],
         [(0, 2, "length"), (1, 1, None)],
         [(1, 2, "length")],
     ])(object(), object())
-    events = list(adapter._drive(generator, [0, 1], [7, 9], {}))
+    events = list(adapter._drive(generator, [0, 1], [7, 9], {}, prompt_token_count = 5))
+    finished = [index for index, event in enumerate(events) if event.result is not None]
+    nine = [index for index, event in enumerate(events) if event.index == 9]
 
     assert {event.index for event in events} == {7, 9}
-    finished = [index for index, event in enumerate(events) if event.result is not None]
     assert events[finished[0]].index == 7
-    nine = [index for index, event in enumerate(events) if event.index == 9]
     assert any(index < finished[0] for index in nine)
     assert any(index > finished[0] for index in nine)
-
+    assert [event.prompt_tokens for event in events] == [5] * len(events)
+    # The exact running count: a fixed one would answer every stop the same way.
+    assert [event.generated_tokens for event in events if event.index == 7] == [1, 2]
+    assert [event.generated_tokens for event in events if event.index == 9] == [1, 2, 3]
     for index in (7, 9):
         row = [event for event in events if event.index == index]
         assert "".join(event.delta for event in row) == row[-1].result.text
+        assert row[-1].generated_tokens == len(row[-1].result.token_ids)
+
 
 class _OpenBatchGenerator:
-    """A BatchGenerator that reports one token per row per step, for as long as"""
+    """A BatchGenerator reporting one token per row per step, while it has tokens left."""
 
     def __init__(self, *_args, **_kwargs):
         self.rows: dict[int, int] = {}
         self.removed: list[int] = []
-        self.closed = False
-        self.steps = 0
-        self._next_uid = 100
+        self.closed, self.steps, self._next_uid = False, 0, 100
 
     def insert(self, prompts, max_tokens=None, samplers=None, logits_processors=None):
         uids = []
         for index in range(len(prompts)):
             self._next_uid += 1
-            budget = (max_tokens or [1])[index]
-            self.rows[self._next_uid] = int(budget)
+            self.rows[self._next_uid] = int((max_tokens or [1])[index])
             uids.append(self._next_uid)
         return uids
 
@@ -1255,16 +1223,16 @@ class _OpenBatchGenerator:
         self.closed = True
 
 
-def _stub_generation_mode(monkeypatch, generator_type=_OpenBatchGenerator):
-    """A model that can enter generation mode, decoding through a fake generator."""
+def _open_stream(monkeypatch, generator_type=_OpenBatchGenerator, **defaults):
+    """A BatchStream over a fake generator, with the generation lock stubbed out."""
     import unsloth_zoo.mlx.generate as module
+    from unsloth_zoo.mlx.generate import BatchStream
 
     def adapter(model, tok, defaults_):
         built = object.__new__(_TextBatchAdapter)
         built.model, built.tokenizer, built.defaults = model, tok, defaults_
-        built.batch_generator_type = generator_type
+        built.batch_generator_type, built.sample_utils = generator_type, None
         built.make_sampler = lambda **_kwargs: None
-        built.sample_utils = None
         return built
 
     monkeypatch.setattr(module, "_TextBatchAdapter", adapter)
@@ -1273,22 +1241,13 @@ def _stub_generation_mode(monkeypatch, generator_type=_OpenBatchGenerator):
     monkeypatch.setattr(module, "_restore_metal_limits", lambda _snapshot: None)
     model = types.SimpleNamespace(training=False, eval=lambda: None)
     model.named_modules = lambda: [("", model)]
-    return model
-
-
-def _open_stream(monkeypatch, generator_type=_OpenBatchGenerator, **defaults):
-    """A BatchStream over a fake generator, with the generation lock stubbed out."""
-    from unsloth_zoo.mlx.generate import BatchStream
-
     tokenizer = _CharTokenizer()
     tokenizer.eos_token_ids = ()
-    model = _stub_generation_mode(monkeypatch, generator_type=generator_type)
     return BatchStream(model, tokenizer, defaults=GenerationDefaults(**defaults))
 
 
 def test_a_batch_left_open_patches_the_cache_before_it_decodes(monkeypatch):
-    """mlx-lm's ArraysCache.advance strands a Metal buffer per token until it is
-    replaced, and a batch left open decodes for as long as the session lasts."""
+    """mlx-lm's ArraysCache.advance strands a Metal buffer per token until patched."""
     from unsloth_zoo.mlx import generate as engine
 
     installed = []
@@ -1301,34 +1260,20 @@ def test_a_batch_left_open_patches_the_cache_before_it_decodes(monkeypatch):
         stream.close()
 
 
-def test_a_row_added_mid_batch_decodes_with_the_rows_already_running(monkeypatch):
-    """A request that arrived later joins the batch already running: serving"""
-    stream = _open_stream(monkeypatch, max_tokens=6)
-    try:
-        first = stream.add(GenerationRequest(prompt_token_ids=[9], max_tokens=6))
-        early = [event.index for _ in range(2) for event in stream.step()]
-        second = stream.add(GenerationRequest(prompt_token_ids=[9, 9], max_tokens=3))
-        together = [event.index for _ in range(2) for event in stream.step()]
-    finally:
-        stream.close()
-
-    assert (first, second) == (0, 1)
-    assert early == [0, 0]
-    assert together == [0, 1, 0, 1]
-
-
-def test_a_cancelled_row_leaves_the_batch_and_its_neighbour_runs_on(monkeypatch):
+def test_rows_join_and_leave_a_batch_while_the_rest_of_it_runs_on(monkeypatch):
+    """A later request joins the batch already running, and a cancelled row leaves it."""
     stream = _open_stream(monkeypatch, max_tokens=8)
     try:
         stream.add(GenerationRequest(prompt_token_ids=[9], max_tokens=8))
-        stream.add(GenerationRequest(prompt_token_ids=[9, 9, 9], max_tokens=8))
-        assert [event.index for event in stream.step()] == [0, 1]
-        generator = stream._session.generator
+        assert [event.index for _ in range(2) for event in stream.step()] == [0, 0]
+        assert stream.add(GenerationRequest(prompt_token_ids=[9, 9, 9], max_tokens=8)) == 1
+        assert [event.index for _ in range(2) for event in stream.step()] == [0, 1, 0, 1]
+
         managed = stream.withdraw(1)
         assert managed is not None and managed.finish_reason == "stop"
         assert managed.prompt_token_count == 3
         assert managed.text and len(managed.token_ids) == len(managed.logprobs) > 0
-        assert generator.removed == [102]
+        assert stream._session.generator.removed == [102]
         assert [event.index for event in stream.step()] == [0]
         assert stream.rows_in_flight == 1
         assert stream.withdraw(1) is None and stream.withdraw(7) is None
@@ -1342,10 +1287,8 @@ class _OpenVLMGenerator:
 
     def __init__(self, *args, **kwargs):
         self.kwargs = kwargs
-        self.inserted = []
-        self.removed = []
+        self.inserted, self.removed, self.events = [], [], []
         self.closed = False
-        self.events = []
         self._next_uid = 0
         self._prompt_batch = None
         self._generation_batch = types.SimpleNamespace(uids = [])
@@ -1374,13 +1317,12 @@ class _OpenVLMGenerator:
 
 def _vlm_adapter(generator_type = None):
     """The release surface a vision session actually uses, over fakes."""
-    def embeddings(input_ids, *a, **k):
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+
+    def keeps_nothing(input_ids, *a, **k):
         width = len(input_ids.tolist()[0])
         embeds = types.SimpleNamespace(shape = (1, width, 4), width = width)
         return types.SimpleNamespace(to_dict = lambda: {"inputs_embeds": embeds})
-
-    def keeps_nothing(input_ids, *a, **k):
-        return embeddings(input_ids, *a, **k)
 
     adapter = types.SimpleNamespace(
         defaults = GenerationDefaults(max_tokens = 5),
@@ -1404,7 +1346,9 @@ def _vlm_adapter(generator_type = None):
         },
         generator_type = generator_type or _OpenVLMGenerator,
     )
-    adapter.wired = []
+    adapter.row_logits_processors, adapter.wired = True, []
+    adapter._row_logits_processors = types.MethodType(
+        _VLMBatchAdapter._row_logits_processors, adapter)
     adapter._wired_limit = lambda: _wired_ctx(adapter.wired)
     adapter._decode_image = lambda request: request
     adapter._add_special_tokens = lambda: True
@@ -1420,98 +1364,47 @@ def _vlm_session(generator_type = None):
     return _VLMBatchSession(_vlm_adapter(generator_type))
 
 
-def test_a_model_keeping_state_one_call_down_is_still_seen_to_keep_it():
-    """Several models do the assignment in a helper rather than in
-    get_input_embeddings itself, where reading that method alone misses it."""
+def test_a_model_keeping_state_is_seen_to_keep_it_however_it_says_so():
+    """A model may do the assignment in a helper, or spell it as something other than a name."""
     from unsloth_zoo.mlx.generate import _keeps_what_it_prepared
 
-    class Clean:
-        def _measure(self, ids):
-            return len(ids)
+    class Submodule:
+        def __call__(self, pixels): return pixels
 
-        def get_input_embeddings(self, ids):
-            return self._measure(ids)
+    class Clean:
+        def _measure(self, ids): return len(ids)
+        def get_input_embeddings(self, ids): return self._measure(ids)
 
     class Deep:
-        def _remember(self, ids):
-            self.language_model._position_ids = ids
-
-        def _prepare(self, ids):
-            self._remember(ids)
-
-        def get_input_embeddings(self, ids):
-            self._prepare(ids)
+        def _remember(self, ids): self.language_model._position_ids = ids
+        def _prepare(self, ids): self._remember(ids)
+        def get_input_embeddings(self, ids): self._prepare(ids)
 
     class Circular:
-        def _left(self, ids):
-            return self._right(ids)
-
-        def _right(self, ids):
-            return self._left(ids)
-
-        def get_input_embeddings(self, ids):
-            return self._left(ids)
-
-    class Submodule:
-        def __call__(self, pixels):
-            return pixels
+        def _left(self, ids): return self._right(ids)
+        def _right(self, ids): return self._left(ids)
+        def get_input_embeddings(self, ids): return self._left(ids)
 
     class Tower:
-        """Every vision model runs its tower as ``self.<submodule>(...)``."""
-
-        def __init__(self):
-            self.vision_tower = Submodule()
-
-        def get_input_embeddings(self, ids, pixels):
-            return self.vision_tower(pixels)
+        def __init__(self): self.vision_tower = Submodule()
+        def get_input_embeddings(self, ids, pixels): return self.vision_tower(pixels)
 
     class Opaque:
         get_input_embeddings = Submodule()
 
-    assert _keeps_what_it_prepared(Clean()) is False
-    assert _keeps_what_it_prepared(Deep()) is True
-    assert _keeps_what_it_prepared(Circular()) is False
-    assert _keeps_what_it_prepared(Tower()) is False
-    assert _keeps_what_it_prepared(Opaque()) is True
+    class Subscript:
+        def get_input_embeddings(self, ids): self.state["ids"] = ids
 
+    class Unpacked:
+        def get_input_embeddings(self, ids): self._ids, self._mask = ids, None
 
-def test_a_shipped_vision_model_is_not_refused_for_running_its_tower():
-    """A tower is run as ``self.<submodule>(...)``, which has no body to read.
-    Reading that as retained state refuses every vision model mlx-vlm ships."""
-    pytest.importorskip("mlx_vlm")
-    from unsloth_zoo.mlx.generate import _keeps_what_it_prepared
-
-    checked = {}
-    for name in ("gemma3", "llava", "qwen2_vl", "smolvlm", "idefics3"):
-        try:
-            module = importlib.import_module(f"mlx_vlm.models.{name}.{name}")
-        except ImportError:
-            continue
-        model = module.Model
-        checked[name] = _keeps_what_it_prepared(model.__new__(model))
-
-    assert len(checked) >= 3, checked
-    assert not any(checked.values()), checked
-
-
-def test_a_release_settling_its_prefill_before_any_prompt_keeps_no_batch_open():
-    """A batch left open is built first and admits prompts after, so a release
-    deciding how to prefill at construction would chunk a prompt whose model
-    needs one pass. The releases that re-decide per prompt are the ones exposing
-    the policy helper."""
-    from unsloth_zoo.mlx.generate import _require_streamable_vlm
-
-    adapter = _vlm_adapter()
-    adapter.batch_module = types.SimpleNamespace()
-    with pytest.raises(ValueError, match = "settles how to prefill"):
-        _require_streamable_vlm(adapter)
-    adapter.batch_module = types.SimpleNamespace(
-        _chunked_prefill_enabled = lambda model, **kwargs: True)
-    assert _require_streamable_vlm(adapter) is None
+    keeping = [Deep, Opaque, Subscript, Unpacked]
+    for model in (Clean, Deep, Circular, Tower, Opaque, Subscript, Unpacked):
+        assert _keeps_what_it_prepared(model()) is (model in keeping), model.__name__
 
 
 def test_a_vision_request_preparing_unlike_the_batch_s_others_cannot_join():
-    """A key only some rows carry leaves the merged batch with fewer of it than"""
+    """A key only some rows carry cannot be merged into a batch-wide keyword."""
     session = _vlm_session()
     plain = session.adapter.model.get_input_embeddings
     assert session.add(GenerationRequest(prompt = "abc")) == 0
@@ -1527,31 +1420,52 @@ def test_a_vision_request_preparing_unlike_the_batch_s_others_cannot_join():
     assert session.add(GenerationRequest(prompt = "fg")) == 1
 
 
-def _vlm_event(uid, token, finish_reason):
-    return types.SimpleNamespace(
-        uid = uid, token = token, finish_reason = finish_reason, token_logprob = -0.5,
+def test_a_processor_is_shown_its_own_row_s_history_from_its_own_offset():
+    """Rows rarely share a prompt length, so each latches its own offset."""
+    from unsloth_zoo.mlx.generate import _row_processors
+
+    adapter = _vlm_adapter()
+    shown = [[], []]
+    rows = adapter._row_logits_processors([
+        GenerationRequest(prompt = "p", logits_processors = [_pin(7, seen)])
+        for seen in shown
+    ])
+    for processor, history in zip(rows, ([1, 2, 3], [1, 2, 3, 4, 5, 6, 7])):
+        _shows(processor[0], history)
+    assert shown == [[[3]], [[7]]]
+
+    alone = []
+    processor, = _row_processors(
+        GenerationRequest(prompt = "p", logits_processors = [_pin(7, alone)])
     )
+    # A prompt of five, then one sampled token, then a second.
+    for history in ([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6, 7]):
+        _shows(processor, history)
+    assert alone == [[5], [5, 6], [5, 6, 7]]
 
 
-def test_a_vision_batch_reports_each_row_and_polls_quietly_through_a_prefill():
-    """A poll with nothing in it is ordinary here: a long prompt prefills over"""
-    session = _vlm_session()
-    session.add(GenerationRequest(prompt = "ab"))
-    session.add(GenerationRequest(prompt = "cd"))
-    session.generator.events = [
-        [],                                          # prefill still running
-        [_vlm_event(0, 1, None), _vlm_event(1, 4, None)],
-        [_vlm_event(0, 1, "stop")],
-        [_vlm_event(1, 1, None)],
-    ]
-    quiet = list(session.step())
-    assert (quiet, session.rows_in_flight) == ([], 2)
-    assert [(event.index, event.delta) for event in session.step()] == [
-        (0, "hello "), (1, "tailSTOPsuffix"),
-    ]
-    finished = list(session.step())
-    assert [event.index for event in finished] == [0]
-    assert finished[-1].result.finish_reason == "stop"
-    assert session.rows_in_flight == 1
-    assert [(event.index, event.delta) for event in session.step()] == [(1, "hello ")]
+@pytest.mark.parametrize("carrying", (0, 1))
+def test_a_text_row_carries_its_own_logits_processors_into_the_batch(monkeypatch, carrying):
+    """The text path admits rows one at a time too, and each keeps its own list."""
+    seen = []
+
+    class _Recording(_OpenBatchGenerator):
+        def insert(self, prompts, max_tokens = None, samplers = None,
+                   logits_processors = None):
+            seen.append(logits_processors)
+            return super().insert(prompts, max_tokens, samplers, logits_processors)
+
+    lists = [None, None]
+    lists[carrying] = [_pin(7)]
+    stream = _open_stream(monkeypatch, generator_type = _Recording, max_tokens = 4)
+    try:
+        for processors in lists:
+            stream.add(GenerationRequest(
+                prompt_token_ids = [9], max_tokens = 4, logits_processors = processors,
+            ))
+    finally:
+        stream.close()
+    assert seen[1 - carrying] == [[]]
+    assert [_shows(processor, [4, 5, 6]) for processor in seen[carrying][0]] == [7]
+
 

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -495,14 +495,16 @@ def test_vlm_requests_reject_token_id_prompts_and_unsupported_controls():
     cases = ((GenerationRequest(prompt_token_ids=[1]), GenerationDefaults(), "rendered prompt string"),
         (GenerationRequest(prompt=""), GenerationDefaults(), "must not be empty"),
         (GenerationRequest(prompt="a"), GenerationDefaults(max_kv_size=64), "max_kv_size is not supported"),
-        # One that stopped being refused would reach generation and be dropped.
-        *((GenerationRequest(prompt="a"), GenerationDefaults(**{name: value}),
-           "not forwarded by this engine")
-          for name, value in (("kv_bits", 4), ("kv_group_size", 64),
-                              ("kv_quant_scheme", "affine"), ("quantized_kv_start", 100))))
+        # One mlx-vlm would drop rather than apply is refused: an inert start or bogus scheme,
+        # a group size on a turboquant cache, an explicit scheme that fractional bits override.
+        *((GenerationRequest(prompt="a"), GenerationDefaults(**kw), f"{name} would be dropped")
+          for kw, name in (({"kv_bits": 4, "quantized_kv_start": 100}, "quantized_kv_start"), ({"kv_bits": 4, "kv_quant_scheme": "bogus"}, "kv_quant_scheme"), ({"kv_bits": 4, "kv_quant_scheme": "turboquant", "kv_group_size": 32}, "kv_group_size"), ({"kv_bits": 4.5, "kv_quant_scheme": "uniform"}, "kv_quant_scheme"))))  # noqa: E501
     for request, defaults, message in cases:
         with pytest.raises(ValueError, match=message):
             _validate_vlm_requests([request], defaults)
+    # Forwarded, not refused: mlx-vlm's cache builder applies these.
+    accepted = ({"kv_group_size": 32}, {"kv_quant_scheme": "uniform"}, {"kv_quant_scheme": "turboquant"}, {"kv_bits": 4.5}, {"kv_bits": 4.5, "quantized_kv_start": 9})  # noqa: E501
+    assert all(_validate_vlm_requests([GenerationRequest(prompt="a")], GenerationDefaults(**{"kv_bits": 4, **kw})) for kw in accepted)  # noqa: E501
     # Path images normalize to str once: mlx-vlm's loader opens str only, and
     # grouping and preprocessing must see the same value.
     assert _validate_vlm_requests([GenerationRequest(prompt="a", image=pathlib.Path("/tmp/i.png"))], GenerationDefaults())[0].image == "/tmp/i.png"  # noqa: E501
@@ -599,9 +601,10 @@ def test_vlm_run_chunk_builds_the_generator_after_embeddings():
     ids, embeds = (types.SimpleNamespace(tolist=lambda: [[1], [2]]),
                    types.SimpleNamespace(to_dict=lambda: {"inputs_embeds": "E", "position_ids": None}))
     adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
-    adapter.defaults, adapter.per_row_prompt_kwargs = GenerationDefaults(), True
+    adapter.defaults = GenerationDefaults(kv_bits=4, kv_quant_scheme="turboquant")
+    adapter.per_row_prompt_kwargs = True
     adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
-    adapter.constructor_params = {"prefill_batch_size", "completion_batch_size", "sampler", "stop_tokens"}  # noqa: E501
+    adapter.constructor_params = {"prefill_batch_size", "completion_batch_size", "sampler", "stop_tokens", "kv_bits", "kv_quant_scheme", "quantized_kv_start"}  # noqa: E501
     adapter.prepare_inputs = lambda *a, **k: {"input_ids": ids, "extra": "D", "position_ids": "P"}  # noqa: E501
     adapter.make_sampler = lambda **k: object()
     adapter._add_special_tokens = lambda: True
@@ -625,6 +628,8 @@ def test_vlm_run_chunk_builds_the_generator_after_embeddings():
     assert seen["kwargs"]["extra"] == "D"
     # A None embedding field must not overwrite a valid preprocessing value.
     assert seen["kwargs"]["position_ids"] == "P"
+    # The KV-quant controls reach the constructor that builds the cache, turboquant from token one.
+    assert [seen["ctor"][n] for n in ("kv_bits", "kv_quant_scheme", "quantized_kv_start")] == [4, "turboquant", 0]
     # Per-row keeps configured sizes; EOS stays with the processor.
     assert (seen["ctor"]["prefill_batch_size"], seen["ctor"]["completion_batch_size"]) == (8, 32)
     assert "stop_tokens" not in seen["ctor"]
@@ -1018,6 +1023,24 @@ def test_audio_fallback_forwards_the_request_to_the_stream():
     assert shown == [[6]]
 
 
+def test_an_audio_row_decodes_with_the_quantization_the_batch_was_given():
+    from unsloth_zoo.mlx.generate import _KV_QUANT_CONTROLS, _validate_vlm_requests
+    # Each one validation accepts, as given: a sequential turboquant row keeps mlx-vlm's own start.
+    for kw in ({"kv_bits": 4, "kv_group_size": 32, "kv_quant_scheme": "uniform"}, {"kv_bits": 4, "kv_quant_scheme": "turboquant", "quantized_kv_start": 9}, {"kv_bits": 4.5}):  # noqa: E501
+        adapter = _audio_adapter(_audio_events((1, None), (2, "length")))
+        adapter.defaults = GenerationDefaults(**kw)
+        assert _validate_vlm_requests([GenerationRequest(prompt = "p", audio = "a.wav")], adapter.defaults)
+        _audio_row(adapter, GenerationRequest(prompt = "p", audio = "a.wav"))
+        assert {k: v for k, v in adapter.stream_calls[0][1].items() if k in _KV_QUANT_CONTROLS} == kw
+
+
+def test_a_turboquant_batch_without_a_start_quantizes_from_the_first_token():
+    from unsloth_zoo.mlx.generate import _batch_kv_quant_options
+    for kw in ({"kv_bits": 4.5}, {"kv_bits": 4, "kv_quant_scheme": "turboquant"}):
+        assert _batch_kv_quant_options(GenerationDefaults(**kw)) == {**kw, "quantized_kv_start": 0}
+    assert _batch_kv_quant_options(GenerationDefaults(kv_bits = 4)) == {"kv_bits": 4}  # uniform: start stays mlx-vlm's
+
+
 def test_audio_fallback_honours_stop_strings():
     # Audio reaches the same scanner: "<ST" + "OP>" completes the stop string.
     result, _streamed = _audio_row(
@@ -1358,10 +1381,20 @@ def _vlm_adapter(generator_type = None):
     return adapter
 
 
-def _vlm_session(generator_type = None):
+def _vlm_session(generator_type = None, **defaults):
     from unsloth_zoo.mlx.generate import _VLMBatchSession
 
-    return _VLMBatchSession(_vlm_adapter(generator_type))
+    adapter = _vlm_adapter(generator_type)
+    adapter.defaults = GenerationDefaults(max_tokens = 5, **defaults)
+    adapter.constructor_params = adapter.constructor_params | set(defaults)
+    return _VLMBatchSession(adapter)
+
+
+def test_an_open_batch_builds_its_cache_with_the_quantization_it_was_given():
+    with contextlib.closing(_vlm_session(kv_bits = 8, kv_group_size = 32)) as session:
+        assert [session.generator.kwargs[n] for n in ("kv_bits", "kv_group_size")] == [8, 32]
+    with contextlib.closing(_vlm_session(kv_bits = 4, kv_quant_scheme = "turboquant", quantized_kv_start = None)) as session:  # noqa: E501
+        assert session.generator.kwargs["quantized_kv_start"] == 0  # from the first token, not mlx-vlm's 5000
 
 
 def test_a_model_keeping_state_is_seen_to_keep_it_however_it_says_so():
@@ -1474,3 +1507,28 @@ def test_stream_batch_checks_the_defaults_type_before_reading_stop_strings():
     with pytest.raises(ValueError, match="cannot apply stop_strings"):
         stream_batch(object(), object(), [],
                      defaults = GenerationDefaults(stop_strings = ("X",)))
+
+
+def test_a_cache_with_model_specific_state_refuses_a_quantized_batch_before_it_starts():
+    from unsloth_zoo.mlx.generate import stream_unavailable_reason
+
+    _SideCache = type("_SideCache", (), {"to_batch": lambda self, left_padding: self})
+    caches = [object(), _SideCache(), object()]
+    model = types.SimpleNamespace(_is_vlm_model = True, language_model = types.SimpleNamespace(make_cache = lambda: list(caches)))  # noqa: E501
+    gap = lambda **kw: stream_unavailable_reason(model, object(), defaults = GenerationDefaults(kv_bits = 8, **kw)) or ""  # noqa: E501,E731
+    assert "cannot quantize across a batch" in gap()
+    assert "kv_quant_scheme would be dropped" in gap(kv_quant_scheme = "bogus")  # refused before the cache is looked at
+    caches[1], caches[2] = caches[2], caches[1]  # only in the last layer, which stays unquantized
+    assert "cannot quantize" not in gap()
+
+
+def test_a_prefill_batch_charges_each_row_its_own_prompt_and_not_the_padded_width():
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter, _unpadded_lengths
+
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.per_row_prompt_kwargs, adapter.defaults = True, GenerationDefaults()
+    adapter.processor = types.SimpleNamespace(tokenizer = _CharTokenizer())
+    generator = _vlm_stub(True, events = [[(0, 3, "stop"), (1, 3, "stop")]])(object(), object())
+    mask = types.SimpleNamespace(sum = lambda axis: {-1: types.SimpleNamespace(tolist = lambda: [1.0, 11.0])}[axis])  # noqa: E501
+    results = _results(adapter._drive(generator, [0, 1], [0, 1], {}, prompt_token_counts = _unpadded_lengths(mask)))  # noqa: E501
+    assert [r.prompt_token_count for r in results] == [1, 11]

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -17,7 +17,7 @@ if importlib.util.find_spec("mlx") is None:
 
 from unsloth_zoo.mlx.generate import (  # noqa: E402
     GenerationDefaults, GenerationEvent, GenerationRequest, SamplingParams,
-    _GENERATION_MODE_LOCK, _PendingResult, _PerRowSeededSampler,
+    _GENERATION_MODE_LOCK, _PendingResult, _PerRowSampler,
     _StopStringScanner, _TextBatchAdapter,
     _eos_stop_tokens, _new_detokenizer, _probe_sampler_api, _probe_text_api,
     _generation_cache_hygiene, _restore_training_flags,
@@ -568,6 +568,7 @@ def test_vlm_chunking_respects_release_capabilities():
     from unsloth_zoo.mlx.generate import _VLMBatchAdapter
     adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
     adapter.defaults = GenerationDefaults(prefill_batch_size=2, completion_batch_size=4)
+    adapter.batches_observable = True
     chunks = []
     adapter._group_key = lambda request: "same"
     adapter._run_chunk = lambda requests, indices: (
@@ -656,6 +657,7 @@ def test_vlm_images_are_decoded_once_and_flow_to_preprocessing():
     adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
     adapter.defaults, adapter.per_row_prompt_kwargs = GenerationDefaults(), True
     adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
+    adapter.batches_observable = True
     adapter.process_image = lambda src, shape, proc: loads.append(src) or decoded
     adapter._run_chunk = lambda requests, indices: (
         seen.update(image=requests[indices[0]].image),
@@ -755,31 +757,6 @@ def test_vlm_drive_raises_on_true_stall_and_survives_long_prefill():
             return ([], [])
     with pytest.raises(RuntimeError, match="admitted no prompt"):
         _results(adapter._drive(Stalled(object(), object()), [0], [0], {}))
-
-
-def test_vlm_requests_group_by_sampling_params():
-    # Differing sampling must not share one constructor-level sampler.
-    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
-    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
-    adapter.defaults, adapter.per_row_prompt_kwargs = GenerationDefaults(), True
-    adapter.process_image = None
-    chunks = []
-    adapter._run_chunk = lambda requests, indices: (
-        chunks.append(list(indices))
-        or [GenerationEvent(index = index, result = object()) for index in indices])
-    hot = SamplingParams(temperature=0.9)
-    adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
-    _results(adapter.stream([GenerationRequest(prompt="a"),
-                             GenerationRequest(prompt="b", sampling=hot),
-                             GenerationRequest(prompt="c")]))
-    assert sorted(chunks) == [[0, 2], [1]]
-    # Preprocessing stacks a group without padding, so differing prompt lengths
-    # must not share a chunk; upstream raises when they do.
-    chunks.clear()
-    _results(adapter.stream([GenerationRequest(prompt="a"),
-                             GenerationRequest(prompt="bb"),
-                             GenerationRequest(prompt="c")]))
-    assert sorted(chunks) == [[0, 2], [1]]
 
 
 @pytest.mark.parametrize("plural", (True, False))
@@ -1049,6 +1026,7 @@ def test_audio_requests_decode_alone_while_the_rest_of_the_batch_still_batches()
     adapter._decode_image = lambda request: request
     adapter._group_key = lambda request: "g"
     adapter.per_row_prompt_kwargs = True
+    adapter.batches_observable = True
     adapter._run_chunk = lambda chunk, indices: (
         batched.append(list(indices)),
         [GenerationEvent(index = index, result = "batched") for index in indices])[1]
@@ -1088,6 +1066,113 @@ def test_seed_is_reduced_onto_the_random_key_domain():
     for bad in (True, 1.5, "7"):
         with pytest.raises(TypeError):
             SamplingParams(seed = bad)
+
+
+def _rows(width):
+    return types.SimpleNamespace(shape = (width,))
+
+
+def _row_sampler(params):
+    return _PerRowSampler(
+        params,
+        sample_utils_module = types.SimpleNamespace(),
+        make_sampler = lambda **knobs: (lambda logprobs: logprobs),
+    )
+
+
+def test_a_per_row_sampler_refuses_a_batch_it_cannot_match_to_rows():
+    """Silence here would cross two requests' draws."""
+    sampler = _row_sampler(
+        [SamplingParams(temperature = 0.9, seed = 11),
+         SamplingParams(temperature = 0.9, seed = 22)],
+    )
+    sampler.bind_uids([4, 9])
+    assert sampler.row_uids == [4, 9]
+    with pytest.raises(RuntimeError, match = "cannot be matched to rows"):
+        sampler(_rows(3))
+    with pytest.raises(RuntimeError, match = "cannot be matched to rows"):
+        sampler(_rows(1))
+
+    with pytest.raises(RuntimeError, match = "cannot be matched to rows"):
+        sampler.bind_uids([1, 2, 3])
+
+
+def _knob_sampler(**knobs):
+    """A sampler that reports every knob it was built for."""
+    import mlx.core as mx
+    token = (int(round(knobs["temp"] * 10)) + 10 * int(round(knobs["top_p"] * 10))
+             + 100 * knobs["top_k"] + 1000 * int(round(knobs["min_p"] * 10)))
+    return lambda logprobs: mx.array([token])
+
+
+def _batched_generator(prompt_uids = None, generation_uids = None):
+    return types.SimpleNamespace(
+        _prompt_batch = (
+            None if prompt_uids is None
+            else types.SimpleNamespace(uids = list(prompt_uids))
+        ),
+        _generation_batch = (
+            None if generation_uids is None
+            else types.SimpleNamespace(uids = list(generation_uids))
+        ),
+    )
+
+
+def _warm(temps):
+    return [SamplingParams(temperature = temp) for temp in temps]
+
+
+def test_a_per_row_sampler_places_rows_by_the_batch_that_is_drawing():
+    """The batch's own row order decides, not the order this adapter inferred."""
+    import mlx.core as mx
+    sampler = _PerRowSampler(
+        _warm([0.1, 0.2, 0.3]),
+        sample_utils_module = types.SimpleNamespace(),
+        make_sampler = _knob_sampler,
+    )
+    sampler.bind_uids([10, 20, 30])
+    sampler.row_uids = [30, 20, 10]
+    logprobs = mx.zeros((3, 4))
+
+    sampler.bind_generator(_batched_generator(generation_uids = [10, 20, 30]))
+    assert sampler.sample_target(logprobs, row_ids = [0] * 3,
+                                 positions = [1, 2, 3]).tolist() == [1, 2, 3]
+    sampler.bind_generator(_batched_generator(generation_uids = [30, 10, 20]))
+    assert sampler.sample_target(logprobs, row_ids = [0] * 3,
+                                 positions = [4, 5, 6]).tolist() == [3, 1, 2]
+    sampler.bind_generator(_batched_generator(generation_uids = [30, 20]))
+    assert sampler.sample_target(mx.zeros((2, 4)), row_ids = [0] * 2,
+                                 positions = [7, 8]).tolist() == [3, 2]
+
+
+def test_a_per_row_sampler_builds_each_row_every_knob_it_asked_for():
+    """Temperature is the obvious one, and the filters are the easy ones to drop."""
+    import mlx.core as mx
+    rows = [
+        SamplingParams(temperature = 0.5),
+        SamplingParams(temperature = 0.5, top_p = 0.8),
+        SamplingParams(temperature = 0.5, top_k = 3),
+        SamplingParams(temperature = 0.5, min_p = 0.2),
+    ]
+    sampler = _PerRowSampler(
+        rows,
+        sample_utils_module = types.SimpleNamespace(),
+        make_sampler = _knob_sampler,
+    )
+    sampler.bind_uids([10, 20, 30, 40])
+    sampler.bind_generator(_batched_generator(generation_uids = [10, 20, 30, 40]))
+    drawn = sampler.sample_target(
+        mx.zeros((4, 4)), row_ids = [0] * 4, positions = [1, 2, 3, 4],
+    ).tolist()
+    assert len(set(drawn)) == 4
+    assert drawn == [5, 85, 305, 2005]
+
+
+_UNREADABLE: dict = {}
+exec(compile(
+    "def draw(self):\n"
+    "    return _sample_with_positions(self.sampler, None, row_ids=[0], positions=[1])\n",
+    "<generated>", "exec"), _UNREADABLE)
 
 
 def test_a_row_is_reported_as_it_goes_and_its_deltas_rebuild_its_text():

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -16,7 +16,8 @@ if importlib.util.find_spec("mlx") is None:
 
 from unsloth_zoo.mlx.generate import (  # noqa: E402
     GenerationDefaults, GenerationRequest, SamplingParams,
-    _GENERATION_MODE_LOCK, _PendingResult, _StopStringScanner, _TextBatchAdapter,
+    _GENERATION_MODE_LOCK, _PendingResult, _PerRowSeededSampler,
+    _StopStringScanner, _TextBatchAdapter,
     _eos_stop_tokens, _new_detokenizer, _probe_sampler_api, _probe_text_api,
     _generation_cache_hygiene, _restore_training_flags,
     _validate_text_requests, generate_batch, generation_mode,
@@ -871,6 +872,13 @@ def test_detokenizer_never_re_emits_after_a_shortening_decode():
 class _EosTokenizer(_CharTokenizer):
     eos_token_id = 3
 
+def _sample_utils():
+    """The release's filtering stages, as a seeded sampler reaches for them."""
+    return types.SimpleNamespace(
+        apply_top_p=lambda x, p: x, apply_min_p=lambda x, p, n: x,
+        apply_top_k=lambda x, k: x,
+    )
+
 def _audio_events(*specs):
     """Sequential events; `finish` omitted models releases carrying no reason.
 
@@ -894,6 +902,7 @@ def _audio_adapter(events, tokenizer=None, stops=()):
     adapter.sampler = object()
     adapter.sampler_kwargs = {}
     adapter.make_sampler = lambda **k: (adapter.sampler_kwargs.update(k), adapter.sampler)[1]
+    adapter.sample_utils = _sample_utils()
     adapter._wired_limit = contextlib.nullcontext
     adapter.stream_calls = []
     def stream(*args, **kwargs):
@@ -1021,3 +1030,15 @@ def test_vision_generation_resolves_the_saved_processor(monkeypatch):
     model = types.SimpleNamespace(_is_vlm_model=True, _processor=processor)
     assert engine_generate_batch(model, object(), [GenerationRequest(prompt="a")]) == ["ok"]
     assert seen["tok"] is processor
+
+
+def test_seed_is_reduced_onto_the_random_key_domain():
+    """Any int is accepted; mx.random.key rejects negatives and >= 2**64."""
+    assert SamplingParams().seed is None
+    assert SamplingParams(seed = 0).seed == 0
+    assert SamplingParams(seed = -1).seed == 2**64 - 1
+    assert SamplingParams(seed = 2**64 + 5).seed == 5
+    for bad in (True, 1.5, "7"):
+        with pytest.raises(TypeError):
+            SamplingParams(seed = bad)
+

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1248,7 +1248,7 @@ class _OpenBatchGenerator:
 
 def _open_stream(monkeypatch, generator_type=_OpenBatchGenerator, **defaults):
     """A BatchStream over a fake generator, with the generation lock stubbed out."""
-    import unsloth_zoo.mlx.generate as module
+    from unsloth_zoo.mlx import generate as module
     from unsloth_zoo.mlx.generate import BatchStream
 
     def adapter(model, tok, defaults_):

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -406,3 +406,30 @@ def test_arrays_cache_advance_defers_instead_of_stranding_metal_buffers():
     left.extend(right)
     assert left.left_padding.tolist() == [-2, 2, 2]
     assert left.lengths.tolist() == [4, 7, -2]
+
+
+def test_a_penalised_row_answers_the_same_batched_and_alone():
+    """A row shown its whole prompt is penalised against text it never sees alone, and the
+    two prompts differ in length, so one offset cannot serve both rows."""
+    from mlx_lm import load, stream_generate
+    from mlx_lm.sample_utils import make_logits_processors, make_sampler
+    from unsloth_zoo.mlx.generate import (
+        GenerationDefaults, GenerationRequest, generate_batch,
+    )
+
+    model, tokenizer = load(MODEL)
+    prompts = ("red red red red red red red red. Name a colour:", "one one one. Count:")
+    penalty = dict(repetition_penalty = 1.6, repetition_context_size = 20)
+    batched = generate_batch(model, tokenizer, [
+        GenerationRequest(prompt = prompt, max_tokens = 12,
+                          logits_processors = make_logits_processors(**penalty))
+        for prompt in prompts
+    ], defaults = GenerationDefaults())
+
+    for prompt, result in zip(prompts, batched):
+        alone = [int(event.token) for event in stream_generate(
+            model, tokenizer, tokenizer.encode(prompt, add_special_tokens = False),
+            max_tokens = 12, sampler = make_sampler(temp = 0.0),
+            logits_processors = make_logits_processors(**penalty),
+        ) if event.finish_reason != "stop"]
+        assert result.token_ids == alone, prompt

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -97,25 +97,25 @@ def test_batched_greedy_matches_sequential_and_preserves_sampled_ids():
     # The cache patch must be installed before any decoding runs.
     order = []
     real_install = generate_module._install_arrays_cache_advance_fix
-    real_adapter_generate = generate_module._TextBatchAdapter.generate
+    real_adapter_stream = generate_module._TextBatchAdapter.stream
 
     def record_install():
         order.append("install")
         return real_install()
 
-    def record_generate(self, requests):
-        order.append("generate")
-        return real_adapter_generate(self, requests)
+    def record_stream(self, requests):
+        order.append("stream")
+        return real_adapter_stream(self, requests)
 
     generate_module._install_arrays_cache_advance_fix = record_install
-    generate_module._TextBatchAdapter.generate = record_generate
+    generate_module._TextBatchAdapter.stream = record_stream
     try:
         batched = generate_batch(model, tokenizer, requests, defaults=defaults)
     finally:
         generate_module._install_arrays_cache_advance_fix = real_install
-        generate_module._TextBatchAdapter.generate = real_adapter_generate
+        generate_module._TextBatchAdapter.stream = real_adapter_stream
     from mlx_lm.models.cache import ArraysCache
-    assert order == ["install", "generate"]
+    assert order == ["install", "stream"]
     assert generate_module._ARRAYS_CACHE_ADVANCE_RESOLVED
     assert isinstance(ArraysCache.left_padding, property)
     sequential = []

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -408,6 +408,7 @@ def test_arrays_cache_advance_defers_instead_of_stranding_metal_buffers():
     assert left.lengths.tolist() == [4, 7, -2]
 
 
+@metal_only
 def test_a_penalised_row_answers_the_same_batched_and_alone():
     """A row shown its whole prompt is penalised against text it never sees alone, and the
     two prompts differ in length, so one offset cannot serve both rows."""

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -550,8 +550,28 @@ class _PerRowSampler:
                 f"batch admitted {len(uids)} rows for {len(self._params)} "
                 "requests; per-row sampling cannot be matched to rows."
             )
-        self._by_uid = dict(zip(uids, self._params))
-        self.row_uids = list(uids)
+        self._by_uid.clear()
+        self.row_uids.clear()
+        for uid, params in zip(uids, self._params):
+            self.register(uid, params)
+
+    def register(self, uid, params: SamplingParams) -> None:
+        """Take one more row, for a caller that learns them one at a time."""
+        self._by_uid[uid] = params
+        self.row_uids.append(uid)
+
+    def release(self, uid) -> None:
+        """Forget a row the batch can no longer draw."""
+        self._by_uid.pop(uid, None)
+        self._samplers.pop(uid, None)
+        if uid in self.row_uids:
+            self.row_uids.remove(uid)
+
+    def release_all(self) -> None:
+        """Forget every row at once, for a batch that has gone."""
+        self._by_uid.clear()
+        self._samplers.clear()
+        self.row_uids.clear()
 
     def bind_generator(self, generator) -> None:
         self._generator = generator
@@ -1281,6 +1301,7 @@ class _TextBatchSession:
             completion_batch_size=defaults.completion_batch_size,
             max_kv_size=defaults.max_kv_size,
         )
+        self._row_signature = None
         self._pending: dict[int, _PendingResult] = {}
         self._row_of: dict[int, int] = {}
         self._uid_of: dict[int, int] = {}
@@ -1616,6 +1637,136 @@ def _vlm_batches_observable(batch_module) -> bool:
     )
 
 
+_LAYER_MAJOR_PROMPT_KWARGS = frozenset({"deepstack_visual_embeds"})
+
+
+def _padded_prompt_kwargs(batch_module) -> frozenset:
+    """The keys this release stretches to the batch's longest prompt."""
+
+    return frozenset({
+        "inputs_embeds",
+        *(getattr(batch_module, "_SEQUENCE_ALIGNED_PROMPT_KWARGS", None) or ()),
+    })
+
+
+def _row_shape(key, value, padded: frozenset):
+    """What a row's value has to match in the batch's other rows."""
+
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        if isinstance(value, (list, tuple)):
+            return (type(value).__name__,
+                    tuple(_row_shape(key, item, padded) for item in value))
+        if value is None or isinstance(value, (str, bytes, int, float, bool)):
+            return value
+        return type(value).__name__
+    shape = list(shape)
+    if key in padded:
+        axis = 2 if key == "position_ids" and len(shape) == 3 else 1
+        if axis < len(shape):
+            shape[axis] = None
+    return tuple(shape)
+
+
+def _row_signature(prepared: dict, padded: frozenset) -> dict:
+    return {key: _row_shape(key, value, padded) for key, value in prepared.items()}
+
+
+def _own_body(method):
+    """One method's own statements, minus anything nested inside it."""
+
+    source = textwrap.dedent(inspect.getsource(method))
+    definition = ast.parse(source).body[0]
+    if not isinstance(definition, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        raise TypeError("not a function definition")
+    nested = {
+        inner for node in ast.walk(definition)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda))
+        and node is not definition
+        for inner in ast.walk(node)
+    }
+    return [node for node in ast.walk(definition) if node not in nested]
+
+
+def _keeps_what_it_prepared(model, method = "get_input_embeddings") -> bool:
+    """Whether preparing a request leaves anything on this model.
+
+    Follows the helpers the method calls on itself: several models do the
+    assignment one call down, where reading the method alone would not see it.
+    A ``self.<name>(...)`` with no readable body is a submodule being run --
+    every vision model runs its tower that way -- and is stepped over. Only the
+    prepare method itself being unreadable counts as keeping something, since
+    then nothing at all is known about it.
+    """
+
+    seen = set()
+
+    def follows(name, entry = False) -> bool:
+        if name in seen:
+            return False
+        seen.add(name)
+        try:
+            body = _own_body(getattr(model, name))
+        except (AttributeError, OSError, TypeError, SyntaxError, IndentationError):
+            return entry
+        calls = set()
+        for node in body:
+            targets = (
+                list(node.targets) if isinstance(node, ast.Assign)
+                else [node.target] if isinstance(node, (ast.AugAssign, ast.AnnAssign))
+                else []
+            )
+            for target in targets:
+                while isinstance(target, ast.Attribute):
+                    target = target.value
+                if isinstance(target, ast.Name) and target.id == "self":
+                    return True
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+            ):
+                calls.add(node.func.attr)
+        return any(follows(call) for call in sorted(calls))
+
+    return follows(method, entry = True)
+
+
+def _require_streamable_vlm(adapter: "_VLMBatchAdapter") -> None:
+    """Refuse a release that cannot keep a vision batch open."""
+
+    if not adapter.per_row_prompt_kwargs:
+        raise ValueError(
+            f"{_installed_mlx_vlm_version()} admits one set of embeddings for a "
+            "whole prefill batch, so a vision row cannot join a batch it was not "
+            "preprocessed with. Generate with generate_batch or stream_batch, or "
+            "upgrade mlx-vlm."
+        )
+    if not adapter.batches_observable:
+        raise ValueError(
+            f"{_installed_mlx_vlm_version()} does not let a sampler tell which "
+            "row it is drawing for, which a batch that widens while it decodes "
+            "needs. Generate with generate_batch or stream_batch, or upgrade "
+            "mlx-vlm."
+        )
+    if not callable(getattr(adapter.batch_module, "_chunked_prefill_enabled", None)):
+        raise ValueError(
+            f"{_installed_mlx_vlm_version()} settles how to prefill when the "
+            "batch is built, before any prompt has arrived, so a row whose model "
+            "needs its prompt prefilled in one pass would be chunked anyway. "
+            "Generate with generate_batch or stream_batch, which build a batch "
+            "around the prompts it holds, or upgrade mlx-vlm."
+        )
+    if _keeps_what_it_prepared(adapter.model):
+        raise ValueError(
+            "This model keeps what it worked out about one request, which a "
+            "batch admitting requests one at a time would hand to whichever "
+            "prepared last. Generate it with generate_batch or stream_batch, "
+            "which prepare a whole batch together."
+        )
+
+
 def _resolve_cancel(generator):
     """How this generator cancels one sequence, decided once.
 
@@ -1714,6 +1865,7 @@ class _VLMBatchAdapter:
         self.generator_type = batch_module.BatchGenerator
         self.per_row_prompt_kwargs = "prompt_kwargs" in insert_params
         self.batches_observable = _vlm_batches_observable(batch_module)
+        self.padded_prompt_kwargs = _padded_prompt_kwargs(batch_module)
         self.stream_module = _resolve_module_attr(_VLM_STREAM_MODULES, "wired_limit")
         utils = importlib.import_module("mlx_vlm.utils")
         self.prepare_inputs = utils.prepare_inputs
@@ -2250,6 +2402,297 @@ def generate_batch(
     return results
 
 
+class _VLMBatchSession:
+    """One mlx-vlm ``BatchGenerator`` with its row set left open.
+
+    The vision counterpart of ``_TextBatchSession``, under the same contract:
+    rows keep the number they were given, and ``usable`` goes false where a call
+    may already have changed the batch.
+
+    A row is let go only once the batch can no longer draw it, since its
+    settings go with it. mlx-vlm will not withdraw a row being prefilled beside
+    others, so a cancelled one stays the caller's until it is decoding and can
+    be withdrawn; where it cannot stay -- its text is already out, or it was
+    never recorded -- the batch is no longer answerable and ``usable`` goes
+    false.
+
+    Each row is preprocessed alone and admitted with its own embeddings, which
+    is what lets rows of unrelated image shapes and prompt lengths merge: the
+    release left-pads them to the batch's longest before the prefill forward,
+    which preprocessing a whole chunk at once cannot do.
+
+    Preparing rows apart is what the merging costs. It serves only models that
+    keep nothing from preparing one request, which is settled before any row is
+    admitted, and requests whose preparation lines up with what the batch's
+    other rows prepared -- the same values of the same shapes, but for the
+    length the release evens out. What a request prepares follows the request
+    and not the model, so that second condition is asked of every row.
+    """
+
+    def __init__(self, adapter: "_VLMBatchAdapter"):
+        self.adapter = adapter
+        self.tokenizer = getattr(adapter.processor, "tokenizer", adapter.processor)
+        self.sampler = _PerRowSampler(
+            (),
+            sample_utils_module = adapter.sample_utils,
+            make_sampler = adapter.make_sampler,
+        )
+        self._row_signature = None
+        self._pending: dict[int, _PendingResult] = {}
+        self._row_of: dict[int, int] = {}
+        self._uid_of: dict[int, int] = {}
+        self._next_row = 0
+        self.usable = True
+        self._stack = ExitStack()
+        try:
+            self._stack.enter_context(adapter._wired_limit())
+            self.generator = self._open()
+        except BaseException:
+            self._stack.close()
+            raise
+
+    @property
+    def rows_in_flight(self) -> int:
+        return len(self._pending)
+
+    def add(self, request: GenerationRequest) -> int:
+        adapter = self.adapter
+        defaults = adapter.defaults
+        if request.audio is not None:
+            raise ValueError(
+                "An audio request decodes on its own and cannot join a batch; "
+                "generate it with generate_batch or stream_batch."
+            )
+        input_ids, prompt_kwargs = self._prepare(request)
+        token_ids = input_ids.tolist()
+        try:
+            uids = self.generator.insert(
+                token_ids,
+                [int(request.max_tokens or defaults.max_tokens)],
+                prompt_kwargs = adapter._split_prompt_kwargs(prompt_kwargs, 1),
+            )
+        except BaseException:
+            self.usable = False
+            raise
+        try:
+            if len(uids) != 1:
+                raise RuntimeError(
+                    f"mlx-vlm answered a one-prompt insert with {len(uids)} uids."
+                )
+            uid = uids[0]
+            state = _PendingResult(
+                detokenizer = _new_detokenizer(
+                    self.tokenizer, require_independent = True,
+                ),
+                scanner = _StopStringScanner(defaults.stop_strings),
+                prompt_token_count = len(token_ids[0]),
+            )
+        except BaseException as active_error:
+            try:
+                for admitted in uids:
+                    if not self._withdraw(admitted):
+                        self.usable = False
+            except BaseException as rollback_error:
+                self.usable = False
+                _warn_preserving(
+                    "handing a rejected row back to mlx-vlm",
+                    active_error,
+                    rollback_error,
+                )
+            raise
+        row = self._next_row
+        self._next_row += 1
+        self._pending[uid] = state
+        self._row_of[uid] = row
+        self._uid_of[row] = uid
+        self.sampler.register(uid, request.sampling or defaults.sampling)
+        self._row_signature = _row_signature(
+            prompt_kwargs, adapter.padded_prompt_kwargs)
+        return row
+
+    def cancel(self, row: int) -> bool:
+        """Withdraw a row. False if it was never added, or has already ended.
+
+        Also false where the batch would not give it back, which mlx-vlm answers
+        for a row being prefilled beside others. The row is still the caller's
+        then -- it keeps reporting, and cancelling it once it is decoding works
+        -- because retiring it here would leave it decoding where nothing can
+        see it and nothing can end it.
+        """
+        uid = self._uid_of.get(row)
+        if uid is None or uid not in self._pending:
+            return False
+        try:
+            withdrawn = self._withdraw(uid)
+        except BaseException:
+            self.usable = False
+            raise
+        if not withdrawn:
+            return False
+        self._retire(uid)
+        return True
+
+    def step(self) -> Iterator[GenerationEvent]:
+        """One decode step's worth of events, or none while no row is in flight."""
+        if not self._pending:
+            return
+        try:
+            if not self.generator.has_work:
+                raise RuntimeError(
+                    "mlx-vlm ended its event stream before every request "
+                    "reported a finish reason."
+                )
+            _, events = self.generator.next()
+            if not events:
+                if self.adapter._admission_stalled(self.generator):
+                    raise self.adapter._stall_error()
+                return
+            for event in events:
+                yield from self._consume(event)
+        except BaseException:
+            self.usable = False
+            raise
+
+    def close(self):
+        closer = getattr(self.generator, "close", None)
+        try:
+            if callable(closer):
+                closer()
+        finally:
+            self.sampler.bind_generator(None)
+            self.sampler.release_all()
+            self.generator = None
+            self._row_signature = None
+            self._pending.clear()
+            self._row_of.clear()
+            self._uid_of.clear()
+            self._stack.close()
+
+    def _prepare(self, request: GenerationRequest):
+        """One request's token ids and the embeddings it is admitted with."""
+
+        adapter = self.adapter
+        request = adapter._decode_image(request)
+        config = getattr(adapter.model, "config", None)
+        inputs = adapter.prepare_inputs(
+            adapter.processor,
+            images = None if request.image is None else [request.image],
+            audio = None,
+            prompts = [request.prompt],
+            image_token_index = getattr(config, "image_token_index", None),
+            resize_shape = None,
+            add_special_tokens = adapter._add_special_tokens(),
+            pad_to_uniform_size = False,
+        )
+        input_ids = inputs.get("input_ids")
+        data_kwargs = {
+            key: value
+            for key, value in inputs.items()
+            if key not in ("input_ids", "pixel_values", "attention_mask")
+        }
+        embedding_output = adapter.model.get_input_embeddings(
+            input_ids,
+            inputs.get("pixel_values"),
+            mask = inputs.get("attention_mask"),
+            **data_kwargs,
+        )
+        embeddings = embedding_output.to_dict()
+        prepared = {**data_kwargs, **{
+            key: value
+            for key, value in embeddings.items()
+            if value is not None
+        }}
+        layered = sorted(_LAYER_MAJOR_PROMPT_KWARGS.intersection(prepared))
+        if layered:
+            raise ValueError(
+                f"This request comes back with {', '.join(layered)} per layer, "
+                "which merging lines up as though the layers were rows. "
+                "Generate it with generate_batch or stream_batch, which prepare "
+                "a whole batch together."
+            )
+        signature = _row_signature(prepared, adapter.padded_prompt_kwargs)
+        if self._row_signature is not None and signature != self._row_signature:
+            differing = sorted(
+                key for key in set(signature) | set(self._row_signature)
+                if signature.get(key, _MISSING) != self._row_signature.get(key, _MISSING)
+            )
+            raise ValueError(
+                f"This request prepares {', '.join(differing)} unlike the "
+                "batch's other requests, which merging lines up against rows "
+                "that do not match it. Generate it with generate_batch or "
+                "stream_batch, which prepare a whole batch together."
+            )
+        return input_ids, prepared
+
+    def _open(self):
+        """The batch, built for the whole session."""
+
+        adapter = self.adapter
+        defaults = adapter.defaults
+        options = {
+            "prefill_batch_size": defaults.prefill_batch_size,
+            "completion_batch_size": defaults.completion_batch_size,
+            "sampler": self.sampler,
+            "compute_logprobs": True,
+        }
+        generator = adapter.generator_type(
+            adapter.model.language_model,
+            adapter.processor,
+            **{
+                key: value
+                for key, value in options.items()
+                if key in adapter.constructor_params
+            },
+        )
+        self.sampler.bind_generator(generator)
+        return generator
+
+    def _withdraw(self, uid: int) -> bool:
+        """Hand a row back, and say whether the batch took it."""
+
+        if self.adapter.cancel is None:
+            return False
+        return self.adapter.cancel(self.generator, uid) is not False
+
+    def _retire(self, uid: int):
+        """Let a row go, once the batch can no longer draw it."""
+
+        row = self._row_of.pop(uid, None)
+        self._pending.pop(uid, None)
+        if row is not None:
+            self._uid_of.pop(row, None)
+        self.sampler.release(uid)
+        if not self._pending:
+            self._row_signature = None
+
+    def _consume(self, event) -> Iterator[GenerationEvent]:
+        tokenizer = self.tokenizer
+        state = self._pending.get(event.uid)
+        if state is None:
+            return
+        row = self._row_of[event.uid]
+        finish_reason = event.finish_reason
+        if finish_reason is None:
+            stopped = state.append(tokenizer, int(event.token), _event_logprob(event))
+            if not stopped:
+                yield from _text_events(row, state)
+                return
+            if not self._withdraw(event.uid):
+                self.usable = False
+            yield from _finished_events(row, state, tokenizer)
+            self._retire(event.uid)
+            return
+        if finish_reason not in ("stop", "length"):
+            raise RuntimeError(
+                f"mlx-vlm emitted an unsupported finish reason: {finish_reason!r}."
+            )
+        if finish_reason == "length":
+            state.add_terminal(int(event.token), _event_logprob(event))
+        state.finish(tokenizer, finish_reason)
+        yield from _finished_events(row, state, tokenizer)
+        self._retire(event.uid)
+
+
 class BatchStream:
     """A batch left open: rows join and leave while the batch decodes.
 
@@ -2265,16 +2708,17 @@ class BatchStream:
     close it in a ``finally``. A call from anywhere else is refused before
     anything is torn down, so the stream stays closable by its owner.
 
-    Text models only. A vision batch is grouped by image shape and prefilled
-    together, so its rows cannot join a decode already running; ``stream_batch``
-    serves those.
+    Vision models are served too, on a release whose batch can place a drawn row
+    and take a row's embeddings with it; where it cannot, a vision model is
+    refused rather than mis-sampled and ``stream_batch`` serves it. Audio rows
+    decode on their own and never join.
 
     ``stop_strings`` are unavailable here for the reason ``stream_batch`` gives:
     they cut on token boundaries, which would retract text already handed out.
 
     Any call that raises where it may already have changed the batch retires the
-    whole stream: mlx-lm takes and releases a row in several steps, so what it
-    holds afterwards is a question neither side can answer. ``add``, ``step`` and
+    whole stream: the engine takes and releases a row in several steps, so what
+    it holds afterwards is a question neither side can answer. ``add``, ``step`` and
     ``cancel`` then refuse; only ``close`` still works. Open another.
     """
 
@@ -2296,23 +2740,35 @@ class BatchStream:
                 "boundaries, which would retract text already streamed. Scan "
                 "the deltas for them instead."
             )
-        if bool(getattr(model, "_is_vlm_model", False)):
-            raise ValueError(
-                "BatchStream decodes text models. A vision batch is grouped by "
-                "image shape and prefilled together, so its rows cannot join a "
-                "decode already running; use stream_batch."
-            )
+        # Routing follows the model, not the request: a vision model
+        # preprocesses text-only prompts too.
+        is_vlm = bool(getattr(model, "_is_vlm_model", False))
+        if is_vlm:
+            # A text-only multimodal load stays on the vision path but publishes
+            # its inner tokenizer, which cannot drive mlx-vlm preprocessing.
+            tokenizer = getattr(model, "_processor", None) or tokenizer
         if tokenizer is None:
-            raise ValueError("Text batched generation requires a tokenizer.")
+            raise ValueError(
+                "Batched generation requires a processor."
+                if is_vlm
+                else "Text batched generation requires a tokenizer."
+            )
         self._stack = ExitStack()
         self._session = None
+        self._is_vlm = is_vlm
         self._closed = False
         self._owner = (threading.get_ident(), _current_async_task())
         try:
             self._stack.enter_context(generation_mode(model))
             self._stack.enter_context(_generation_cache_hygiene())
-            adapter = _TextBatchAdapter(model, tokenizer, defaults)
-            self._session = _TextBatchSession(adapter)
+            if is_vlm:
+                adapter = _VLMBatchAdapter(model, tokenizer, defaults)
+                _require_streamable_vlm(adapter)
+                self._session = _VLMBatchSession(adapter)
+            else:
+                self._session = _TextBatchSession(
+                    _TextBatchAdapter(model, tokenizer, defaults)
+                )
             self._stack.callback(self._session.close)
         except BaseException as active_error:
             try:
@@ -2342,11 +2798,12 @@ class BatchStream:
     def add(self, request: GenerationRequest) -> int:
         """Admit one request, and answer with the row number reporting it."""
         session = self._require_open()
-        (validated,) = _validate_text_requests([request], session.adapter.defaults)
+        validate = _validate_vlm_requests if self._is_vlm else _validate_text_requests
+        (validated,) = validate([request], session.adapter.defaults)
         return session.add(validated)
 
     def cancel(self, row: int) -> bool:
-        """Withdraw a row. False if it was never added, or has already ended."""
+        """Withdraw a row, answering whether it is gone."""
         return self._require_open().cancel(row)
 
     def step(self) -> list[GenerationEvent]:
@@ -2362,13 +2819,13 @@ class BatchStream:
         self._session = None
         self._stack.close()
 
-    def _require_open(self) -> "_TextBatchSession":
+    def _require_open(self):
         if self._session is None:
             raise RuntimeError("This BatchStream is closed.")
         self._require_owner()
         if not self._session.usable:
             raise RuntimeError(
-                "This BatchStream holds a batch neither it nor mlx-lm can "
+                "This BatchStream holds a batch neither it nor the engine can "
                 "answer for, left by an earlier call that failed partway. "
                 "Close it and open another."
             )

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -2937,6 +2937,8 @@ def stream_batch(
     defaults: GenerationDefaults | None = None,
 ) -> Iterator[GenerationEvent]:
     """``generate_batch``, reporting each row as it goes."""
+    if defaults is not None and not isinstance(defaults, GenerationDefaults):
+        raise TypeError("defaults must be GenerationDefaults.")
     if defaults is not None and defaults.stop_strings:
         raise ValueError(
             "stream_batch cannot apply stop_strings: they cut on token "

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -18,9 +18,11 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import importlib
 import inspect
+import textwrap
 import math
 import os
 import sys
@@ -513,72 +515,103 @@ def _seeded_sampler(sample_utils_module, params: SamplingParams):
     return sampler
 
 
-class _PerRowSeededSampler:
-    """One RNG stream per row for a backend that takes only one sampler.
+def _sampler_key(params: SamplingParams):
+    """The settings one sampler can serve. A seed is not among them: rows"""
+    return (params.temperature, params.top_p, params.top_k, params.min_p)
 
-    mlx-vlm's ``BatchGenerator`` holds a single sampler for the whole batch and
-    hands every row the same ``row_ids`` and ``positions`` in the plain decode
-    path, so rows sharing a prompt sample identically -- an ``n``-way fan-out
-    returns one answer ``n`` times. Identity therefore has to come from the
-    caller: ``row_uids`` is the live row order, set before each step from the
-    finish reasons the event stream already reports. Width is checked against it
-    as a guard -- it catches a batch that admitted or retired rows this adapter
-    did not see, which is the failure that would silently swap RNG streams; it
-    cannot confirm the order itself.
 
-    Rows without a seed fall through to ``fallback``, which draws from the global
-    RNG exactly as an unbatched unseeded request does.
-    """
+def _sampler_for(sample_utils_module, params: SamplingParams, make_sampler):
+    """The sampler one request's settings ask for."""
+    if _draws_seeded(params):
+        return _seeded_sampler(sample_utils_module, params)
+    return make_sampler(
+        temp=params.temperature,
+        top_p=params.top_p,
+        top_k=params.top_k,
+        min_p=params.min_p,
+    )
 
-    def __init__(self, seeds, *, params: SamplingParams, sample_utils_module, fallback):
-        self._params = params
+
+class _PerRowSampler:
+    """One sampler per row for a backend that takes only one for the batch."""
+
+    def __init__(self, params, *, sample_utils_module, make_sampler):
         self._sample_utils = sample_utils_module
-        self._fallback = fallback
-        self._seeds = list(seeds)
+        self._make_sampler = make_sampler
+        self._params = list(params)
         self._by_uid: dict[Any, Any] = {}
         self._samplers: dict[Any, Any] = {}
+        self._generator = None
         self.row_uids: list[Any] = []
 
     def bind_uids(self, uids) -> None:
-        if len(uids) != len(self._seeds):
+        if len(uids) != len(self._params):
             raise RuntimeError(
-                f"batch admitted {len(uids)} rows for {len(self._seeds)} seeded "
-                "requests; per-row seeds cannot be matched to rows."
+                f"batch admitted {len(uids)} rows for {len(self._params)} "
+                "requests; per-row sampling cannot be matched to rows."
             )
-        self._by_uid = dict(zip(uids, self._seeds))
+        self._by_uid = dict(zip(uids, self._params))
         self.row_uids = list(uids)
+
+    def bind_generator(self, generator) -> None:
+        self._generator = generator
 
     def _row_sampler(self, uid):
         sampler = self._samplers.get(uid)
         if sampler is None:
-            seed = self._by_uid.get(uid)
-            sampler = (
-                self._fallback
-                if seed is None
-                else _seeded_sampler(
-                    self._sample_utils,
-                    replace(self._params, seed=seed),
+            params = self._by_uid.get(uid)
+            if params is None:
+                raise RuntimeError(
+                    f"{_installed_mlx_vlm_version()} drew a row this batch was "
+                    "not given, so per-row sampling cannot be matched to rows."
                 )
-            )
+            sampler = _sampler_for(self._sample_utils, params, self._make_sampler)
             self._samplers[uid] = sampler
         return sampler
 
-    def __call__(self, logprobs):
-        import mlx.core as mx
+    def _drawing_uids(self, width, positions):
+        """The rows of this draw, in the order their logprobs are stacked."""
 
-        width = logprobs.shape[0]
+        if self._generator is not None and positions is not None:
+            name = (
+                "_prompt_batch"
+                if all(position == 0 for position in positions)
+                else "_generation_batch"
+            )
+            batch = getattr(self._generator, name, _MISSING)
+            if batch is not _MISSING:
+                uids = list(getattr(batch, "uids", ()) or ())
+                if len(uids) != width:
+                    raise RuntimeError(
+                        f"{_installed_mlx_vlm_version()} drew {width} rows from a "
+                        f"{name.lstrip('_').replace('_', ' ')} holding {len(uids)}, "
+                        "so per-row sampling cannot be matched to rows."
+                    )
+                return uids
         if width != len(self.row_uids):
             raise RuntimeError(
                 f"{_installed_mlx_vlm_version()} stepped a batch of {width} rows "
                 f"while {len(self.row_uids)} were tracked as live, so per-row "
-                "seeds cannot be matched to rows. Generate without seeds, or "
-                "pin a release whose batch admits and retires rows through its "
-                "event stream."
+                "sampling cannot be matched to rows. Give every request in a "
+                "batch the same sampling settings and no seed, or pin a release "
+                "whose batch admits and retires rows through its event stream."
             )
+        return self.row_uids
+
+    def sample_target(self, logprobs, *, row_ids=None, positions=None):
+        return self._draw(logprobs, positions)
+
+    def __call__(self, logprobs):
+        return self._draw(logprobs, None)
+
+    def _draw(self, logprobs, positions):
+        import mlx.core as mx
+
+        uids = self._drawing_uids(logprobs.shape[0], positions)
         return mx.concatenate(
             [
                 self._row_sampler(uid)(logprobs[row : row + 1])
-                for row, uid in enumerate(self.row_uids)
+                for row, uid in enumerate(uids)
             ],
             axis=0,
         )
@@ -1524,6 +1557,65 @@ def _probe_vlm_api(batch_module):
     return constructor, insert, _resolve_cancel(generator)
 
 
+def _statements(body):
+    """Every node written in this body, skipping nested definitions."""
+
+    for node in body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        yield node
+        yield from _statements(list(ast.iter_child_nodes(node)))
+
+
+def _draws_by_position(owner, method) -> bool:
+    """Whether this draw hands the sampler the rows and positions it draws at."""
+
+    try:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(getattr(owner, method))))
+    except (AttributeError, OSError, TypeError, SyntaxError, IndentationError):
+        return False
+    definition = tree.body[0] if tree.body else None
+    if not isinstance(definition, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return False
+    for node in _statements(definition.body):
+        if not isinstance(node, ast.Call):
+            continue
+        called = node.func
+        name = (
+            called.attr if isinstance(called, ast.Attribute)
+            else called.id if isinstance(called, ast.Name)
+            else None
+        )
+        if name != "_sample_with_positions":
+            continue
+        given = {keyword.arg: keyword.value for keyword in node.keywords}
+        if not {"row_ids", "positions"}.issubset(given):
+            continue
+        if any(
+            isinstance(given[argument], ast.Constant) and given[argument].value is None
+            for argument in ("row_ids", "positions")
+        ):
+            continue
+        return True
+    return False
+
+
+def _vlm_batches_observable(batch_module) -> bool:
+    """Whether a sampler can tell which of a release's rows a draw is for."""
+
+    generator = getattr(batch_module, "BatchGenerator", None)
+    code = getattr(getattr(generator, "__init__", None), "__code__", None)
+    if not {"_prompt_batch", "_generation_batch"}.issubset(
+        getattr(code, "co_names", ())
+    ):
+        return False
+    return _draws_by_position(
+        getattr(batch_module, "PromptProcessingBatch", None), "generate"
+    ) and _draws_by_position(
+        getattr(batch_module, "GenerationBatch", None), "_step"
+    )
+
+
 def _resolve_cancel(generator):
     """How this generator cancels one sequence, decided once.
 
@@ -1621,6 +1713,7 @@ class _VLMBatchAdapter:
         self.batch_module = batch_module
         self.generator_type = batch_module.BatchGenerator
         self.per_row_prompt_kwargs = "prompt_kwargs" in insert_params
+        self.batches_observable = _vlm_batches_observable(batch_module)
         self.stream_module = _resolve_module_attr(_VLM_STREAM_MODULES, "wired_limit")
         utils = importlib.import_module("mlx_vlm.utils")
         self.prepare_inputs = utils.prepare_inputs
@@ -1733,18 +1826,13 @@ class _VLMBatchAdapter:
         # Prompt length is part of the key: preprocessing stacks a group without
         # padding, so mixing lengths raises instead of generating. Grouping by
         # length keeps varied batches working, at the cost of smaller groups.
-        sampling = request.sampling or self.defaults.sampling
         shape = self._image_shape(request.image)
         tokenizer = getattr(self.processor, "tokenizer", self.processor)
-        return (
-            sampling.temperature,
-            sampling.top_p,
-            sampling.top_k,
-            sampling.min_p,
-            request.image is None,
-            shape,
-            len(tokenizer.encode(request.prompt)),
-        )
+        key = (request.image is None, shape, len(tokenizer.encode(request.prompt)))
+        if self.batches_observable:
+            return key
+        sampling = request.sampling or self.defaults.sampling
+        return (_sampler_key(sampling), *key)
 
     def _decode_image(self, request: GenerationRequest) -> GenerationRequest:
         """Load a path or URL image once, before grouping.
@@ -1813,21 +1901,13 @@ class _VLMBatchAdapter:
             if request.audio is None:
                 groups.setdefault(self._group_key(request), []).append(index)
         for indices in groups.values():
-            # Older releases slice shared kwargs from row zero on every prefill
-            # batch, pairing later prompts with earlier embeddings, so they run one
-            # chunk per generator. Per-row releases keep the configured sizes.
-            #
-            # A group carrying per-row seeds takes the smaller sizes too: seeds
-            # identify rows by the live batch width, which is unambiguous only
-            # while it never grows, and a chunk larger than the prefill batch
-            # admits its rows in waves. Only the groups that need it pay.
-            seeded = any(
+            inferred_rows = not self.batches_observable and any(
                 _draws_seeded(requests[index].sampling or self.defaults.sampling)
                 for index in indices
             )
             capacity = (
                 None
-                if self.per_row_prompt_kwargs and not seeded
+                if self.per_row_prompt_kwargs and not inferred_rows
                 else min(
                     self.defaults.prefill_batch_size,
                     self.defaults.completion_batch_size,
@@ -1931,7 +2011,10 @@ class _VLMBatchAdapter:
         batch_size = len(chunk)
         prompts = [request.prompt for request in chunk]
         images = [request.image for request in chunk if request.image is not None]
-        sampling = chunk[0].sampling or self.defaults.sampling
+        row_sampling = [
+            request.sampling or self.defaults.sampling for request in chunk
+        ]
+        sampling = row_sampling[0]
         config = getattr(self.model, "config", None)
         inputs = self.prepare_inputs(
             self.processor,
@@ -1969,22 +2052,14 @@ class _VLMBatchAdapter:
                 min_p=sampling.min_p,
             ),
         }
-        # Grouping keys on the sampling knobs but not the seed, so one chunk can
-        # carry several seeds and the fan-out case -- one prompt, n seeds -- stays
-        # a single batch.
-        seeds = [
-            (request.sampling or self.defaults.sampling).seed
-            if _draws_seeded(request.sampling or self.defaults.sampling)
-            else None
-            for request in chunk
-        ]
         row_sampler = None
-        if any(seed is not None for seed in seeds):
-            row_sampler = _PerRowSeededSampler(
-                seeds,
-                params=sampling,
+        if any(_draws_seeded(params) for params in row_sampling) or len(
+            {_sampler_key(params) for params in row_sampling}
+        ) > 1:
+            row_sampler = _PerRowSampler(
+                row_sampling,
                 sample_utils_module=self.sample_utils,
-                fallback=options["sampler"],
+                make_sampler=self.make_sampler,
             )
             options["sampler"] = row_sampler
         if "compute_logprobs" in self.constructor_params:
@@ -2037,6 +2112,7 @@ class _VLMBatchAdapter:
                     uids = generator.insert(token_ids, max_tokens)
                 if row_sampler is not None:
                     row_sampler.bind_uids(uids)
+                    row_sampler.bind_generator(generator)
                 yield from self._drive(
                     generator, uids, indices, gen_kwargs, row_sampler,
                     prompt_token_count=len(token_ids[0]),
@@ -2082,10 +2158,6 @@ class _VLMBatchAdapter:
             for uid in uids
         }
         row_of = dict(zip(uids, indices))
-        # Rows still in the batch, in batch order. A per-row sampler reads this to
-        # tell its rows apart, since the release gives it nothing that can (see
-        # _PerRowSeededSampler). Retirement is observable: a row leaves on its
-        # finish reason, or when a stop string cancels it below.
         live = list(uids)
         while pending:
             if row_sampler is not None:

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -714,6 +714,14 @@ def _restore_metal_limits(snapshot: dict[str, int] | None):
         raise first_error
 
 
+def _require_evaluable(model):
+    """The model's eval(), or a refusal: what generation mode needs to switch a model"""
+    switch = getattr(model, "eval", None)
+    if not callable(switch):
+        raise TypeError("generation_mode requires a model with eval().")
+    return switch
+
+
 @contextmanager
 def generation_mode(model):
     """Temporarily switch a model to eval mode and steward global MLX limits.
@@ -735,10 +743,7 @@ def generation_mode(model):
         if _GENERATION_MODE_DEPTH == 0:
             _GENERATION_LIMIT_SNAPSHOT = _snapshot_metal_limits()
         training_states = _snapshot_training_flags(model)
-        eval_model = getattr(model, "eval", None)
-        if not callable(eval_model):
-            raise TypeError("generation_mode requires a model with eval().")
-        eval_model()
+        _require_evaluable(model)()
         _GENERATION_MODE_DEPTH += 1
         entered = True
         yield model
@@ -1020,6 +1025,10 @@ class GenerationEvent:
     result: GenerationResult | None = None
 
 
+class BatchRowRefused(ValueError):
+    """A row a batch will not take, for what it is rather than for being wrong."""
+
+
 def _text_events(index: int, state: "_PendingResult") -> Iterator[GenerationEvent]:
     delta = state.release()
     if delta:
@@ -1146,6 +1155,13 @@ def _replay_stream_text(detokenizer, token_ids: Sequence[int]) -> str:
         text += detokenizer.last_segment
     detokenizer.finalize()
     return text + detokenizer.last_segment
+
+
+def _cancelled_result(tokenizer, state: "_PendingResult") -> GenerationResult:
+    """What a row had managed when it was withdrawn."""
+    if state.finish_reason is None:
+        state.finish(tokenizer, "stop")
+    return state.result(tokenizer)
 
 
 @dataclass
@@ -1368,16 +1384,26 @@ class _TextBatchSession:
 
     def cancel(self, row: int) -> bool:
         """Withdraw a row. False if it was never added, or has already ended."""
+        return self._take_back(row) is not None
+
+    def withdraw(self, row: int) -> GenerationResult | None:
+        """Withdraw a row, answering with what it managed."""
+        state = self._take_back(row)
+        return None if state is None else _cancelled_result(self.adapter.tokenizer, state)
+
+    def _take_back(self, row: int) -> "_PendingResult | None":
+        """Take a row out of the batch, answering with what it was holding."""
         uid = self._uid_of.get(row)
         if uid is None or uid not in self._pending:
-            return False
+            return None
         try:
             self.generator.remove([uid])
         except BaseException:
             self.usable = False
             raise
+        state = self._pending[uid]
         self._retire(uid)
-        return True
+        return state
 
     def step(self) -> Iterator[GenerationEvent]:
         """One decode step's worth of events, or none while no row is in flight."""
@@ -2403,31 +2429,7 @@ def generate_batch(
 
 
 class _VLMBatchSession:
-    """One mlx-vlm ``BatchGenerator`` with its row set left open.
-
-    The vision counterpart of ``_TextBatchSession``, under the same contract:
-    rows keep the number they were given, and ``usable`` goes false where a call
-    may already have changed the batch.
-
-    A row is let go only once the batch can no longer draw it, since its
-    settings go with it. mlx-vlm will not withdraw a row being prefilled beside
-    others, so a cancelled one stays the caller's until it is decoding and can
-    be withdrawn; where it cannot stay -- its text is already out, or it was
-    never recorded -- the batch is no longer answerable and ``usable`` goes
-    false.
-
-    Each row is preprocessed alone and admitted with its own embeddings, which
-    is what lets rows of unrelated image shapes and prompt lengths merge: the
-    release left-pads them to the batch's longest before the prefill forward,
-    which preprocessing a whole chunk at once cannot do.
-
-    Preparing rows apart is what the merging costs. It serves only models that
-    keep nothing from preparing one request, which is settled before any row is
-    admitted, and requests whose preparation lines up with what the batch's
-    other rows prepared -- the same values of the same shapes, but for the
-    length the release evens out. What a request prepares follows the request
-    and not the model, so that second condition is asked of every row.
-    """
+    """One mlx-vlm ``BatchGenerator`` with its row set left open."""
 
     def __init__(self, adapter: "_VLMBatchAdapter"):
         self.adapter = adapter
@@ -2459,7 +2461,7 @@ class _VLMBatchSession:
         adapter = self.adapter
         defaults = adapter.defaults
         if request.audio is not None:
-            raise ValueError(
+            raise BatchRowRefused(
                 "An audio request decodes on its own and cannot join a batch; "
                 "generate it with generate_batch or stream_batch."
             )
@@ -2511,26 +2513,29 @@ class _VLMBatchSession:
         return row
 
     def cancel(self, row: int) -> bool:
-        """Withdraw a row. False if it was never added, or has already ended.
+        """Withdraw a row. False if it was never added, has already ended, or the"""
+        return self._take_back(row) is not None
 
-        Also false where the batch would not give it back, which mlx-vlm answers
-        for a row being prefilled beside others. The row is still the caller's
-        then -- it keeps reporting, and cancelling it once it is decoding works
-        -- because retiring it here would leave it decoding where nothing can
-        see it and nothing can end it.
-        """
+    def withdraw(self, row: int) -> GenerationResult | None:
+        """Withdraw a row, answering with what it managed."""
+        state = self._take_back(row)
+        return None if state is None else _cancelled_result(self.tokenizer, state)
+
+    def _take_back(self, row: int) -> "_PendingResult | None":
+        """Take a row out of the batch, answering with what it was holding."""
         uid = self._uid_of.get(row)
         if uid is None or uid not in self._pending:
-            return False
+            return None
         try:
             withdrawn = self._withdraw(uid)
         except BaseException:
             self.usable = False
             raise
         if not withdrawn:
-            return False
+            return None
+        state = self._pending[uid]
         self._retire(uid)
-        return True
+        return state
 
     def step(self) -> Iterator[GenerationEvent]:
         """One decode step's worth of events, or none while no row is in flight."""
@@ -2604,7 +2609,7 @@ class _VLMBatchSession:
         }}
         layered = sorted(_LAYER_MAJOR_PROMPT_KWARGS.intersection(prepared))
         if layered:
-            raise ValueError(
+            raise BatchRowRefused(
                 f"This request comes back with {', '.join(layered)} per layer, "
                 "which merging lines up as though the layers were rows. "
                 "Generate it with generate_batch or stream_batch, which prepare "
@@ -2616,7 +2621,7 @@ class _VLMBatchSession:
                 key for key in set(signature) | set(self._row_signature)
                 if signature.get(key, _MISSING) != self._row_signature.get(key, _MISSING)
             )
-            raise ValueError(
+            raise BatchRowRefused(
                 f"This request prepares {', '.join(differing)} unlike the "
                 "batch's other requests, which merging lines up against rows "
                 "that do not match it. Generate it with generate_batch or "
@@ -2693,34 +2698,52 @@ class _VLMBatchSession:
         self._retire(event.uid)
 
 
+def _stream_setup(model, tokenizer, defaults: GenerationDefaults):
+    """What a stream settles before it takes anything: the request it was asked"""
+    if defaults.stop_strings:
+        raise ValueError(
+            "BatchStream cannot apply stop_strings: they cut on token "
+            "boundaries, which would retract text already streamed. Scan "
+            "the deltas for them instead."
+        )
+    is_vlm = bool(getattr(model, "_is_vlm_model", False))
+    if is_vlm:
+        tokenizer = getattr(model, "_processor", None) or tokenizer
+    if tokenizer is None:
+        raise ValueError(
+            "Batched generation requires a processor."
+            if is_vlm
+            else "Text batched generation requires a tokenizer."
+        )
+    if is_vlm:
+        adapter = _VLMBatchAdapter(model, tokenizer, defaults)
+        _require_streamable_vlm(adapter)
+    else:
+        adapter = _TextBatchAdapter(model, tokenizer, defaults)
+    return is_vlm, adapter
+
+
+def stream_unavailable_reason(
+    model,
+    tokenizer = None,
+    *,
+    defaults: GenerationDefaults | None = None,
+) -> str | None:
+    """Why ``BatchStream`` would refuse this model here, or None if nothing here"""
+    if defaults is None:
+        defaults = GenerationDefaults()
+    if not isinstance(defaults, GenerationDefaults):
+        raise TypeError("defaults must be GenerationDefaults.")
+    try:
+        _stream_setup(model, tokenizer, defaults)
+        _require_evaluable(model)
+    except Exception as refusal:
+        return str(refusal)
+    return None
+
+
 class BatchStream:
-    """A batch left open: rows join and leave while the batch decodes.
-
-    ``stream_batch`` decodes one fixed set of requests and ends. This is the
-    same decode with the set open, so a server can merge requests that arrived
-    separately into one batch, and retire each row where it ends rather than at
-    the end of the batch. Rows are numbered in the order they were added and
-    keep their number for the stream's life.
-
-    The process-wide generation lock is held from construction until ``close``,
-    and it belongs to the thread *and* the asyncio task that took it: the same
-    one constructs, adds, steps, and closes. Use it as a context manager, or
-    close it in a ``finally``. A call from anywhere else is refused before
-    anything is torn down, so the stream stays closable by its owner.
-
-    Vision models are served too, on a release whose batch can place a drawn row
-    and take a row's embeddings with it; where it cannot, a vision model is
-    refused rather than mis-sampled and ``stream_batch`` serves it. Audio rows
-    decode on their own and never join.
-
-    ``stop_strings`` are unavailable here for the reason ``stream_batch`` gives:
-    they cut on token boundaries, which would retract text already handed out.
-
-    Any call that raises where it may already have changed the batch retires the
-    whole stream: the engine takes and releases a row in several steps, so what
-    it holds afterwards is a question neither side can answer. ``add``, ``step`` and
-    ``cancel`` then refuse; only ``close`` still works. Open another.
-    """
+    """A batch left open: rows join and leave while the batch decodes."""
 
     def __init__(
         self,
@@ -2734,25 +2757,7 @@ class BatchStream:
         if not isinstance(defaults, GenerationDefaults):
             raise TypeError("defaults must be GenerationDefaults.")
         _install_arrays_cache_advance_fix()
-        if defaults.stop_strings:
-            raise ValueError(
-                "BatchStream cannot apply stop_strings: they cut on token "
-                "boundaries, which would retract text already streamed. Scan "
-                "the deltas for them instead."
-            )
-        # Routing follows the model, not the request: a vision model
-        # preprocesses text-only prompts too.
-        is_vlm = bool(getattr(model, "_is_vlm_model", False))
-        if is_vlm:
-            # A text-only multimodal load stays on the vision path but publishes
-            # its inner tokenizer, which cannot drive mlx-vlm preprocessing.
-            tokenizer = getattr(model, "_processor", None) or tokenizer
-        if tokenizer is None:
-            raise ValueError(
-                "Batched generation requires a processor."
-                if is_vlm
-                else "Text batched generation requires a tokenizer."
-            )
+        is_vlm, adapter = _stream_setup(model, tokenizer, defaults)
         self._stack = ExitStack()
         self._session = None
         self._is_vlm = is_vlm
@@ -2761,14 +2766,9 @@ class BatchStream:
         try:
             self._stack.enter_context(generation_mode(model))
             self._stack.enter_context(_generation_cache_hygiene())
-            if is_vlm:
-                adapter = _VLMBatchAdapter(model, tokenizer, defaults)
-                _require_streamable_vlm(adapter)
-                self._session = _VLMBatchSession(adapter)
-            else:
-                self._session = _TextBatchSession(
-                    _TextBatchAdapter(model, tokenizer, defaults)
-                )
+            self._session = (
+                _VLMBatchSession(adapter) if is_vlm else _TextBatchSession(adapter)
+            )
             self._stack.callback(self._session.close)
         except BaseException as active_error:
             try:
@@ -2805,6 +2805,10 @@ class BatchStream:
     def cancel(self, row: int) -> bool:
         """Withdraw a row, answering whether it is gone."""
         return self._require_open().cancel(row)
+
+    def withdraw(self, row: int) -> GenerationResult | None:
+        """The same, answering with what the row managed rather than whether it"""
+        return self._require_open().withdraw(row)
 
     def step(self) -> list[GenerationEvent]:
         """What the batch produced in one decode step."""
@@ -2971,6 +2975,7 @@ def fast_generate(
 
 
 __all__ = [
+    "BatchRowRefused",
     "BatchStream",
     "GenerationDefaults",
     "GenerationEvent",
@@ -2981,4 +2986,5 @@ __all__ = [
     "generate_batch",
     "generation_mode",
     "stream_batch",
+    "stream_unavailable_reason",
 ]

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -128,11 +128,16 @@ class SamplingParams:
     top_p: float = 0.0
     top_k: int = 0
     min_p: float = 0.0
+    seed: int | None = None
 
     def __post_init__(self):
         temperature = float(self.temperature)
         top_p = float(self.top_p)
         min_p = float(self.min_p)
+        if self.seed is not None:
+            if isinstance(self.seed, bool) or not isinstance(self.seed, Integral):
+                raise TypeError("seed must be an integer or None.")
+            object.__setattr__(self, "seed", int(self.seed) % (2**64))
         if not math.isfinite(temperature) or temperature < 0:
             raise ValueError("temperature must be a finite value >= 0.")
         if not math.isfinite(top_p) or not 0 <= top_p <= 1:
@@ -474,6 +479,108 @@ def _probe_sampler_api(sample_utils_module):
         signature.bind(temp=0.0, top_p=0.0, top_k=0, min_p=0.0)
     except TypeError as exc:
         raise _api_shape_error("make_sampler call signature is incompatible") from exc
+
+
+def _draws_seeded(sampling: SamplingParams) -> bool:
+    """Whether this request's seed changes anything: argmax draws nothing."""
+    return sampling.seed is not None and sampling.temperature != 0
+
+
+def _seeded_sampler(sample_utils_module, params: SamplingParams):
+    """``make_sampler``'s chain drawing from a request key instead of global RNG."""
+    import mlx.core as mx
+
+    if params.temperature == 0:
+        return lambda logprobs: mx.argmax(logprobs, axis=-1)
+
+    stages = []
+    if 0 < params.top_p < 1.0:
+        stages.append(lambda x: sample_utils_module.apply_top_p(x, params.top_p))
+    if params.min_p != 0.0:
+        stages.append(lambda x: sample_utils_module.apply_min_p(x, params.min_p, 1))
+    if params.top_k > 0:
+        stages.append(lambda x: sample_utils_module.apply_top_k(x, params.top_k))
+
+    state = {"key": mx.random.key(params.seed)}
+
+    def sampler(logprobs):
+        for stage in stages:
+            logprobs = stage(logprobs)
+        state["key"], subkey = mx.random.split(state["key"])
+        return mx.random.categorical(logprobs * (1 / params.temperature), key=subkey)
+
+    return sampler
+
+
+class _PerRowSeededSampler:
+    """One RNG stream per row for a backend that takes only one sampler.
+
+    mlx-vlm's ``BatchGenerator`` holds a single sampler for the whole batch and
+    hands every row the same ``row_ids`` and ``positions`` in the plain decode
+    path, so rows sharing a prompt sample identically -- an ``n``-way fan-out
+    returns one answer ``n`` times. Identity therefore has to come from the
+    caller: ``row_uids`` is the live row order, set before each step from the
+    finish reasons the event stream already reports. Width is checked against it
+    as a guard -- it catches a batch that admitted or retired rows this adapter
+    did not see, which is the failure that would silently swap RNG streams; it
+    cannot confirm the order itself.
+
+    Rows without a seed fall through to ``fallback``, which draws from the global
+    RNG exactly as an unbatched unseeded request does.
+    """
+
+    def __init__(self, seeds, *, params: SamplingParams, sample_utils_module, fallback):
+        self._params = params
+        self._sample_utils = sample_utils_module
+        self._fallback = fallback
+        self._seeds = list(seeds)
+        self._by_uid: dict[Any, Any] = {}
+        self._samplers: dict[Any, Any] = {}
+        self.row_uids: list[Any] = []
+
+    def bind_uids(self, uids) -> None:
+        if len(uids) != len(self._seeds):
+            raise RuntimeError(
+                f"batch admitted {len(uids)} rows for {len(self._seeds)} seeded "
+                "requests; per-row seeds cannot be matched to rows."
+            )
+        self._by_uid = dict(zip(uids, self._seeds))
+        self.row_uids = list(uids)
+
+    def _row_sampler(self, uid):
+        sampler = self._samplers.get(uid)
+        if sampler is None:
+            seed = self._by_uid.get(uid)
+            sampler = (
+                self._fallback
+                if seed is None
+                else _seeded_sampler(
+                    self._sample_utils,
+                    replace(self._params, seed=seed),
+                )
+            )
+            self._samplers[uid] = sampler
+        return sampler
+
+    def __call__(self, logprobs):
+        import mlx.core as mx
+
+        width = logprobs.shape[0]
+        if width != len(self.row_uids):
+            raise RuntimeError(
+                f"{_installed_mlx_vlm_version()} stepped a batch of {width} rows "
+                f"while {len(self.row_uids)} were tracked as live, so per-row "
+                "seeds cannot be matched to rows. Generate without seeds, or "
+                "pin a release whose batch admits and retires rows through its "
+                "event stream."
+            )
+        return mx.concatenate(
+            [
+                self._row_sampler(uid)(logprobs[row : row + 1])
+                for row, uid in enumerate(self.row_uids)
+            ],
+            axis=0,
+        )
 
 
 def _iter_model_modules(model) -> list[Any]:
@@ -1080,6 +1187,7 @@ class _TextBatchAdapter:
         _probe_sampler_api(sample_utils_module)
         self.batch_generator_type = generate_module.BatchGenerator
         self.make_sampler = sample_utils_module.make_sampler
+        self.sample_utils = sample_utils_module
         self.model = model
         self.tokenizer = tokenizer
         self.defaults = defaults
@@ -1095,7 +1203,9 @@ class _TextBatchAdapter:
             for request in requests
         ]
         samplers = [
-            self.make_sampler(
+            _seeded_sampler(self.sample_utils, params)
+            if params.seed is not None
+            else self.make_sampler(
                 temp=params.temperature,
                 top_p=params.top_p,
                 top_k=params.top_k,
@@ -1388,6 +1498,7 @@ class _VLMBatchAdapter:
         sample_utils = importlib.import_module("mlx_lm.sample_utils")
         _probe_sampler_api(sample_utils)
         self.make_sampler = sample_utils.make_sampler
+        self.sample_utils = sample_utils
         self.model = model
         self.processor = processor
         self.defaults = defaults
@@ -1572,18 +1683,27 @@ class _VLMBatchAdapter:
         for index, request in enumerate(requests):
             if request.audio is None:
                 groups.setdefault(self._group_key(request), []).append(index)
-        # Older releases slice shared kwargs from row zero on every prefill
-        # batch, pairing later prompts with earlier embeddings, so they run one
-        # chunk per generator. Per-row releases keep the configured sizes.
-        capacity = (
-            None
-            if self.per_row_prompt_kwargs
-            else min(
-                self.defaults.prefill_batch_size,
-                self.defaults.completion_batch_size,
-            )
-        )
         for indices in groups.values():
+            # Older releases slice shared kwargs from row zero on every prefill
+            # batch, pairing later prompts with earlier embeddings, so they run one
+            # chunk per generator. Per-row releases keep the configured sizes.
+            #
+            # A group carrying per-row seeds takes the smaller sizes too: seeds
+            # identify rows by the live batch width, which is unambiguous only
+            # while it never grows, and a chunk larger than the prefill batch
+            # admits its rows in waves. Only the groups that need it pay.
+            seeded = any(
+                _draws_seeded(requests[index].sampling or self.defaults.sampling)
+                for index in indices
+            )
+            capacity = (
+                None
+                if self.per_row_prompt_kwargs and not seeded
+                else min(
+                    self.defaults.prefill_batch_size,
+                    self.defaults.completion_batch_size,
+                )
+            )
             step = capacity or len(indices)
             for start in range(0, len(indices), step):
                 chunk = indices[start : start + step]
@@ -1623,11 +1743,15 @@ class _VLMBatchAdapter:
             request.prompt,
             audio=request.audio,
             max_tokens=int(request.max_tokens or self.defaults.max_tokens),
-            sampler=self.make_sampler(
-                temp=sampling.temperature,
-                top_p=sampling.top_p,
-                top_k=sampling.top_k,
-                min_p=sampling.min_p,
+            sampler=(
+                _seeded_sampler(self.sample_utils, sampling)
+                if _draws_seeded(sampling)
+                else self.make_sampler(
+                    temp=sampling.temperature,
+                    top_p=sampling.top_p,
+                    top_k=sampling.top_k,
+                    min_p=sampling.min_p,
+                )
             ),
         )
         for event in events:
@@ -1716,8 +1840,25 @@ class _VLMBatchAdapter:
                 min_p=sampling.min_p,
             ),
         }
+        # Grouping keys on the sampling knobs but not the seed, so one chunk can
+        # carry several seeds and the fan-out case -- one prompt, n seeds -- stays
+        # a single batch.
+        seeds = [
+            (request.sampling or self.defaults.sampling).seed
+            if _draws_seeded(request.sampling or self.defaults.sampling)
+            else None
+            for request in chunk
+        ]
+        row_sampler = None
+        if any(seed is not None for seed in seeds):
+            row_sampler = _PerRowSeededSampler(
+                seeds,
+                params=sampling,
+                sample_utils_module=self.sample_utils,
+                fallback=options["sampler"],
+            )
+            options["sampler"] = row_sampler
         if "compute_logprobs" in self.constructor_params:
-            # The public helper turns this off, but logprobs are contract here.
             options["compute_logprobs"] = True
         max_tokens = [
             int(request.max_tokens or self.defaults.max_tokens) for request in chunk
@@ -1732,8 +1873,6 @@ class _VLMBatchAdapter:
                     mask=mask,
                     **data_kwargs,
                 )
-                # Optional fields enumerate as None and would overwrite valid
-                # prepare_inputs values; upstream filters them the same way.
                 gen_kwargs = {**data_kwargs, **{
                     key: value
                     for key, value in embedding_output.to_dict().items()
@@ -1767,7 +1906,9 @@ class _VLMBatchAdapter:
                     )
                 else:
                     uids = generator.insert(token_ids, max_tokens)
-                return self._drive(generator, uids, gen_kwargs)
+                if row_sampler is not None:
+                    row_sampler.bind_uids(uids)
+                return self._drive(generator, uids, gen_kwargs, row_sampler)
         except BaseException as exc:
             active_error = exc
             raise
@@ -1789,7 +1930,13 @@ class _VLMBatchAdapter:
                     except BaseException:
                         pass
 
-    def _drive(self, generator, uids, gen_kwargs) -> list[GenerationResult]:
+    def _drive(
+        self,
+        generator,
+        uids,
+        gen_kwargs,
+        row_sampler=None,
+    ) -> list[GenerationResult]:
         tokenizer = getattr(self.processor, "tokenizer", self.processor)
         pending = {
             uid: _PendingResult(
@@ -1799,7 +1946,14 @@ class _VLMBatchAdapter:
             for uid in uids
         }
         completed: dict[int, GenerationResult] = {}
+        # Rows still in the batch, in batch order. A per-row sampler reads this to
+        # tell its rows apart, since the release gives it nothing that can (see
+        # _PerRowSeededSampler). Retirement is observable: a row leaves on its
+        # finish reason, or when a stop string cancels it below.
+        live = list(uids)
         while pending:
+            if row_sampler is not None:
+                row_sampler.row_uids = list(live)
             if self.per_row_prompt_kwargs:
                 if not generator.has_work:
                     raise RuntimeError(
@@ -1820,10 +1974,12 @@ class _VLMBatchAdapter:
                     )
                 continue
             for event in events:
+                finish_reason = event.finish_reason
+                if finish_reason is not None and event.uid in live:
+                    live.remove(event.uid)
                 state = pending.get(event.uid)
                 if state is None:
                     continue
-                finish_reason = event.finish_reason
                 if finish_reason is None:
                     stopped = state.append(
                         tokenizer,
@@ -1831,11 +1987,10 @@ class _VLMBatchAdapter:
                         _event_logprob(event),
                     )
                     if stopped:
-                        # Where the release cannot cancel, the sequence keeps
-                        # decoding upstream and its later events are ignored;
-                        # results match either way, only wasted decode differs.
                         if self.cancel is not None:
                             self.cancel(generator, event.uid)
+                            if event.uid in live:
+                                live.remove(event.uid)
                         completed[event.uid] = state.result(tokenizer)
                         del pending[event.uid]
                     continue
@@ -1875,8 +2030,6 @@ def generate_batch(
         defaults = GenerationDefaults()
     if not isinstance(defaults, GenerationDefaults):
         raise TypeError("defaults must be GenerationDefaults.")
-    # Routing follows the model, not the request: a vision model preprocesses
-    # text-only prompts too.
     is_vlm = bool(getattr(model, "_is_vlm_model", False))
     validated = (
         _validate_vlm_requests(requests, defaults)
@@ -1886,8 +2039,6 @@ def generate_batch(
     if not validated:
         return []
     if is_vlm:
-        # A text-only multimodal load stays on the vision path but publishes its
-        # inner tokenizer, which cannot drive mlx-vlm preprocessing.
         tokenizer_or_processor = (
             getattr(model, "_processor", None) or tokenizer_or_processor
         )

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -32,7 +32,7 @@ import warnings
 from collections.abc import Mapping
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field, replace
-from numbers import Integral
+from numbers import Integral, Real
 from typing import Any, Callable, Iterator, Literal, Sequence
 
 
@@ -183,6 +183,22 @@ class GenerationDefaults:
         )
         if self.max_kv_size is not None:
             _validate_positive_int(self.max_kv_size, "defaults.max_kv_size")
+        if self.kv_bits is not None:
+            if isinstance(self.kv_bits, bool) or not isinstance(self.kv_bits, Real):
+                raise TypeError("defaults.kv_bits must be a number.")
+            if not math.isfinite(self.kv_bits) or self.kv_bits <= 0:
+                raise ValueError("defaults.kv_bits must be a finite positive number.")
+        if self.kv_group_size is not None:
+            _validate_positive_int(self.kv_group_size, "defaults.kv_group_size")
+        if self.kv_quant_scheme is not None and not isinstance(self.kv_quant_scheme, str):
+            raise TypeError("defaults.kv_quant_scheme must be a string.")
+        if self.quantized_kv_start is not None:
+            if isinstance(self.quantized_kv_start, bool) or not isinstance(
+                self.quantized_kv_start, Integral
+            ):
+                raise TypeError("defaults.quantized_kv_start must be an integer.")
+            if self.quantized_kv_start < 0:
+                raise ValueError("defaults.quantized_kv_start must not be negative.")
         if not isinstance(self.sampling, SamplingParams):
             raise TypeError("defaults.sampling must be SamplingParams.")
         stops = _normalize_stop_strings(self.stop_strings)
@@ -2683,6 +2699,10 @@ class _VLMBatchSession:
                 "An audio request decodes on its own and cannot join a batch; "
                 "generate it with generate_batch or stream_batch."
             )
+        if request.logits_processors and not adapter.row_logits_processors:
+            raise BatchRowRefused(
+                "This mlx-vlm's batch cannot carry a row's own logits processors."
+            )
         input_ids, prompt_kwargs = self._prepare(request)
         row_processors = adapter._row_logits_processors([request])
         token_ids = input_ids.tolist()
@@ -3222,4 +3242,5 @@ __all__ = [
     "row_logits_processors_unavailable_reason",
     "stream_batch",
     "stream_unavailable_reason",
+    "vlm_batch_adds_special_tokens",
 ]

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -31,7 +31,7 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from numbers import Integral
-from typing import Any, Literal, Sequence
+from typing import Any, Iterator, Literal, Sequence
 
 
 _TEXT_EVENT_FIELDS = frozenset(("uid", "token", "logprobs", "finish_reason"))
@@ -957,6 +957,33 @@ def _install_arrays_cache_advance_fix():
             _VLM_ARRAYS_CACHE_ADVANCE_RESOLVED = True
 
 
+@dataclass(frozen=True)
+class GenerationEvent:
+    """One row's progress through a batch, in the order the batch produced it."""
+
+    index: int
+    delta: str = ""
+    result: GenerationResult | None = None
+
+
+def _text_events(index: int, state: "_PendingResult") -> Iterator[GenerationEvent]:
+    delta = state.release()
+    if delta:
+        yield GenerationEvent(index=index, delta=delta)
+
+
+def _finished_events(
+    index: int,
+    state: "_PendingResult",
+    tokenizer,
+) -> Iterator[GenerationEvent]:
+    yield GenerationEvent(
+        index=index,
+        delta=state.release(),
+        result=state.result(tokenizer),
+    )
+
+
 class _StopStringScanner:
     """Incrementally search new detokenized text with longest-stop lookback."""
 
@@ -1074,8 +1101,15 @@ class _PendingResult:
     token_ids: list[int] = field(default_factory=list)
     logprobs: list[float] = field(default_factory=list)
     text: str = ""
+    released: int = 0
     finish_reason: Literal["stop", "length", "stop_string"] | None = None
     stop_match: str | None = None
+
+    def release(self) -> str:
+        """Text this row has not handed out yet."""
+        delta = self.text[self.released :]
+        self.released = len(self.text)
+        return delta
 
     def _apply_stop_match(
         self,
@@ -1097,6 +1131,7 @@ class _PendingResult:
         del self.token_ids[keep:]
         del self.logprobs[keep:]
         self.text = _replay_stream_text(self.detokenizer, self.token_ids)
+        self.released = min(self.released, len(self.text))
         self.finish_reason = "stop_string"
 
     def add_terminal(self, token: int, logprob: float):
@@ -1192,7 +1227,7 @@ class _TextBatchAdapter:
         self.tokenizer = tokenizer
         self.defaults = defaults
 
-    def generate(self, requests: Sequence[GenerationRequest]) -> list[GenerationResult]:
+    def stream(self, requests: Sequence[GenerationRequest]) -> Iterator[GenerationEvent]:
         prompts = [_encode_prompt(self.tokenizer, request) for request in requests]
         max_tokens = [
             int(request.max_tokens or self.defaults.max_tokens)
@@ -1236,7 +1271,7 @@ class _TextBatchAdapter:
                 )
                 for uid in uids
             }
-            completed: dict[int, GenerationResult] = {}
+            row_of = {uid: row for row, uid in enumerate(uids)}
             while pending:
                 events = generator.next_generated()
                 if not events:
@@ -1248,6 +1283,7 @@ class _TextBatchAdapter:
                     state = pending.get(event.uid)
                     if state is None:
                         continue
+                    row = row_of[event.uid]
                     finish_reason = event.finish_reason
                     if finish_reason is None:
                         stopped = state.append(
@@ -1255,11 +1291,12 @@ class _TextBatchAdapter:
                             int(event.token),
                             _sampled_logprob(event),
                         )
-                        if stopped:
-                            generator.remove([event.uid])
-                            completed[event.uid] = state.result(self.tokenizer)
-                            del pending[event.uid]
+                        if not stopped:
+                            yield from _text_events(row, state)
                             continue
+                        generator.remove([event.uid])
+                        yield from _finished_events(row, state, self.tokenizer)
+                        del pending[event.uid]
                         continue
                     if finish_reason not in ("stop", "length"):
                         raise RuntimeError(
@@ -1272,9 +1309,8 @@ class _TextBatchAdapter:
                             _sampled_logprob(event),
                         )
                     state.finish(self.tokenizer, finish_reason)
-                    completed[event.uid] = state.result(self.tokenizer)
+                    yield from _finished_events(row, state, self.tokenizer)
                     del pending[event.uid]
-            return [completed[uid] for uid in uids]
         except BaseException as exc:
             active_error = exc
             raise
@@ -1471,7 +1507,9 @@ class _VLMBatchAdapter:
     release's chunked-prefill policy, and the wired-limit window.
     """
 
-    def __init__(self, model, processor, defaults: GenerationDefaults):
+    def __init__(
+        self, model, processor, defaults: GenerationDefaults, *, audio_warn_stacklevel = 3,
+    ):
         batch_module = _resolve_module_attr(_VLM_BATCH_MODULES, "BatchGenerator")
         if batch_module is None:
             raise _vlm_api_shape_error("no importable module exposes BatchGenerator")
@@ -1502,6 +1540,7 @@ class _VLMBatchAdapter:
         self.model = model
         self.processor = processor
         self.defaults = defaults
+        self.audio_warn_stacklevel = audio_warn_stacklevel
 
     def _wired_limit(self):
         """Raise the wired limit, which ``generation_mode`` restores but never raises."""
@@ -1663,22 +1702,20 @@ class _VLMBatchAdapter:
             f"Got {type(image).__name__}."
         )
 
-    def generate(self, requests: Sequence[GenerationRequest]) -> list[GenerationResult]:
+    def stream(self, requests: Sequence[GenerationRequest]) -> Iterator[GenerationEvent]:
         requests = [self._decode_image(request) for request in requests]
-        results: list[GenerationResult | None] = [None] * len(requests)
-        audio_indices = [
+        audio_rows = [
             index for index, request in enumerate(requests) if request.audio is not None
         ]
-        if audio_indices:
-            # No supported release batches audio.
+        if audio_rows:
             warnings.warn(
-                f"{len(audio_indices)} audio request(s) decode one at a time: "
+                f"{len(audio_rows)} audio request(s) decode one at a time: "
                 f"{_installed_mlx_vlm_version()} batches text and images only.",
                 RuntimeWarning,
-                stacklevel=3,
+                stacklevel = self.audio_warn_stacklevel,
             )
-            for index in audio_indices:
-                results[index] = self._generate_sequentially(requests[index])
+        for index in audio_rows:
+            yield from self._stream_sequentially(index, requests[index])
         groups: dict[Any, list[int]] = {}
         for index, request in enumerate(requests):
             if request.audio is None:
@@ -1706,18 +1743,13 @@ class _VLMBatchAdapter:
             )
             step = capacity or len(indices)
             for start in range(0, len(indices), step):
-                chunk = indices[start : start + step]
-                for index, result in zip(chunk, self._run_chunk(requests, chunk)):
-                    results[index] = result
-        if any(result is None for result in results):
-            raise RuntimeError(
-                "Internal error: batched vision generation produced no result "
-                f"for {sum(result is None for result in results)} of "
-                f"{len(results)} requests."
-            )
-        return results
+                yield from self._run_chunk(requests, indices[start : start + step])
 
-    def _generate_sequentially(self, request: GenerationRequest) -> GenerationResult:
+    def _stream_sequentially(
+        self,
+        index: int,
+        request: GenerationRequest,
+    ) -> Iterator[GenerationEvent]:
         """One audio request through the release's sequential stream.
 
         The stream's terminal event carries no new token: it repeats the last
@@ -1760,14 +1792,17 @@ class _VLMBatchAdapter:
                 int(previous.token),
                 _event_logprob(previous),
             ):
-                return state.result(tokenizer)
+                yield from _finished_events(index, state, tokenizer)
+                return
+            if previous is not None:
+                yield from _text_events(index, state)
             previous = event
         if previous is None:
             raise RuntimeError(
                 "mlx-vlm produced no events for an audio request."
             )
         state.finish(tokenizer, self._terminal_reason(previous, tokenizer))
-        return state.result(tokenizer)
+        yield from _finished_events(index, state, tokenizer)
 
     @staticmethod
     def _terminal_reason(event, tokenizer) -> Literal["stop", "length"]:
@@ -1797,7 +1832,7 @@ class _VLMBatchAdapter:
         self,
         requests: Sequence[GenerationRequest],
         indices: Sequence[int],
-    ) -> list[GenerationResult]:
+    ) -> Iterator[GenerationEvent]:
         chunk = [requests[index] for index in indices]
         batch_size = len(chunk)
         prompts = [request.prompt for request in chunk]
@@ -1908,7 +1943,9 @@ class _VLMBatchAdapter:
                     uids = generator.insert(token_ids, max_tokens)
                 if row_sampler is not None:
                     row_sampler.bind_uids(uids)
-                return self._drive(generator, uids, gen_kwargs, row_sampler)
+                yield from self._drive(
+                    generator, uids, indices, gen_kwargs, row_sampler,
+                )
         except BaseException as exc:
             active_error = exc
             raise
@@ -1934,9 +1971,10 @@ class _VLMBatchAdapter:
         self,
         generator,
         uids,
+        indices,
         gen_kwargs,
         row_sampler=None,
-    ) -> list[GenerationResult]:
+    ) -> Iterator[GenerationEvent]:
         tokenizer = getattr(self.processor, "tokenizer", self.processor)
         pending = {
             uid: _PendingResult(
@@ -1945,7 +1983,7 @@ class _VLMBatchAdapter:
             )
             for uid in uids
         }
-        completed: dict[int, GenerationResult] = {}
+        row_of = dict(zip(uids, indices))
         # Rows still in the batch, in batch order. A per-row sampler reads this to
         # tell its rows apart, since the release gives it nothing that can (see
         # _PerRowSeededSampler). Retirement is observable: a row leaves on its
@@ -1986,13 +2024,15 @@ class _VLMBatchAdapter:
                         int(event.token),
                         _event_logprob(event),
                     )
-                    if stopped:
-                        if self.cancel is not None:
-                            self.cancel(generator, event.uid)
-                            if event.uid in live:
-                                live.remove(event.uid)
-                        completed[event.uid] = state.result(tokenizer)
-                        del pending[event.uid]
+                    if not stopped:
+                        yield from _text_events(row_of[event.uid], state)
+                        continue
+                    if self.cancel is not None:
+                        self.cancel(generator, event.uid)
+                        if event.uid in live:
+                            live.remove(event.uid)
+                    yield from _finished_events(row_of[event.uid], state, tokenizer)
+                    del pending[event.uid]
                     continue
                 if finish_reason not in ("stop", "length"):
                     raise RuntimeError(
@@ -2002,9 +2042,8 @@ class _VLMBatchAdapter:
                 if finish_reason == "length":
                     state.add_terminal(int(event.token), _event_logprob(event))
                 state.finish(tokenizer, finish_reason)
-                completed[event.uid] = state.result(tokenizer)
+                yield from _finished_events(row_of[event.uid], state, tokenizer)
                 del pending[event.uid]
-        return [completed[uid] for uid in uids]
 
 
 @contextmanager
@@ -2026,6 +2065,48 @@ def generate_batch(
     with them.
     """
 
+    results: list[GenerationResult | None] = [None] * len(requests)
+    for event in _stream_batch(
+        model, tokenizer_or_processor, requests, defaults=defaults,
+        audio_warn_stacklevel=3,
+    ):
+        if event.result is not None:
+            results[event.index] = event.result
+    if any(result is None for result in results):
+        raise RuntimeError(
+            "Internal error: batched generation produced no result for "
+            f"{sum(result is None for result in results)} of {len(results)} requests."
+        )
+    return results
+
+
+def stream_batch(
+    model,
+    tokenizer_or_processor,
+    requests: Sequence[GenerationRequest],
+    *,
+    defaults: GenerationDefaults | None = None,
+) -> Iterator[GenerationEvent]:
+    """``generate_batch``, reporting each row as it goes."""
+    if defaults is not None and defaults.stop_strings:
+        raise ValueError(
+            "stream_batch cannot apply stop_strings: they cut on token "
+            "boundaries, which would retract text already streamed. Scan the "
+            "deltas for them instead, or use generate_batch."
+        )
+    return _stream_batch(
+        model, tokenizer_or_processor, requests, defaults=defaults,
+    )
+
+
+def _stream_batch(
+    model,
+    tokenizer_or_processor,
+    requests: Sequence[GenerationRequest],
+    *,
+    defaults: GenerationDefaults | None = None,
+    audio_warn_stacklevel: int = 2,
+) -> Iterator[GenerationEvent]:
     if defaults is None:
         defaults = GenerationDefaults()
     if not isinstance(defaults, GenerationDefaults):
@@ -2037,7 +2118,7 @@ def generate_batch(
         else _validate_text_requests(requests, defaults)
     )
     if not validated:
-        return []
+        return
     if is_vlm:
         tokenizer_or_processor = (
             getattr(model, "_processor", None) or tokenizer_or_processor
@@ -2052,11 +2133,14 @@ def generate_batch(
     with generation_mode(model):
         with _generation_cache_hygiene():
             adapter = (
-                _VLMBatchAdapter(model, tokenizer_or_processor, defaults)
+                _VLMBatchAdapter(
+                    model, tokenizer_or_processor, defaults,
+                    audio_warn_stacklevel = audio_warn_stacklevel + 1,
+                )
                 if is_vlm
                 else _TextBatchAdapter(model, tokenizer_or_processor, defaults)
             )
-            return adapter.generate(validated)
+            yield from adapter.stream(validated)
 
 
 def fast_generate(
@@ -2127,10 +2211,12 @@ def fast_generate(
 
 __all__ = [
     "GenerationDefaults",
+    "GenerationEvent",
     "GenerationRequest",
     "GenerationResult",
     "SamplingParams",
     "fast_generate",
     "generate_batch",
     "generation_mode",
+    "stream_batch",
 ]

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -325,6 +325,11 @@ def _validate_text_requests(
                 f"requests[{index}] includes media, but text models accept "
                 "text prompts only."
             )
+    _validate_text_defaults(defaults)
+    return validated
+
+
+def _validate_text_defaults(defaults: GenerationDefaults) -> None:
     refused_kv = [
         name for name in _KV_QUANT_CONTROLS if getattr(defaults, name) is not None
     ]
@@ -334,7 +339,6 @@ def _validate_text_requests(
             f"mlx-lm text path (installed: {_installed_mlx_lm_version()}); "
             "omit these controls."
         )
-    return validated
 
 
 def _kv_quant_options(defaults: GenerationDefaults) -> dict:
@@ -499,6 +503,11 @@ def _validate_vlm_requests(
         if isinstance(request.image, os.PathLike):
             # mlx-vlm's loader opens str paths only.
             validated[index] = replace(request, image=os.fspath(request.image))
+    _validate_vlm_defaults(defaults)
+    return validated
+
+
+def _validate_vlm_defaults(defaults: GenerationDefaults) -> None:
     if defaults.prefill_batch_size > defaults.completion_batch_size:
         # An inverted pair never admits anything on mlx-vlm, so generation would
         # hang. mlx-lm normalizes the two, so this is vision-specific.
@@ -522,7 +531,6 @@ def _validate_vlm_requests(
             f"{_installed_mlx_vlm_version()} exposes no KV-window control on "
             "its batch generator. Omit it, or use model.generate."
         )
-    return validated
 
 
 def _api_shape_error(details: str) -> RuntimeError:
@@ -2910,15 +2918,12 @@ class _VLMBatchSession:
 def _stream_setup(model, tokenizer, defaults: GenerationDefaults):
     """What a stream settles before it takes anything: vision or not, and the adapter."""
     if bool(getattr(model, "_is_vlm_model", False)):
-        refused = _vlm_kv_controls_refused(defaults)
-        if refused:
-            raise ValueError(
-                f"{' and '.join(refused)} would be dropped rather than applied by "
-                f"{_installed_mlx_vlm_version()}'s batch generator; omit these controls."
-            )
+        _validate_vlm_defaults(defaults)
         gap = _vlm_quantized_cache_gap(model, defaults)
         if gap is not None:
             raise ValueError(gap)
+    else:
+        _validate_text_defaults(defaults)
     if defaults.stop_strings:
         raise ValueError(
             "BatchStream cannot apply stop_strings: they cut on token "

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -28,7 +28,7 @@ import threading
 import types
 import warnings
 from collections.abc import Mapping
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field, replace
 from numbers import Integral
 from typing import Any, Iterator, Literal, Sequence
@@ -1217,6 +1217,171 @@ def _sampled_logprob(event) -> float:
     return float(value)
 
 
+def _warn_preserving(
+    what: str,
+    active_error: BaseException,
+    secondary: BaseException,
+) -> None:
+    """Report a second failure that must not replace the error already in flight."""
+    try:
+        warnings.warn(
+            f"{what} failed while preserving an active "
+            f"{type(active_error).__name__}: {secondary}",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+    except BaseException:
+        pass
+
+
+class _TextBatchSession:
+    """One mlx-lm ``BatchGenerator`` with its row set left open."""
+
+    def __init__(self, adapter: "_TextBatchAdapter"):
+        self.adapter = adapter
+        defaults = adapter.defaults
+        self.generator = adapter.batch_generator_type(
+            adapter.model,
+            max_tokens=defaults.max_tokens,
+            stop_tokens=_eos_stop_tokens(adapter.tokenizer),
+            prefill_batch_size=defaults.prefill_batch_size,
+            completion_batch_size=defaults.completion_batch_size,
+            max_kv_size=defaults.max_kv_size,
+        )
+        self._pending: dict[int, _PendingResult] = {}
+        self._row_of: dict[int, int] = {}
+        self._uid_of: dict[int, int] = {}
+        self._next_row = 0
+        self.usable = True
+
+    @property
+    def rows_in_flight(self) -> int:
+        return len(self._pending)
+
+    def add(self, request: GenerationRequest) -> int:
+        adapter = self.adapter
+        defaults = adapter.defaults
+        prompt = _encode_prompt(adapter.tokenizer, request)
+        params = request.sampling or defaults.sampling
+        sampler = (
+            _seeded_sampler(adapter.sample_utils, params)
+            if params.seed is not None
+            else adapter.make_sampler(
+                temp=params.temperature,
+                top_p=params.top_p,
+                top_k=params.top_k,
+                min_p=params.min_p,
+            )
+        )
+        try:
+            uids = self.generator.insert(
+                [prompt],
+                max_tokens=[int(request.max_tokens or defaults.max_tokens)],
+                samplers=[sampler],
+                logits_processors=[[]],
+            )
+        except BaseException:
+            self.usable = False
+            raise
+        try:
+            if len(uids) != 1:
+                raise RuntimeError(
+                    f"mlx-lm answered a one-prompt insert with {len(uids)} uids."
+                )
+            uid = uids[0]
+            state = _PendingResult(
+                detokenizer=_new_detokenizer(adapter.tokenizer),
+                scanner=_StopStringScanner(defaults.stop_strings),
+                prompt_token_count=len(prompt),
+            )
+        except BaseException as active_error:
+            try:
+                self.generator.remove(list(uids))
+            except BaseException as rollback_error:
+                self.usable = False
+                _warn_preserving(
+                    "handing a rejected row back to mlx-lm",
+                    active_error,
+                    rollback_error,
+                )
+            raise
+        row = self._next_row
+        self._next_row += 1
+        self._pending[uid] = state
+        self._row_of[uid] = row
+        self._uid_of[row] = uid
+        return row
+
+    def cancel(self, row: int) -> bool:
+        """Withdraw a row. False if it was never added, or has already ended."""
+        uid = self._uid_of.get(row)
+        if uid is None or uid not in self._pending:
+            return False
+        try:
+            self.generator.remove([uid])
+        except BaseException:
+            self.usable = False
+            raise
+        self._retire(uid)
+        return True
+
+    def step(self) -> Iterator[GenerationEvent]:
+        """One decode step's worth of events, or none while no row is in flight."""
+        if not self._pending:
+            return
+        try:
+            responses = self.generator.next_generated()
+            if not responses:
+                raise RuntimeError(
+                    "mlx-lm ended its event stream before every request "
+                    "reported a finish reason."
+                )
+            for response in responses:
+                yield from self._consume(response)
+        except BaseException:
+            self.usable = False
+            raise
+
+    def close(self):
+        self.generator.close()
+
+    def _retire(self, uid: int):
+        row = self._row_of.pop(uid, None)
+        self._pending.pop(uid, None)
+        if row is not None:
+            self._uid_of.pop(row, None)
+
+    def _consume(self, response) -> Iterator[GenerationEvent]:
+        state = self._pending.get(response.uid)
+        if state is None:
+            return
+        row = self._row_of[response.uid]
+        finish_reason = response.finish_reason
+        if finish_reason is None:
+            stopped = state.append(
+                self.adapter.tokenizer,
+                int(response.token),
+                _sampled_logprob(response),
+            )
+            if not stopped:
+                yield from _text_events(row, state)
+                return
+            self.generator.remove([response.uid])
+            yield from _finished_events(row, state, self.adapter.tokenizer)
+            self._retire(response.uid)
+            return
+        if finish_reason not in ("stop", "length"):
+            raise RuntimeError(
+                "mlx-lm emitted an unsupported finish reason: "
+                f"{finish_reason!r}."
+            )
+        if finish_reason == "length":
+            state.add_terminal(int(response.token), _sampled_logprob(response))
+        state.finish(self.adapter.tokenizer, finish_reason)
+        yield from _finished_events(row, state, self.adapter.tokenizer)
+        self._retire(response.uid)
+
+
 class _TextBatchAdapter:
     def __init__(self, model, tokenizer, defaults: GenerationDefaults):
         generate_module = importlib.import_module("mlx_lm.generate")
@@ -1231,96 +1396,19 @@ class _TextBatchAdapter:
         self.defaults = defaults
 
     def stream(self, requests: Sequence[GenerationRequest]) -> Iterator[GenerationEvent]:
-        prompts = [_encode_prompt(self.tokenizer, request) for request in requests]
-        max_tokens = [
-            int(request.max_tokens or self.defaults.max_tokens)
-            for request in requests
-        ]
-        sampling = [
-            request.sampling or self.defaults.sampling
-            for request in requests
-        ]
-        samplers = [
-            _seeded_sampler(self.sample_utils, params)
-            if params.seed is not None
-            else self.make_sampler(
-                temp=params.temperature,
-                top_p=params.top_p,
-                top_k=params.top_k,
-                min_p=params.min_p,
-            )
-            for params in sampling
-        ]
-        generator = self.batch_generator_type(
-            self.model,
-            max_tokens=self.defaults.max_tokens,
-            stop_tokens=_eos_stop_tokens(self.tokenizer),
-            prefill_batch_size=self.defaults.prefill_batch_size,
-            completion_batch_size=self.defaults.completion_batch_size,
-            max_kv_size=self.defaults.max_kv_size,
-        )
+        session = _TextBatchSession(self)
         active_error = None
         try:
-            uids = generator.insert(
-                prompts,
-                max_tokens=max_tokens,
-                samplers=samplers,
-                logits_processors=[[] for _ in requests],
-            )
-            pending = {
-                uid: _PendingResult(
-                    detokenizer=_new_detokenizer(self.tokenizer),
-                    scanner=_StopStringScanner(self.defaults.stop_strings),
-                    prompt_token_count=len(prompt),
-                )
-                for uid, prompt in zip(uids, prompts)
-            }
-            row_of = {uid: row for row, uid in enumerate(uids)}
-            while pending:
-                events = generator.next_generated()
-                if not events:
-                    raise RuntimeError(
-                        "mlx-lm ended its event stream before every request "
-                        "reported a finish reason."
-                    )
-                for event in events:
-                    state = pending.get(event.uid)
-                    if state is None:
-                        continue
-                    row = row_of[event.uid]
-                    finish_reason = event.finish_reason
-                    if finish_reason is None:
-                        stopped = state.append(
-                            self.tokenizer,
-                            int(event.token),
-                            _sampled_logprob(event),
-                        )
-                        if not stopped:
-                            yield from _text_events(row, state)
-                            continue
-                        generator.remove([event.uid])
-                        yield from _finished_events(row, state, self.tokenizer)
-                        del pending[event.uid]
-                        continue
-                    if finish_reason not in ("stop", "length"):
-                        raise RuntimeError(
-                            "mlx-lm emitted an unsupported finish reason: "
-                            f"{finish_reason!r}."
-                        )
-                    if finish_reason == "length":
-                        state.add_terminal(
-                            int(event.token),
-                            _sampled_logprob(event),
-                        )
-                    state.finish(self.tokenizer, finish_reason)
-                    yield from _finished_events(row, state, self.tokenizer)
-                    del pending[event.uid]
+            for request in requests:
+                session.add(request)
+            while session.rows_in_flight:
+                yield from session.step()
         except BaseException as exc:
             active_error = exc
             raise
         finally:
             try:
-                generator.close()
+                session.close()
             except BaseException as close_error:
                 if active_error is None:
                     raise
@@ -2090,6 +2178,140 @@ def generate_batch(
     return results
 
 
+class BatchStream:
+    """A batch left open: rows join and leave while the batch decodes.
+
+    ``stream_batch`` decodes one fixed set of requests and ends. This is the
+    same decode with the set open, so a server can merge requests that arrived
+    separately into one batch, and retire each row where it ends rather than at
+    the end of the batch. Rows are numbered in the order they were added and
+    keep their number for the stream's life.
+
+    The process-wide generation lock is held from construction until ``close``,
+    and it belongs to the thread *and* the asyncio task that took it: the same
+    one constructs, adds, steps, and closes. Use it as a context manager, or
+    close it in a ``finally``. A call from anywhere else is refused before
+    anything is torn down, so the stream stays closable by its owner.
+
+    Text models only. A vision batch is grouped by image shape and prefilled
+    together, so its rows cannot join a decode already running; ``stream_batch``
+    serves those.
+
+    ``stop_strings`` are unavailable here for the reason ``stream_batch`` gives:
+    they cut on token boundaries, which would retract text already handed out.
+
+    Any call that raises where it may already have changed the batch retires the
+    whole stream: mlx-lm takes and releases a row in several steps, so what it
+    holds afterwards is a question neither side can answer. ``add``, ``step`` and
+    ``cancel`` then refuse; only ``close`` still works. Open another.
+    """
+
+    def __init__(
+        self,
+        model,
+        tokenizer,
+        *,
+        defaults: GenerationDefaults | None = None,
+    ):
+        if defaults is None:
+            defaults = GenerationDefaults()
+        if not isinstance(defaults, GenerationDefaults):
+            raise TypeError("defaults must be GenerationDefaults.")
+        _install_arrays_cache_advance_fix()
+        if defaults.stop_strings:
+            raise ValueError(
+                "BatchStream cannot apply stop_strings: they cut on token "
+                "boundaries, which would retract text already streamed. Scan "
+                "the deltas for them instead."
+            )
+        if bool(getattr(model, "_is_vlm_model", False)):
+            raise ValueError(
+                "BatchStream decodes text models. A vision batch is grouped by "
+                "image shape and prefilled together, so its rows cannot join a "
+                "decode already running; use stream_batch."
+            )
+        if tokenizer is None:
+            raise ValueError("Text batched generation requires a tokenizer.")
+        self._stack = ExitStack()
+        self._session = None
+        self._closed = False
+        self._owner = (threading.get_ident(), _current_async_task())
+        try:
+            self._stack.enter_context(generation_mode(model))
+            self._stack.enter_context(_generation_cache_hygiene())
+            adapter = _TextBatchAdapter(model, tokenizer, defaults)
+            self._session = _TextBatchSession(adapter)
+            self._stack.callback(self._session.close)
+        except BaseException as active_error:
+            try:
+                self._stack.close()
+            except BaseException as close_error:
+                _warn_preserving("tearing the batch down", active_error, close_error)
+            raise
+
+    def __enter__(self) -> "BatchStream":
+        return self
+
+    def __exit__(self, _exc_type, active_error, _traceback) -> None:
+        try:
+            self.close()
+        except BaseException as close_error:
+            if active_error is None:
+                raise
+            _warn_preserving("tearing the batch down", active_error, close_error)
+
+
+
+    @property
+    def rows_in_flight(self) -> int:
+        """Rows added and not yet finished or cancelled."""
+        return 0 if self._session is None else self._session.rows_in_flight
+
+    def add(self, request: GenerationRequest) -> int:
+        """Admit one request, and answer with the row number reporting it."""
+        session = self._require_open()
+        (validated,) = _validate_text_requests([request], session.adapter.defaults)
+        return session.add(validated)
+
+    def cancel(self, row: int) -> bool:
+        """Withdraw a row. False if it was never added, or has already ended."""
+        return self._require_open().cancel(row)
+
+    def step(self) -> list[GenerationEvent]:
+        """What the batch produced in one decode step."""
+        return list(self._require_open().step())
+
+    def close(self) -> None:
+        """Release the batch and the generation lock. Safe to call twice."""
+        if self._closed:
+            return
+        self._require_owner()
+        self._closed = True
+        self._session = None
+        self._stack.close()
+
+    def _require_open(self) -> "_TextBatchSession":
+        if self._session is None:
+            raise RuntimeError("This BatchStream is closed.")
+        self._require_owner()
+        if not self._session.usable:
+            raise RuntimeError(
+                "This BatchStream holds a batch neither it nor mlx-lm can "
+                "answer for, left by an earlier call that failed partway. "
+                "Close it and open another."
+            )
+        return self._session
+
+    def _require_owner(self) -> None:
+        current = (threading.get_ident(), _current_async_task())
+        if current == self._owner:
+            return
+        raise RuntimeError(
+            "This BatchStream belongs to the thread and task that opened it: "
+            "the generation lock it holds can only be released there."
+        )
+
+
 def stream_batch(
     model,
     tokenizer_or_processor,
@@ -2220,6 +2442,7 @@ def fast_generate(
 
 
 __all__ = [
+    "BatchStream",
     "GenerationDefaults",
     "GenerationEvent",
     "GenerationRequest",

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -219,13 +219,14 @@ class GenerationRequest:
 
 @dataclass(frozen=True)
 class GenerationResult:
-    """Sampled-token output with text from the backend's streaming detokenizer."""
+    """One row's outcome: its sampled tokens, their text, and what the prompt cost."""
 
     token_ids: list[int]
     text: str
     logprobs: list[float]
     finish_reason: Literal["stop", "length", "stop_string"]
     stop_match: str | None = None
+    prompt_token_count: int = 0
 
 
 def _validate_positive_int(value: Any, name: str):
@@ -1098,6 +1099,7 @@ def _replay_stream_text(detokenizer, token_ids: Sequence[int]) -> str:
 class _PendingResult:
     detokenizer: Any
     scanner: _StopStringScanner
+    prompt_token_count: int = 0
     token_ids: list[int] = field(default_factory=list)
     logprobs: list[float] = field(default_factory=list)
     text: str = ""
@@ -1166,6 +1168,7 @@ class _PendingResult:
             logprobs=list(self.logprobs),
             finish_reason=self.finish_reason,
             stop_match=self.stop_match,
+            prompt_token_count=self.prompt_token_count,
         )
 
 
@@ -1268,8 +1271,9 @@ class _TextBatchAdapter:
                 uid: _PendingResult(
                     detokenizer=_new_detokenizer(self.tokenizer),
                     scanner=_StopStringScanner(self.defaults.stop_strings),
+                    prompt_token_count=len(prompt),
                 )
-                for uid in uids
+                for uid, prompt in zip(uids, prompts)
             }
             row_of = {uid: row for row, uid in enumerate(uids)}
             while pending:
@@ -1787,6 +1791,8 @@ class _VLMBatchAdapter:
             ),
         )
         for event in events:
+            if previous is None:
+                state.prompt_token_count = int(getattr(event, "prompt_tokens", 0) or 0)
             if previous is not None and state.append(
                 tokenizer,
                 int(previous.token),
@@ -1945,6 +1951,7 @@ class _VLMBatchAdapter:
                     row_sampler.bind_uids(uids)
                 yield from self._drive(
                     generator, uids, indices, gen_kwargs, row_sampler,
+                    prompt_token_count=len(token_ids[0]),
                 )
         except BaseException as exc:
             active_error = exc
@@ -1974,12 +1981,15 @@ class _VLMBatchAdapter:
         indices,
         gen_kwargs,
         row_sampler=None,
+        prompt_token_count=0,
     ) -> Iterator[GenerationEvent]:
+        """Report the chunk's rows. ``prompt_token_count`` is what it prefilled,"""
         tokenizer = getattr(self.processor, "tokenizer", self.processor)
         pending = {
             uid: _PendingResult(
                 detokenizer=_new_detokenizer(tokenizer, require_independent=True),
                 scanner=_StopStringScanner(self.defaults.stop_strings),
+                prompt_token_count=prompt_token_count,
             )
             for uid in uids
         }

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -33,7 +33,7 @@ from collections.abc import Mapping
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field, replace
 from numbers import Integral
-from typing import Any, Iterator, Literal, Sequence
+from typing import Any, Callable, Iterator, Literal, Sequence
 
 
 _TEXT_EVENT_FIELDS = frozenset(("uid", "token", "logprobs", "finish_reason"))
@@ -209,6 +209,10 @@ class GenerationRequest:
     bytes and file-like objects are rejected. ``audio`` (vision models only) is
     accepted but decodes one request at a time, since no supported mlx-vlm
     release batches it. At most one of ``image`` and ``audio`` per request.
+
+    ``logits_processors`` are this row's own ``(tokens, logits) -> logits`` callables,
+    run in order on its slice before it draws, and shown the same history on every path
+    so a row answers the same batched or alone. They keep state: never share them.
     """
 
     prompt: str | None = None
@@ -217,11 +221,24 @@ class GenerationRequest:
     audio: Any | None = None
     max_tokens: int | None = None
     sampling: SamplingParams | None = None
+    logits_processors: Sequence[Callable[[Any, Any], Any]] | None = None
+
+    def __post_init__(self):
+        if self.logits_processors is None:
+            return
+        try:
+            processors = tuple(self.logits_processors)
+        except TypeError as exc:
+            raise TypeError(
+                "logits_processors must be a sequence of callables."
+            ) from exc
+        if any(not callable(processor) for processor in processors):
+            raise TypeError("Every logits processor must be callable.")
+        object.__setattr__(self, "logits_processors", processors)
 
 
 @dataclass(frozen=True)
 class GenerationResult:
-    """One row's outcome: its sampled tokens, their text, and what the prompt cost."""
 
     token_ids: list[int]
     text: str
@@ -363,10 +380,9 @@ def _validate_vlm_requests(
         name for name in _KV_QUANT_CONTROLS if getattr(defaults, name) is not None
     ]
     if refused_kv:
-        # Whether these bound anything depends on the release, the rest of the
-        # configuration, and the model's own cache classes, which upstream
-        # resolves per layer. None is forwarded rather than promise a bound
-        # that may not exist.
+        # quantized_kv_start does not reach mlx-vlm's batch cache builder, so quantization
+        # begins at the first token where the sequential path waits. The other controls
+        # are inert without kv_bits.
         raise ValueError(
             f"{' and '.join(refused_kv)} are not forwarded by this engine's "
             "batched vision path; omit these controls, or use model.generate."
@@ -485,7 +501,6 @@ def _probe_sampler_api(sample_utils_module):
 
 
 def _draws_seeded(sampling: SamplingParams) -> bool:
-    """Whether this request's seed changes anything: argmax draws nothing."""
     return sampling.seed is not None and sampling.temperature != 0
 
 
@@ -516,12 +531,10 @@ def _seeded_sampler(sample_utils_module, params: SamplingParams):
 
 
 def _sampler_key(params: SamplingParams):
-    """The settings one sampler can serve. A seed is not among them: rows"""
     return (params.temperature, params.top_p, params.top_k, params.min_p)
 
 
 def _sampler_for(sample_utils_module, params: SamplingParams, make_sampler):
-    """The sampler one request's settings ask for."""
     if _draws_seeded(params):
         return _seeded_sampler(sample_utils_module, params)
     return make_sampler(
@@ -532,8 +545,27 @@ def _sampler_for(sample_utils_module, params: SamplingParams, make_sampler):
     )
 
 
+def _sequential_history(processor):
+    """A processor shown only the last prompt token and what followed it.
+
+    How much prompt a processor sees is otherwise an accident of the prefill, and a
+    repetition penalty windows recent tokens, so that accident would decide the reply.
+    """
+    state = {"offset": None}
+
+    def _shown(tokens, logits):
+        if state["offset"] is None:
+            state["offset"] = max(int(tokens.shape[0]) - 1, 0)
+        return processor(tokens[state["offset"] :], logits)
+
+    return _shown
+
+
+def _row_processors(request: GenerationRequest) -> list:
+    return [_sequential_history(fn) for fn in (request.logits_processors or ())]
+
+
 class _PerRowSampler:
-    """One sampler per row for a backend that takes only one for the batch."""
 
     def __init__(self, params, *, sample_utils_module, make_sampler):
         self._sample_utils = sample_utils_module
@@ -556,19 +588,16 @@ class _PerRowSampler:
             self.register(uid, params)
 
     def register(self, uid, params: SamplingParams) -> None:
-        """Take one more row, for a caller that learns them one at a time."""
         self._by_uid[uid] = params
         self.row_uids.append(uid)
 
     def release(self, uid) -> None:
-        """Forget a row the batch can no longer draw."""
         self._by_uid.pop(uid, None)
         self._samplers.pop(uid, None)
         if uid in self.row_uids:
             self.row_uids.remove(uid)
 
     def release_all(self) -> None:
-        """Forget every row at once, for a batch that has gone."""
         self._by_uid.clear()
         self._samplers.clear()
         self.row_uids.clear()
@@ -590,7 +619,6 @@ class _PerRowSampler:
         return sampler
 
     def _drawing_uids(self, width, positions):
-        """The rows of this draw, in the order their logprobs are stacked."""
 
         if self._generator is not None and positions is not None:
             name = (
@@ -715,7 +743,7 @@ def _restore_metal_limits(snapshot: dict[str, int] | None):
 
 
 def _require_evaluable(model):
-    """The model's eval(), or a refusal: what generation mode needs to switch a model"""
+    """The model's eval(), or a refusal: what switches a model out of training."""
     switch = getattr(model, "eval", None)
     if not callable(switch):
         raise TypeError("generation_mode requires a model with eval().")
@@ -1018,11 +1046,18 @@ def _install_arrays_cache_advance_fix():
 
 @dataclass(frozen=True)
 class GenerationEvent:
-    """One row's progress through a batch, in the order the batch produced it."""
+    """One row's progress through a batch, in the order the batch produced it.
+
+    ``prompt_tokens`` and ``generated_tokens`` are the row's counts so far, carried on
+    every event so a caller that stops a batch early can still report usage. ``result``
+    arrives only when the row ends on its own.
+    """
 
     index: int
     delta: str = ""
     result: GenerationResult | None = None
+    prompt_tokens: int = 0
+    generated_tokens: int = 0
 
 
 class BatchRowRefused(ValueError):
@@ -1032,7 +1067,12 @@ class BatchRowRefused(ValueError):
 def _text_events(index: int, state: "_PendingResult") -> Iterator[GenerationEvent]:
     delta = state.release()
     if delta:
-        yield GenerationEvent(index=index, delta=delta)
+        yield GenerationEvent(
+            index=index,
+            delta=delta,
+            prompt_tokens=state.prompt_token_count,
+            generated_tokens=len(state.token_ids),
+        )
 
 
 def _finished_events(
@@ -1044,6 +1084,8 @@ def _finished_events(
         index=index,
         delta=state.release(),
         result=state.result(tokenizer),
+        prompt_tokens=state.prompt_token_count,
+        generated_tokens=len(state.token_ids),
     )
 
 
@@ -1158,7 +1200,6 @@ def _replay_stream_text(detokenizer, token_ids: Sequence[int]) -> str:
 
 
 def _cancelled_result(tokenizer, state: "_PendingResult") -> GenerationResult:
-    """What a row had managed when it was withdrawn."""
     if state.finish_reason is None:
         state.finish(tokenizer, "stop")
     return state.result(tokenizer)
@@ -1177,7 +1218,6 @@ class _PendingResult:
     stop_match: str | None = None
 
     def release(self) -> str:
-        """Text this row has not handed out yet."""
         delta = self.text[self.released :]
         self.released = len(self.text)
         return delta
@@ -1348,7 +1388,7 @@ class _TextBatchSession:
                 [prompt],
                 max_tokens=[int(request.max_tokens or defaults.max_tokens)],
                 samplers=[sampler],
-                logits_processors=[[]],
+                logits_processors=[_row_processors(request)],
             )
         except BaseException:
             self.usable = False
@@ -1383,16 +1423,13 @@ class _TextBatchSession:
         return row
 
     def cancel(self, row: int) -> bool:
-        """Withdraw a row. False if it was never added, or has already ended."""
         return self._take_back(row) is not None
 
     def withdraw(self, row: int) -> GenerationResult | None:
-        """Withdraw a row, answering with what it managed."""
         state = self._take_back(row)
         return None if state is None else _cancelled_result(self.adapter.tokenizer, state)
 
     def _take_back(self, row: int) -> "_PendingResult | None":
-        """Take a row out of the batch, answering with what it was holding."""
         uid = self._uid_of.get(row)
         if uid is None or uid not in self._pending:
             return None
@@ -1406,7 +1443,6 @@ class _TextBatchSession:
         return state
 
     def step(self) -> Iterator[GenerationEvent]:
-        """One decode step's worth of events, or none while no row is in flight."""
         if not self._pending:
             return
         try:
@@ -1605,7 +1641,6 @@ def _probe_vlm_api(batch_module):
 
 
 def _statements(body):
-    """Every node written in this body, skipping nested definitions."""
 
     for node in body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
@@ -1648,7 +1683,6 @@ def _draws_by_position(owner, method) -> bool:
 
 
 def _vlm_batches_observable(batch_module) -> bool:
-    """Whether a sampler can tell which of a release's rows a draw is for."""
 
     generator = getattr(batch_module, "BatchGenerator", None)
     code = getattr(getattr(generator, "__init__", None), "__code__", None)
@@ -1667,7 +1701,6 @@ _LAYER_MAJOR_PROMPT_KWARGS = frozenset({"deepstack_visual_embeds"})
 
 
 def _padded_prompt_kwargs(batch_module) -> frozenset:
-    """The keys this release stretches to the batch's longest prompt."""
 
     return frozenset({
         "inputs_embeds",
@@ -1676,7 +1709,6 @@ def _padded_prompt_kwargs(batch_module) -> frozenset:
 
 
 def _row_shape(key, value, padded: frozenset):
-    """What a row's value has to match in the batch's other rows."""
 
     shape = getattr(value, "shape", None)
     if shape is None:
@@ -1699,7 +1731,6 @@ def _row_signature(prepared: dict, padded: frozenset) -> dict:
 
 
 def _own_body(method):
-    """One method's own statements, minus anything nested inside it."""
 
     source = textwrap.dedent(inspect.getsource(method))
     definition = ast.parse(source).body[0]
@@ -1717,12 +1748,11 @@ def _own_body(method):
 def _keeps_what_it_prepared(model, method = "get_input_embeddings") -> bool:
     """Whether preparing a request leaves anything on this model.
 
-    Follows the helpers the method calls on itself: several models do the
-    assignment one call down, where reading the method alone would not see it.
-    A ``self.<name>(...)`` with no readable body is a submodule being run --
-    every vision model runs its tower that way -- and is stepped over. Only the
-    prepare method itself being unreadable counts as keeping something, since
-    then nothing at all is known about it.
+    Follows the helpers the method calls on itself, since several models assign one call
+    down. A ``self.<name>(...)`` with no readable body is a submodule being run -- every
+    vision model runs its tower that way -- and is stepped over. A binding counts wherever
+    its target leads back to ``self``; mutating a container the model already holds does
+    not, nor does reaching ``self`` indirectly.
     """
 
     seen = set()
@@ -1739,28 +1769,46 @@ def _keeps_what_it_prepared(model, method = "get_input_embeddings") -> bool:
         for node in body:
             targets = (
                 list(node.targets) if isinstance(node, ast.Assign)
-                else [node.target] if isinstance(node, (ast.AugAssign, ast.AnnAssign))
+                else [node.target]
+                if isinstance(node, (ast.AugAssign, ast.AnnAssign, ast.For, ast.AsyncFor,
+                                     ast.comprehension))
+                else [item.optional_vars for item in node.items if item.optional_vars]
+                if isinstance(node, (ast.With, ast.AsyncWith))
                 else []
             )
-            for target in targets:
-                while isinstance(target, ast.Attribute):
+            while targets:
+                target = targets.pop()
+                if isinstance(target, (ast.Tuple, ast.List)):
+                    targets.extend(target.elts)
+                    continue
+                if isinstance(target, ast.Starred):
+                    targets.append(target.value)
+                    continue
+                while isinstance(target, (ast.Attribute, ast.Subscript)):
                     target = target.value
                 if isinstance(target, ast.Name) and target.id == "self":
                     return True
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "self"
-            ):
-                calls.add(node.func.attr)
+            if isinstance(node, ast.Call):
+                if (
+                    isinstance(node.func, ast.Name)
+                    and node.func.id == "setattr"
+                    and node.args
+                    and isinstance(node.args[0], ast.Name)
+                    and node.args[0].id == "self"
+                ):
+                    return True
+                if (
+                    isinstance(node.func, ast.Attribute)
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "self"
+                ):
+                    calls.add(node.func.attr)
         return any(follows(call) for call in sorted(calls))
 
     return follows(method, entry = True)
 
 
 def _require_streamable_vlm(adapter: "_VLMBatchAdapter") -> None:
-    """Refuse a release that cannot keep a vision batch open."""
 
     if not adapter.per_row_prompt_kwargs:
         raise ValueError(
@@ -1860,6 +1908,36 @@ def _split_prompt_kwargs_fallback(prompt_kwargs: dict, batch_size: int) -> list[
     return rows
 
 
+def _resolve_vlm_batch_module():
+
+    batch_module = _resolve_module_attr(_VLM_BATCH_MODULES, "BatchGenerator")
+    if batch_module is None:
+        raise _vlm_api_shape_error("no importable module exposes BatchGenerator")
+    # Bind the module the class is DEFINED in, where the private helpers live.
+    defining = getattr(batch_module.BatchGenerator, "__module__", None)
+    if defining and defining != batch_module.__name__:
+        try:
+            batch_module = importlib.import_module(defining)
+        except Exception:
+            pass
+    return batch_module
+
+
+def row_logits_processors_unavailable_reason() -> str | None:
+    """Why a batched vision row here cannot carry its own logits processors."""
+
+    try:
+        _, insert_params, _ = _probe_vlm_api(_resolve_vlm_batch_module())
+    except Exception as refusal:
+        return str(refusal)
+    if "logits_processors" in insert_params:
+        return None
+    return (
+        f"{_installed_mlx_vlm_version()} takes no per-row logits processors, "
+        "so a batched vision reply cannot carry a penalty or bias"
+    )
+
+
 class _VLMBatchAdapter:
     """Event-level adapter over mlx-vlm's BatchGenerator.
 
@@ -1871,17 +1949,7 @@ class _VLMBatchAdapter:
     def __init__(
         self, model, processor, defaults: GenerationDefaults, *, audio_warn_stacklevel = 3,
     ):
-        batch_module = _resolve_module_attr(_VLM_BATCH_MODULES, "BatchGenerator")
-        if batch_module is None:
-            raise _vlm_api_shape_error("no importable module exposes BatchGenerator")
-        # Bind the module the class is DEFINED in: that is where the private
-        # helpers and event class live, however the package re-exports them.
-        defining = getattr(batch_module.BatchGenerator, "__module__", None)
-        if defining and defining != batch_module.__name__:
-            try:
-                batch_module = importlib.import_module(defining)
-            except Exception:
-                pass
+        batch_module = _resolve_vlm_batch_module()
         (
             self.constructor_params,
             insert_params,
@@ -1890,6 +1958,7 @@ class _VLMBatchAdapter:
         self.batch_module = batch_module
         self.generator_type = batch_module.BatchGenerator
         self.per_row_prompt_kwargs = "prompt_kwargs" in insert_params
+        self.row_logits_processors = "logits_processors" in insert_params
         self.batches_observable = _vlm_batches_observable(batch_module)
         self.padded_prompt_kwargs = _padded_prompt_kwargs(batch_module)
         self.stream_module = _resolve_module_attr(_VLM_STREAM_MODULES, "wired_limit")
@@ -1968,6 +2037,17 @@ class _VLMBatchAdapter:
         if callable(upstream) and callable(mrope_aware):
             return upstream(prompt_kwargs, batch_size)
         return _split_prompt_kwargs_fallback(prompt_kwargs, batch_size)
+
+    def _row_logits_processors(self, requests) -> list[list] | None:
+        rows = [_row_processors(request) for request in requests]
+        if not any(rows):
+            return None
+        if not self.row_logits_processors:
+            raise _vlm_api_shape_error(
+                "BatchGenerator.insert does not take logits_processors, so a "
+                "request cannot carry a penalty or bias into a batch"
+            )
+        return rows
 
     def _admission_stalled(self, generator) -> bool | None:
         """True when no prompt can ever be admitted; None when unobservable.
@@ -2125,6 +2205,7 @@ class _VLMBatchAdapter:
             request.prompt,
             audio=request.audio,
             max_tokens=int(request.max_tokens or self.defaults.max_tokens),
+            logits_processors=_row_processors(request),
             sampler=(
                 _seeded_sampler(self.sample_utils, sampling)
                 if _draws_seeded(sampling)
@@ -2245,6 +2326,7 @@ class _VLMBatchAdapter:
         max_tokens = [
             int(request.max_tokens or self.defaults.max_tokens) for request in chunk
         ]
+        row_processors = self._row_logits_processors(chunk)
         generator = None
         active_error = None
         try:
@@ -2277,17 +2359,15 @@ class _VLMBatchAdapter:
                     **options,
                 )
                 token_ids = input_ids.tolist()
+                insert_kwargs = {}
                 if self.per_row_prompt_kwargs:
-                    uids = generator.insert(
-                        token_ids,
-                        max_tokens,
-                        prompt_kwargs=self._split_prompt_kwargs(
-                            gen_kwargs,
-                            batch_size,
-                        ),
+                    insert_kwargs["prompt_kwargs"] = self._split_prompt_kwargs(
+                        gen_kwargs,
+                        batch_size,
                     )
-                else:
-                    uids = generator.insert(token_ids, max_tokens)
+                if row_processors is not None:
+                    insert_kwargs["logits_processors"] = row_processors
+                uids = generator.insert(token_ids, max_tokens, **insert_kwargs)
                 if row_sampler is not None:
                     row_sampler.bind_uids(uids)
                     row_sampler.bind_generator(generator)
@@ -2325,7 +2405,7 @@ class _VLMBatchAdapter:
         row_sampler=None,
         prompt_token_count=0,
     ) -> Iterator[GenerationEvent]:
-        """Report the chunk's rows. ``prompt_token_count`` is what it prefilled,"""
+        """Report the chunk's rows, charging ``prompt_token_count`` to each."""
         tokenizer = getattr(self.processor, "tokenizer", self.processor)
         pending = {
             uid: _PendingResult(
@@ -2466,12 +2546,18 @@ class _VLMBatchSession:
                 "generate it with generate_batch or stream_batch."
             )
         input_ids, prompt_kwargs = self._prepare(request)
+        row_processors = adapter._row_logits_processors([request])
         token_ids = input_ids.tolist()
+        insert_kwargs = {
+            "prompt_kwargs": adapter._split_prompt_kwargs(prompt_kwargs, 1),
+        }
+        if row_processors is not None:
+            insert_kwargs["logits_processors"] = row_processors
         try:
             uids = self.generator.insert(
                 token_ids,
                 [int(request.max_tokens or defaults.max_tokens)],
-                prompt_kwargs = adapter._split_prompt_kwargs(prompt_kwargs, 1),
+                **insert_kwargs,
             )
         except BaseException:
             self.usable = False
@@ -2513,16 +2599,13 @@ class _VLMBatchSession:
         return row
 
     def cancel(self, row: int) -> bool:
-        """Withdraw a row. False if it was never added, has already ended, or the"""
         return self._take_back(row) is not None
 
     def withdraw(self, row: int) -> GenerationResult | None:
-        """Withdraw a row, answering with what it managed."""
         state = self._take_back(row)
         return None if state is None else _cancelled_result(self.tokenizer, state)
 
     def _take_back(self, row: int) -> "_PendingResult | None":
-        """Take a row out of the batch, answering with what it was holding."""
         uid = self._uid_of.get(row)
         if uid is None or uid not in self._pending:
             return None
@@ -2538,7 +2621,6 @@ class _VLMBatchSession:
         return state
 
     def step(self) -> Iterator[GenerationEvent]:
-        """One decode step's worth of events, or none while no row is in flight."""
         if not self._pending:
             return
         try:
@@ -2574,7 +2656,6 @@ class _VLMBatchSession:
             self._stack.close()
 
     def _prepare(self, request: GenerationRequest):
-        """One request's token ids and the embeddings it is admitted with."""
 
         adapter = self.adapter
         request = adapter._decode_image(request)
@@ -2630,7 +2711,6 @@ class _VLMBatchSession:
         return input_ids, prepared
 
     def _open(self):
-        """The batch, built for the whole session."""
 
         adapter = self.adapter
         defaults = adapter.defaults
@@ -2653,14 +2733,12 @@ class _VLMBatchSession:
         return generator
 
     def _withdraw(self, uid: int) -> bool:
-        """Hand a row back, and say whether the batch took it."""
 
         if self.adapter.cancel is None:
             return False
         return self.adapter.cancel(self.generator, uid) is not False
 
     def _retire(self, uid: int):
-        """Let a row go, once the batch can no longer draw it."""
 
         row = self._row_of.pop(uid, None)
         self._pending.pop(uid, None)
@@ -2699,7 +2777,7 @@ class _VLMBatchSession:
 
 
 def _stream_setup(model, tokenizer, defaults: GenerationDefaults):
-    """What a stream settles before it takes anything: the request it was asked"""
+    """What a stream settles before it takes anything: vision or not, and the adapter."""
     if defaults.stop_strings:
         raise ValueError(
             "BatchStream cannot apply stop_strings: they cut on token "
@@ -2729,7 +2807,7 @@ def stream_unavailable_reason(
     *,
     defaults: GenerationDefaults | None = None,
 ) -> str | None:
-    """Why ``BatchStream`` would refuse this model here, or None if nothing here"""
+    """Why ``BatchStream`` would refuse this model, or None. Asked before committing."""
     if defaults is None:
         defaults = GenerationDefaults()
     if not isinstance(defaults, GenerationDefaults):
@@ -2743,7 +2821,14 @@ def stream_unavailable_reason(
 
 
 class BatchStream:
-    """A batch left open: rows join and leave while the batch decodes."""
+    """A batch left open: rows join and leave while the batch decodes.
+
+    A row joins immediately, but which admitted row prefills next is the underlying
+    generator's decision, not this one's. mlx-lm takes them in arrival order; mlx-vlm
+    sorts its unprocessed prompts shortest-first on every insert, so a long vision
+    prompt waits behind shorter ones that arrived after it. Rows already decoding are
+    unaffected either way.
+    """
 
     def __init__(
         self,
@@ -2792,22 +2877,21 @@ class BatchStream:
 
     @property
     def rows_in_flight(self) -> int:
-        """Rows added and not yet finished or cancelled."""
         return 0 if self._session is None else self._session.rows_in_flight
 
     def add(self, request: GenerationRequest) -> int:
-        """Admit one request, and answer with the row number reporting it."""
         session = self._require_open()
         validate = _validate_vlm_requests if self._is_vlm else _validate_text_requests
         (validated,) = validate([request], session.adapter.defaults)
         return session.add(validated)
 
     def cancel(self, row: int) -> bool:
-        """Withdraw a row, answering whether it is gone."""
         return self._require_open().cancel(row)
 
     def withdraw(self, row: int) -> GenerationResult | None:
-        """The same, answering with what the row managed rather than whether it"""
+        """The same, answering with what the row managed rather than whether it was
+        still there to withdraw.
+        """
         return self._require_open().withdraw(row)
 
     def step(self) -> list[GenerationEvent]:
@@ -2985,6 +3069,7 @@ __all__ = [
     "fast_generate",
     "generate_batch",
     "generation_mode",
+    "row_logits_processors_unavailable_reason",
     "stream_batch",
     "stream_unavailable_reason",
 ]

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -337,6 +337,137 @@ def _validate_text_requests(
     return validated
 
 
+def _kv_quant_options(defaults: GenerationDefaults) -> dict:
+    """The caller's KV-quant controls, which validation has already vetted."""
+    return {
+        name: getattr(defaults, name)
+        for name in _KV_QUANT_CONTROLS
+        if getattr(defaults, name) is not None
+    }
+
+
+def _batch_kv_quant_options(defaults: GenerationDefaults) -> dict:
+    """The controls a batch cache is built with.
+
+    A sequential decode quantizes a turboquant cache once it reaches the start; a batch
+    decides at construction, so mlx-vlm's default start (5000) leaves a shorter batch
+    unquantized for good. Building from the first token is what was asked.
+    """
+    options = _kv_quant_options(defaults)
+    if "quantized_kv_start" not in options and _vlm_turboquant(defaults):
+        options["quantized_kv_start"] = 0
+    return options
+
+
+def _vlm_turboquant(defaults: GenerationDefaults) -> bool:
+    """Whether these controls make mlx-vlm build a turboquant cache."""
+    if defaults.kv_bits is None:
+        return False
+    try:
+        return bool(_resolve_vlm_batch_module().turboquant_enabled(
+            defaults.kv_bits, defaults.kv_quant_scheme))
+    except Exception:
+        return False
+
+
+def _vlm_kv_controls_refused(defaults: GenerationDefaults) -> list[str]:
+    """The KV-quant controls set here that mlx-vlm would drop rather than apply."""
+    requested = [
+        name for name in _KV_QUANT_CONTROLS if getattr(defaults, name) is not None
+    ]
+    if not requested:
+        return []
+    try:
+        accepted = inspect.signature(
+            _resolve_vlm_batch_module().BatchGenerator.__init__
+        ).parameters
+    except Exception:
+        return requested
+    refused = [name for name in requested if name not in accepted]
+    scheme = defaults.kv_quant_scheme
+    if scheme is not None and "kv_quant_scheme" not in refused and scheme not in _vlm_kv_quant_schemes():
+        # Any other name quietly resolves to uniform.
+        refused.append("kv_quant_scheme")
+    if defaults.kv_bits is None:
+        # Every other control reads off kv_bits, so without it none of them build anything.
+        refused += [name for name in requested if name != "kv_bits" and name not in refused]
+        return refused
+    turbo = _vlm_turboquant(defaults)
+    # Fractional bits make the cache turboquant whatever the scheme says; a turboquant cache
+    # takes no group size; quantized_kv_start gates only a turboquant cache.
+    dropped = ["kv_group_size"] if turbo else ["quantized_kv_start"]
+    if turbo and scheme is not None and scheme != "turboquant":
+        dropped.append("kv_quant_scheme")
+    refused += [name for name in dropped if name in requested and name not in refused]
+    return refused
+
+
+def _vlm_kv_quant_schemes() -> tuple[str, ...]:
+    """The scheme names the installed mlx-vlm resolves."""
+    try:
+        from mlx_vlm import kv_quant
+
+        return (kv_quant.UNIFORM_SCHEME, kv_quant.TURBOQUANT_SCHEME)
+    except Exception:
+        return ("uniform", "turboquant")
+
+
+def vlm_batch_adds_special_tokens(model, processor) -> bool:
+    """Whether a batched prompt is tokenized with the tokenizer's own special tokens.
+
+    A Gemma template writes ``<bos>`` itself, so a processor carrying one must not add
+    another. A caller whose rendered prompt already opens with the BOS text strips it
+    when this is true, or the batch would see two.
+    """
+    model_type = getattr(getattr(model, "config", None), "model_type", None)
+    if model_type in ("gemma3", "gemma3n", "gemma4", "gemma4_unified"):
+        return getattr(processor, "chat_template", None) is None
+    return True
+
+
+def _vlm_quantized_cache_gap(model, defaults: GenerationDefaults) -> str | None:
+    """Why mlx-vlm would refuse to quantize this model's batch cache, or None.
+
+    It refuses while building the batch, after the rows were admitted, for a cache
+    that converts itself (``to_batch``); asked here so a caller can decline first.
+    """
+    if defaults.kv_bits is None:
+        return None
+    make_cache = getattr(getattr(model, "language_model", model), "make_cache", None)
+    if not callable(make_cache):
+        return None
+    try:
+        from mlx_vlm.models.cache import should_quantize_kv_layer
+    except ImportError:
+        should_quantize_kv_layer = lambda index, count: True  # noqa: E731
+    try:
+        entries = list(make_cache())
+    except Exception:
+        return None
+    for index, entry in enumerate(entries):
+        if hasattr(entry, "to_batch") and should_quantize_kv_layer(index, len(entries)):
+            return (
+                f"{type(entry).__name__} keeps model-specific cache state that "
+                f"{_installed_mlx_vlm_version()} cannot quantize across a batch; "
+                "omit kv_bits."
+            )
+    return None
+
+
+def _unpadded_lengths(mask) -> list[int] | None:
+    """Each row's own prompt length from the attention mask, or None without one.
+
+    mlx-vlm left-pads a prefill batch to its widest prompt, so the padded width is
+    not what a shorter row cost.
+    """
+    if mask is None:
+        return None
+    try:
+        return [int(n) for n in mask.sum(axis=-1).tolist()]
+    except Exception:
+        return None
+
+
 def _validate_vlm_requests(
     requests: Sequence[GenerationRequest],
     defaults: GenerationDefaults,
@@ -376,16 +507,12 @@ def _validate_vlm_requests(
             "batched vision generation (got "
             f"{defaults.prefill_batch_size} > {defaults.completion_batch_size})."
         )
-    refused_kv = [
-        name for name in _KV_QUANT_CONTROLS if getattr(defaults, name) is not None
-    ]
+    refused_kv = _vlm_kv_controls_refused(defaults)
     if refused_kv:
-        # quantized_kv_start does not reach mlx-vlm's batch cache builder, so quantization
-        # begins at the first token where the sequential path waits. The other controls
-        # are inert without kv_bits.
         raise ValueError(
-            f"{' and '.join(refused_kv)} are not forwarded by this engine's "
-            "batched vision path; omit these controls, or use model.generate."
+            f"{' and '.join(refused_kv)} would be dropped rather than applied by "
+            f"{_installed_mlx_vlm_version()}'s batch generator; omit these "
+            "controls, or use model.generate."
         )
     if defaults.max_kv_size is not None:
         # No supported BatchGenerator takes a KV-window control, so say so rather
@@ -2000,11 +2127,7 @@ class _VLMBatchAdapter:
             return _null_context()
 
     def _add_special_tokens(self) -> bool:
-        config = getattr(self.model, "config", None)
-        model_type = getattr(config, "model_type", None)
-        if model_type in ("gemma3", "gemma3n", "gemma4", "gemma4_unified"):
-            return getattr(self.processor, "chat_template", None) is None
-        return True
+        return vlm_batch_adds_special_tokens(self.model, self.processor)
 
     def _chunked_prefill_kwargs(self, *, input_ids=None, prefill_kwargs=None) -> dict:
         """Apply the release's chunked-prefill policy, which needs real inputs."""
@@ -2206,6 +2329,7 @@ class _VLMBatchAdapter:
             audio=request.audio,
             max_tokens=int(request.max_tokens or self.defaults.max_tokens),
             logits_processors=_row_processors(request),
+            **_kv_quant_options(self.defaults),
             sampler=(
                 _seeded_sampler(self.sample_utils, sampling)
                 if _draws_seeded(sampling)
@@ -2323,6 +2447,7 @@ class _VLMBatchAdapter:
             options["sampler"] = row_sampler
         if "compute_logprobs" in self.constructor_params:
             options["compute_logprobs"] = True
+        options.update(_batch_kv_quant_options(self.defaults))
         max_tokens = [
             int(request.max_tokens or self.defaults.max_tokens) for request in chunk
         ]
@@ -2374,6 +2499,7 @@ class _VLMBatchAdapter:
                 yield from self._drive(
                     generator, uids, indices, gen_kwargs, row_sampler,
                     prompt_token_count=len(token_ids[0]),
+                    prompt_token_counts=_unpadded_lengths(mask),
                 )
         except BaseException as exc:
             active_error = exc
@@ -2404,16 +2530,20 @@ class _VLMBatchAdapter:
         gen_kwargs,
         row_sampler=None,
         prompt_token_count=0,
+        prompt_token_counts=None,
     ) -> Iterator[GenerationEvent]:
-        """Report the chunk's rows, charging ``prompt_token_count`` to each."""
+        """Report the chunk's rows, charging each its own prompt count, or
+        ``prompt_token_count`` to every row when none are given."""
         tokenizer = getattr(self.processor, "tokenizer", self.processor)
+        if prompt_token_counts is None:
+            prompt_token_counts = [prompt_token_count] * len(uids)
         pending = {
             uid: _PendingResult(
                 detokenizer=_new_detokenizer(tokenizer, require_independent=True),
                 scanner=_StopStringScanner(self.defaults.stop_strings),
-                prompt_token_count=prompt_token_count,
+                prompt_token_count=count,
             )
-            for uid in uids
+            for uid, count in zip(uids, prompt_token_counts)
         }
         row_of = dict(zip(uids, indices))
         live = list(uids)
@@ -2719,6 +2849,7 @@ class _VLMBatchSession:
             "completion_batch_size": defaults.completion_batch_size,
             "sampler": self.sampler,
             "compute_logprobs": True,
+            **_batch_kv_quant_options(defaults),
         }
         generator = adapter.generator_type(
             adapter.model.language_model,
@@ -2778,6 +2909,16 @@ class _VLMBatchSession:
 
 def _stream_setup(model, tokenizer, defaults: GenerationDefaults):
     """What a stream settles before it takes anything: vision or not, and the adapter."""
+    if bool(getattr(model, "_is_vlm_model", False)):
+        refused = _vlm_kv_controls_refused(defaults)
+        if refused:
+            raise ValueError(
+                f"{' and '.join(refused)} would be dropped rather than applied by "
+                f"{_installed_mlx_vlm_version()}'s batch generator; omit these controls."
+            )
+        gap = _vlm_quantized_cache_gap(model, defaults)
+        if gap is not None:
+            raise ValueError(gap)
     if defaults.stop_strings:
         raise ValueError(
             "BatchStream cannot apply stop_strings: they cut on token "
@@ -2968,6 +3109,8 @@ def _stream_batch(
         if is_vlm
         else _validate_text_requests(requests, defaults)
     )
+    if is_vlm and (gap := _vlm_quantized_cache_gap(model, defaults)) is not None:
+        raise ValueError(gap)
     if not validated:
         return
     if is_vlm:

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -1223,14 +1223,16 @@ class BatchRowRefused(ValueError):
 
 
 def _text_events(index: int, state: "_PendingResult") -> Iterator[GenerationEvent]:
-    delta = state.release()
-    if delta:
-        yield GenerationEvent(
-            index=index,
-            delta=delta,
-            prompt_tokens=state.prompt_token_count,
-            generated_tokens=len(state.token_ids),
-        )
+    # Emitted even when the token decoded to no text. A tokenizer buffering an
+    # incomplete byte sequence is ordinary, not an edge case, and the counts ride on
+    # every event so a caller that cancels or withdraws right then still reports what
+    # the row actually consumed.
+    yield GenerationEvent(
+        index=index,
+        delta=state.release(),
+        prompt_tokens=state.prompt_token_count,
+        generated_tokens=len(state.token_ids),
+    )
 
 
 def _finished_events(
@@ -2711,7 +2713,15 @@ class _VLMBatchSession:
                 "This mlx-vlm's batch cannot carry a row's own logits processors."
             )
         input_ids, prompt_kwargs = self._prepare(request)
-        row_processors = adapter._row_logits_processors([request])
+        try:
+            row_processors = adapter._row_logits_processors([request])
+        except RuntimeError as refusal:
+            # Reachable when the penalties come from the defaults rather than the
+            # request, so the check above passes. add() refuses a row without
+            # disturbing the batch, and nothing here has been inserted yet, so this
+            # is a row refusal rather than the API-shape error raised when a whole
+            # batch is being built.
+            raise BatchRowRefused(str(refusal)) from refusal
         token_ids = input_ids.tolist()
         insert_kwargs = {
             "prompt_kwargs": adapter._split_prompt_kwargs(prompt_kwargs, 1),
@@ -3102,6 +3112,49 @@ class BatchStream:
         )
 
 
+class _OwnedStream:
+    """A ``_stream_batch`` iterator pinned to the thread and task that opened it.
+
+    The generator holds ``generation_mode``'s process-wide lock across its yields, and
+    that lock refuses a release from anyone else. Resuming or closing the iterator
+    elsewhere therefore runs the cleanup on the wrong owner: the release raises before
+    it can decrement the depth, the underlying RLock is never dropped, and every later
+    generation in the process blocks forever. ``BatchStream`` pins itself the same way.
+    """
+
+    def __init__(self, events: Iterator[GenerationEvent]):
+        self._events = events
+        self._owner = (threading.get_ident(), _current_async_task())
+
+    def _require_owner(self, action: str) -> None:
+        if (threading.get_ident(), _current_async_task()) == self._owner:
+            return
+        raise RuntimeError(
+            f"This stream_batch iterator belongs to the thread and task that "
+            f"opened it: the generation lock it holds can only be released there, "
+            f"so it cannot be {action} from another one."
+        )
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> GenerationEvent:
+        self._require_owner("advanced")
+        return next(self._events)
+
+    def send(self, value):
+        self._require_owner("advanced")
+        return self._events.send(value)
+
+    def throw(self, *args):
+        self._require_owner("advanced")
+        return self._events.throw(*args)
+
+    def close(self):
+        self._require_owner("closed")
+        self._events.close()
+
+
 def stream_batch(
     model,
     tokenizer_or_processor,
@@ -3118,9 +3171,12 @@ def stream_batch(
             "boundaries, which would retract text already streamed. Scan the "
             "deltas for them instead, or use generate_batch."
         )
-    return _stream_batch(
+    return _OwnedStream(_stream_batch(
         model, tokenizer_or_processor, requests, defaults=defaults,
-    )
+        # _OwnedStream.__next__ sits between the caller and the generator body, so
+        # the audio warning needs one more frame to reach the caller.
+        audio_warn_stacklevel=3,
+    ))
 
 
 def _stream_batch(

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -3090,6 +3090,35 @@ class BatchStream:
         self._session = None
         self._stack.close()
 
+    def __del__(self):
+        # An open stream dropped without close() unwinds here instead. ExitStack has
+        # no finalizer, but the generation_mode generator it holds does, so the
+        # cleanup runs in whatever thread collected this. On the owner, which is where
+        # refcounting collects, closing repairs it; off-owner nothing can release an
+        # RLock the owner holds, so swallow the non-owner release rather than let it
+        # surface from unrelated code, and name the leak.
+        if self.__dict__.get("_closed", True):
+            return
+        self._closed = True
+        self._session = None
+        stack = self.__dict__.get("_stack")
+        if stack is None:
+            return
+        if (threading.get_ident(), _current_async_task()) == self._owner:
+            stack.close()
+            return
+        try:
+            stack.close()
+        except RuntimeError:
+            pass
+        warnings.warn(
+            "A BatchStream was dropped by a thread or task other than the one that "
+            "opened it, so the generation lock it holds cannot be released and later "
+            "generation will block. Close it on the thread that opened it.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
     def _require_open(self):
         if self._session is None:
             raise RuntimeError("This BatchStream is closed.")

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -3154,6 +3154,37 @@ class _OwnedStream:
         self._require_owner("closed")
         self._events.close()
 
+    def __del__(self):
+        # Dropping the last reference finalizes the generator in whatever thread ran
+        # the collection, which does not come through close(). Off-owner that runs
+        # generation_mode's cleanup as a non-owner: the release raises before dropping
+        # the RLock, leaving the depth inconsistent on top of a lock only the owner
+        # could ever have released. Refcounting usually collects on the thread that
+        # dropped the reference, so closing here repairs the ordinary abandonment.
+        events = self.__dict__.pop("_events", None)
+        if events is None:
+            return
+        if (threading.get_ident(), _current_async_task()) == self._owner:
+            events.close()
+            return
+        # Off-owner there is nothing that can release the lock: an RLock is only
+        # releasable by the thread holding it. Let the generator finalize, swallow the
+        # non-owner release so it does not surface as an unraisable exception from
+        # whatever code happened to trigger the collection, and say plainly what
+        # leaked, since the alternative is a process that blocks with no explanation.
+        try:
+            events.close()
+        except RuntimeError:
+            pass
+        warnings.warn(
+            "A stream_batch iterator was dropped by a thread or task other than "
+            "the one that opened it, so the generation lock it holds cannot be "
+            "released and later generation will block. Close it on the thread that "
+            "opened it.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
 
 def stream_batch(
     model,

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -459,7 +459,14 @@ def _vlm_quantized_cache_gap(model, defaults: GenerationDefaults) -> str | None:
     try:
         from mlx_vlm.models.cache import should_quantize_kv_layer
     except ImportError:
-        should_quantize_kv_layer = lambda index, count: True  # noqa: E731
+        # mlx-vlm only exported this policy as a helper from 0.6.6. Before that the
+        # same rule is inline in generate/ar.py, which builds each layer's batch cache
+        # with `quantize=(i < n - 1 if n > 2 else True)`: a deep stack leaves its last
+        # layer unquantized. Reproducing it keeps the refusal in step with what the
+        # installed release actually does, where assuming every layer quantizes made
+        # this refuse a model mlx-vlm would have batched.
+        def should_quantize_kv_layer(index, count):
+            return True if count <= 2 else index < count - 1
     try:
         entries = list(make_cache())
     except Exception:


### PR DESCRIPTION
## What this changes

`unsloth_zoo.mlx.generate` could decode several prompts in one batch, but everything about a batch was decided once for the whole batch. This makes the row the unit: each row draws from its own seeded sampler, reports its own tokens as they arrive, carries its own logits processors, and can join or leave a batch that is already decoding.

That last part is what a server needs. Until now a batch was a closed set fixed at construction, so a second chat arriving mid-decode had to wait for the first to finish or start a batch of its own. `BatchStream` keeps one open: `add` admits a prompt while the batch is running, `withdraw` takes a row back out, and the rows that remain are untouched.

## Why

Decode on Apple Silicon is memory-bandwidth bound, so a second sequence costs far less than a second forward pass. The win is decode throughput — forwards per token — not time to first token. A batch that cannot be joined gives that up whenever requests do not arrive together, which for interactive serving is nearly always.

## The row-level changes

- **Its own seeded sampler.** Rows previously shared one sampler, so two rows asking for different temperatures or seeds got neither. Each row is now drawn through its own, and a row's seed reproduces the same tokens whether it decoded alone or beside others.
- **Reported as it goes.** Results arrived only when the whole batch finished; rows now report token by token, so a caller streams each reply independently.
- **Its own prompt cost.** Each row reports what its own prompt cost rather than a batch-wide total.
- **Its own logits processors.** Repetition, presence and frequency penalties and logit bias are per-row, so one reply's penalty state cannot reach another's.
- **Its counts travel with it.** Every event carries the row's prompt and generated counts as they stand. A row's result arrives only when it ends on its own, so a caller that stops a batch early would otherwise have nothing to report usage from and would say the row read and wrote nothing, after handing its text to the client.
- **Refusal is explicit.** A row a batch cannot take raises `RowRefused` and the batch is left exactly as it was, so the caller can place that reply elsewhere without losing the rows already decoding.

## Vision

The same for `mlx_vlm`. Vision rows draw through their own samplers and join an open batch, subject to what the installed mlx-vlm release supports; `stream_unavailable_reason` reports why a batch cannot stay open for a given model rather than failing at admission.

One detail worth a reviewer's attention: a vision model that keeps request state on itself cannot be batched, because two rows preparing in sequence would overwrite each other. `_keeps_what_it_prepared` decides this by following the prepare method and the helpers it calls, counting a binding wherever its target leads back to `self`. A call with no readable body is a submodule being run — every vision model runs its tower that way — and is stepped over; only the prepare method itself being unreadable counts as keeping something, since then nothing about it is known.

Measured against every model in the installed mlx-vlm: 182 model classes, 13 refused, each traceable to a concrete assignment (`self.language_model._position_ids`, `_rope_deltas`, `_deepstack_target_layers`, `_detections`, `_image_cache`, `_active_lora`, and chunked-prefill mode).

## A quantized KV cache in a batch

mlx-lm's batch generator takes no KV-quantization controls, so a text load that asks for a quantized cache could not batch. mlx-vlm's does, and it builds every architecture mlx-lm loads, so a server can batch such a load on mlx-vlm. The vision adapter now forwards `kv_bits`, `kv_group_size`, `kv_quant_scheme` and `quantized_kv_start` to both places mlx-vlm builds a batch cache (a fixed prefill chunk and the resident session) and to the sequential stream an audio row decodes on; before, every one of them was refused as not forwarded.

A control is either applied or refused, never dropped. Validation and the preflight refuse a control the installed constructor lacks, everything without `kv_bits`, a scheme the installed release does not name (it resolves any other to uniform), `quantized_kv_start` under a uniform cache (inert there), and a group size or a non-turboquant scheme once fractional bits or a turboquant scheme make the cache turboquant. Two things the batch generator does differently from the sequential path are handled rather than inherited: a turboquant batch given no start is built quantized from the first token, because mlx-vlm's default start defers the batch cache past a 5000-token prompt and never promotes it (the sequential path converts once the cache reaches the start, so it keeps its own default); and a model whose cache converts itself (`to_batch`) is refused a quantized batch before any row is admitted, where mlx-vlm fails mid-generation.

Two smaller things came with it. Each row of a batch is charged its own prompt length from the attention mask rather than the padded width. And `vlm_batch_adds_special_tokens(model, processor)` exports the rule the adapter tokenizes with, so a caller whose rendered prompt already opens with the BOS text can strip it rather than send two.

## Scheduling is upstream's, not replaced

Which admitted row prefills first is the underlying generator's decision. mlx-lm takes them in arrival order; mlx-vlm sorts its unprocessed prompts shortest-first on every insert, so a long vision prompt can wait behind shorter ones that arrived after it. Rows already decoding are unaffected. This is inherited by using upstream's batch generator rather than bypassing its prefill, and it is documented on `BatchStream` rather than worked around.

## Validation

```bash
python -m pytest tests/test_mlx_generate.py -q
# 76 passed

python -m pytest tests/test_mlx_generate_metal.py -q
# 6 passed, 2 failed
```

The real-runtime coverage runs on Apple Silicon and skips elsewhere. `tests/test_mlx_generate_metal.py` checks batched output against mlx-lm's own sequential decoding on real weights, including that two prompts of different lengths each get their own repetition-penalty offset.

The two failures there are pre-existing and unrelated to this change: `mlx-community/FastVLM-0.5B-bf16` needs `timm` for its remote code, and the same two tests fail identically on `main` on a machine without it.

