### PR TITLE
Reduce comment volume in tests/

### DIFF
--- a/tests/test_check_hf_model_exists_transport_errors.py
+++ b/tests/test_check_hf_model_exists_transport_errors.py
@@ -203,7 +203,6 @@ def test_a_plain_absent_repo_does_not_warn_about_gating(monkeypatch):
     assert [w for w in caught if "gated" in str(w.message)] == []
 
 
-# The success paths are unchanged.
 
 def test_repo_with_safetensors_returns_true(monkeypatch):
     _patch_ls(monkeypatch, [

--- a/tests/test_checkpoint_compile_mix.py
+++ b/tests/test_checkpoint_compile_mix.py
@@ -41,17 +41,13 @@ from torch.utils.checkpoint import checkpoint
 from unsloth_zoo.temporary_patches import utils as U
 
 
-# aot_eager, not inductor: this file tests the compile-mode switch and what
-# autograd saves, both of which AOTAutograd already covers. Inductor adds a C++
-# codegen step that fails for reasons of its own once an earlier test touched
-# the inductor config -- why these passed alone and failed in a full run.
+# aot_eager, not inductor: inductor's C++ codegen fails once an earlier test touched its config.
 _BACKEND = "aot_eager"
 
 
 def _norm(w, x, k):
-    # `k` is a plain int, so Dynamo specialises on its value and every block
-    # forces a fresh compilation. A real vision run exhausts the cache the same
-    # way, one guard per shape rather than per constant.
+    # `k` is a plain int, so Dynamo specialises on it and every block recompiles, the
+    # way a real vision run exhausts the cache one guard a shape.
     return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-6) * w * (1.0 + 0.0 * k)
 
 
@@ -99,25 +95,18 @@ def dynamo_limits():
     saved = {n: getattr(dynamo.config, n) for n in names
              if hasattr(dynamo.config, n)}
     n_wrappers = len(U._EAGER_FALLBACK_WRAPPERS)
-    # These tests end with a bump deliberately outstanding, so the bookkeeping
-    # has to come back too: left behind, a later fallback restores this test's
-    # limit of 2 over the process default, or finds the allowance spent. Running
-    # out also takes EVERY live borrower eager, including the package's own
-    # patched kernels, which would stay latched for the rest of the worker.
+    # These tests end with a bump deliberately outstanding: left behind, a later
+    # fallback restores this test's limit of 2 over the process default, or finds the
+    # allowance spent and takes EVERY live borrower eager.
     saved_states = [(_w, dict(_w._unsloth_fallback_state))
                     for _w in (_r() for _r in U._EAGER_FALLBACK_WRAPPERS)
                     if _w is not None]
     saved_global = U._GLOBAL_BUMPS
     saved_orig = dict(U._ORIGINAL_RECOMPILE_LIMITS)
-    # Deep copy: the map is {bumped value: the value it came from} with lists
-    # appended to and popped in place, so copying it as a set broke the restore
-    # chain, and copying only the outer layers let a test that settles a debt
-    # mutate the snapshot teardown restores from.
+    # Deep copy: the lists are mutated in place, so a shallow copy let a settled debt mutate the snapshot.
     saved_bumped = {k: {kk: list(vv) for kk, vv in v.items()}
                     for k, v in U._BUMPED_RECOMPILE_LIMITS.items()}
-    # The give-up decision is kept by LABEL, so it outlives the wrapper. Every
-    # test here reuses "test_norm", so an earlier latch would start the next
-    # one already eager.
+    # The give-up decision is kept by LABEL, and every test here reuses "test_norm".
     U._LATCHED_EAGER_LABELS.discard("test_norm")
     U._PENDING_EAGER_LABELS.discard("test_norm")
     try:
@@ -125,9 +114,7 @@ def dynamo_limits():
     finally:
         for n, v in saved.items():
             setattr(dynamo.config, n, v)
-        # Drop only what died: the registry is process-wide, and a module
-        # imported during these tests appends its own kernels past the mark, so
-        # truncating deregistered gemma/gemma4/qwen3 for the rest of the worker.
+        # Process-wide registry: truncating past the mark deregistered gemma/gemma4/qwen3.
         _tail = [_r for _r in U._EAGER_FALLBACK_WRAPPERS[n_wrappers:]
                  if _r() is not None]
         del U._EAGER_FALLBACK_WRAPPERS[n_wrappers:]
@@ -154,8 +141,7 @@ def test_exhausted_recompile_cache_does_not_break_the_backward(dynamo_limits):
                              backend = _BACKEND)
     fn = U._fall_back_to_eager_on_recompile_limit(compiled, _norm, "test_norm")
 
-    # Before the fix this raises: the first blocks pack compiled activations,
-    # the fallback flips to eager mid-forward, and the recompute disagrees.
+    # Before the fix this raises: eager mid-forward disagrees with what was packed compiled.
     _run_checkpointed_step(fn)
 
     state = fn._unsloth_fallback_state
@@ -184,9 +170,7 @@ def test_a_spent_budget_ends_the_step_instead_of_flipping_mid_region(dynamo_limi
                              backend = _BACKEND)
     fn = U._fall_back_to_eager_on_recompile_limit(compiled, _norm, "test_norm")
 
-    # Deny the loan at its source: pinning `_GLOBAL_BUMPS` stopped working once
-    # the allowance became a live measurement rather than a stored count, and
-    # the retry silently succeeded.
+    # Pinning `_GLOBAL_BUMPS` stopped working once the allowance became a live measurement.
     real_bump = U._bump_recompile_limits
     U._bump_recompile_limits = lambda *a, **k: False
     try:
@@ -199,9 +183,7 @@ def test_a_spent_budget_ends_the_step_instead_of_flipping_mid_region(dynamo_limi
     assert state["eager"], "the wrapper must latch so the retry is consistent"
     assert state["bumps"] == 0, "no budget was borrowed"
 
-    # The promise is that the caller can retry the step. torch holds
-    # `with _checkpoint_hook(...)` open across the generator's yield, so our
-    # raise abandons it with the hooks installed; the boundary settles that.
+    # torch holds `_checkpoint_hook` open across the yield, so the raise abandons it installed.
     U.apply_pending_eager_fallbacks()
     def plain(x): return torch.nn.functional.softmax(x * 2, dim = -1)
     checkpoint(plain, torch.randn(4, 4, requires_grad = True),
@@ -334,8 +316,6 @@ def test_pending_switch_is_applied_at_the_step_boundary(dynamo_limits):
     assert fn._unsloth_fallback_state["eager"]
     assert not fn._unsloth_fallback_state["pending_eager"]
 
-    # A second call is a no-op, and the next step is now consistently eager,
-    # so the backward keeps working.
     assert U.apply_pending_eager_fallbacks() == 0
     _run_checkpointed_step(fn)
 
@@ -363,8 +343,7 @@ def test_settlement_retries_until_the_generator_is_actually_collected():
             cycle = {"exc": exc}                # a cycle, as raising through
             cycle["self"] = cycle               # compiled frames leaves
             U._RAISED_INSIDE_CHECKPOINT = True
-            # The step boundary the caller reaches before retrying: the
-            # traceback is still live, so no collection can finalise anything.
+            # The traceback is still live, so no collection can finalise anything.
             U.apply_pending_eager_fallbacks()
             assert U._in_non_reentrant_checkpoint() is True, "hooks already gone"
 

--- a/tests/test_chunked_log_softmax_device.py
+++ b/tests/test_chunked_log_softmax_device.py
@@ -80,9 +80,7 @@ def test_head_on_another_device_matches_single_device():
     hidden_states, lm_head, index = _inputs("cuda:0")
     same = chunked_hidden_states_selective_log_softmax(hidden_states, lm_head, index, **KWARGS)
 
-    # The head is the tensor that moves: accelerate puts the tail of the model
-    # on the last device it fills, while the hidden states arrive from earlier
-    # layers on an earlier device.
+    # The head is the tensor that moves: accelerate puts the model's tail on the last device it fills.
     split = chunked_hidden_states_selective_log_softmax(
         hidden_states, lm_head.to("cuda:1"), index, **KWARGS,
     )
@@ -113,8 +111,7 @@ def test_row_cap_default_keeps_chunk_boundaries():
 
 
 def test_row_cap_splits_further_without_changing_the_answer():
-    # float32 in, so pure loop splitting is exact here. In lower precision the
-    # matmul shape changes and tiny last-bit differences are expected.
+    # float32 in, so pure loop splitting is exact; lower precision changes the matmul shape.
     hidden_states, lm_head, index = _inputs("cpu", batch = 2, seq = 64)
     ref = _run(hidden_states, lm_head, index, **KWARGS)
     capped = _run(hidden_states, lm_head, index, max_rows_per_chunk = 8, **KWARGS)

--- a/tests/test_ci_lane_scripts_parse.py
+++ b/tests/test_ci_lane_scripts_parse.py
@@ -109,13 +109,10 @@ def test_no_double_backslash_continuations(workflow: str, job: str, name: str, r
 
 
 # The twenty drift files the fused Core lane inherited from the three matrix cells it
-# replaced. Named rather than counted: the risk this guard exists for is a continuation
-# that silently DROPS files, and a name tells you which one went missing where a count
-# only tells you that one did. Adding a drift file is routine and must not fail here --
-# an exact count made #1114 (which legitimately added the mxfp4 load-path file) turn this
-# guard red, so the fix for a real bug was blocked by the test meant to protect it.
-# Removing a file from the lane is the deliberate act: drop it from this set too, in the
-# same commit, and the reviewer sees the coverage shrink.
+# replaced. Named rather than counted: a name tells you which file a dropped
+# continuation lost. An exact count made #1114 (which legitimately added the mxfp4
+# load-path file) turn this guard red. Removing a file from the lane is the deliberate
+# act: drop it from this set in the same commit.
 _FUSED_CORE_LANE_REQUIRED = frozenset({
     "tests/test_compiler_dynamic_exec.py",
     "tests/test_compiler_rewriter_exhaustive.py",
@@ -152,7 +149,6 @@ def test_the_fused_core_job_still_runs_every_drift_file() -> None:
 
     body = run[run.index("-m pytest"):]
     body = body[: body.index("|| trc=$?")]
-    # Join the continuations the way the shell does, then read off what is left.
     joined = body.replace("\\\n", " ")
     files = re.findall(r"tests/\S+\.py", joined)
 
@@ -162,8 +158,8 @@ def test_the_fused_core_job_still_runs_every_drift_file() -> None:
         f"matrix cells it replaced each ran all of them, so dropping one silently "
         f"narrows upstream-drift coverage. Lane currently runs: {sorted(files)}"
     )
-    # A name repeated across continuations parses as two entries and would mask a drop
-    # from the set check above, which is order- and multiplicity-blind.
+    # A repeated name would mask a drop from the set check above, which is
+    # multiplicity-blind.
     duplicated = sorted({name for name in files if files.count(name) > 1})
     assert not duplicated, (
         f"the fused Core lane names {duplicated} more than once; pytest would collect "
@@ -175,15 +171,11 @@ def test_the_fused_core_job_still_runs_every_drift_file() -> None:
     )
 
 
-# A lane records its own exit status in the background, and that status is all the
-# job ever learns about it. The capture is `{ cmd1; ...; cmdN } > "$log" || rc=$?`,
-# and a brace group reports only cmdN -- so every earlier failure was recorded as
-# rc=0, the "could not be built" guard never fired, and the job continued with a
-# half-built venv. A truncated mlx download surfaced two steps later as
-# ModuleNotFoundError, with the build step green.
-#
-# `set -e` inside the group does NOT help: it sits on the left of `|| rc=$?`, where
-# POSIX ignores errexit. `&&`-chaining does, so the first failure becomes rc.
+# The capture is `{ cmd1; ...; cmdN } > "$log" || rc=$?`, and a brace group reports
+# only cmdN -- so every earlier failure was recorded as rc=0 and the job continued
+# with a half-built venv: a truncated mlx download surfaced two steps later as
+# ModuleNotFoundError, with the build step green. `set -e` inside the group does NOT
+# help: it sits on the left of `|| rc=$?`, where POSIX ignores errexit.
 
 def _capture_groups(run: str) -> list[str]:
     """Bodies of every `{ ... } > ... || rc=$?` status-capture group in a lane."""

--- a/tests/test_compile_already_compiled_callable.py
+++ b/tests/test_compile_already_compiled_callable.py
@@ -86,7 +86,7 @@ def _run_with_compile_enabled(body):
     return done.stdout
 
 
-# ---- the unwrap itself ----------------------------------------------------
+# ---- the unwrap itself ----
 
 def test_unwrap_already_compiled_returns_the_eager_original():
     from unsloth_zoo.temporary_patches.common import unwrap_already_compiled
@@ -103,7 +103,6 @@ def test_unwrap_already_compiled_returns_the_eager_original():
 
     assert unwrap_already_compiled(fallback_wrapper) is eager
     assert unwrap_already_compiled(compiled) is eager
-    # A plain function is handed straight back; nothing to unwrap.
     assert unwrap_already_compiled(eager) is eager
 
 
@@ -154,7 +153,7 @@ def test_unwrap_already_compiled_keeps_a_bound_method_bound():
     assert unwrap_already_compiled(bound) is bound
 
 
-# ---- the funnel -----------------------------------------------------------
+# ---- the funnel ----
 
 def test_torch_compile_hands_torch_the_eager_function():
     """Version independent: observe WHICH callable reaches `torch.compile`.

--- a/tests/test_compile_bare_decorators_unwrap.py
+++ b/tests/test_compile_bare_decorators_unwrap.py
@@ -85,8 +85,7 @@ def _run(*bodies, **extra_env):
     return done.stdout
 
 
-# The carrier every test starts from: a `functools.wraps` copy of a compiled
-# function, built the way the library builds it, not by hand.
+# The carrier every test starts from: a `functools.wraps` copy of a compiled function.
 _CARRIER = """
     from unsloth_zoo.temporary_patches import common as C
     from unsloth_zoo.temporary_patches.utils import torch_compile_with_fallback

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -77,8 +77,7 @@ def _seed_bundle(root):
             }
         )
     )
-    # Trusted bundles are owner-only: mirror the tool's 0600 so the reader
-    # accepts them (umask 0002 would otherwise seed 0664).
+    # Trusted bundles are owner-only: mirror the tool's 0600 (umask 0002 seeds 0664).
     if os.name == "posix":
         (key_dir / bundle_name).chmod(0o600)
         (key_dir / "manifest.json").chmod(0o600)
@@ -102,7 +101,6 @@ def _configure_load(monkeypatch, module, root, loaded):
 def test_megacache_default_is_platform_aware_with_kill_switch(monkeypatch):
     module = _load_module()
 
-    # explicit values win on every platform
     for value in ("1", "on", "true", "yes"):
         monkeypatch.setenv("UNSLOTH_MEGA_CACHE", value)
         assert module.megacache_is_enabled() is True
@@ -190,8 +188,7 @@ def test_megacache_does_not_load_through_directory_symlinks(
     if unsafe_component == "root":
         configured_root = tmp_path / "cache-link"
         configured_root.symlink_to(real_root, target_is_directory = True)
-        # realpath follows the link, so the resolved target must itself be
-        # untrusted (world-writable) to be rejected.
+        # realpath follows the link, so the target itself must be world-writable.
         real_root.chmod(0o777)
     else:
         configured_root = tmp_path / "cache"
@@ -338,8 +335,7 @@ def test_megacache_rejects_cache_below_foreign_owned_sticky_parent(monkeypatch, 
     directory.chmod(0o700)
     parent.chmod(0o1777)
 
-    # Sticky bit is not enough: the parent's owner can rename our leaf, so a
-    # foreign-owned sticky parent is rejected.
+    # Sticky is not enough: the parent's owner can rename our leaf.
     real_lstat = module.os.lstat
 
     def foreign_owner(path, *args, **kwargs):
@@ -363,8 +359,7 @@ def test_megacache_does_not_load_a_group_writable_bundle_file(monkeypatch, tmp_p
     key_dir, _ = _seed_bundle(root)
     root.chmod(0o700)
     key_dir.chmod(0o700)
-    # Directories are trusted, but a group-writable bundle file can be rewritten
-    # in place by a same-group attacker along with its checksum.
+    # A group-writable bundle can be rewritten in place with its checksum.
     (key_dir / "megacache-seeded.bin").chmod(0o664)
 
     loaded = []
@@ -380,8 +375,8 @@ def test_megacache_refuses_a_fifo_bundle_without_blocking(tmp_path):
     fifo = tmp_path / "bundle.fifo"
     os.mkfifo(fifo)
     os.chmod(fifo, 0o600)
-    # O_NONBLOCK keeps the open from hanging on a writerless FIFO so the
-    # S_ISREG check can refuse this non-regular file.
+    # O_NONBLOCK keeps the open from hanging on a writerless FIFO, so the S_ISREG
+    # check can refuse this non-regular file.
     assert module._read_trusted_file(fifo, binary = True) is None
 
 
@@ -413,8 +408,7 @@ def test_megacache_ignores_bundle_name_path_traversal(monkeypatch, tmp_path):
 @pytest.mark.skipif(os.name != "posix", reason = "POSIX umask semantics")
 def test_megacache_creates_private_parents_under_lax_umask(tmp_path):
     module = _load_module()
-    # makedirs' mode only clamps the leaf, so a lax umask must not leave a
-    # group-writable parent that the trust walk would then reject.
+    # makedirs' mode only clamps the leaf, not the parents it creates.
     old = os.umask(0o002)
     try:
         nested = tmp_path / "root" / "unsloth" / "mega_cache"
@@ -464,8 +458,7 @@ def test_megacache_save_does_not_repermission_existing_root(monkeypatch, tmp_pat
     module._STATE["loaded_key"] = "deadbeef"
 
     assert module.megacache_save() is True
-    # A configured root the user pointed at keeps its mode; only our own
-    # per-key child is clamped to owner-only.
+    # A configured root keeps its mode; only our per-key child is clamped.
     assert (root.stat().st_mode & 0o777) == 0o755
     assert ((root / "deadbeef").stat().st_mode & 0o777) == 0o700
 
@@ -496,7 +489,6 @@ def test_megacache_save_repairs_group_writable_existing_bundle(monkeypatch, tmp_
     key_dir.chmod(0o700)
     data = b"artifact-bytes"
     bundle_name = "megacache-%s.bin" % hashlib.sha256(data).hexdigest()[:16]
-    # a leftover group-writable bundle at the content-addressed name
     (key_dir / bundle_name).write_bytes(data)
     (key_dir / bundle_name).chmod(0o664)
     fake_torch = types.SimpleNamespace(compiler = types.SimpleNamespace(
@@ -520,8 +512,7 @@ def test_megacache_cache_root_is_symlink_canonicalized(monkeypatch, tmp_path):
     (tmp_path / "trusted").mkdir()
     (tmp_path / "trusted" / "link").symlink_to(
         tmp_path / "attacker", target_is_directory = True)
-    # A symlink followed by ".." resolves differently than abspath collapses it;
-    # _cache_root must return the real path so validation matches actual access.
+    # A symlink followed by ".." resolves differently than abspath collapses it.
     configured = tmp_path / "trusted" / "link" / ".." / "unsafe"
     monkeypatch.setenv("UNSLOTH_MEGA_CACHE_DIR", str(configured))
     root = module._cache_root()
@@ -537,8 +528,7 @@ def test_megacache_permits_private_key_under_root_owned_sticky_root(monkeypatch,
     shared.chmod(0o1777)
     key_dir.chmod(0o700)
 
-    # Present `shared` as a root-owned sticky parent like /tmp: the per-key dir
-    # is still owned by us, so the bundle must load.
+    # Present `shared` as a root-owned sticky parent like /tmp; the key dir is ours.
     fixture_lstat = module.os.lstat
 
     def sticky_root(path, *args, **kwargs):

--- a/tests/test_compile_overwrite_trl_stamp.py
+++ b/tests/test_compile_overwrite_trl_stamp.py
@@ -43,8 +43,7 @@ from unsloth_zoo import compiler
 PROBE_NAME = "UnslothCompileStampProbe"
 PROBE_SOURCE = "def _unsloth_stamp_probe():\n    return 1\n"
 
-# What unsloth/models/rl.py passes for a generated RL trainer, and what the
-# zoo's own peft / combined-module call sites pass.
+# What unsloth/models/rl.py passes for a generated RL trainer, versus the zoo's own call sites.
 TRL_LOCATION = "trl.trainer.sft_trainer"
 NON_TRL_LOCATION = "transformers.models.qwen2.modeling_qwen2"
 
@@ -278,8 +277,7 @@ def test_the_trl_marker_is_matched_as_a_whole_word(tmp_path, monkeypatch):
         tmp_path, monkeypatch, overwrite=True,
         model_location=NON_TRL_LOCATION, source=ctrl_body,
     )
-    # The body comment above deliberately contains a real whole-word `trl`;
-    # strip it so only `ctrl` remains, which must not trip the backstop.
+    # The fixture body carries a real whole-word `trl`; strip it so only `ctrl` remains.
     path.write_text(path.read_text().replace("# ctrl, not trl", "# ctrl only"))
     _rewrite_trl_stamp(path, "0.0.1-stale")
 

--- a/tests/test_compiler_decorated_forward.py
+++ b/tests/test_compiler_decorated_forward.py
@@ -131,13 +131,11 @@ def test_decorated_forward_emits_the_real_body_and_no_unbound_name(tmp_path, mon
     module = _load_fake_modeling_module(tmp_path, monkeypatch, "fake_bare_closure_codegen")
     generated = _generate("fake_bare_closure_codegen", "FakeGatedDeltaNet", module)
 
-    # The real body is emitted, and the decorator's wrapper is not.
     assert "real_body_ran = self.in_proj(hidden_states)" in generated
     assert "def wrapped(" not in generated
     assert "return wrapped(" not in generated
 
-    # The forwarding call is built from the real signature, so `args` / `kwargs`
-    # are never referenced without being bound.
+    # The forwarding call is built from the real signature, so nothing is unbound.
     assert "return FakeGatedDeltaNet_forward(" in generated
     assert "hidden_states=hidden_states" in generated
     assert "cache_params=cache_params" in generated
@@ -208,9 +206,7 @@ def test_undecorated_forward_is_untouched(tmp_path, monkeypatch):
     compile(generated, "<fake-bare-closure-plain>", "exec")
 
 
-# ---------------------------------------------------------------------------
 # _unwrap_undecorated_method must be inert for every other shape.
-# ---------------------------------------------------------------------------
 
 def test_unwrap_returns_plain_method_identically():
     class Plain:

--- a/tests/test_compiler_dynamic_exec.py
+++ b/tests/test_compiler_dynamic_exec.py
@@ -56,8 +56,7 @@ def _compile_disabled(monkeypatch):
     monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "1")
 
 
-# Model types the zoo compiler drives end-to-end (from
-# unsloth_compile_transformers call sites and test_apply_fused_lm_head).
+# Model types the zoo compiler drives end-to-end (from its call sites).
 KNOWN_MODEL_TYPES = [
     "llama",
     "llama4",
@@ -115,9 +114,7 @@ def _load_modeling(model_type: str):
             f"transformers, can't drive compiler"
         )
     except ImportError as exc:
-        # Present but raising on the way in: gemma3n's config imports
-        # ImageNetInfo from timm.data, which a newer timm dropped. Nothing to
-        # drive either way, but say which.
+        # gemma3n's config imports ImageNetInfo from a timm.data that dropped it.
         pytest.skip(
             f"model_type {model_type} raised on import, so the compiler cannot "
             f"be driven for it: {type(exc).__name__}: {exc}"
@@ -164,9 +161,7 @@ def _assert_execs(rewritten: str, entry_point: str, *, dedent: bool = False):
         pass
 
 
-# Per-rewriter tests against real transformers source. gemma3 is the
-# canonical driver: it exercises almost every rewriter path (RMSNorm,
-# sliding-window attn, RoPE, MoE routing, projector, ForConditionalGeneration).
+# gemma3 is the canonical driver: RMSNorm, sliding attn, RoPE, MoE, ForCondGen.
 
 
 @pytest.fixture(scope="module")
@@ -534,10 +529,8 @@ def test_replace_with_grouped_query_attention_inserts_enable_gqa():
     )
 
 
-# End-to-end: unsloth_compile_transformers(model_type=X) chains every
-# rewriter and emits unsloth_compiled_module_<type>.py to
-# unsloth_compiled_cache/ (see ``unsloth_zoo/compiler.py:66-67``
-# COMBINED_UNSLOTH_NAME). Drive per known model type, AST-parse the cache.
+# unsloth_compile_transformers(X) emits unsloth_compiled_module_<type>.py
+# (``unsloth_zoo/compiler.py:66-67``).
 
 
 def _compile_and_get_cache(model_type: str, monkeypatch) -> str:
@@ -545,7 +538,6 @@ def _compile_and_get_cache(model_type: str, monkeypatch) -> str:
     monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "1")
     monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "1")
 
-    # Clear __UNSLOTH_PATCHED__ so the pipeline rebuilds each time.
     try:
         mod = importlib.import_module(
             f"transformers.models.{model_type}.modeling_{model_type}",
@@ -556,9 +548,7 @@ def _compile_and_get_cache(model_type: str, monkeypatch) -> str:
             f"transformers, can't drive compiler"
         )
     except ImportError as exc:
-        # Present but raising on the way in: gemma3n's config imports
-        # ImageNetInfo from timm.data, which a newer timm dropped. Nothing to
-        # drive either way, but say which.
+        # gemma3n's config imports ImageNetInfo from a timm.data that dropped it.
         pytest.skip(
             f"model_type {model_type} raised on import, so the compiler cannot "
             f"be driven for it: {type(exc).__name__}: {exc}"
@@ -664,8 +654,8 @@ def test_smoke_unsloth_compile_transformers_unknown_model_type(monkeypatch):
     )
 
 
-# AST validity of constant source blocks in compiler.py, exec()'d verbatim
-# by ``create_new_function`` (see ``unsloth_zoo/compiler.py:801-1126``).
+# Constant source blocks exec()'d verbatim by ``create_new_function``
+# (``unsloth_zoo/compiler.py:801-1126``).
 
 
 @pytest.mark.parametrize(
@@ -685,9 +675,7 @@ def test_compiler_constant_source_blocks_parse(const_name):
     block = getattr(compiler, const_name, None)
     if block is None:
         pytest.skip(f"{const_name} not present (renamed?)")
-    # replace_gradient_checkpointing template has LAYER / ARGS /
-    # MODULELIST_ITEM / $ placeholders substituted in the rewriter;
-    # substitute representative values here so the parser sees real source.
+    # The rewriter substitutes LAYER / ARGS / MODULELIST_ITEM / $; do the same.
     if const_name == "replace_gradient_checkpointing":
         block = (
             block.replace("LAYER", "layer")

--- a/tests/test_compiler_getsource_tokenerror.py
+++ b/tests/test_compiler_getsource_tokenerror.py
@@ -70,10 +70,8 @@ def _run(body: str, cache_dir: Path, timeout: int = 900):
     env["UNSLOTH_COMPILE_DISABLE"] = "1"
     # On a CPU-only runner the zoo's get_device_type raises "Unsloth cannot find
     # any torch accelerator" during the child's import, before either TokenError
-    # handler is reached. It does not today, but only because tests/conftest.py
-    # does os.environ.setdefault("UNSLOTH_ALLOW_CPU", "1") at import and this
-    # copy of os.environ carries it. Measured: neuter that one conftest line and
-    # all three tests here die on the import. That is too far away to rely on.
+    # handler is reached. Measured: neuter tests/conftest.py's UNSLOTH_ALLOW_CPU
+    # setdefault and all three tests here die on the import.
     env.setdefault("UNSLOTH_ALLOW_CPU", "1")
     return subprocess.run(
         [sys.executable, "-c", script],

--- a/tests/test_compiler_inference_logit_transforms.py
+++ b/tests/test_compiler_inference_logit_transforms.py
@@ -58,8 +58,7 @@ def test_every_inference_branch_applies_the_softcap():
 
 def test_training_and_inference_use_the_same_transform_order():
     src = _template_source()
-    # scale multiply, then scale divide, then softcap. Any arm that applies the
-    # transforms must do so in this order, otherwise the two paths differ.
+    # scale multiply, then scale divide, then softcap, or the two paths differ.
     order = re.compile(
         r"logits = logits \* \(\\\\2\).*?logits = logits / \(\\\\3\).*?torch\.tanh\(logits\)",
         re.S,

--- a/tests/test_compiler_output_capture.py
+++ b/tests/test_compiler_output_capture.py
@@ -1,5 +1,4 @@
-# Tests for the transformers v5 output capture helpers in unsloth_zoo.compiler:
-# patch_output_capture_targets and calls_output_capture_target.
+# Tests for the transformers v5 output capture helpers in unsloth_zoo.compiler.
 
 import types
 
@@ -80,7 +79,6 @@ def test_retargets_specs_to_replacement_classes():
     # Bare classes without a replacement stay untouched.
     assert flags["hidden_states"] is FakeDecoderLayer
 
-    # List and tuple specs keep their container type and are retargeted.
     assert isinstance(flags["attentions"], list)
     assert flags["attentions"][0].target_class is ReplacementAttention
     assert flags["attentions"][0].index == 1

--- a/tests/test_compiler_rewriter_exhaustive.py
+++ b/tests/test_compiler_rewriter_exhaustive.py
@@ -361,7 +361,7 @@ def test_compiler_dtype_mismatch_finfo_attention_mask_pinned():
     )
     if not _probe_modules(candidates, lambda s: pattern.search(s) is not None):
         # Exact idiom removed in masking_utils 4.50+; only fail when both
-        # `torch.finfo(...).min` AND `(1.0 - <mask>)` primitives are gone.
+        # `torch.finfo(...).min` and `(1.0 - <mask>)` are gone.
         finfo_present = _probe_modules(
             candidates,
             lambda s: "torch.finfo" in s,
@@ -799,15 +799,13 @@ def test_patching_utils_compiled_autograd_end_capture_return_compiled_fn_pinned(
         return
     needle = "return compiled_fn(inputs, sizes, scalars, hooks)"
     pattern = re.compile(r"\n([ ]{1,})return compiled_fn")
-    # Pass if exact str+regex present (rewriter works), or `with disable()`
-    # / `with _disable()` already in src (torch 2.7+ native fix).
+    # `with disable()` / `with _disable()` in src is the torch 2.7+ native fix.
     if needle in src and pattern.search(src) is not None:
         return
     if "with disable()" in src or "with _disable()" in src:
         return
     if "compiled_fn(" in src:
-        # BENIGN on torch 2.7+: upstream fixed PR #135795 natively; zoo
-        # recognises both forms and no-ops cleanly.
+        # BENIGN on torch 2.7+: upstream fixed PR #135795 natively.
         pytest.skip(
             "BENIGN: torch 2.7+ fixed PR #135795-style double-compile "
             "upstream natively (now wraps compiled_fn in `with _disable()`); "
@@ -903,8 +901,7 @@ def test_patching_utils_replace_with_bnb_linear_skip_modules_pinned():
         )
         return
 
-    # Read upstream source from the module file: zoo rebinds the live
-    # function, so inspect.getsource off it returns the patched body.
+    # Zoo rebinds the live function, so inspect.getsource returns the patched body.
     live = bnb._replace_with_bnb_linear
     is_zoo_patched = (
         getattr(live, "__name__", "") == "_unsloth_replace_with_bnb_linear"
@@ -1032,7 +1029,6 @@ def test_patching_utils_replace_with_bnb_linear_ast_wrap_target():
         src = inspect.getsource(bnb._replace_with_bnb_linear)
     except (OSError, TypeError):
         pytest.skip("Source unavailable")
-    # The recursive call is the AST anchor.
     pattern = re.compile(r"=\s*_replace_with_bnb_linear\s*\(")
     if pattern.search(src) is None:
         _drift(
@@ -1088,7 +1084,6 @@ def test_saving_utils_save_pretrained_state_dict_contiguous_pinned_string():
             "on 5.x but is present; refresh the zoo prod-fix anchor "
             "list at saving_utils.py:_required_anchors"
         )
-        # Assert zoo's preflight check includes the now-missing anchor.
         import unsloth_zoo.saving_utils as zsu
         zsu_src = inspect.getsource(zsu.merge_and_dequantize_lora)
         assert needle in zsu_src, (

--- a/tests/test_convert_hf_to_gguf_patcher.py
+++ b/tests/test_convert_hf_to_gguf_patcher.py
@@ -32,10 +32,8 @@ def _load_llama_cpp_module():
     return module
 
 
-# --- Synthetic fixtures matching upstream layouts ---------------------------
 
-# A minimal but realistic stand-in for the new `convert_hf_to_gguf.py`
-# entrypoint. The structural anchor we detect on is `from conversion import`.
+# New-layout entrypoint. The structural anchor we detect on is `from conversion import`.
 _PACKAGE_ENTRYPOINT = b"""\
 #!/usr/bin/env python3
 import argparse
@@ -56,8 +54,7 @@ from conversion import (
 )
 """
 
-# A minimal stand-in for conversion/base.py containing the canonical
-# Metadata.load call site at 8-space indent (matches conversion/base.py:912).
+# conversion/base.py: canonical Metadata.load at 8-space indent (base.py:912).
 _PACKAGE_BASE_PY = b"""\
 import gguf
 from enum import IntEnum
@@ -80,8 +77,7 @@ class ModelBase:
             self.metadata.name = self.remote_hf_model_id
 """
 
-# A minimal stand-in for conversion/__init__.py with realistic TEXT_MODEL_MAP
-# and MMPROJ_MODEL_MAP dict literals (matches __init__.py:19-231,234-283).
+# conversion/__init__.py TEXT_MODEL_MAP + MMPROJ_MODEL_MAP (__init__.py:19-231,234-283).
 _PACKAGE_INIT_PY = b"""\
 from __future__ import annotations
 from .base import ModelBase, ModelType
@@ -111,8 +107,8 @@ def get_model_class(name, mmproj=False):
     return ModelBase
 """
 
-# Stand-in for the new conversion/qwen.py: contains both expert-key literals
-# in the same find_hparam call (upstream already handles the alias).
+# conversion/qwen.py: both expert-key literals in one find_hparam call (upstream
+# already handles the alias).
 _PACKAGE_QWEN_PY = b"""\
 from .base import ModelBase
 
@@ -123,9 +119,7 @@ class Qwen2MoeModel(ModelBase):
         return n_experts
 """
 
-# A minimal stand-in for the OLD monolithic convert_hf_to_gguf.py. Note: NO
-# `from conversion import` anywhere; that is the structural anchor for layout
-# detection. ModelBase and ModelType are defined inline.
+# The OLD monolith: NO `from conversion import`, the anchor for layout detection.
 _MONOLITH = b"""\
 import argparse
 import gguf
@@ -176,7 +170,6 @@ def monolith_layout(tmp_path):
     return root
 
 
-# --- Layout detection -------------------------------------------------------
 
 
 def test_detect_layout_returns_package_for_new_tree(package_layout):
@@ -198,7 +191,6 @@ def test_detect_layout_falls_back_to_monolith_when_conversion_dir_missing(tmp_pa
     assert llama_cpp._detect_converter_layout(_PACKAGE_ENTRYPOINT, str(tmp_path)) == "monolith"
 
 
-# --- Arch enumeration from conversion/__init__.py ---------------------------
 
 
 def test_extract_text_model_map_keys(package_layout):
@@ -231,14 +223,12 @@ def test_extract_returns_empty_for_unparseable_file(tmp_path):
     assert llama_cpp._extract_dict_keys_from_conversion_init(str(tmp_path / "nope.py"), "TEXT_MODEL_MAP") == set()
 
 
-# --- Branding patch on conversion/base.py -----------------------------------
 
 
 def test_branding_patch_applies_and_is_idempotent(package_layout):
     llama_cpp = _load_llama_cpp_module()
     base_py = package_layout / "conversion" / "base.py"
 
-    # First call: applies.
     assert llama_cpp._apply_branding_patch_to_base(str(base_py)) == "applied"
     content = base_py.read_bytes()
     assert b"# UNSLOTH_BRANDING_APPLIED" in content
@@ -246,9 +236,7 @@ def test_branding_patch_applies_and_is_idempotent(package_layout):
     assert b"self.metadata.repo_url = 'https://huggingface.co/unsloth'" in content
     assert b"self.metadata.tags = ['unsloth', 'llama.cpp']" in content
 
-    # Second call: no-op (idempotent).
     assert llama_cpp._apply_branding_patch_to_base(str(base_py)) == "already-applied"
-    # File contents should be unchanged after the second call.
     assert base_py.read_bytes() == content
 
 
@@ -267,17 +255,13 @@ def test_branding_patch_preserves_lines_around_target(package_layout):
     llama_cpp._apply_branding_patch_to_base(str(base_py))
     patched = base_py.read_bytes()
 
-    # The Metadata.load line itself is preserved verbatim.
     assert b"self.metadata = gguf.Metadata.load(" in patched
-    # Code that followed the target (the if self.remote_hf_model_id... block)
-    # is still present after the patch (we only inserted lines, not deleted).
+    # Code after the target survives: the patch only inserts lines.
     assert b"if self.remote_hf_model_id:" in patched
     assert b"self.metadata.name = self.remote_hf_model_id" in patched
-    # File grew (we added 4 branding lines + marker), not shrank.
     assert len(patched) > len(original)
 
 
-# --- Qwen expert-key alias detection ---------------------------------------
 
 
 def test_qwen_aliases_detected_when_both_keys_present(package_layout):
@@ -293,7 +277,6 @@ def test_qwen_aliases_not_detected_when_only_one_key_present(tmp_path):
     assert llama_cpp._qwen_already_handles_expert_aliases(str(qwen_py)) is False
 
 
-# --- Cache-key invalidation (sibling info) ---------------------------------
 
 
 def test_conversion_sibling_info_changes_when_base_py_changes(package_layout):
@@ -353,11 +336,7 @@ def test_package_layout_does_not_require_module_import(tmp_path, monkeypatch):
     to-end with `UNSLOTH_LLAMA_CPP_SCRIPTS_DIR` set."""
     llama_cpp = _load_llama_cpp_module()
 
-    # Build a custom package-layout checkout in tmp_path. We extend the
-    # shared fixture with a parse_args() stub so the end-to-end pipeline can
-    # finish its flag-parsing step on the patched file (the real upstream
-    # entrypoint has these calls; the shared fixture omits them because no
-    # other test exercises the full pipeline).
+    # A parse_args() stub so the end-to-end pipeline can finish its flag parsing.
     entry_with_args = _PACKAGE_ENTRYPOINT + (
         b"\n"
         b"def parse_args():\n"
@@ -379,17 +358,15 @@ def test_package_layout_does_not_require_module_import(tmp_path, monkeypatch):
 
     monkeypatch.setenv("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR", str(root))
 
-    # Sentinel: any call here means the patcher fell through to the
-    # monolith path on package layout, which is the bug we're guarding.
+    # A call here means the patcher fell through to the monolith path on package
+    # layout, which is the bug being guarded.
     called = {"hit": False}
     def _trap(*a, **kw):
         called["hit"] = True
         raise AssertionError("monolith-only arch extraction ran on package layout")
     monkeypatch.setattr(llama_cpp, "_extract_archs_from_monolith_source", _trap)
 
-    # Cache must be cleared between runs because @lru_cache(1) keys include
-    # the resolved local_script_info -- but a stale entry from a previous
-    # test would short-circuit the new call.
+    # @lru_cache(1) keys include local_script_info; a stale entry short-circuits.
     llama_cpp._download_convert_hf_to_gguf_cached.cache_clear()
 
     patched_path, text_archs, vision_archs = llama_cpp._download_convert_hf_to_gguf("regression_no_module_import")
@@ -398,7 +375,6 @@ def test_package_layout_does_not_require_module_import(tmp_path, monkeypatch):
     assert patched_path.endswith(".py")
     assert "LlamaForCausalLM" in text_archs
     assert text_archs == frozenset(text_archs)
-    # base.py was patched in place under the override dir.
     assert b"# UNSLOTH_BRANDING_APPLIED" in (conv / "base.py").read_bytes()
     # Cleanup for follow-on tests.
     llama_cpp._download_convert_hf_to_gguf_cached.cache_clear()
@@ -506,7 +482,6 @@ def test_latest_upstream_arch_enumeration_non_empty(latest_llama_cpp):
         f"upstream TEXT_MODEL_MAP missing LlamaForCausalLM; "
         f"got {sorted(text_archs)[:10]}..."
     )
-    # The set should also contain at least some Qwen entries since this is the
-    # user's reported architecture family.
+    # Qwen* entries: the user's reported architecture family.
     qwen_keys = {k for k in text_archs if k.startswith("Qwen")}
     assert qwen_keys, f"upstream TEXT_MODEL_MAP has no Qwen* entries: {sorted(text_archs)[:20]}..."

--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -166,8 +166,7 @@ def test_convert_to_gguf_reconciles_mtp_config_to_index(llama_cpp, tmp_path, has
     updated = json.loads(config_path.read_text(encoding = "utf-8"))
     assert "unsloth_fixed_mtp" not in updated
     assert "unsloth_fixed_mtp" not in updated["text_config"]
-    # The declaration survives either way: kept as-is with MTP tensors, and kept
-    # because `--no-mtp` carries the intent without them.
+    # The declaration survives either way: `--no-mtp` carries the intent.
     assert "mtp_num_hidden_layers" in updated
     assert "mtp_num_hidden_layers" in updated["text_config"]
     command, = _read_converter_commands(tmp_path)
@@ -554,8 +553,7 @@ def test_convert_to_gguf_retries_with_no_mtp_after_the_inference_assertion(llama
         ("  File \"qwen.py\", line 303\n    assert self.opt_num_mtp_layers != 0\nAssertionError\n", True),
         ("AssertionError: something else entirely\n", False),
         ("INFO:hf-to-gguf:opt_num_mtp_layers resolved to 1\n", False),
-        # Both words, different lines: a recognised head that then failed for
-        # another reason keeps it.
+        # Both words, different lines: a recognised head that failed otherwise.
         (
             "INFO:hf-to-gguf:opt_num_mtp_layers resolved to 1\n"
             "AssertionError: tensor shape mismatch\n",
@@ -618,8 +616,7 @@ def test_convert_to_gguf_refuses_to_retry_when_the_checkpoint_has_mtp_tensors(ll
     carry a head must surface the disagreement, not export a reduced GGUF."""
     model_dir = tmp_path / "model"
     model_dir.mkdir()
-    # No declaration, the shape that reaches the assertion, but the head is
-    # there, indexed past the trunk.
+    # No declaration, but the head is there, indexed past the trunk.
     (model_dir / "config.json").write_text(
         json.dumps(
             {

--- a/tests/test_convert_to_gguf_self_heal.py
+++ b/tests/test_convert_to_gguf_self_heal.py
@@ -56,7 +56,6 @@ def test_stale_package_self_heals(tmp_path, monkeypatch):
     mod = _load_llama_cpp_module()
     monkeypatch.chdir(tmp_path)
 
-    # Fail with an ImportError until a "healed" marker exists, then succeed.
     converter = _write_converter(tmp_path, '''
         p = argparse.ArgumentParser()
         p.add_argument("--outfile"); p.add_argument("--outtype"); p.add_argument("--split-max-size")

--- a/tests/test_cross_entropy_chunk_cap.py
+++ b/tests/test_cross_entropy_chunk_cap.py
@@ -20,11 +20,8 @@ def _load_module(monkeypatch, free_bytes):
     try:
         ce = importlib.import_module("unsloth_zoo.fused_losses.cross_entropy_loss")
     except ImportError as e:
-        # A zoo-only checkout (no separate `unsloth` package installed) makes
-        # `unsloth_zoo/__init__` raise before this module loads. Skip rather
-        # than fail; where `unsloth` is present the full assertions still run.
+        # A zoo-only checkout (no `unsloth` installed) makes `unsloth_zoo/__init__` raise first.
         pytest.skip(f"unsloth_zoo import unavailable: {e}")
-    # Force the CUDA path and a fixed, very large free pool.
     monkeypatch.setattr(ce, "DEVICE_TYPE", "cuda", raising=False)
 
     fake_cuda = types.SimpleNamespace(mem_get_info=lambda index=0: (free_bytes, free_bytes))
@@ -38,7 +35,6 @@ def test_chunk_count_stays_above_one_on_huge_gpu(monkeypatch):
     huge_free = 180 * 1024 ** 3  # 180 GiB, e.g. a B200
     ce = _load_module(monkeypatch, huge_free)
 
-    # A realistic large-vocab, long-context step.
     vocab_size = 256_000
     bsz, qlen = 1, 32_768
     n_splits = ce.get_chunk_size(bsz, qlen, vocab_size)
@@ -46,31 +42,26 @@ def test_chunk_count_stays_above_one_on_huge_gpu(monkeypatch):
 
 
 def test_cap_effective_in_4_to_8_gib_band(monkeypatch):
-    # Full float32 logits between 4 and 8 GiB used to round down to a single
-    # uncapped chunk (round(0.5) * 4 == 0 -> max(.., 1) == 1). vocab=65536,
-    # qlen=32768 is exactly 8 GiB; the cap must split it.
+    # 4-8 GiB of float32 logits used to round down to one uncapped chunk
+    # (round(0.5) * 4 == 0 -> max(.., 1) == 1); 65536 x 32768 is exactly 8 GiB.
     huge_free = 180 * 1024 ** 3
     ce = _load_module(monkeypatch, huge_free)
     vocab_size = 65_536
     bsz, qlen = 1, 32_768
     n_splits = ce.get_chunk_size(bsz, qlen, vocab_size)
     assert n_splits > 1, f"expected the 4-8 GiB band to chunk, got {n_splits}"
-    # Every chunk must stay within the 4 GiB target.
     total_gib = bsz * qlen * vocab_size * 4 / 1024 ** 3
     assert total_gib / n_splits <= 4.0 + 1e-6, (total_gib, n_splits)
 
 
 def test_small_logits_stay_single_chunk(monkeypatch):
-    # Configs whose full logits already fit the target keep a single chunk.
     ce = _load_module(monkeypatch, 180 * 1024 ** 3)
     # 2 GiB of float32 logits (< 4 GiB cap).
     assert ce.get_chunk_size(1, 8_192, 65_536) == 1
 
 
 def test_cap_bounds_target_independent_of_free(monkeypatch):
-    # The multiplier for the auto (target_gb=None) path must not shrink as the
-    # free pool grows past the cap: two very different huge pools give the same
-    # multiplier once the cap dominates.
+    # The auto (target_gb=None) multiplier must not shrink as the free pool grows past the cap.
     ce = _load_module(monkeypatch, 120 * 1024 ** 3)
     m_120 = ce._get_chunk_multiplier(256_000)
     ce = _load_module(monkeypatch, 320 * 1024 ** 3)

--- a/tests/test_dataset_num_proc.py
+++ b/tests/test_dataset_num_proc.py
@@ -19,9 +19,8 @@ from pathlib import Path
 import pytest
 
 try:
-    # Import before the dnp fixture spoofs sys.platform: multiprocess picks its
-    # concrete contexts from it at import time, so a first import under a spoofed
-    # one hands a Windows runner the POSIX fork contexts.
+    # multiprocess picks its contexts from sys.platform at import time; the dnp fixture
+    # spoofs it, and a first import under the spoof hands a Windows runner POSIX fork contexts.
     import multiprocess  # noqa: F401
 except ImportError:
     pass
@@ -45,15 +44,10 @@ def dnp(monkeypatch):
     module = _load_module()
     module.reset_warning_state()
     monkeypatch.delenv(module.NUM_PROC_ENV_VAR, raising = False)
-    # Pin the platform: macOS is refused by policy whatever the start method
-    # says. Platform tests set their own value afterwards, which wins.
+    # macOS is refused by policy whatever the start method says; platform tests re-pin it.
     monkeypatch.setattr(module.sys, "platform", "linux")
-    # Pin the memory ceiling too, at its two sources rather than at the reader,
-    # so the memory tests can still patch either and win. Every count this
-    # module returns is clamped by free RAM and by the cgroup budget, so on a
-    # memory-limited runner a test about the start method or about an explicit
-    # value silently becomes a test of the clamp instead:
-    # `get_dataset_num_proc(6) == 6` returns 4 in a small container.
+    # Pin the memory ceiling at its two sources, not at the reader, so the memory
+    # tests can still win. Unpinned, `get_dataset_num_proc(6) == 6` returns 4 in a container.
     try:
         import psutil
         monkeypatch.setattr(
@@ -61,28 +55,16 @@ def dnp(monkeypatch):
         )
     except ImportError:
         pass
-    # Point this module's cgroup reader at a path that does not exist rather than
-    # stubbing the reader itself, so the tests that are about it can still
-    # install a fixture tree and win.
+    # Point the cgroup reader at a nonexistent path rather than stubbing it, so reader tests win.
     monkeypatch.setattr(module, "CGROUP_ROOT", "/nonexistent-cgroup-root-for-tests")
-    # hf_xet_tuning's readers are neutralised by name instead, and without
-    # requiring the name to be there: pinning hf_xet_tuning.CGROUP_ROOT alone
-    # only works against an installed zoo that has that global. An older one
-    # still exposes the private dir helpers this module prefers, monkeypatch
-    # finds no attribute to pin, and the policy reads the runner's real cgroup --
-    # which in a memory-limited container turns a test about the start method
-    # into a test of the clamp. The tests that are about these readers install
-    # their own unsloth_zoo.hf_xet_tuning in sys.modules, so they are unaffected.
+    # hf_xet_tuning's readers are neutralised by name, without requiring the name:
+    # an older installed zoo has no CGROUP_ROOT to pin, so the policy would read the
+    # runner's real cgroup. Tests about these readers install their own module.
     try:
         from unsloth_zoo import hf_xet_tuning
     except Exception:
-        # Importing the package can fail long after it has imported this
-        # submodule (__init__ pulls in hf_xet_tuning near the top and only
-        # raises "Please install Unsloth" at the end), and the failure removes
-        # unsloth_zoo from sys.modules while leaving unsloth_zoo.hf_xet_tuning
-        # behind. The module under test reaches it through exactly that cache
-        # entry, so treating the failure as absence would leave the real readers
-        # live on the runner's own /sys/fs/cgroup.
+        # unsloth_zoo/__init__ can raise "Please install Unsloth" after importing
+        # hf_xet_tuning, leaving the submodule cached - which is what the policy reaches.
         hf_xet_tuning = sys.modules.get("unsloth_zoo.hf_xet_tuning")
     if hf_xet_tuning is not None:
         for name, neutral in (
@@ -155,8 +137,7 @@ def test_serial_as_none_false_preserves_an_explicit_one(monkeypatch, dnp):
     """
     _force_start_method(monkeypatch, dnp, "fork")
     assert dnp.get_dataset_num_proc(1, serial_as_none = False) == 1
-    # 0 and negatives are incoherent but still mean "not parallel", so they land
-    # on the config serial sentinel (1), not on None.
+    # 0 and negatives still mean "not parallel", so they land on the config serial sentinel (1).
     assert dnp.get_dataset_num_proc(0, serial_as_none = False) == 1
     assert dnp.get_dataset_num_proc(-4, serial_as_none = False) == 1
 
@@ -169,7 +150,6 @@ def test_config_layer_never_returns_none_while_forking_is_available(monkeypatch,
     psutil = pytest.importorskip("psutil")
     _force_cpus(monkeypatch, dnp, 64)
 
-    # memory clamp all the way down to serial
     _force_start_method(monkeypatch, dnp, "fork")
     monkeypatch.setattr(
         psutil, "virtual_memory", lambda: type("m", (), {"available": 1 * 1024**3})()
@@ -214,11 +194,8 @@ def test_layering_config_then_map_site_is_correct(monkeypatch, dnp):
     cfg = lambda v: dnp.get_dataset_num_proc(v, serial_as_none = False)  # noqa: E731
     site = dnp.get_dataset_num_proc
 
-    # serial stays serial, never auto-inflated
     assert site(cfg(1)) is None
-    # a specific count is honoured end to end
     assert site(cfg(6)) == 6
-    # nothing asked for -> capped auto, and re-applying is idempotent
     assert cfg(None) == dnp.AUTO_NUM_PROC_CAP
     assert site(cfg(None)) == dnp.AUTO_NUM_PROC_CAP
 
@@ -285,7 +262,6 @@ def test_explicit_value_is_clamped_by_memory(monkeypatch, dnp, capsys):
 
 
 def test_explicit_value_is_not_capped_by_the_auto_cap(monkeypatch, dnp):
-    # AUTO_NUM_PROC_CAP bounds auto-sizing only.
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(
@@ -298,7 +274,6 @@ def test_explicit_value_is_not_capped_by_the_auto_cap(monkeypatch, dnp):
 
 
 def test_memory_clamp_is_skipped_without_psutil(monkeypatch, dnp):
-    # No psutil means no memory reading, so honour the request.
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: None)
     _force_start_method(monkeypatch, dnp, "fork")
     assert dnp.get_dataset_num_proc(32) == 32
@@ -326,8 +301,7 @@ def test_env_override_beats_start_method_veto(monkeypatch, dnp):
     assert dnp.get_dataset_num_proc(None) == 24
 
 
-# "1" belongs here as much as "0": it is the value datasets >= 4.1 turns into a
-# Pool(1), so the hatch has its own instance of this PR's headline trap.
+# "1" belongs here as much as "0": datasets >= 4.1 turns it into a Pool(1).
 @pytest.mark.parametrize("raw", ["0", "none", "None", "false", "", "1"])
 def test_env_override_can_force_in_process(monkeypatch, dnp, raw):
     _force_start_method(monkeypatch, dnp, "fork")
@@ -337,10 +311,7 @@ def test_env_override_can_force_in_process(monkeypatch, dnp, raw):
 
 @pytest.mark.parametrize("raw", ["0", "none", "None", "false", "", "1"])
 def test_env_override_in_process_is_encoded_for_the_config_layer(monkeypatch, dnp, raw):
-    # Regression: the env override used to return before _serial(), writing None
-    # into the *config*, read downstream as "auto-size me" -- so the hatch the
-    # dead-worker message recommends raised the worker count instead of removing
-    # it. Config serial is 1, never None.
+    # Regression: the override returned before _serial(), writing None ("auto-size me") into the config.
     _force_start_method(monkeypatch, dnp, "fork")
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, raw)
     assert dnp.get_dataset_num_proc(16, serial_as_none = False) == 1
@@ -350,10 +321,7 @@ def test_env_override_is_uncapped(monkeypatch, dnp):
     _force_start_method(monkeypatch, dnp, "fork")
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "100")
     assert dnp.get_dataset_num_proc(None) == 100
-    # Above the auto cap is the easy half. The memory clamp is the one that
-    # matters: the fixture leaves room for 512 workers, so without pinning it
-    # this asserts nothing about the exemption. map_failure_diagnostics points
-    # users at this hatch on exactly the host where the clamp would bite.
+    # Pin the clamp too: the fixture otherwise leaves room for 512 workers.
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: 2)
     assert dnp.get_dataset_num_proc(None) == 100
     assert dnp.get_dataset_num_proc(4) == 100
@@ -381,8 +349,7 @@ def test_start_method_probe_prefers_multiprocess_and_has_no_side_effects(dnp):
 
     method = dnp.multiprocessing_start_method()
 
-    # Must name a method this host offers: the private default-context chain has
-    # answered "fork" on Windows, which offers only spawn.
+    # The private default-context chain has answered "fork" on Windows, which offers only spawn.
     assert method in multiprocess.get_all_start_methods()
     assert multiprocess.get_start_method(allow_none = True) == before_mp
     assert multiprocessing.get_start_method(allow_none = True) == before_std
@@ -454,7 +421,6 @@ def test_macos_stays_in_process_even_though_multiprocess_forks(monkeypatch, dnp,
     assert dnp.get_dataset_num_proc(None) is None
     assert "macOS" in capsys.readouterr().out
 
-    # The escape hatch still overrides it, and Linux is unaffected.
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "4")
     assert dnp.get_dataset_num_proc(8) == 4
     monkeypatch.delenv(dnp.NUM_PROC_ENV_VAR)
@@ -492,8 +458,7 @@ _DATASETS_MESSAGE = (
 
 
 def test_worker_death_is_reraised_with_context(dnp):
-    # datasets discards the child's exit status, so its message cannot tell an
-    # OOM kill from anything else.
+    # datasets discards the child's exit status, so its message cannot name an OOM kill.
     with pytest.raises(RuntimeError) as caught:
         with dnp.map_failure_diagnostics(8):
             raise RuntimeError(_DATASETS_MESSAGE)
@@ -504,7 +469,6 @@ def test_worker_death_is_reraised_with_context(dnp):
     assert "8GB" in message, "should estimate what those workers cost"
     assert dnp.NUM_PROC_ENV_VAR in message, "must name the escape hatch"
     assert "out-of-memory" in message
-    # The child's traceback must survive.
     assert isinstance(caught.value.__cause__, RuntimeError)
     assert _DATASETS_MESSAGE in str(caught.value.__cause__)
 
@@ -519,7 +483,6 @@ def test_worker_death_diagnostics_handles_in_process_runs(dnp):
 
 
 def test_unrelated_errors_pass_through_untouched(dnp):
-    # Only the dead-worker message is rewritten; other types are not caught.
     original = RuntimeError("CUDA out of memory")
     with pytest.raises(RuntimeError) as caught:
         with dnp.map_failure_diagnostics(4):
@@ -532,9 +495,7 @@ def test_unrelated_errors_pass_through_untouched(dnp):
             raise key
     assert caught_key.value is key
 
-    # The identity assertions above hold under `except Exception` as well, since
-    # the guard re-raises the same object. This one does not: it carries the
-    # dead-worker text, so a widened clause would rewrite it into a RuntimeError.
+    # This one carries the dead-worker text, so a widened `except` would rewrite it.
     lookalike = ValueError(
         "One of the subprocesses has abruptly died during map operation."
     )
@@ -762,8 +723,7 @@ def test_memory_budget_follows_the_cgroup_not_the_host(monkeypatch, dnp):
 
 
 def test_memory_already_spent_in_the_container_is_not_counted_as_free(monkeypatch, dnp):
-    # Otherwise a container that has already spent most of its limit still reads
-    # as having the whole thing available.
+    # Otherwise a container that has spent most of its limit still reads as free.
     psutil = pytest.importorskip("psutil")
     _force_start_method(monkeypatch, dnp, "fork")
     _force_cpus(monkeypatch, dnp, 64)
@@ -779,8 +739,7 @@ def test_memory_already_spent_in_the_container_is_not_counted_as_free(monkeypatc
 
 
 def test_cpu_count_follows_the_affinity_mask(monkeypatch, dnp):
-    # Under taskset or Slurm pinning the host count is not what this process can
-    # run on, and workers would only contend for the cores it does have.
+    # Under taskset or Slurm pinning, the host count is not what this process can run on.
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 128)
     monkeypatch.setattr(dnp, "_cgroup_cpu_quota", lambda: None)
@@ -843,8 +802,7 @@ def test_serial_is_one_when_the_two_modules_disagree(monkeypatch, dnp, capsys):
 
 
 def test_serial_stays_none_when_the_zoo_would_refuse_workers_too(monkeypatch, dnp):
-    # macOS: multiprocess forks, stdlib spawns. Its own veto fires, so None is
-    # genuinely in-process there and 1 would be a pool it did not need.
+    # macOS: multiprocess forks, stdlib spawns. Its own veto fires, so None is genuinely in-process.
     _force_start_method(monkeypatch, dnp, "fork")
     monkeypatch.setattr(dnp.sys, "platform", "darwin")
     _force_stdlib_start_method(monkeypatch, dnp, "spawn")
@@ -906,8 +864,7 @@ def test_free_memory_pairs_each_limit_with_its_own_usage(monkeypatch, dnp, tmp_p
     leaf = slice_dir / "session.scope"
     leaf.mkdir(parents = True)
 
-    # The slice caps 32GB and 30 of them are spent, mostly by a sibling; this
-    # leaf has a 16GB cap of its own and has spent 1.
+    # The slice caps 32GB with 30 spent, mostly by a sibling; the leaf caps 16GB with 1 spent.
     (slice_dir / "memory.max").write_text("34359738368\n")
     (slice_dir / "memory.current").write_text("32212254720\n")
     (leaf / "memory.max").write_text("17179869184\n")
@@ -1066,10 +1023,8 @@ def _no_hf_xet_tuning(monkeypatch):
 
 
 def test_no_unsloth_zoo_and_no_cgroup_is_not_a_ceiling(monkeypatch, dnp, tmp_path):
-    # The cgroup tree is pointed away from the host's on purpose: the unaided
-    # reader needs no unsloth_zoo, so leaving it on the real /sys/fs/cgroup would
-    # make the assertion depend on whether the runner is itself in a limited
-    # container, which is how this test would fail on CI and pass on a laptop.
+    # The cgroup tree is pointed away from the host's: the unaided reader needs no
+    # unsloth_zoo, so the real /sys/fs/cgroup would fail on CI and pass on a laptop.
     _no_hf_xet_tuning(monkeypatch)
     monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path / "absent"))
     monkeypatch.setattr(dnp, "_proc_self_cgroup", lambda: [])
@@ -1113,8 +1068,7 @@ def test_env_forced_serial_is_in_process_on_a_small_split(monkeypatch, dnp):
 
 
 def test_a_memory_starved_explicit_count_is_in_process_on_a_small_split(monkeypatch, dnp):
-    # Same shape without the env var: the memory clamp resolves to serial, and
-    # under the threshold that has an exact encoding.
+    # Same without the env var: the memory clamp resolves to serial, exactly encodable here.
     _force_start_method(monkeypatch, dnp, "fork")
     _force_stdlib_start_method(monkeypatch, dnp, "fork")
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: 0)
@@ -1222,8 +1176,7 @@ def test_the_unaided_reader_picks_the_right_line_under_systemd_hybrid(
     v2_leaf.mkdir(parents = True)
     (v2_leaf / "memory.max").write_text("8589934592\n")
     (v2_leaf / "memory.current").write_text("6442450944\n")
-    # The v1 controller root exists but names a different path, so reading the
-    # first line instead of the "0::" one would miss the limit entirely.
+    # The v1 controller root names a different path, so reading the first line misses the limit.
     v1_leaf = tmp_path / "memory" / "slurm" / "job_1"
     v1_leaf.mkdir(parents = True)
     (v1_leaf / "memory.limit_in_bytes").write_text("9223372036854771712\n")
@@ -1252,9 +1205,7 @@ def test_a_bool_num_proc_counts_as_auto_for_the_responses_only_resolver(monkeypa
             self.eval_dataset = None
 
     small = _Trainer(_Split(dnp.ZOO_MIN_ROWS_FOR_MULTIPROC - 1))
-    # Passed straight back, so the helper still sees "auto" and its own per-split
-    # guard runs the small split in-process. Reading the bool as an explicit
-    # count instead would hand it a worker pool.
+    # Passed straight back, so the helper still sees "auto" and runs the small split in-process.
     assert dnp.resolve_responses_only_num_proc(small, True) is True
 
 

--- a/tests/test_deepseek_v2_moe_alias.py
+++ b/tests/test_deepseek_v2_moe_alias.py
@@ -90,8 +90,7 @@ def test_noop_when_neither_name_present(monkeypatch):
 
 
 def test_noop_when_module_import_fails(monkeypatch):
-    # None in sys.modules makes importlib.import_module raise ImportError; the
-    # function's try/except must swallow it.
+    # None in sys.modules makes import_module raise ImportError, which the try/except must swallow.
     _set_tf_version(monkeypatch, "5.0.0")
     monkeypatch.setitem(sys.modules, _LEAF, None)
 

--- a/tests/test_device_map_planner.py
+++ b/tests/test_device_map_planner.py
@@ -95,9 +95,8 @@ def test_headroom_grows_with_rows_and_vocab():
 
 
 def test_headroom_retained_term_scales_with_total_rows():
-    # The retained term is what makes the backward pass expensive: it depends on
-    # the total number of rows, not on the chunk size, so chunking alone cannot
-    # bound it.
+    # The retained term depends on the total rows, not the chunk size, so
+    # chunking alone cannot bound it.
     a = logit_headroom_bytes(200000, 128, retained_rows = 1024)
     b = logit_headroom_bytes(200000, 128, retained_rows = 4096)
     assert b > a
@@ -135,9 +134,6 @@ def test_refuses_instead_of_spilling_when_it_cannot_fit():
         )
 
 
-# --------------------------------------------------------------------------- #
-# quantised sizing
-# --------------------------------------------------------------------------- #
 def test_quantised_sizes_use_the_storage_dtype():
     """`preprocess_model` leaves a meta `Params4bit` at the full unpacked shape
     in float32, so measuring the modules directly reports a 4-bit checkpoint at
@@ -180,8 +176,7 @@ def test_quantised_sizes_use_the_storage_dtype():
     plain = _compute_module_sizes(model)[""]
     quant = _compute_module_sizes(model, Q())[""]
     assert quant < plain, (quant, plain)
-    # lm_head is not converted, so it keeps the load dtype rather than shrinking
-    # with everything else.
+    # lm_head is not converted, so it keeps the load dtype.
     assert _compute_module_sizes(model, Q())["lm_head"] == 512 * 64 * 2
 
 
@@ -190,9 +185,6 @@ def test_no_quantizer_leaves_sizes_untouched():
     assert _compute_module_sizes(model, None) == _compute_module_sizes(model)
 
 
-# --------------------------------------------------------------------------- #
-# placement units
-# --------------------------------------------------------------------------- #
 class _RootState(nn.Module):
     _no_split_modules = ["_Block"]
 
@@ -256,9 +248,6 @@ def test_a_composite_head_is_pinned_whole():
     assert plan.device_map["lm_head.proj"] == plan.head_device
 
 
-# --------------------------------------------------------------------------- #
-# packing
-# --------------------------------------------------------------------------- #
 class _Sized(nn.Module):
     def __init__(self, n):
         super().__init__()
@@ -305,9 +294,6 @@ def test_in_order_layout_is_kept_when_it_fits():
     assert layers == sorted(layers), layers
 
 
-# --------------------------------------------------------------------------- #
-# reserves
-# --------------------------------------------------------------------------- #
 def test_an_explicit_reserve_is_a_hard_constraint():
     """The relaxation loop walks the non-head reserve down to zero. Doing that
     to a reserve the caller measured is how a run OOMs on a card the plan still
@@ -338,9 +324,6 @@ def test_the_auto_reserve_is_still_relaxable():
     assert set(plan.device_map.values()) <= {0, 1}
 
 
-# --------------------------------------------------------------------------- #
-# remote code
-# --------------------------------------------------------------------------- #
 def test_remote_code_config_picks_the_auto_class_the_repo_registered():
     """A dynamic config is in no `_model_mapping`, so the mapping walk falls
     through to AutoModel and `from_config` then fails instead of honouring the
@@ -447,9 +430,6 @@ def test_each_backend_is_called_with_the_arguments_it_accepts(monkeypatch):
     assert seen["accelerate"][0] is torch.int8
 
 
-# --------------------------------------------------------------------------- #
-# budgets, packing and shared parameters
-# --------------------------------------------------------------------------- #
 _MiB = 1024 ** 2
 
 
@@ -624,8 +604,7 @@ def test_directly_owned_tensors_use_the_quantizer_aware_sizes():
     refuses a model that fits (or overcommits one that does not)."""
     with torch.device("meta"):
         model = _OwnState()
-    # A quantiser that halves every parameter, the shape of a 4-bit checkpoint
-    # whose meta tensors still report the unpacked float32 size.
+    # A 4-bit checkpoint whose meta tensors still report the unpacked float32 size.
     sizes = {k: v // 2 for k, v in _compute_module_sizes(model).items()}
     units = _split_units(model, [], sizes)
     assert sum(size for _, size in units) == sizes[""]
@@ -695,8 +674,7 @@ class _TiedDirectState(nn.Module):
         self.embed_tokens = nn.Embedding(vocab, hidden)
         self.trunk = _Composite(hidden)
         self.lm_head = nn.Linear(hidden, vocab, bias = False)
-        # Registered after `embed_tokens`, so sizing counts the tensor there and
-        # this module's own share of the size table is zero.
+        # Registered after `embed_tokens`, so sizing counts the tensor there.
         self.trunk.shadow = self.embed_tokens.weight
 
     def get_output_embeddings(self):
@@ -762,8 +740,7 @@ def test_keep_in_fp32_modules_mirror_the_loader():
         def update_dtype(self, dtype):
             return dtype
 
-    # bfloat16: the strict list always applies, the plain one only because the
-    # quantiser asks for it.
+    # bfloat16: the strict list always applies, the plain one only on request.
     assert _keep_in_fp32_modules(model, Bnb()) == ["norm", "lm_head"]
     assert _keep_in_fp32_modules(model, Other()) == ["lm_head"]
     assert _keep_in_fp32_modules(model, None) == ["lm_head"]
@@ -966,7 +943,6 @@ def test_fp32_loader_exceptions_apply_without_a_quantizer():
     plain = _compute_module_sizes(model)
     model._keep_in_fp32_modules = ["norm"]
     upcast = _compute_module_sizes(model)
-    # The norm doubles from float16 to float32; nothing else moves.
     assert upcast["norm"] == plain["norm"] * 2
     assert upcast["layers"] == plain["layers"]
     assert upcast[""] == plain[""] + plain["norm"]
@@ -1028,9 +1004,8 @@ def test_the_balanced_reserve_is_derived_per_head_candidate():
     )
     assert plan.head_device == 1
     kept = plan.activation_reserve_by_device
-    # cuda:0 does not hold the head, so its cap is its own 3 GiB less the weight
-    # share (about 2.98 GiB). The shared cap charged it the 2.5 GiB of headroom
-    # as well and left it under 0.5 GiB.
+    # cuda:0 holds no head, so its cap is 3 GiB less the weight share (2.98 GiB).
+    # The shared cap also charged it the 2.5 GiB headroom, leaving under 0.5 GiB.
     assert kept[0] > 1 * _GiB
     for device, reserve in kept.items():
         head_extra = plan.headroom_bytes if device == plan.head_device else 0
@@ -1052,7 +1027,6 @@ def test_runtime_quantization_options_build_a_quantizer(monkeypatch):
     assert _runtime_quantization_config({}) is None
     assert _runtime_quantization_config({"load_in_8bit": True}).load_in_8bit is True
 
-    # The loader consumes every BitsAndBytesConfig option from its kwargs, and
     # `llm_int8_skip_modules` becomes `modules_to_not_convert`: ignoring it sizes
     # whole modules at the quantised width that the loader keeps full precision.
     kwargs = {"load_in_8bit": True, "llm_int8_skip_modules": ["lm_head"],
@@ -1147,8 +1121,7 @@ def _muse_shaped_budgets(model):
     total = sum(sizes.values())
     head = sizes["lm_head.weight"]
     budget = 3 * total // 2
-    # Inside (budget - total/2, budget - head], which is non-empty exactly
-    # when head < total/2.
+    # Inside (budget - total/2, budget - head], non-empty iff head < total/2.
     assert head < total // 2, "fixture no longer has a head under half the weights"
     headroom = (budget - total // 2 + budget - head) // 2
     assert budget - total // 2 < headroom <= budget - head
@@ -1343,8 +1316,7 @@ def test_the_smaller_card_of_an_asymmetric_pair_is_not_packed_to_zero():
             f"reserve ({kept}); it is being charged the flat average weight again"
         )
 
-        # Reserving the small card's WHOLE budget would satisfy the line above
-        # by leaving it empty, which is not a two-GPU plan.
+        # Reserving the small card's WHOLE budget leaves it empty, not a plan.
         assert plan.weight_bytes[0] > 0, (
             f"{small}+{big} GiB: the smaller card was left holding nothing "
             f"({plan.weight_bytes})"
@@ -1358,7 +1330,6 @@ def test_the_smaller_card_of_an_asymmetric_pair_is_not_packed_to_zero():
             f"{small}+{big} GiB: kept {kept[0]} but only {free[0]} is free"
         )
 
-        # And it is not packed disproportionately tighter than the big card.
         small_frac = free[0] / max_memory[0]
         big_frac = free[1] / max_memory[1]
         assert small_frac >= big_frac / 2, (
@@ -1393,8 +1364,7 @@ def test_identical_cards_still_get_the_flat_average_share():
         plan = plan_device_map(model, max_memory = {d: budget for d in range(n)})
         assert plan is not None, f"{n} x 14.56 GiB was refused"
 
-        # The pre-proration formula: one flat average share for every device,
-        # with the pinned head as its floor.
+        # Pre-proration: one flat average share, pinned head as its floor.
         total = plan.total_weight_bytes
         headroom = plan.headroom_bytes
         value = max(0, (n * budget - total - headroom) // n)
@@ -1475,7 +1445,6 @@ def test_prorating_never_charges_the_head_card_more_than_the_flat_average():
             f"flat-average planner kept {flat[head]}; proration must only "
             f"loosen the cap, never tighten it"
         )
-        # And the small card still gets the reserve this whole change is about.
         assert all(v > 0 for v in kept.values()), kept
 
 
@@ -1573,9 +1542,6 @@ def test_a_small_card_is_not_charged_the_pinned_head_it_never_holds():
     assert free[0] >= kept[0], f"cuda:0 was packed below its own reserve: {free}"
 
 
-# --------------------------------------------------------------------------- #
-# logit transform detection
-# --------------------------------------------------------------------------- #
 class _Cfg:
     """A model config stands in as a plain attribute holder."""
 

--- a/tests/test_diffusion_canvas_maxtok.py
+++ b/tests/test_diffusion_canvas_maxtok.py
@@ -7,9 +7,8 @@
 # (at your option) any later version.
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Coverage for visual_engine._canvas_maxtok: the per-turn DiffusionGemma canvas is
-# non-causal, so its compute buffer is ~quadratic in size; oversized values must defer
-# to the server's MAXTOK=0 auto-size path instead of reserving a buffer that OOMs.
+# The per-turn DiffusionGemma canvas is non-causal, so its compute buffer is
+# ~quadratic: oversized values must defer to the MAXTOK=0 auto-size path or OOM.
 
 from __future__ import annotations
 

--- a/tests/test_diffusion_shim_thought_split.py
+++ b/tests/test_diffusion_shim_thought_split.py
@@ -27,8 +27,7 @@ that keeps marker fragments out of both channels.
 
 import pytest
 
-# The shim imports fastapi/uvicorn at module level; neither ships in the
-# [core] extras the CI runners install, so skip (not fail) collection there.
+# The shim imports fastapi/uvicorn, which the CI [core] extras do not ship.
 pytest.importorskip("fastapi")
 pytest.importorskip("uvicorn")
 
@@ -107,7 +106,7 @@ def test_holdback_covers_partial_markers():
     assert _marker_holdback("text</thin") == len("</thin")
 
 
-# ── streaming reconstruction (mirrors the shim's gen() loop) ─────────
+# Streaming reconstruction mirrors the shim's gen() loop.
 
 
 def _stream(full):

--- a/tests/test_diffusion_visual_engine_env.py
+++ b/tests/test_diffusion_visual_engine_env.py
@@ -79,8 +79,8 @@ def test_garbage_env_ngl_falls_back_to_default():
     assert env["NGL"] == "99"
 
 
-# Note: paths here are colon-free so the assertions hold regardless of the host's
-# os.pathsep (on a Linux CI host os.pathsep is ":", which would split a "C:\..." path).
+# Paths here are colon-free so the assertions hold regardless of the host's
+# os.pathsep (on Linux it is ":", which would split a "C:\..." path).
 def test_windows_prepends_torch_lib_to_path_only(monkeypatch):
     monkeypatch.setattr(V, "_bundled_cuda_lib_dirs", lambda: ["/wheel/nvidia/cu13/lib"])
     monkeypatch.setattr(V, "_torch_cuda_lib_dir", lambda: "/py/torch/lib")

--- a/tests/test_disabled_hook_graph_break.py
+++ b/tests/test_disabled_hook_graph_break.py
@@ -52,7 +52,6 @@ DISABLE_MSG = (
 )
 
 
-# ---- the matcher ----------------------------------------------------------
 
 def test_it_recognises_our_own_disabled_hook():
     assert U._is_our_own_disabled_hook(RuntimeError(DISABLE_MSG))
@@ -61,12 +60,10 @@ def test_it_recognises_our_own_disabled_hook():
 _HOOK = ("<function requires_grad_for_gradient_checkpointing.<locals>."
          "requires_grad_pre_hook at 0x7f00>")
 
-# Dynamo's refusal to trace a disabled callable, once per wording inside the
-# torch>=2.4,<2.13 pyproject declares. 2.4 to 2.6 emit the `_dynamo.disable`
-# text from `variables/functions.py` (2.4.0 L604, 2.5.1 L655, 2.6.0 L620); 2.7
-# replaced it with the structured `unimplemented_v2` block (2.7.0 L1173) and 2.8
-# added the trailing reason. Missing a wording means the run dies on that torch
-# instead of slowing down, which is exactly what this fallback exists to stop.
+# Dynamo's refusal to trace a disabled callable, one wording per torch in the
+# >=2.4,<2.13 range: 2.4-2.6 use `variables/functions.py`'s `_dynamo.disable` text
+# (2.4.0 L604, 2.5.1 L655, 2.6.0 L620), 2.7 `unimplemented_v2` (2.7.0 L1173), 2.8
+# added the trailing reason. Miss a wording and the run dies on that torch.
 _OLD_WORDING = f"call torch._dynamo.disable() wrapped function {_HOOK}"
 _NEW_WORDING = (
     "Skip calling `torch.compiler.disable()`d function\n"
@@ -105,8 +102,7 @@ def test_a_mention_of_disable_alone_is_not_enough():
     talks about torch.compiler.disable does not qualify."""
     assert not U._is_our_own_disabled_hook(
         RuntimeError("consider using torch.compiler.disable here"))
-    # Same for the pre-2.7 wording: the whole literal is required, not the
-    # decorator's name, so advice to apply it is not a disabled-hook break.
+    # Same for the pre-2.7 wording: the whole literal is required, not the name.
     assert not U._is_our_own_disabled_hook(
         RuntimeError("try torch._dynamo.disable() on this function"))
 
@@ -118,7 +114,6 @@ def test_an_unstringifiable_exception_does_not_crash():
     assert U._is_our_own_disabled_hook(Bad()) is False
 
 
-# ---- the fallback ---------------------------------------------------------
 
 def _wrap(compiled, eager=None):
     eager = eager or (lambda *a, **k: "eager")

--- a/tests/test_disk_utils_kaggle.py
+++ b/tests/test_disk_utils_kaggle.py
@@ -94,9 +94,7 @@ def _fake_free(disk_utils, monkeypatch, sizes):
     monkeypatch.setattr(disk_utils, "free_bytes", fake)
 
 
-# --------------------------------------------------------------------------
 # Detection
-# --------------------------------------------------------------------------
 
 
 class TestKaggleDetection:
@@ -172,9 +170,7 @@ class TestKaggleDetection:
         assert disk_utils.is_kaggle_environment() is False
 
 
-# --------------------------------------------------------------------------
 # Sizing
-# --------------------------------------------------------------------------
 
 
 class _FakeQuantState:
@@ -389,14 +385,11 @@ class TestGGUFEstimate:
         assert old_style < free, "the old estimate let this through, which is the bug"
         assert three < free, "three copies still let it through"
         assert four > free, "the full peak has to be caught"
-        # And the export does fit without the pre-warm, so refusing outright
-        # would have been the wrong answer.
+        # The export does fit without the pre-warm, so refusing outright is wrong.
         assert three < free
 
 
-# --------------------------------------------------------------------------
 # The /tmp redirect
-# --------------------------------------------------------------------------
 
 
 class TestKaggleTmpRedirect:

--- a/tests/test_dora_merge.py
+++ b/tests/test_dora_merge.py
@@ -64,7 +64,6 @@ def test_dora_merge_matches_peft():
             with torch.no_grad():
                 p.add_(torch.randn_like(p) * 0.1)
 
-    # Ground truth: PEFT's own DoRA merge.
     merged_peft = copy.deepcopy(pm).merge_and_unload()
     W_peft = None
     for n, p in merged_peft.named_parameters():

--- a/tests/test_gated_and_offline_config_classification.py
+++ b/tests/test_gated_and_offline_config_classification.py
@@ -61,9 +61,8 @@ from unsloth_zoo import saving_utils
 _REPO = "ns/base-bnb-4bit"
 _NF4 = {"load_in_4bit": True, "bnb_4bit_quant_type": "nf4"}
 
-# Same shape as test_quant_status_transport_errors.py: the Hub branch of
-# `check_model_quantization_status` is reached only when `os.path.exists(name)` is
-# False while `check_local_model_exists(name)` still finds a copy.
+# Same shape as test_quant_status_transport_errors.py: the Hub branch is reached
+# only when `os.path.exists(name)` is False while `check_local_model_exists` hits.
 _REQUESTED = "Outputs/MyModel"
 _ON_DISK = ("outputs", "mymodel")
 
@@ -361,9 +360,8 @@ def test_a_healthy_hub_base_is_used_when_the_local_config_cannot_be_read(monkeyp
     def fake_ls(self, path, detail = True, **kwargs):
         return [{"name": f"{path}/model.safetensors"}]
     monkeypatch.setattr(saving_utils.HfFileSystem, "ls", fake_ls, raising = True)
-    # The Hub serves a readable config for the same name. Stubbed at the download, not at
-    # `check_model_quantization_status`, so the real function runs on both sides: the
-    # directory reaches the real parser and the real raise, which is the subject here.
+    # The Hub serves a readable config for the same name. Stubbed at the download, not
+    # at `check_model_quantization_status`, so the directory still reaches the real raise.
     good_config = tmp_path / "hub-config.json"
     good_config.write_text(json.dumps({"model_type": "llama"}), encoding = "utf-8")
     import huggingface_hub

--- a/tests/test_gc_rewriter_bound_keywords.py
+++ b/tests/test_gc_rewriter_bound_keywords.py
@@ -56,9 +56,7 @@ from unsloth_zoo.gradient_checkpointing import (
 )
 
 
-# ---------------------------------------------------------------------------
 # A miniature model whose forward has the exact shape the rewriter looks for.
-# ---------------------------------------------------------------------------
 
 _TOY_SOURCE = '''
 class _ToyBlocks(torch.nn.Module):
@@ -80,8 +78,7 @@ class _ToyBlocks(torch.nn.Module):
 '''
 
 
-# Same shape, but with a named layer class so the rewriter can resolve the
-# ModuleList's element type and check a replacement against its signature.
+# Same shape, but with a named layer class the rewriter can resolve.
 _TOY_NAMED_SOURCE = '''
 class _ToyLayer(torch.nn.Module):
     def forward(self, hidden_states, extra, **kwargs):
@@ -118,8 +115,7 @@ _TOY_NAMED_REPLACE = """hidden_states = layer(
 
 @functools.lru_cache(maxsize = None)
 def _build_toy():
-    # patch_gradient_checkpointing() reads the class through inspect.getsource(),
-    # so the toy has to live in a real file on disk.
+    # patch_gradient_checkpointing() reads the class through inspect.getsource().
     import importlib.util
     import tempfile
 
@@ -234,10 +230,8 @@ def test_rewriter_binds_declared_keyword_into_the_callable(monkeypatch, declarat
     checkpointed = branch.body[0].value
     assert isinstance(checkpointed, ast.Call)
     assert ast.unparse(checkpointed.func) == "self._gradient_checkpointing_func"
-    # NOTHING may be left as a keyword on the checkpoint function itself - not
-    # the declared keyword and not the layer's own **kwargs expansion, which is
-    # empty often enough to look harmless and then raises `Unexpected keyword
-    # arguments` the first time a caller passes anything.
+    # No keyword may be left on the checkpoint function, not even the layer's own
+    # **kwargs: `Unexpected keyword arguments` the first time a caller passes one.
     assert [kw.arg for kw in checkpointed.keywords] == [], (
         "no keyword may reach _gradient_checkpointing_func; "
         f"got {[kw.arg for kw in checkpointed.keywords]}"
@@ -277,8 +271,6 @@ def test_rewriter_both_branches_call_the_layer_identically(monkeypatch):
 
     positional = [ast.unparse(a) for a in checkpointed.args[1:]]
     assert positional == [ast.unparse(a) for a in direct.args]
-    # Every keyword the direct branch passes - named or expanded - has to be on
-    # the partial instead, and none of them on the checkpoint function.
     assert sorted(
         (str(kw.arg), ast.unparse(kw.value)) for kw in checkpointed.args[0].keywords
     ) == sorted(
@@ -418,8 +410,7 @@ def test_qwen2_vl_5x_entry_declares_max_seqlen():
         "max_seqlen must leave the argument list; it comes back bound into the "
         "callable"
     )
-    # And the 5.x entry has to stay last, after both 4.x entries, because its
-    # replacement text is literally the 4.x call site.
+    # The 5.x entry must stay last: its replacement text is the 4.x call site.
     assert entries.index(entry) == len(entries) - 1
 
 
@@ -432,16 +423,13 @@ def test_generated_module_imports_functools():
     assert '"import functools\\n"' in source
 
 
-# ---------------------------------------------------------------------------
 # Checkpoint shims
-# ---------------------------------------------------------------------------
 
 def test_bind_checkpoint_kwargs_is_identity_without_kwargs():
     def fn(x):
         return x
     assert _bind_checkpoint_kwargs(fn, {}) == (fn, ())
-    # torch's own checkpoint keywords are consumed by the checkpoint machinery
-    # and must never be bound into the wrapped function.
+    # torch's own checkpoint keywords must never be bound into the function.
     only_torch = {k: object() for k in _TORCH_CHECKPOINT_KEYWORDS}
     assert _bind_checkpoint_kwargs(fn, only_torch) == (fn, ())
 
@@ -484,8 +472,7 @@ def test_bind_checkpoint_kwargs_binds_the_rest():
     def fn(x, flag = None):
         return (x, flag)
     bound, extra = _bind_checkpoint_kwargs(fn, {"flag": 7, "preserve_rng_state": False})
-    # Nothing differentiable here, so the cheap partial is kept and no extra
-    # positional input is handed to the checkpoint Function.
+    # Nothing differentiable here, so the cheap partial is kept.
     assert isinstance(bound, functools.partial)
     assert extra == ()
     assert bound(1) == (1, 7)
@@ -551,16 +538,9 @@ def test_unsloth_gradient_checkpointer_still_accepts_a_one_tuple_return():
     assert torch.allclose(x.grad, torch.full_like(x, 3.0))
 
 
-# ---------------------------------------------------------------------------
-# Tensor keywords stay visible to autograd
-# ---------------------------------------------------------------------------
-# A keyword whose value is a non-leaf tensor that requires grad cannot be closed
-# over by functools.partial: the checkpoint autograd.Function would never see it
-# as an input, so its gradient could only arrive as a side effect of the nested
-# torch.autograd.backward() the reentrant recompute performs. When that tensor is
-# shared - handed to more than one checkpointed layer, or also feeding the loss -
-# the first nested backward frees the shared history and the next traversal dies
-# with "Trying to backward through the graph a second time".
+# Tensor keywords stay visible to autograd. A non-leaf tensor keyword closed over
+# by functools.partial is never an input of the checkpoint autograd.Function, so
+# a shared one dies with "Trying to backward through the graph a second time".
 
 
 @pytest.fixture
@@ -676,16 +656,11 @@ def test_reentrant_checkpointer_returns_gradients_for_tensor_args():
     assert torch.allclose(leaf.grad, torch.full_like(leaf, 6.0))
 
 
-# ---------------------------------------------------------------------------
-# A frozen first activation next to a differentiable later input
-# ---------------------------------------------------------------------------
-# UnslothCheckpointFunction decided "this Function has a gradient to produce"
-# from positional input zero alone. Autograd calls backward whenever ANY input
-# requires grad, so a frozen activation zero next to a differentiable later
-# input reached the early return and the engine got a single None where it
-# wanted one gradient per input. torch's own reentrant CheckpointFunction has no
-# such gate - it saves unconditionally - so this was a divergence from the
-# function these shims stand in for.
+# A frozen first activation next to a differentiable later input.
+# UnslothCheckpointFunction decided "this Function has a gradient to produce" from
+# positional input zero alone, so a frozen input zero reached the early return and
+# the engine got one None where it wanted a gradient per input. torch's own reentrant
+# CheckpointFunction has no such gate: it saves every tensor input unconditionally.
 
 
 def _frozen_first_input(checkpoint_fn, as_keyword):

--- a/tests/test_gemma3_forced_float32_boundary_dtype.py
+++ b/tests/test_gemma3_forced_float32_boundary_dtype.py
@@ -109,9 +109,8 @@ def _install(monkeypatch, force_float32, patchers):
     for patcher in patchers:
         patcher()
 
-    # Guard against a vacuous run: patch_function() silently declines to patch when
-    # the upstream signature drifts, and then these tests would exercise stock
-    # transformers and pass no matter what the fix does.
+    # Guard against a vacuous run: patch_function() silently declines when the
+    # upstream signature drifts, leaving these tests on stock transformers.
     patched = {target for target in targets if target.forward is not before[target]}
     return patched
 
@@ -174,8 +173,8 @@ def test_forced_float32_mlp_float16_weights_are_bitwise_identical_to_pre_fix(for
 
     out = mlp(x)
 
-    # Pre-fix algorithm, inline: projections in fp16, upcast, act_fn and product in
-    # fp32, bare .to(torch.float16), down_proj.
+    # Pre-fix algorithm inline: fp16 projections, fp32 act_fn and product, bare
+    # .to(torch.float16), down_proj.
     gate_proj_out = mlp.gate_proj(x)
     up_proj_out = mlp.up_proj(x)
     gate_proj_fp32 = gate_proj_out.to(torch.float32)
@@ -259,8 +258,8 @@ def test_linear_boundary_dtype_reads_the_first_floating_point_projection_weight(
     bfloat16_module = _Projections(**{name: torch.nn.Linear(4, 4, bias = False, dtype = torch.bfloat16) for name in names})
     assert _linear_boundary_dtype(bfloat16_module, *names) == torch.bfloat16
 
-    # bitsandbytes 4bit keeps the base weight as a packed uint8 blob, which is not
-    # floating point: no weight answers, so leave the activation alone.
+    # bitsandbytes 4bit keeps the base weight as a packed uint8 blob: not floating
+    # point, so no weight answers and the activation is left alone.
     quantized_module = _Projections(**{name: _Projections(weight = torch.zeros(8, 1, dtype = torch.uint8)) for name in names})
     assert _linear_boundary_dtype(quantized_module, *names) is None
 
@@ -271,7 +270,6 @@ def test_linear_boundary_dtype_reads_the_first_floating_point_projection_weight(
     )
     assert _linear_boundary_dtype(mixed_module, *names) == torch.float32
 
-    # No projections at all, and projections explicitly set to None.
     assert _linear_boundary_dtype(_Projections(), *names) is None
     assert _linear_boundary_dtype(_Projections(**{name: None for name in names}), *names) is None
 
@@ -384,11 +382,10 @@ def test_to_boundary_dtype_casts_to_the_weight_dtype_and_is_identity_when_it_mat
     float32_activation = torch.randn(2, 3, dtype = torch.float32)
     float16_activation = torch.randn(2, 3, dtype = torch.float16)
 
-    # Matching dtype: exact same tensor object back, no copy, no numerics change.
+    # Matching dtype: same tensor object back, no copy.
     assert _to_boundary_dtype(float32_activation, torch.float32) is float32_activation
     assert _to_boundary_dtype(float16_activation, torch.float16) is float16_activation
 
-    # Mismatched dtype: moved onto the Linear's dtype.
     assert _to_boundary_dtype(float16_activation, torch.float32).dtype == torch.float32
     assert _to_boundary_dtype(float32_activation, torch.float16).dtype == torch.float16
     assert torch.equal(
@@ -478,16 +475,14 @@ def test_to_forced_output_dtype_defaults_to_float16_and_is_not_identity_on_none(
     """The whole distinction between the two helpers, asserted directly."""
     float32_reduction = torch.randn(2, 3, dtype = torch.float32)
 
-    # No weight answered: the forced output boundary is the old bare fp16 cast...
     assert _to_forced_output_dtype(float32_reduction, None).dtype == torch.float16
     assert torch.equal(
         _to_forced_output_dtype(float32_reduction, None),
         float32_reduction.to(torch.float16),
     )
-    # ...while the generic input helper is deliberately identity on None.
+    # The generic input helper is deliberately identity on None.
     assert _to_boundary_dtype(float32_reduction, None) is float32_reduction
 
-    # A weight that did answer still wins over the fp16 default.
     assert _to_forced_output_dtype(float32_reduction, torch.float32) is float32_reduction
     assert _to_forced_output_dtype(float32_reduction, torch.bfloat16).dtype == torch.bfloat16
 
@@ -569,8 +564,7 @@ def test_an_unquantized_weight_still_answers_and_the_skip_is_not_blanket(weight_
     assert getattr(module.q_proj.weight, "quant_state", None) is None
     assert _linear_boundary_dtype(module, *names) == weight_dtype
 
-    # A plain nn.Parameter has no `quant_state` attribute at all: getattr, not
-    # hasattr-then-read, so this stays a no-op on any non-bitsandbytes backend.
+    # A plain nn.Parameter has no `quant_state` at all: getattr, not hasattr-then-read.
     bare = _Projections(**{name: torch.nn.Parameter(torch.zeros(4, 4, dtype = weight_dtype))
                            for name in names})
     assert _linear_boundary_dtype(bare, *names) == weight_dtype

--- a/tests/test_gemma3_processor_batched.py
+++ b/tests/test_gemma3_processor_batched.py
@@ -62,8 +62,8 @@ def test_max_length_padding():
 
 
 def test_existing_token_type_ids_stripped_in_lockstep():
-    # Tokenizer-provided token_type_ids must be BOS-stripped too, or the row desyncs when
-    # return_mm_token_type_ids is False.
+    # Tokenizer-provided token_type_ids must be BOS-stripped too, or the row desyncs
+    # when return_mm_token_type_ids is False (True overwrites them anyway).
     text_inputs = {
         "input_ids": [[BOS, BOS, 10, 11], [BOS, BOS, 20]],
         "attention_mask": [[1, 1, 1, 1], [1, 1, 1]],
@@ -74,8 +74,7 @@ def test_existing_token_type_ids_stripped_in_lockstep():
 
 
 def test_special_tokens_mask_stripped_and_padded():
-    # any per-token field (here special_tokens_mask) must be stripped and padded, not left ragged;
-    # its pad fill is 1 (padding is a special token).
+    # Any per-token field must be stripped and padded; its pad fill is 1.
     text_inputs = {
         "input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]],
         "attention_mask": [[1, 1, 1], [1, 1, 1, 1]],
@@ -112,8 +111,7 @@ def test_max_length_uses_model_max_when_unset():
 
 
 def test_non_aligned_fields_untouched():
-    # overflowing_tokens is a per-example list whose rows do NOT match input_ids lengths; it must be
-    # left exactly as-is (not BOS-stripped or padded).
+    # overflowing_tokens rows do NOT match input_ids lengths, so leave it as-is.
     text_inputs = {
         "input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]],
         "attention_mask": [[1, 1, 1], [1, 1, 1, 1]],

--- a/tests/test_gemma4_banded_attention.py
+++ b/tests/test_gemma4_banded_attention.py
@@ -59,8 +59,7 @@ def test_matches_full_sdpa_fp32(S, w, H, Hkv, d):
 
 
 def test_batch_general_matches_full_sdpa_fp32():
-    # The banded core is batch-general (the router drops the batch == 1 gate), so
-    # a B > 1 unpadded band must match full SDPA + band mask on every element.
+    # The banded core is batch-general (the router drops the batch == 1 gate).
     torch.manual_seed(2)
     B, S, w, H, Hkv, d = 3, 300, 64, 8, 2, 32
     q = torch.randn(B, H, S, d)
@@ -92,9 +91,7 @@ def test_gradients_match_fp32():
 
 
 def test_mask_is_plain_band_defers_while_compiling(monkeypatch):
-    # Under torch.compile the .item() verdict and the tensor-attribute write are
-    # untraceable, so while compiling the probe must return False and route to the
-    # original SDPA regardless of the mask contents (here a genuine band).
+    # Under torch.compile the .item() verdict is untraceable, so the probe defers.
     S, w = 128, 32
     band = _band_mask_full(S, w)[None, None].clone()
     assert _mask_is_plain_band(band.clone(), S, w)          # eager: a real band is accepted
@@ -103,8 +100,7 @@ def test_mask_is_plain_band_defers_while_compiling(monkeypatch):
 
 
 def test_block_mask_cache_is_bounded(monkeypatch):
-    # Varying sequence lengths yield many distinct (w, nb) keys; the FIFO bound
-    # must keep _MASK_CACHE from growing without limit (cap 8).
+    # Many distinct (w, nb) keys: the FIFO bound caps _MASK_CACHE at 8.
     monkeypatch.setattr(gba, "_MASK_CACHE", {})
     w = 8
     for nb in range(1, 40):
@@ -119,7 +115,6 @@ def test_block_mask_block0_masks_phantom_prev():
     assert m.shape == (nb, 1, w, 2 * w)
     # Block 0 must not attend the (padded) previous block.
     assert not m[0, 0, :, :w].any()
-    # Later blocks follow the same local band for every block index.
     assert torch.equal(m[1], m[2])
 
 
@@ -135,8 +130,8 @@ def test_mask_is_plain_band_detection():
 
 
 def test_mask_is_plain_band_rejects_non_probe_violation():
-    # A band broken only at an interior row (a packed-sequence boundary) must be
-    # rejected: the verifier checks every row, not a sampled subset.
+    # A band broken at an interior row (a packed-sequence boundary) must be rejected:
+    # the verifier checks every row, not a sampled subset.
     S, w = 128, 32
     packed = _band_mask_full(S, w)[None, None].clone()
     packed[..., 50, 40] = False    # drop an in-band key at a non-probe row
@@ -144,8 +139,7 @@ def test_mask_is_plain_band_rejects_non_probe_violation():
 
 
 def test_mask_is_plain_band_rejects_per_head_mask():
-    # A 4D mask with a head dim > 1 cannot be honoured by the single block mask
-    # applied to every head, so it must be rejected even if head 0 is a band.
+    # A head dim > 1 cannot be honoured by one block mask shared across heads.
     S, w = 128, 32
     band = _band_mask_full(S, w)
     per_head = band[None, None].expand(1, 4, S, S).clone()   # (1, 4, S, S)
@@ -154,9 +148,7 @@ def test_mask_is_plain_band_rejects_per_head_mask():
 
 
 def test_mask_is_plain_band_rejects_per_batch_padding():
-    # The probe validates every batch element, not just batch 0: a batch whose
-    # element 0 is a full band but a later element carries padding must be
-    # rejected so the fast path never runs on an unhonoured padded sample.
+    # Every batch element is validated, so the fast path never runs on a padded one.
     S, w = 128, 32
     band = _band_mask_full(S, w)                              # (S, S)
     batched = band[None, None].expand(1, 1, S, S).clone()
@@ -168,8 +160,7 @@ def test_mask_is_plain_band_rejects_per_batch_padding():
 
 
 def test_mask_is_plain_band_rejects_inband_bias():
-    # A finite in-band bias (soft penalty) must be rejected: the banded path
-    # swaps in a boolean block mask and would silently drop the bias.
+    # A finite in-band bias must be rejected: the boolean block mask would drop it.
     S, w = 128, 32
     band = _band_mask_full(S, w)
     biased = torch.where(band, -5.0, float("-inf")).to(torch.float32)[None, None]
@@ -226,9 +217,8 @@ class Gemma4SlidingFake:
 
 @pytest.mark.parametrize("with_mask", [False, True])
 def test_router_falls_back_to_banded_without_flash(monkeypatch, with_mask):
-    # With flash-attn forced unavailable the unified wrapper must route a sliding
-    # Gemma-4 plain-band case through _banded_sdpa_core (never the wrapped SDPA)
-    # and match full SDPA + band mask. Runs on CPU regardless of flash-attn.
+    # Without flash-attn a sliding Gemma-4 plain band must route through
+    # _banded_sdpa_core, never the wrapped SDPA. Runs on CPU regardless of flash-attn.
     from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
 
     monkeypatch.setattr(gf, "_HAS_FA2", False)
@@ -272,8 +262,7 @@ def test_router_falls_back_to_banded_without_flash(monkeypatch, with_mask):
 
 
 def test_router_force_banded_env_skips_flash(monkeypatch):
-    # UNSLOTH_BANDED_SDPA=1 must force the banded kernel even when flash-attn is
-    # importable: the flash function must never be called.
+    # UNSLOTH_BANDED_SDPA=1 forces the banded kernel even when flash-attn imports.
     from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
 
     def _flash_should_not_run(*a, **kw):
@@ -312,8 +301,7 @@ def test_router_force_banded_env_skips_flash(monkeypatch):
 
 
 def test_router_kill_switch_defers_to_sdpa(monkeypatch):
-    # UNSLOTH_GEMMA4_FLASH_SLIDING=0 must disable both fast kernels and defer to
-    # the wrapped SDPA, neither FA2 nor banded may engage.
+    # UNSLOTH_GEMMA4_FLASH_SLIDING=0 disables both kernels: no FA2, no banded.
     from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
 
     monkeypatch.setattr(gf, "_HAS_FA2", False)

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -45,11 +45,8 @@ except Exception:
 requires_gemma4 = pytest.mark.skipif(not HAS_GEMMA4, reason="transformers gemma4 not installed")
 
 
-# ---------------------------------------------------------------------------
-# Guard 3: the eager and compiler PLE helpers must share ONE name (string/AST).
-# This is what broke as the cross-path NameError. Any reintroduction of a second
-# spelling fails here instantly, with no GPU / model needed.
-# ---------------------------------------------------------------------------
+# Guard 3: the eager and compiler PLE helpers must share ONE name; a second
+# spelling is the cross-path NameError, caught here with no GPU / model needed.
 def _ple_cast_identifiers(source):
     return set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*_ple_cast_input", source))
 
@@ -66,8 +63,7 @@ def test_ple_cast_helper_has_exactly_one_name_across_eager_and_compiler():
 
 
 def test_compiler_generated_helper_defines_the_name_it_calls():
-    # The name the compiler REWRITE inserts must equal the name the appended
-    # helper DEFINES. Extract both from the compiler source directly.
+    # The name the compiler REWRITE inserts must equal the one the helper DEFINES.
     on_flag = _run_ple_rewrite("Gemma4TextDecoderLayer")
     called = set(re.findall(r"([A-Za-z_][A-Za-z0-9_]*_ple_cast_input)\(", on_flag))
     defined = set(re.findall(r"def ([A-Za-z_][A-Za-z0-9_]*_ple_cast_input)\b", _GEMMA4_PLE_CAST_HELPER))
@@ -94,10 +90,7 @@ def _run_ple_rewrite(module, monkey_env="1"):
             os.environ["UNSLOTH_FORCE_FLOAT32"] = prev
 
 
-# ---------------------------------------------------------------------------
-# Guard: eager and compiler helper implementations must stay behaviourally
-# identical (both copies are hand-maintained; catch silent drift between them).
-# ---------------------------------------------------------------------------
+# Both helper copies are hand-maintained, so catch silent behavioural drift.
 def _compiler_helper_callable():
     ns = {}
     exec(_GEMMA4_PLE_CAST_HELPER, ns)
@@ -136,10 +129,7 @@ def test_eager_and_compiler_helpers_agree(label, module):
     assert e.dtype == c.dtype, f"{label}: dtype divergence {e.dtype} vs {c.dtype}"
 
 
-# ---------------------------------------------------------------------------
-# Guard 1 & 2 behaviour (pure CPU torch): prove the fix actually resolves the
-# two dtype crashes. No gemma4 needed - exercises the exact failing op.
-# ---------------------------------------------------------------------------
+# Guard 1 & 2 behaviour (pure CPU torch): exercises the exact failing op.
 @pytest.mark.parametrize("dst_dt", [torch.float16, torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("src_dt", [torch.float16, torch.bfloat16, torch.float32])
 def test_audio_dtype_cast_fixes_masked_scatter(dst_dt, src_dt):
@@ -150,7 +140,6 @@ def test_audio_dtype_cast_fixes_masked_scatter(dst_dt, src_dt):
         # BEFORE the fix (device-only cast) the merge raises.
         with pytest.raises(RuntimeError, match="same dtype"):
             dst.masked_scatter(mask, src.to(dst.device))
-    # AFTER the fix (device + dtype) it works and preserves values.
     out = dst.masked_scatter(mask, src.to(dst.device, dst.dtype))
     assert out.dtype == dst_dt
     torch.testing.assert_close(out, src.to(dst_dt))
@@ -163,7 +152,6 @@ def test_ple_helper_fixes_fp32_into_lowprec_linear(w_dt):
     # BEFORE: fp32 activation into low-precision weight raises.
     with pytest.raises(RuntimeError, match="same dtype"):
         lin(x)
-    # AFTER: helper casts the input to the weight dtype; forward + backward work.
     out = lin(_unsloth_gemma4_ple_cast_input(lin, x))
     assert out.dtype == w_dt
     out.float().sum().backward()
@@ -182,20 +170,12 @@ def test_ple_helper_never_casts_to_fp8_or_packed_weight():
     assert _unsloth_gemma4_ple_cast_input(_ModWithWeight(q), x) is x
 
 
-# ---------------------------------------------------------------------------
-# Real-source drift canaries: the highest-value "never again" guards. They read
-# the REAL transformers gemma4 module FILE FROM DISK (no mutation, no GPU) and
-# assert the exact call sites the unsloth patches target are still present.
-#
-# Reading from disk is deliberate: importing unsloth_zoo monkeypatches
-# Gemma4Model.forward (the KV-carrier wrapper) and can poison linecache for the
-# PLE methods, so inspect.getsource() on the class attributes returns the
-# unsloth-wrapped source, not upstream. The on-disk file is pristine upstream.
-#
-# If a future transformers reshapes a call site so the patch can no longer match
-# AND upstream has not fixed the dtype itself, these FAIL loudly instead of the
-# patch silently no-op-ing and the dtype crash quietly returning.
-# ---------------------------------------------------------------------------
+# Real-source drift canaries: they read the REAL transformers gemma4 module FILE
+# FROM DISK, because importing unsloth_zoo monkeypatches Gemma4Model.forward and
+# can poison linecache for the PLE methods, so inspect.getsource() returns the
+# unsloth-wrapped source rather than pristine upstream. If a call site drifts AND
+# upstream has not fixed the dtype itself, these FAIL loudly instead of the patch
+# silently no-op-ing.
 def _gemma4_modeling_source():
     import pathlib
     return pathlib.Path(inspect.getsourcefile(real_gemma4)).read_text()
@@ -203,27 +183,18 @@ def _gemma4_modeling_source():
 
 # Upstream may spell the dtype alignment at the merge call
 # (`audio_features.to(inputs_embeds.device, inputs_embeds.dtype)`, tf 5.15+) or on
-# the statement that produced the features (tf 5.5-5.14). A substring anchor on one
-# spelling breaks on cosmetic refactors while staying blind to a real regression
-# written in another, so the canaries trace dtype ALIGNMENT structurally: every
+# the statement that produced the features (tf 5.5-5.14), so the canaries trace
+# dtype ALIGNMENT structurally instead of anchoring on one spelling: every
 # `inputs_embeds.masked_scatter` consuming the features needs an
-# `inputs_embeds.dtype` cast at the call or on the last assignment that DOMINATES
-# the merge (same block or an enclosing one, so a cast stranded in a branch the
-# merge does not run under does not count), a receiver still AT
-# `inputs_embeds.dtype`, and a result that is actually used (masked_scatter is
-# out-of-place).
+# `inputs_embeds.dtype` cast at the call or on the last DOMINATING assignment, a
+# receiver still AT `inputs_embeds.dtype`, and a result that is actually used.
 # Deliberate limits, none hit by any transformers 5.5.0-5.15.0 source (checked
 # against every gemma4-bearing release, and the spellings against all 503 model
-# families of 5.15.0):
-#   * `match`/`case` bindings are not tracked - no transformers modeling file has
-#     a `match` statement;
-#   * the merged result only has to REACH `inputs_embeds`; a later overwrite is not
-#     modelled, since requiring survival to the end would red-flag "merge, use,
-#     then release the name" without a use-before-overwrite analysis;
-#   * `.to(other_tensor)` counts as alignment here but not in the eager patch's own
-#     matcher (unsloth_zoo/temporary_patches/gemma4.py), which reads only the
-#     spelling upstream actually ships. Upstream adopting the overload would
-#     surface as a drift warning telling us to update the patch, as intended.
+# families of 5.15.0): `match`/`case` bindings are not tracked (no transformers
+# modeling file has a `match` statement); a later overwrite of the merged result is
+# not modelled; `.to(other_tensor)` counts here but not in the eager patch's own
+# matcher (unsloth_zoo/temporary_patches/gemma4.py), which reads only the spelling
+# upstream actually ships.
 def _is_attr(node, owner, attr):
     """`<owner>.<attr>` as an AST node, e.g. `inputs_embeds.dtype`."""
     return (
@@ -265,9 +236,8 @@ def _casts_to_inputs_embeds_dtype(node):
 
 
 # Methods that may sit between `inputs_embeds` and `.masked_scatter(...)` without
-# changing the destination dtype. Anything else (`.float()`, `.type(...)`, an
-# unknown helper) can retype it, leaving an fp32 destination and a low-precision
-# source, so an `inputs_embeds.dtype` source cast would prove nothing.
+# changing the destination dtype. Anything else (`.float()`, `.type(...)`, an unknown
+# helper) can retype it, leaving an fp32 destination and a low-precision source.
 _DTYPE_PRESERVING_METHODS = frozenset({
     "clone", "contiguous", "detach", "cpu", "cuda",
     "view", "reshape", "flatten", "squeeze", "unsqueeze",
@@ -276,10 +246,8 @@ _DTYPE_PRESERVING_METHODS = frozenset({
 
 
 # `torch.<name>` constants that provably are NOT dtypes, so they cannot retype the
-# receiver: `clone(memory_format = torch.preserve_format)` keeps the embedding dtype
-# exactly. Reading every `torch.<attr>` as a dtype turned that cosmetic upstream
-# addition into a "destination was retyped" false red - the very failure this
-# structural trace exists to remove. Resolved against the live torch, so an
+# receiver: reading `clone(memory_format = torch.preserve_format)` as a dtype was a
+# "destination was retyped" false red. Resolved against the live torch, so an
 # attribute torch does not have stays dtype-bearing: the safe default.
 _NON_DTYPE_TORCH_CONSTANTS = (torch.memory_format, torch.layout)
 
@@ -299,8 +267,7 @@ def _is_dtype_bearing(node, aliases = frozenset()):
         and isinstance(node.value, ast.Name)
         and node.value.id == "torch"
     ):
-        # A memory format or layout does not retype; `Tensor.view(torch.int32)`
-        # does, so the check is on the constant, not the method.
+        # `Tensor.view(torch.int32)` retypes but a memory format does not.
         return not isinstance(
             getattr(torch, node.attr, None), _NON_DTYPE_TORCH_CONSTANTS
         )
@@ -489,10 +456,8 @@ _LOOP_NODES = (ast.For, ast.AsyncFor)
 _WITH_NODES = (ast.With, ast.AsyncWith)
 # Every construct that can rebind a plain name in the code's OWN scope: `for
 # image_features in ...`, `with self.autocast() as image_features:` and
-# `(image_features := ...)` replace the tensor as completely as an assignment does.
-# Counting only assignments lets an earlier aligned cast keep proving alignment for
-# a value one of these has overwritten, and the replacement reaches masked_scatter
-# un-cast. (Comprehensions bind in their own scope.)
+# `(image_features := ...)` replace the tensor as completely as an assignment does,
+# and the replacement reaches masked_scatter un-cast.
 _BINDING_NODES = _ASSIGN_NODES + _LOOP_NODES + _WITH_NODES + (ast.NamedExpr,)
 
 
@@ -600,7 +565,6 @@ def _rebinding_alignment(stmt, feature):
         and _assigns_feature(stmt, feature)
     ):
         return _binding_is_aligned(stmt, feature)
-    # A bare `(image_features := ...)` statement rebinds like an assignment.
     if (
         isinstance(stmt, ast.Expr)
         and isinstance(stmt.value, ast.NamedExpr)
@@ -609,10 +573,8 @@ def _rebinding_alignment(stmt, feature):
         return _binding_is_aligned(stmt.value, feature)
     # `if <feature>.dtype != inputs_embeds.dtype: <feature> = <feature>.to(...)` is
     # the cast-if-needed idiom (blip_2 / granite_speech): the untaken branch is
-    # aligned by definition, so it counts as unconditional. Both branches are still
-    # analysed as PATHS, not as a bag of rebindings whose textually last one wins,
-    # or an aligned `else` after an unaligned body would report the guard aligned
-    # while the mismatch path leaves the feature un-cast.
+    # aligned by definition. Both branches are analysed as PATHS, or an aligned
+    # `else` after an unaligned body reports aligned while the mismatch path does not.
     if isinstance(stmt, ast.If) and _is_dtype_guard(stmt.test, feature):
         if _feature_rebindings(stmt, feature):
             # Body runs only on a mismatch (starts unaligned); `orelse` only when
@@ -621,8 +583,7 @@ def _rebinding_alignment(stmt, feature):
                 _sequence_alignment(stmt.body, feature, False)
                 and _sequence_alignment(stmt.orelse, feature, True)
             )
-    # Any OTHER compound statement that rebinds the feature is still a rebinding on
-    # the path to the merge (`if enabled: image_features = image_features.float()`).
+    # `if enabled: image_features = image_features.float()` still rebinds on the path.
     rebindings = _feature_rebindings(stmt, feature)
     if not rebindings:
         return None
@@ -639,9 +600,8 @@ def _rebinding_alignment(stmt, feature):
                 alignment = inner_alignment
         return alignment
     # Conditionally executed (`if` / `for` / `while` / `try`): the rebinding may not
-    # run, so an unaligned branch reports unaligned while a branch that only ever
-    # casts to `inputs_embeds.dtype` leaves the earlier verdict standing (`None`).
-    # A loop's own target is one of those rebindings, typed by the iterable.
+    # run, so an unaligned branch reports unaligned while an always-aligned one
+    # leaves the earlier verdict standing (`None`).
     for rebinding in rebindings:
         if not _binding_is_aligned(rebinding, feature):
             return False
@@ -677,9 +637,8 @@ def _dominating_alignment(forward, feature, merge_arg):
 
 _MERGE_METHODS = ("masked_scatter", "masked_scatter_")
 
-# Attributes / methods that read a tensor's METADATA rather than its values.
-# `fallback.to(image_features.device, inputs_embeds.dtype)` mentions
-# `image_features` but scatters none of it.
+# Attributes / methods that read a tensor's METADATA rather than its values:
+# `fallback.to(image_features.device, ...)` scatters no `image_features` value.
 _METADATA_ATTRS = frozenset({
     "device", "dtype", "shape", "ndim", "size", "numel", "layout",
     "requires_grad", "is_cuda", "element_size", "itemsize", "stride",
@@ -749,11 +708,9 @@ def _feature_merges(forward, feature):
     return sorted(calls, key=lambda n: (n.lineno, n.col_offset))
 
 
-# The merge RESULT is followed by the same value-flow rule as the source. A
-# metadata read (`merged.device`, `merged.dtype`, `merged.shape`) discards every
-# scattered value, so `inputs_embeds = original.to(merged.device)` hands the
-# embeddings the ORIGINAL tensor. Treating that mention as value flow reported the
-# merge used, so a refactor dropping the effective merge stayed green.
+# The merge RESULT follows the same value-flow rule as the source: a metadata read
+# (`merged.device`, `.dtype`, `.shape`) discards every scattered value, so
+# `inputs_embeds = original.to(merged.device)` hands back the ORIGINAL tensor.
 def _contains(node, target):
     return _carries_value(node, lambda n: n is target)
 
@@ -807,8 +764,6 @@ def _merge_result_is_used(forward, call):
     tainted = set()
     for position, statement in enumerate(statements):
         for node in _walk_own_scope(statement, descend = False):
-            # A `return` carrying the merge, or its taint, is the merged embedding
-            # leaving `forward`.
             if isinstance(node, ast.Return) and node.value is not None:
                 if (position == 0 and _contains(node.value, call)) or _references(node.value, tainted):
                     return True
@@ -817,11 +772,9 @@ def _merge_result_is_used(forward, call):
             for target, value in _binding_pairs(node):
                 if target is None or value is None:
                     continue
-                # Each name is judged on the RHS element it actually receives.
-                # Reading the whole RHS made `inputs_embeds, aux = original, merged`
-                # taint `inputs_embeds` while the embeddings were handed the
-                # ORIGINAL. A non-literal RHS keeps the whole value, so
-                # `inputs_embeds, aux = self.pack(merged)` still counts.
+                # Each name is judged on the RHS element it actually receives:
+                # reading the whole RHS made `inputs_embeds, aux = original, merged`
+                # taint `inputs_embeds` while it was handed the ORIGINAL.
                 element = value if isinstance(node, _ELEMENTWISE_NODES) else None
                 for name in _bound_names(target):
                     part = _element_value(target, element, name) if element is not None else value
@@ -833,9 +786,8 @@ def _merge_result_is_used(forward, call):
                         tainted.add(name)
                     elif node is statement and not isinstance(node, ast.AugAssign):
                         # A direct, unconditional rebinding to something the merge
-                        # did NOT flow into overwrites the name. One nested in a
-                        # conditional may not run, and `+=` adds rather than
-                        # replaces, so neither clears the taint.
+                        # did NOT flow into overwrites the name; a conditional one
+                        # may not run, and `+=` adds rather than replaces.
                         tainted.discard(name)
         if "inputs_embeds" in tainted:
             return True
@@ -921,9 +873,8 @@ def test_real_gemma4_audio_merge_site_is_recognized():
 @requires_gemma4
 @pytest.mark.parametrize("feature", ["image_features", "video_features"])
 def test_real_gemma4_image_and_video_merges_still_cast_dtype(feature):
-    # Regression anchor: image/video have always aligned dtype before the merge,
-    # so unsloth patches only audio. If upstream ever drops the alignment here
-    # too, that is a new modality that also needs patching.
+    # Image/video have always aligned dtype before the merge, so unsloth patches
+    # only audio; upstream dropping the alignment here is a new modality to patch.
     src = _gemma4_modeling_source()
     found, aligned = _merge_dtype_alignment(src, feature)
     assert found, (
@@ -946,9 +897,7 @@ def test_real_gemma4_audio_eager_patch_matches_real_merge_site():
     # The canary above only proves the COMPILER rewriter (a regex) still fires. The
     # eager patch is stricter - the merge source argument must BE the
     # `audio_features.to(inputs_embeds.device, ...)` call - so a wrapped spelling
-    # matches the regex but not the AST matcher, and the eager path would no-op
-    # with the dtype crash back and every other guard green. Run the patch's OWN
-    # matcher over the real source so that spelling fails loudly here instead.
+    # matches the regex but not the AST matcher, and the eager path would no-op.
     src = _gemma4_modeling_source()
     forward = _gemma4_model_forward_node(src)
     assert forward is not None, "Gemma4Model.forward not found in the real source"
@@ -984,8 +933,7 @@ def test_real_gemma4_ple_call_sites_are_recognized():
 
 @requires_gemma4
 def test_real_gemma4_audio_compiler_transform_emits_dtype_cast():
-    # Drive the compiler's audio rewrite against the REAL upstream source; either
-    # upstream already casts dtype, or our regex still matches and inserts it.
+    # Either upstream already casts dtype, or our regex still matches and inserts it.
     src = _gemma4_modeling_source()
     out = C.fix_gemma4_audio_feature_dtype(src)
     found, aligned = _merge_dtype_alignment(out, "audio_features")
@@ -998,8 +946,7 @@ def test_real_gemma4_audio_compiler_transform_emits_dtype_cast():
 
 def test_audio_compiler_transform_still_fixes_the_device_only_spelling():
     # transformers 5.15.0 fixed the audio merge upstream, so the real-source test
-    # above passes without the rewriter doing anything. Keep it under test against
-    # the historical buggy spelling while older transformers are still supported.
+    # above no-ops; the historical buggy spelling stays covered for 5.5.0-5.14.1.
     buggy = (
         "        inputs_embeds = inputs_embeds.masked_scatter(\n"
         "            audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)\n"
@@ -1012,12 +959,8 @@ def test_audio_compiler_transform_still_fixes_the_device_only_spelling():
     )
 
 
-# ---------------------------------------------------------------------------
 # Tracer unit tests. A hole in `_merge_dtype_alignment` is invisible: it reports
-# GREEN on a source that crashes. These feed it a minimal synthetic
-# `Gemma4Model.forward` (no transformers needed, so they run on every supported
-# version) and pin the verdict on the spellings that used to slip through.
-# ---------------------------------------------------------------------------
+# GREEN on a source that crashes, so pin the spellings that slipped through.
 _DEFAULT_MERGE = (
     "inputs_embeds = inputs_embeds.masked_scatter(\n"
     "    image_mask.to(inputs_embeds.device), image_features.to(inputs_embeds.device)\n"
@@ -1113,16 +1056,13 @@ _GUARD_CONTROLS = [
     "label,body", _GUARD_CONTROLS, ids = [case[0] for case in _GUARD_CONTROLS],
 )
 def test_cast_if_needed_guards_still_count_as_alignment(label, body):
-    # Controls: dtype-safe on every path, so they must not turn red or the canaries
-    # start failing on a healthy upstream.
+    # Controls: dtype-safe on every path, so a red here fails a healthy upstream.
     found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
     assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
 
 
-# A destructuring assignment rebinds the feature name just like a plain one, and
-# `image_features, feature_lens = self.pack_image_features(...)` is upstream's own
-# llava_next spelling. Skipping it lets an earlier aligned assignment keep proving
-# alignment for a tensor that has since been replaced.
+# A destructuring assignment rebinds the feature name just like a plain one:
+# `image_features, feature_lens = self.pack_image_features(...)` is llava_next's.
 _UNPACK_HOLES = [
     ("tuple unpack",
      f"{_ALIGNED_ASSIGN}\n"
@@ -1156,9 +1096,8 @@ def test_destructuring_rebindings_of_the_feature_are_not_skipped(label, body):
     )
 
 
-# A destructuring target takes its RHS ELEMENT, not the whole RHS: reading the
-# whole tuple lets a cast belonging to another name keep the feature green
-# (transformers writes literal-tuple destructuring in vilt).
+# A destructuring target takes its RHS ELEMENT, not the whole RHS, or a cast
+# belonging to another name keeps the feature green (vilt writes literal tuples).
 _UNPACK_PAIRING_HOLES = [
     ("tuple RHS whose cast belongs to the other name",
      f"{_ALIGNED_ASSIGN}\n"
@@ -1248,15 +1187,13 @@ _UNPACK_CONTROLS = [
     "label,body", _UNPACK_CONTROLS, ids = [case[0] for case in _UNPACK_CONTROLS],
 )
 def test_non_rebinding_targets_do_not_break_alignment(label, body):
-    # Controls for the test above.
     found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
     assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
 
 
 # The trace is "the source is cast to `inputs_embeds.dtype`, so the merge is safe",
 # which only holds while the DESTINATION is still at that dtype: a receiver
-# transformation that retypes it leaves `inputs_embeds.float().masked_scatter(mask,
-# image_features.to(inputs_embeds.dtype))` with an fp32 destination and an fp16/bf16
+# transformation that retypes it leaves an fp32 destination and an fp16/bf16
 # source, raising the exact error this file exists to prevent.
 _RECEIVER_HOLES = [
     ("receiver upcast with .float()",
@@ -1279,14 +1216,11 @@ _RECEIVER_HOLES = [
      "inputs_embeds = self.upcast(inputs_embeds).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.dtype)\n"
      ")"),
-    # `Tensor.view(dtype)` reinterprets the storage, so a real dtype constant must
-    # still be caught now that memory formats do not count.
+    # `Tensor.view(dtype)` reinterprets storage, so a dtype constant still counts.
     ("receiver .view(torch.int32) reinterprets the dtype",
      "inputs_embeds = inputs_embeds.view(torch.int32).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.dtype)\n"
      ")"),
-    # ... just as thoroughly when the dtype arrives in a variable, which reads as a
-    # plain name at the call site.
     ("receiver .view(alias of torch.float32)",
      "target_dtype = torch.float32\n"
      "inputs_embeds = inputs_embeds.view(target_dtype).masked_scatter(\n"
@@ -1324,8 +1258,7 @@ def test_receiver_that_changes_dtype_is_not_alignment(label, merge):
 
 
 _RECEIVER_CONTROLS = [
-    # blip_2 really ships this spelling; the receiver predicate stays loose enough
-    # to recognise it, and `.to(<device>)` keeps the dtype.
+    # blip_2 really ships this spelling, and `.to(<device>)` keeps the dtype.
     ("blip_2 receiver .to(other.device)",
      "inputs_embeds = inputs_embeds.to(image_features.device).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1350,8 +1283,7 @@ _RECEIVER_CONTROLS = [
      "inputs_embeds = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
-    # A memory format is not a dtype, and transformers already ships
-    # `.clone(memory_format = torch.contiguous_format)` (higgs_audio_v2).
+    # A memory format is not a dtype (higgs_audio_v2 ships `contiguous_format`).
     ("receiver .clone(memory_format = torch.preserve_format)",
      "inputs_embeds = inputs_embeds.clone(memory_format = torch.preserve_format).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1364,8 +1296,7 @@ _RECEIVER_CONTROLS = [
      "inputs_embeds = inputs_embeds.contiguous(torch.channels_last).masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
-    # `Tensor.view` also takes a shape sequence, so a plain name is more often a
-    # shape than a dtype. Only a name actually BOUND to a dtype may retype.
+    # `Tensor.view` also takes a shape, so only a name BOUND to a dtype may retype.
     ("receiver .view(shape variable)",
      "target_shape = image_features.shape\n"
      "inputs_embeds = inputs_embeds.view(target_shape).masked_scatter(\n"
@@ -1383,7 +1314,6 @@ _RECEIVER_CONTROLS = [
     "label,merge", _RECEIVER_CONTROLS, ids = [case[0] for case in _RECEIVER_CONTROLS],
 )
 def test_dtype_preserving_receivers_still_count_as_alignment(label, merge):
-    # Controls: every destination here is still at `inputs_embeds.dtype`.
     found, aligned = _merge_dtype_alignment(
         _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
     )
@@ -1391,9 +1321,8 @@ def test_dtype_preserving_receivers_still_count_as_alignment(label, merge):
 
 
 # `masked_scatter` is out-of-place: losing the surrounding `inputs_embeds =` leaves
-# every dtype cast in place and silently drops the features. Upstream assigns the
-# result on 5.5.0-5.15.0, so requiring it costs nothing; in-place `masked_scatter_`
-# (qwen2_5_omni / blt) needs no assignment and must still be accepted.
+# every dtype cast in place and silently drops the features. In-place
+# `masked_scatter_` (qwen2_5_omni / blt) needs no assignment and stays accepted.
 def test_discarded_out_of_place_merge_is_not_alignment():
     merge = (
         "inputs_embeds.masked_scatter(\n"
@@ -1443,19 +1372,16 @@ _RESULT_USE_CONTROLS = [
     "label,merge", _RESULT_USE_CONTROLS, ids = [case[0] for case in _RESULT_USE_CONTROLS],
 )
 def test_used_merge_results_still_count_as_alignment(label, merge):
-    # Controls for the test above.
     found, aligned = _merge_dtype_alignment(
         _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
     )
     assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
 
 
-# ---------------------------------------------------------------------------
 # Merge DISCOVERY keys on the feature's VALUES reaching the scatter source. A source
 # that only reads `<feature>.device` / `.dtype` / `.shape` merges some other tensor,
 # so accepting it would let a metadata mention impersonate a merge upstream had
 # deleted, reporting (True, True) while no image value reaches the model.
-# ---------------------------------------------------------------------------
 _METADATA_ONLY_MERGES = [
     ("source reads the feature device only",
      "inputs_embeds = inputs_embeds.masked_scatter(\n"
@@ -1530,13 +1456,9 @@ def test_in_place_merge_with_an_unaligned_source_is_still_traced():
     )
 
 
-# ---------------------------------------------------------------------------
 # `Tensor.to(other)` is documented as returning a tensor with the same dtype AND
 # device as `other`, so `image_features.to(inputs_embeds)` aligns both in one call.
-# Reading only the explicit `inputs_embeds.dtype` spelling would fail these canaries
-# on a healthy upstream that preferred the overload, claiming the dtype is never
-# aligned - a false red that hides nothing and costs a release.
-# ---------------------------------------------------------------------------
+# Reading only the explicit spelling fails these canaries on a healthy upstream.
 _TENSOR_OVERLOAD_CONTROLS = [
     ("tensor overload at the merge argument",
      "inputs_embeds = inputs_embeds.masked_scatter(\n"
@@ -1598,12 +1520,9 @@ def test_tensor_overload_to_another_tensor_is_not_alignment(label, body):
     )
 
 
-# ---------------------------------------------------------------------------
 # `masked_scatter` is out-of-place, so the merged embedding exists ONLY in the
-# return value. Rejecting just the bare-expression spelling is not enough: a result
-# bound to a name nothing reads, or passed to a logger, is discarded as completely
-# and `forward` returns the UNCHANGED `inputs_embeds` with every canary green.
-# ---------------------------------------------------------------------------
+# return value: a result bound to a name nothing reads, or passed to a logger,
+# leaves `forward` returning the UNCHANGED `inputs_embeds` with every canary green.
 _DISCARDED_RESULT_HOLES = [
     ("result bound to a name nothing reads",
      "dead = inputs_embeds.masked_scatter(\n"
@@ -1633,8 +1552,7 @@ _DISCARDED_RESULT_HOLES = [
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")"),
     # A destructuring target takes its own RHS element; crediting the whole RHS let
-    # a tuple hand `inputs_embeds` the ORIGINAL while the merge went to a name
-    # nothing reads - the modality silently dropped, every canary green.
+    # a tuple hand `inputs_embeds` the ORIGINAL while the merge went to a dead name.
     ("destructuring hands the embeddings the original, not the merge",
      "merged = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1651,8 +1569,7 @@ _DISCARDED_RESULT_HOLES = [
      ")\n"
      "(inputs_embeds, aux), sizes = (original, merged), image_sizes"),
     # A metadata read of the merge scatters nothing: the embeddings are handed the
-    # ORIGINAL tensor. Propagating taint through it reported the merge used, so a
-    # refactor dropping the effective merge kept every canary here green.
+    # ORIGINAL tensor, so a refactor dropping the effective merge stays green.
     ("embeddings take the original, reading only the merge device",
      "merged = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1704,8 +1621,7 @@ _RESULT_REACHES_CONTROLS = [
      "        image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      "    )"),
     # The mirror image: element-by-element pairing must still see the merge when it
-    # IS the element the embeddings receive, and a non-literal RHS keeps the whole
-    # value, so an unpacking call still propagates it.
+    # IS the element the embeddings receive, and a non-literal RHS keeps it whole.
     ("destructuring hands the embeddings the merge",
      "merged = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1726,8 +1642,7 @@ _RESULT_REACHES_CONTROLS = [
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
      ")\n"
      "inputs_embeds, *aux = merged, original"),
-    # Skipping metadata must not skip a real use that merely mentions it alongside:
-    # the merged VALUES still reach the embeddings here.
+    # Skipping metadata must not skip a real use that mentions it alongside.
     ("result reshaped by its own shape",
      "merged = inputs_embeds.masked_scatter(\n"
      "    image_mask, image_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1745,19 +1660,14 @@ _RESULT_REACHES_CONTROLS = [
     "label,merge", _RESULT_REACHES_CONTROLS, ids = [c[0] for c in _RESULT_REACHES_CONTROLS],
 )
 def test_results_that_do_reach_the_embeddings_still_count(label, merge):
-    # Controls: the merged tensor really does land back on `inputs_embeds`.
     found, aligned = _merge_dtype_alignment(
         _synthetic_forward(_ALIGNED_ASSIGN, merge = merge), "image_features",
     )
     assert found and aligned, f"{label}: a surviving merge result reported unaligned"
 
 
-# ---------------------------------------------------------------------------
-# A name is not only rebound by an assignment: a `for` target, a `with ... as`
-# target and a named expression all replace the tensor the name refers to, so an
-# earlier aligned assignment stops describing it. Skipping them lets the
-# replacement, which nothing cast, reach masked_scatter.
-# ---------------------------------------------------------------------------
+# A `for` target, a `with ... as` target and a named expression all replace the
+# tensor a name refers to, so the un-cast replacement reaches masked_scatter.
 _NON_ASSIGN_BINDING_HOLES = [
     ("for target",
      f"{_ALIGNED_ASSIGN}\n"
@@ -1828,18 +1738,13 @@ _NON_ASSIGN_BINDING_CONTROLS = [
     "label,body", _NON_ASSIGN_BINDING_CONTROLS, ids = [c[0] for c in _NON_ASSIGN_BINDING_CONTROLS],
 )
 def test_aligned_or_unrelated_bindings_do_not_break_alignment(label, body):
-    # Controls for the test above.
     found, aligned = _merge_dtype_alignment(_synthetic_forward(body), "image_features")
     assert found and aligned, f"{label}: dtype-safe spelling reported unaligned"
 
 
-# ---------------------------------------------------------------------------
-# The eager patch's own matcher must be tied to the EMBEDDING merge. Accepting
-# `masked_scatter` on any receiver let an aligned merge on a scratch tensor land in
-# `fixed_casts`, which reads to `_patch_gemma4_audio_feature_dtype_on_class` as
-# "upstream fixed it": it sets the marker and returns, leaving a real,
-# still-device-only `inputs_embeds` merge unpatched and crashing.
-# ---------------------------------------------------------------------------
+# The eager patch's own matcher must be tied to the EMBEDDING merge: an aligned
+# merge on a scratch tensor landing in `fixed_casts` reads to
+# `_patch_gemma4_audio_feature_dtype_on_class` as "upstream fixed it".
 def _audio_forward(body):
     return (
         "class Gemma4Model:\n"
@@ -1860,9 +1765,8 @@ _ALIGNED_SCRATCH_MERGE = (
     "    audio_mask, audio_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
     ")"
 )
-# The same decoy with a receiver that MENTIONS `inputs_embeds` without being it.
-# Matching the name anywhere in the receiver accepted this as the embedding merge;
-# the receiver has to be anchored at its base instead.
+# The same decoy with a receiver that MENTIONS `inputs_embeds` without being it:
+# matching the name anywhere in the receiver accepted this as the embedding merge.
 _ALIGNED_SCRATCH_MERGE_ON_EMBEDS_DEVICE = (
     "scratch = scratch.to(inputs_embeds.device).masked_scatter(\n"
     "    audio_mask, audio_features.to(inputs_embeds.device, inputs_embeds.dtype)\n"
@@ -1877,7 +1781,6 @@ def _audio_merge_casts(body):
 
 
 def test_eager_matcher_ignores_merges_onto_other_tensors():
-    # An aligned decoy on a scratch tensor is not the audio merge already fixed.
     buggy, fixed = _audio_merge_casts(_ALIGNED_SCRATCH_MERGE)
     assert not buggy and not fixed, (
         f"_gemma4_audio_merge_casts counted a `scratch.masked_scatter(...)` as the "
@@ -1888,8 +1791,6 @@ def test_eager_matcher_ignores_merges_onto_other_tensors():
 
 
 def test_eager_matcher_still_finds_the_real_merge_next_to_a_decoy():
-    # The decoy is ignored AND the real device-only merge still picked up, so the
-    # patch fires exactly once.
     buggy, fixed = _audio_merge_casts(_ALIGNED_SCRATCH_MERGE + "\n" + _REAL_AUDIO_MERGE)
     assert len(buggy) == 1 and not fixed, (
         f"expected the one real device-only `inputs_embeds` merge to be patchable "
@@ -1904,9 +1805,8 @@ def test_eager_matcher_still_finds_the_real_merge_next_to_a_decoy():
 )
 def test_a_decoy_merge_never_hides_the_real_one(decoy):
     # `scratch.to(inputs_embeds.device)` is a different tensor however often it
-    # names `inputs_embeds`. Counting it puts an aligned cast in `fixed_casts`, and
-    # `len(buggy) == 1 and fixed_casts` is exactly the branch on which the eager
-    # patch returns without patching and without warning.
+    # names `inputs_embeds`, and `len(buggy) == 1 and fixed_casts` is exactly the
+    # branch on which the eager patch returns without patching and without warning.
     buggy, fixed = _audio_merge_casts(decoy + "\n" + _REAL_AUDIO_MERGE)
     assert len(buggy) == 1 and not fixed, (
         f"expected the one real device-only `inputs_embeds` merge to be patchable "
@@ -1916,8 +1816,7 @@ def test_a_decoy_merge_never_hides_the_real_one(decoy):
 
 def test_eager_matcher_still_accepts_a_transformed_inputs_embeds_receiver():
     # Discovery must stay loose about HOW the receiver mentions `inputs_embeds`
-    # (blip_2 ships `inputs_embeds.to(...).masked_scatter(...)`), or a real merge
-    # is dropped instead of patched.
+    # (blip_2 ships `inputs_embeds.to(...).masked_scatter(...)`), or a merge is lost.
     buggy, fixed = _audio_merge_casts(
         "inputs_embeds = inputs_embeds.to(audio_features.device).masked_scatter(\n"
         "    audio_mask.to(inputs_embeds.device), audio_features.to(inputs_embeds.device)\n"

--- a/tests/test_gemma4_flash_sliding.py
+++ b/tests/test_gemma4_flash_sliding.py
@@ -85,8 +85,7 @@ def test_mask_probe_rejects_packed_boundary():
 
 
 def test_float_mask_inband_bias_rejected():
-    # A finite in-band bias would be silently dropped when routing to FA2, so a
-    # float mask is only accepted when in-band entries are exactly 0.
+    # A finite in-band bias would be silently dropped when routing to FA2.
     from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
     S, w = 256, 64
     band = _band(S, w)
@@ -97,8 +96,6 @@ def test_float_mask_inband_bias_rejected():
 
 
 def test_chunked_verification_matches_dense():
-    # Row-chunked verification must agree with a single-block scan on band,
-    # padded, and packed masks (the memory win needs no test).
     from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
     S, w = 96, 16
     band = _band(S, w)
@@ -125,8 +122,8 @@ class Gemma4SlidingFake:
 
 
 def test_router_routes_to_fa2_and_matches_band(monkeypatch):
-    # With flash-attn present the unified wrapper must take the FA2 window branch
-    # (never the wrapped SDPA) and match full SDPA + band mask.
+    # With flash-attn present the wrapper must take the FA2 window branch, never
+    # the wrapped SDPA.
     from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
 
     monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")

--- a/tests/test_gemma4_forced_float32_ple_dtype.py
+++ b/tests/test_gemma4_forced_float32_ple_dtype.py
@@ -387,7 +387,6 @@ def test_gemma4_ple_dry_run_classifies_without_mutating(tmp_path, monkeypatch):
     ) is False
     assert drift_cls.project_per_layer_inputs.__code__ is drift_code
 
-    # Dry run on the already-marked good class reports ALREADY.
     assert _patch_gemma4_ple_dtype_on_method(ok_cls, "project_per_layer_inputs", targets) is True
     assert _patch_gemma4_ple_dtype_on_method(
         ok_cls, "project_per_layer_inputs", targets, dry_run=True,
@@ -422,7 +421,7 @@ def test_gemma4_ple_compiler_appends_helper_only_when_call_present(tmp_path, mon
     module = _make_fake_decoder_module(tmp_path, monkeypatch, "fake_gemma4_ple_append")
     monkeypatch.setattr(compiler, "fake_gemma4_ple_append", module, raising=False)
 
-    # Flag off: no PLE rewrite, so no helper call and no appended helper def.
+    # Flag off: no PLE rewrite, so no appended helper def.
     monkeypatch.delenv("UNSLOTH_FORCE_FLOAT32", raising=False)
     off = compiler.create_standalone_class(
         "Gemma4TextDecoderLayer", "fake_gemma4_ple_append", dir(module), disable=True,
@@ -430,7 +429,7 @@ def test_gemma4_ple_compiler_appends_helper_only_when_call_present(tmp_path, mon
     assert "_unsloth_gemma4_ple_cast_input(" not in off
     assert "def _unsloth_gemma4_ple_cast_input" not in off
 
-    # Flag on: the rewrite inserts the call, so the helper def is appended exactly once.
+    # Flag on: the helper def is appended exactly once.
     monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
     on = compiler.create_standalone_class(
         "Gemma4TextDecoderLayer", "fake_gemma4_ple_append", dir(module), disable=True,
@@ -454,11 +453,9 @@ def test_gemma4_ple_eager_then_compile_share_one_helper_name(tmp_path, monkeypat
         decoder_cls, "forward",
         (("per_layer_input_gate", "hidden_states"), ("per_layer_projection", "hidden_states")),
     ) is True
-    # inspect.getsource (which the compiler uses) now returns the eager-patched source.
     assert "_unsloth_gemma4_ple_cast_input(" in inspect.getsource(decoder_cls.forward)
 
-    # The compiler reads that poisoned source; the generated module must DEFINE the
-    # same helper name it CALLS.
+    # The generated module must DEFINE the same helper name it CALLS.
     monkeypatch.setattr(compiler, "fake_gemma4_ple_crosspath", module, raising=False)
     generated = compiler.create_standalone_class(
         "Gemma4TextDecoderLayer", "fake_gemma4_ple_crosspath", dir(module), disable=True,

--- a/tests/test_gemma4_moe_lora_registration.py
+++ b/tests/test_gemma4_moe_lora_registration.py
@@ -61,7 +61,7 @@ def test_register_is_idempotent():
     cls = _fresh_stub_class()
     assert g4._register_gemma4_lora_extractor(cls) is True
     fn_before = cls._unsloth_lora_extractor_fn
-    # Second call short-circuits on the registered flag; identity unchanged.
+    # Second call short-circuits on _unsloth_lora_extractor_registered.
     assert g4._register_gemma4_lora_extractor(cls) is True
     assert cls._unsloth_lora_extractor_fn is fn_before
     assert cls._unsloth_model_type == "gemma4_moe"

--- a/tests/test_gemma4_probe_two_tone_gate.py
+++ b/tests/test_gemma4_probe_two_tone_gate.py
@@ -23,8 +23,7 @@ import pathlib
 import pytest
 
 # The probe is a runnable script rather than a package module, so load it by
-# path. It imports only the standard library at module level, which is why
-# this costs nothing and needs neither mlx nor a checkpoint.
+# path. It imports only the standard library: no mlx, no checkpoint.
 _PROBE = pathlib.Path(__file__).with_name("gemma4_audio_version_probe.py")
 _spec = importlib.util.spec_from_file_location("gemma4_audio_version_probe", _PROBE)
 probe = importlib.util.module_from_spec(_spec)
@@ -52,25 +51,18 @@ def test_importing_the_probe_does_not_rewrite_the_environment(monkeypatch, var):
 @pytest.mark.parametrize(
     "name, repeats, other, expected",
     [
-        # A machine where the model is reproducible: the repeats agree, so the
-        # noise floor is zero and the gap only has to be non-zero. This is the
-        # behaviour that existed before and must not change.
+        # Reproducible machine: repeats agree, so the noise floor is zero.
         ("reproducible_and_connected", [19.3557] * 3, 19.6828, "pass"),
         ("reproducible_and_disconnected", [19.3557] * 3, 19.3557, "same_loss"),
-        # Apple Silicon, measured rather than invented: macos-14, mlx-vlm
-        # 0.6.3, run 2 of three. Three identical 440 Hz forwards spread by
-        # 0.827 while the gap to 1760 Hz was 1.30, so the spread is the same
-        # size as the signal and the stage cannot decide. It reports that,
-        # instead of reporting a pass the numbers do not support.
+        # Apple Silicon, measured on macos-14, mlx-vlm 0.6.3: three identical
+        # 440 Hz forwards spread by 0.827, the gap to 1760 Hz was only 1.30.
         ("measured_on_metal", [24.8986, 25.4577, 25.7256], 26.1988,
          "below_noise"),
-        # The same machine if the audio were plainly connected: a gap that
-        # dwarfs the spread still decides.
+        # Same machine, audio connected: a gap dwarfing the spread still decides.
         ("drifting_but_signal_dwarfs_it", [24.8986, 25.4577, 25.7256], 40.0,
          "pass"),
-        # Two repeats can agree by luck on a drifting machine, which would put
-        # the floor back at zero and pass the disconnected case; the third is
-        # what stops that.
+        # Two repeats can agree by luck on a drifting machine, putting the floor
+        # back at zero and passing the disconnected case; the third stops that.
         ("two_repeats_agree_by_luck", [19.30, 19.30, 19.81], 19.62,
          "below_noise"),
     ],
@@ -78,10 +70,8 @@ def test_importing_the_probe_does_not_rewrite_the_environment(monkeypatch, var):
 def test_two_tone_verdict(name, repeats, other, expected):
     verdict, detail = probe.two_tone_verdict(repeats, other)
     assert verdict == expected, f"{name}: {detail}"
-    # Every non-pass verdict the function can actually produce must have a
-    # message, or the caller raises KeyError instead of reporting. Checked
-    # here, against verdicts really returned, rather than against a hardcoded
-    # list that a newly added verdict would not appear in.
+    # Every non-pass verdict must have a message, or the caller raises KeyError
+    # instead of reporting. Checked against verdicts really returned.
     if verdict != "pass":
         assert probe.TWO_TONE_REASONS[verdict]
 

--- a/tests/test_gemma4_vision_pooler_fp16.py
+++ b/tests/test_gemma4_vision_pooler_fp16.py
@@ -65,7 +65,7 @@ def make_buggy_classes(standardize=True, model_dtype=torch.float16, return_tuple
 
         def forward(self, pixel_values):
             # Upstream-like: cast pixels to the weight dtype, then run the real
-            # (autocast-eligible) Linear; identity weight keeps amax controlled.
+            # (autocast-eligible) Linear; the identity weight keeps amax controlled.
             return self.input_proj(pixel_values.to(self.input_proj.weight.dtype))
 
     class TinyVisionModel(torch.nn.Module):
@@ -174,9 +174,7 @@ def test_patched_standardize_false_casts_back():
 
 
 def test_mixed_fp32_pixels_fp16_tower_casts_to_tower_dtype():
-    # HF processor output is fp32; the embedder casts it to fp16. The cast-back
-    # target must be the tower dtype, not the pixel dtype, or fp32 features hit
-    # the fp16 embed_vision projection downstream.
+    # Cast back to the tower dtype: fp32 features would hit the fp16 embed_vision.
     TinyPooler, TinyVisionModel = make_buggy_classes()
     assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
     out = make_model(TinyVisionModel)(fp16_overflow_input(torch.float32)).last_hidden_state
@@ -233,8 +231,7 @@ def test_bf16_autocast_over_fp16_weights_untouched():
 
 
 def test_captured_hidden_states_stay_consistent():
-    # The capture wrapper ties hidden_states[-1] to the pre-cast final
-    # state; that entry must be cast too.
+    # hidden_states[-1] is the pre-cast final state; it must be cast too.
     TinyPooler, TinyVisionModel = make_buggy_classes()
 
     original_forward = TinyVisionModel.forward
@@ -286,8 +283,7 @@ def test_idempotent():
 
 
 def test_repair_reinstalls_missing_vision_wrapper():
-    # A marked pooler without its paired vision wrapper (only external rebind
-    # can produce this) must be repaired, never reported "already".
+    # A marked pooler missing its vision wrapper is repaired, never "already".
     TinyPooler, TinyVisionModel = make_buggy_classes()
     original_vision = TinyVisionModel.forward
     assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"

--- a/tests/test_generated_fullgraph_fallback.py
+++ b/tests/test_generated_fullgraph_fallback.py
@@ -45,9 +45,8 @@ from unsloth_zoo.temporary_patches.utils import torch_compile_with_fallback
 
 ZOO = Path(__file__).resolve().parents[1] / "unsloth_zoo"
 COMPILER = ZOO / "compiler.py"
-# Every module that hands torch a fullgraph region, not just the compiler: the
-# first pass scanned compiler.py alone and passed while GRPO's own
-# `grpo_compute_loss_slow` and `accumulate_chunk` stayed bare, and so fatal.
+# Not just the compiler: the first pass scanned compiler.py alone and passed while
+# GRPO's own `grpo_compute_loss_slow` and `accumulate_chunk` stayed bare, and so fatal.
 FULLGRAPH_SITES = (COMPILER, ZOO / "rl_replacements.py",
                    ZOO / "temporary_patches" / "common.py")
 
@@ -98,7 +97,6 @@ def _run_with_compile_disabled(body):
     _run_in_fresh_interpreter(body, "1")
 
 
-# ---- what the compiler emits ---------------------------------------------
 
 def test_no_emitter_writes_a_bare_fullgraph_compile():
     """Every emitted `fullgraph` decorator has to carry the fallback.
@@ -141,9 +139,8 @@ def test_maybe_compile_routes_fullgraph_through_the_fallback(monkeypatch):
     # Without fullgraph Dynamo already falls back by itself, so leave it alone.
     assert 'if not kwargs.get("fullgraph"):' in body
 
-    # In process, unlike the alias below: `_maybe_compile` reads both switches
-    # in its own body on every call, so pinning the module attributes is exact
-    # and the assertion then holds in every configuration the suite runs under.
+    # `_maybe_compile` reads both switches on every call, so pinning the module
+    # attributes is exact.
     monkeypatch.setattr(common, "UNSLOTH_COMPILE_DISABLE", False)
     monkeypatch.setattr(common, "UNSLOTH_COMPILE_DISABLE_PARTIAL", False)
 
@@ -152,14 +149,11 @@ def test_maybe_compile_routes_fullgraph_through_the_fallback(monkeypatch):
     wrapped = common._maybe_compile(fullgraph = True, dynamic = True)(f)
     assert hasattr(wrapped, "_unsloth_fallback_state")
 
-    # The other direction needs a second observable. `_unsloth_fallback_state`
-    # is stamped on only under fullgraph (utils.py returns the plain compiled
-    # object before it), so its absence cannot tell a non-fullgraph compile that
-    # wrongly went through the helper from one that did not. Record the call
-    # instead: `_maybe_compile` resolves the name off `utils` at call time, so
-    # rebinding the attribute is enough. Verified by replacing the guard's body
-    # with `pass`, which the `hasattr` form did not notice in any switch
-    # position and this does.
+    # `_unsloth_fallback_state` is stamped on only under fullgraph, so its absence
+    # cannot single out a non-fullgraph compile that went through the helper anyway.
+    # Record the call instead: `_maybe_compile` imports the name off `utils` at call
+    # time, so rebinding the attribute is enough. Verified by replacing the guard's
+    # body with `pass`, which the `hasattr` form did not notice and this does.
     import unsloth_zoo.temporary_patches.utils as U
     calls = []
 
@@ -228,7 +222,6 @@ def test_the_cross_entropy_template_carries_its_own_import():
     assert "import torch_compile_with_fallback" in block
 
 
-# ---- what the helper does -------------------------------------------------
 
 def test_fullgraph_false_is_returned_untouched():
     """Dynamo already falls back on its own there, so a wrapper could never
@@ -248,10 +241,8 @@ def test_fullgraph_true_is_wrapped():
     assert hasattr(wrapped, "_unsloth_fallback_state")
 
 
-# aot_eager, not inductor: inductor shells out to a host compiler, so this
-# raised `Compiler: cl is not found` on the Windows runner, a statement about
-# MSVC and not about the wrapper. Any backend answers what is under test, that
-# the wrapper returns what the eager function returns.
+# aot_eager, not inductor: inductor shells out to a host compiler, so this raised
+# `Compiler: cl is not found` on the Windows runner, a statement about MSVC.
 _BACKEND = "aot_eager"
 
 
@@ -297,7 +288,6 @@ def test_the_eager_path_is_the_original_function():
     assert wrapped.__wrapped__ is some_forward
 
 
-# --- what the seventh review round found ------------------------------------
 
 def _bare_fullgraph_alias_sites():
     """Every `@torch_compile(... fullgraph = True)` in the package.
@@ -334,8 +324,8 @@ def test_the_alias_sites_exist_and_are_covered_by_the_alias_itself():
     assert "torch_compile_with_fallback" in common
     # By line, not by substring: `_torch_compile = ...` is a substring of
     # `_raw_torch_compile = ...`, which deliberately DOES partial torch.compile
-    # (compile_with_eager_fallback applies the wrapper itself, and wrapping a
-    # wrapper leaves the inner one swallowing the exhaustion).
+    # (compile_with_eager_fallback applies the wrapper itself, and wrapping a wrapper
+    # leaves the inner one swallowing the exhaustion).
     lines = common.split("\n")
     for name in ("torch_compile", "_torch_compile"):
         starts = [i for i, ln in enumerate(lines)

--- a/tests/test_generated_trainer_is_installed.py
+++ b/tests/test_generated_trainer_is_installed.py
@@ -59,14 +59,13 @@ def _run(body: str, timeout: int = 900):
         {body}
     """)
     env = dict(os.environ)
-    # NOT /tmp: writes are blocked in this sandbox, and a cache the compiler
-    # cannot write to fails generation for an unrelated reason.
+    # NOT /tmp: writes are blocked here and an unwritable cache fails generation.
     cache = Path(os.environ.get("UNSLOTH_WORKSPACE", ROOT.parent)) / "temp" / "gen_test_cache"
     cache.mkdir(parents=True, exist_ok=True)
     env["UNSLOTH_COMPILE_LOCATION"] = str(cache)
     # conftest sets UNSLOTH_ALLOW_CPU=1 suite-wide, which makes PatchFastRL
-    # early-return on purpose. Inherited here it would guarantee a plain
-    # SFTTrainer and this file would "fail" on a healthy tree.
+    # early-return: inherited here it would guarantee a plain SFTTrainer and so
+    # fail this file on a healthy tree.
     env.pop("UNSLOTH_ALLOW_CPU", None)
     return subprocess.run([sys.executable, "-c", script], capture_output=True,
                           text=True, timeout=timeout, env=env)

--- a/tests/test_get_transformers_model_type_empty.py
+++ b/tests/test_get_transformers_model_type_empty.py
@@ -75,7 +75,6 @@ def _lora_config(base_model_name_or_path):
     )
 
 
-# --- adapter-name unwrapping -------------------------------------------------
 
 def test_single_adapter_dict_with_non_default_name_resolves(local_llama_base):
     """`get_peft_model(..., adapter_name = "my_adapter")` produces a peft_config keyed
@@ -131,7 +130,6 @@ def test_config_object_without_to_dict_raises():
         get_transformers_model_type(NoToDict())
 
 
-# --- paths that already worked must be byte-identical ------------------------
 
 def test_plain_transformers_config_unchanged():
     from transformers import LlamaConfig

--- a/tests/test_gguf_bitsandbytes_guard.py
+++ b/tests/test_gguf_bitsandbytes_guard.py
@@ -49,7 +49,6 @@ def test_top_level_bitsandbytes_is_found():
 
 
 def test_nested_text_config_is_found():
-    # VLMs keep it under a sub-config.
     cfg = {"text_config": {"quantization_config": {"quant_method": "bitsandbytes"}}}
     assert find(cfg) == "config.json['text_config']"
 
@@ -85,7 +84,7 @@ def test_non_dict_inputs_are_safe():
 def test_guard_is_wired_into_convert_to_gguf():
     body = _SRC[_SRC.index("def convert_to_gguf("):]
     assert "_find_bitsandbytes_quantization(config_file)" in body
-    # Failing fast: the guard must precede the converter subprocess.
+    # The guard must precede the converter subprocess.
     guard = body.index("_find_bitsandbytes_quantization(config_file)")
     launch = body.index("subprocess.run")
     assert guard < launch

--- a/tests/test_gguf_oom_temp_file_retry.py
+++ b/tests/test_gguf_oom_temp_file_retry.py
@@ -42,7 +42,6 @@ from unsloth_zoo.llama_cpp import (  # noqa: E402
 )
 
 
-# ---- recognising the kill --------------------------------------------------
 
 def test_sigkill_from_the_message():
     assert _converter_was_oom_killed(
@@ -70,7 +69,6 @@ def test_a_nonzero_exit_is_not_a_kill():
     assert not _converter_was_oom_killed(_Called())
 
 
-# ---- building the retry ----------------------------------------------------
 
 BASE = ["/usr/bin/python3", "/root/.unsloth/llama.cpp/unsloth_convert_hf_to_gguf.py",
         "--outfile", "model.F16.gguf", "--outtype", "f16",
@@ -127,7 +125,6 @@ def test_the_result_is_a_new_list():
     assert "--split-max-size" in BASE, "the caller's command must not be mutated"
 
 
-# ---- how the run loop uses it ----------------------------------------------
 
 def _loop_src():
     src = (ROOT / "unsloth_zoo" / "llama_cpp.py").read_text(encoding="utf-8")
@@ -157,7 +154,6 @@ def test_the_dependency_repair_retry_is_independent():
     assert body.index("attempted_repair") < body.index("attempted_temp_file = True")
 
 
-# ---- clearing what the killed run left behind ------------------------------
 
 def _touch(directory, name, data = b"GGUF"):
     path = directory / name
@@ -214,13 +210,9 @@ def test_the_paths_include_the_file_and_its_shards(tmp_path):
 
 
 def test_the_retry_clears_the_old_output_first():
-    # Anchored on the OOM branch. The loop grew a second `command = retry`, for
-    # a converter that rejects --no-mtp, and a bare index() finds that one
-    # first. That retry re-runs the same command minus one flag, keeps
-    # --split-max-size and so overwrites the same paths, which is why it has no
-    # cleanup; only the OOM retry drops --split-max-size and can leave the
-    # killed run's shards behind. Searching from the kill check keeps the
-    # assertion on the branch that actually needs it.
+    # Anchored on the OOM branch: the loop grew a second `command = retry`, for a
+    # converter that rejects --no-mtp, that a bare index() finds first. Only the OOM
+    # retry drops --split-max-size and can leave the killed run's shards behind.
     body = _loop_src()
     oom = body.index("_converter_was_oom_killed(e)")
     assert body.index("_remove_gguf_outputs(output_file)", oom) < body.index("command = retry", oom)

--- a/tests/test_grpo_chunked_reduction_dim.py
+++ b/tests/test_grpo_chunked_reduction_dim.py
@@ -42,7 +42,6 @@ sys.path.insert(0, str(ROOT))
 SRC = (ROOT / "unsloth_zoo" / "rl_replacements.py").read_text(encoding="utf-8")
 
 
-# ---- the source ------------------------------------------------------------
 
 def _fn_source():
     import ast
@@ -86,7 +85,6 @@ def test_the_function_is_still_compiled_by_default():
     assert "_maybe_compile(dynamic = True, fullgraph = True" in preceding
 
 
-# ---- the numbers -----------------------------------------------------------
 
 def _setup():
     torch = pytest.importorskip("torch")

--- a/tests/test_grpo_packed_raw_logits_dispatch.py
+++ b/tests/test_grpo_packed_raw_logits_dispatch.py
@@ -41,12 +41,12 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 SRC = (ROOT / "unsloth_zoo" / "rl_replacements.py").read_text(encoding = "utf-8")
-# One shared parse: nodes from separate parses never compare equal, which would
-# make the containment tests below vacuous.
+# One shared parse: nodes from separate parses never compare equal, which would make
+# the containment tests below vacuous.
 TREE = ast.parse(SRC)
 
 
-# ---- the message ----------------------------------------------------------
+# the message
 
 def _mismatched_call(fn, torch):
     """Vocab-wide logits where hidden states are expected, as an unpatched
@@ -79,7 +79,7 @@ def test_the_width_mismatch_names_both_operands():
     assert "32" in message and "128" in message, message
 
 
-# ---- the dispatch ---------------------------------------------------------
+# the dispatch
 
 def _packed_block():
     """The packed call inside `grpo_accumulated_loss`, located by AST so

--- a/tests/test_hf_transfer_windows_arm.py
+++ b/tests/test_hf_transfer_windows_arm.py
@@ -248,10 +248,8 @@ class TestWiring:
         assert "_offline_env" in ast.dump(enable.test)
 
     def test_no_later_statement_re_enables_the_variable(self):
-        # Executing two statements in isolation says nothing about the other few
-        # hundred. Without this, appending one os.environ[...] = "1" anywhere
-        # below leaves all of the above green while Windows on ARM is broken
-        # again: a test that passes for the wrong reason.
+        # Without this, appending one os.environ[...] = "1" anywhere below leaves
+        # every test above green while Windows on ARM is broken again.
         detect, assign, enable = _statements()
         for node in _TREE.body:
             if node in (detect, assign, enable):

--- a/tests/test_hf_xet_applies_automatically.py
+++ b/tests/test_hf_xet_applies_automatically.py
@@ -145,8 +145,7 @@ def test_a_fresh_vm_with_an_empty_xet_log_dir_does_not_import_into_high_performa
     """, {"HF_XET_CACHE": str(xet_cache), "HF_HOME": str(tmp_path / "hf")})
 
     # Judge the flag with the parser the tuning code uses: it strips and lowercases, so a raw
-    # membership test would let "True" or " on " through while the process is in fact sized for
-    # high performance -- the regression back, in a different spelling.
+    # membership test would let "True" or " on " through -- the regression back, respelled.
     from unsloth_zoo.hf_xet_tuning import _is_true
 
     assert not _is_true(result["hp"]), (

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -53,9 +53,8 @@ def _load(name: str, filename: str):
     return module
 
 
-# Package placeholder so intra-package imports in hf_xet_fallback resolve to the
-# files loaded below. Restored afterwards: a leftover would shadow the real
-# unsloth_zoo; the loaded modules keep their own references and work regardless.
+# Package placeholder so intra-package imports in hf_xet_fallback resolve to the files
+# loaded below. Restored afterwards: a leftover would shadow the real unsloth_zoo.
 _saved_modules = {
     name: sys.modules.get(name)
     for name in ("unsloth_zoo", "unsloth_zoo.hf_cache_state", "unsloth_zoo.hf_xet_fallback")
@@ -168,8 +167,7 @@ def test_transient_unmeasurable_tick_is_progress(hf_cache, monkeypatch):
     seq = {"n": 0}
     frozen = (2048, True)  # constant size + active .incomplete
     # A real partial as well as the mocked repo-wide figure: the watchdog phases its clocks on bytes
-    # in ACTIVE partials, so a mocked total alone would leave it in the 90s connect phase and the
-    # 0.3s data deadline asserted below would never apply.
+    # in ACTIVE partials, so a mocked total alone would sit in the 90s connect phase, never the 0.3s one.
     (_blobs_dir(hf_cache) / "frozen.incomplete").write_bytes(b"\0" * 2048)
 
     def fake_state(*args, **kwargs):
@@ -224,7 +222,6 @@ def test_file_watchdog_scopes_to_child_partial(hf_cache):
     grower = threading.Thread(target = _grow, daemon = True)
     grower.start()
 
-    # This download's child writes its own constant (stalled) partial, not in baseline.
     (blobs / "child.incomplete").write_bytes(b"\0" * 2048)
 
     calls: list[str] = []
@@ -391,7 +388,6 @@ def test_file_watchdog_pid_scope_ignores_unowned_sibling(hf_cache):
 def test_file_watchdog_empty_open_set_ignores_sibling(hf_cache, monkeypatch):
     """An EMPTY child open-set means the child owns no partial yet (connect/metadata phase), so a stalled sibling must not fire."""
     blobs = _blobs_dir(hf_cache)
-    # Sibling partial created after baseline (not name-excluded), constant (stalled).
     (blobs / "sibling.incomplete").write_bytes(b"\0" * 4096)
     monkeypatch.setattr(xf, "_child_open_incomplete_blobs", lambda pid: set())  # child owns none
 
@@ -463,12 +459,10 @@ def test_custom_cache_dir_is_watched_and_cleaned(tmp_path, monkeypatch):
     partial = blobs / "stalled.incomplete"
     partial.write_bytes(b"partial-bytes")
 
-    # Default cache sees nothing; the custom cache sees the active partial.
     assert xf.get_hf_download_state([REPO]) == (0, False)
     total, has_incomplete = xf.get_hf_download_state([REPO], cache_dir = str(custom_cache))
     assert has_incomplete is True and total > 0
 
-    # The watchdog fires for the custom cache, not the (empty) default one.
     calls: list[str] = []
     stop = xf.start_watchdog(
         repo_ids = [REPO], on_stall = calls.append, cache_dir = str(custom_cache),
@@ -681,9 +675,8 @@ def test_status_callback_failure_does_not_kill_watchdog(hf_cache):
         stop.set()
 
 
-# Transport policy: cached short-circuit, cancel, error propagation, the single
-# Xet->HTTP fallback, injected prepare seam, and UNSLOTH_DISABLE_XET. The download
-# seam (_run_download_attempt) is faked, so no real spawn.
+# Transport policy: cached short-circuit, cancel, error propagation, the single Xet->HTTP
+# fallback, injected prepare seam, UNSLOTH_DISABLE_XET. _run_download_attempt is faked, so no spawn.
 DL_REPO, FILE = "ztest/xet-dl", "model-Q4_K_XL.gguf"
 
 
@@ -698,7 +691,6 @@ def _no_real_cache_hit(monkeypatch):
     monkeypatch.setattr(huggingface_hub, "snapshot_download", _snap_miss)
     # Neutralize the generic cache purge; tests that care record it.
     monkeypatch.setattr(xf, "_default_prepare_for_http", lambda *a, **k: None)
-    # No env knob unless a test sets it.
     monkeypatch.delenv("UNSLOTH_DISABLE_XET", raising = False)
     monkeypatch.delenv("UNSLOTH_STABLE_DOWNLOADS", raising = False)
     monkeypatch.delenv("HF_HUB_DISABLE_XET", raising = False)
@@ -806,8 +798,7 @@ def test_snapshot_cancel_honored_even_when_cached(monkeypatch, tmp_path):
 
 def test_nonstall_error_propagates_without_fallback(monkeypatch):
     fake = _install(monkeypatch, [("error", "RepositoryNotFoundError: 404 not found")])
-    # Deterministic Hub error re-raised with its original type across the spawn boundary,
-    # reconstructed from the child's "<Name>: ..." prefix.
+    # Deterministic Hub error re-raised with its original type, rebuilt from the child's "<Name>: " prefix.
     expected_cls = xf._resolve_exception_class("RepositoryNotFoundError")
     assert expected_cls is not None and expected_cls is not RuntimeError
     with pytest.raises(expected_cls, match = "RepositoryNotFoundError"):
@@ -872,7 +863,6 @@ def test_is_retryable_download_error_classification():
     def f(exc, on_xet = True):
         return xf._is_retryable_download_error(exc, on_xet = on_xet)
 
-    # Transient transport failures -> retryable.
     assert f(Exception("hf_xet download failed: data processing error")) is True
     assert f(TimeoutError("connection reset by peer")) is True
     assert f(Exception("CasClientError: deadline exceeded")) is True
@@ -942,7 +932,6 @@ def test_local_entry_not_found_transient_is_retryable():
     class LocalEntryNotFoundError(Exception):
         pass
 
-    # Transient connection wrapper -> retryable.
     transient = LocalEntryNotFoundError(
         "An error happened while trying to locate the file on the Hub and we cannot find the "
         "requested files in the local cache. Please check your connection and try again."
@@ -950,7 +939,6 @@ def test_local_entry_not_found_transient_is_retryable():
     assert f(transient) is True
     timed_out = LocalEntryNotFoundError("Read timed out while fetching metadata")
     assert f(timed_out) is True
-    # Genuine offline miss (no transient hint) -> deterministic, type-preserved.
     offline = LocalEntryNotFoundError(
         "Cannot find the requested files in the disk cache and outgoing traffic has been disabled."
     )
@@ -1324,13 +1312,11 @@ def test_http_retry_backoff_honours_zero(monkeypatch):
     assert xf._http_retry_backoff() == 0.0
     monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "1.5")
     assert xf._http_retry_backoff() == 1.5
-    # Negative and unparseable are junk and fall back; unset falls back too.
     for bad in ("abc", "-1", "  "):
         monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", bad)
         assert xf._http_retry_backoff() == xf.DEFAULT_HTTP_RETRY_BACKOFF, bad
     monkeypatch.delenv("UNSLOTH_HTTP_RETRY_BACKOFF")
     assert xf._http_retry_backoff() == xf.DEFAULT_HTTP_RETRY_BACKOFF
-    # A zero backoff really does return at once, with no cancel event in play.
     monkeypatch.setenv("UNSLOTH_HTTP_RETRY_BACKOFF", "0")
     started = time.monotonic()
     xf._wait_before_http_retry(None)
@@ -1441,9 +1427,8 @@ def test_file_path_accepts_cache_dir(monkeypatch):
     assert fake.calls[0].cache_dir == "/custom/cache"
 
 
-# Spawn env-timing: the parent sets HF_HUB_DISABLE_XET before the child starts, so
-# the child inherits it before re-importing huggingface_hub (constants cache it at
-# import). Uses a fake spawn context -- no real subprocess.
+# Spawn env-timing: the parent sets HF_HUB_DISABLE_XET before the child starts, so the child
+# inherits it before re-importing huggingface_hub (constants cache it at import). Fake spawn context.
 class _FakeProc:
     def __init__(self, recorder):
         self._rec = recorder
@@ -1504,10 +1489,8 @@ def test_http_retry_sets_disable_xet_before_spawn(monkeypatch):
         stall_timeout = 0.2, interval = 0.05, grace_period = 0.2, on_status = None,
     )
     assert (kind_result, payload) == ("ok", "/cache/x")
-    # Child inherited HTTP transport env at spawn time.
     assert rec["disable_xet"] == "1"
     assert rec["hf_transfer"] == "0"
-    # Parent env restored afterwards (was unset).
     assert "HF_HUB_DISABLE_XET" not in os.environ
 
 
@@ -1713,7 +1696,6 @@ def test_scrub_redacts_presigned_url():
     assert "X-Amz-Signature" not in out
     assert "deadbeefcafe" not in out and "AKIAEXAMPLE123" not in out
     assert "cas-bridge.xethub.hf.co/xet-bridge-us/abc/def?***" in out
-    # A non-signed URL keeps its (harmless) query string.
     plain = xf._default_scrub_secrets("see https://huggingface.co/org/repo?download=true now")
     assert "download=true" in plain
 
@@ -1728,7 +1710,6 @@ def test_scrub_redaction_preserves_surrounding_delimiters():
     assert "deadbeef" not in out                       # signed query redacted
     assert "cas-bridge.xethub.hf.co/x/y?***" in out
     assert out.endswith('"}')                           # closing delimiters preserved
-    # A signed URL wrapped in single quotes / parens keeps those delimiters too.
     wrapped = "(https://s3.amazonaws.com/b/k?X-Amz-Signature=abc123) tail"
     out2 = xf._default_scrub_secrets(wrapped)
     assert "abc123" not in out2 and "?***)" in out2 and out2.endswith(") tail")
@@ -1854,8 +1835,7 @@ def test_unclearable_partial_forces_clean_redownload(hf_cache, monkeypatch):
     fake = _install(monkeypatch, [("stall", None), ("stall", None), ("ok", "/cache/x")])
     out = xf.snapshot_download_with_xet_fallback(DL_REPO, token = None)
     assert out == "/cache/x"
-    # Neither Xet attempt is forced: Xet rewrites from zero anyway, and forcing would discard the
-    # finalized blobs the retry is meant to keep.
+    # Neither Xet attempt is forced: Xet rewrites from zero, and forcing discards finalized blobs.
     assert [c.force_download for c in fake.calls] == [False, False, True]
 
 
@@ -1975,13 +1955,11 @@ def test_snapshot_dir_is_complete_checkpoint_index_does_not_gate_root(tmp_path):
     blob = tmp_path / "blob"
     blob.write_bytes(b"x")
     (snap / "model.safetensors").symlink_to(blob)                    # complete root weight
-    # Incomplete checkpoint shard index (shard 2 missing) under checkpoint-7/.
     (snap / "checkpoint-7" / "model-00001-of-00002.safetensors").symlink_to(blob)
     (snap / "checkpoint-7" / "model.safetensors.index.json").write_text(
         json.dumps({"weight_map": {"a": "model-00001-of-00002.safetensors",
                                    "b": "model-00002-of-00002.safetensors"}})
     )
-    # Root warm is complete: the checkpoint index is skipped, the root weight suffices.
     assert hcs.snapshot_dir_is_complete(snap) is True
 
 
@@ -2121,16 +2099,12 @@ def test_request_can_include_weights_index_json_only():
 
 def test_request_can_include_weights_path_qualified():
     """Path-qualified allow_patterns resolve inside their directory, so a subfolder/checkpoint/shard weight request is not misread as weightless."""
-    # Concrete subfolder globs: weights live under the directory.
     assert hcs.request_can_include_weights(["checkpoint-10/*"], None) is True
     assert hcs.request_can_include_weights(["checkpoint-10/*.safetensors"], None) is True
     assert hcs.request_can_include_weights(["models/*.bin"], None) is True
-    # A specific (non-first) shard named verbatim.
     assert hcs.request_can_include_weights(["model-00002-of-00005.safetensors"], None) is True
     assert hcs.request_can_include_weights(["checkpoint-10/pytorch_model.bin"], None) is True
-    # Globbed parent dir, weight-targeting basename.
     assert hcs.request_can_include_weights(["checkpoint-*/*.safetensors"], None) is True
-    # Subfolder requests targeting only non-weight files stay weightless.
     assert hcs.request_can_include_weights(["checkpoint-10/config.json"], None) is False
     assert hcs.request_can_include_weights(["checkpoint-10/*.json"], None) is False
     assert hcs.request_can_include_weights(["checkpoint-*/tokenizer.json"], None) is False
@@ -2146,7 +2120,6 @@ def test_request_can_include_weights_path_qualified_custom_globs():
     assert hcs.request_can_include_weights(["checkpoint-*/lora_*.bin"], None) is True
     assert hcs.request_can_include_weights(["models/custom_*.pt"], None) is True
     assert hcs.request_can_include_weights(["checkpoint-10/model-[0-9].safetensors"], None) is True
-    # A non-weight basename under a subfolder stays weightless.
     assert hcs.request_can_include_weights(["checkpoint-10/tokenizer.json"], None) is False
 
 
@@ -2172,7 +2145,6 @@ def test_request_can_include_weights_string_form():
     assert hcs.request_can_include_weights("*.safetensors", None) is True
     assert hcs.request_can_include_weights("config.json", None) is False
     assert hcs.request_can_include_weights(None, "*.safetensors") is True   # ignore as str
-    # A string ignore that drops every weight format leaves the request weightless.
     assert hcs.request_can_include_weights(
         "config.json", ["*.safetensors", "*.bin", "*.pt", "*.pth", "*.gguf",
                         "*.h5", "*.msgpack", "*.ckpt", "*.onnx", "*.pdparams"]
@@ -2359,7 +2331,6 @@ def test_requested_named_files_present_exact_request(tmp_path):
     assert hcs.requested_named_files_present(snap, allow_patterns = ["tokenizer.json"]) is True
     # A glob list is best-effort: a missing optional file does not fail it.
     assert hcs.requested_named_files_present(snap, allow_patterns = ["tokenizer*", "vocab.txt"]) is True
-    # No allow_patterns -> trivially satisfied.
     assert hcs.requested_named_files_present(snap) is True
     # An ignore-filtered name is not requested, so its absence does not fail.
     assert hcs.requested_named_files_present(
@@ -2455,7 +2426,6 @@ def test_oserror_subclass_errno_preserved(monkeypatch):
 
 def test_raise_child_error_errno_only_for_builtin_oserror():
     """errno is preserved only for a BUILTIN OSError type; a non-builtin OSError subclass (e.g. HfHubHTTPError) with a bracketed [Errno N] gets no spurious errno."""
-    # Builtin OSError subclass -> errno preserved.
     with pytest.raises(FileNotFoundError) as excinfo:
         xf._raise_child_error("FileNotFoundError: [Errno 2] No such file or directory")
     assert excinfo.value.errno == 2
@@ -2555,10 +2525,9 @@ def test_disable_xet_read_under_spawn_lock(monkeypatch):
     assert seen.get("held") is True
 
 
-# Conservative fast-path gate + pre/post-download acceptance split. The gate fast-paths
-# ONLY the unambiguous canonical model cache, deferring everything else to the watched
-# child. Pre-download (skip the child?) and post-download (accept the result?) are
-# deliberately asymmetric: strict pre, lenient post.
+# Conservative fast-path gate + pre/post-download acceptance split. The gate fast-paths ONLY the
+# unambiguous canonical model cache, deferring everything else to the watched child. Pre-download
+# (skip the child?) and post-download (accept the result?) are asymmetric: strict pre, lenient post.
 def _mk_snapshot(tmp_path, name):
     blob = tmp_path / "_blob"
     if not blob.exists():
@@ -2613,9 +2582,7 @@ def test_gate_defers_incomplete_preferred_index_masked_by_complete_bin(tmp_path)
                                    "b": "model-00002-of-00002.safetensors"}}))
     (snap / "pytorch_model.bin").symlink_to(blob)  # complete bin co-resident
     assert hcs.snapshot_dir_is_complete(snap) is False  # load prefers the incomplete safetensors
-    # safetensors ignored -> the load reads the complete bin -> eligible.
     assert hcs.snapshot_dir_is_complete(snap, ignore_patterns = ["*.safetensors"]) is True
-    # A complete safetensors index alongside the bin is eligible.
     (snap / "model-00002-of-00002.safetensors").symlink_to(blob)
     assert hcs.snapshot_dir_is_complete(snap) is True
 
@@ -2699,7 +2666,6 @@ def test_request_can_include_weights_partial_ignore_strip_is_weight_bearing():
     r = hcs.request_can_include_weights
     assert r(None, ["model.safetensors", "pytorch_model.bin"]) is True  # variant / other-format survives
     assert r(None, ["*.safetensors", "*.bin"]) is True                  # .pt / .gguf / .pth / ... survive
-    # Only stripping EVERY weight format is weightless.
     all_formats = ["*.safetensors", "*.bin", "*.pt", "*.pth", "*.gguf", "*.ckpt",
                    "*.onnx", "*.msgpack", "*.h5", "*.pdparams"]
     assert r(None, all_formats) is False
@@ -2735,7 +2701,6 @@ def test_pre_download_defers_bin_only_when_safetensors_preferred(tmp_path):
     assert xf._cache_can_skip_download(
         snap, repo_type = "model", allow_patterns = None,
         ignore_patterns = ["*.safetensors", "*.safetensors.index.json"]) is True
-    # PRE: safetensors present -> fast-path.
     (snap / "model.safetensors").symlink_to(blob)
     assert xf._cache_can_skip_download(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
@@ -2745,7 +2710,6 @@ def test_pre_download_defers_bin_only_when_safetensors_preferred(tmp_path):
     (snap2 / "pytorch_model.bin").symlink_to(blob2)
     assert xf._download_result_usable(
         snap2, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
-    # POST: a sharded bin-only repo is likewise accepted.
     snap3, blob3 = _mk_snapshot(tmp_path, "binonly_sharded_post")
     (snap3 / "pytorch_model-00001-of-00002.bin").symlink_to(blob3)
     (snap3 / "pytorch_model-00002-of-00002.bin").symlink_to(blob3)
@@ -2796,7 +2760,6 @@ def test_post_accepts_nonstandard_sharded_safetensors_names(tmp_path):
     assert xf._download_result_usable(
         snap2, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
 
-    # Sanity: the standard sharded layout still passes.
     snap3, blob3 = _mk_snapshot(tmp_path, "qwen35_standard")
     (snap3 / "config.json").write_text("{}")
     std = ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"]
@@ -2832,7 +2795,6 @@ def test_pre_download_defers_sentence_transformers_missing_subfolder_weight(tmp_
     assert xf._cache_can_skip_download(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
 
-    # Complete: the 2_Dense weight is now present -> fast-path.
     (snap / "2_Dense" / "model.safetensors").symlink_to(blob)
     assert xf._cache_can_skip_download(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
@@ -2873,7 +2835,6 @@ def test_post_download_rejects_sentence_transformers_missing_known_subfolder_wei
             *mods,
         ])
 
-    # Known Dense module missing its weight -> reject.
     snap, blob = _mk_snapshot(tmp_path, "st_post_dense_missing")
     (snap / "model.safetensors").symlink_to(blob)
     (snap / "modules.json").write_text(_modules(
@@ -2882,7 +2843,6 @@ def test_post_download_rejects_sentence_transformers_missing_known_subfolder_wei
     (snap / "2_Dense" / "config.json").write_text("{}")  # config only, weight missing
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
-    # Dense weight present -> accept.
     (snap / "2_Dense" / "model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
@@ -2912,7 +2872,6 @@ def test_post_download_rejects_ignored_only_format(tmp_path):
     (snap / "pytorch_model.bin").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.bin"]) is False
-    # The requested safetensors present -> accepted.
     (snap / "model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.bin"]) is True
@@ -2929,7 +2888,6 @@ def test_post_download_rejects_canonical_only_for_variant(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
         variant = "fp16") is True
-    # A complete sharded variant set (shards + index) is accepted.
     snap2, blob2 = _mk_snapshot(tmp_path, "varshard")
     (snap2 / "model.fp16-00001-of-00002.safetensors").symlink_to(blob2)
     (snap2 / "model.fp16-00002-of-00002.safetensors").symlink_to(blob2)
@@ -2948,7 +2906,6 @@ def test_post_accepts_nonstandard_sharded_variant_names(tmp_path):
     completeness is still enforced via the index: a missing shard is rejected."""
     shards = ["model.fp16.safetensors-00001-of-00002.safetensors",
               "model.fp16.safetensors-00002-of-00002.safetensors"]
-    # Complete cache with the non-standard variant shard names -> accepted.
     snap, blob = _mk_snapshot(tmp_path, "varnonstd")
     (snap / "config.json").write_text("{}")
     for s in shards:
@@ -2990,12 +2947,10 @@ def test_post_download_rejects_patterned_canonical_only_for_variant(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["weights/*"], ignore_patterns = None,
         variant = "fp16") is False
-    # The in-scope variant weight present -> accepted.
     (sub / "model.fp16.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["weights/*"], ignore_patterns = None,
         variant = "fp16") is True
-    # A complete sharded in-scope variant weight (dash infix + variant index) is accepted.
     snap2, blob2 = _mk_snapshot(tmp_path, "subvarshard")
     sub2 = snap2 / "weights"
     sub2.mkdir()
@@ -3037,14 +2992,11 @@ def test_post_download_rejects_variant_only_diffusers_for_plain_load(tmp_path):
     for comp in ("unet", "vae"):
         (snap / comp).mkdir()
         (snap / comp / "diffusion_pytorch_model.fp16.safetensors").symlink_to(blob)
-    # plain load: variant-only components do not satisfy it -> retry.
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None, variant = None) is False
-    # the same cache is a complete fp16 warm -> the variant load accepts it.
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
         variant = "fp16") is True
-    # a complete plain pipeline (non-variant component weights) is accepted.
     snap2, blob2 = _mk_snapshot(tmp_path, "plaincomplete")
     (snap2 / "model_index.json").write_text(
         _mi(unet = ["diffusers", "UNet2DConditionModel"], vae = ["diffusers", "AutoencoderKL"]))
@@ -3068,7 +3020,6 @@ def test_post_download_rejects_incomplete_sharded_glob(tmp_path):
                                    "b": "model-00002-of-00002.safetensors"}}))
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["*.safetensors"], ignore_patterns = None) is False
-    # The missing shard present -> complete -> accepted.
     (snap / "model-00002-of-00002.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["*.safetensors"], ignore_patterns = None) is True
@@ -3119,7 +3070,6 @@ def test_post_download_rejects_incomplete_ignored_format_shards(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None,
         ignore_patterns = ["*.safetensors"]) is False
-    # Ignoring the .bin instead (load reads the complete safetensors) -> accepted.
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.bin"]) is True
 
@@ -3140,12 +3090,10 @@ def test_post_download_rejects_incomplete_variant_shards(tmp_path):
     assert xf._download_result_usable(
         snap_noidx, repo_type = "model", allow_patterns = None, ignore_patterns = None,
         variant = "fp16") is False
-    # The missing variant shard present -> complete set -> accepted.
     (snap / "model.fp16-00002-of-00002.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
         variant = "fp16") is True
-    # A single-file variant (no index) is accepted.
     snap2, blob2 = _mk_snapshot(tmp_path, "variant_single")
     (snap2 / "model.fp16.safetensors").symlink_to(blob2)
     assert xf._download_result_usable(
@@ -3160,7 +3108,6 @@ def test_post_download_accepts_exact_named_shard_subset(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model",
         allow_patterns = ["model-00001-of-00002.safetensors"], ignore_patterns = None) is True
-    # The exact-named shard absent -> rejected.
     snap2, _ = _mk_snapshot(tmp_path, "exact_shard_absent")
     (snap2 / "config.json").write_text("{}")
     assert xf._download_result_usable(
@@ -3177,7 +3124,6 @@ def test_post_download_accepts_from_tf_flax_weights(tmp_path):
         (snap / "config.json").write_text("{}")
         assert xf._download_result_usable(
             snap, repo_type = "model", allow_patterns = None, ignore_patterns = ig) is True
-    # Both PyTorch formats ignored but no h5/msgpack present -> still rejected.
     snap, _ = _mk_snapshot(tmp_path, "tf_none")
     (snap / "config.json").write_text("{}")
     assert xf._download_result_usable(
@@ -3195,20 +3141,17 @@ def test_post_download_checks_sharded_tf_flax_completeness(tmp_path):
     for base, ext in (("tf_model", "h5"), ("flax_model", "msgpack")):
         idx = json.dumps({"weight_map": {"a": f"{base}-00001-of-00002.{ext}",
                                          "b": f"{base}-00002-of-00002.{ext}"}})
-        # Complete sharded set -> accepted.
         snap, blob = _mk_snapshot(tmp_path, f"tfshard_ok_{base}")
         (snap / f"{base}-00001-of-00002.{ext}").symlink_to(blob)
         (snap / f"{base}-00002-of-00002.{ext}").symlink_to(blob)
         (snap / f"{base}.{ext}.index.json").write_text(idx)
         assert xf._download_result_usable(
             snap, repo_type = "model", allow_patterns = None, ignore_patterns = ig) is True
-        # A shard listed by the index is missing -> rejected.
         snap2, blob2 = _mk_snapshot(tmp_path, f"tfshard_missing_{base}")
         (snap2 / f"{base}-00001-of-00002.{ext}").symlink_to(blob2)
         (snap2 / f"{base}.{ext}.index.json").write_text(idx)
         assert xf._download_result_usable(
             snap2, repo_type = "model", allow_patterns = None, ignore_patterns = ig) is False
-        # A lone shard with no index -> rejected.
         snap3, blob3 = _mk_snapshot(tmp_path, f"tfshard_lone_{base}")
         (snap3 / f"{base}-00001-of-00002.{ext}").symlink_to(blob3)
         assert xf._download_result_usable(
@@ -3223,7 +3166,6 @@ def test_post_download_checks_explicit_checkpoint_shard_completeness(tmp_path):
     (snap / "checkpoint-7" / "model-00001-of-00002.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["checkpoint-7/*"], ignore_patterns = None) is False
-    # Complete checkpoint shard set (index + all shards) -> accepted.
     snap2, blob2 = _mk_snapshot(tmp_path, "ckpt_complete")
     (snap2 / "checkpoint-7").mkdir()
     (snap2 / "checkpoint-7" / "model-00001-of-00002.safetensors").symlink_to(blob2)
@@ -3241,8 +3183,8 @@ def test_post_download_checks_explicit_checkpoint_shard_completeness(tmp_path):
     (snap3 / "checkpoint-7" / "model-00001-of-00002.safetensors").symlink_to(blob3)  # lone, but not read
     assert xf._download_result_usable(
         snap3, repo_type = "model", allow_patterns = ["unet/*"], ignore_patterns = None) is True
-    # A nested checkpoint the request explicitly targets (allow=['foo/checkpoint-7/*']) still rejects its lone shard
-    # (the scope check matches a checkpoint dir at any leading segment).
+    # A nested checkpoint the request targets (allow=['foo/checkpoint-7/*']) still rejects its lone
+    # shard: the scope check matches a checkpoint dir at any leading segment.
     snap4, blob4 = _mk_snapshot(tmp_path, "ckpt_nested")
     (snap4 / "foo" / "checkpoint-7").mkdir(parents = True)
     (snap4 / "foo" / "checkpoint-7" / "model-00001-of-00002.safetensors").symlink_to(blob4)
@@ -3259,7 +3201,6 @@ def test_post_download_accepts_exact_named_variant_shard_subset(tmp_path):
         snap, repo_type = "model",
         allow_patterns = ["model.fp16-00001-of-00002.safetensors"], ignore_patterns = None,
         variant = "fp16") is True
-    # The exact-named variant shard absent -> still rejected.
     snap2, _ = _mk_snapshot(tmp_path, "exact_var_absent")
     (snap2 / "config.json").write_text("{}")
     assert xf._download_result_usable(
@@ -3275,7 +3216,6 @@ def test_post_download_rejects_patterned_incomplete_variant_shards(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["*.safetensors"], ignore_patterns = None,
         variant = "fp16") is False
-    # Complete variant shard set -> accepted.
     (snap / "model.fp16-00002-of-00002.safetensors").symlink_to(blob)
     (snap / "model.safetensors.index.fp16.json").write_text(json.dumps(
         {"weight_map": {"a": "model.fp16-00001-of-00002.safetensors",
@@ -3293,7 +3233,6 @@ def test_post_download_applies_ignore_to_diffusers_components(tmp_path):
     (snap / "unet" / "diffusion_pytorch_model.bin").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.bin"]) is False
-    # The safetensors component present -> usable.
     (snap / "unet" / "diffusion_pytorch_model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.bin"]) is True
@@ -3308,7 +3247,6 @@ def test_post_download_rejects_index_only_sharded_masked_by_bin(tmp_path):
     (snap / "pytorch_model.bin").symlink_to(blob)  # complete bin, no ST shards at all
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
-    # safetensors explicitly ignored -> load reads the complete bin -> usable.
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.safetensors"]) is True
 
@@ -3349,7 +3287,6 @@ def test_post_download_root_variant_weight_honors_ignore(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.bin"],
         variant = "fp16") is False
-    # The safetensors variant present -> usable.
     (snap / "model.fp16.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.bin"],
@@ -3380,7 +3317,6 @@ def test_post_download_rejects_variant_index_only_masked_by_bin(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
         variant = "fp16") is False
-    # The variant safetensors ignored -> load reads the complete variant bin -> usable.
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.safetensors"],
         variant = "fp16") is True
@@ -3397,7 +3333,6 @@ def test_post_download_rejects_incomplete_sharded_adapter(tmp_path):
     allow = ["adapter_config.json", "adapter_model*"]
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = allow, ignore_patterns = None) is False
-    # The missing adapter shard present -> complete set -> accepted.
     (snap / "adapter_model-00002-of-00002.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = allow, ignore_patterns = None) is True
@@ -3425,7 +3360,6 @@ def test_post_download_rejects_gguf_only_default_load(tmp_path):
     (snap / "config.json").write_text("{}")
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
-    # The safetensors weight present -> the default warm accepts, even beside the gguf.
     (snap / "model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
@@ -3598,7 +3532,6 @@ def test_post_download_single_safetensors_beats_stale_index(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
     assert hcs.snapshot_dir_is_complete(snap) is True  # the PRE gate agrees
-    # No single weight, only the stale index -> incomplete.
     snap2, _ = _mk_snapshot(tmp_path, "stale_index_only")
     (snap2 / "config.json").write_text("{}")
     (snap2 / "model.safetensors.index.json").write_text(json.dumps(
@@ -3664,7 +3597,6 @@ def test_post_download_variant_presence_requires_canonical_name(tmp_path):
     assert xf._download_result_usable(
         snap_dot, repo_type = "model", allow_patterns = None, ignore_patterns = None,
         variant = "fp16") is False
-    # The canonical single variant weight -> accepted.
     (snap / "model.fp16.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
@@ -3673,7 +3605,6 @@ def test_post_download_variant_presence_requires_canonical_name(tmp_path):
 
 def test_post_download_rejects_selected_shard_without_index(tmp_path):
     """A selected non-root numbered shard with no index is an incomplete set the load cannot enumerate, so it is rejected; a complete indexed set is accepted."""
-    # A sharded adapter with a lone shard and no index.
     snap, blob = _mk_snapshot(tmp_path, "adapter_lone_shard")
     (snap / "config.json").write_text("{}")
     (snap / "adapter_config.json").write_text("{}")
@@ -3681,7 +3612,6 @@ def test_post_download_rejects_selected_shard_without_index(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["adapter_model*", "adapter_config.json"],
         ignore_patterns = None) is False
-    # Complete it with the second shard + index -> accepted.
     (snap / "adapter_model-00002-of-00002.safetensors").symlink_to(blob)
     (snap / "adapter_model.safetensors.index.json").write_text(json.dumps(
         {"weight_map": {"a": "adapter_model-00001-of-00002.safetensors",
@@ -3707,7 +3637,6 @@ def test_post_download_diffusers_presence_scoped_to_declared(tmp_path):
     (snap / "controlnet" / "diffusion_pytorch_model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
-    # The declared components present -> accepted.
     for comp in ("unet", "vae"):
         (snap / comp).mkdir()
         (snap / comp / "diffusion_pytorch_model.safetensors").symlink_to(blob)
@@ -3725,7 +3654,6 @@ def test_post_download_diffusers_variant_presence_scoped_to_declared(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
         variant = "fp16") is False
-    # The declared component variant weights present -> accepted.
     for comp in ("unet", "vae"):
         (snap / comp).mkdir()
         (snap / comp / "diffusion_pytorch_model.fp16.safetensors").symlink_to(blob)
@@ -3883,7 +3811,6 @@ def test_post_download_rejects_diffusers_component_with_only_sidecar_weight(tmp_
     (unet / "adapter_model.safetensors").symlink_to(blob)  # sidecar, not the base weight
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
-    # The canonical base weight present -> accepted.
     (unet / "diffusion_pytorch_model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
@@ -3903,7 +3830,6 @@ def test_post_download_diffusers_component_weight_must_be_at_component_root(tmp_
     (unet / "old" / "diffusion_pytorch_model.safetensors").symlink_to(blob)  # nested, not read
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
-    # The top-level component weight present -> accepted.
     (unet / "diffusion_pytorch_model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
@@ -3936,7 +3862,6 @@ def test_post_download_subfolder_single_weight_beats_stale_index(tmp_path):
     """In a selected subfolder, a single canonical weight is read before a same-format shard index
     (transformers precedence), so a stale co-resident index must not false-reject the warm; a shard index
     with no single is still required complete."""
-    # encoder/model.safetensors present beside a stale encoder/model.safetensors.index.json -> accepted.
     snap, blob = _mk_snapshot(tmp_path, "subdir_single_beats_index")
     enc = snap / "encoder"
     enc.mkdir()
@@ -3946,7 +3871,6 @@ def test_post_download_subfolder_single_weight_beats_stale_index(tmp_path):
                         "b": "model-00002-of-00002.safetensors"}}))  # shards absent (stale)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["encoder/*"], ignore_patterns = None) is True
-    # No single, index missing shards -> still incomplete.
     snap2, blob2 = _mk_snapshot(tmp_path, "subdir_index_only")
     enc2 = snap2 / "encoder"
     enc2.mkdir()
@@ -3969,7 +3893,6 @@ def test_post_download_single_variant_beats_stale_variant_index(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
         variant = "fp16") is True
-    # A single .bin variant beside a stale .bin variant index (no ST) -> usable.
     snapb, blobb = _mk_snapshot(tmp_path, "single_bin_variant_beats_index")
     (snapb / "config.json").write_text("{}")
     (snapb / "pytorch_model.fp16.bin").symlink_to(blobb)
@@ -4004,7 +3927,6 @@ def test_post_download_variant_component_sidecar_is_not_warm(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
         variant = "fp16") is False
-    # The canonical component variant weight present -> accepted.
     (unet / "diffusion_pytorch_model.fp16.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
@@ -4015,7 +3937,6 @@ def test_post_download_diffusers_component_single_beats_stale_index(tmp_path):
     """A diffusers pipeline component reads a single canonical weight before a same-format shard index in
     its own subfolder, so a stale co-resident index must not false-reject a complete component; a component
     holding only a stale index (no single) is still incomplete."""
-    # unet single diffusion_pytorch_model.safetensors beside a stale same-dir index -> accepted.
     snap, blob = _mk_snapshot(tmp_path, "diff_comp_single_beats_index")
     (snap / "model_index.json").write_text(json.dumps(
         {"_class_name": "P", "unet": ["diffusers", "UNet2DConditionModel"]}))
@@ -4028,7 +3949,6 @@ def test_post_download_diffusers_component_single_beats_stale_index(tmp_path):
                         "b": "diffusion_pytorch_model-00002-of-00002.safetensors"}}))  # shards absent
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
-    # No single, index lists a missing shard -> still incomplete.
     snap2, blob2 = _mk_snapshot(tmp_path, "diff_comp_index_only")
     (snap2 / "model_index.json").write_text(json.dumps(
         {"_class_name": "P", "unet": ["diffusers", "UNet2DConditionModel"]}))
@@ -4056,7 +3976,6 @@ def test_post_download_adapter_single_beats_stale_index(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["adapter_model*", "adapter_config.json"],
         ignore_patterns = None) is True
-    # Sharded adapter, one shard absent, no single -> incomplete.
     snap2, blob2 = _mk_snapshot(tmp_path, "adapter_sharded_incomplete")
     (snap2 / "adapter_config.json").write_text("{}")
     (snap2 / "adapter_model.safetensors.index.json").write_text(json.dumps(
@@ -4090,7 +4009,6 @@ def test_post_download_model_component_stray_sidecar_rejected(tmp_path):
     (unet / "tokenizer_config.json").write_text("{}")  # stray weightless-shaped sidecar, no weight/config
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
-    # unet now holds its config + canonical weight -> accepted (scheduler still needs no weight).
     (unet / "config.json").write_text("{}")
     (unet / "diffusion_pytorch_model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
@@ -4193,7 +4111,6 @@ def test_post_download_out_of_scope_malformed_index_not_rejected(tmp_path):
 
 def test_selected_readable_weight_complete_entry_point(tmp_path):
     """The acceptance helper enforces (A) a readable weight present, (B) its shard set complete: exercise present+complete, absent, and incomplete-shard cases."""
-    # Present + complete single weight -> True.
     snap, blob = _mk_snapshot(tmp_path, "srwc_ok")
     (snap / "model.safetensors").symlink_to(blob)
     assert xf._selected_readable_weight_complete(
@@ -4260,7 +4177,6 @@ def test_gate_rejects_malformed_shard_index(tmp_path):
     (snap2 / "model-00001-of-00002.safetensors").symlink_to(blob2)
     (snap2 / "model.safetensors.index.json").write_text(json.dumps({"weight_map": {}}))
     assert hcs.snapshot_dir_is_complete(snap2) is False
-    # weight_map not a dict.
     snap3, blob3 = _mk_snapshot(tmp_path, "listidx")
     (snap3 / "model.safetensors.index.json").write_text(json.dumps({"weight_map": ["a", "b"]}))
     assert hcs._weight_shard_index_complete(snap3 / "model.safetensors.index.json") is False
@@ -4283,7 +4199,6 @@ def test_shard_index_rejects_unsafe_path_refs(tmp_path):
     assert hcs._weight_shard_index_complete(snap / "model.safetensors.index.json") is False
     # The enumerator returns None (defer) rather than a path escaping the snapshot.
     assert hcs._index_shard_rel_paths(snap / "model.safetensors.index.json", "") is None
-    # A well-formed relative index still enumerates + validates.
     snap2, blob2 = _mk_snapshot(tmp_path, "safe_shard_idx")
     (snap2 / "model-00001-of-00002.safetensors").symlink_to(blob2)
     (snap2 / "model-00002-of-00002.safetensors").symlink_to(blob2)
@@ -4339,7 +4254,6 @@ def test_gate_ignored_canonical_weight_does_not_prove_complete(tmp_path):
         json.dumps({"weight_map": {"a": "pytorch_model-00001-of-00001.bin"}}))
     assert hcs.snapshot_dir_is_complete(snap2, ignore_patterns = ["*.bin"]) is False
     assert hcs.snapshot_dir_is_complete(snap2) is True
-    # A safetensors warm survives an *.bin ignore.
     snap3, blob3 = _mk_snapshot(tmp_path, "stignbin")
     (snap3 / "config.json").write_text("{}")
     (snap3 / "model.safetensors").symlink_to(blob3)
@@ -4368,7 +4282,6 @@ def test_gate_rejects_variant_only_shard_index(tmp_path):
     (snap / "model.safetensors.index.fp16.json").write_text(
         json.dumps({"weight_map": {"a": "model-00001-of-00001.fp16.safetensors"}}))
     assert hcs.snapshot_dir_is_complete(snap) is False
-    # The canonical index for the same model still fast-paths.
     (snap / "model-00001-of-00001.safetensors").symlink_to(blob)
     (snap / "model.safetensors.index.json").write_text(
         json.dumps({"weight_map": {"a": "model-00001-of-00001.safetensors"}}))
@@ -4445,7 +4358,6 @@ def test_post_download_rejects_incomplete_canonical_root_shards(tmp_path):
     (snap / "model-00001-of-00002.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
-    # Complete the set with its index -> accepted.
     (snap / "model-00002-of-00002.safetensors").symlink_to(blob)
     (snap / "model.safetensors.index.json").write_text(
         json.dumps({"weight_map": {"a": "model-00001-of-00002.safetensors",
@@ -4555,7 +4467,6 @@ def test_post_download_rejects_adapter_only_for_default_load(tmp_path):
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["adapter_model*", "adapter_config.json"],
         ignore_patterns = None) is True
-    # The base weight present -> the default warm accepts, even beside the adapter.
     (snap / "model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
@@ -4595,7 +4506,6 @@ def test_post_download_rejects_variant_only_root_for_default_load(tmp_path):
     (snap_sh / "config.json").write_text("{}")
     assert xf._download_result_usable(
         snap_sh, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
-    # The canonical weight present -> accepted, even beside the variant.
     (snap / "model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
@@ -4619,7 +4529,6 @@ def test_post_download_variant_either_format_exact_alternatives(tmp_path):
         snap, repo_type = "model",
         allow_patterns = ["model.fp16.safetensors", "pytorch_model.fp16.bin"],
         ignore_patterns = None, variant = "fp16") is True
-    # The canonical either-format pair keeps working.
     snap_c, blob_c = _mk_snapshot(tmp_path, "canon_either")
     (snap_c / "pytorch_model.bin").symlink_to(blob_c)
     assert xf._download_result_usable(
@@ -4642,7 +4551,6 @@ def test_post_download_validates_weightless_named_subset(tmp_path):
         snap, repo_type = "model", allow_patterns = ["tokenizer.json"], ignore_patterns = None) is False
     assert xf._download_result_usable(
         snap, repo_type = "dataset", allow_patterns = ["data.parquet"], ignore_patterns = None) is False
-    # Present named file -> accepted; a glob stays lenient.
     (snap / "tokenizer.json").write_text("{}")
     assert xf._download_result_usable(
         snap, repo_type = "model", allow_patterns = ["tokenizer.json"], ignore_patterns = None) is True
@@ -4663,7 +4571,6 @@ def test_post_download_rejects_missing_exact_weight_request(tmp_path):
     assert xf._download_result_usable(
         base, repo_type = "model",
         allow_patterns = ["model.safetensors", "pytorch_model.bin"], ignore_patterns = None) is True
-    # Both present -> accepted.
     (base / "adapter_model.safetensors").symlink_to(blob)
     assert xf._download_result_usable(
         base, repo_type = "model",
@@ -4800,8 +4707,7 @@ def test_post_download_init_is_not_a_stall(hf_cache):
     try:
         # Hold the partial long enough that the watchdog thread certainly measured it once: a 0.15s
         # hold passed on an idle box but not under a loaded suite, where the thread could first run
-        # AFTER the unlink, and a watchdog that never saw a partial cannot tell "finished" from
-        # "never started".
+        # AFTER the unlink, and a watchdog that never saw a partial cannot tell finished from never started.
         time.sleep(0.6)
         part.unlink()                      # download completed
         (blobs / "finishing").write_bytes(b"\0" * 1024)
@@ -5444,8 +5350,7 @@ def test_a_seeded_parent_still_hands_the_child_its_own_disks_numbers(monkeypatch
     for var in ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP", "UNSLOTH_XET_FORCE_CAPS"):
         monkeypatch.delenv(var, raising = False)
 
-    # Exactly what import leaves behind: the roomy default cache's numbers, in the environment and
-    # recorded as ours.
+    # Exactly what import leaves behind: the roomy default cache's numbers, recorded as ours.
     key = "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"
     monkeypatch.setenv("HF_HUB_CACHE", str(roomy / "hub"))
     monkeypatch.setenv(key, str(64 * GB))

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -36,8 +36,7 @@ def _profile(ram_gb: float, cpus: int = 8, free_disk_gb: float = 0) -> tuning.Sy
         ram_source = "test",
         cpu_source = "test",
         free_disk_bytes = int(free_disk_gb * GB),
-        # 0 GB means "not measured" for the tests that do not care; a REAL zero is a full disk and
-        # gets a source, because the two take different branches.
+        # 0 GB means "not measured"; a REAL zero is a full disk, gets a source, and branches apart.
         disk_source = "test" if free_disk_gb else "unknown",
     )
 
@@ -45,26 +44,21 @@ def _profile(ram_gb: float, cpus: int = 8, free_disk_gb: float = 0) -> tuning.Sy
 @pytest.mark.parametrize(
     "ram_gb, cpus, limit, size, perfile, files, streams",
     [
-        # An eighth of RAM is the budget and a thirty-second is a per-file buffer, so the numbers
-        # describe ONE allocation. The shared buffer is the exception: it reaches for xet-core's
-        # own 2 GB default and only falls short where half the budget or a sixth of RAM says it
-        # must, because a quarter of the budget measured 0.73x on an 8 GB laptop.
+        # An eighth of RAM is the budget, a thirty-second a per-file buffer. The shared buffer
+        # reaches for xet-core's 2 GB default: a quarter of it measured 0.73x on an 8 GB laptop.
         (8, 4, 1 * GB, 500 * MB, 128 * MB, 3, 8),
-        # No cliffs: 12 GB sits between the old table's 8 and 16 GB rows and gets a budget to match,
-        # where the old step function gave it the 8 GB row's.
+        # No cliffs: 12 GB sits between the old table's 8 and 16 GB rows and gets a budget to match.
         (12, 4, 1500 * MB, 750 * MB, 128 * MB, 4, 8),
         (16, 8, 2 * GB, 1 * GB, 128 * MB, 7, 16),
         # 32 GB is the first machine that can hold xet-core's stock buffer outright.
         (32, 16, 4 * GB, 2 * GB, 128 * MB, 15, 32),
-        # A big host is bounded by a budget proportional to what it has, not by a laptop's. Holding
-        # a 2 TB server to the old flat 4 GB row cost 30% against xet-core's own defaults.
+        # A budget proportional to RAM: the old flat 4 GB row cost a 2 TB server 30%.
         (128, 64, 16 * GB, 4 * GB, 500 * MB, 24, 124),
         (2048, 192, 64 * GB, 16 * GB, 2000 * MB, 24, 124),
         # Cores bound concurrency independently of RAM: 8 cores on a 2 TB box still gets 8 files.
         (2048, 8, 64 * GB, 16 * GB, 2000 * MB, 8, 16),
         # ...and so does the budget. A 64-core container with 8 GB (CI, or a cgroup-limited pod)
-        # cannot use 64 file buffers or 128 streams out of a 1 GB budget, and opening them anyway is
-        # how a small machine on a thin link ends up worse off than with no tuning at all.
+        # cannot use 64 file buffers out of a 1 GB budget: worse than no tuning on a thin link.
         (8, 64, 1 * GB, 500 * MB, 128 * MB, 3, 14),
     ],
 )
@@ -101,8 +95,7 @@ def test_the_budget_never_promises_more_than_the_disk_can_take():
     tight = tuning.xet_env_overrides(_profile(2048, cpus = 192, free_disk_gb = 40))
     assert int(roomy["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 64 * GB
     assert int(tight["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 10 * GB
-    # Never below the floor, though: a full disk must not shrink the buffer to nothing, because the
-    # download can still be the one that frees space (a resume, or a cache on another filesystem).
+    # Never below the floor: this download may be the one that frees space (a resume, say).
     full = tuning.xet_env_overrides(_profile(2048, cpus = 192, free_disk_gb = 0.5))
     assert int(full["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
 
@@ -134,7 +127,6 @@ def test_cache_root_follows_hubs_full_precedence(monkeypatch, tmp_path):
     monkeypatch.setenv("HF_HOME", str(tmp_path / "home"))
     assert tuning.hf_cache_root() == tmp_path / "home" / "hub"
 
-    # HF_HUB_CACHE is still the most specific and wins over all of them.
     monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "explicit"))
     assert tuning.hf_cache_root() == tmp_path / "explicit"
 
@@ -152,8 +144,7 @@ def test_worst_case_buffer_stays_under_the_limit():
         limit = int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"])
         assert worst <= limit, f"{ram_gb}GB: worst case {worst} exceeds limit {limit}"
         # The bound that matters is proportional, not absolute: never more than a third of the
-        # machine's RAM, so the buffer cannot be the reason a box OOMs. A large host is allowed a
-        # large budget precisely because it has one to spare.
+        # machine's RAM, so the buffer cannot be the reason a box OOMs.
         assert worst <= ram_gb * GB / 3, f"{ram_gb}GB: worst case {worst} is too much of it"
 
 
@@ -186,11 +177,9 @@ def test_cpu_count_bounds_concurrency():
     large = tuning.xet_env_overrides(_profile(32, cpus = 128))
     assert int(small["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"]) == 2
     assert int(small["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]) == 4
-    # Two streams per core, but no more than the 4 GB budget has 64 MiB xorb slots for, and never
-    # more files than the budget affords buffers for.
+    # Two streams per core, bounded by the 64 MiB xorb slots and file buffers the budget affords.
     assert int(large["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]) == 59
     assert int(large["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"]) <= 24
-    # The ramp always starts at or below the ceiling, whichever bound produced it.
     for env in (small, large):
         assert int(env["HF_XET_CLIENT_AC_INITIAL_DOWNLOAD_CONCURRENCY"]) <= int(
             env["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]
@@ -210,7 +199,6 @@ def test_apply_never_overwrites_a_user_setting():
     env = {"HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT": "16000000000"}
     tuning.apply_xet_env(env, profile = _profile(16))
     assert env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"] == "16000000000"
-    # ...but the rest is still filled in.
     assert env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE"] == str(128 * MB)
 
 
@@ -233,7 +221,6 @@ def test_high_performance_also_stands_our_sizing_down():
     tuning.apply_xet_env(env, profile = _profile(16))
     for key in tuning._CAPS_VOIDED_BY_HIGH_PERFORMANCE:
         assert key not in env, key
-    # Non-sizing settings are unrelated to the memory bound and still apply.
     assert env["HF_XET_CHUNK_CACHE_SIZE_BYTES"] == "0"
 
 
@@ -259,7 +246,6 @@ def test_a_large_machine_is_not_held_to_a_laptops_buffer():
     for (small_ram, small), (big_ram, big) in zip(seen, seen[1:]):
         assert big >= small, f"{big_ram}GB got {big} but {small_ram}GB got {small}"
     assert seen[-1][1] > seen[2][1], f"a 2TB box still capped like a 32GB one: {seen}"
-    # And the small end is untouched, which is where the bound earns its keep.
     assert seen[0][1] == 1 * GB
 
 
@@ -274,8 +260,7 @@ def test_cgroup_limit_beats_the_host_total(monkeypatch, tmp_path):
     assert profile.ram_source == "cgroup"
     assert profile.cpu_count == 2
     env = tuning.xet_env_overrides(profile)
-    # An eighth of 8 GB is the 1 GB floor, and the 2-core quota allows only 2 files in flight, so
-    # the worst case (256MB + 2*128MB) sits well inside it.
+    # An eighth of 8 GB is the 1 GB floor and the 2-core quota allows 2 files: 256MB + 2*128MB fits.
     assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
     assert int(env["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"]) == 2
 
@@ -472,9 +457,8 @@ def test_only_the_big_hosts_get_the_big_numbers():
 
 # Every HF_XET_* name xet-core 1.5.x actually reads, filtered to the groups we touch. Regenerate
 # with:  grep -rhno "HF_XET_[A-Z_]\+" <xet-core>/xet_runtime --include=*.rs | cut -d: -f2- | sort -u
-# We used to set HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY, which xet-core has never had a variable of
-# that name for (the real one is HF_XET_RECONSTRUCTION_USE_VECTORED_WRITE, default true): a silent
-# no-op that read, in review and in the logs, exactly like a setting that was being honoured.
+# We used to set HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY, a name xet-core has never had (the real
+# one is HF_XET_RECONSTRUCTION_USE_VECTORED_WRITE, default true): a no-op that read like a setting.
 XET_CORE_VARS = frozenset({
     "HF_XET_CACHE",
     "HF_XET_CHUNK_CACHE_SIZE_BYTES",
@@ -535,8 +519,7 @@ def test_no_module_sets_a_variable_xet_core_does_not_read():
     root = pathlib.Path(tuning.__file__).parent
     unknown: dict[str, set] = {}
     for path in root.rglob("*.py"):
-        # Only quoted names: a variable is only ever read or written as a string literal, so this
-        # skips prose ("any explicit HF_XET_RECONSTRUCTION_* cap") without needing to parse it.
+        # Only quoted names: this skips prose ("any explicit HF_XET_RECONSTRUCTION_* cap") unparsed.
         for name in re.findall(r"[\"'](HF_XET_[A-Z_]+)[\"']", path.read_text(errors = "ignore")):
             if name not in XET_CORE_VARS:
                 unknown.setdefault(name, set()).add(path.relative_to(root).as_posix())
@@ -556,7 +539,6 @@ def test_a_machine_that_can_hold_xet_cores_own_buffer_gets_it(ram_gb, cpus):
     # Only two things may hold it under stock, and only as far as they reach: half the budget, and
     # a sixth of RAM. Anything smaller than both of those is a choice, not a constraint.
     assert size >= min(stock, limit // 2, max(256 * MB, ram_gb * GB / 6)), f"{ram_gb}GB got {size}"
-    # ...so a machine with room for stock on both counts is never handed less than stock.
     if limit // 2 >= stock and ram_gb * GB / 6 >= stock:
         assert size >= stock, f"{ram_gb}GB undercut stock: {size}"
 
@@ -647,7 +629,6 @@ def test_an_explicit_cache_dir_is_the_disk_that_gets_measured(monkeypatch, tmp_p
     _two_volumes(monkeypatch, str(roomy), str(tight))
 
     monkeypatch.setenv("HF_HUB_CACHE", str(roomy / "hub"))
-    # A full target volume is not sized from the roomy default cache.
     assert tuning.hf_cache_root(tight / "hub") == tight / "hub"
     profile = tuning.system_profile(tight / "hub")
     assert profile.free_disk_bytes == 0 and profile.disk_source.startswith(str(tight))
@@ -713,7 +694,7 @@ def test_a_throttle_asked_for_by_a_logged_429_survives_the_resize(monkeypatch, t
         directory.mkdir()
     _two_volumes(monkeypatch, str(roomy), str(tight))
     # Pin the cores too: on a 1-2 CPU runner the ceiling is already the floor of 4, so halving it
-    # would be indistinguishable from not halving it and the test would prove nothing.
+    # would be indistinguishable from not halving it.
     monkeypatch.setattr(_os, "sched_getaffinity", lambda _pid: set(range(16)))
     monkeypatch.setattr(tuning, "cgroup_cpu_limit", lambda: None)
 
@@ -728,7 +709,6 @@ def test_a_throttle_asked_for_by_a_logged_429_survives_the_resize(monkeypatch, t
 
     resized = tuning.resize_for_cache_dir(dict(fake_env), roomy / "hub")
     assert int(resized[key]) == throttled_streams, "the 429 reduction has to reach the downloader"
-    # Still overridable, for a caller that knows the throttle has lifted.
     assert int(tuning.resize_for_cache_dir(dict(fake_env), roomy / "hub", throttled = False)[key]) \
         > throttled_streams
 

--- a/tests/test_merge_e2e_resized.py
+++ b/tests/test_merge_e2e_resized.py
@@ -101,10 +101,8 @@ def _check(base, merged, ref_embed, ref_head, adapted, dtype):
 
     assert merged[embed_key].shape[0] == NEW_VOCAB
     assert merged[head_key].shape[0] == NEW_VOCAB
-    # resized weights written through exactly
     assert torch.equal(merged[embed_key], ref_embed), "resized embed mismatch"
     assert torch.equal(merged[head_key], ref_head), "resized lm_head mismatch"
-    # old vocab rows preserved from the base
     assert torch.equal(merged[embed_key][: base[embed_key].shape[0]], base[embed_key]), \
         "old embed rows not preserved"
 

--- a/tests/test_merge_e2e_vision_passthrough.py
+++ b/tests/test_merge_e2e_vision_passthrough.py
@@ -92,7 +92,6 @@ def test_vision_language_only_merge_preserves_vision(family, tmp_path):
 
     pm = get_peft_model(model, LoraConfig(
         r=8, lora_alpha=16, lora_dropout=0.0, bias="none", target_modules=_LANG_QV))
-    # no adapter may land on the vision tower
     in_vision = [n for n, m in pm.named_modules()
                  if getattr(m, "lora_A", None) is not None
                  and hasattr(m.lora_A, "__contains__") and "default" in m.lora_A

--- a/tests/test_mlx_adapter_metadata_persistence.py
+++ b/tests/test_mlx_adapter_metadata_persistence.py
@@ -199,17 +199,16 @@ def test_enrich_does_not_raise_on_module_with_none_tensors():
 
 
 def test_infer_rank_rejects_one_dimensional_lora_b():
-    # A bare 1D lora_b means the pair is half-built; rank inference would
-    # otherwise read shape[-1] from lora_a and persist nonsense metadata.
+    # Half-built pair: without the guard the raw-array branch returns lora_a's
+    # shape[-1] and persists nonsense rank metadata.
     mlx_utils = _load_utils()
     bad = _FakeLoRAModule((512, 4), (4,))
     assert mlx_utils._infer_mlx_lora_rank(bad) is None
 
 
 def test_normalize_mlx_lora_module_paths_handles_string_input():
-    # Hand-authored adapter_config.json files sometimes store a single
-    # path as a bare string; the loader must convert it to a single-
-    # element list rather than iterating its characters.
+    # Hand-authored adapter_config.json files store a single path as a bare
+    # string; it must be wrapped, not iterated character by character.
     _load_utils()
     from unsloth_zoo.mlx.loader import _normalize_mlx_lora_module_paths
 
@@ -222,17 +221,14 @@ def test_normalize_mlx_lora_module_paths_handles_string_input():
 
 
 def test_infer_rank_rejects_switch_lora_b_without_expert_prefix():
-    # MoE/Switch lora_a (num_experts, rank, in_dims) paired with bare 2D
-    # lora_b (out_dims, rank) is malformed; the helper must reject it
-    # instead of returning a plausible rank.
+    # MoE/Switch lora_a (num_experts, rank, in_dims) paired with a bare 2D
+    # lora_b (out_dims, rank) is malformed, not a plausible rank.
     mlx_utils = _load_utils()
     bad = _FakeLoRAModule((8, 4, 512), (512, 4))
     assert mlx_utils._infer_mlx_lora_rank(bad) is None
 
 
 def test_enrich_normalizes_string_explicit_path():
-    # A caller-supplied single-string path must be normalized to a list so
-    # the loader does not iterate it character-by-character.
     mlx_utils = _load_utils()
     model = _FakeModel([
         ("layers.0.q_proj", _FakeLoRAModule((512, 4), (4, 512), scale=2.0,
@@ -313,9 +309,6 @@ def test_trainer_metadata_loop_returns_none_when_no_lora_modules():
 
 
 def test_trainer_metadata_loop_returns_none_when_rank_inference_fails():
-    # Module has lora_a/lora_b but _infer_mlx_lora_rank returns None
-    # (e.g. 1-D lora_b). Trainer must not persist the old placeholder
-    # rank=8 / scale=1.0 / dropout=0.0 defaults.
     one_d_lora = _FakeLoRAModule(lora_a=(8, 4), lora_b=(8,))
     model = _FakeModel([("layers.0.q_proj", one_d_lora)])
     assert _trainer_loop_metadata(model) == (None, None, None)
@@ -348,13 +341,12 @@ def test_trainer_metadata_loop_coerces_mxarray_scale_safely():
     _, scale_wide,   _ = _trainer_loop_metadata(_FakeModel([("q", m_wide)]))
 
     assert scale_zero_d == 2.5
-    assert scale_wide == 1.0  # safe fallback, not a crash
+    assert scale_wide == 1.0
 
 
 def _build_trainer_adapter_dict(rank, scale, dropout, num_layers, hf_repo=""):
-    # Mirror the dict-building gate in MLXTrainer.save_model: keys are only
-    # included when their source values are valid, so reload sees no
-    # placeholder sentinels.
+    # Mirrors the dict-building gate in MLXTrainer.save_model: keys are only
+    # included when their source values are valid, so reload sees no sentinels.
     cfg = {
         "fine_tune_type": "lora",
         "peft_type": "LORA",
@@ -395,9 +387,7 @@ def test_trainer_adapter_dict_omits_rank_when_inference_failed():
 
 
 def test_normalize_mlx_lora_module_paths_handles_dict_input():
-    # Older / hand-authored configs sometimes group paths by tower.
-    # Dict input must flatten into a list, not silently return [].
-    _load_utils()  # installs mlx torch simulation so loader imports cleanly
+    _load_utils()
     from unsloth_zoo.mlx.loader import _normalize_mlx_lora_module_paths
 
     grouped = {"language": ["layers.0.q_proj"], "vision": ["vision.proj"]}
@@ -406,8 +396,8 @@ def test_normalize_mlx_lora_module_paths_handles_dict_input():
 
 
 def test_normalize_mlx_lora_module_paths_handles_pathlike_elements():
-    # pathlib.Path elements in the saved list must coerce via os.fspath,
-    # not be silently dropped by the isinstance(p, str) gate.
+    # pathlib.Path elements must coerce via os.fspath, not be dropped by the
+    # isinstance(p, str) gate.
     import pathlib
     _load_utils()
     from unsloth_zoo.mlx.loader import _normalize_mlx_lora_module_paths
@@ -419,7 +409,6 @@ def test_normalize_mlx_lora_module_paths_handles_pathlike_elements():
 
 
 def test_normalize_mlx_lora_module_paths_handles_bare_pathlike():
-    # A bare pathlib.Path (not wrapped in a list) should also coerce.
     import pathlib
     _load_utils()
     from unsloth_zoo.mlx.loader import _normalize_mlx_lora_module_paths
@@ -431,8 +420,7 @@ def test_normalize_mlx_lora_module_paths_handles_bare_pathlike():
 
 
 def test_enrich_mlx_adapter_config_normalizes_dict_explicit_paths():
-    # Save-side path normalization must accept the same shapes the load
-    # side does: dict-grouped paths, pathlib.Path elements, set, etc.
+    # Save-side normalization must accept the shapes the load side does.
     # Otherwise vision/projector LoRA topology is silently erased before
     # it reaches adapter_config.json.
     mlx_utils = _load_utils()
@@ -497,10 +485,8 @@ def test_enrich_mlx_adapter_config_coerces_mxarray_scale_without_aborting():
         _FakeModel([("vision.q_proj", m_zerod)]), {},
     )
 
-    # Both must complete with metadata and module-path list, not silently
-    # abandon after the float() raise.
     assert cfg_wide.get("unsloth_mlx_lora_module_paths") == ["vision.q_proj"]
-    assert cfg_wide.get("scale") == 1.0  # safe fallback
+    assert cfg_wide.get("scale") == 1.0
     assert cfg_wide.get("rank") == 4
     assert cfg_zd.get("unsloth_mlx_lora_module_paths") == ["vision.q_proj"]
     assert cfg_zd.get("scale") == 0.5

--- a/tests/test_mlx_autodetect_template_source.py
+++ b/tests/test_mlx_autodetect_template_source.py
@@ -107,14 +107,12 @@ def test_text_override_detects_from_configured_template():
     override_markers = get_parts(override)
     assert native_markers != override_markers, (native_markers, override_markers)
 
-    # No override -> resolver leaves the tokenizer's own template in force.
     tok0 = _new_tok(); tok0.chat_template = CHATML
     tr0 = _Trainer(tok0, _Args(chat_template=None))
     resolved0 = T._resolve_response_mask_tokenizer(tok0)
     detect0 = T._resolve_autodetect_template_source(tr0, tok0, resolved0)
     assert get_parts(detect0) == native_markers
 
-    # Override set -> resolver applies it, so detection reflects the override.
     tok1 = _new_tok(); tok1.chat_template = CHATML
     tr1 = _Trainer(tok1, _Args(chat_template=INST))
     resolved1 = T._resolve_response_mask_tokenizer(tok1)
@@ -144,7 +142,6 @@ def test_vlm_processor_only_template_is_used_for_detection():
     assert detect is proc
     assert get_parts(detect) == expected
 
-    # And the full wrapper builds a mask function without raising.
     fn = T.train_on_responses_only(tr, return_function=True)
     assert callable(fn)
 
@@ -155,18 +152,16 @@ def test_vlm_override_aligns_with_who_applies_the_mask():
     trainer.processor when the trainer applies it to its own batches (return_function=False)."""
     T, get_parts = _load()
 
-    # trainer.processor renders ChatML; the caller overrides with an INST processor.
     trainer_proc = _ProcessorOnly(_new_tok_none(), _new_tok_with(CHATML))
     override_proc = _ProcessorOnly(_new_tok_none(), _new_tok_with(INST))
     tr = _Trainer(trainer_proc, _Args(), is_vlm=True, processor=trainer_proc)
     resolved = T._resolve_response_mask_tokenizer(override_proc)
 
-    # return_function=True: caller renders with the override -> honor it.
     detect = T._resolve_autodetect_template_source(tr, override_proc, resolved, return_function=True)
     assert detect is override_proc
 
-    # return_function=False: trainer renders batches with trainer.processor -> detect from that,
-    # otherwise the mask is built for one template and applied to text from another.
+    # return_function=False: the trainer renders batches with trainer.processor, so detect
+    # from that, otherwise the mask is built for one template and applied to text from another.
     detect = T._resolve_autodetect_template_source(tr, override_proc, resolved, return_function=False)
     assert detect is trainer_proc
 
@@ -176,8 +171,8 @@ def test_explicit_markers_bypass_template_resolution():
     require a chat_template and must return a working mask function."""
     T, _ = _load()
     inner = _new_tok(); inner.chat_template = None
-    proc = _ProcessorOnly(inner, _new_tok())  # render tok irrelevant here
-    proc.chat_template = None                  # no template anywhere
+    proc = _ProcessorOnly(inner, _new_tok())
+    proc.chat_template = None
     tr = _Trainer(proc, _Args(), is_vlm=True, processor=proc)
     fn = T.train_on_responses_only(
         tr, instruction_part="[INST]", response_part="[/INST]",
@@ -259,7 +254,7 @@ def test_processor_template_preferred_over_inner_when_both_present():
     """When both the processor and its inner tokenizer carry a chat_template, detection must
     render with the processor's (what VLM batching uses), not the inner tokenizer's."""
     _, get_parts = _load()
-    proc = _ProcessorOnly(_new_tok_with(CHATML), _new_tok_with(INST))  # inner=ChatML, render=INST
+    proc = _ProcessorOnly(_new_tok_with(CHATML), _new_tok_with(INST))
     proc.tokenizer.chat_template = CHATML   # inner tokenizer ALSO has a (different) template
     assert get_parts(proc) == get_parts(_new_tok_with(INST))  # processor (INST) wins
 

--- a/tests/test_mlx_baseline_loss_parity.py
+++ b/tests/test_mlx_baseline_loss_parity.py
@@ -35,7 +35,6 @@ def _labels_none_block():
     )
     assert m, "make_baseline_loss_fn must keep a `labels is None` fast path"
     raw = textwrap.dedent(m.group(1))
-    # Strip whole-line comments so assertions on code ignore explanatory prose.
     code_lines = []
     for line in raw.splitlines():
         stripped = line.strip()
@@ -51,8 +50,6 @@ def test_no_fp32_mask_cast_in_fast_path():
     casting to fp32 produces a different MLX autodiff graph and shifts
     gradients by ~1e-2 per step on small fixtures."""
     block = _labels_none_block()
-    # Anything that would cast a mask to fp32: `.astype(mx.float32)` or
-    # `astype(float32)` immediately on a `mask` / `length_mask` name.
     bad_patterns = (
         r"length_mask\.astype\(mx\.float32\)",
         r"mask\s*=\s*[^=]*\.astype\(mx\.float32\)",
@@ -95,9 +92,8 @@ def test_fast_path_returns_ce_and_ntoks_in_that_order():
     """Match the (loss, ntoks) return signature mlx-lm uses; the test
     pins return-order so a future refactor doesn't accidentally swap."""
     block = _labels_none_block()
-    # Look for a `return X, Y` somewhere in the fast path. The variable
-    # names are loose (mlx-lm uses `ce`; zoo previously used `loss`),
-    # but the order matters.
+    # The names are loose (mlx-lm uses `ce`; zoo previously used `loss`), so only
+    # the order is pinned.
     m = re.search(r"return\s+(\w+),\s*(\w+)", block)
     assert m, "labels=None fast path must return a (loss, ntoks) tuple"
     loss_name, ntoks_name = m.group(1), m.group(2)
@@ -112,8 +108,7 @@ def test_labels_aware_path_still_uses_safe_targets():
     `safe_targets` and the fp32 mask because labels can contain -100."""
     from unsloth_zoo.mlx import utils
     src = inspect.getsource(utils.make_baseline_loss_fn)
-    # The labels-aware path lives after the fast path's `return`. Look
-    # at the full source to verify the machinery still exists somewhere.
+    # This path lives after the fast path's `return`, so read the full source.
     assert "mx.where" in src, (
         "make_baseline_loss_fn must still call mx.where on the labels-aware path"
     )

--- a/tests/test_mlx_batch_padding.py
+++ b/tests/test_mlx_batch_padding.py
@@ -36,18 +36,14 @@ def _zoo_padded_len(max_len, pad_multiple=32):
 @pytest.mark.parametrize(
     "max_len, expected",
     [
-        # Inside the first 32-token bucket -> 33.
         (1, 33),
         (14, 33),  # the probe fixture's TRAIN_TEXT length
         (31, 33),
         (32, 33),
-        # Second bucket -> 65.
         (33, 65),
         (63, 65),
         (64, 65),
-        # Third bucket -> 97.
         (65, 97),
-        # Larger buckets.
         (97, 129),
         (128, 129),
         (129, 161),

--- a/tests/test_mlx_batching_and_decay.py
+++ b/tests/test_mlx_batching_and_decay.py
@@ -203,7 +203,6 @@ def test_ordered_text_fractional_num_epochs_builds_the_partial_pass():
 
     assert len(plan_for(0.5)) == 3
     assert len(plan_for(1.5)) == 8
-    # Whole counts are unchanged.
     assert len(plan_for(2)) == 10
 
 
@@ -211,7 +210,7 @@ def test_ordered_text_fractional_epochs_match_transformers_step_budget():
     # Golden values measured by running a real transformers.Trainer on the same
     # shapes: HF quantizes a fractional num_train_epochs to whole accumulation
     # windows and re-iterates the dataloader, so 0.5 epochs of 5 rows at batch 2
-    # and accum 2 is one update over 4 rows, not a proportional 3 rows.
+    # and accum 2 is one update over 4 rows, not a proportional 3.
     _skip_if_mlx_core_was_replaced()
     from unsloth_zoo.mlx.utils import create_ordered_batches
 
@@ -395,7 +394,6 @@ def _digest_vlm_batches(batches):
                         tuple(_tuplify(item) for item in x)
                         if isinstance(x, list) else x
                     )
-                # dtype-native values: float drift must fail the oracle.
                 entry.append((
                     key, str(value.dtype), tuple(value.shape),
                     _tuplify(value.tolist()),
@@ -489,7 +487,7 @@ def test_checker_reaches_collective_without_materialization_on_fake_rank(monkeyp
 
     def spy_all_sum(value, **kwargs):
         collective_calls.append(value.tolist())
-        return value  # identity: single fake rank stands in for the sum
+        return value
 
     monkeypatch.setattr(mx_core.distributed, "all_sum", spy_all_sum)
     try:
@@ -502,7 +500,6 @@ def test_checker_reaches_collective_without_materialization_on_fake_rank(monkeyp
     assert processor.calls == calls_before_check
 
 
-    # The fake-rank collective test covers no-materialization more strictly.
 
 
 def test_vlm_family_invariant_against_live_mx_compile_traces():
@@ -556,8 +553,8 @@ def test_vlm_family_invariant_against_live_mx_compile_traces():
         if kind == "merge":
             assert same_key and fam_left == fam_right and plannable(fam_left)
         elif kind == "split":
-            # Distinct values stay ELIGIBLE while splitting: making common
-            # constants unplannable would regress ordinary batches to eager.
+            # Both stay plannable while splitting: making common constants
+            # unplannable would regress ordinary batches to eager.
             assert not same_key and fam_left != fam_right
             assert plannable(fam_left) and plannable(fam_right)
         else:
@@ -590,7 +587,7 @@ def test_per_row_audio_spans_stay_plannable():
     )
 
     cases = [
-        ([np.zeros((0, 2), np.int32)] * 2, [[], []]),         # a text-only batch
+        ([np.zeros((0, 2), np.int32)] * 2, [[], []]),
         ([np.array([[1, 3]]), np.array([[1, 3], [4, 7]])],
          [[[1, 3]], [[1, 3], [4, 7]]]),
     ]
@@ -599,7 +596,7 @@ def test_per_row_audio_spans_stay_plannable():
             "input_ids": np.zeros((2, 8), dtype=np.int32),
             "audio_bounds": spans,
         })
-        # Both halves matter here: the generic conversion also yields something
+        # Both halves matter: the generic conversion also yields something
         # plannable, by stacking equal rows and keeping only the first of ragged
         # ones, so plannability alone would not show the rows survived.
         assert [np.asarray(row).tolist() for row in batch["audio_bounds"]] == expected
@@ -650,7 +647,6 @@ def test_vlm_plan_survey_is_lazy_idempotent_per_index_and_cache_free():
     cached_batch = plan.materialize(0)
     assert processor.calls == 1 and plan._mru is not None
     descriptors = plan.ensure_descriptors()
-    # The pre-populated cache is invalidated, not consulted.
     assert processor.calls == 1 + len(plan) == 4
     assert plan._mru is None
     assert plan.ensure_descriptors() is descriptors
@@ -665,7 +661,6 @@ def test_vlm_plan_survey_is_lazy_idempotent_per_index_and_cache_free():
         assert descriptors[index] == _vlm_batch_family(
             rebuilt, symbolic_axes=axes,
         )
-    # Widths merge symbolically; the structural sidecar still splits.
     assert len(set(descriptors)) == 2
     assert plan.batch_family(1) == descriptors[1]
     assert len(descriptors) == 3
@@ -715,7 +710,6 @@ def test_vlm_plan_survey_does_not_consume_preprocessing_rng():
     unsurveyed, unsurveyed_tail = _stream(False)
     surveyed, surveyed_tail = _stream(True)
     assert surveyed == unsurveyed
-    # The survey also leaves no offset behind for anything drawing afterwards.
     assert surveyed_tail == unsurveyed_tail
 
 
@@ -839,7 +833,6 @@ def test_vlm_plan_does_not_pin_one_file_descriptor_per_row(tmp_path):
         f"row must not keep its image file open until materialization"
     )
 
-    # Releasing the descriptor has to leave a row that still materializes.
     batch = plan[0]
     assert batch["input_ids"].shape[0] == 2
 
@@ -894,7 +887,7 @@ def test_vlm_family_drift_check_fails_hard_with_location():
     reordered = dict(reversed(list(batch.items())))
     with pytest.raises(RuntimeError, match="drifted"):
         plan.check_family_drift(1, reordered)
-    # Families genuinely differ, so a checker pinned wrong cannot pass.
+    # Families genuinely differ, so the cross-index check cannot pass vacuously.
     assert plan.batch_family(0) != plan.batch_family(1)
     with pytest.raises(RuntimeError, match="batch 0 drifted"):
         plan.check_family_drift(0, batch)
@@ -988,8 +981,6 @@ def test_vlm_shape_planning_follows_the_resolved_override_mode():
         mode="best_effort", arch_overrides=((arch, "strict"),),
     )
     decision = resolve_training_compile(arch, policy=strict_override)
-    # Qualified arch: the decision is enabled, so planning runs past the
-    # should_raise and unqualified guards and reaches the failure branches.
     assert decision.enabled and decision.policy_mode == "strict"
     assert not decision.fallback_allowed and not decision.should_raise
     with pytest.raises(RuntimeError, match="not stable enough"):
@@ -1058,7 +1049,6 @@ def test_vlm_admission_covers_only_the_batches_the_loop_visits():
         _shape_plan, report, allowed, _frontier = _plan(poison_call)
         assert allowed and report.reason != "vlm_unplannable_family"
 
-    # Still enforced for a batch the loop does reach.
     with pytest.raises(RuntimeError, match="cannot plan VLM batch 3"):
         _plan(4)
 
@@ -1132,7 +1122,6 @@ def test_vlm_batches_keep_unbounded_max_seq_length_as_none():
         dataset_order="sequential",
     )
 
-    # The processor is never handed a cap, so nothing is truncated.
     assert set(processor.seen_max_length) == {"<absent>"}
     assert len(batches) == 2
     assert all(batch["input_ids"].shape == (2, 12) for batch in batches)
@@ -1147,7 +1136,6 @@ def test_vlm_batches_keep_unbounded_max_seq_length_as_none():
     )
     assert plan.max_seq_length is None
 
-    # A finite cap still coerces to int and still truncates.
     capped_processor = _ProcessorNativeLimitProcessor(native_width=12)
     capped = create_vlm_batches(
         dataset=[{"text": str(i)} for i in range(4)],
@@ -1431,7 +1419,6 @@ def test_vlm_eval_splits_each_draw_their_own_augmentation_stretch(
         processor_log=calls,
     )
 
-    # Evaluation never moves the training stream, whatever the split count.
     assert len(without_eval) == 4
     assert with_splits == without_eval
 
@@ -1443,7 +1430,6 @@ def test_vlm_eval_splits_each_draw_their_own_augmentation_stretch(
     assert sorted(per_split) == [1, 2, 3]
     assert [len(draws) for draws in per_split.values()] == [2, 2, 2]
 
-    # No split may replay a draw another split already consumed.
     eval_draws = [draw for draws in per_split.values() for draw in draws]
     assert len(set(eval_draws)) == len(eval_draws)
 
@@ -1697,12 +1683,10 @@ def test_vlm_plan_is_excluded_from_eager_fallback_refetch():
 def test_vlm_fallback_refetch_would_shift_the_augmentation_stream():
     """Why the exclusion exists: the refetch is a second processor call whose
     draws offset every later batch, and the reuse it replaces is loss-safe."""
-    # Reference: an eager-from-start run, which never surveys or materializes.
     plan = _make_plan()
     eager = [_pixels(plan[i]) for i in range(len(plan))]
     eager_tail = int(np.random.randint(0, 1 << 30))
 
-    # What the removed refetch did: materialize, then re-index the same visit.
     plan = _install_and_get()
     calls_before = plan._processor.calls
     plan.materialize(0, phase="full_step")
@@ -1717,7 +1701,6 @@ def test_vlm_fallback_refetch_would_shift_the_augmentation_stream():
     )
     assert refetch_tail != eager_tail
 
-    # What the fix does: reuse the materialized batch, drawing nothing extra.
     plan = _install_and_get()
     calls_before = plan._processor.calls
     reused = [_pixels(plan.materialize(0, phase="full_step"))]
@@ -1862,7 +1845,6 @@ def test_vlm_exact_plan_compiles_without_a_pad_token():
             for index, width in enumerate(plan.planned_event_widths())
         )
         assert endpoints == raw == (32,) * len(plan)
-        # The planned fetch the training loop makes must not need a pad id.
         batch = plan.materialize(0, phase=phase_for_microstep(
             FULL_STEP_SCOPE, 1, 0,
         ))
@@ -1954,8 +1936,6 @@ def test_vlm_planned_width_steps_above_the_surveyed_maximum_on_collision():
     assert surveyed_max == 32
     assert planned == (33,) * len(plan)
     assert all(width > surveyed_max for width in planned)
-    # One shared endpoint, and every batch reaches it: above its own prepared
-    # width and clear of every extent the pipeline does not pad.
     assert [
         int(
             plan.materialize(index, target_width=planned[index])
@@ -2027,7 +2007,7 @@ def test_vlm_drift_error_names_the_survey_for_privately_owned_draw_state():
         max_seq_length=8,
     )
     plan.ensure_descriptors()
-    assert processor.calls == 4      # one private advance per scheduled batch
+    assert processor.calls == 4
 
     rebuilt = plan._build_batch(0)
     # Training resumes the private stream past the survey, so batch 0 rebuilds
@@ -2100,11 +2080,9 @@ def test_vlm_plan_releases_the_previous_batch_before_building_the_next(
         batch_data = plan.materialize(index)
     del batch_data
 
-    # No build ever started while a previously built batch was still held.
     assert live_at_build_start == [0, 0, 0, 0]
     assert alive["peak"] == 1
 
-    # Releasing the cache early must not cost a rebuild for a repeated fetch.
     calls_before = processor.calls
     again = plan.materialize(len(plan) - 1)
     assert processor.calls == calls_before
@@ -2201,7 +2179,6 @@ def test_vlm_plan_rechecks_media_between_setup_and_the_batch_that_uses_it():
         num_batches=2,
         dataset_order="sequential",
     )
-    # Clean at setup: nothing aliases, so every batch builds.
     assert plan.materialize(0) is not None
 
     dataset.arrays[2][:] = 99
@@ -2230,7 +2207,7 @@ def test_vlm_plan_keeps_referencing_media_payloads_it_does_not_own():
         config={"image_size": 16, "image_token_id": 200},
         batch_size=1,
         max_seq_length=8,
-        num_batches=9,          # three full revisits of every row
+        num_batches=9,
         dataset_order="sequential",
     )
 
@@ -2388,8 +2365,6 @@ def test_vlm_plan_reports_an_in_place_augmentation_over_a_reused_buffer():
             num_batches=3,
             dataset_order="sequential",
         )
-    # Every read really did hand back a permutation of the previous one, so
-    # the sum and the xor were identical at every pin.
     sums = {int(np.asarray(image).sum()) for image in dataset.returned}
     assert len(dataset.returned) == 6 and len(sums) == 1
 
@@ -2427,7 +2402,6 @@ def test_vlm_plan_releases_image_handles_nested_in_a_tuple(tmp_path):
     assert isinstance(restored["images"], tuple)
     assert int(np.asarray(restored["images"][0]).reshape(-1)[0]) == 6
 
-    # A namedtuple keeps its type rather than collapsing to a plain tuple.
     holder = collections.namedtuple("holder", "left right")
     row = {"media": holder(left=Image.open(paths[0]), right="caption")}
     out = _release_vlm_row_image_handles(row)
@@ -2436,7 +2410,6 @@ def test_vlm_plan_releases_image_handles_nested_in_a_tuple(tmp_path):
     back = _restore_vlm_row_image_handles(out)
     assert int(np.asarray(back["media"].left).reshape(-1)[0]) == 1
 
-    # A tuple holding nothing releasable keeps its exact identity.
     plain = {"images": ("a", "b")}
     assert _release_vlm_row_image_handles(plain)["images"] is plain["images"]
 
@@ -2480,8 +2453,6 @@ def test_vlm_plan_reports_a_dataset_that_reuses_one_temporary_image_path(tmp_pat
             dataset_order="sequential",
         )
 
-    # Six distinct samples really did go through the one file, and the file now
-    # holds only the last of them -- which is what every row would have read.
     assert dataset.written == [1, 2, 3, 4, 5, 6]
     assert int(np.asarray(Image.open(str(shared))).reshape(-1)[0]) == 6
 

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -33,13 +33,10 @@ def _install_shim():
     simulate_mlx_on_torch()
 
 
-# ---------------------------------------------------------------------------
-# 1. CCE end-to-end: forward + backward (autograd) match a numpy reference.
-# ---------------------------------------------------------------------------
 
 def _ce_reference(hidden, weight, targets, ignore_index=-100, softcap=0.0):
     """Numpy/torch reference for cross_entropy with optional logit softcap."""
-    logits = hidden @ weight.T  # (n, vocab)
+    logits = hidden @ weight.T
     if softcap > 0:
         logits = softcap * torch.tanh(logits / softcap)
     valid = targets != ignore_index
@@ -133,9 +130,6 @@ def test_cce_chunked_matches_unchunked():
                                    msg=f"mismatch at chunk_size={chunk_size}")
 
 
-# ---------------------------------------------------------------------------
-# 2. Dequantize: the affine helper round-trips correctly.
-# ---------------------------------------------------------------------------
 
 def test_dequantize_affine_roundtrip():
     """Construct a known-good packed weight and verify dequant."""
@@ -145,14 +139,14 @@ def test_dequantize_affine_roundtrip():
     # uint32, element 0 in the lowest bits.
     bits = 4
     group_size = 8
-    elements_per_word = 32 // bits  # = 8
+    elements_per_word = 32 // bits
 
     packed_value = 0
     for i, v in enumerate([0, 1, 2, 3, 4, 5, 6, 7]):
         packed_value |= v << (i * bits)
-    packed = torch.tensor([[packed_value]], dtype=torch.int32)  # shape (1, 1)
-    scales = torch.tensor([[2.0]])  # shape (1, 1) - per-group scale
-    biases = torch.tensor([[1.0]])  # shape (1, 1) - per-group bias
+    packed = torch.tensor([[packed_value]], dtype=torch.int32)
+    scales = torch.tensor([[2.0]])
+    biases = torch.tensor([[1.0]])
 
     out = dequantize_affine(packed, scales, biases, group_size=group_size, bits=bits)
     expected = torch.tensor([[0*2+1, 1*2+1, 2*2+1, 3*2+1, 4*2+1, 5*2+1, 6*2+1, 7*2+1]],
@@ -173,9 +167,6 @@ def test_dequantize_unsupported_mode_raises():
         )
 
 
-# ---------------------------------------------------------------------------
-# 3. mx.custom_function VJP cycle: forward + backward via torch.autograd.
-# ---------------------------------------------------------------------------
 
 def test_custom_function_forward_and_backward():
     """Define a simple square op with custom VJP; verify autograd traverses it."""
@@ -198,23 +189,16 @@ def test_custom_function_forward_and_backward():
     torch.testing.assert_close(x.grad, 2 * torch.tensor([1.0, 2.0, 3.0]))
 
 
-# ---------------------------------------------------------------------------
-# 4. mx.array isinstance contract that MLX trainer relies on.
-# ---------------------------------------------------------------------------
 
 def test_torch_tensor_is_mx_array():
     import mlx.core as mx
     t = torch.tensor([1.0, 2.0])
     assert isinstance(t, mx.array)
-    # Reverse contract: mx.array(...) returns torch.Tensor
     a = mx.array([1, 2, 3], dtype=mx.int32)
     assert isinstance(a, torch.Tensor)
     assert a.dtype == torch.int32
 
 
-# ---------------------------------------------------------------------------
-# 5. Tensor monkey-patches: .astype, .expand_dims, .at[].add
-# ---------------------------------------------------------------------------
 
 def test_tensor_astype():
     t = torch.tensor([1.0, 2.0])
@@ -233,7 +217,6 @@ def test_tensor_at_add_functional_update():
     t = torch.tensor([1.0, 2.0, 3.0, 4.0])
     out = t.at[1].add(10.0)
     torch.testing.assert_close(out, torch.tensor([1.0, 12.0, 3.0, 4.0]))
-    # Original unchanged
     torch.testing.assert_close(t, torch.tensor([1.0, 2.0, 3.0, 4.0]))
 
 
@@ -243,13 +226,9 @@ def test_tensor_at_set():
     torch.testing.assert_close(out, torch.tensor([99.0, 2.0, 3.0]))
 
 
-# ---------------------------------------------------------------------------
-# 6. multi-arg .transpose() = MLX permute semantics.
-# ---------------------------------------------------------------------------
 
 def test_transpose_multi_axis_is_permute():
     t = torch.zeros(2, 3, 4, 5)
-    # 4-axis transpose = full permute -> (5, 4, 3, 2)
     out = t.transpose(3, 2, 1, 0)
     assert out.shape == (5, 4, 3, 2)
 
@@ -261,7 +240,6 @@ def test_transpose_two_args_unchanged():
     assert out.shape == (3, 2, 4)
 
 
-# 7. logit_scale discovery/normalization feeding CCE loss selection.
 
 def _stub_model(where=None, value=None):
     class _Holder:
@@ -394,21 +372,17 @@ def test_dead_tie_flag_fails_closed_to_unknown():
     for src in ("flag_guarded", "flag_ref_calls_lm_head"):
         d = U.describe_output_head(_lm(nn, args_flag=True, head=head(), call_src=src))
         assert d.status == "tied" and d.path == "model.embed_tokens"
-    # False flag resolves the live head; no live head keeps the True flag tied.
     assert U.describe_output_head(
         _lm(nn, args_flag=False, head=head(), call_src="calls_lm_head")).status == "untied"
     assert U.describe_output_head(
         _lm(nn, args_flag=True, emb_name="tok_embeddings")).status == "tied"
-    # A non-bool truthy tie flag (int 1 or string "true"; from_dict does not
-    # coerce) is read by truthiness like the forward -> tied, not a fall-through
-    # to lm_head; a falsy value ("" / 0) stays untied.
+    # from_dict does not coerce, so a non-bool tie flag is read by truthiness like
+    # the forward: 1 / "true" are tied, "" stays untied, never a fall-through.
     for truthy in (1, "true"):
         assert U.describe_output_head(
             _lm(nn, args_flag=truthy, head=head(), call_src="flag_guarded")).status == "tied"
     assert U.describe_output_head(
         _lm(nn, args_flag="", head=head(), call_src="calls_lm_head")).status == "untied"
-    # A config-only truthy flag is read; with no resolvable anchor it fails
-    # closed to unknown, never falling through to a (dead) lm_head.
     cfg = _lm(nn, head=head(), call_src="calls_lm_head")
     cfg.model, cfg.config = nn.Module(), type("C", (), {"tie_word_embeddings": True})()
     assert U.describe_output_head(cfg).status == "unknown"
@@ -422,9 +396,8 @@ def test_is_lm_head_trainable_follows_descriptor_path():
     # fine-tuning: name segments used to miss it and drop the head gradient.
     assert U._is_lm_head_trainable(
         _lm(nn, tied_flag=True, emb_name="tok_embeddings")) is True
-    # Property-backed wrapper: language_model returns self, so the descriptor
-    # access path is not a registered prefix — module identity must still find
-    # the head in the parameter tree.
+    # Property-backed wrapper: language_model returns self, so the descriptor access
+    # path is not a registered prefix and module identity must find the head instead.
     class _PropWrapped(nn.Module):
         def __init__(self):
             super().__init__()
@@ -435,7 +408,6 @@ def test_is_lm_head_trainable_follows_descriptor_path():
             return self
 
     assert U._is_lm_head_trainable(_PropWrapped()) is True
-    # Unresolved head never reports trainable, even with an empty tree.
     unresolved = _lm(nn)
     unresolved.freeze()
     assert U._is_lm_head_trainable(unresolved) is False
@@ -464,8 +436,6 @@ def test_backboneless_text_model_selects_baseline_fallback(capsys):
 @pytest.mark.parametrize("case", ["no_embeddings", "no_backbone", "invalid_scale",
                                   "masked_tail_knob"])
 def test_vlm_cce_fallbacks_are_marked(case):
-    # Every VLM fallback path returns a loss fn carrying the eager marker,
-    # including the knob-table routes (invalid scale, masked-tail knob).
     from unsloth_zoo.mlx.utils import make_vlm_cce_loss_fn
 
     from unsloth_zoo.mlx import utils as U
@@ -551,7 +521,6 @@ def test_describe_output_head_evidence_ladder():
 
     nn = U.nn
     rows = [
-        # (model, status, path, candidate_path)
         (_lm(nn, head=nn.Linear(32, 96, bias=False)), "untied", "lm_head", None),
         # Helium-style dead lm_head + True flag -> tied via embedding
         (_lm(nn, args_flag=True, head=nn.Linear(32, 96, bias=False)),

--- a/tests/test_mlx_cce_target_classification.py
+++ b/tests/test_mlx_cce_target_classification.py
@@ -8,10 +8,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # MLX CCE target-classification coverage on non-Apple-Silicon hosts via the
-# simulation shim. tests/test_mlx_runtime_cce_compile.py gates on real Metal
-# and skips under the shim, leaving the pure-Python validation, in-vocab
-# ignore_index precedence, and logit_softcap fallback paths uncovered on Linux
-# CI. This file fills those gaps.
+# simulation shim. tests/test_mlx_runtime_cce_compile.py gates on real Metal and
+# skips under the shim, leaving these paths uncovered on Linux CI.
 
 from __future__ import annotations
 
@@ -35,9 +33,7 @@ def _expected_valid_loss(vocab_size: int) -> float:
     return math.log(float(vocab_size))
 
 
-# ----------------------------------------------------------------------
 # Pure-Python validation: shape, length, zero-token mismatch
-# ----------------------------------------------------------------------
 
 def test_runtime_cce_zero_tokens_with_non_empty_targets_raises():
     import mlx.core as mx
@@ -133,9 +129,7 @@ def test_runtime_cce_chunk_plan_cache_canonicalizes_bounds_and_recreates():
     assert cache_info()["misses"] > misses_before
 
 
-# ----------------------------------------------------------------------
 # In-vocab ignore_index must take precedence over invalid classification
-# ----------------------------------------------------------------------
 
 @pytest.mark.parametrize("ignore_index", [0, 5, 31])
 def test_in_vocab_ignore_index_zero_loss_not_nan(ignore_index):
@@ -188,9 +182,7 @@ def test_in_vocab_ignore_index_does_not_poison_other_rows():
     assert losses[3].item() == pytest.approx(_expected_valid_loss(vocab_size), rel=1e-5)
 
 
-# ----------------------------------------------------------------------
 # logit_softcap > 0 must preserve NaN poisoning for invalid labels
-# ----------------------------------------------------------------------
 
 @pytest.mark.parametrize("bad_target", [-1, 32])
 def test_softcap_invalid_label_poisons_loss(bad_target):

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -89,7 +89,6 @@ def test_untied_cpt_partition_lr_key_and_save_reload():
     assert {"lm_head.lora_a", "lm_head.lora_b"} <= trainable
     assert "lm_head.weight" not in trainable
     assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
-    # Save keeps the full module; a reloaded model (no marker) saves it too.
     from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters  # noqa: E402
     d, d2 = tempfile.mkdtemp(), tempfile.mkdtemp()
     _mlx_save_lora_adapters(m, d)
@@ -103,12 +102,11 @@ def test_tied_trains_shared_matrix_and_rejects_lm_head():
     m = _tiny(tied=True)
     _peft(m, target_modules=["embed_tokens"], finetune_language_layers=False)
     assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
-    # Co-requesting lm_head trains the shared matrix rather than erroring.
     m2 = _tiny(tied=True)
     _peft(m2, target_modules=["embed_tokens", "lm_head"], finetune_language_layers=False)
     assert m2._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
     trn = set(dict(mu.tree_flatten(m2.trainable_parameters())))
-    assert not any(k.startswith("lm_head") for k in trn)  # tied: no separate head
+    assert not any(k.startswith("lm_head") for k in trn)
     with pytest.raises(ValueError, match="tied"):
         _peft(_tiny(tied=True), target_modules=["lm_head"])
 
@@ -151,7 +149,6 @@ def test_all_linear_expands_inside_a_mixed_cpt_target_list():
     assert {"lm_head.lora_a", "lm_head.lora_b"} <= trn
     assert any(k.endswith("q_proj.lora_a") for k in trn)
 
-    # Set form, and a duplicate sentinel, resolve the same way.
     s = _tiny()
     _peft(s, target_modules={"all-linear", "embed_tokens", "lm_head"})
     trn = set(dict(mu.tree_flatten(s.trainable_parameters())))
@@ -160,8 +157,8 @@ def test_all_linear_expands_inside_a_mixed_cpt_target_list():
 
 
 def test_full_module_only_checkpoint_reloads_without_unfreezing_the_base():
-    # No LoRA anywhere, so the artifact is stamped fine_tune_type="full" with
-    # no exact LoRA paths and reload takes the pathless route. mlx-lm's
+    # No LoRA anywhere, so the artifact is stamped fine_tune_type="full" with no
+    # exact LoRA paths and reload takes the pathless route. mlx-lm's
     # load_adapters never freezes, so without a selective freeze every base
     # tensor came back trainable and the scoped-LR keys were lost.
     import json
@@ -194,7 +191,6 @@ def test_full_module_only_checkpoint_reloads_without_unfreezing_the_base():
         "model.embed_tokens.weight"}
     assert mx.array_equal(r.model.embed_tokens.weight, m.model.embed_tokens.weight)
 
-    # A full-module head-only checkpoint restores the head, nothing else.
     hm = _tiny()
     _peft(hm, target_modules=[], modules_to_save=["lm_head"])
     hd = tempfile.mkdtemp()
@@ -208,7 +204,6 @@ def test_full_module_only_checkpoint_reloads_without_unfreezing_the_base():
     assert getattr(hr, "_unsloth_cpt_full_module_weight_keys", set()) == {
         "lm_head.weight"}
 
-    # A whole-model artifact is a real full fine-tune: keep it unfrozen.
     fd = tempfile.mkdtemp()
     whole = _tiny()
     mx.save_safetensors(
@@ -217,14 +212,12 @@ def test_full_module_only_checkpoint_reloads_without_unfreezing_the_base():
     )
     assert not _is_partial_mlx_checkpoint(
         _tiny(), os.path.join(fd, "adapters.safetensors"))
-    # full_finetuning=True never freezes either.
     ff = _load_pathless_mlx_adapter(_tiny(), d, weights, cfg, True)
     assert len(dict(mu.tree_flatten(ff.trainable_parameters()))) == len(
         dict(mu.tree_flatten(ff.parameters())))
 
 
 def test_set_target_modules_respects_finetune_filters():
-    # A set selection must still honor finetune_attention_modules=False.
     m = _tiny()
     _peft(m, target_modules={"q_proj", "embed_tokens"},
           finetune_attention_modules=False)
@@ -280,7 +273,6 @@ class _WrappedHead(nn.Module):
 
 
 def test_lm_head_wrapper_mlx_lm_cannot_lora_is_dropped_not_fatal():
-    # An unwrappable head must warn, not abort; modules_to_save still trains it.
     m = _tiny(); m.lm_head = _WrappedHead()
     with pytest.warns(UserWarning, match="cannot wrap as a LoRA layer"):
         _peft(m, target_modules=["q_proj", "lm_head"])
@@ -302,7 +294,6 @@ def test_wrapper_head_records_its_real_weight_keys_for_the_scoped_lr():
     assert keys == {"lm_head.ln.weight", "lm_head.linear.weight"}
     trainable = set(dict(mu.tree_flatten(m.trainable_parameters())))
     assert keys <= trainable
-    # A plain Linear / Embedding full module keeps the exact previous key.
     plain = _tiny()
     _peft(plain, target_modules=["q_proj", "embed_tokens"],
           modules_to_save=["lm_head"])
@@ -319,7 +310,6 @@ def test_quantized_child_of_a_wrapper_head_is_rejected():
         m.lm_head.linear, group_size=32, bits=4)
     with pytest.raises(ValueError, match=r"quantized module at 'lm_head\.linear'"):
         _peft(m, target_modules=["q_proj"], modules_to_save=["lm_head"])
-    # A directly quantized full module still reports its own path.
     e = _tiny()
     e.model.embed_tokens = nn.QuantizedEmbedding.from_embedding(
         e.model.embed_tokens, group_size=32, bits=4)
@@ -369,7 +359,6 @@ def test_root_lm_head_lora_is_attached_outside_the_layer_walk():
     assert {"lm_head.lora_a", "lm_head.lora_b"} <= trn
     assert any(k.endswith("q_proj.lora_a") for k in trn)
 
-    # CPT recipe: an lm_head adapter plus a full embedding, no layer targets.
     cpt = _tiny()
     _peft(cpt, target_modules=["embed_tokens", "lm_head"])
     trn = set(dict(mu.tree_flatten(cpt.trainable_parameters())))

--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -587,8 +587,6 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
         and "trainer_state.json" in rank["resume_adapter_only"]
         for rank in ranks
     ), [rank["resume_adapter_only"] for rank in ranks]
-    # A directory that is not adapter-shaped keeps the coordinated
-    # visibility message, which warm-start guidance would not fit.
     assert all(
         "not visible on every rank" in rank["resume_no_adapters"]
         and "FastMLXModel.from_pretrained" not in rank["resume_no_adapters"]

--- a/tests/test_mlx_dequantize_modules.py
+++ b/tests/test_mlx_dequantize_modules.py
@@ -82,7 +82,6 @@ def test_dequantize_selected_mlx_modules_swap():
     scales = torch.cat([scales0, scales1], dim=0)          # (2, 1)
     biases = torch.cat([biases0, biases1], dim=0)          # (2, 1)
 
-    # Build a wrapper Module with a QuantizedLinear submodule.
     class TinyModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -96,21 +95,17 @@ def test_dequantize_selected_mlx_modules_swap():
 
     model = TinyModel()
 
-    # Sanity: named_modules walks self + the QuantizedLinear child.
     names = [n for n, _ in model.named_modules()]
     assert "" in names and "layer" in names, f"unexpected names: {names!r}"
 
-    # Run the dequant-replace helper.
     n_replaced = _dequantize_selected_mlx_modules(
         model, predicate=lambda path, mod: isinstance(mod, nn.QuantizedLinear)
     )
     assert n_replaced == 1, f"expected 1 replacement, got {n_replaced}"
 
-    # The QuantizedLinear has been swapped for an nn.Linear.
     assert isinstance(model.layer, nn.Linear), f"got {type(model.layer)!r}"
     assert not isinstance(model.layer, nn.QuantizedLinear)
 
-    # Weight values: row 0 = [0..7], row 1 = [7..0]
     expected_row0 = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.float32)
     expected_row1 = torch.tensor([7, 6, 5, 4, 3, 2, 1, 0], dtype=torch.float32)
     torch.testing.assert_close(model.layer.weight[0].float(), expected_row0)
@@ -134,7 +129,6 @@ def test_dequantize_predicate_filters():
             self.swap.weight, self.swap.scales, self.swap.biases = packed, scales, biases
 
     m = TwoLayers()
-    # Only swap the .swap submodule
     n = _dequantize_selected_mlx_modules(m, predicate=lambda path, mod: path == "swap")
     assert n == 1
     assert isinstance(m.swap, nn.Linear)

--- a/tests/test_mlx_dtype_downcast_warning.py
+++ b/tests/test_mlx_dtype_downcast_warning.py
@@ -131,7 +131,6 @@ def test_gemma3_comma_does_not_match_gemma3n():
     assert _is_force_float32_arch("gemma3") is True
     assert _is_force_float32_arch("gemma3n") is True
     assert _is_force_float32_arch("gemma3text") is True
-    # An invented gemma3 variant not in the list returns False
     assert _is_force_float32_arch("gemma3_audio_only_pretend") is False
 
 

--- a/tests/test_mlx_finetune_last_n_layers.py
+++ b/tests/test_mlx_finetune_last_n_layers.py
@@ -57,7 +57,6 @@ def test_get_peft_model_passes_finetune_last_n_layers_through(monkeypatch):
     """
     import unsloth_zoo.mlx.loader as loader_mod
 
-    # Build a minimal text-only fake model with .model.layers of len=8.
     class FakeLayer: pass
     class FakeInner:
         layers = [FakeLayer() for _ in range(8)]
@@ -72,14 +71,11 @@ def test_get_peft_model_passes_finetune_last_n_layers_through(monkeypatch):
         def parameters(self): return {}
         def trainable_parameters(self): return {}
 
-    # Capture num_layers values seen by linear_to_lora_layers.
     captured = {"calls": []}
     def fake_linear_to_lora_layers(model, num_layers, config):
         captured["calls"].append(num_layers)
         return 1
 
-    # Stub out the helpers get_peft_model uses internally so the test
-    # doesn't need to walk a real model tree.
     import unsloth_zoo.mlx.loader as L
     monkeypatch.setattr(L, "_fix_missing_no_grad", lambda m: None)
     monkeypatch.setattr(L, "_resolve_lora_keys", lambda m, t: [

--- a/tests/test_mlx_gated_delta_batch_grad.py
+++ b/tests/test_mlx_gated_delta_batch_grad.py
@@ -76,9 +76,6 @@ if not _HAS_MLX:
 mlx_only = pytest.mark.skipif(not _HAS_MLX, reason=_SKIP_REASON)
 
 
-# --------------------------------------------------------------------------- #
-# Helpers
-# --------------------------------------------------------------------------- #
 def _make_inputs(B, T, Hk, Dk, Hv, Dv, vectorized_gating, with_mask, identical_rows=False, seed=0):
     mx.random.seed(seed)
 
@@ -158,7 +155,7 @@ def _rel_l2(a, b):
 _NAMES = ("q", "k", "v", "g", "beta")
 
 # B>1, both gating forms, GQA on/off, single- and multi-chunk (CHUNK_SIZE=min(64,T)),
-# and masked/unmasked. Small dims keep this well under a second per case.
+# and masked/unmasked.
 _PARITY_CASES = [
     (B, T, gqa, mask_on, vec)
     for B in (2, 3, 4)

--- a/tests/test_mlx_gated_delta_vjp.py
+++ b/tests/test_mlx_gated_delta_vjp.py
@@ -13,16 +13,10 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-# Gated-delta VJP tests:
-#   * consumer-binding sweep: stale `from .gated_delta import ...` bindings
-#     must be rebound by identity, foreign impls left alone (torch shim on CI).
-#   * structural gated-delta detection for the patch trigger.
+# Gated-delta VJP tests, including:
 #   * gradient parity vs PLAIN AUTODIFF for the ops and fused-kernel VJP,
 #     B >= 2 (mx `.at[:, t].add` corrupted rows past the first on mlx 0.31,
 #     fixed by ml-explore/mlx#3483). Metal-only.
-#   * kernel routing: training calls must reach the fused-kernel VJP.
-#   * the training window that turns those patches on, the index detachment it
-#     installs, and the fusions it must disable.
 
 from __future__ import annotations
 
@@ -36,12 +30,11 @@ import pytest
 from mlx_simulation import mlx_is_simulated, simulate_mlx_on_torch
 
 # `find_spec("mlx")` alone answers "can mlx be imported", which is NOT the same
-# question once any sibling module has installed the torch shim: that registers
+# question once a sibling module has installed the torch shim: that registers
 # `mlx` in sys.modules and a finder in sys.meta_path, so the spec exists and this
 # file concludes it is on real MLX. It then runs the `requires_real_mlx` tests
-# against a shim where `mx.argpartition` is a `_Noop`. Whether that happens comes
-# down to collection order, which is why it surfaced only when a new sibling
-# sorting before this one began installing the shim at import.
+# against a shim where `mx.argpartition` is a `_Noop`, and whether that happens
+# comes down to collection order.
 _HAS_REAL_MLX = importlib.util.find_spec("mlx") is not None and not mlx_is_simulated()
 if not _HAS_REAL_MLX:
     simulate_mlx_on_torch()
@@ -62,8 +55,8 @@ requires_metal = pytest.mark.skipif(
 )
 requires_real_mlx = pytest.mark.skipif(not _HAS_REAL_MLX, reason="needs real MLX")
 
-# Snapshot the REAL mlx/mlx_lm modules now, before sibling test files install
-# the mlx_simulation torch-stub into sys.modules, so the code under test
+# Snapshot the REAL mlx/mlx_lm modules now, before sibling test files install the
+# mlx_simulation torch-stub into sys.modules, so the code under test
 # resolves the real stack regardless of order. The explicit import pulls in
 # mlx_lm.models.gated_delta (the kernel path from-imports it at call time).
 if _HAS_REAL_MLX:
@@ -102,7 +95,6 @@ def _restore_real_mlx_modules():
                 sys.modules[name] = module
 
 
-# -- consumer-binding sweep ---------------------------------------------------
 
 
 @pytest.fixture()
@@ -189,7 +181,6 @@ def test_second_call_sweeps_consumers_imported_after_first_patch(
     assert fake_mlx_lm.gated_delta.gated_delta_update is patched
 
 
-# -- structural gated-delta detection -----------------------------------------
 
 
 def test_structural_detection():
@@ -248,7 +239,6 @@ def test_structural_detection_matches_unnamed_linear_attention(monkeypatch):
         assert not model_has_gated_delta_layers(_model(mixer, attn))
 
 
-# -- gradient parity vs plain autodiff (Metal only) ---------------------------
 
 
 def _plain_reference(q, k, v, g, beta, state):
@@ -280,7 +270,7 @@ def _make_case(B, T, Hk, Hv, Dk, Dv, dtype, vectorized=False):
 
 
 CASES = [
-    # (B, T, Hk, Hv, Dk, Dv, dtype, tol, vectorized) — B >= 2 everywhere.
+    # (B, T, Hk, Hv, Dk, Dv, dtype, tol, vectorized); B >= 2 everywhere.
     # vectorized=True exercises kimi_linear-style per-column gating.
     (2, 96, 2, 4, 64, 32, mx.float32, 5e-4, False),
     (3, 70, 2, 4, 32, 16, mx.float32, 5e-4, False),
@@ -406,7 +396,6 @@ def test_kernel_dispatch_guards_partial_threadgroup_rows():
     assert not gv.gated_delta_kernel_supported(q, g, None, bad_v)
 
 
-# -- training window and index detachment -------------------------------------
 
 @pytest.fixture
 def index_stop():
@@ -424,9 +413,9 @@ def test_window_depth_accounting():
     assert not mlx_training_patches_active()
     acquire_mlx_training_patches()
     acquire_mlx_training_patches()
-    # The outer run still needs the patches, so removing them is refused -- but
-    # the evaluation doing the pausing must still stop reading as training,
-    # otherwise nesting silently routes it down the training paths.
+    # The outer run still needs the patches, so removing them is refused, but the
+    # evaluation doing the pausing must still stop reading as training, otherwise
+    # nesting silently routes it down the training paths.
     assert pause_mlx_training_patches() is False
     assert not mlx_training_patches_active()
     assert mx.take_along_axis._unsloth_index_stop_gradient
@@ -441,7 +430,6 @@ def test_window_depth_accounting():
     release_mlx_training_patches()
     assert not mlx_training_patches_active()
     assert all(getattr(mx, n) is originals[n] for n in _MLX_INDEX_OP_NAMES)
-    # Outside a run there is nothing to close, and nothing to reopen.
     resume_mlx_training_patches(pause_mlx_training_patches())
     assert not mlx_training_patches_active()
 
@@ -559,7 +547,7 @@ def test_patch_gated_delta_survives_an_mlx_lm_without_the_module(monkeypatch):
     if mlx_lm_models is not None:
         monkeypatch.delattr(mlx_lm_models, "gated_delta", raising=False)
 
-    gated_delta_vjp.patch_gated_delta()          # must not raise
+    gated_delta_vjp.patch_gated_delta()
 
 
 @requires_real_mlx
@@ -647,7 +635,6 @@ def test_only_the_index_argument_is_detached(index_stop):
     assert mx.gather_mm(a, b, lhs_indices=None, rhs_indices=rhs).shape == (4, 3, 2)
 
 
-# -- the shared mlx-vlm gated-delta module ------------------------------------
 
 # mlx-vlm 0.6.5 keeps the shared module under `text_models`; 0.6.6 moved it up.
 _SHARED_GATED_DELTA = ("mlx_vlm.models.gated_delta",
@@ -683,7 +670,6 @@ def test_shared_patch_rebinds_consumers_and_forwards_lower_bound(shared_name, mo
     assert consumer.gated_delta_update is patched
     assert shared._unsloth_gated_delta_patched
 
-    # A cached call keeps the fused kernel and must carry the gate lower bound.
     assert patched(*[object()] * 7, state="kv", lower_bound=-5.0) == ("cached", "kv")
     assert seen["kw"] == {"lower_bound": -5.0}
 
@@ -708,7 +694,6 @@ def test_shared_patch_rebinds_consumers_and_forwards_lower_bound(shared_name, mo
     assert seen["bound"] == -5.0
 
 
-# -- fusions and caches the trainer must turn off -----------------------------
 
 class _FakeModel:
     def __init__(self, *modules):

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -139,7 +139,6 @@ def test_text_api_probe_accepts_supported_shape_and_names_gap_on_mismatch():
 def test_falsey_defaults_are_not_silently_replaced(monkeypatch):
     with pytest.raises(TypeError, match="defaults"):
         generate_batch(object(), None, [], defaults={})
-    # Refused per backend, not by the container, so each reason is true.
     from unsloth_zoo.mlx.generate import _validate_text_requests
     for name in ("kv_bits", "kv_group_size", "kv_quant_scheme", "quantized_kv_start"):
         value = "affine" if name == "kv_quant_scheme" else 4
@@ -258,7 +257,6 @@ def test_a_module_getattr_that_raises_does_not_stop_the_clear(monkeypatch):
     ]
 
 def test_a_runtime_without_synchronize_still_clears(monkeypatch):
-    # No real runtime is this shape, but a partial test double is.
     events = _record_cache_calls(monkeypatch)
     monkeypatch.setattr("mlx.core.synchronize", None, raising=False)
     _fake_stream_module(monkeypatch, "mlx_lm.generate", "stream<mlx_lm>")
@@ -577,7 +575,6 @@ def test_vlm_chunking_respects_release_capabilities():
 
 
 def test_vlm_run_chunk_builds_the_generator_after_embeddings():
-    # The policy needs real inputs, so the generator is built after embeddings.
     from unsloth_zoo.mlx.generate import _VLMBatchAdapter
     order, seen = [], {}
     ids, embeds = (types.SimpleNamespace(tolist=lambda: [[1], [2]]),
@@ -591,7 +588,7 @@ def test_vlm_run_chunk_builds_the_generator_after_embeddings():
     adapter._add_special_tokens, adapter._drive = (lambda: True), (lambda *a: ["ok"] * 2)
     adapter._split_prompt_kwargs = lambda kw, n: (seen.update(kwargs=kw), [{}] * n)[1]
     # Recording on ENTRY proves embeddings run inside the wired-limit context.
-    adapter._wired_limit = lambda: _entry_ctx(order)  # records on ENTRY
+    adapter._wired_limit = lambda: _entry_ctx(order)
     adapter._chunked_prefill_kwargs = lambda **kw: (
         order.append("policy"), seen.update(policy=kw), {})[2]
     adapter.model = types.SimpleNamespace(
@@ -612,8 +609,6 @@ def test_vlm_run_chunk_builds_the_generator_after_embeddings():
 
 @pytest.mark.parametrize("nested", (True, False))
 def test_vlm_probe_accepts_both_event_class_locations(nested):
-    # Pre-0.5 nests Response with a logprob vector; 0.5+ moves it to
-    # GenerationBatch with a scalar token_logprob.
     from unsloth_zoo.mlx.generate import _probe_vlm_api
     response = type("Response", (), {"__dataclass_fields__": dict.fromkeys(
         ("uid", "token", "finish_reason", "logprobs" if nested else "token_logprob"))})
@@ -640,8 +635,6 @@ def test_vlm_prompt_kwargs_prefer_upstream_only_when_mrope_aware():
 
 
 def test_vlm_images_are_decoded_once_and_flow_to_preprocessing():
-    # One fetch per request; the decoded object reaches grouping and
-    # prepare_inputs; raw bytes are rejected.
     from unsloth_zoo.mlx.generate import _VLMBatchAdapter
     loads, seen = [], {}
     decoded = types.SimpleNamespace(size=(8, 8))
@@ -658,9 +651,9 @@ def test_vlm_images_are_decoded_once_and_flow_to_preprocessing():
 
 
 def test_vlm_adapter_initializes_against_newer_module_layout(monkeypatch):
-    # Newer layout: the package re-exports BatchGenerator while helpers and the
-    # event class live on the defining module. Delegation via __getattr__ is
-    # omitted so this proves the defining-module binding alone.
+    # Newer layout: the package re-exports BatchGenerator while the helpers and the
+    # event class live on the defining module. __getattr__ delegation is left out so
+    # this proves the defining-module binding alone.
     import sys
     import mlx_vlm.utils  # noqa: F401  (cache the real module before shadowing)
     from unsloth_zoo.mlx import generate as engine
@@ -683,7 +676,7 @@ def test_vlm_adapter_initializes_against_newer_module_layout(monkeypatch):
     policy_calls = []
     ar._chunked_prefill_enabled = lambda model, **kwargs: policy_calls.append(model) or True
     bare = types.ModuleType("mlx_vlm.generate")
-    bare.BatchGenerator = Generator  # re-export only; no delegation here
+    bare.BatchGenerator = Generator
     monkeypatch.setitem(sys.modules, "mlx_vlm.generate", bare)
     monkeypatch.setitem(sys.modules, "mlx_vlm.generate.ar", ar)
     adapter = engine._VLMBatchAdapter(object(), _CharTokenizer(), GenerationDefaults())
@@ -691,7 +684,7 @@ def test_vlm_adapter_initializes_against_newer_module_layout(monkeypatch):
     assert adapter.batch_module is ar and adapter.per_row_prompt_kwargs
     assert adapter._split_prompt_kwargs({}, 3) == [{}, {}, {}]  # upstream splitter chosen
     assert adapter._chunked_prefill_kwargs(input_ids=None, prefill_kwargs={}) == {}
-    assert policy_calls  # the policy helper was consulted, not bypassed
+    assert policy_calls
     # The probed capability must reach the adapter, not merely exist on the module.
     assert adapter.cancel is not None
 
@@ -706,12 +699,10 @@ def test_module_resolution_separates_an_absent_release_from_a_broken_install(mon
     monkeypatch.setattr(importlib_module, "import_module", fake_import)
     with pytest.raises(ModuleNotFoundError, match="timm"):
         _resolve_module_attr(("mlx_vlm.generate",), "BatchGenerator")
-    # The candidate itself being absent still degrades to None.
     assert _resolve_module_attr(("mlx_vlm.generate.ar",), "BatchGenerator") is None
 
 
 def test_vlm_drive_raises_on_true_stall_and_survives_long_prefill():
-    # Impossible admission raises; a multi-poll prefill must still complete.
     from unsloth_zoo.mlx.generate import _VLMBatchAdapter
     adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
     adapter.defaults, adapter.per_row_prompt_kwargs = GenerationDefaults(), True
@@ -729,7 +720,6 @@ def test_vlm_drive_raises_on_true_stall_and_survives_long_prefill():
             if self._empty_polls:
                 self._empty_polls -= 1
                 if not self._empty_polls:
-                    # Prefill done: the sequence is promoted into decoding.
                     self._prompt_batch, self._generation_batch = None, [1]
                 return ([], [])
             return super().next(**kwargs)
@@ -760,8 +750,8 @@ def test_vlm_requests_group_by_sampling_params():
     adapter.generate([GenerationRequest(prompt="a"), GenerationRequest(prompt="b", sampling=hot),
                       GenerationRequest(prompt="c")])
     assert sorted(chunks) == [[0, 2], [1]]
-    # Preprocessing stacks a group without padding, so differing prompt lengths
-    # must not share a chunk; upstream raises when they do.
+    # Preprocessing stacks a group without padding, so differing prompt lengths must
+    # not share a chunk; upstream raises when they do.
     chunks.clear()
     adapter.generate([GenerationRequest(prompt="a"), GenerationRequest(prompt="bb"),
                       GenerationRequest(prompt="c")])
@@ -770,7 +760,6 @@ def test_vlm_requests_group_by_sampling_params():
 
 @pytest.mark.parametrize("plural", (True, False))
 def test_vlm_stop_strings_trim_and_cancel_in_the_release_form(plural):
-    # Both signature forms, collection and single uid, must drive correctly.
     from unsloth_zoo.mlx.generate import _VLMBatchAdapter, _resolve_cancel
     cancelled = []
     class Generator(_vlm_stub(True, events=[[(0, 2, None)], [(0, 3, None)]])):
@@ -796,13 +785,13 @@ def test_vlm_stop_strings_drop_later_events_when_the_release_cannot_cancel():
     Generator = _vlm_stub(False, events=[
         [(0, 2, None), (1, 1, None)],
         [(0, 3, None), (1, 1, None)],       # uid 0 completes "<STOP>" here
-        [(0, 1, None), (1, 1, "length")]])  # uid 0's late token must be ignored
+        [(0, 1, None), (1, 1, "length")]])
     adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
     adapter.defaults = GenerationDefaults(stop_strings=("STOP",))
     adapter.per_row_prompt_kwargs = False
     adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
     adapter.cancel = _resolve_cancel(Generator)
-    assert adapter.cancel is None  # no cancellation on this release
+    assert adapter.cancel is None
     stopped, sibling = adapter._drive(Generator(object(), object()), [0, 1], {})
     assert (stopped.token_ids, stopped.finish_reason, stopped.stop_match) == (
         [], "stop_string", "STOP")
@@ -827,9 +816,9 @@ def test_generation_mode_serializes_threads_and_rejects_overlapping_tasks():
         try:
             assert held.wait(5)
             acquired = _GENERATION_MODE_LOCK.acquire(True, 0.05)
-            if acquired:  # never leak global lock state on failure
+            if acquired:
                 _GENERATION_MODE_LOCK.release()
-            assert acquired is False  # serialized across threads
+            assert acquired is False
         finally:
             release.set()
             task.result()
@@ -857,7 +846,6 @@ def test_detokenizer_buffers_partial_characters_and_emits_once():
 
 
 def test_detokenizer_never_re_emits_after_a_shortening_decode():
-    # A shortening decode must not push the offset back and re-emit that tail.
     from unsloth_zoo.mlx.generate import _PendingResult, _StopStringScanner
     tokenizer = _TableTokenizer({(1,): "hello", (1, 2): "he", (1, 2, 3): "hello there"})
     state = _PendingResult(detokenizer=_new_detokenizer(tokenizer),
@@ -918,7 +906,6 @@ class _CriteriaTokenizer(_CharTokenizer):
     (((1, None), (3, None)), _CriteriaTokenizer(), ([1], "stop")),
     # ... and that same authority reports an ordinary token as a length cut-off.
     (((1, None), (2, None), (2, None)), _CriteriaTokenizer(), ([1, 2], "length")),
-    # A reported reason is believed, not re-inferred, in both directions.
     (((1, None), (2, "stop")), None, ([1], "stop")),
     (((1, None), (3, "length")), _CriteriaTokenizer(), ([1], "length")),
     # Nothing generated at all: newer releases emit one event with no token.
@@ -952,7 +939,6 @@ def test_audio_fallback_forwards_the_request_to_the_stream():
     assert args[2] == "p"  # the rendered prompt, after model and processor
     assert (kwargs["audio"], kwargs["max_tokens"]) == ("a.wav", 9)
     assert kwargs["sampler"] is adapter.sampler
-    # Per-request sampling, not the batch-wide default.
     assert (adapter.sampler_kwargs["temp"], adapter.sampler_kwargs["top_k"]) == (0.25, 7)
 
 
@@ -966,8 +952,8 @@ def test_audio_fallback_honours_stop_strings():
 
 
 def test_audio_requests_reach_the_fallback_through_the_public_entry_point(monkeypatch):
-    # The tests above drive the adapter directly and would stay green if the
-    # old blanket audio rejection came back.
+    # The tests above drive the adapter directly and would stay green if the old
+    # blanket audio rejection came back.
     from unsloth_zoo.mlx import generate as engine
     seen = []
     monkeypatch.setattr(engine._VLMBatchAdapter, "__init__",
@@ -988,7 +974,6 @@ def test_audio_requests_reach_the_fallback_through_the_public_entry_point(monkey
 
 
 def test_audio_requests_decode_alone_while_the_rest_of_the_batch_still_batches():
-    # Audio has no batched path, but must not drag the others out of theirs.
     from unsloth_zoo.mlx.generate import _VLMBatchAdapter
     adapter = _audio_adapter(_audio_events((1, None), (2, "length")))
     batched = []
@@ -1001,7 +986,7 @@ def test_audio_requests_decode_alone_while_the_rest_of_the_batch_still_batches()
                 GenerationRequest(prompt="c")]
     with pytest.warns(RuntimeWarning, match="decode one at a time"):
         results = _VLMBatchAdapter.generate(adapter, requests)
-    assert batched == [[0, 2]]  # the audio row never reached the batched path
+    assert batched == [[0, 2]]
     assert [results[0], results[2]] == ["batched", "batched"]
     assert results[1].token_ids == [1]
 

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -94,7 +94,6 @@ def test_batched_greedy_matches_sequential_and_preserves_sampled_ids():
         GenerationRequest(prompt="Two plus two equals", max_tokens=8),
     ]
     defaults = GenerationDefaults()
-    # The cache patch must be installed before any decoding runs.
     order = []
     real_install = generate_module._install_arrays_cache_advance_fix
     real_adapter_generate = generate_module._TextBatchAdapter.generate
@@ -186,8 +185,6 @@ def test_compiled_training_state_survives_generation():
         # Sampling consumes the global RNG stream, so the same seed reproduces.
         result, repeat = [types.SimpleNamespace(token_ids=sample(11))], sample(11)
         assert result[0].token_ids and repeat == result[0].token_ids
-        # Parameters untouched, block runs in eval with the checkpoint patch
-        # installed, flags restored, and the compiled step keeps training.
         assert snapshot() == state_after_train
         assert (False, True) in model.layers[0].seen_states
         assert hasattr(_CompileBlock, "_orig_call")
@@ -223,7 +220,6 @@ def test_vlm_batched_generation_is_ordered_and_aligned():
     results = generate_batch(model, processor, requests, defaults=defaults)
     assert len(results) == 3
     for result in results:
-        # The RL contract: ids come from sampled events, logprobs align to them.
         assert result.token_ids
         assert result.logprobs is None or len(result.logprobs) == len(result.token_ids)
         assert result.finish_reason in ("stop", "length")
@@ -234,16 +230,12 @@ def test_vlm_batched_generation_is_ordered_and_aligned():
     events = [event for event in stream_generate(
         model, processor, requests[0].prompt, image=[requests[0].image],
         max_tokens=4, sampler=make_sampler(temp=0.0))]
-    # The terminal event contributes text only: its token is the stopping token,
-    # or a repeat of the last body token when the budget ran out.
     tail = events[-1]
     body = events[:-1]
     assert results[0].token_ids == [int(event.token) for event in body]
     assert results[0].logprobs == pytest.approx(
         [float(event.logprobs[event.token].item()) for event in body], abs=0.02)
     assert results[0].text == "".join(event.text for event in events)
-    # Derived from the stream, not our own rule: fewer body events than the
-    # budget means it stopped early.
     assert tail is not None
     assert results[0].finish_reason == ("stop" if len(body) < 4 else "length")
     # Chunking must not pair a prompt with an earlier chunk's embeddings.
@@ -253,7 +245,6 @@ def test_vlm_batched_generation_is_ordered_and_aligned():
     # Concurrent sequences must not share a detokenizer buffer, so text must
     # match too, not just ids.
     assert [item.text for item in chunked] == [item.text for item in results]
-    # Independent buffers: no result may carry another's decoded text appended.
     assert all(r.text == "" or not r.text.startswith(results[0].text + results[1].text) for r in results)  # noqa: E501
 
 
@@ -274,13 +265,10 @@ def test_vlm_stop_strings_cut_generation_through_the_public_path():
     free = generate_batch(model, processor, [request],
                           defaults=GenerationDefaults(max_tokens=12))[0]
     assert len(free.text) > 1
-    # The whole public path must carry stop strings, not just the event loop.
     stop = free.text[1]
     stopped = generate_batch(model, processor, [request], defaults=GenerationDefaults(
         max_tokens=12, stop_strings=(stop,)))[0]
     assert (stopped.finish_reason, stopped.stop_match) == ("stop_string", stop)
-    # Trimming is token-aligned: whole tokens before the match survive, possibly
-    # none, and never the stop string itself.
     assert free.text.startswith(stopped.text) and stop not in stopped.text
     assert len(stopped.token_ids) < len(free.token_ids)
 
@@ -312,7 +300,6 @@ def test_arrays_cache_advance_patch_only_replaces_the_body_it_reproduces():
                 self.left_padding += N
 
     class Decrementing(Incrementing):
-        # A matcher that reached for an instance trips this instead of passing quietly.
         def __init__(self):
             raise AssertionError("candidacy must not instantiate the candidate")
 
@@ -381,7 +368,6 @@ def test_arrays_cache_advance_defers_instead_of_stranding_metal_buffers():
     assert (batch.lengths.tolist(), batch.left_padding.tolist()) == ([2], [-1])
     batch.advance(3)
     batch.prepare(lengths=[7])
-    # Re-arming a field replaces it outright, deferred count included.
     assert batch.lengths.tolist() == [7]
     batch.finalize()
     batch.advance(5)
@@ -394,7 +380,6 @@ def test_arrays_cache_advance_defers_instead_of_stranding_metal_buffers():
     legacy.advance(1)
     assert legacy.left_padding.tolist() == [1] and legacy.lengths is None
 
-    # extend() concatenates two caches carrying different deferred counts.
     left = ArraysCache(1)
     left[0] = mx.zeros((2, 4))
     left.left_padding, left.lengths = mx.array([0, 4]), mx.array([6, 9])

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -35,8 +35,8 @@ import torch
 
 
 # Imported at module level on purpose: this file is a CI hard gate needing neither a GPU nor
-# vLLM (tests/conftest.py handles the device probe), so an import failure is a regression
-# and must fail the gate instead of skipping it.
+# vLLM (tests/conftest.py handles the device probe), so an import failure must fail
+# the gate instead of skipping it.
 import unsloth_zoo.vllm_utils as vllm_utils
 
 

--- a/tests/test_vllm_flashinfer_linkability.py
+++ b/tests/test_vllm_flashinfer_linkability.py
@@ -147,11 +147,9 @@ def test_an_empty_library_path_entry_is_not_a_directory(tmp_path):
 
 
 # ------------------------------------------- false negatives are the bad kind
-#
 # False when the link would have succeeded silently disables FlashInfer on a
 # machine where it works; True when the link then fails merely restores the
-# pre-check behaviour. The two tests below cover the two ways the first,
-# dangerous mistake was reachable.
+# pre-check behaviour. Below: the two ways the first mistake was reachable.
 
 
 def test_a_stub_in_a_default_linker_directory_counts(tmp_path):

--- a/tests/test_vllm_standby_expandable_segments_error.py
+++ b/tests/test_vllm_standby_expandable_segments_error.py
@@ -101,8 +101,7 @@ _KV_CACHE_OOM = (
 )
 
 _REAL_OOM_ERRORS = (
-    # torch. Captured verbatim from torch 2.9.1+cu128. Note it recommends
-    # expandable segments, so classification must not key off that phrase alone.
+    # torch 2.9.1+cu128, verbatim. It recommends expandable segments itself.
     "CUDA out of memory. Tried to allocate 37252.90 GiB. GPU 0 has a total capacity of "
     "178.35 GiB of which 177.06 GiB is free. Process 597697 has 692.00 MiB memory in use. "
     "Including non-PyTorch memory, this process has 612.00 MiB memory in use. Of the "
@@ -134,9 +133,8 @@ _REAL_OOM_ERRORS = (
     ("PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_HIP_ALLOC_CONF", "PYTORCH_ALLOC_CONF"),
 )
 def test_expandable_segments_assertion_is_not_an_oom(env_var):
-    # The bug: this returned True via the bare "alloc" substring (and via
-    # "memory" for the upstream wording), so a config clash was raised as
-    # MemoryError("Your GPU ran out of memory").
+    # The bug: the bare "alloc" substring (and "memory" for the upstream wording)
+    # returned True, so a config clash was raised as MemoryError.
     error = _unsloth_assertion(env_var)
     assert vllm_utils._is_expandable_segments_error(error) is True
     assert vllm_utils._is_out_of_memory_error(error) is False
@@ -167,10 +165,8 @@ def test_unrelated_errors_are_neither(error):
 
 
 def test_torch_oom_hint_about_expandable_segments_is_not_a_config_clash():
-    # torch's genuine OOM text ends with "try setting
-    # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation",
-    # so the config-clash markers must be full phrases, not a bare substring,
-    # or a real OOM would be routed to the configuration message.
+    # torch's genuine OOM text recommends PYTORCH_CUDA_ALLOC_CONF=
+    # expandable_segments:True, so the config-clash markers must be full phrases.
     torch_oom = _REAL_OOM_ERRORS[0]
     assert "expandable_segments:True" in torch_oom
     assert vllm_utils._is_out_of_memory_error(torch_oom) is True
@@ -199,11 +195,9 @@ def test_message_names_the_offending_env_var_on_every_platform(env_var):
     # Never claim the GPU ran out of memory for a config clash.
     assert "ran out of memory" not in message
     assert "NOT an out of memory error" in message
-    # The remedy that actually works must be present, the useless ones absent.
     assert "expandable_segments" in message
     assert "load_in_4bit" not in message
     assert "gpu_memory_utilization=0.6" not in message
-    # Preserve the underlying error for debugging.
     assert "Original error:" in message
     assert "Standby mode is not supported with expandable segments." in message
 
@@ -238,9 +232,8 @@ def test_profiling_race_and_kv_cache_oom_classify_differently():
 
 
 def test_free_memory_marker_still_covers_the_real_startup_shortfall():
-    # Dropping the "free memory" marker is the easy way to stop matching the
-    # profiling race, and it would silently lose this genuine shortfall, whose
-    # text never says "out of memory" (vllm/v1/worker/utils.py request_memory).
+    # Dropping the "free memory" marker would silently lose this genuine shortfall,
+    # whose text never says "out of memory" (vllm/v1/worker/utils.py request_memory).
     shortfall = (
         "Free memory on device (78.68/79.15 GiB) on startup is less than desired GPU memory "
         "utilization (0.9, 71.24 GiB). Decrease GPU memory utilization or reduce GPU memory "
@@ -261,12 +254,10 @@ def test_profiling_race_message_never_offers_the_oom_remedies(standby):
     message = vllm_utils._memory_profiling_race_message(
         _PROFILING_RACE, trials = 3, unsloth_vllm_standby = standby,
     )
-    # Name the actual cause: a shared GPU, and a transient one.
     assert "transient" in message
     assert "sharing this GPU" in message
     assert "NOT an out of memory error" in message
     assert "ran out of memory" not in message
-    # Say it can simply be retried.
     assert "Load the model again" in message
     assert "Unsloth already tried loading 3 times." in message
     # None of the three OOM remedies may be *offered*. Scope this to the list of
@@ -275,15 +266,13 @@ def test_profiling_race_message_never_offers_the_oom_remedies(standby):
     for useless in ("load_in_4bit", "smaller model", "4bit", "Lower gpu_memory_utilization"):
         assert useless not in remedies
     assert "gpu_memory_utilization" not in remedies
-    # Preserve the underlying error for debugging.
     assert "Original error:" in message
     assert _PROFILING_RACE in message
 
 
 def test_profiling_race_message_explains_why_standby_cannot_retry_in_process():
-    # Standby keeps weights in CuMemAllocator, a process wide singleton, and
-    # Unsloth runs the engine in-process (VLLM_ENABLE_V1_MULTIPROCESSING=0), so
-    # the retry has to be a fresh process. Say so instead of staying silent.
+    # CuMemAllocator is a process wide singleton and Unsloth runs the engine
+    # in-process (VLLM_ENABLE_V1_MULTIPROCESSING=0), so a retry needs a new process.
     standby = vllm_utils._memory_profiling_race_message(
         _PROFILING_RACE, trials = 1, unsloth_vllm_standby = True,
     )
@@ -299,26 +288,22 @@ def test_profiling_race_message_explains_why_standby_cannot_retry_in_process():
 
 def test_load_vllm_retries_a_profiling_race_without_shrinking_anything():
     # The generic branch below reacts to "memory" by scaling gpu_memory_utilization
-    # by 0.85 and max_num_seqs by 0.75 for the rest of the run. Nothing about
-    # either caused a profiling race, so the retry must be of the identical load.
+    # by 0.85 and max_num_seqs by 0.75, neither of which caused a profiling race.
     source = inspect.getsource(vllm_utils.load_vllm)
     race_at = source.index("_is_memory_profiling_race_error(error)")
     standby_at = source.index("if trials >= 2 or unsloth_vllm_standby:")
     shrink_at = source.index('engine_args["gpu_memory_utilization"] *= 0.85')
-    # Checked before the standby short-circuit, which would otherwise give up
-    # after a single attempt on a transient fault.
+    # Checked before the standby short-circuit, which gives up after a single
+    # attempt on a transient fault.
     assert race_at < standby_at < shrink_at
-    # And it retries rather than falling through to the shrink.
     assert "continue" in source[race_at:standby_at]
     assert "_MEMORY_PROFILING_RACE_MAX_TRIALS" in source[race_at:standby_at]
     assert vllm_utils._MEMORY_PROFILING_RACE_MAX_TRIALS >= 2
 
 
 def test_profiling_race_retries_do_not_spend_the_generic_retry_budget():
-    # A race is counted on its own `race_trials`. If it shared `trials` with the
-    # generic handler, a race on the first attempt followed by a genuine OOM on
-    # the second would hit `trials >= 2` and raise, skipping the shrink-and-retry
-    # that a first-attempt OOM gets today.
+    # A race is counted on its own `race_trials`. Sharing `trials` would make a race
+    # then a real OOM hit `trials >= 2` and raise, skipping the shrink-and-retry.
     source = inspect.getsource(vllm_utils.load_vllm)
     race_at = source.index("_is_memory_profiling_race_error(error)")
     bump_at = source.index("            trials += 1")
@@ -326,16 +311,14 @@ def test_profiling_race_retries_do_not_spend_the_generic_retry_budget():
     # The generic counter is bumped only after the race branch has passed on it.
     assert race_at < bump_at < standby_at
     assert source.count("            trials += 1") == 1
-    # The race branch uses its own counter, never the generic one.
     race_branch = source[race_at:bump_at]
     assert "race_trials += 1" in race_branch
     assert "trials <" not in race_branch.replace("race_trials <", "")
 
 
 def test_load_vllm_retry_handler_is_wired_to_the_precise_classifiers():
-    # Guards the raise site itself: the loose substring test must be gone, the
-    # config clash must be checked before the MemoryError, and the OOM branch
-    # must keep `Original error:`.
+    # Guards the raise site: the loose substring test must be gone, the config clash
+    # checked before the MemoryError, and the OOM branch keeps `Original error:`.
     source = inspect.getsource(vllm_utils.load_vllm)
     assert '"alloc" in error.lower()' not in source
     assert not re.search(r'\(\s*"memory" in error\.lower\(\)', source)

--- a/tests/test_vllm_to_hf_conversion.py
+++ b/tests/test_vllm_to_hf_conversion.py
@@ -140,8 +140,7 @@ def _config(model_type="qwen3_5", has_vision=False):
 
 
 def test_finalize_fixes_layer_idx_on_standard_causal_lm():
-    # Pre-fix: only new_model.model.language_model.layers was traversed, so
-    # standard-LM paths kept the stub layer_idx.
+    # Pre-fix: only model.language_model.layers was traversed; standard LMs kept the stub layer_idx.
     from unsloth_zoo.empty_model import finalize_huggingface_model
     model = _StandardLM(n_layers=4)
     finalize_huggingface_model(
@@ -220,7 +219,7 @@ def test_set_dtype_in_config_no_torch_dtype_deprecation():
 
 
 def test_set_dtype_in_config_writes_torch_dtype_value():
-    # set_dtype_in_config stores a JSON-safe string (e.g. "float16") so
+    # set_dtype_in_config stores a JSON-safe string ("float16") so
     # config.save_pretrained() and patching_utils string comparisons work.
     from transformers import PretrainedConfig
     from unsloth_zoo.hf_utils import set_dtype_in_config, dtype_from_config
@@ -263,7 +262,6 @@ def test_normalize_state_dict_tensor_guards_non_tensor():
 def test_gemma4_lora_patch_preserves_signature_for_inspect():
     # Pre-fix: patched_create_lora_manager(model, *args, **kwargs) hid
     # vllm_config, breaking _call_create_lora_manager's signature forwarding.
-    # Fix wraps with functools.wraps and delegates to the original manager.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
     assert "@wraps(original_create_lora_manager)" in src
@@ -272,8 +270,8 @@ def test_gemma4_lora_patch_preserves_signature_for_inspect():
 
 
 def test_gemma4_k_eq_v_patch_handles_split_kv_layout():
-    # Pre-fix: only packed self_attn.qkv_proj.weight was searched, so the
-    # upstream split q/k/v_proj Gemma4 layout never got synthetic V quant-state.
+    # Pre-fix: only packed self_attn.qkv_proj.weight was searched, so the split
+    # q/k/v_proj Gemma4 layout never got synthetic V quant-state.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
     assert "k_proj.weight" in src and "v_proj.weight" in src
@@ -291,8 +289,7 @@ class _FakeQuantState:
 
 
 class _FakeBnBParam(torch.nn.Parameter):
-    # Parameter is a Tensor subclass; attaching bnb_quant_state keeps the
-    # wrapper-vs-raw-tensor distinction.
+    # Parameter is a Tensor subclass; bnb_quant_state keeps the wrapper-vs-raw distinction.
     def __new__(cls, data, bnb_quant_state=None):
         inst = torch.nn.Parameter.__new__(cls, data, requires_grad=False)
         inst.bnb_quant_state = bnb_quant_state
@@ -344,8 +341,7 @@ class _FakeBnBGDN(torch.nn.Module):
 
 def test_extract_gdn_layers_emits_bnb_quant_state_for_all_shards():
     # Pre-fix: extract_gdn_layers() unwrapped Params4bit before reading
-    # `bnb_quant_state` (always None), and the in_proj_ba split emitted no
-    # quant-state for in_proj_b/in_proj_a.
+    # `bnb_quant_state` (always None), and in_proj_ba's split emitted none.
     from unsloth_zoo.empty_model import extract_gdn_layers
     gdn = _FakeBnBGDN()
     state_dict, quant_state_dict = {}, {}
@@ -359,8 +355,7 @@ def test_extract_gdn_layers_emits_bnb_quant_state_for_all_shards():
 
 
 def test_assert_same_state_dict_tied_embed_fallback_has_tolerances():
-    # Pre-fix: tied-embeddings fallback used strict tolerances vs the outer
-    # atol=1e-4, rtol=1e-3, producing spurious failures.
+    # Pre-fix: tied-embeddings fallback used strict tolerances vs the outer atol=1e-4, rtol=1e-3.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.assert_same_state_dict)
     tied_idx = src.index("model.embed_tokens.weight")
@@ -370,8 +365,7 @@ def test_assert_same_state_dict_tied_embed_fallback_has_tolerances():
 
 
 def test_gemma4_lora_soft_imports_vllm_v1_worker():
-    # Pre-fix: patch_gemma4_vllm_lora_support hard-imported `vllm.v1.worker`
-    # and crashed with ModuleNotFoundError on older vLLM builds.
+    # Pre-fix: hard-imported `vllm.v1.worker` -> ModuleNotFoundError on older vLLM builds.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
     assert "try:" in src
@@ -381,9 +375,8 @@ def test_gemma4_lora_soft_imports_vllm_v1_worker():
 
 
 def test_conv1d_rebuild_uses_real_channels_and_groups():
-    # Pre-fix: conv1d was treated as a layernorm and rebuilt by weight-swap
-    # only, leaving a placeholder Conv1d(groups=1, kernel_size=1) that crashes
-    # on first forward.
+    # Pre-fix: conv1d was treated as a layernorm and rebuilt by weight-swap only, leaving a
+    # placeholder Conv1d(groups=1, kernel_size=1) that crashes on first forward.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
     assert '".conv1d"' in src
@@ -394,8 +387,7 @@ def test_conv1d_rebuild_uses_real_channels_and_groups():
 
 
 def test_lm_head_extraction_collapsed_to_single_path():
-    # Pre-fix: the two lm_head elif fallbacks were dead code since
-    # named_modules() already traverses the full subtree.
+    # Pre-fix: the two lm_head elif fallbacks were dead code; named_modules() traverses all.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils._get_vllm_state_dict)
     lm_start = src.index("# LM Head")
@@ -405,8 +397,7 @@ def test_lm_head_extraction_collapsed_to_single_path():
 
 
 def test_gemma4_kv_shared_set_uses_shared_config_helper():
-    # Route Gemma4 config matching through the shared helper so text-only
-    # configs (model_type == "gemma4_text") match too.
+    # The shared helper also matches text-only configs (model_type == "gemma4_text").
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils._get_vllm_state_dict)
     assert "if _is_gemma4_config(config):" in src
@@ -414,8 +405,7 @@ def test_gemma4_kv_shared_set_uses_shared_config_helper():
 
 
 def test_gemma4_layer_types_none_is_guarded():
-    # Gemma4 configs may carry layer_types=None. Direct enumerate(None) crashed
-    # BnB k_eq_v quant-state patching.
+    # Gemma4 layer_types=None: enumerate(None) crashed BnB k_eq_v quant-state patching.
     from unsloth_zoo import empty_model
     empty_src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
     assert 'getattr(text_config, "layer_types", None) or ()' in empty_src
@@ -433,8 +423,7 @@ def test_gemma4_k_eq_v_does_not_skip_v_proj_extraction():
 
 
 def test_merger_linear_fc_moved_to_non_layered():
-    # Pre-fix: model.visual.merger.linear_fc1/2 (no {kk} placeholder) sat in
-    # additional_layers and were reassigned once per layer.
+    # Pre-fix: model.visual.merger.linear_fc1/2 (no {kk}) sat in additional_layers and were reassigned per layer.
     from unsloth_zoo.empty_model import get_model_layer_config
     cfg = get_model_layer_config()
     additional = set(cfg["additional_layers"])
@@ -446,8 +435,7 @@ def test_merger_linear_fc_moved_to_non_layered():
 
 
 def test_finalize_does_not_overwrite_unrelated_submodule_config_dtype():
-    # Behavioral: a submodule with its own config (distinct identity from the
-    # top/text/vision/audio configs) must not get its dtype overwritten.
+    # A submodule config with an identity distinct from top/text/vision/audio must not be overwritten.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _SubConfig:
@@ -474,23 +462,18 @@ def test_finalize_does_not_overwrite_unrelated_submodule_config_dtype():
         model, None, top_cfg, torch.bfloat16,
         quantization_config={"x": 1}, bnb_config=None,
     )
-    # Unknown submodule config must keep its original dtype.
     assert model.sub.config.dtype == "float32"
-    # Top-level config is a known config and should be updated to bfloat16.
     assert top_cfg.dtype == "bfloat16"
 
 
 def test_finalize_keeps_gemma4_rotary_buffers_float32_after_dtype_cast():
-    # Behavioral: on Gemma4, rotary_emb buffers stay float32 even after
-    # finalize casts the model to bf16/fp16.
+    # On Gemma4, rotary_emb buffers stay float32 even after the bf16/fp16 cast.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _RotaryCfg:
         pass
 
     class _FakeRotaryEmb(torch.nn.Module):
-        # Minimal interface finalize touches: a config plus float buffers that
-        # stay float32 on Gemma4.
         def __init__(self, config=None, device=None):
             super().__init__()
             self.config = config if config is not None else _RotaryCfg()
@@ -529,8 +512,7 @@ def test_finalize_keeps_gemma4_rotary_buffers_float32_after_dtype_cast():
 
 
 def test_finalize_non_gemma4_rotary_buffers_follow_model_dtype():
-    # Behavioral: non-Gemma4 rotary buffers follow the requested model dtype
-    # (buffer_dtype = dtype branch).
+    # Non-Gemma4 rotary buffers take the buffer_dtype = dtype branch.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _RotaryCfg:
@@ -573,8 +555,7 @@ def test_finalize_non_gemma4_rotary_buffers_follow_model_dtype():
 
 
 def test_set_dtype_in_config_else_branch_picks_correct_field():
-    # Pre-fix: the else-branch selection was inverted; exercise the
-    # neither-attribute path.
+    # Pre-fix: the else-branch selection was inverted; exercise the neither-attribute path.
     from unsloth_zoo.hf_utils import set_dtype_in_config, HAS_TORCH_DTYPE
 
     class _Bare:
@@ -585,14 +566,12 @@ def test_set_dtype_in_config_else_branch_picks_correct_field():
     expected_field = "torch_dtype" if HAS_TORCH_DTYPE else "dtype"
     other_field = "dtype" if HAS_TORCH_DTYPE else "torch_dtype"
     assert getattr(obj, expected_field, None) == "float16"
-    # Only one field should be written (no leakage into the other slot).
     assert getattr(obj, other_field, None) is None
 
 
 def test_assert_same_state_dict_ignores_quantstate_entries():
-    # Behavioral: _normalize_state_dict_tensor returns None for non-tensor
-    # values (BnB QuantState dicts) and the loop skips them; previously these
-    # caused an AttributeError masked into failures.
+    # _normalize_state_dict_tensor returns None for non-tensor values (BnB QuantState
+    # dicts) and the loop skips them; previously these raised AttributeError.
     from unsloth_zoo.vllm_utils import assert_same_state_dict
 
     w = torch.randn(4, 4)
@@ -603,14 +582,13 @@ def test_assert_same_state_dict_ignores_quantstate_entries():
 
 
 def test_normalize_state_dict_tensor_handles_parameter():
-    # Behavioral: a Parameter is detached and normalized to a tensor.
+    # A Parameter is detached and normalized to a tensor.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.assert_same_state_dict)
-    # Smoke: full comparison with a Parameter on both sides.
     p_old = torch.nn.Parameter(torch.ones(2, 2), requires_grad=False)
     p_new = torch.nn.Parameter(torch.ones(2, 2), requires_grad=False)
     vllm_utils.assert_same_state_dict({"w": p_old}, {"w": p_new})
-    # And returning None for a non-tensor is reachable via the guarded path.
+    # Returning None for a non-tensor is only reachable via the guarded path.
     assert "return None" in src
 
 
@@ -621,8 +599,7 @@ class _FakeLinearModule(torch.nn.Module):
 
 
 class _FakeGemma4Layer(torch.nn.Module):
-    # Minimal stand-in so hasattr(layer, "per_layer_input_gate") hits the new
-    # extraction branch without a real Gemma4 model.
+    # Stand-in so hasattr(layer, "per_layer_input_gate") hits the new extraction branch.
     def __init__(self, hidden=4):
         super().__init__()
         self.per_layer_input_gate = _FakeLinearModule(hidden, hidden)
@@ -630,9 +607,8 @@ class _FakeGemma4Layer(torch.nn.Module):
 
 
 def test_gemma4_per_layer_extraction_emits_state_dict_entries():
-    # Behavioral: a layer exposing per_layer_input_gate / per_layer_projection
-    # must populate state_dict with those paths for the reconstruction
-    # templates.
+    # per_layer_input_gate / per_layer_projection must reach state_dict for the
+    # reconstruction templates.
     state_dict = {}
 
     def fake_get_state_dict(prefix, kk, sd, module, slice_weights=True):
@@ -641,8 +617,7 @@ def test_gemma4_per_layer_extraction_emits_state_dict_entries():
     layer = _FakeGemma4Layer()
     kk = 0
     prefix = "model.language_model"
-    # Mirror the calls the fix adds in _get_vllm_state_dict to pin the emitted
-    # key shape without reproducing its full setup.
+    # Mirror the calls the fix adds in _get_vllm_state_dict to pin the emitted key shape.
     if hasattr(layer, "per_layer_input_gate"):
         fake_get_state_dict(
             f"{prefix}.layers.{kk}.per_layer_input_gate",
@@ -658,8 +633,7 @@ def test_gemma4_per_layer_extraction_emits_state_dict_entries():
 
 
 def test_set_additional_modules_loads_visual_merger_linear_fc():
-    # Regression: the "linear" filter dropped model.visual.merger.linear_fc1/2
-    # after they moved into non_layered_components; they must be restored.
+    # Regression: the "linear" filter dropped model.visual.merger.linear_fc1/2 once they moved into non_layered_components.
     from unsloth_zoo.empty_model import set_additional_modules
 
     class _LM(torch.nn.Module):
@@ -708,9 +682,8 @@ def test_set_additional_modules_loads_visual_merger_linear_fc():
 
 
 def test_get_vllm_state_dict_extracts_layernorm_when_layer_lacks_mlp():
-    # Regression: the early `continue` for layers without `mlp` ran before the
-    # layernorm loop, dropping input_layernorm.weight on linear-attn / MoE
-    # layers.
+    # Regression: the early `continue` for layers without `mlp` ran before the layernorm
+    # loop, dropping input_layernorm.weight on linear-attn / MoE layers.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils._get_vllm_state_dict)
     layernorm_idx = src.index('layer_config[\'layernorms\']')
@@ -722,9 +695,8 @@ def test_get_vllm_state_dict_extracts_layernorm_when_layer_lacks_mlp():
 
 
 def test_finalize_huggingface_model_dtype_propagates_to_replaced_live_config():
-    # Regression: copy_attributes can replace new_model.config with an object
-    # whose id() differs from the input config, so the id-keyed dtype reapply
-    # loop missed it; the fix also updates the live config tree.
+    # Regression: copy_attributes can replace new_model.config with an object whose id()
+    # differs from the input config, so the id-keyed dtype reapply loop missed it.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _LiveCfg:
@@ -751,9 +723,8 @@ def test_finalize_huggingface_model_dtype_propagates_to_replaced_live_config():
 
 
 def test_finalize_huggingface_model_vision_rotary_uses_identity_check():
-    # Regression: comparing the rotary config's __class__ against
-    # vision_config's class misfires when text and vision share a class. The
-    # identity check must not reroute a text rotary to vision_config.
+    # Regression: comparing the rotary config's __class__ against vision_config's class
+    # misfires when text and vision share a class.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _SharedCfg:
@@ -805,9 +776,8 @@ def test_finalize_huggingface_model_vision_rotary_uses_identity_check():
 
 
 def test_layer_scalar_keeps_buffer_registration_after_conversion():
-    # Regression: the `if layer_name in quant_state_dict` branch always wrapped
-    # the value in nn.Parameter, moving Gemma4 layer_scalar from _buffers to
-    # _parameters.
+    # Regression: the `if layer_name in quant_state_dict` branch always wrapped the value
+    # in nn.Parameter, moving Gemma4 layer_scalar from _buffers to _parameters.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
     assert "_buffers" in src
@@ -817,7 +787,6 @@ def test_layer_scalar_keeps_buffer_registration_after_conversion():
 def test_assert_same_state_dict_uses_tight_tolerance_for_same_dtype():
     # Regression: assert_same_state_dict applied atol=1e-4/rtol=1e-3
     # unconditionally, masking extraction errors on same-dtype non-FP8 weights.
-    # The relaxed tolerance must apply only to the dtype-mismatch / FP8 branch.
     from unsloth_zoo.vllm_utils import assert_same_state_dict
     a = torch.randn(8, 8, dtype=torch.float32)
     b = a.clone()
@@ -860,10 +829,9 @@ def test_get_model_layer_config_includes_gemma4_top_level_ple_modules():
 
 
 def test_finalize_non_gemma4_rotary_stays_fp32_through_to_dtype():
-    # Regression: the non-Gemma4 branch skipped float32 rotary restoration
-    # after new_model.to(dtype), downcasting inv_freq / original_inv_freq to
-    # bf16/fp16. Exercise the (quantization_config == {} and bnb_config is
-    # None) path so .to(dtype) runs.
+    # Regression: the non-Gemma4 branch skipped float32 rotary restoration after
+    # new_model.to(dtype), downcasting inv_freq / original_inv_freq to bf16/fp16.
+    # quantization_config == {} and bnb_config is None so .to(dtype) runs.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _Cfg:
@@ -906,10 +874,9 @@ def test_finalize_non_gemma4_rotary_stays_fp32_through_to_dtype():
 
 
 def test_finalize_tolerates_rotary_rebuild_failure_without_crashing():
-    # Regression: rotary_emb.__class__(config=..., device=...) can raise for
-    # Gemma4 multimodal rotary when copy_attributes drifts config identity.
-    # finalize must catch it, keep the existing rotary, and float32-lift its
-    # buffers.
+    # Regression: rotary_emb.__class__(config=..., device=...) can raise for Gemma4
+    # multimodal rotary when copy_attributes drifts config identity; finalize must catch
+    # it, keep the existing rotary, and float32-lift its buffers.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _BadCfg:
@@ -956,10 +923,8 @@ def test_finalize_tolerates_rotary_rebuild_failure_without_crashing():
 
 
 def test_finalize_routes_vision_tower_rotary_to_vision_config_by_module_path():
-    # Regression: id()-based routing drifted after copy_attributes, misrouting
-    # vision rotary through text_config. The fix adds a module-path fallback so
-    # a rotary under 'vision_tower' builds with vision_config when identity
-    # match fails.
+    # Regression: id()-based routing drifted after copy_attributes, misrouting vision
+    # rotary through text_config; a module-path fallback covers 'vision_tower'.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _TextCfg:
@@ -982,8 +947,7 @@ def test_finalize_routes_vision_tower_rotary_to_vision_config_by_module_path():
     class _Inner(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            # Unrelated config so id() match against top-level vision_config
-            # fails; the module-path fallback must take over.
+            # Unrelated config so the id() match fails and the path fallback takes over.
             self.rotary_emb = _Rotary(config=object())
 
     class _VisionTower(torch.nn.Module):
@@ -1014,9 +978,8 @@ def test_finalize_routes_vision_tower_rotary_to_vision_config_by_module_path():
 
 
 def test_extract_gdn_layers_dequantize_uses_unpacked_midpoint(monkeypatch):
-    # Regression: `mid = ba_weight.shape[0] // 2` was computed on the packed
-    # uint8 buffer then reused to slice the dequantized full tensor (shape[0] =
-    # out_features); when they differ, in_proj_b/a got wrong rows.
+    # Regression: `mid = ba_weight.shape[0] // 2` was computed on the packed uint8 buffer
+    # then reused to slice the dequantized tensor, giving in_proj_b/a the wrong rows.
     from unsloth_zoo.empty_model import extract_gdn_layers
 
     class _PlainProj(torch.nn.Module):
@@ -1070,28 +1033,15 @@ def test_extract_gdn_layers_dequantize_uses_unpacked_midpoint(monkeypatch):
             )
             self.out_proj = _PlainProj(self.hidden_size, self.value_dim)
 
-    # monkeypatch.setitem, not a bare assignment: these entries have to come back
-    # out of sys.modules when the test ends.
-    #
-    # The stub carries dequantize_4bit and nothing else, so while it is installed
-    # `from bitsandbytes.functional import QuantState` fails with "cannot import
-    # name 'QuantState' from 'bitsandbytes.functional' (unknown location)" -- the
-    # "unknown location" being this module having no file behind it. That is
-    # precisely what unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py:735 does at
-    # import time, so leaving the stub in place breaks every later test that
-    # reaches it, in a process that has already left this file.
-    #
-    # Serially that never showed: this file sorts after
-    # test_moe_bnb4bit_per_expert_conversions.py, so the victim always ran first.
-    # Under pytest-xdist a worker can take them in the other order, and six tests
-    # there failed with that ImportError while the same run passed serially. The
-    # order was the trigger; the missing cleanup was the bug.
-    #
-    # The vllm stubs further down this file already save and restore. This one was
-    # the exception, not the convention.
-    # setdefault leaked too, in the case where it does anything: on a runner without
-    # bitsandbytes it inserted a bare parent module and left it there, which shadows
-    # the real package for anything that installs later in the same process.
+    # monkeypatch.setitem, not a bare assignment: these entries have to come back out of
+    # sys.modules when the test ends. The stub carries dequantize_4bit and nothing else,
+    # so while it is installed `from bitsandbytes.functional import QuantState` fails with
+    # "cannot import name 'QuantState' from 'bitsandbytes.functional' (unknown location)",
+    # which is what temporary_patches/moe_utils_bnb4bit.py:735 does at import time: six
+    # tests in test_moe_bnb4bit_per_expert_conversions.py failed that way under
+    # pytest-xdist while passing serially, since this file sorts after them.
+    # setdefault leaked too: on a runner without bitsandbytes it inserted a bare parent
+    # module that shadows the real package for anything installed later in the process.
     if "bitsandbytes" not in sys.modules:
         monkeypatch.setitem(sys.modules, "bitsandbytes", types.ModuleType("bitsandbytes"))
     bnb = sys.modules["bitsandbytes"]
@@ -1122,7 +1072,6 @@ def test_lm_head_lookup_uses_exact_name_not_substring():
     src = inspect.getsource(vllm_utils._get_vllm_state_dict)
     assert 'name == "lm_head"' in src
     assert 'name.endswith(".lm_head")' in src
-    # Loose substring test must not be present.
     assert '"lm_head" in name' not in src
 
 
@@ -1145,10 +1094,8 @@ def test_convert_regex_handles_trailing_digit_parameter_paths():
 
 
 def test_convert_vllm_to_huggingface_uses_robust_bracket_regex():
-    # The Parameter-assignment path must use the anchor-or-end regex so keys
-    # ending in `.DIGIT` get bracketed. Anchor on the bracketing code (first
-    # occurrence is this branch), not a comment, so the check survives reworded
-    # comments.
+    # The Parameter-assignment path must use the anchor-or-end regex so keys ending in
+    # `.DIGIT` get bracketed. Anchor on the bracketing code, not a comment.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
     assert r'r"\.([\d]+)(?=\.|$)"' in src
@@ -1235,10 +1182,9 @@ def test_load_vllm_routes_gemma4_gate_through_helper():
 
 
 def test_load_vllm_gemma4_patch_runs_after_bnb_autodetect():
-    # Regression: the Gemma4 k_eq_v patch was gated on caller-provided
-    # `use_bitsandbytes` before model-name/quant_method autodetect, so
-    # `-bnb-4bit` models with use_bitsandbytes=False skipped it; the fix moves
-    # the gate below autodetect.
+    # Regression: the Gemma4 k_eq_v patch was gated on caller-provided `use_bitsandbytes`
+    # before model-name/quant_method autodetect, so `-bnb-4bit` models with
+    # use_bitsandbytes=False skipped it.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.load_vllm)
     autodetect_anchor = "use_bitsandbytes = use_bitsandbytes or"
@@ -1272,9 +1218,8 @@ def test_gemma4_bnb_skip_module_aliases_cover_vllm_text_prefixes():
 
 
 def test_patch_gemma4_vllm_lora_support_preserves_embedding_modules():
-    # Regression: `cls.embedding_modules = {}` clobbered the vLLM class's
-    # existing embedding registry (used to route adapters to embedding layers);
-    # the fix guards the assignment to run only when the attribute is absent.
+    # Regression: `cls.embedding_modules = {}` clobbered the vLLM class's existing
+    # embedding registry, which routes adapters to embedding layers.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
     assert 'if not hasattr(cls, "embedding_modules"):' in src
@@ -1287,8 +1232,7 @@ def test_patch_gemma4_vllm_lora_support_preserves_embedding_modules():
 
 def test_patch_gemma4_vllm_lora_support_guards_gemma4_mm_import():
     # Regression: a hard `from vllm...gemma4_mm import ...` crashed with
-    # ModuleNotFoundError on text-only Gemma4 vLLM builds; the fix wraps each
-    # class import in try/except.
+    # ModuleNotFoundError on text-only Gemma4 vLLM builds.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
     mm_line = "from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration"
@@ -1301,9 +1245,8 @@ def test_patch_gemma4_vllm_lora_support_guards_gemma4_mm_import():
 
 
 def test_patch_gemma4_vllm_k_eq_v_support_guards_private_loader_attr():
-    # Regression: hasattr(BitsAndBytesModelLoader._stack_quantization_states,
-    # ...) raised AttributeError when the private method was renamed/absent;
-    # the fix routes through getattr with a None default.
+    # Regression: hasattr(BitsAndBytesModelLoader._stack_quantization_states, ...) raised
+    # AttributeError when the private method was renamed or absent.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
     assert 'getattr(\n        BitsAndBytesModelLoader, "_stack_quantization_states", None' in src \
@@ -1312,9 +1255,8 @@ def test_patch_gemma4_vllm_k_eq_v_support_guards_private_loader_attr():
 
 
 def test_patch_gemma4_vllm_k_eq_v_support_searches_hf_style_prefix():
-    # Regression: _get_gemma4_k_eq_v_pairs searched only
-    # ("language_model.model", "model"), missing HF-style model.language_model
-    # for multimodal Gemma4.
+    # Regression: _get_gemma4_k_eq_v_pairs searched only ("language_model.model", "model"),
+    # missing HF-style model.language_model for multimodal Gemma4.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
     assert '"model.language_model"' in src
@@ -1356,7 +1298,6 @@ def test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes():
     for name, mod in stub_packages.items():
         saved[name] = _sys.modules.get(name)
         _sys.modules[name] = mod
-    # Ensure neither gemma4 nor gemma4_mm submodules resolve.
     for missing in (
         "vllm.model_executor.models.gemma4",
         "vllm.model_executor.models.gemma4_mm",
@@ -1365,17 +1306,15 @@ def test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes():
     ):
         saved[missing] = _sys.modules.get(missing)
         _sys.modules[missing] = None
-    # Evict any cached copy so the no-classes path is exercised against a
-    # fresh import regardless of test order. vllm_lora_worker_manager needs
-    # vllm.config (not stubbed here), which only resolves on a real vllm
-    # install; the early return must not pull it in.
+    # Evict any cached copy so the no-classes path runs against a fresh import regardless
+    # of test order. vllm_lora_worker_manager needs vllm.config (not stubbed here), which
+    # only resolves on a real vllm install; the early return must not pull it in.
     saved_worker_manager = _sys.modules.pop(
         "unsloth_zoo.vllm_lora_worker_manager", None
     )
     try:
         # Must not raise when no gemma4 class is importable.
         empty_model.patch_gemma4_vllm_lora_support()
-        # fake create_lora_manager must be left in place.
         assert stub_packages["vllm.lora.model_manager"].create_lora_manager is fake_create
     finally:
         for name, prev in saved.items():


### PR DESCRIPTION
Trims restating and boilerplate comments across 71 files in `tests/`, the first batch of a comment reduction pass over this repo. Net 771 comment lines removed.

## What was kept

The dominant comment register here is evidence, not description, so the rule applied was: the sentence that names the failure mode or the model survives, the sentence that restates the code goes. Explicitly preserved:

- named failure modes ("would silently train on nothing", "crashes on first forward", "rather than iterating its characters")
- model, version and platform names (Gemma-4, Falcon-H1, Qwen2-MoE, transformers 5.10-5.14, mlx-vlm 0.6.4, macos-14)
- measured numbers and literals (`atol=1e-4, rtol=1e-3`, the 2 GB xet-core default, `0600` / umask `0002`, `HIDDEN = 1152`, `2300 * 33.94 = 78k > 65504`)
- upstream references (`unslothai/unsloth-zoo#1122`, `unsloth#6273`, `vllm/v1/worker/utils.py request_memory`, `compiler.py:66-67`)
- aligned mini-tables and the legends that make bare tuples readable, for example the `(B, T, Hk, Hv, Dk, Dv, dtype, tol, vectorized)` key in `test_mlx_gated_delta_vjp.py`
- every functional comment: `# noqa`, `# pragma: no cover`, `# type: ignore`
- all 15 line licence headers, byte for byte

A review pass over the full diff restored 73 comments that the first pass cut too far, mostly cases where a comment had been truncated mid-sentence and left a fragment with no subject. Those are fixed here rather than in a follow-up.

## Verification against main

- **No code changes.** For all 71 files the non-comment token stream is byte-identical to main. This is stronger than an AST comparison: it also proves no `#` inside a string literal was altered, which matters because several tests use commented source as fixture data.
- **Comment-only diff**, via the in-repo `scripts/verify_comment_only_diff.py`: 71/71 OK.
- **Codegen unchanged**, 96 files, no rewriter in `compiler.py` changes its decision. This repo rewrites Python source text at runtime, and several finders anchor on consecutive lines, so a comment sitting between them suppresses a rewrite and deleting it turns the rewrite on. That change is invisible to an AST diff.
- **Comment sentinels intact**: the `vllm_utils.py` `# LM Head` slice anchor and the 800 character window after it, the PrefixGrouper anchor whose slice is `exec`d, the mlx fp16 phrase asserted by a hard-gated test, `_AITER_MARKER`, `_full_license_header`, and the versioning header whose line count is parsed positionally.
- **Licence headers** byte-identical in all 50 files that carry one.
- **Lint**: `ruff check` and `ruff format --check` produce identical results to main; the narrow CI gate (`E9,F63,F7,F82`) and `compileall` are clean.

## Tests

- `tests/security` (hard gate): 156 passed
- bulk suite: 4877 passed, 105 skipped
- mlx files, one process each since the shim replaces `sys.modules["mlx.core"]` process-wide: 222 passed, 49 skipped

`test_rl_replacements_compile_disable.py` reports 4 failures. That file is byte-identical to main and the same 4 failures reproduce on a clean main checkout, so they are unrelated to this change.