### PR TITLE
Reduce comment volume in unsloth_zoo/mlx/

### DIFF
--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -1940,7 +1940,6 @@ def _install_safe_fused_sdpa_mask_patches():
 
         out = original_fast_sdpa(q, k, v, scale=scale, mask=mask, **kwargs)
         if row_all_masked is not None:
-            # Restore zero-output for fully masked query rows.
             out = mx.where(
                 mx.expand_dims(row_all_masked, axis=-1),
                 mx.zeros_like(out),

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -1932,14 +1932,14 @@ def _fix_gemma4_kv_sharing(model):
     first_shared = getattr(backbone, "first_kv_shared_layer_idx", None)
     num_layers = getattr(backbone, "num_hidden_layers", None)
     if first_shared is None or num_layers is None or first_shared >= num_layers:
-        return  # No shared layers
+        return
 
     if _gemma4_has_native_shared_kv(backbone):
         return  # Native mlx-vlm shared_kv support
 
     cls = backbone.__class__
     if getattr(cls, "_kv_sharing_patched", False):
-        return  # Already patched
+        return
 
     original_call = cls.__call__
 
@@ -1987,7 +1987,6 @@ def _fix_qwen35_attention_cache(model):
     original_attn_call = attn_cls.__call__
 
     def patched_attn_call(self, x, mask=None, cache=None, position_ids=None, **kwargs):
-        # Compute position_ids when training (cache=None, position_ids=None).
         if cache is None and position_ids is None:
             import mlx.core as mx
             L = x.shape[1]
@@ -3321,9 +3320,7 @@ def _patch_mixed_precision_set_dtype(model):
     model._unsloth_mixed_precision_set_dtype_patched = True
 
 
-# ---------------------------------------------------------------------------
 # VLM prompt/template compatibility patches
-# ---------------------------------------------------------------------------
 _vlm_prompt_utils_patched = False
 _original_vlm_apply_chat_template = None
 
@@ -6441,9 +6438,8 @@ def _lora_walk_module(
                     if name == "":
                         setattr(model, attr_name, lora_layer)
                         continue
-                    # Navigate to parent and replace. The final segment can
-                    # be a numeric string (list index) for some VLM trees
-                    # like Qwen2.5-VL's vision merger.
+                    # The final segment can be a numeric string (list index)
+                    # for some VLM trees like Qwen2.5-VL's vision merger.
                     parts = name.split(".")
                     parent = root
                     for p in parts[:-1]:
@@ -7560,7 +7556,6 @@ class FastMLXModel:
 
         model_type = config_data.get("model_type", "")
 
-        # Route based on text_only.
         is_vlm = False
         force_vlm_text_path = bool(
             text_only is True and _prefer_vlm_loader_for_text(config_data, model_type)
@@ -8099,7 +8094,6 @@ class FastMLXModel:
         is_vlm = getattr(model, "_is_vlm_model", False)
 
         if is_vlm:
-            # Freeze everything, then apply LoRA selectively.
             _fix_missing_no_grad(model)
             _fix_gemma4_kv_sharing(model)
             model.freeze()
@@ -8110,7 +8104,6 @@ class FastMLXModel:
                 p[len("language_model."):] if p.startswith("language_model.") else p
                 for p in _cpt_lm_head_keys
             }
-            # LoRA the language model (filtered by target_modules).
             language_lora_count = 0
             if (finetune_language_layers and (
                 target_modules is None or (isinstance(target_modules, list) and len(target_modules) > 0)
@@ -8139,7 +8132,6 @@ class FastMLXModel:
                         config={**lora_config, "keys": language_lora_keys},
                     )
 
-            # Optionally LoRA the vision tower.
             vision_lora_count = 0
             if train_vision:
                 vision_lora_count = _lora_walk_module(
@@ -8149,9 +8141,8 @@ class FastMLXModel:
                     attr_names=("vision_tower", "vision_model", "vision_encoder"),
                 )
 
-            # Optionally LoRA the projector/connector. LoRA beats unfreezing
-            # raw weights since many projectors are QuantizedLinear and MLX
-            # can't backprop into quantized weights.
+            # LoRA beats unfreezing raw weights since many projectors are
+            # QuantizedLinear and MLX can't backprop into quantized weights.
             projector_lora_count = 0
             if train_projector:
                 projector_lora_count = _lora_walk_module(
@@ -8191,9 +8182,7 @@ class FastMLXModel:
                     )
                 _raise_no_lora_targets(target_modules)
 
-            # Unfreeze all LoRA params across the tree.
             model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
-            # CPT full modules (embed_tokens / lm_head weight).
             _unfreeze_full_modules(_cpt_full_specs)
         else:
             # Text-only path. _fix_missing_no_grad handles modules using

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2031,7 +2031,6 @@ class MLXTrainer:
         self._mlx_train_dataset_for_batches = train_dataset
         self.eval_dataset = eval_dataset
         self.formatting_func = formatting_func
-        # Use args or defaults
         self.args = args or self.config_class()
         if self.preference_kind and not isinstance(self.args, self.config_class):
             raise TypeError(
@@ -2045,10 +2044,8 @@ class MLXTrainer:
             self.args = copy.copy(self.args)
         self.args.greater_is_better = _resolve_greater_is_better(self.args)
 
-        # Auto-detect VLM
         self._is_vlm = _is_vlm_model(model)
 
-        # Constructor params override args if provided
         if dataset_text_field is not None:
             self.args.dataset_text_field = dataset_text_field
         if max_seq_length is not None:
@@ -4706,7 +4703,6 @@ class MLXTrainer:
                         "compiled signature. Use a finite dataset, or train "
                         "with compile disabled or in best-effort mode."
                     )
-                # No plan to survey: peek one batch, chained back.
                 stream_carries_audio, batch_iter = (
                     self._peek_stream_carries_audio(batch_iter)
                 )
@@ -4847,7 +4843,6 @@ class MLXTrainer:
                     batches, batch_iter, total_steps, report, compile_allowed,
                 )
 
-            # (memory limits already applied above; just log what we configured)
             if self._memory_limits_applied:
                 parts = []
                 if "memory_limit_gb" in self._memory_limits_applied:
@@ -4867,7 +4862,6 @@ class MLXTrainer:
                     f"({', '.join(parts)})."
                 )
 
-            # Apply gradient checkpointing if requested
             if args.gradient_checkpointing:
                 apply_gradient_checkpointing(model)
                 _main_print("Unsloth: Using gradient checkpointing to reduce memory.")
@@ -4964,7 +4958,6 @@ class MLXTrainer:
                     _module.fused_apply = True
                 except Exception:
                     pass
-            # Restore Qwen3-VL vision-block flag to its pre-train value.
             try:
                 from . import compile as _mlx_compile
                 _mlx_compile.set_qwen3_vision_norm_cast_output(
@@ -5234,7 +5227,6 @@ class MLXTrainer:
                     f"({', '.join(frozen_audio)})."
                 )
 
-        # Build optimizer with LR schedule
         optimizer = self._build_optimizer(total_steps)
 
         # Resume: adapters were already loaded into the model before train(), so
@@ -5447,7 +5439,6 @@ class MLXTrainer:
         # Build loss+grad function — returns ((loss, ntoks), grads)
         loss_and_grad_fn = nn.value_and_grad(model, loss_fn)
 
-        # Per-group learning rates (LoRA+, embedding LR) via post-update rescale
         lora_plus_ratio = args.lora_plus_ratio
         use_lora_plus = lora_plus_ratio > 0
         if use_lora_plus:
@@ -5455,7 +5446,6 @@ class MLXTrainer:
 
         embedding_lr = args.embedding_learning_rate
         main_lr = args.learning_rate
-        # Ratio < 1 slows embeddings down; 0 = disabled
         use_embedding_lr = embedding_lr > 0 and main_lr > 0
         embedding_lr_ratio = embedding_lr / main_lr if use_embedding_lr else 1.0
         if use_embedding_lr:
@@ -5527,10 +5517,6 @@ class MLXTrainer:
                 updates.append((name, pre + r * (post - pre)))
             model.update(tree_unflatten(updates))
 
-        # Build step functions following mlx-lm's pattern. `max_grad_value`
-        # remains an elementwise clamp. MLX's cheap default is now the clearer
-        # `max_grad_leaf_norm`, a proportional per-leaf norm cap that avoids
-        # global norm clipping's cross-tree memory overhead.
         (
             max_grad_norm,
             max_grad_value,
@@ -5938,7 +5924,6 @@ class MLXTrainer:
         if _ddp_update_outside_step and not _ddp_compile_local_grad:
             step_fn = _ddp_eager_local_step_fn
 
-        # Prepare eval batches
         eval_batches = None
         # (split_name, prompt_text, prompt_token_ids), filled by the plan
         # builder's own pass so the eval dataset is never read twice.
@@ -6030,7 +6015,6 @@ class MLXTrainer:
                 getattr(args, "per_device_eval_batch_size", None)
                 or args.per_device_train_batch_size
             )
-            # Use pre-built labeled eval batches if available
             _labeled_eval = getattr(self, '_eval_batches_labeled', None)
             if _labeled_eval is not None:
                 eval_batches = _labeled_eval
@@ -6256,7 +6240,6 @@ class MLXTrainer:
                     f"  - {rec.setting}={rec.recommended_value!r}: {rec.reason}"
                 )
 
-        # Training loop — mlx-lm pattern
         model.train()
         # HF's include_num_input_tokens_seen gate: "no"/False (its default, and the
         # one _ensure_callback_args_compat applies) skips input-token counting
@@ -7193,7 +7176,6 @@ class MLXTrainer:
 
             tic = time.perf_counter()
 
-            # Get next batch
             batch_error = None
             batch_data = None
             try:
@@ -7463,7 +7445,6 @@ class MLXTrainer:
                 train_time += pending_time
                 pending_time = 0
 
-            # Only log/eval on actual optimizer steps
             if not do_update:
                 accum_progress += 1
                 _fire("on_substep_end")
@@ -7591,9 +7572,6 @@ class MLXTrainer:
             if should_log:
                 _run_training_log(current_step, grad_norm)
 
-            # Eval (cadence or a synced callback request). _run_eval builds eval
-            # batches lazily on every rank, runs the collective eval, then fires
-            # on_evaluate on rank 0 and syncs any stop before best tracking.
             # The static cadence mirrors DefaultFlowCallback's step-strategy
             # rule (strategy is STEPS, on a multiple of eval_steps, past
             # eval_delay); an explicit callback request stays independent of
@@ -7714,8 +7692,6 @@ class MLXTrainer:
                 sum(self._train_loss_history) / len(self._train_loss_history)
                 if self._train_loss_history else 0.0
             )
-        # Total wall-clock training time, consumed by the summary line and the
-        # distributed diagnostics / train_runtime metrics below.
         total_time = time.perf_counter() - start_time
 
         # Report the step actually reached, which is < total_steps after an
@@ -8490,7 +8466,6 @@ class MLXTrainer:
                     self.model, "_unsloth_quantized_source", None,
                 ),
             }
-            # Always emit num_layers for mlx-lm.load_adapters() attr-access.
             adapter_config["num_layers"] = _num_layers
             if _lora_rank is not None:
                 adapter_config["lora_parameters"] = {
@@ -8614,7 +8589,6 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
     pad_id = getattr(tokenizer, "pad_token_id", None)
     pad_id = 0 if pad_id is None else int(pad_id)
 
-    # 1. Gather all text strings (serial, fast)
     all_texts = []
     for item in dataset:
         if formatting_func is not None:
@@ -8761,7 +8735,6 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
         if cycle_length is None and len(epoch_schedule) > 0:
             cycle_length = len(epoch_schedule)
 
-    # Limit if needed
     if num_batches is not None and len(schedule) > num_batches:
         schedule = schedule[:num_batches]
         widths = widths[:num_batches]
@@ -9024,7 +8997,6 @@ def train_on_responses_only(
         train_on_responses_only as _hf_train_on_responses_only,
     )
 
-    # Resolve tokenizer: kwarg > trainer.tokenizer
     _source = tokenizer
     if _source is None and trainer is not None:
         _source = trainer.tokenizer
@@ -9034,7 +9006,6 @@ def train_on_responses_only(
             "kwarg or via trainer.tokenizer."
         )
 
-    # Callable HF tokenizer for token matching and text batch encoding.
     _tokenizer = _resolve_response_mask_tokenizer(_source)
     _lazy_text_eval = False
     eval_dataset = getattr(trainer, "eval_dataset", None)
@@ -9076,7 +9047,6 @@ def train_on_responses_only(
     else:
         _detect_source = _tokenizer
 
-    # Get masking closure from the HF/CUDA implementation
     mask_fn = _hf_train_on_responses_only(
         None,
         instruction_part=instruction_part,
@@ -9098,7 +9068,6 @@ def train_on_responses_only(
         )
 
     if trainer._is_vlm:
-        # VLM path: store mask_fn for application during batch creation
         trainer._vlm_response_mask_fn = mask_fn
         print("Unsloth: train_on_responses_only enabled (VLM mode).")
     else:
@@ -9135,7 +9104,6 @@ def train_on_responses_only(
             print("Unsloth: train_on_responses_only enabled (lazy text mode).")
             return trainer
 
-        # Eager/sized text path: tokenize, mask, and create batches now.
         total_batches_needed = (
             args.max_steps * args.gradient_accumulation_steps
             if args.max_steps > 0 else None

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2216,10 +2216,6 @@ def make_baseline_loss_fn(label_smoothing=0.0):
     return loss_fn
 
 
-# ---------------------------------------------------------------------------
-# VLM helpers
-# ---------------------------------------------------------------------------
-
 # Image/vision/audio special tokens that should never contribute to loss.
 # Single source of truth shared with the CUDA collator (unsloth_zoo/vlm_tokens.py),
 # so the two backends cannot drift apart.
@@ -2800,7 +2796,6 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
             # Vision token injection can change seq length
             logits, targets = _align_logits_with_labels(logits, targets)
 
-            # Build mask from attention_mask (shifted to match targets)
             if attention_mask is not None:
                 length_mask = attention_mask[:, 1:]
                 length_mask = length_mask[:, :targets.shape[1]]
@@ -2809,7 +2804,6 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
 
             targets = _mask_image_tokens(targets, _image_token_ids)
             targets = _mask_prompt_tokens(targets, _assistant_token_id)
-            # Exclude masked positions from length_mask
             mask = mx.where(
                 targets == -100,
                 mx.array(0, dtype=length_mask.dtype),
@@ -3013,7 +3007,6 @@ def _vlm_cce_forward(model, batch_dict, image_token_ids=None,
         masked_targets = mx.where(length_mask, targets, ignore)
 
         masked_targets = _mask_image_tokens(masked_targets, image_token_ids)
-        # Completion-only: mask prompt before first assistant response
         masked_targets = _mask_prompt_tokens(masked_targets, assistant_token_id)
 
         ntoks = (masked_targets != -100).sum()
@@ -12460,7 +12453,6 @@ class _LazyTextPrefetcher:
         self._lifecycle_lock = threading.Lock()
         self._close_lock = threading.Lock()
 
-    # -- producer side ----------------------------------------------------
     def _run(self):
         iterator = None
         try:
@@ -12529,7 +12521,6 @@ class _LazyTextPrefetcher:
             if self._closed or self._stop.is_set():
                 raise StopIteration
 
-    # -- consumer side ----------------------------------------------------
     def __iter__(self):
         return self
 
@@ -12553,7 +12544,6 @@ class _LazyTextPrefetcher:
             raise StopIteration
         raise payload
 
-    # -- lifecycle --------------------------------------------------------
     def quiesce(self):
         """RUNNING -> PAUSE_REQUESTED -> QUIESCENT; bounded, actionable."""
         if self._thread is None or not self._thread.is_alive():
@@ -14342,7 +14332,6 @@ def _enrich_mlx_adapter_config(model, adapter_config):
                 )
                 lora_dropout = _read_mlx_lora_dropout(module)
 
-        # Auto-fill only when the caller did not supply the key.
         if lora_paths and not has_explicit_paths:
             adapter_config["unsloth_mlx_lora_module_paths"] = lora_paths
 
@@ -14475,7 +14464,6 @@ def _get_model_config(model):
     """
     import dataclasses
 
-    # Prefer the raw config dict stashed by our loader
     if hasattr(model, "_config") and isinstance(model._config, dict):
         return _config_to_plain_python(model._config)
 
@@ -14490,7 +14478,6 @@ def _get_model_config(model):
             if isinstance(config, dict):
                 return _config_to_plain_python(config)
 
-    # Reconstruct from the ModelArgs dataclass
     if hasattr(model, "args"):
         if dataclasses.is_dataclass(model.args) and not isinstance(model.args, type):
             return _config_to_plain_python(model.args)
@@ -16694,7 +16681,6 @@ def save_merged_model(model, tokenizer, path, dequantize=False):
     # Save sharded safetensors + index.json
     save_model(path, de_lora_model, donate_model=False)
 
-    # Save config.json
     config = _get_model_config(model)
     if config:
         is_vlm = _is_vlm_model(model) or _has_vision_config(config)
@@ -16704,14 +16690,12 @@ def save_merged_model(model, tokenizer, path, dequantize=False):
             is_vlm=is_vlm,
         )
 
-    # Save tokenizer
     tokenizer.save_pretrained(str(path))
 
     src_path = _get_src_path(model)
     if src_path is not None:
         _copy_source_sidecars(src_path, path)
 
-    # Model card
     hf_repo = getattr(model, "_hf_repo", None)
     try:
         create_model_card(path, hf_repo)
@@ -17173,7 +17157,6 @@ def _install_llama_cpp_macos(llama_cpp_folder=None):
         "llama.cpp cmake build",
     )
 
-    # Copy binaries to llama.cpp root
     bin_dir = os.path.join(build_dir, "bin")
     if os.path.exists(bin_dir):
         import glob as globmod
@@ -17317,7 +17300,6 @@ def save_pretrained_gguf(
         _download_convert_hf_to_gguf,
     )
 
-    # Map friendly names to llama.cpp quant types
     quant_map = {
         "not_quantized": "bf16",
         "fast_quantized": "q8_0",
@@ -17395,7 +17377,6 @@ def save_pretrained_gguf(
             "torch is only needed for GGUF export, not for training."
         )
 
-    # Step 1: Save merged model to a temp HF-format directory
     with tempfile.TemporaryDirectory() as tmp_dir:
         # Before the merge so a bad path fails in seconds, and outside save_directory so the
         # result is never mistaken for an exported model.
@@ -17435,7 +17416,6 @@ def save_pretrained_gguf(
         if _config_path.exists():
             _cfg = json.loads(_config_path.read_text())
             _changed = False
-            # Restore architectures from the original HF config
             if "architectures" not in _cfg:
                 _orig_cfg_path = getattr(tokenizer, "name_or_path", None)
                 if _orig_cfg_path:
@@ -17448,7 +17428,6 @@ def save_pretrained_gguf(
             if _changed:
                 _config_path.write_text(json.dumps(_cfg, indent=2))
 
-        # Step 2: Ensure llama.cpp is installed.
         llama_cpp_folder = LLAMA_CPP_DEFAULT_DIR
         try:
             quantizer_location, converter_location = check_llama_cpp(llama_cpp_folder)
@@ -17486,7 +17465,6 @@ def save_pretrained_gguf(
                 quantizer_location, converter_location = check_llama_cpp(llama_cpp_folder)
         llama_cpp_folder = os.path.dirname(converter_location)
 
-        # Step 3: Download and patch convert_hf_to_gguf.py.
         # why: always go through the wrapper so UNSLOTH_LLAMA_CPP_SCRIPTS_DIR
         # is honored even when a cached converter file exists.
         converter = os.path.join(llama_cpp_folder, "unsloth_convert_hf_to_gguf.py")
@@ -17508,7 +17486,6 @@ def save_pretrained_gguf(
         elif isinstance(result, str):
             converter = result
 
-        # Step 4: Get model name for output filename
         hf_repo = getattr(model, "_hf_repo", None)
         if hf_repo:
             model_name = hf_repo.split("/")[-1]
@@ -17517,7 +17494,6 @@ def save_pretrained_gguf(
 
         output_base = str(save_directory / model_name)
 
-        # Step 5: Convert HF -> GGUF
         print(f"Unsloth: Converting to GGUF format...")
         kwargs = dict(
             model_name=output_base,
@@ -17550,7 +17526,6 @@ def save_pretrained_gguf(
                 else:
                     os.environ["PYTHONPATH"] = original_pythonpath
 
-        # Step 6: Quantize if the target quant differs from first_conversion
         if quant_type not in ("bf16", "f16", "f32") and first_conversion != quant_type:
             quantizer = quantizer_location
             if not produced_files:
@@ -17580,7 +17555,6 @@ def save_pretrained_gguf(
                 os.remove(stale)
                 print(f"Unsloth: Removed intermediate {Path(stale).name}")
 
-    # List produced files
     gguf_files = _exported_gguf_files(save_directory, imatrix_source)
     for f in gguf_files:
         size_gb = f.stat().st_size / (1024**3)
@@ -17625,7 +17599,6 @@ def push_to_hub_merged(
 
     save_directory = Path(save_directory)
 
-    # Save first if not already saved
     if not (save_directory / "model.safetensors.index.json").exists():
         save_merged_model(model, tokenizer, save_directory)
 
@@ -17763,7 +17736,6 @@ def push_to_hub_gguf(
 
     save_directory = Path(save_directory)
 
-    # Export to GGUF
     save_pretrained_gguf(
         model,
         tokenizer,
@@ -17774,7 +17746,6 @@ def push_to_hub_gguf(
         imatrix_file=imatrix_file,
     )
 
-    # Upload GGUF files
     api = HfApi(token=token)
     # Same fail-loud private=True rule as the LoRA / merged paths so a
     # private=True request never silently leaks GGUF shards public.


### PR DESCRIPTION
Second batch of the comment reduction pass, after #1156 which covers `tests/`. This one touches shipping code, so it is deliberately much smaller: 73 comment lines across 4 files.

## Why the yield is low

`unsloth_zoo/mlx/` is already written to the standard this pass is trying to enforce. I swept all 2981 comment lines in the package and nearly every one names a failure mode, an upstream version, a measured number or a model, which is exactly the material worth keeping. Six of the ten files had nothing worth cutting and are untouched.

What did come out is concentrated in one place: the GGUF export tail of `utils.py`, which carries `Step 1` through `Step 6` scaffolding and block labels like `# Save tokenizer`, `# Save config.json`, `# Model card`. That style does not appear anywhere else in the package.

The rest are comments that narrate the following statement, for example `# Route based on text_only.` above `is_vlm = False`, `# Get next batch`, `# Freeze everything, then apply LoRA selectively.`

## One removal is a correctness fix

At the eval-cadence site in `trainer.py` a comment said `_run_eval` builds eval batches lazily on every rank, "then fires `on_evaluate` on rank 0". `_fire` now dispatches on every rank, so the comment described behaviour the code no longer has. Anyone debugging multi-rank eval would have been misled by it. The HF-parity half of that block, covering `DefaultFlowCallback` step strategy and `eval_delay`, is kept.

## What was kept

- the mlx-vlm 0.4.4 through 0.6.10 per-family audio qualification block, including the re-upload that invalidated the old 0.4.4 key and the macos-14 measurement
- the `gather_qmm` guard citing `ml-explore/mlx#3887`, `#3856` and `#3922`
- epoch and step arithmetic worked out with numbers, for example "1.5 epochs of 3 at accum 2 is 2 + 1 = 3 updates"
- the three `do NOT latch a callback should_training_stop here` blocks: each names a different same-step action that would be corrupted, so none is a duplicate
- named silent-corruption paths, for example "the stale columns stay attended, so nothing downstream objects" and "fp16 cannot represent token counts >= 65520"
- every inline comment, all 49 in `utils.py` included: each is a legend, a value note or a why
- all 23 commented-out call-shaped lines across these files

## Verification against main

- **No code changes.** For all 4 files the non-comment token stream is byte-identical to main. That is stronger than an AST comparison: it also proves nothing inside a string literal moved.
- **Comment-only diff**, via the in-repo `scripts/verify_comment_only_diff.py`: 4/4 OK.
- **Codegen unchanged**, 96 files, no rewriter in `compiler.py` changes its decision. This matters more here than in `tests/`. Several finders anchor on consecutive lines and are not comment tolerant, so a comment between the anchored lines suppresses a rewrite today and deleting it turns the rewrite on. An AST diff cannot see that, because the source really did only change in its comments.
- **33 comment-dependent test assertions still resolve.** Each is a string literal a test asserts against this module's source which occurs only inside a comment, for example `linear_fc1 (up-projection) overflows fp16` in `compile.py`. Reflowing one of those onto two lines fails a hard-gated test with every word retained, so none of them were reworded or rewrapped.
- **Licence headers** byte-identical in all 4 files, and blank-line runs are back at parity with main after removing a banner.
- **Lint**: narrow CI gate (`E9,F63,F7,F82`) clean on all 4 files, `compileall` clean, both dynamic-execution linters clean.

## Tests

- mlx suite run one process per file, since `tests/mlx_simulation/` replaces `sys.modules["mlx.core"]` process-wide: **51 files, 848 passed, 172 skipped**, identical to main file by file
- `tests/security` (hard gate): 156 passed

Worth noting that a number of the mlx files are Metal gated and skip wholesale on Linux, so the macOS CI leg is the real signal for those paths rather than a local run.