### PR TITLE
Reduce comment volume in the rest of tests/

### DIFF
--- a/tests/_merge_e2e_helpers.py
+++ b/tests/_merge_e2e_helpers.py
@@ -252,7 +252,6 @@ def assert_merge_correct_model_space(*, family, base_dir, out_dir,
         f"-{sorted(set(base_p) - set(merged_p))[:4]})"
     )
 
-    # map each adapted key onto its parameter name (usually identical)
     resolved: dict[str, _Adapted] = {}
     for ak, a in adapted.items():
         if ak in base_p:
@@ -301,7 +300,6 @@ def assert_merge_correct(*, family, base_tensors, out_dir, save_dtype,
     assert merged, f"[{family}] no safetensors written to {out_dir}"
     base_keys = set(base_tensors.keys())
 
-    # no adapter remnants leaked
     leaked = [k for k in merged if any(m in k for m in _LORA_REMNANT_MARKERS)]
     assert not leaked, f"[{family}] adapter remnants in merged output: {leaked[:5]}"
 
@@ -320,7 +318,6 @@ def assert_merge_correct(*, family, base_tensors, out_dir, save_dtype,
             adapted=adapted, save_dtype=save_dtype,
         )
 
-    # resolve adapted keys against real base keys (VLM prefix tolerance)
     resolved: dict[str, _Adapted] = {}
     for ak, a in adapted.items():
         rk = _resolve_key(ak, base_keys)
@@ -351,18 +348,15 @@ def assert_merge_correct(*, family, base_tensors, out_dir, save_dtype,
             _assert_equal(family, key, mt, base_tensors[key])
             n_passthru += 1
 
-    # every adapted target appeared and was checked
     if not allow_missing_adapted:
         missing = [k for k in resolved if k not in merged]
         assert not missing, f"[{family}] adapted targets missing from merged output: {missing}"
     assert n_adapted >= 1, f"[{family}] no adapted tensors were checked (LoRA not attached?)"
 
-    # MoE merge must not have fallen back
     assert _MOE_MERGE_STATE.get("fallback", 0) == 0, (
         f"[{family}] MoE merge fell back: {_MOE_MERGE_STATE}"
     )
 
-    # index consistency
     idx = read_index(out_dir)
     if idx is not None:
         wm = idx.get("weight_map", {})
@@ -412,7 +406,6 @@ class FamilySpec:
     fused_params: tuple = ()        # fused-expert target_parameters
 
 
-# distinct dims so fused-expert orientation is unambiguous (transpose bugs show)
 _H = 32
 _I = 64
 _MOE_I = 48      # distinct from _H and 2*_MOE_I

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,11 +44,6 @@ import sys
 import types
 
 
-# ---------------------------------------------------------------------------
-# 1. GPU-free harness: pre-load device_type so importing unsloth_zoo
-#    without CUDA / XPU / HIP visible doesn't raise.
-# ---------------------------------------------------------------------------
-
 def _has_real_accelerator() -> bool:
     try:
         import torch
@@ -215,24 +210,17 @@ if not _has_real_accelerator():
     _patch_torch_cuda_for_import()
 
 
-# ---------------------------------------------------------------------------
-# 2. Make ``tests/mlx_simulation`` importable as ``mlx_simulation`` for
-#    the MLX-on-torch shim suite.
-# ---------------------------------------------------------------------------
-
 _TESTS_DIR = pathlib.Path(__file__).resolve().parent
 if str(_TESTS_DIR) not in sys.path:
     sys.path.insert(0, str(_TESTS_DIR))
 
 
-# ---------------------------------------------------------------------------
 # 3. Apply upstream-drift fixes (triton CompiledKernel attrs, vLLM rename,
 #    peft transformers_weight_conversion shim, etc.) by triggering
 #    ``import unsloth``. Fixes live on ``unsloth/import_fixes.py`` and run
 #    at unsloth import time; zoo no longer carries a copy. Security-only
 #    test suites without unsloth installed keep passing -- ImportError is
 #    swallowed below.
-# ---------------------------------------------------------------------------
 
 def _apply_upstream_import_fixes_for_tests() -> None:
     # Let `import unsloth` succeed on a CPU-only CI runner. The flag is

--- a/tests/gemma4_audio_version_probe.py
+++ b/tests/gemma4_audio_version_probe.py
@@ -357,7 +357,6 @@ def check_loss(_repo):
                 {"type": "audio", "audio": clip},
                 {"type": "text", "text": "Transcribe."}]},
                 {"role": "assistant", "content": "ok"}]
-            # Collate on the host, then finalize to MLX, as the trainer does.
             staged = _collate_vlm_batch(
                 [{"messages": messages}], processor, 512, None)
             batch = _finalize_vlm_batch(staged)
@@ -403,7 +402,6 @@ def main():
           f"transformers {transformers.__version__}, {args.model} ===",
           flush=True)
 
-    # Open the gate for whatever is installed: the question is what is behind it.
     from unsloth_zoo.mlx import utils as U
     U._AUDIO_QUALIFIED_FAMILIES = dict(
         U._AUDIO_QUALIFIED_FAMILIES,
@@ -411,8 +409,6 @@ def main():
     )
     U._AUDIO_MIN_TRANSFORMERS = {}
 
-    # Stage 0 never gates. Later stages need zoo's load, so they skip rather
-    # than error when it fails.
     path = resolve(args.model)
     load_upstream(path)
     ok_zoo = load_via_zoo(path)

--- a/tests/mlx_simulation/mlx_lm_stub.py
+++ b/tests/mlx_simulation/mlx_lm_stub.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Unsloth Zoo - Utilities for Unsloth
 # mlx_lm stub — load, utils, tuner.lora, tuner.utils, sample_utils, stream_generate
 """
 mlx_lm — sample/load/tuner facade.
@@ -35,9 +34,6 @@ import types
 import torch
 
 
-# ---------------------------------------------------------------------------
-# mlx_lm.load — top-level entry
-# ---------------------------------------------------------------------------
 def load(repo_path, *args, **kwargs):
     """Load a model + tokenizer pair.
 
@@ -47,17 +43,12 @@ def load(repo_path, *args, **kwargs):
     return real_load(repo_path, *args, **kwargs)
 
 
-# ---------------------------------------------------------------------------
-# mlx_lm.stream_generate — generation streaming
-# ---------------------------------------------------------------------------
 def stream_generate(model, tokenizer, prompt, *args, **kwargs):
     from .mlx_helpers.stream_generate import stream_generate as real_sg
     yield from real_sg(model, tokenizer, prompt, *args, **kwargs)
 
 
-# ---------------------------------------------------------------------------
 # Submodules — populate after inject_into_sys_modules
-# ---------------------------------------------------------------------------
 def _pkg(name):
     m = types.ModuleType(name)
     m.__path__ = []
@@ -132,7 +123,6 @@ def _placeholder_lora_linear(*args, **kwargs):
     return LoRALinear(*args, **kwargs)
 
 
-# Expose the LoRALinear class itself for `isinstance` checks.
 class LoRALinear:
     """Placeholder until mlx_helpers.lora_linear is wired in Phase 5.
 
@@ -232,7 +222,6 @@ def _iterate_batches(dataset, batch_size, max_seq_length, train=True, *args, **k
 tuner_trainer_module.iterate_batches = _iterate_batches
 
 
-# --- mlx_lm.sample_utils -----------------------------------------------
 sample_utils_module = _pkg("mlx_lm.sample_utils")
 
 
@@ -252,7 +241,6 @@ def _make_sampler(temp=1.0, top_p=1.0, top_k=0, min_p=0.0, min_tokens_to_keep=1,
             sorted_probs = torch.softmax(sorted_logits, dim=-1)
             cum = torch.cumsum(sorted_probs, dim=-1)
             remove = cum > top_p
-            # always keep top min_tokens_to_keep
             remove[..., :min_tokens_to_keep] = False
             sorted_logits[remove] = float("-inf")
             scaled = torch.gather(sorted_logits, -1, torch.argsort(sorted_idx, dim=-1))
@@ -270,7 +258,6 @@ sample_utils_module.make_sampler = _make_sampler
 sample_utils_module.make_logits_processors = _make_logits_processors
 
 
-# --- mlx_lm.models.gated_delta -----------------------------------------
 models_module = _pkg("mlx_lm.models")
 gated_delta_module = _pkg("mlx_lm.models.gated_delta")
 
@@ -286,7 +273,6 @@ gated_delta_module.gated_delta_update = _gated_delta_placeholder
 models_module.gated_delta = gated_delta_module
 
 
-# ---------------------------------------------------------------------------
 __path__ = []
 
 

--- a/tests/mlx_simulation/mlx_nn_stub.py
+++ b/tests/mlx_simulation/mlx_nn_stub.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Unsloth Zoo - Utilities for Unsloth
-# MLX nn stub — Module base + common layers + losses + value_and_grad
 """
 mlx.nn — neural network primitives.
 
@@ -41,11 +39,9 @@ import torch
 import torch.nn.functional as F
 
 
-# ---------------------------------------------------------------------------
 # nn.Module — lightweight wrapper around torch.nn.Module that mimics MLX's
 # dict-derived parameter model.  MLX's Module IS a dict; here we keep a
 # torch.nn.Module under the hood and expose MLX-flavored API on top.
-# ---------------------------------------------------------------------------
 class Module:
     """Lightweight stand-in for mlx.nn.Module.
 
@@ -123,7 +119,6 @@ class Module:
         yield prefix, self
         seen = {id(self)}
         for attr_name, attr_val in vars(self).items():
-            # plain Module attribute
             if isinstance(attr_val, Module) and id(attr_val) not in seen:
                 seen.add(id(attr_val))
                 sub_prefix = f"{prefix}.{attr_name}" if prefix else attr_name
@@ -135,7 +130,6 @@ class Module:
                         seen.add(id(item))
                         sub_prefix = f"{prefix}.{attr_name}.{i}" if prefix else f"{attr_name}.{i}"
                         yield from item.named_modules(sub_prefix)
-            # dict of Modules
             elif isinstance(attr_val, dict):
                 for k, item in attr_val.items():
                     if isinstance(item, Module) and id(item) not in seen:
@@ -321,10 +315,8 @@ class AvgPool2d(Module):
         return self.pool(x)
 
 
-# ---------------------------------------------------------------------------
 # Quantized layers — dequantize on each forward.  Phase 4 wires these to
 # mlx_helpers/quant.py for affine bit-layouts.
-# ---------------------------------------------------------------------------
 class QuantizedLinear(Module):
     def __init__(self, in_features, out_features, bias=True, group_size=64, bits=4, mode="affine"):
         super().__init__()
@@ -374,11 +366,9 @@ class QuantizedEmbedding(Module):
         return F.embedding(x, w_fp)
 
 
-# ---------------------------------------------------------------------------
 # value_and_grad — MLX's `nn.value_and_grad(model, fn)` returns a function
 # that computes (loss, grads) where grads is a tree shaped like the model's
 # trainable parameters.  See mlx_helpers/value_and_grad.py for the real impl.
-# ---------------------------------------------------------------------------
 def value_and_grad(model, fn=None):
     """mlx.nn.value_and_grad(model, fn) -> (model_aware_loss_and_grad).
 
@@ -392,13 +382,9 @@ def value_and_grad(model, fn=None):
     return nn_value_and_grad(model, fn)
 
 
-# ---------------------------------------------------------------------------
-# Losses
-# ---------------------------------------------------------------------------
 def _ce_loss(logits, targets, axis=-1, weights=None, label_smoothing=0.0,
              reduction="mean", **kw):
     if axis != -1:
-        # rotate target axis last
         logits = logits.movedim(axis, -1)
     flat_logits = logits.reshape(-1, logits.shape[-1])
     flat_targets = targets.reshape(-1).long()
@@ -427,9 +413,7 @@ losses_module.l1_loss = _l1_loss
 losses_module.binary_cross_entropy = _binary_ce_loss
 
 
-# ---------------------------------------------------------------------------
 # Initializers (returns callables that fill a tensor of given shape)
-# ---------------------------------------------------------------------------
 def _init_constant(value):
     def _init(shape, dtype=torch.float32):
         return torch.full(shape, value, dtype=dtype)
@@ -455,9 +439,7 @@ init_module.normal = _init_normal
 init_module.uniform = _init_uniform
 
 
-# ---------------------------------------------------------------------------
 # Module-level __getattr__: any unknown nn.X returns _Noop.
-# ---------------------------------------------------------------------------
 from . import mlx_stub  # for _Noop
 
 __path__ = []

--- a/tests/mlx_simulation/mlx_optimizers_stub.py
+++ b/tests/mlx_simulation/mlx_optimizers_stub.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Unsloth Zoo - Utilities for Unsloth
-# MLX optimizers stub — wraps torch.optim.* via the functional update API.
 """
 mlx.optimizers — Adam/AdamW/SGD/Adafactor/Muon/Lion + schedulers.
 
@@ -64,13 +62,11 @@ class _OptimizerBase:
         torch.optim.X.step() once.  Phase 4 extends to MLX's exact tree
         semantics.
         """
-        # Gather parameters as a flat list with stable ordering.
         from .mlx_utils_stub import tree_flatten
         params = [p for _, p in tree_flatten(model.parameters() if callable(getattr(model, "parameters", None)) else model)]
         flat_grads = [g for _, g in tree_flatten(grads)]
         if self._torch_opt is None:
             self._torch_opt = self._build_torch_opt(params)
-        # Assign grads
         for p, g in zip(params, flat_grads):
             if isinstance(p, torch.Tensor) and isinstance(g, torch.Tensor):
                 if p.grad is None:
@@ -167,7 +163,6 @@ class Lion(_OptimizerBase):
 
 class Muon(_OptimizerBase):
     def _build_torch_opt(self, params):
-        # Muon is a recent optimizer; if not installed, fall back to SGD.
         try:
             from muon import Muon as _Muon  # placeholder package name
             return _Muon(params, lr=self.learning_rate)
@@ -190,9 +185,7 @@ class MultiOptimizer:
             self.optimizers[0].update(model, grads)
 
 
-# ---------------------------------------------------------------------------
 # Schedulers — MLX returns lr-schedule callables (step -> lr) directly.
-# ---------------------------------------------------------------------------
 def linear_schedule(init, end, steps):
     def _sched(step):
         if step >= steps:
@@ -253,7 +246,6 @@ def decay_weight(weights, decay):
     return tree_map(lambda w: w * (1.0 - decay) if isinstance(w, torch.Tensor) else w, weights)
 
 
-# ---------------------------------------------------------------------------
 schedulers_module = types.ModuleType("mlx.optimizers.schedulers")
 schedulers_module.__path__ = []
 schedulers_module.linear_schedule = linear_schedule

--- a/tests/mlx_simulation/mlx_stub.py
+++ b/tests/mlx_simulation/mlx_stub.py
@@ -59,9 +59,6 @@ from importlib.machinery import ModuleSpec
 import torch
 
 
-# ---------------------------------------------------------------------------
-# Permissive module + Noop sentinel — same shape as triton_stub.
-# ---------------------------------------------------------------------------
 class _PermissiveModule(types.ModuleType):
     """Module where any missing attribute returns a `_Noop`.
 
@@ -124,9 +121,6 @@ def _make_module(name, attrs=None):
     return mod
 
 
-# ---------------------------------------------------------------------------
-# Meta-path finder — catches any `import mlx.X.Y.Z` not seeded explicitly.
-# ---------------------------------------------------------------------------
 class _MLXLoader:
     def create_module(self, spec):
         return _make_module(spec.name)
@@ -147,7 +141,6 @@ class _MLXFinder(MetaPathFinder):
     _loader = _MLXLoader()
 
     def find_spec(self, fullname, path, target=None):
-        # Match top-level 'mlx', 'mlx_lm', 'mlx_vlm' or any submodule.
         for prefix in _MLX_PREFIXES:
             if fullname == prefix or fullname.startswith(prefix + "."):
                 if fullname not in sys.modules:
@@ -211,7 +204,6 @@ unsignedinteger = "unsignedinteger"
 inexact = "inexact"
 
 
-# Special scalars
 inf = math.inf
 nan = math.nan
 
@@ -273,7 +265,7 @@ def default_device():
 
 
 def set_default_device(device):
-    pass  # no-op
+    pass
 
 
 # ---------------------------------------------------------------------------
@@ -347,11 +339,6 @@ def depends(*args):
     """mx.depends — explicit dependency edge. No-op in eager torch."""
     return None
 
-
-# ---------------------------------------------------------------------------
-# Tier 2: trivial passthroughs to torch.
-# ---------------------------------------------------------------------------
-# Reductions / elementwise / shape ops mapped 1:1.
 
 class _ArrayMeta(type):
     """Metaclass that makes any torch.Tensor an instance of mx.array.
@@ -525,7 +512,6 @@ def topk(a, k, axis=-1, **kw):
     return torch.topk(a, k=k, dim=axis)
 
 
-# Constructors
 def zeros(shape, dtype=None, **kw):
     if isinstance(shape, int): shape = (shape,)
     return torch.zeros(*shape, dtype=dtype)
@@ -551,7 +537,6 @@ def identity(n, dtype=None, **kw):
     return torch.eye(n, dtype=dtype)
 
 
-# Shape ops
 def reshape(a, shape, **kw): return a.reshape(*shape) if isinstance(shape, (tuple, list)) else a.reshape(shape)
 def flatten(a, start_axis=0, end_axis=-1, **kw): return torch.flatten(a, start_dim=start_axis, end_dim=end_axis)
 def squeeze(a, axis=None, **kw):
@@ -628,7 +613,6 @@ def meshgrid(*xs, indexing="xy", **kw):
     return tuple(torch.meshgrid(*xs, indexing=indexing))
 
 
-# Bitwise
 def bitwise_and(a, b, **kw): return torch.bitwise_and(a, b)
 def bitwise_or(a, b, **kw): return torch.bitwise_or(a, b)
 def bitwise_xor(a, b, **kw): return torch.bitwise_xor(a, b)
@@ -663,10 +647,6 @@ globals()["slice"] = slice_
 def contiguous(a, **kw):
     return a.contiguous() if hasattr(a, "contiguous") else a
 
-
-# ---------------------------------------------------------------------------
-# Submodules: random, linalg, fft, fast, metal, cuda, distributed
-# ---------------------------------------------------------------------------
 
 # --- mx.random — JAX-style key plumbing on top of torch.Generator ----
 def _rng_seed(s):
@@ -733,7 +713,6 @@ random = _make_module("mlx.core.random", {
 })
 
 
-# --- mx.linalg ---
 def _la_norm(a, ord=None, axis=None, keepdims=False, **kw):
     return torch.linalg.norm(a, ord=ord, dim=axis, keepdim=keepdims)
 
@@ -752,7 +731,6 @@ linalg = _make_module("mlx.core.linalg", {
 })
 
 
-# --- mx.fft ---
 fft_mod = _make_module("mlx.core.fft", {
     "fft":   lambda a, **kw: torch.fft.fft(a),
     "ifft":  lambda a, **kw: torch.fft.ifft(a),
@@ -767,7 +745,6 @@ fft_mod = _make_module("mlx.core.fft", {
 })
 
 
-# --- mx.fast ---
 def _fast_sdpa(q, k, v, scale=None, mask=None, **kw):
     return torch.nn.functional.scaled_dot_product_attention(
         q, k, v, attn_mask=mask, scale=scale, is_causal=False)
@@ -822,7 +799,6 @@ fast = _make_module("mlx.core.fast", {
 })
 
 
-# --- mx.metal ---
 def _metal_is_available():
     return False  # we're pretending to be Apple but with no actual Metal
 
@@ -859,13 +835,11 @@ metal = _make_module("mlx.core.metal", {
 })
 
 
-# --- mx.cuda ---
 cuda = _make_module("mlx.core.cuda", {
     "is_available": lambda: torch.cuda.is_available(),
 })
 
 
-# --- mx.distributed ---
 def _dist_is_available(): return False
 def _dist_init(*args, **kw): return None
 def _dist_pass(x, *args, **kw): return x
@@ -887,9 +861,6 @@ distributed = _make_module("mlx.core.distributed", {
 })
 
 
-# ---------------------------------------------------------------------------
-# Saving / loading — safetensors + npz
-# ---------------------------------------------------------------------------
 def save_safetensors(path, arrays, metadata=None, **kw):
     from safetensors.torch import save_file
     if not isinstance(arrays, dict):
@@ -937,7 +908,6 @@ def savez_compressed(path, **arrays):
 
 
 # ---------------------------------------------------------------------------
-# Lazy-graph functions: compile, checkpoint, eval, vmap, grad, custom_function
 # Bodies live in mlx_helpers.compile_passthrough and mlx_helpers.custom_function.
 # ---------------------------------------------------------------------------
 def compile(fn=None, inputs=None, outputs=None, shapeless=False, **kw):
@@ -1024,10 +994,6 @@ def quantize(*args, **kw):
     )
 
 
-# ---------------------------------------------------------------------------
-# inject_into_sys_modules — registers this module under `mlx`/`mlx.core`
-# plus all named submodules.
-# ---------------------------------------------------------------------------
 def inject_into_sys_modules():
     """Install the meta-path finder and register seeded submodules."""
     import builtins

--- a/tests/mlx_simulation/mlx_utils_stub.py
+++ b/tests/mlx_simulation/mlx_utils_stub.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Unsloth Zoo - Utilities for Unsloth
-# MLX utils stub: tree_map, tree_flatten, tree_unflatten, etc.
 """
 mlx.utils — tree functions that walk nested dicts/lists/tuples/namedtuples.
 
@@ -63,7 +62,6 @@ def tree_unflatten(items: list[tuple[str, Any]]) -> Any:
     """Inverse of tree_flatten: rebuild a nested dict from flat keys."""
     if not items:
         return {}
-    # If all top-level keys are integers, rebuild a list.
     out: dict = {}
     for path, value in items:
         parts = path.split(".") if path else []
@@ -152,10 +150,8 @@ def tree_merge(a, b, merge_fn=None):
     return out
 
 
-# ---------------------------------------------------------------------------
 def inject_into_sys_modules():
     this = sys.modules[__name__]
     sys.modules["mlx.utils"] = this
-    # Also expose as attribute on top-level mlx package.
     if "mlx" in sys.modules:
         setattr(sys.modules["mlx"], "utils", this)

--- a/tests/mlx_simulation/mlx_vlm_stub.py
+++ b/tests/mlx_simulation/mlx_vlm_stub.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Unsloth Zoo - Utilities for Unsloth
-# mlx_vlm stub — Unsloth inference + permissive submodules for 40+ VLM archs
 """
 mlx_vlm — Vision Language Model wrapper.
 
@@ -48,7 +47,6 @@ def load(*args, **kwargs):
     )
 
 
-# Submodules
 def _pkg(name):
     """Make a module that's also a package (so finders can resolve submodules)."""
     m = types.ModuleType(name)

--- a/tests/test_active_merge_device_matrix.py
+++ b/tests/test_active_merge_device_matrix.py
@@ -34,10 +34,6 @@ import pytest
 import torch
 
 
-# ---------------------------------------------------------------------------
-# Profile definition
-# ---------------------------------------------------------------------------
-
 @dataclass
 class AcceleratorProfile:
     name: str
@@ -90,10 +86,6 @@ PROFILES = [
 PROFILE_IDS = [p.name for p in PROFILES]
 
 
-# ---------------------------------------------------------------------------
-# Spoofing fixture
-# ---------------------------------------------------------------------------
-
 @pytest.fixture
 def spoof_accelerator(monkeypatch):
     """Apply an AcceleratorProfile to torch in-process and clear the
@@ -129,10 +121,6 @@ def spoof_accelerator(monkeypatch):
 
     _active_merge_device.cache_clear()
 
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("profile", PROFILES, ids=PROFILE_IDS)
 def test_active_merge_device_cascade(profile, spoof_accelerator):

--- a/tests/test_add_new_tokens_padded_vocab.py
+++ b/tests/test_add_new_tokens_padded_vocab.py
@@ -70,12 +70,9 @@ def test_padded_embedding_preserves_trained_rows_and_places_new_tokens():
     emb2 = model.get_input_embeddings().weight
     head2 = model.get_output_embeddings().weight
 
-    # 1. No shrink: all trained rows survive byte-identical.
     assert emb2.shape[0] == PADDED, "padded embedding must not shrink"
     assert torch.equal(emb2[:VOCAB_TOK], trained_rows), "trained rows corrupted"
 
-    # 2. New tokens land at their real tokenizer IDs, each pointing at its OWN
-    #    mean-initialised row (not a leftover padding row).
     new_len = len(tokenizer)
     for offset, tok in enumerate(new_tokens):
         tid = tokenizer.convert_tokens_to_ids(tok)
@@ -92,11 +89,9 @@ def test_padded_embedding_preserves_trained_rows_and_places_new_tokens():
     assert torch.equal(emb2[new_len:PADDED], sentinel_rows[new_len - VOCAB_TOK:]), \
         "alignment padding rows were overwritten"
 
-    # 4. Tied weights stay tied, and share storage at a new-token row.
     assert emb2.data_ptr() == head2.data_ptr(), "tie broken by resize"
     assert torch.equal(emb2[VOCAB_TOK], head2[VOCAB_TOK])
 
-    # 5. config.vocab_size tracks the matrix, so the model round-trips.
     assert model.config.vocab_size == PADDED
     with tempfile.TemporaryDirectory() as d:
         model.save_pretrained(d)
@@ -104,7 +99,6 @@ def test_padded_embedding_preserves_trained_rows_and_places_new_tokens():
     assert reloaded.get_input_embeddings().weight.shape[0] == PADDED
     assert reloaded.config.vocab_size == PADDED
 
-    # 6. Forward pass over the new IDs works.
     with torch.no_grad():
         logits = model(torch.tensor([[VOCAB_TOK, VOCAB_TOK + 1, 3, 4]])).logits
     assert logits.shape[-1] == PADDED

--- a/tests/test_alloc_conf_platform_matrix.py
+++ b/tests/test_alloc_conf_platform_matrix.py
@@ -127,8 +127,6 @@ def _conf(*, torch_version, wsl=False, wsl_interop=False, windows=False,
     return json.loads(lines[-1][len("RESULT:"):])
 
 
-# --- torch version boundary (Linux CUDA, no user config) -------------------
-
 class TestBoundary:
     @pytest.mark.parametrize("ver", ["2.6.0", "2.8.1", "2.9.1"])
     def test_le_2_9_uses_legacy_cuda_var(self, ver):
@@ -151,7 +149,7 @@ class TestBoundary:
         assert conf["PYTORCH_HIP_ALLOC_CONF"] is None, conf
 
 
-# --- Windows / WSL fragmentation fallback (issue #7203) --------------------
+# Windows / WSL fragmentation fallback (issue #7203)
 
 class TestWindowsWslFallback:
     def test_wsl_torch_2_9_roundup_on_legacy(self):
@@ -187,8 +185,6 @@ class TestWindowsWslFallback:
         assert "IS_WSL_OR_WINDOWS" in text
         assert "roundup_power2_divisions" in text
 
-
-# --- user precedence + promotion gap ---------------------------------------
 
 class TestUserPrecedence:
     def test_user_unified_backend_preserved_2_10(self):
@@ -232,8 +228,6 @@ class TestUserPrecedence:
         assert conf["PYTORCH_CUDA_ALLOC_CONF"] == "", conf
 
 
-# --- opt-out and vLLM standby ----------------------------------------------
-
 class TestControls:
     def test_opt_out_disables_fallback_2_10(self):
         conf = _conf(torch_version="2.10.0", wsl=True, opt_out=True)
@@ -246,8 +240,6 @@ class TestControls:
             assert "expandable_segments:True" not in (val or ""), (key, val)
             assert "roundup" not in (val or ""), (key, val)
 
-
-# --- backend isolation: AMD (hip) / Intel (xpu) never get the CUDA fallback -
 
 class TestBackendIsolation:
     def test_hip_wsl_no_roundup(self):

--- a/tests/test_assert_same_keys_base_model.py
+++ b/tests/test_assert_same_keys_base_model.py
@@ -76,10 +76,8 @@ class _PeftLike(nn.Module):
 
 
 def test_assert_same_keys_survives_peft_base_without_model():
-    # The exact layout PR #95 reports: base_model present, but it has no `.model`.
     base = _BaseNoModel()
     model = _PeftLikeNoInnerModel(base)
-    # The shared helper must stop at base_model (per-level guard) and not raise.
     assert find_lora_base_model(model) is base
     # new_state_dict is built the way create_lora_statistics does: from find_lora_base_model(model).
     new_state_dict = dict(base.state_dict())  # {"linear.weight": ...}
@@ -88,7 +86,6 @@ def test_assert_same_keys_survives_peft_base_without_model():
 
 
 def test_assert_same_keys_normal_peft_layout_unchanged():
-    # Standard PEFT layout (base_model.model present) must behave exactly as before.
     inner = _Inner()
     model = _PeftLike(_LoraModel(inner))
     assert find_lora_base_model(model) is inner

--- a/tests/test_bin_only_base_diagnosis.py
+++ b/tests/test_bin_only_base_diagnosis.py
@@ -110,7 +110,6 @@ def test_caller_raises_the_specific_message():
     j = src.index("could not be read locally or on Hugging Face")
     assert i < j, "the bin-only check must run before the generic message"
 
-    # Render every f-string in the module, then find the one this branch raises.
     rendered = [
         re.sub(r"\s+", " ", "".join(v.value for v in n.values
                                     if isinstance(v, ast.Constant)))

--- a/tests/test_eager_fallback_latch.py
+++ b/tests/test_eager_fallback_latch.py
@@ -79,8 +79,6 @@ def _pair(fail_after=0):
     return compiled, eager, calls
 
 
-# ---- the latch -----------------------------------------------------------
-
 def test_a_healthy_compiled_function_is_never_wrapped_out_of_the_way():
     compiled, eager, calls = _pair(fail_after=100)
     w = U._fall_back_to_eager_on_recompile_limit(compiled, eager, "M.forward")
@@ -147,8 +145,6 @@ def test_the_compiled_callable_stays_reachable():
     assert w.__wrapped__ is eager
 
 
-# ---- the graph-break arm is unchanged ------------------------------------
-
 def test_our_own_disabled_hook_falls_back_and_latches(monkeypatch):
     class GraphBreak(Exception):
         pass
@@ -182,8 +178,6 @@ def test_someone_elses_graph_break_still_raises(monkeypatch):
     with pytest.raises(GraphBreak):
         w(1)
 
-
-# ---- force_eager_fallback ------------------------------------------------
 
 def test_force_does_nothing_when_nothing_ever_fell_back():
     """The honest default. A caller getting 0 back knows the activation

--- a/tests/test_encode_conversations_with_harmony.py
+++ b/tests/test_encode_conversations_with_harmony.py
@@ -453,8 +453,6 @@ def test_assistant_thinking_only_emits_single_analysis(
     monkeypatch,
     gpt_oss_module,
 ):
-    # A pure-reasoning turn (thinking present, no/empty content) must produce only the
-    # analysis message carrying the reasoning, and no final message.
     messages = [
         {"role": "assistant", "thinking": "just reasoning", "content": ""},
     ]
@@ -471,7 +469,6 @@ def test_assistant_plain_content_unchanged_final_only(
     monkeypatch,
     gpt_oss_module,
 ):
-    # No thinking and no tool_calls: exactly one final-channel message from content.
     messages = [
         {"role": "assistant", "content": "plain answer"},
     ]
@@ -501,7 +498,6 @@ def test_mixed_multi_turn_preserves_channels_and_branches(
     gpt_oss_module.encode_conversations_with_harmony(messages)
     conversation = encoding.calls[0][1]
 
-    # Drop the leading system message, then assert the channel sequence.
     body = [m for m in conversation if m.role != _Role.SYSTEM]
     channels = [m.channel for m in body]
     assert channels == [None, "analysis", "final", "commentary", "final"]
@@ -565,8 +561,6 @@ def test_assistant_thinking_empty_string_falls_back_to_final(
     monkeypatch,
     gpt_oss_module,
 ):
-    # Empty-string thinking is treated as absent (no empty analysis message); only the
-    # final-channel message from content is emitted.
     messages = [
         {"role": "assistant", "thinking": "", "content": "the answer"},
     ]

--- a/tests/test_encode_conversations_with_harmony_render.py
+++ b/tests/test_encode_conversations_with_harmony_render.py
@@ -166,7 +166,6 @@ def test_thinking_tool_calls_and_content_keeps_tool_call(real_encoding, gpt_oss_
 
 @pytest.mark.parametrize("thinking", [None, ""])
 def test_nullable_thinking_does_not_crash(real_encoding, gpt_oss_module, thinking):
-    # Nullable / empty thinking columns must not raise; the answer must still be encoded.
     decoded = _decode(
         [{"role": "assistant", "thinking": thinking, "content": "ANSWER_SENTINEL"}],
         gpt_oss_module,

--- a/tests/test_extended_dep_api_pins.py
+++ b/tests/test_extended_dep_api_pins.py
@@ -36,10 +36,8 @@ from typing import Iterable
 import pytest
 
 
-# ---------------------------------------------------------------------------
 # Shared helpers (intentional copies of test_zoo_source_upstream_refs.py
 # helpers so this file is grep-self-contained).
-# ---------------------------------------------------------------------------
 
 
 def _resolve(dotted: str) -> object:
@@ -96,9 +94,7 @@ def _require_module(name: str):
     return pytest.importorskip(name)
 
 
-# ===========================================================================
 # accelerate
-# ===========================================================================
 
 
 def test_accelerate_init_empty_weights_signature_shape():
@@ -152,9 +148,7 @@ def test_accelerate_utils_imports_module_surface():
     ])
 
 
-# ===========================================================================
 # safetensors
-# ===========================================================================
 
 
 def test_safetensors_safe_open_top_level_exists():
@@ -240,9 +234,7 @@ def test_safetensors_torch_load_file_present():
     _resolve("safetensors.torch.load_file")
 
 
-# ===========================================================================
 # bitsandbytes
-# ===========================================================================
 
 
 def test_bnb_top_level_import_and_version_attr():
@@ -367,9 +359,7 @@ def test_bnb_nn_modules_module_path_present():
     _resolve("bitsandbytes.nn.modules")
 
 
-# ===========================================================================
 # triton
-# ===========================================================================
 
 
 def test_triton_top_level_version_attr():
@@ -444,9 +434,7 @@ def test_triton_jit_decorator_present():
         )
 
 
-# ===========================================================================
 # datasets
-# ===========================================================================
 
 
 def test_datasets_load_dataset_top_level():
@@ -524,9 +512,7 @@ def test_datasets_torchcodec_audio_decoder_present_or_absent_cleanly():
         )
 
 
-# ===========================================================================
 # huggingface_hub
-# ===========================================================================
 
 
 def test_hf_hub_top_level_save_path_symbols():
@@ -685,9 +671,7 @@ def test_hf_hub_hf_hub_download_signature_local_dir_and_repo_id():
         )
 
 
-# ===========================================================================
 # xformers
-# ===========================================================================
 # Zoo has no direct xformers imports; only re-exports if installed.
 # transformers.modeling_utils probes xformers.ops at attention-kernel
 # selection time -- a regression in xformers' module layout silently

--- a/tests/test_fla_hopper_tile.py
+++ b/tests/test_fla_hopper_tile.py
@@ -66,11 +66,6 @@ def _load_vendored_fla():
     return chunk_o
 
 
-# ---------------------------------------------------------------------------
-# 1. Tile selection: BK must never land on 64 in the affected range
-# ---------------------------------------------------------------------------
-
-
 _KEEP = object()
 
 
@@ -189,8 +184,6 @@ def test_hopper_at_a_nonzero_device_index_still_steps_down(monkeypatch):
     )
     chunk_o._device_is_nvidia_hopper.cache_clear()
     try:
-        # hopper=False -> the module global does NOT report Hopper, exactly as on a
-        # host whose device 0 is not Hopper. The tensor's device does.
         got = _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch)
         assert got["BK"] == 32, (
             "a Hopper device that the import-time global missed still selected the "
@@ -206,11 +199,6 @@ def test_hopper_at_a_nonzero_device_index_still_steps_down(monkeypatch):
     monkeypatch.undo()
     chunk_o._device_is_nvidia_hopper.cache_clear()
     assert _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch, tensor_hopper=False)["BK"] == 64
-
-
-# ---------------------------------------------------------------------------
-# 2. The override is a tiling change, not an algebra change
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(not _cuda_available(), reason="needs CUDA")
@@ -272,11 +260,6 @@ def test_bk_override_does_not_change_gradients(monkeypatch):
         denom = a.norm().clamp_min(1e-12)
         rel = (a - b).norm() / denom
         assert rel < 5e-3, f"{name}: BK=32 diverged from BK=64 (rel L2 {rel:.3e})"
-
-
-# ---------------------------------------------------------------------------
-# 3. No fla is left bound unpatched on a suspect host (the #5276 crash path)
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -597,7 +580,6 @@ def test_in_place_patch_is_thread_safe(monkeypatch):
         else:
             slow_inside.set()
             fast_done.wait(5)
-        # What the real kernel launcher reads, at exactly this moment.
         if chunk_o.IS_NVIDIA_HOPPER:
             raise RuntimeError(f"{tag}: blanket #640 guard fired mid-call")
         seen[tag] = 128 if chunk_o.check_shared_mem("hopper", 0) else 32
@@ -633,13 +615,7 @@ def test_in_place_patch_is_thread_safe(monkeypatch):
     # Both concurrent calls asked for K=64, so both must get the safe 32-wide tile;
     # neither may have had its override cancelled by the other's restore.
     assert seen == {"fast": 32, "slow": 32}, seen
-    # And nothing is left behind on either thread.
     assert fv._installed_fla_forcing_small_tile() is False
-
-
-# ---------------------------------------------------------------------------
-# 4. The opt-out
-# ---------------------------------------------------------------------------
 
 
 def test_opt_out_forces_pure_torch(monkeypatch, fake_gated_delta_modeling):
@@ -784,11 +760,6 @@ def test_opt_out_is_inert_off_hopper(monkeypatch, fake_gated_delta_modeling):
         assert mod.chunk_gated_delta_rule is not None
 
 
-# ---------------------------------------------------------------------------
-# 5. End to end: a real gated-deltanet model trains on a simulated Hopper
-# ---------------------------------------------------------------------------
-
-
 def _has_qwen3_next() -> bool:
     import importlib.util
 
@@ -858,11 +829,6 @@ def test_qwen3_next_trains_with_simulated_hopper_tile(monkeypatch):
     grads = [p.grad for p in model.parameters() if p.grad is not None]
     assert grads, "no gradients were produced"
     assert all(torch.isfinite(g).all() for g in grads), "non-finite gradients"
-
-
-# ---------------------------------------------------------------------------
-# 6. Non-Hopper hosts are untouched
-# ---------------------------------------------------------------------------
 
 
 def test_this_blackwell_host_is_not_suspect():
@@ -1073,7 +1039,6 @@ def test_installed_patch_leaves_non_hopper_tensors_alone(monkeypatch):
         "a non-Hopper tensor must not be forced onto the narrow tile"
     )
 
-    # Same call on a device reported as Hopper does take the override.
     monkeypatch.setattr(fv, "_device_index_is_hopper", lambda index: True)
     chunk_o.chunk_bwd_dqkwg(q=k, k=k, v=k, do=k, h=None, dh=None, g=g)
     assert seen["small_tile"] is True, "a Hopper tensor at K=64 must take the override"
@@ -1098,7 +1063,6 @@ def test_vendored_guard_uses_the_tensor_device_not_device_zero(monkeypatch):
     monkeypatch.setattr(chunk_o, "_is_hopper_tensor", lambda x: False)
     assert _record_bk(chunk_o, K=64, V=128, hopper=True, monkeypatch=monkeypatch)["BK"] == 64
 
-    # Tensor on Hopper while the global says otherwise: step down.
     monkeypatch.setattr(chunk_o, "_is_hopper_tensor", lambda x: True)
     assert _record_bk(chunk_o, K=64, V=128, hopper=False, monkeypatch=monkeypatch)["BK"] == 32
 

--- a/tests/test_forced_float32_cache_release_devices.py
+++ b/tests/test_forced_float32_cache_release_devices.py
@@ -87,8 +87,6 @@ class _CudaCallRecorder:
 
 
 def test_cpu_model_never_touches_a_gpu(monkeypatch):
-    # A rank that holds no CUDA tensors must not initialise a context anywhere,
-    # however many GPUs it can see. Faked so the claim is tested on any runner.
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 8)
 

--- a/tests/test_forward_native_moe_loop_lora.py
+++ b/tests/test_forward_native_moe_loop_lora.py
@@ -45,7 +45,6 @@ def _build_lora_for(experts, rank, scaling):
     """
     E = experts.num_experts
     if experts.gate_up_proj.shape[1] == 2 * (experts.down_proj.shape[1] if experts.down_proj.shape[1] != experts.gate_up_proj.shape[2] else experts.down_proj.shape[2]):
-        # Heuristic that holds for both layouts in this test
         pass
     # Derive in/out from the actual base shape to stay layout-agnostic
     if experts.gate_up_proj.shape[1] > experts.gate_up_proj.shape[2]:
@@ -130,7 +129,6 @@ def test_forward_native_moe_loop_with_lora_matches_naive(transposed_storage):
     experts = _build_experts(num_experts, hidden, intermediate, transposed_storage)
     gate_up_lora, down_lora = _build_lora_for(experts, rank, scaling=2.0)
 
-    # Stash the LoRA tensors where forward_native_moe_loop expects them.
     experts._unsloth_lora_gate_up_proj = gate_up_lora
     experts._unsloth_lora_down_proj = down_lora
 
@@ -187,7 +185,6 @@ def test_forward_native_moe_loop_square_dim_uses_grouped_mm_flag():
 
     experts = nn.Module()
     experts.num_experts = num_experts
-    # Transposed (grouped_mm) storage:
     experts.gate_up_proj = nn.Parameter(
         torch.randn(num_experts, hidden, 2 * intermediate, dtype=torch.float32)
     )
@@ -236,7 +233,6 @@ def test_forward_native_moe_loop_lora_dtype_precast_no_loop_alloc(dtype):
 
     experts = _build_experts(num_experts, hidden, intermediate, False)
     gate_up_lora, down_lora = _build_lora_for(experts, rank, scaling=1.5)
-    # Cast everything (params + lora) to the target dtype.
     experts.gate_up_proj.data = experts.gate_up_proj.data.to(dtype)
     experts.down_proj.data = experts.down_proj.data.to(dtype)
     experts._unsloth_lora_gate_up_proj = (
@@ -255,7 +251,6 @@ def test_forward_native_moe_loop_lora_dtype_precast_no_loop_alloc(dtype):
                          experts._unsloth_lora_gate_up_proj,
                          experts._unsloth_lora_down_proj)
 
-    # Looser tolerance for low-precision dtypes
     atol = 1e-4 if dtype == torch.float32 else 1e-1
     rtol = 1e-4 if dtype == torch.float32 else 1e-1
     torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)

--- a/tests/test_fp8_dense_merge.py
+++ b/tests/test_fp8_dense_merge.py
@@ -131,13 +131,11 @@ def test_fp8_dense_dequantizes_and_drops_scales(tmp_path):
 
     with safe_open(str(shard), framework="pt", device="cpu") as f:
         keys = list(f.keys())
-        # No FP8 left, no dangling scale companions.
         assert all(f.get_tensor(k).dtype != torch.float8_e4m3fn for k in keys)
         assert not any(k.endswith(("weight_scale", "weight_scale_inv", "input_scale")) for k in keys)
         # Dequantized weight matches the real value within FP8 round-trip tolerance.
         merged = f.get_tensor("model.layers.0.mlp.down_proj.weight").float()
         assert torch.allclose(merged, W_real, atol=0.05)
-        # bf16 passthrough tensor preserved.
         assert "lm_head.weight" in keys
 
 
@@ -180,7 +178,7 @@ def test_fp8_dense_missing_scale_raises(tmp_path):
 
     W_fp8, _ = _fp8_quant_channel(torch.randn(16, 16) * 0.1)
     shard = tmp_path / "model.safetensors"
-    _write_shard(shard, {"model.layers.0.mlp.up_proj.weight": W_fp8})  # no companion scale
+    _write_shard(shard, {"model.layers.0.mlp.up_proj.weight": W_fp8})
 
     with pytest.raises(RuntimeError, match="weight_scale"):
         _merge_and_overwrite_lora(
@@ -204,7 +202,6 @@ def test_fp8_quant_config_detection():
         "quant_method": "compressed-tensors",
         "config_groups": {"group_0": {"weights": {"type": "float", "num_bits": 8}}},
     })
-    # Non-FP8 schemes must NOT be reclassified.
     assert not _is_fp8_quant_config({"load_in_4bit": True, "bnb_4bit_quant_type": "nf4"})
     assert not _is_fp8_quant_config({"quant_method": "mxfp4"})
     # Microscaling FP8 (mxfp8) carries its own block scales, not dense FP8.
@@ -337,7 +334,6 @@ def _run_cross_shard_merge(tmp_path, weight_in, scale_in, process_order):
             keys |= set(f.keys())
             if "model.layers.0.mlp.down_proj.weight" in f.keys():
                 merged = f.get_tensor("model.layers.0.mlp.down_proj.weight")
-    # Weight dequantized via cross-shard scale; orphaned scale dropped; other tensor kept.
     assert merged is not None and merged.dtype == torch.bfloat16
     assert torch.allclose(merged.float(), W_real, atol=0.05)
     assert "model.layers.0.mlp.down_proj.weight_scale" not in keys
@@ -589,7 +585,7 @@ def test_fp8_e5m2_dequantizes(tmp_path):
     amax = W_real.abs().amax(dim=1, keepdim=True).clamp_min(1e-12)
     scale = (amax / 57344.0).to(torch.float32)  # e5m2 max ~57344
     q = (W_real / scale).clamp(-57344.0, 57344.0).to(torch.float8_e5m2)
-    ref = q.to(torch.float32) * scale  # the correct dequantization
+    ref = q.to(torch.float32) * scale
     shard = tmp_path / "model.safetensors"
     _write_shard(shard, {
         "model.layers.0.mlp.down_proj.weight": q,
@@ -624,7 +620,7 @@ def test_fp8_fused_expert_underscore_scale(tmp_path):
     shard = tmp_path / "model.safetensors"
     _write_shard(shard, {
         "model.layers.0.mlp.experts.gate_up_proj": W_fp8,
-        "model.layers.0.mlp.experts.gate_up_proj_scale_inv": scale,  # underscore naming
+        "model.layers.0.mlp.experts.gate_up_proj_scale_inv": scale,
     })
 
     _merge_and_overwrite_lora(
@@ -635,7 +631,7 @@ def test_fp8_fused_expert_underscore_scale(tmp_path):
 
     with safe_open(str(shard), framework="pt", device="cpu") as f:
         keys = list(f.keys())
-        assert "model.layers.0.mlp.experts.gate_up_proj_scale_inv" not in keys  # scale dropped
+        assert "model.layers.0.mlp.experts.gate_up_proj_scale_inv" not in keys
         merged = f.get_tensor("model.layers.0.mlp.experts.gate_up_proj").float()
     assert torch.allclose(merged, W_real, atol=0.05)
 
@@ -708,10 +704,8 @@ def test_fp8_keeps_non_companion_scale_tensors(tmp_path):
 
     with safe_open(str(shard), framework="pt", device="cpu") as f:
         keys = set(f.keys())
-        # FP8 companion dropped, weight dequantized.
         assert "model.layers.0.mlp.down_proj.weight_scale" not in keys
         assert f.get_tensor("model.layers.0.mlp.down_proj.weight").dtype == torch.bfloat16
-        # Unrelated *_scale / *_scale_inv tensors preserved (not FP8 companions).
         for k in ("model.layers.0.mlp.router.per_expert_scale", "model.embed_scale",
                   "logit_scale", "model.layers.0.attn.k_scale_inv"):
             assert k in keys, f"{k} was wrongly dropped"
@@ -740,9 +734,7 @@ def test_fp8_preserves_non_fp8_buffer_dtypes(tmp_path):
     )
 
     with safe_open(str(shard), framework="pt", device="cpu") as f:
-        # FP8 weight dequantized to output_dtype.
         assert f.get_tensor("model.layers.0.self_attn.q_proj.weight").dtype == torch.bfloat16
-        # Buffers keep their original dtypes.
         assert f.get_tensor("model.rotary_emb.inv_freq").dtype == torch.float32
         assert f.get_tensor("model.layers.0.attn.bias_mask").dtype == torch.bool
         ids = f.get_tensor("model.position_ids")

--- a/tests/test_fused_forward_install.py
+++ b/tests/test_fused_forward_install.py
@@ -62,11 +62,6 @@ def enable_env(monkeypatch):
     monkeypatch.setenv("UNSLOTH_FUSED_FORWARD", "1")
 
 
-# ---------------------------------------------------------------------------
-# AST rewriter unit tests
-# ---------------------------------------------------------------------------
-
-
 CANONICAL_KW_SRC = """
 def forward(self, input_ids=None, labels=None, logits_to_keep=0, **kwargs):
     outputs = self.model(input_ids=input_ids, **kwargs)
@@ -260,11 +255,6 @@ def test_ast_rewriter_forwards_explicit_extra_kwargs():
     assert "num_items_in_batch=" in new_src
 
 
-# ---------------------------------------------------------------------------
-# install_for_class
-# ---------------------------------------------------------------------------
-
-
 _SYNTH_COUNTER = 0
 
 
@@ -301,7 +291,6 @@ def test_install_noop_when_disabled(fresh_install, monkeypatch):
 
 
 def test_install_default_is_on(fresh_install, monkeypatch):
-    # With no env var set, the installer must be active.
     monkeypatch.delenv("UNSLOTH_FUSED_FORWARD", raising=False)
     cls = _make_synthetic_class(CANONICAL_KW_SRC)
     assert fresh_install.is_enabled() is True
@@ -406,11 +395,6 @@ def test_audit_dump(fresh_install, enable_env):
     assert cls.__qualname__ in out["patched"]
 
 
-# ---------------------------------------------------------------------------
-# Numerical equivalence on a small toy model
-# ---------------------------------------------------------------------------
-
-
 def _toy_forward_src():
     # Mirrors the canonical HF template enough to be rewriter-eligible.
     return """
@@ -430,7 +414,6 @@ def test_rewritten_forward_loss_matches_reference(fresh_install, enable_env):
 
     cls = _make_synthetic_class(_toy_forward_src(), name="ToyForCausalLM")
 
-    # Wire a config + lm_head + reference loss_function.
     B, T, H, V = 2, 8, 32, 64
 
     class _Config:
@@ -458,7 +441,6 @@ def test_rewritten_forward_loss_matches_reference(fresh_install, enable_env):
     ref_loss, _ = instance.forward(hidden, labels=labels)
     ref_loss_value = float(ref_loss.detach().cpu().item())
 
-    # Install fused forward.
     ok = fresh_install.install_for_class(cls)
     assert ok is True
 
@@ -668,11 +650,6 @@ def test_adapter_num_items_in_batch_as_int_and_tensor_equal():
     )
 
 
-# ---------------------------------------------------------------------------
-# Env-var branch: UNSLOTH_RETURN_LOGITS
-# ---------------------------------------------------------------------------
-
-
 def _install_toy_cls(fresh_install):
     cls = _make_synthetic_class(_toy_forward_src(), name="EnvVarToyForCausalLM")
     assert fresh_install.install_for_class(cls) is True
@@ -716,7 +693,6 @@ def test_rewritten_forward_returns_real_logits_when_env_set(
     hidden = torch.randn(B, T, H, device=device, dtype=torch.bfloat16)
     labels = torch.randint(0, V, (B, T), device=device)
 
-    # Count lm_head invocations to prove single-matmul on the opt-in path.
     lm_head_calls = {"n": 0}
     orig_call = inst.lm_head.__class__.__call__
     def _counting_call(self, *a, **kw):
@@ -724,8 +700,6 @@ def test_rewritten_forward_returns_real_logits_when_env_set(
         return orig_call(self, *a, **kw)
     monkeypatch.setattr(inst.lm_head.__class__, "__call__", _counting_call)
 
-    # Also count self.loss_function invocations to confirm the opt-in path
-    # routes through the model's own loss function.
     loss_fn_calls = {"n": 0}
     real_loss_fn = inst.loss_function
     def _counting_loss_fn(*a, **kw):

--- a/tests/test_grpo_prefix_grouper_raw_logits.py
+++ b/tests/test_grpo_prefix_grouper_raw_logits.py
@@ -163,8 +163,6 @@ def test_pg_forward_source_dispatches_on_width():
     assert "lm_head.shape[1]" in src
 
 
-# --- the property the reshape comment protects -------------------------------
-
 @pytest.mark.parametrize("vocab,hidden", [
     (23, 6),    # vocab not divisible by hidden
     (24, 6),    # divisible: reshaping on lm_head's width would silently succeed

--- a/tests/test_hub_transport_errors_single_segment.py
+++ b/tests/test_hub_transport_errors_single_segment.py
@@ -105,8 +105,6 @@ def _stdlib_json_decode_error():
     return json.JSONDecodeError("Expecting value", "<html>", 0)
 
 
-# A ValueError *subclass* on a single segment name is a transport failure.
-
 _SUBCLASS_TRANSPORT_ERRORS = [
     pytest.param(_requests_json_decode_error, id = "requests-JSONDecodeError"),
     pytest.param(_stdlib_json_decode_error,   id = "stdlib-JSONDecodeError"),
@@ -148,8 +146,6 @@ def test_determine_base_model_source_propagates_single_segment_transport_error(
     with pytest.raises(RuntimeError):
         saving_utils.determine_base_model_source("gpt2")
 
-
-# The real single segment rejection still answers False.
 
 @pytest.mark.parametrize("name", ["gpt2", "bert-base-uncased", "distilgpt2"])
 def test_single_segment_rejection_still_reports_absent(monkeypatch, name):
@@ -342,8 +338,6 @@ def test_repo_types_that_cannot_be_a_base_model_stay_rejected(monkeypatch, name)
     assert saving_utils._is_hub_repo_id(name) is False
 
 
-# A root URI addresses the repository itself.
-
 @pytest.mark.parametrize("given, expected", [
     pytest.param("hf://openai-community/gpt2/",  "openai-community/gpt2", id = "root-uri"),
     pytest.param("hf://openai-community/gpt2//", "openai-community/gpt2", id = "doubled"),
@@ -488,8 +482,6 @@ def test_hf_uri_error_is_still_absent_not_transport(monkeypatch):
     assert saving_utils.check_hf_model_exists("gpt2") is False
 
 
-# No previously working input regressed: True stays True.
-
 @pytest.mark.parametrize("name", ["gpt2", "bert-base-uncased", "distilgpt2"])
 def test_listable_single_segment_id_still_returns_true(monkeypatch, name):
     """0.36.2 lists `gpt2` happily (17 entries, safetensors among them). The narrowing
@@ -513,8 +505,6 @@ def test_offline_mode_on_a_single_segment_id_raises(monkeypatch):
     with pytest.raises(RuntimeError):
         saving_utils.check_hf_model_exists("gpt2")
 
-
-# End to end over real HTTP: a proxy answering 200 with a non-JSON body.
 
 class _GarbageHandler(http.server.BaseHTTPRequestHandler):
     """200 with HTML, which is what a captive portal does to an API call."""

--- a/tests/test_inductor_codegen_fallback.py
+++ b/tests/test_inductor_codegen_fallback.py
@@ -462,7 +462,6 @@ def test_restoring_the_marker_cannot_erase_an_earlier_compiled_pack(monkeypatch)
     """
     monkeypatch.setattr(patch_utils, "_in_non_reentrant_checkpoint",
                         lambda **_: True)
-    # An earlier region in this same checkpoint already packed compiled.
     monkeypatch.setattr(patch_utils, "_PACKED_COMPILED_IN_CHECKPOINT", True)
     monkeypatch.setattr(
         patch_utils, "_note_packed_under_checkpoint",
@@ -930,7 +929,6 @@ def test_releasing_borrowed_budget_keeps_compiled_pack_history(monkeypatch):
         "handing back the recompile budget mid-step erased a wrapper's record "
         "of having packed compiled activations"
     )
-    # The genuine step boundary still clears it.
     patch_utils.apply_pending_eager_fallbacks()
     assert "test-packed-earlier" not in patch_utils._COMPILED_OK_LABELS, \
         "the step boundary must still reset the history"

--- a/tests/test_llama_cpp_bundle_converter.py
+++ b/tests/test_llama_cpp_bundle_converter.py
@@ -60,7 +60,6 @@ def test_returns_none_when_dir_missing(mod, monkeypatch, tmp_path):
 
 
 def test_returns_none_when_default_dir_empty_or_unset(mod, monkeypatch):
-    # An unset / empty default dir must not crash and must fall through.
     monkeypatch.setattr(mod, "LLAMA_CPP_DEFAULT_DIR", "")
     assert mod._resolve_bundle_convert_script() is None
 

--- a/tests/test_llama_cpp_prebuilt.py
+++ b/tests/test_llama_cpp_prebuilt.py
@@ -1,6 +1,3 @@
-# Tests for the prebuilt-first llama.cpp install path: release resolution,
-# asset selection, archive extraction/placement, fallback-to-compile contract,
-# and reuse of an existing prebuilt install without deletion.
 
 from __future__ import annotations
 
@@ -65,8 +62,6 @@ def _patch_platform(monkeypatch, system, machine):
     monkeypatch.setattr(llama_cpp.platform, "machine", lambda: machine)
 
 
-# --- asset selection ---------------------------------------------------------
-
 @pytest.mark.parametrize("system,machine,expected", [
     ("Linux",   "x86_64",  "llama-b9000-bin-ubuntu-x64.tar.gz"),
     ("Linux",   "AMD64",   "llama-b9000-bin-ubuntu-x64.tar.gz"),
@@ -100,8 +95,6 @@ def test_select_asset_missing_from_release(monkeypatch):
     assert llama_cpp._select_prebuilt_asset(tag, assets) is None
 
 
-# --- release resolution ------------------------------------------------------
-
 def test_resolve_release_env_pin_hits_tag_endpoint(monkeypatch):
     seen = {}
     class FakeResponse:
@@ -127,8 +120,6 @@ def test_resolve_release_failure_returns_none(monkeypatch):
     monkeypatch.setattr(llama_cpp, "_requests_get_with_retries", fake_get)
     assert llama_cpp._resolve_llama_cpp_release() is None
 
-
-# --- gates -------------------------------------------------------------------
 
 def test_force_compile_skips_prebuilt(monkeypatch, tmp_path):
     monkeypatch.setenv("UNSLOTH_LLAMA_FORCE_COMPILE", "1")
@@ -285,8 +276,6 @@ def test_gpu_sha256_mismatch_falls_back(monkeypatch, tmp_path):
     assert not os.path.exists(folder)
 
 
-# --- extraction and placement ------------------------------------------------
-
 def test_extract_rejects_path_traversal(tmp_path):
     evil = tmp_path / "evil.tar.gz"
     with tarfile.open(evil, "w:gz") as tar:
@@ -409,11 +398,8 @@ def test_extract_and_place_windows_zip(monkeypatch, tmp_path):
     assert (release / "llama-quantize.exe").is_file()
     assert (release / "llama-cli.exe").is_file()
     assert (release / "ggml.dll").is_file()
-    # On Windows nothing is placed at the flat install root.
     assert not (install / "llama-quantize.exe").exists()
 
-
-# --- full install orchestration ----------------------------------------------
 
 def _wire_fake_downloads(monkeypatch, tmp_path, tag, quantize_script = FAKE_QUANTIZE):
     """Point release resolution and downloads at local fixture archives."""
@@ -455,7 +441,6 @@ def test_full_prebuilt_install_happy_path(monkeypatch, tmp_path):
     marker = json.load(open(os.path.join(folder, llama_cpp.UNSLOTH_PREBUILT_INFO_FILENAME)))
     assert marker["tag"] == "b9000"
     assert marker["asset"] == "llama-b9000-bin-ubuntu-x64.tar.gz"
-    # Staging directories are cleaned up
     leftovers = [e for e in os.listdir(tmp_path) if e.startswith(".llama_cpp_prebuilt_")]
     assert leftovers == []
 
@@ -465,7 +450,6 @@ def test_validation_failure_falls_back(monkeypatch, tmp_path):
     _wire_fake_downloads(monkeypatch, tmp_path, "b9000", quantize_script = FAKE_QUANTIZE_BROKEN)
     folder = str(tmp_path / "llama.cpp")
     assert llama_cpp._install_llama_cpp_prebuilt(folder) is None
-    # A failed install never materializes the target folder
     assert not os.path.exists(folder)
 
 
@@ -546,14 +530,12 @@ def test_select_cpu_assets_unsupported(monkeypatch, system, machine):
 
 
 def test_select_cpu_assets_macos_missing_bundle(monkeypatch):
-    # Darwin asks for the Metal bundle by convention; absent -> no fork CPU asset.
     _patch_platform(monkeypatch, "Darwin", "arm64")
     assets = {k: v for k, v in FORK_ASSETS.items() if k != "llama-b9585-bin-macos-arm64.tar.gz"}
     assert llama_cpp._select_cpu_assets("b9585", assets, FORK_MANIFEST) == []
 
 
 def test_select_cpu_assets_linux_missing_from_release(monkeypatch):
-    # Manifest lists linux-cpu but the asset isn't in the release map -> skipped.
     _patch_platform(monkeypatch, "Linux", "x86_64")
     assets = {k: v for k, v in FORK_ASSETS.items() if k != "app-b9585-linux-x64-cpu.tar.gz"}
     assert llama_cpp._select_cpu_assets("b9585", assets, FORK_MANIFEST) == []
@@ -594,7 +576,6 @@ def test_hydrate_strips_mix_tag_when_no_fork_source(monkeypatch, tmp_path):
 
 
 def test_hydrate_plain_ggml_tag_unchanged(monkeypatch, tmp_path):
-    # A plain ggml-org tag carries no -mix- suffix, so resolution is a no-op.
     seen = _capture_hydrate_url(monkeypatch)
     with pytest.raises(RuntimeError):
         llama_cpp._hydrate_converter_sources("b9000", str(tmp_path / "install"))
@@ -626,7 +607,6 @@ def _wire_attempt_recorder(monkeypatch, *, fork_release, ggml_release, manifest 
 
 
 def test_attempt_order_cpu_only_linux(monkeypatch, tmp_path):
-    # gpu_support=False on Linux: fork CPU bundle first, ggml-org CPU as tertiary.
     _patch_platform(monkeypatch, "Linux", "x86_64")
     monkeypatch.delenv("UNSLOTH_LLAMA_FORCE_COMPILE", raising = False)
     ggml = _fake_release("b9000", ["llama-b9000-bin-ubuntu-x64.tar.gz"])
@@ -694,7 +674,6 @@ def test_attempt_order_darwin_fork_only_no_ggml(monkeypatch, tmp_path):
 
 
 def test_attempt_order_fork_unreachable_uses_ggml(monkeypatch, tmp_path):
-    # Fork release resolution fails -> ggml-org CPU is still tried (resilience).
     _patch_platform(monkeypatch, "Linux", "x86_64")
     monkeypatch.delenv("UNSLOTH_LLAMA_FORCE_COMPILE", raising = False)
     ggml = _fake_release("b9000", ["llama-b9000-bin-ubuntu-x64.tar.gz"])
@@ -751,15 +730,12 @@ def test_cpu_fork_full_install_happy_path(monkeypatch, tmp_path):
     marker = json.load(open(os.path.join(folder, llama_cpp.UNSLOTH_PREBUILT_INFO_FILENAME)))
     assert marker["repo"] == "unslothai/llama.cpp"
     assert marker["asset"] == asset
-    # Converter hydrated from the fork's own source asset, not ggml-org codeload.
     from urllib.parse import urlparse
     assert f"https://example.invalid/{fork_source}" in downloaded
     assert all(urlparse(u).netloc != "codeload.github.com" for u in downloaded)
 
 
 def test_force_compile_skips_prebuilt_gpu(monkeypatch, tmp_path):
-    # UNSLOTH_LLAMA_FORCE_COMPILE=1 must bypass the prebuilt path for gpu_support=True
-    # too (no release resolution, no GPU probing).
     monkeypatch.setenv("UNSLOTH_LLAMA_FORCE_COMPILE", "1")
     def boom(*a, **k):
         raise AssertionError("network must not be touched")

--- a/tests/test_local_base_model_resolution_offline.py
+++ b/tests/test_local_base_model_resolution_offline.py
@@ -105,9 +105,6 @@ _OFFLINE = OfflineModeIsEnabled(
 )
 
 
-# 1. check_hf_model_exists: a string that cannot name a repo is absent, not
-#    unreachable, and must cost no network call.
-
 _NOT_REPO_IDS = [
     pytest.param("./base", id = "dot-slash-relative-path"),
     pytest.param("/home/user/models/base", id = "absolute-path"),
@@ -232,8 +229,6 @@ def test_transport_error_on_a_valid_repo_id_still_raises(monkeypatch):
         saving_utils.check_hf_model_exists("unsloth/Llama-3.2-1B-Instruct")
 
 
-# 2. determine_base_model_source: a local base model resolves with no network.
-
 @pytest.mark.parametrize("shape", ["relative", "dot-slash", "absolute"])
 def test_local_base_model_resolves_without_network(monkeypatch, tmp_path, shape):
     """The three shapes a user actually passes for a local base model."""
@@ -309,9 +304,6 @@ def test_local_mxfp4_also_outranks_the_hub_without_network(monkeypatch, tmp_path
     )
 
 
-# 3. The original bug stays fixed: no local fallback plus an unreachable Hub must still
-#    be loud.
-
 _UNREACHABLE = [
     pytest.param(_OFFLINE, id = "hf-hub-offline"),
     pytest.param(ConnectionError("Temporary failure in name resolution"), id = "dns-failure"),
@@ -353,9 +345,6 @@ def test_absent_repo_with_no_local_copy_still_reports_nothing_found(monkeypatch,
         None, False, "", False, None,
     )
 
-
-# 4. A local copy that only wins at priority 5 must NOT rescue an unreachable Hub,
-#    because the merge cannot use it for a 16bit export.
 
 def test_unreachable_hub_does_not_fall_back_to_a_priority_5_local_copy(
     monkeypatch, tmp_path,

--- a/tests/test_local_fp8_base_offline_resolution.py
+++ b/tests/test_local_fp8_base_offline_resolution.py
@@ -98,8 +98,6 @@ def _same_path(a, b):
     return os.path.realpath(str(a)) == os.path.realpath(str(b))
 
 
-# The regression: a repo-id shaped local FP8 directory with the Hub down.
-
 @pytest.mark.parametrize("error", _TRANSPORT_ERRORS)
 @pytest.mark.parametrize("quant_config", [
     pytest.param(FP8_CONFIG,        id = "finegrained-fp8"),
@@ -148,8 +146,6 @@ def test_local_fp8_fallback_emits_no_warning(monkeypatch, tmp_path, error):
     assert [str(w.message) for w in caught
             if issubclass(w.category, UserWarning)] == []
 
-
-# Everything the merge cannot complete offline must keep raising.
 
 @pytest.mark.parametrize("error", _TRANSPORT_ERRORS)
 @pytest.mark.parametrize("quant_config, label", [
@@ -207,8 +203,6 @@ def test_the_4bit_merges_still_fall_back_at_any_quantization(monkeypatch, tmp_pa
     assert is_local is True
     assert source == "local_nf4"
 
-
-# A half downloaded snapshot is not a base the merge can read.
 
 def _shard(directory, name):
     open(os.path.join(directory, name), "wb").close()
@@ -502,8 +496,6 @@ def test_no_local_copy_still_raises(monkeypatch, tmp_path, error):
         saving_utils.determine_base_model_source("unsloth/does-not-exist")
 
 
-# A reachable Hub stays authoritative: nothing that resolved before changed.
-
 def test_reachable_hub_16bit_repo_still_outranks_the_local_fp8_copy(monkeypatch, tmp_path):
     """Catching the failure rather than hoisting priority 5 is what preserves this: with
     the Hub up, the 16bit repo still wins at priority 3."""
@@ -570,9 +562,6 @@ def test_local_mxfp4_still_resolves_before_the_probe(monkeypatch, tmp_path):
     assert source == "local_mxfp4"
     assert quant_type == "mxfp4"
 
-
-# The FP8 16bit sibling lookup must not report "no sibling" for a Hub it could not
-# reach.
 
 @pytest.mark.parametrize("error", _TRANSPORT_ERRORS)
 def test_sibling_lookup_says_so_when_the_hub_is_unreachable(monkeypatch, tmp_path, error):

--- a/tests/test_longrope_attention_factor.py
+++ b/tests/test_longrope_attention_factor.py
@@ -107,8 +107,6 @@ def _att(cfg):
 DERIVED = math.sqrt(1 + math.log(32) / math.log(4096))   # ~1.1902
 
 
-# ---- the published configs ------------------------------------------------
-
 def test_impossible_value_is_replaced_by_the_derivation():
     cfg = _cfg(attention_factor=32.0)
     assert _att(cfg) == pytest.approx(DERIVED, rel=1e-6)
@@ -138,8 +136,6 @@ def test_patching_twice_does_not_stack():
     patch_longrope_impossible_attention_factor()
     assert R.ROPE_INIT_FUNCTIONS["longrope"] is first
 
-
-# ---- configs that mean what they say --------------------------------------
 
 def test_a_real_attention_factor_is_preserved():
     assert _att(_cfg(attention_factor=1.19)) == pytest.approx(1.19)
@@ -189,8 +185,6 @@ def test_missing_original_max_still_strips_the_bad_value():
     _att(cfg)
     assert "attention_factor" not in cfg.rope_scaling
 
-
-# ---- every call shape transformers uses -----------------------------------
 
 def test_device_stays_optional_for_a_transformers_5_original():
     """transformers 5 gives every parameter but `config` a default, and

--- a/tests/test_loss_normalization_contract.py
+++ b/tests/test_loss_normalization_contract.py
@@ -127,8 +127,6 @@ def test_get_batch_samples_still_returns_the_documented_pair():
     )
 
 
-# Numerical: the guard is what makes accumulated gradients match a single batch.
-
 def _tiny_model():
     """A token normalising loss: sum / count when a count is given, mean otherwise.
 
@@ -256,9 +254,6 @@ def test_accumulated_gradient_matches_the_single_batch_gradient():
     )
 
 
-
-# Packed / padding-free boundary counting.
-#
 # The N-1 internal boundaries of a packed row are not training positions, but
 # subtracting N-1 double counts every boundary a collator already masked with
 # -100 (TRL >= 0.23.1 labels[position_ids == 0] = -100, completion_only_loss /
@@ -516,7 +511,6 @@ def test_applying_the_boundary_removal_twice_is_idempotent():
     first = _counted(batch)
     second = _counted(batch)
     assert first == second == 7, f"first {first}, second {second}"
-    # And the caller's batch must come back unharmed.
     assert int((batch["labels"] != -100).sum()) == 7, (
         "the counting path mutated the caller's labels"
     )

--- a/tests/test_mamba_ssm_pre_ampere_fallback.py
+++ b/tests/test_mamba_ssm_pre_ampere_fallback.py
@@ -506,8 +506,6 @@ def test_no_mamba_ssm_is_untouched(env):
     assert iu.is_mamba_ssm_available() is True
 
 
-# ---- transformers 5's Hub kernels ----------------------------------------
-#
 # lazy_load_kernel resolves mamba-ssm from kernels-community when the `kernels`
 # package is installed. It needs no local wheel and never calls
 # is_mamba_ssm_available, so the predicates above cannot reach it.

--- a/tests/test_merge_e2e_classification_head.py
+++ b/tests/test_merge_e2e_classification_head.py
@@ -204,8 +204,6 @@ def test_a_plain_causal_lm_export_is_untouched(tmp_path):
     assert "id2label" not in data or len(data["id2label"]) == 2   # transformers' own default
 
 
-# ---- unit level -------------------------------------------------------------------
-
 def test_only_modules_to_save_is_seeded_not_an_unbacked_lora():
     """A LoRA target missing from the base has no trained tensor of its own to lose, so it
     must stay excluded; only `modules_to_save` carries weights that exist nowhere else."""

--- a/tests/test_merge_e2e_hub_unreachable.py
+++ b/tests/test_merge_e2e_hub_unreachable.py
@@ -91,8 +91,6 @@ def _looks_like_a_successful_export(out_dir):
     return any(name.endswith(".safetensors") for name in os.listdir(out_dir))
 
 
-# The regression this whole branch exists to remove.
-
 def test_unreachable_hub_raises_and_writes_nothing(monkeypatch, tmp_path):
     """The bug, end to end: a base only on the Hub, a rate limited Hub and a 16bit
     merge. The old code warned, returned None and created no output directory."""
@@ -211,8 +209,6 @@ def test_an_hf_uri_is_still_addressed_as_a_repo(monkeypatch):
     assert saving_utils._is_hub_repo_id("hf://a/b/c") is False
     assert saving_utils._is_hub_repo_id("/abs/base") is False
 
-
-# The complement: an unreachable Hub must not break a merge that never needed it.
 
 def test_a_local_base_still_merges_with_the_hub_down(monkeypatch, tmp_path):
     """The base is on disk, so nothing about this merge is the Hub's to decide: it must

--- a/tests/test_merge_e2e_text_only_config.py
+++ b/tests/test_merge_e2e_text_only_config.py
@@ -189,8 +189,6 @@ def test_base_config_read_failure_falls_back_with_a_warning(tmp_path, monkeypatc
         "the fallback must not lose the export it is protecting"
 
 
-# vocab-size helpers, config-level only
-
 _MISSING = object()
 
 

--- a/tests/test_mlx_grad_clip_resolution.py
+++ b/tests/test_mlx_grad_clip_resolution.py
@@ -28,9 +28,6 @@ def _resolve(raw_mgv=None, raw_mgln=None, max_grad_norm=0.0):
     return _resolve_mlx_grad_clipping(cfg)
 
 
-# -- field defaults ---------------------------------------------------------
-
-
 def test_field_defaults_are_none_sentinels():
     """Defaults are sentinels meaning 'use MLX cheap default'."""
     from unsloth_zoo.mlx.trainer import MLXTrainingConfig
@@ -64,9 +61,6 @@ def test_fields_accept_explicit_positive():
     )
     assert cfg.max_grad_value == 2.5
     assert cfg.max_grad_leaf_norm == 1.5
-
-
-# -- resolution semantics ---------------------------------------------------
 
 
 def test_default_uses_cheap_leaf_norm():
@@ -140,9 +134,6 @@ def test_max_grad_value_wins_over_leaf_norm_when_both_positive():
     assert mgv == 2.0
     assert mgln == 0.0
     assert mode == "value"
-
-
-# -- trainer source assertions (defense-in-depth) ---------------------------
 
 
 def test_trainer_source_pins_resolution_rule():

--- a/tests/test_mlx_module_exports.py
+++ b/tests/test_mlx_module_exports.py
@@ -32,10 +32,6 @@ def _install_shim():
     simulate_mlx_on_torch()
 
 
-# ---------------------------------------------------------------------------
-# 1. Top-level imports must succeed.
-# ---------------------------------------------------------------------------
-
 @pytest.mark.parametrize("module_path", [
     "unsloth_zoo.mlx.loader",
     "unsloth_zoo.mlx.trainer",
@@ -50,11 +46,6 @@ def test_mlx_module_imports(module_path):
     mod = importlib.import_module(module_path)
     assert mod is not None
 
-
-# ---------------------------------------------------------------------------
-# 2. Unsloth backend contract: FastMLXModel and the dynamically-attached save methods
-#    must be reachable.
-# ---------------------------------------------------------------------------
 
 def test_fast_mlx_model_class_exists():
     from unsloth_zoo.mlx.loader import FastMLXModel
@@ -90,11 +81,9 @@ def test_fast_mlx_model_save_helpers_exist():
     loader.py and attached via types.MethodType after load.
     """
     import unsloth_zoo.mlx.loader as ml
-    # Free functions must exist.
     assert hasattr(ml, "_mlx_save_pretrained_merged")
     assert hasattr(ml, "_mlx_save_lora_adapters")
     assert hasattr(ml, "_mlx_push_to_hub_merged")
-    # And the underlying utils targets.
     import unsloth_zoo.mlx.utils as mu
     assert hasattr(mu, "save_pretrained_merged")
     assert hasattr(mu, "save_lora_adapters")
@@ -111,23 +100,14 @@ def test_trainer_classes():
     assert hasattr(mt, "train_on_responses_only") or hasattr(mt, "MLXTrainer")
 
 
-# ---------------------------------------------------------------------------
-# 3. MLX loader: dequantize-and-replace logic surface
-# ---------------------------------------------------------------------------
-
 def test_mlx_loader_dequantize_replace_callable():
     """The dequantize-and-replace helper used by FastMLXModel.from_pretrained."""
     import unsloth_zoo.mlx.loader as ml
-    # The loader names this `_dequantize_selected_mlx_modules`.
     assert hasattr(ml, "_dequantize_selected_mlx_modules"), (
         "expected _dequantize_selected_mlx_modules in unsloth_zoo.mlx.loader. "
         f"Got dequant-related: {[a for a in dir(ml) if 'dequant' in a.lower()]}"
     )
 
-
-# ---------------------------------------------------------------------------
-# 4. CCE: pure-Python fallback fires when mx.metal.is_available() is False.
-# ---------------------------------------------------------------------------
 
 def test_cce_fallback_path_runs():
     """Construct a tiny CCE loss and verify the no-kernel branch fires."""
@@ -169,17 +149,9 @@ def test_cce_forward_chunked_pure_python():
     assert torch.isfinite(lse).all(), f"non-finite lse: {lse}"
 
 
-# ---------------------------------------------------------------------------
-# 5. compile: VLM dispatcher should at minimum import.
-# ---------------------------------------------------------------------------
-
 def test_compile_import_does_not_error():
     import unsloth_zoo.mlx.compile  # full module-level execution
 
-
-# ---------------------------------------------------------------------------
-# 6. gated_delta_vjp: custom_function decorator should be applied.
-# ---------------------------------------------------------------------------
 
 def test_gated_delta_vjp_imports():
     import unsloth_zoo.gated_delta_vjp as gd
@@ -187,10 +159,6 @@ def test_gated_delta_vjp_imports():
     # gated_delta_ops_efficient is the main entry
     assert hasattr(gd, "gated_delta_ops_efficient")
 
-
-# ---------------------------------------------------------------------------
-# 7. Optimizer construction: each MLXTrainingConfig optim string maps cleanly.
-# ---------------------------------------------------------------------------
 
 def test_trainer_config_smoke():
     """MLXTrainingConfig should construct with sane defaults."""
@@ -205,12 +173,10 @@ def test_trainer_config_smoke():
     assert ok
 
 
-# ---------------------------------------------------------------------------
 # 8. Warm-start contract: the documented from_pretrained behaviour must match
 #    the adapter-reload code. The reload restores the non-adapter tensors a
 #    save_trainable_adapters checkpoint recorded as trainable, so the docstring
 #    must describe that instead of promising an adapter-only trainable set.
-# ---------------------------------------------------------------------------
 
 def test_from_pretrained_documents_restored_non_adapter_trainables():
     import inspect

--- a/tests/test_mlx_neftune_quant_map.py
+++ b/tests/test_mlx_neftune_quant_map.py
@@ -102,7 +102,6 @@ def test_neftune_saved_map_reloads_against_base():
     finally:
         emb.__class__ = original
 
-    # Reload validates the saved map against the now-unmodified base model.
     adapter_cfg = {"base_resolved_quantization_map": saved_map}
     _validate_mlx_adapter_base(model, adapter_cfg)  # must not raise
 
@@ -199,7 +198,6 @@ def test_lora_wrapped_embedding_map_key_and_reload():
                 f"{sorted(set(wrapped_map) ^ set(base_map))}"
             )
 
-        # Reload validates the saved-while-wrapped map against a fresh base.
         fresh, _ = FastMLXModel.from_pretrained(MODEL, max_seq_length=128)
         _validate_mlx_adapter_base(
             fresh, {"base_resolved_quantization_map": wrapped_map}
@@ -456,7 +454,6 @@ def test_embed_scale_probe_reads_the_installed_transformers():
 
     # gemma3 has scaled inside the embedding in every transformers that has it.
     assert probe("gemma3_text") is True
-    # A plain-embedding architecture, and one transformers does not know at all.
     assert probe("qwen3") is False
     assert probe("not_a_real_architecture") is None
     # It must answer without importing: a modeling module needs torch, which is
@@ -477,7 +474,6 @@ def test_embed_scale_probe_reads_the_installed_transformers():
     with mock.patch.object(loader, "get_source", lambda self, name: None):
         assert probe("gemma3_text") is True, "source-less package must still answer"
     probe.cache_clear()
-    # Only when neither is available is the question genuinely unanswerable.
     def _raise(self, name):
         raise OSError("no code")
     with mock.patch.object(loader, "get_source", lambda self, name: None), \
@@ -639,7 +635,6 @@ def test_embed_scale_reads_both_spellings_of_a_family(
     from types import SimpleNamespace
     from unsloth_zoo.mlx import utils as mlx_utils
 
-    # Force the fallback: this is the path that reads the family sets.
     monkeypatch.setattr(mlx_utils, "_transformers_scales_inside_embedding",
                         lambda _mt: None)
     found = []
@@ -670,8 +665,6 @@ def test_probe_survives_the_backends_own_random_state():
     # mx.compile captured, which stops a compiled step redrawing.
     assert isinstance(mx.random.state, list) is _RNG_STATE_WRITABLE
 
-    # The rewind must work on whatever this mlx exposes, not just the pre-0.32
-    # list form.
     import mlx.nn as nn
     from unsloth_zoo.mlx.utils import _mlx_rng_key, _restore_mlx_rng_key
 

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -98,7 +98,6 @@ def test_active_layer_k_norm_and_q_norm_still_raises():
 def test_non_qk_norm_mismatch_passes_through():
     from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
 
-    # Other extra-weight mismatches / unrelated errors must pass through.
     _raise_if_qk_norm_version_gap(
         "gemma4",
         "Received 4 parameters not in model: per_layer_model_projection.scales",

--- a/tests/test_mlx_quantized_optimizer_state.py
+++ b/tests/test_mlx_quantized_optimizer_state.py
@@ -135,7 +135,6 @@ def _moment(optimizer, key="m"):
     return optimizer.state["layers"][0]["weight"][key]
 
 
-# 1 ------------------------------------------------------------------------
 def test_loss_decreases_with_quantized_first_moment():
     x, y = _batch()
     losses = _train(QuantizedMomentAdam(1e-3, bias_correction=True), _build_model(), x, y)
@@ -146,7 +145,6 @@ def test_loss_decreases_with_quantized_first_moment():
     assert losses[-1] < losses[0]
 
 
-# 2 ------------------------------------------------------------------------
 def test_loss_trajectory_tracks_fp32_baseline():
     """Compare the whole trajectory over a target the model CANNOT fit. On the
     overparameterised fixture the loss reaches ~1e-9, where a relative comparison
@@ -167,7 +165,6 @@ def test_loss_trajectory_tracks_fp32_baseline():
     assert all(l == l for l in int8), "quantized run produced a NaN"
 
 
-# 3 ------------------------------------------------------------------------
 def test_optimizer_state_is_measurably_smaller():
     x, y = _batch()
     fp32_opt = optim.Adam(learning_rate=1e-3, bias_correction=True)
@@ -186,7 +183,6 @@ def test_optimizer_state_is_measurably_smaller():
     )
 
 
-# 4 ------------------------------------------------------------------------
 def test_quantized_state_saves_reloads_and_resumes_identically():
     """Compares POST-update parameters and every state leaf. ``_train`` returns the
     loss computed before the update, so comparing that would pass even with
@@ -228,7 +224,6 @@ def test_quantized_state_saves_reloads_and_resumes_identically():
         assert delta == 0.0, f"resumed state leaf {name} differs by {delta:.3e}"
 
 
-# 5 ------------------------------------------------------------------------
 def test_second_moment_is_never_quantized():
     """Quantizing v diverges to NaN; it must not be silently enabled."""
     x, y = _batch()
@@ -249,7 +244,6 @@ def test_second_moment_is_never_quantized():
     )
 
 
-# 6 ------------------------------------------------------------------------
 def test_compiled_and_uncompiled_agree():
     x, y = _batch()
     plain = _train(QuantizedMomentAdam(1e-3, bias_correction=True), _build_model(), x, y)
@@ -278,7 +272,6 @@ def test_compiled_and_uncompiled_agree():
     assert worst <= 1e-6, f"mx.compile changed the loss trajectory by {worst:.3e}: {plain} vs {compiled}"
 
 
-# 7 ------------------------------------------------------------------------
 def test_model_with_no_quantizable_parameters_still_trains():
     """Nothing eligible -> every moment fp32, must still train."""
     model = _build_ineligible_model()
@@ -300,7 +293,6 @@ def test_model_with_no_quantizable_parameters_still_trains():
     )
 
 
-# 8 ------------------------------------------------------------------------
 @pytest.mark.parametrize("bits", [2, 4, 16, 32])
 def test_bit_widths_other_than_8_are_rejected(bits):
     """Narrower widths are refused, not offered untested."""
@@ -310,7 +302,6 @@ def test_bit_widths_other_than_8_are_rejected(bits):
         QuantizedMomentAdamW(1e-3, bits=bits)
 
 
-# 9 ------------------------------------------------------------------------
 @pytest.mark.parametrize("group_size", SUPPORTED_GROUP_SIZES)
 def test_every_supported_group_size_trains(group_size):
 
@@ -330,8 +321,6 @@ def test_unsupported_group_size_is_rejected(group_size):
         QuantizedMomentAdam(1e-3, group_size=group_size)
 
 
-# 10 -----------------------------------------------------------------------
-# 11 -----------------------------------------------------------------------
 def test_zero_gradient_coordinates_never_move():
     """A coordinate whose gradient is identically zero keeps v == 0, so the Adam
     denominator is eps alone and any dequantization residue is amplified ~1e8x.
@@ -362,7 +351,6 @@ def test_zero_gradient_coordinates_never_move():
     assert float(got[0, 0]) != 0.0, "the live coordinate should still train"
 
 
-# 12 -----------------------------------------------------------------------
 def test_plain_checkpoint_migrates_to_packed_on_resume():
     """Before this optimizer existed, adamw_8bit produced plain AdamW state. Such a
     checkpoint must not leave the moment full width for the rest of the run."""
@@ -385,7 +373,6 @@ def test_plain_checkpoint_migrates_to_packed_on_resume():
     )
 
 
-# 13 -----------------------------------------------------------------------
 def test_packed_checkpoint_loads_into_plain_optimizer():
     """Switching back to optim="adamw" must not hand a list to mlx's b1 * m."""
     x, y = _batch()
@@ -403,7 +390,6 @@ def test_packed_checkpoint_loads_into_plain_optimizer():
     _train(plain, plain_model, x, y, steps=1)
 
 
-# 13b ----------------------------------------------------------------------
 def test_unpacking_does_not_carry_the_zero_residue_out():
     """Dequantization leaves a residue where the true moment is zero. Handing that
     to a plain optimizer would divide it by eps while v == 0, reintroducing the
@@ -438,7 +424,6 @@ def test_unpacking_does_not_carry_the_zero_residue_out():
     assert drift == 0.0, f"zero-gradient coordinates drifted {drift:.3e} after unpacking"
 
 
-# 14 -----------------------------------------------------------------------
 @pytest.mark.parametrize("saved,resumed", [(32, 128), (128, 32)])
 def test_group_size_is_read_back_from_the_checkpoint(saved, resumed):
     """group_size is an instance attribute, so it rides in safetensors metadata."""
@@ -456,7 +441,6 @@ def test_group_size_is_read_back_from_the_checkpoint(saved, resumed):
     _train(other, other_model, x, y, steps=1)
 
 
-# 15 -----------------------------------------------------------------------
 @pytest.mark.parametrize("kwargs", [{"bits": 8.9}, {"group_size": 64.9}, {"bits": True}])
 def test_non_integral_settings_are_rejected(kwargs):
     """int() truncates, so bits=8.9 would silently pass the bits == 8 check."""
@@ -464,7 +448,6 @@ def test_non_integral_settings_are_rejected(kwargs):
         QuantizedMomentAdam(1e-3, **kwargs)
 
 
-# 16 -----------------------------------------------------------------------
 def test_moments_follow_the_parameter_dtype():
     """The saving is 8-bit against the parameter dtype, not against float32."""
     mx.random.seed(0)
@@ -495,7 +478,6 @@ def test_adamw_variant_also_quantizes():
     assert (DEFAULT_GROUP_SIZE, DEFAULT_BITS) == (opt.group_size, opt.bits)
 
 
-# 12 -----------------------------------------------------------------------
 # Eligibility counts elements, not axes. The earlier rule was 2-D with a
 # divisible last axis, which excluded the shapes below while packing their
 # partner matrices, so a LoRA run saved half of what it reported.

--- a/tests/test_mlx_real_detection_is_order_independent.py
+++ b/tests/test_mlx_real_detection_is_order_independent.py
@@ -161,7 +161,6 @@ def test_the_shim_does_not_implement_the_ops_the_gate_protects():
     )
 
 
-# --------------------------------------------------------------------------- #
 # The same rule, asked of the VALUE rather than of the source.
 #
 # Everything above is syntactic: it proves a module consults mlx_is_simulated(),
@@ -170,7 +169,6 @@ def test_the_shim_does_not_implement_the_ops_the_gate_protects():
 # gate computed before the module installs its own shim would pass too. So each
 # gate is also EVALUATED, in a subprocess with the shim already up, which is the
 # state a sibling module leaves behind during collection.
-# --------------------------------------------------------------------------- #
 
 def _gate_assignments(tree: ast.AST) -> set:
     """Module-level names whose value is derived from a real-mlx probe.

--- a/tests/test_mlx_rng_rewind.py
+++ b/tests/test_mlx_rng_rewind.py
@@ -127,8 +127,6 @@ def _draw_after_seed(seed):
     return _draw()
 
 
-# --- Key arithmetic ---
-
 @pytest.mark.parametrize("seed", [
     0, 1, 2**31 - 1, 2**31, 2**32 - 1, 2**32, 2**63 - 1, 2**63, 2**64 - 1,
     _SPLIT_KEY_SEED,
@@ -293,8 +291,6 @@ def test_an_unreadable_state_does_not_warn():
             assert _mlx_rng_key() is None
 
 
-# --- _preserved_preprocessing_rng ---
-
 def test_preserved_preprocessing_rng_rewinds_the_mlx_key():
     mx.random.seed(99)
     expected = _draw()
@@ -331,8 +327,6 @@ def test_preserved_preprocessing_rng_is_inert_when_the_state_is_unreadable():
             with _preserved_preprocessing_rng():
                 raise KeyError("inner")
 
-
-# --- Compile fallback ---
 
 class _TinyLM(nn.Module):
     def __init__(self):
@@ -462,7 +456,6 @@ def test_every_compile_fallback_rewinds_the_rng_before_retrying_eagerly():
             node = parents[node]
             yield node
 
-    # Both restores must sit on a recovery branch and precede its eager retry.
     # The branch type is not pinned: single-process recovers inside `except`,
     # DDP inside an `if` after the try (it syncs ranks first).
     for restore in restores:

--- a/tests/test_mlx_runtime_cce_compile.py
+++ b/tests/test_mlx_runtime_cce_compile.py
@@ -89,7 +89,6 @@ def test_runtime_cce_int64_wrap_to_ignore_index_poisons_gradients():
     [2**32, -(2**32), 2**32 + 5, 2**32 - 100],
 )
 def test_runtime_cce_int64_invalid_labels_do_not_wrap_to_valid(bad_target):
-    # int64 labels outside int32 range must NaN, not wrap to valid ids.
     _skip_torch_shim()
     from unsloth_zoo.mlx.cce import make_chunked_cross_entropy_loss
 

--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -44,9 +44,6 @@ def _patch_mlx_tensor_helpers_for_torch(monkeypatch, mutils):
     monkeypatch.setattr(mutils.mx, "all", _all)
 
 
-# --- Group 1: _mlx_arrays_match ---
-
-
 def test_arrays_match_rank3_checks_values(monkeypatch):
     import unsloth_zoo.mlx.utils as mutils
     _patch_mlx_tensor_helpers_for_torch(monkeypatch, mutils)
@@ -124,9 +121,6 @@ def test_arrays_match_nan_tensors_do_not_match(monkeypatch):
     # NaN != NaN elementwise, so a clone never value-matches; identity does.
     assert mutils._mlx_arrays_match(nan, nan.clone()) is False
     assert mutils._mlx_arrays_match(nan, nan) is True
-
-
-# --- Group 2: _rewrite_mlx_vlm_tensor_for_gguf branches ---
 
 
 def test_rewrite_handles_5d_layout_transform(monkeypatch):
@@ -256,9 +250,6 @@ def test_rewrite_model_prefixed_alias_families(monkeypatch):
     assert new_name == "model.visual.embed.bias"
 
 
-# --- Group 3: _MlxVlmSanitizeProxy (2-param sanitize path) ---
-
-
 def test_two_param_sanitize_receives_config_proxy():
     import unsloth_zoo.mlx.utils as mutils
 
@@ -302,9 +293,6 @@ def test_sanitize_missing_method_returns_weights_unchanged():
 
     weights = {"w": torch.zeros(1)}
     assert mutils._call_mlx_vlm_sanitize(NoSanitize, {}, weights) is weights
-
-
-# --- Group 4: _prepare_mlx_gguf_export_directory end-to-end (real shards) ---
 
 
 class _ConvAndRenameSanitizer:
@@ -610,9 +598,6 @@ def test_nextn_handles_language_and_thinker_nested_configs():
     assert "nextn_predict_layers" not in config["thinker_config"]["text_config"]
 
 
-# --- Group 5: _copy_source_sidecars filesystem edges ---
-
-
 def test_sidecars_src_equals_dst_copies_nothing(tmp_path):
     import unsloth_zoo.mlx.utils as mutils
 
@@ -690,9 +675,6 @@ def test_sidecars_windows_style_path_object_does_not_crash():
     assert mutils._copy_source_sidecars(PureWindowsPath("C:/no/such"), "out") == 0
 
 
-# --- Group 6: _read_json_file non-dict payloads + processor repair robustness ---
-
-
 @pytest.mark.parametrize("payload", ["[]", '"just a string"', "null", "3.14"])
 def test_read_json_file_non_dict_payload_yields_dict(tmp_path, payload):
     """Non-object JSON must degrade to {}; callers .get() on the result."""
@@ -753,9 +735,6 @@ def test_read_json_file_accepts_str_and_path(tmp_path):
     assert loader._read_json_file(sidecar) == {"a": 1}
 
 
-# --- Group 7: _get_model_config fallback ladder ---
-
-
 def test_get_model_config_to_dict_returning_non_dict_falls_through():
     import unsloth_zoo.mlx.utils as mutils
 
@@ -810,9 +789,6 @@ def test_get_model_config_non_dict_private_config_falls_through():
     assert mutils._get_model_config(model) == {"model_type": "qwen3"}
 
 
-# --- Group 8: _save_mlx_config routing and quantization key handling ---
-
-
 def _capture_save_config(monkeypatch, module_name):
     calls = {}
     fake = types.ModuleType(module_name)
@@ -863,9 +839,6 @@ def test_save_config_vlm_without_quantization_key_adds_nothing(monkeypatch, tmp_
     assert "quantization" not in calls["config"]
 
 
-# --- Group 9: _is_vlm_model real body ---
-
-
 def test_is_vlm_explicit_flag_overrides_structure():
     import unsloth_zoo.mlx.utils as mutils
 
@@ -903,9 +876,6 @@ def test_is_vlm_requires_language_model():
     assert mutils._is_vlm_model(types.SimpleNamespace(vision_tower=object())) is False
     assert mutils._is_vlm_model(types.SimpleNamespace(language_model=object())) is False
     assert mutils._is_vlm_model(object()) is False
-
-
-# --- Group 10: save_merged_model contracts ---
 
 
 def _install_fake_lm_save(monkeypatch):
@@ -1026,9 +996,6 @@ def test_merged_save_keeps_quantization_when_not_dequantizing(
     mutils.save_merged_model(Model(), _Tokenizer(), tmp_path, dequantize=False)
     assert calls["dequantize"] == 0
     assert calls["saved_config"]["quantization"] == {"bits": 4}
-
-
-# --- Group 11: save_pretrained_gguf first_conversion derivation + quantize step ---
 
 
 def _gguf_export_scaffold(
@@ -1318,9 +1285,6 @@ def test_gguf_keeps_the_intermediates_when_quantization_fails(monkeypatch, tmp_p
     ]
 
 
-# --- Group 12: concurrency over the patcher env mutation ---
-
-
 def test_concurrent_gguf_exports_serialize_env_mutation(monkeypatch, tmp_path):
     import unsloth_zoo.llama_cpp as llama_cpp
 
@@ -1407,8 +1371,6 @@ def test_gguf_export_respects_preexisting_scripts_dir_override(
     assert seen["env"] == custom
     assert os.environ.get("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR") == custom
 
-
-# --- Group 13: converter placement contract (monolith vs package layout) ---
 
 _PACKAGE_ENTRYPOINT = b"""\
 #!/usr/bin/env python3
@@ -1584,9 +1546,6 @@ def test_monolith_layout_patched_script_stays_in_default_dir(
     assert (root / "convert_hf_to_gguf.py").read_bytes() == _MONOLITH
 
 
-# --- Group 14: path-shape portability ---
-
-
 def test_save_config_accepts_str_and_path_targets(monkeypatch, tmp_path):
     import unsloth_zoo.mlx.utils as mutils
 
@@ -1616,9 +1575,6 @@ def test_repair_with_backslash_path_string_returns_processor_unchanged():
         processor, "C:\\models\\fake", "fake_type"
     )
     assert repaired is processor
-
-
-# --- Group 15: review follow-ups ---
 
 
 def test_push_to_hub_gguf_positional_token_stays_token(monkeypatch, tmp_path):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -2540,14 +2540,12 @@ def test_gguf_install_fallback_prefers_prebuilt_then_macos_helper(
         first_conversion="f16",
     )
 
-    # Prebuilt-first is attempted on every platform.
     assert "install_llama_cpp" in calls
     # Export only needs the CPU-only llama-quantize, so gpu_support=False on every
     # platform. On macOS this still resolves the universal unslothai/llama.cpp
     # Metal bundle (same archive from the CPU selector), and the Metal source build
     # is handled by the macOS helper below, not by this flag.
     assert gpu_support_seen["value"] is False
-    # The macOS source helper is reached only on the darwin apt-get path.
     assert ("_install_llama_cpp_macos" in calls) == expect_macos_helper
 
 
@@ -2732,7 +2730,6 @@ def test_macos_helper_refuses_unmanaged_non_source_dir(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError, match="will not be removed"):
         mutils._install_llama_cpp_macos(str(folder))
 
-    # The user's directory and its contents must be left fully intact.
     assert folder.is_dir()
     assert (folder / "important.txt").read_text() == "precious user file"
 
@@ -3073,7 +3070,6 @@ def test_imatrix_file_true_resolves_the_upstream_gguf_repo(monkeypatch, tmp_path
 
     assert seen["looked_up"] == ["unsloth/Missing-GGUF", "unsloth/TestModel-GGUF"]
     assert seen["token"] == "hf_token"
-    # The download must be authenticated too, and aimed at the repo that actually had the file.
     assert seen["downloaded"] == {
         "repo_id": "unsloth/TestModel-GGUF", "filename": upstream_name, "token": "hf_token",
     }
@@ -3351,7 +3347,6 @@ def test_macos_helper_installs_gguf_py_from_operator_named_checkout(monkeypatch,
     assert any(str(folder / "gguf-py") in arg for arg in pip_cmds[0]), pip_cmds[0]
 
 
-# --- _is_trusted_local_llama_cpp_dir path semantics -------------------------
 # `pip install <dir>` runs that directory's build backend, so the containment
 # check that guards it has to be exact. These cover the ways a naive prefix
 # comparison goes wrong.
@@ -3406,7 +3401,6 @@ def test_trusted_dir_rejects_cwd_relative_checkout(monkeypatch, tmp_path):
     monkeypatch.chdir(cwd)
     assert _trusted(monkeypatch, "llama.cpp", home) is False
     assert _trusted(monkeypatch, os.path.join(".", "llama.cpp"), home) is False
-    # An operator who names that same directory does get the local install.
     assert _trusted(monkeypatch, "llama.cpp", home, env_value=cwd / "llama.cpp") is True
 
 
@@ -3419,7 +3413,6 @@ def test_trusted_dir_accepts_operator_named_checkout(monkeypatch, tmp_path):
     assert _trusted(monkeypatch, studio / "gguf-py", home, env_value=studio) is True
     # Whitespace is stripped, matching how Studio itself reads the variable.
     assert _trusted(monkeypatch, studio, home, env_value=f"  {studio}  ") is True
-    # An empty or blank value must not trust anything.
     assert _trusted(monkeypatch, tmp_path / "other", home, env_value="") is False
     assert _trusted(monkeypatch, tmp_path / "other", home, env_value="   ") is False
 

--- a/tests/test_mlx_save_lora_adapters_filter.py
+++ b/tests/test_mlx_save_lora_adapters_filter.py
@@ -108,9 +108,6 @@ def test_save_lora_adapters_keeps_only_lora_tensors(tmp_path):
 
 
 def test_save_lora_adapters_does_not_leak_paths_containing_lora_(tmp_path):
-    # Anchor-on-modules filter must drop a non-LoRA tensor whose path
-    # happens to contain "lora_" (e.g. a routing layer literally named
-    # `lora_router`).
     from unsloth_zoo.mlx.utils import save_lora_adapters
 
     real = _MockLoRALinear(8, 16, 4, 1.0, _MockDropoutKeepProb(0.0))
@@ -173,8 +170,6 @@ class _MockHalfLoRA:
 
 
 def _make_model_with_named_modules(layers):
-    # Variant of _make_model that exposes upper- and lower-case LoRA attr
-    # pairs when listing parameters.
     class _M:
         def __init__(self):
             for k, v in layers.items():
@@ -210,11 +205,6 @@ def _make_model_with_named_modules(layers):
 
 
 def test_collect_lora_helper_skips_uppercase_only_module(tmp_path):
-    # mlx-lm reload only recreates lowercase lora_a/lora_b wrappers, so
-    # adapter tensors saved under uppercase keys can never bind back to
-    # the recreated wrappers. The collector must skip these modules and
-    # save_lora_adapters must raise rather than silently produce an
-    # unreloadable artifact.
     from unsloth_zoo.mlx.utils import (
         collect_mlx_lora_adapter_tensors,
         save_lora_adapters,
@@ -230,9 +220,6 @@ def test_collect_lora_helper_skips_uppercase_only_module(tmp_path):
 
 
 def test_collect_lora_helper_drops_half_adapter_module(tmp_path):
-    # A module that only exposes lora_a (no lora_b) cannot be reloaded; the
-    # collector must skip it so save_lora_adapters surfaces the empty-set
-    # error rather than write a half-broken adapter file.
     from unsloth_zoo.mlx.utils import (
         collect_mlx_lora_adapter_tensors,
         save_lora_adapters,
@@ -294,8 +281,6 @@ def test_collect_lora_helper_finds_adapters_after_reload():
             }
 
         def trainable_parameters(self):
-            # mimic the post-reload state where adapter tensors are not
-            # explicitly marked trainable.
             return {"up_proj.weight": plain.weight}
 
         def named_modules(self):
@@ -539,8 +524,6 @@ def test_save_pretrained_merged_lora_mixed_external_drops_inside_lora_base(tmp_p
                 "embed_tokens.weight": embed,
             }
         def trainable_parameters(self):
-            # mimic reload: base weight inside the LoRA module is unfrozen
-            # AND user intentionally trains the embedding.
             return self.parameters()
         def named_modules(self):
             yield "", self
@@ -560,9 +543,6 @@ def test_save_pretrained_merged_lora_mixed_external_drops_inside_lora_base(tmp_p
 
 
 def test_save_pretrained_merged_lora_strips_accidental_trainable_base_tensors(tmp_path):
-    # After a reload, base weights such as q_proj.weight may end up
-    # marked trainable. save_method="lora" must still ship a lean
-    # adapter file rather than leaking those base tensors.
     from unsloth_zoo.mlx.utils import save_pretrained_merged
 
     lora = _MockLoRALinear(8, 16, 4, 1.0, _MockDropoutKeepProb(0.0))
@@ -602,9 +582,6 @@ def test_save_pretrained_merged_lora_strips_accidental_trainable_base_tensors(tm
 
 
 def test_save_pretrained_merged_merged_methods_skip_lora_collection(tmp_path, monkeypatch):
-    # Merged exports (merged_16bit / merged_4bit) must not call the
-    # adapter collector; the lora-only presence check belongs inside
-    # the method == "lora" branch.
     from unsloth_zoo.mlx import utils as mlx_utils
 
     collect_calls = []
@@ -779,8 +756,6 @@ def test_save_pretrained_merged_lora_method_preserves_external_trainables(
 def test_save_pretrained_merged_lora_method_pure_lora_uses_lean_writer(
     tmp_path, monkeypatch
 ):
-    # When no non-LoRA tensor is trainable, the public API keeps the lean
-    # adapter-only artifact (no over-eager routing to the trainable writer).
     from unsloth_zoo.mlx import utils as mlx_utils
 
     lora = _MockLoRALinear(8, 16, 4, 1.0, _MockDropoutKeepProb(0.0))
@@ -834,10 +809,6 @@ def test_save_pretrained_merged_lora_method_pure_lora_uses_lean_writer(
 def test_save_trainable_adapters_preserves_frozen_lora_alongside_trainable_norm(
     tmp_path,
 ):
-    # After a checkpoint reload + norm-only fine-tune, the LoRA pair lives
-    # in parameters() but is absent from trainable_parameters(). The
-    # checkpoint writer must still emit the LoRA tensors so the saved
-    # artifact remains a valid, reloadable adapter file.
     from unsloth_zoo.mlx.utils import save_trainable_adapters
 
     lora = _MockLoRALinear(8, 16, 4, 1.0, _MockDropoutKeepProb(0.0))
@@ -1026,7 +997,6 @@ def test_save_trainable_adapters_drops_quantized_base_scales_biases(tmp_path):
     assert "q_proj.weight" not in keys
     assert "q_proj.scales" not in keys
     assert "q_proj.biases" not in keys
-    # Singular `.bias` is a legitimate Linear bias, not quantization state.
     assert "q_proj.bias" in keys
 
 
@@ -1130,8 +1100,6 @@ def test_save_trainable_adapters_preserves_bias_under_lora_wrapped_linear(tmp_pa
     from safetensors.torch import load_file
 
     class _LoRALinearWithBias:
-        # Path: q_proj has lora_a / lora_b plus the wrapped base
-        # Linear's weight + bias (flattened to q_proj.weight, q_proj.bias).
         def __init__(self):
             self.lora_a = _t.zeros(4, 8)
             self.lora_b = _t.zeros(8, 4)
@@ -1162,8 +1130,6 @@ def test_save_trainable_adapters_preserves_bias_under_lora_wrapped_linear(tmp_pa
     save_trainable_adapters(_Model(), out)
     keys = set(load_file(out / "adapters.safetensors").keys())
 
-    # LoRA tensors kept; base weight inside LoRA dropped; bias kept;
-    # external weight kept.
     assert "q_proj.lora_a" in keys
     assert "q_proj.lora_b" in keys
     assert "q_proj.weight" not in keys
@@ -1186,7 +1152,6 @@ def test_enrich_stamps_fine_tune_type_full_when_no_lora_modules(tmp_path):
 
     cfg = _enrich_mlx_adapter_config(_Model(), {})
     assert cfg.get("fine_tune_type") == "full", cfg
-    # Should NOT have peft_type=LORA on a full-finetune save.
     assert cfg.get("peft_type") is None or cfg.get("peft_type") != "LORA", cfg
 
 
@@ -1254,7 +1219,6 @@ def test_is_lm_head_trainable_skips_base_weight_under_lora_wrapped_lm_head(monke
         def named_modules(self):
             yield "lm_head", self._lm
 
-    # lm_head.weight under a LoRA-wrapped lm_head must be filtered out;
     # the trainable check should return False (LoRA-only training). The
     # descriptor is stubbed to resolve this head so the leaked-base filter
     # is actually on the decision path (an unresolved head would return
@@ -1312,7 +1276,6 @@ def test_push_lora_adapters_uses_allow_patterns_to_avoid_stale_uploads(
     patterns = sent["allow_patterns"]
     assert "adapters.safetensors" in patterns
     assert "adapter_config.json" in patterns
-    # No catch-all that would re-include the stale merged-model shard.
     assert "*.safetensors" not in patterns
     assert "*" not in patterns
 
@@ -1380,7 +1343,6 @@ def test_collect_lora_skips_unrelated_m_attribute_on_non_dora_module():
             yield "q_proj", _MockLoRAWithUnrelatedM()
 
     tensors = collect_mlx_lora_adapter_tensors(_Model())
-    # lora_a / lora_b must be collected; `m` must not (non-DoRA class).
     assert "q_proj.lora_a" in tensors
     assert "q_proj.lora_b" in tensors
     assert "q_proj.m" not in tensors
@@ -1445,9 +1407,6 @@ def test_push_to_hub_merged_honors_create_pr_via_upload_folder(
         create_pr=True,
     )
 
-    # Custom commit_message + create_pr=True must route through
-    # upload_folder so both reach the Hub. upload_large_folder would
-    # silently drop them.
     assert len(calls["folder"]) == 1, calls
     assert calls["large"] == [], calls
     sent = calls["folder"][0]
@@ -1504,9 +1463,6 @@ def test_push_to_hub_merged_revision_alone_keeps_large_folder_route(
 def test_push_to_hub_merged_uses_large_folder_when_no_custom_metadata(
     tmp_path, monkeypatch,
 ):
-    # When the caller did NOT pass custom commit metadata, prefer
-    # upload_large_folder so multi-GB merged dirs get chunked uploads
-    # with resume. This preserves the original large-merge behavior.
     import huggingface_hub
     from unsloth_zoo.mlx.utils import push_to_hub_merged
 
@@ -1546,9 +1502,6 @@ def test_push_to_hub_merged_uses_large_folder_when_no_custom_metadata(
 def test_push_lora_adapters_falls_back_to_large_folder_when_unavailable(
     tmp_path, monkeypatch,
 ):
-    # On a hypothetical environment without upload_folder (or with a
-    # TypeError signature mismatch), the helper should still complete the
-    # upload via upload_large_folder rather than crash silently.
     import huggingface_hub
     from unsloth_zoo.mlx.utils import _push_lora_adapters_to_hub
 

--- a/tests/test_mlx_text_path_contract.py
+++ b/tests/test_mlx_text_path_contract.py
@@ -62,9 +62,6 @@ def _is_array(value):
     return not isinstance(value, (tuple, list)) and hasattr(value, "shape")
 
 
-# --- the array-grid families keep an indexable grid -------------------------
-
-
 @pytest.mark.parametrize("model_type", ["glm4v", "glm_ocr", "muse_glimmer"])
 def test_array_grid_families_get_an_indexable_grid(mutils, model_type):
     out = _prepare(mutils, model_type, image_grid_thw = [[1, 2, 2]])
@@ -77,9 +74,6 @@ def test_compile_patched_families_keep_the_traceable_tuple(mutils, model_type):
     # which is why these keep Python tuples.
     out = _prepare(mutils, model_type, image_grid_thw = [[1, 2, 2]])
     assert isinstance(out["image_grid_thw"], tuple)
-
-
-# --- aliases resolve the same way the loader resolves them ------------------
 
 
 def test_an_aliased_config_still_reaches_the_array_form(mutils, remapping):
@@ -103,9 +97,6 @@ def test_the_video_grid_follows_the_image_grid(mutils, remapping):
     )
     assert _is_array(out["image_grid_thw"])
     assert _is_array(out["video_grid_thw"])
-
-
-# --- resolution never becomes a new way to fail -----------------------------
 
 
 def test_an_unlisted_architecture_is_untouched(mutils, remapping):
@@ -147,9 +138,6 @@ def test_a_capitalised_model_type_resolves_like_mlx_vlm_resolves_it(mutils):
     assert mutils._mlx_vlm_canonical_model_type("Muse_Glimmer") == "muse_glimmer"
 
 
-# --- what the losses accept from a model call -------------------------------
-
-
 def test_logits_come_back_from_a_wrapper_and_from_a_raw_array(mutils):
     import types
     array = object()
@@ -163,9 +151,6 @@ def test_a_wrapper_with_no_logits_says_so(mutils):
     import types
     with pytest.raises(ValueError, match="`logits` is None"):
         mutils._model_logits(types.SimpleNamespace(logits=None))
-
-
-# --- generate() picks the processor by presence, not truthiness -------------
 
 
 def test_generate_keeps_a_falsy_processor(monkeypatch):

--- a/tests/test_mlx_torch_shim_smoke.py
+++ b/tests/test_mlx_torch_shim_smoke.py
@@ -41,10 +41,6 @@ def _install_mlx_shim():
     simulate_mlx_on_torch()
 
 
-# ---------------------------------------------------------------------------
-# 1. All named imports succeed.
-# ---------------------------------------------------------------------------
-
 @pytest.mark.parametrize("module_path", [
     "mlx",
     "mlx.core",
@@ -98,10 +94,6 @@ def test_vlm_subarch_auto_resolve(submodule):
     assert mod is not None
 
 
-# ---------------------------------------------------------------------------
-# 2. Tier 1: Unsloth backend fresh symbols.
-# ---------------------------------------------------------------------------
-
 def test_metal_is_available_returns_false():
     import mlx.core as mx
     assert mx.metal.is_available() is False
@@ -131,10 +123,6 @@ def test_synchronize_no_op():
     import mlx.core as mx
     mx.synchronize()
 
-
-# ---------------------------------------------------------------------------
-# 3. Tier 2: trivial passthroughs.
-# ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
 def test_elementwise_math(dtype):
@@ -269,10 +257,6 @@ def test_module_children_preserves_direct_child_tree():
     ]
 
 
-# ---------------------------------------------------------------------------
-# 4. Tree utils round-trip.
-# ---------------------------------------------------------------------------
-
 def test_tree_flatten_unflatten():
     import mlx.utils as mlxu
     tree = {"a": {"b": 1, "c": [2, 3]}, "d": 4}
@@ -291,10 +275,6 @@ def test_tree_map():
     assert doubled == {"a": 2, "b": [4, 6]}
 
 
-# ---------------------------------------------------------------------------
-# 5. RNG keys are deterministic.
-# ---------------------------------------------------------------------------
-
 def test_random_seed_reproducible():
     import mlx.core as mx
     mx.random.seed(123)
@@ -304,14 +284,10 @@ def test_random_seed_reproducible():
     torch.testing.assert_close(a, b)
 
 
-# ---------------------------------------------------------------------------
 # 6. _Noop raises loudly on call (regression guard against silent masking).
-# ---------------------------------------------------------------------------
 
 def test_noop_raises_on_call():
     import mlx.core as mx
-    # An unknown attribute returns _Noop; calling raises NotImplementedError
-    # with the symbol name.
     noop = mx.this_is_a_definitely_unknown_symbol_xyz
     with pytest.raises(NotImplementedError, match="this_is_a_definitely_unknown_symbol_xyz"):
         noop()

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -846,10 +846,6 @@ def test_response_masked_text_batches_can_remain_a_lazy_plan():
     assert eager[2].dtype == mx.int32
 
 
-# ---------------------------------------------------------------------------
-# 1. MLXTrainingConfig: full surface check.
-# ---------------------------------------------------------------------------
-
 def test_mlx_training_config_is_dataclass_with_all_fields():
     from unsloth_zoo.mlx.trainer import MLXTrainingConfig
     assert dataclasses.is_dataclass(MLXTrainingConfig)
@@ -1118,7 +1114,6 @@ def test_distributed_text_batches_use_token_length_not_cache_itemlen(monkeypatch
         for batch in batches
         for row in batch[0].tolist()
     }
-    # Rows survived the >=2-token filter (token length, not itemlen).
     assert (5, 6) in content or (7, 8, 9) in content
 
 
@@ -2542,12 +2537,9 @@ def test_num_input_tokens_seen_persisted_and_restored_across_resume():
     from unsloth_zoo.mlx.trainer import MLXTrainer
 
     ti = inspect.getsource(MLXTrainer._train_inner)
-    # Saved in the checkpoint state dict ...
     assert '"num_input_tokens_seen": int(' in ti
-    # ... and restored from it on resume into the resume attr.
     assert 'ts.get("num_input_tokens_seen"' in ti
     assert "_resume_num_input_tokens_seen = int(" in ti
-    # ... then seeded into the callback-visible TrainerState.
     ics = inspect.getsource(MLXTrainer._init_callback_state)
     assert "num_input_tokens_seen=int(" in ics
     assert "_resume_num_input_tokens_seen" in ics
@@ -2561,13 +2553,10 @@ def test_should_epoch_stop_field_reset_and_honored():
     import inspect
     from unsloth_zoo.mlx.trainer import MLXTrainer, _MLXTrainerControl
 
-    # (1) Field exists and defaults False.
     assert _MLXTrainerControl().should_epoch_stop is False
 
     src = inspect.getsource(MLXTrainer._train_inner)
-    # (2) Reset at epoch begin.
     assert "self.control.should_epoch_stop = False" in src
-    # (3) Rank-synced honoring: an all-reduced flag drives an epoch-boundary skip.
     assert "def _sync_epoch_stop" in src
     assert "_distributed_any_flag(self.control.should_epoch_stop)" in src
     assert "_sync_epoch_stop()" in src
@@ -3140,19 +3129,15 @@ def test_qwen3_vl_vision_block_mlp_fp32_guard_for_fp16():
 
     source = inspect.getsource(mc._install_qwen3_family_compile_patches)
 
-    # Guard is present
     assert "linear_fc1 (up-projection) overflows fp16" in source, (
         "Missing comment documenting the fp16 overflow rationale"
     )
-    # Dtype-conditional branch keys on residual_dtype (the activation dtype)
     assert "if residual_dtype == mx.float16:" in source, (
         "MLP fp32 guard must be gated on residual_dtype == mx.float16"
     )
-    # fp16 path: upcast input to fp32 before calling self.mlp
     assert "self.mlp(mlp_norm_out.astype(mx.float32))" in source, (
         "fp16 branch must upcast mlp input to fp32"
     )
-    # non-fp16 path: original (cheaper) cast-only flow preserved
     assert "self.mlp(mlp_norm_out)" in source, (
         "bf16/fp32 path must keep the original self.mlp(...) call"
     )
@@ -3542,11 +3527,6 @@ def test_gemma3_training_compile_verified():
     assert "gemma3" in mc._VERIFIED_TRAINING_ARCHES
 
 
-# ---------------------------------------------------------------------------
-# 2. compile module-level discovery functions return sensible defaults
-#    on a host with no real MLX architectures.
-# ---------------------------------------------------------------------------
-
 def test_compile_discovers_no_archs_under_shim():
     """No real mlx_vlm.models.* installed -> empty discovery, not crash."""
     import unsloth_zoo.mlx.compile as mc
@@ -3617,10 +3597,6 @@ def test_compile_summarize_qualifications_returns_dict():
     assert "architectures" in s
 
 
-# ---------------------------------------------------------------------------
-# 3. CCE backward via the pure-Python fallback.
-# ---------------------------------------------------------------------------
-
 def test_cce_backward_via_torch_autograd():
     """Build a tiny CCE forward and verify torch.autograd traverses it."""
     from unsloth_zoo.mlx.cce.runtime_cce import _forward_chunked_fused_finalize
@@ -3643,10 +3619,6 @@ def test_cce_backward_via_torch_autograd():
     assert weight.grad is not None and torch.isfinite(weight.grad).all()
 
 
-# ---------------------------------------------------------------------------
-# 4. mx.dequantize cross-validation against the helper's output.
-# ---------------------------------------------------------------------------
-
 def test_mx_dequantize_with_nonzero_bias_and_scale():
     import mlx.core as mx
 
@@ -3668,10 +3640,6 @@ def test_mx_dequantize_with_nonzero_bias_and_scale():
     torch.testing.assert_close(out, expected)
 
 
-# ---------------------------------------------------------------------------
-# 5. mx.fast.scaled_dot_product_attention works for a small attention.
-# ---------------------------------------------------------------------------
-
 def test_mx_fast_sdpa_works():
     import mlx.core as mx
     B, H, T, D = 1, 2, 4, 8
@@ -3682,10 +3650,6 @@ def test_mx_fast_sdpa_works():
     assert out.shape == (B, H, T, D)
     assert torch.isfinite(out).all()
 
-
-# ---------------------------------------------------------------------------
-# 6. Tree utilities round-trip.
-# ---------------------------------------------------------------------------
 
 def test_tree_flatten_unflatten_roundtrip():
     from mlx.utils import tree_flatten, tree_unflatten
@@ -3700,10 +3664,6 @@ def test_tree_flatten_unflatten_roundtrip():
     assert set(rebuilt.keys()) == {"a", "d"}
     torch.testing.assert_close(rebuilt["d"], torch.tensor([3.0]))
 
-
-# ---------------------------------------------------------------------------
-# 7. Quantized layer __call__ works (forward through nn.QuantizedLinear).
-# ---------------------------------------------------------------------------
 
 def test_quantized_linear_forward():
     import mlx.nn as nn
@@ -5401,7 +5361,6 @@ def test_callback_num_train_epochs_mirrors_hf_arithmetic():
     # Streaming: no finite plan, no epoch events, field left alone.
     assert trainer._callback_num_train_epochs(50, None) == 0
 
-    # Epoch-count runs are unchanged.
     epochs = MLXTrainer.__new__(MLXTrainer)
     epochs.args = MLXTrainingConfig(num_train_epochs=3, max_steps=-1)
     epochs._prepared_batches_include_epochs = True
@@ -5993,8 +5952,6 @@ def test_checkpoint_includes_committed_unlogged_loss_totals(monkeypatch):
     # the final totals still cover exactly the 4 applied steps.
     assert whole._train_loss_token_total == 2 * saved["train_loss_token_total"]
 
-    # End to end: stop right after the step-2 checkpoint, resume, and the final
-    # token-weighted train loss matches the uninterrupted run's.
     interrupted = build(stop_after=2)
     interrupted.train()
     resumed = build()
@@ -6046,7 +6003,6 @@ def test_integration_callback_args_cover_stock_trackio_and_swanlab():
         for field in sorted(set(reader.findall(inspect.getsource(callback)))):
             assert hasattr(args, field), f"{name} reads args.{field}"
 
-    # A caller that configures the run keeps their value across the next run.
     args.project = "my-project"
     args.hub_private_repo = True
     trainer._ensure_callback_args_compat()
@@ -6159,7 +6115,6 @@ def test_callback_events_dispatch_on_every_rank(monkeypatch):
     rank0_lr_cb, rank0_io_cb, rank0_seen = run(0)
     rank1_lr_cb, rank1_io_cb, rank1_seen = run(1)
 
-    # The callback runs on the peer too, so both ranks step with the same LR.
     assert rank0_lr_cb.calls == 4
     assert rank1_lr_cb.calls == 4
     assert rank0_seen == [override_lr] * 4
@@ -6197,12 +6152,10 @@ def test_training_config_exposes_sanitized_dict_for_integration_callbacks():
 
     assert sanitized["train_batch_size"] == 2
     assert sanitized["eval_batch_size"] == 3
-    # Every raw field survives; only the values are coerced.
     assert set(config.to_dict()) <= set(sanitized)
     assert all(type(value) in (bool, int, float, str) for value in sanitized.values())
     # A tracker must be able to serialize the whole payload.
     json.dumps(sanitized)
-    # Non-scalars are stringified rather than dropped, and bool stays bool.
     assert sanitized["compile_arch_overrides"] == str({"a": "b"})
     assert isinstance(sanitized["packing"], bool)
 
@@ -6894,7 +6847,6 @@ def test_callback_interrupt_joins_the_ddp_failure_consensus(monkeypatch, interru
     peer_contexts, peer_outcome, _ = run(raising=False)
     raiser_contexts, raiser_outcome, raiser_stop = run(raising=True)
 
-    # The peer runs to completion and reports no failure of its own.
     assert peer_outcome is None
     # The interrupt still reaches the caller unwrapped, exactly as HF's
     # callback_handler.call_event lets it propagate (transformers
@@ -7939,7 +7891,6 @@ def test_epoch_cadence_closes_a_callback_stopped_epoch(monkeypatch):
         # skip lands the loop on the next boundary.
         assert probe["saved"][0] == 2, (with_flow, probe["saved"])
         assert probe["checkpoints"][0] == 2, (with_flow, probe["checkpoints"])
-    # And the two configurations agree exactly, which is the whole point.
     runs = [
         _run_log_save_cadence_probe(
             monkeypatch, logging_steps=10 ** 6, save_steps=10 ** 6,
@@ -8095,7 +8046,6 @@ def test_dict_eval_rebuilds_the_prediction_bar_per_split(monkeypatch):
         (3, 1), (3, 2), (3, 3),
         (4, 1), (4, 2), (4, 3), (4, 4),
     ], bar.geometry
-    # No bar ever runs past its own total.
     assert all(seen <= total for total, seen in bar.geometry), bar.geometry
     # The last split's bar is still torn down by on_evaluate, exactly as in HF.
     assert bar.closing == (4, 4), bar.closing

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -572,8 +572,6 @@ def test_reporting_flag_never_changes_update_numerics(tmp_path):
     assert on_t._grad_norm_history and not off_t._grad_norm_history
 
 
-# ---- Compiled global-norm clipping with gradient accumulation ----
-
 @metal_only
 def test_compiled_clip_accum_matches_eager_bitwise(tmp_path, capsys):
     import numpy as np
@@ -715,13 +713,11 @@ def test_lora_plus_scales_layer_wrapped_lora_b_weight(tmp_path, nested):
     )
 
 
-# ---------------------------------------------------------------------------
 # Warm-starting continued training from a saved adapter: reloading a LoRA/DoRA
 # adapter via FastMLXModel.from_pretrained must freeze the base and leave the
 # adapter parameters trainable, together with any non-adapter tensors the
 # checkpoint itself recorded as trainable. Uses a tiny locally-built Llama so
 # the full_finetuning and DoRA branches stay cheap.
-# ---------------------------------------------------------------------------
 
 
 def _trainable_names(model):
@@ -845,7 +841,6 @@ def test_dora_reload_keeps_magnitude_trainable(tmp_path):
     dora_modules = [n for n, m in iter_mlx_lora_modules(model)
                     if type(m).__name__.startswith("DoRA")]
     assert len(dora_modules) > 0
-    # Every DoRA magnitude must stay trainable (not just one).
     assert len([n for n in trainable if n.endswith(".m")]) == len(dora_modules)
     # Exactly the adapter tensors, so no base weight leaks in. (A base parameter
     # literally named "m" does not exist on this fixture, so that pathological
@@ -929,7 +924,6 @@ def test_reload_keeps_saved_non_adapter_trainables(tmp_path):
     # The base freeze must not silently drop the saved auxiliary trainables.
     assert aux <= trainable, sorted(aux - trainable)
     assert _adapter_keys(reloaded) <= trainable
-    # Still a warm start, not a full finetune: nothing beyond adapters + aux.
     assert trainable == _adapter_keys(reloaded) | aux
 
 
@@ -1049,8 +1043,6 @@ def test_vlm_planned_vs_unplanned_training_parity(monkeypatch, tmp_path):
     planned_result, planned_plan, planned_widths = run(planned=True)
     planned_compiled_calls = len(compiled_invocations)
 
-    # The planned run really executes through mx.compile, one invocation per
-    # training step, while the unplanned eager run never compiles.
     assert unplanned_compiled_calls == 0
     assert planned_compiled_calls == 4
     assert planned_result["compile_enabled"] is True
@@ -1061,8 +1053,6 @@ def test_vlm_planned_vs_unplanned_training_parity(monkeypatch, tmp_path):
     assert planned_result["train_loss"] == pytest.approx(
         unplanned_result["train_loss"], rel=1e-4,
     )
-    # Every compiled width is a planned endpoint at or above the raw width, and
-    # the planned run exposed at most the admitted variants.
     endpoints = {
         planned_plan._shape_plan.endpoint_for(
             planned_plan.batch_family(index),
@@ -1317,7 +1307,6 @@ def test_post_head_multiplier_reaches_the_fused_cce_loss(softcap):
         if softcap:
             del text_model.final_logit_softcapping
 
-    # Reference: cross-entropy over the logits the model's own tail would emit.
     logits = model(ids[:, :-1]).astype(mx.float32) * multiplier
     if softcap:
         logits = mx.tanh(logits / softcap) * softcap

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1443,7 +1443,6 @@ def test_vlm_host_label_authority_and_staged_finalize():
         completion_only_loss=False)
     assert off["labels"].dtype == off["input_ids"].dtype
 
-    # MLX-returning processors flag host_valued=False, nested too; reject raises first.
     assert _vlm_inputs_host_valued(
         {"input_ids": np.array([[1]])}) is True
     assert _vlm_inputs_host_valued(
@@ -1474,7 +1473,6 @@ def test_vlm_host_label_authority_and_staged_finalize():
             yield_host_staged=True))
     assert probe.pulls == 0 and probe.epochs == []
 
-    # Value-carrying closures finalize through the legacy pipeline unchanged.
     from unsloth_zoo.mlx.utils import _build_response_masked_vlm_batch
     def _value_closure(mask_batch):
         width = len(mask_batch["input_ids"][0])
@@ -1553,7 +1551,6 @@ def test_vlm_prefetch_identity_laziness_and_masked_rejection():
     assert prefetched == sync  # bit-for-bit consumer-visible sequence
     assert control["prefetcher"].close()
 
-    # Trainer wiring: eligibility, control registration, and cleanup.
     shell_probe = _LifecycleVLMRows(6)
     trainer = _vlm_trainer_shell_for(shell_probe, prefetch=2)
     _b, shell_stream = trainer._prepare_data(is_vlm=True)
@@ -1909,11 +1906,9 @@ def test_a_natively_shared_backbone_gets_no_legacy_slots():
     # Native: no slots at all, so `cache` stays unset and every layer runs.
     assert _build_shared_kv_caches(_model(4, 2, native=True)) is None
 
-    # Legacy backbones still get exactly one slot per producer layer.
     legacy = _build_shared_kv_caches(_model(4, 2, native=False))
     assert legacy is not None and len(legacy) == 2
 
-    # And a stack that shares nothing is unaffected either way.
     assert _build_shared_kv_caches(_model(4, 0, native=False)) is None
     assert _build_shared_kv_caches(_model(4, 0, native=True)) is None
 
@@ -2116,7 +2111,6 @@ def test_paligemma_mask_is_left_alone_without_token_types():
     assert _paligemma_replace_mask(
         SimpleNamespace(attention_mask_4d=None),
         mx_.zeros((1, 4), dtype=mx_.int32), padding).attention_mask_4d is None
-    # But it is replaced once the token types are there.
     replaced = _paligemma_replace_mask(
         SimpleNamespace(attention_mask_4d=outer_product),
         mx_.array([[0, 0, 1, 1]], dtype=mx_.int32), padding)
@@ -2142,7 +2136,6 @@ def test_paligemma_embedder_wrapper_replaces_the_mask_it_wrapped():
     got = wrapped(object(), mx_.zeros((1, 4), dtype=mx_.int32), None,
                   mx_.ones((1, 4), dtype=mx_.int32),
                   token_type_ids=mx_.array([[0, 0, 1, 1]], dtype=mx_.int32))
-    # Upstream still runs and still sees its kwargs.
     assert "token_type_ids" in seen["kwargs"]
     # And its all-visible mask does not survive: the suffix cannot read ahead.
     assert got.attention_mask_4d is not outer_product
@@ -2182,7 +2175,6 @@ def test_paligemma_plain_loss_path_also_gets_the_causal_suffix():
 
     assert seen["mask"] is not outer_product
     assert not np.asarray(seen["mask"]).reshape(4, 4)[2, 3]
-    # And nothing is left pending once the call returns.
     assert _paligemma_pending_token_types() is None
 
 
@@ -2267,7 +2259,6 @@ def test_paligemma_token_types_do_not_cross_between_concurrent_callers():
     for thread in threads:
         thread.join(timeout=10)
 
-    # Each caller saw its own token types, not the other's.
     for name, mark in marks.items():
         assert _Model.seen[name] is mark, f"{name} saw another caller's batch"
     assert _paligemma_pending_token_types() is None
@@ -2374,7 +2365,6 @@ def test_gemma3n_altup_patch_declines_a_release_that_is_already_correct():
         model=SimpleNamespace(layers=[SimpleNamespace(altup=altup)])))
     assert not _fix_gemma3n_altup_batch(model)
     assert cls.correct is fixed, "an already-correct release must be left alone"
-# --- Audio input collation -------------------------------------------------
 
 
 class _FakeGemmaAudioProcessor(_ConversationalPromptCompletionProcessor):
@@ -2641,7 +2631,6 @@ def test_processors_taking_audio_pairs_are_accommodated(monkeypatch):
     batch, is_pc = _finalized_collate([pc_row], processor, 16, None,
                                       return_prompt_completion=True)
     assert is_pc and "input_features" in batch
-
 
 
 def test_placeholders_without_features_are_rejected(monkeypatch):
@@ -3268,8 +3257,6 @@ def test_the_corrected_count_rides_a_copy_and_only_for_its_family(monkeypatch):
 
     # Same family name, so the repair is reached, but not independently
     # copyable -- correcting either would correct the caller's own processor.
-    # A copy that is the original, and one that keeps its own attributes but
-    # writes just that hook through -- the narrowest sharing there is.
     for cls in (type("Gemma4Processor", (Gemma4Processor,),
                      {"__copy__": lambda self: self}),
                 type("Gemma4Processor", (_ForwardsTheHook,), {})):
@@ -3341,7 +3328,6 @@ def test_audio_merge_patch_is_held_and_restored_exactly():
 
     model = _Model()
     original = model.get_input_embeddings
-    # Every caller taking a hold is told so, and releases exactly one.
     assert install_audio_merge_patch(model, 1) is True
     assert install_audio_merge_patch(model, 1) is True    # second holder
     assert remove_audio_merge_patch(model) is False       # first release
@@ -3355,7 +3341,6 @@ def test_audio_merge_patch_is_held_and_restored_exactly():
     install_audio_merge_patch(model, 1)
     remove_audio_merge_patch(model)
     assert model.get_input_embeddings() == "instance wrapper"
-
 
 
 def test_concurrent_installs_take_one_wrapper_and_one_hold_each():
@@ -3560,7 +3545,6 @@ def test_phi4mm_token_ids_fall_back_to_the_mlx_vlm_defaults():
 
     # The real checkpoint's shape: model_type present, neither index declared.
     assert _phi4mm_token_ids({"model_type": "phi4mm"}) == expected
-    # A config that does declare them wins over the defaults.
     assert _phi4mm_token_ids(
         {"image_token_index": -7, "audio_token_index": 11}
     ) == (-7, 11)
@@ -3714,8 +3698,6 @@ def test_a_bare_message_list_row_is_scanned_for_audio(monkeypatch):
     assert _raw_row_has_audio({"messages": messages}) is True
     assert _raw_row_has_audio(messages) is True, "the same row, unwrapped"
 
-    # An unqualified family must still be refused when the formatter hides the
-    # clips, which is the whole point of scanning before formatting.
     from unsloth_zoo.mlx import utils as mlx_utils
 
     monkeypatch.setattr(
@@ -3746,11 +3728,9 @@ def test_a_row_that_is_one_message_dict_is_scanned_for_audio(monkeypatch):
     row = {"role": "user", "content": [{"type": "audio", "audio": clip},
                                        {"type": "text", "text": "transcribe"}]}
 
-    # Supported: collation turns this row into exactly one message.
     assert len(_normalize_vlm_messages(row)) == 1
     assert _raw_row_has_audio(row) is True
 
-    # A message dict carrying no audio must not be gated.
     assert _raw_row_has_audio(
         {"role": "user", "content": [{"type": "text", "text": "hi"}]}
     ) is False
@@ -3858,7 +3838,6 @@ def test_an_audio_part_canonicalizes_whichever_alias_it_uses(monkeypatch):
                     assert np.array_equal(
                         np.asarray(clip), ramp["array"]), (part, content)
 
-    # A type outside the audio spellings is never rewritten.
     kept = _normalize_vlm_messages(
         [{"role": "user", "content": [{"type": "video", "video": "v.mp4"}]}])
     assert kept[0]["content"][0]["type"] == "video"
@@ -5235,7 +5214,6 @@ def test_qwen3_omni_deficit_still_lands_only_on_the_anchor():
         prompt_utils, "qwen3_omni_moe", messages, num_images = 1, num_audios = 2, kwargs = {},
     )
 
-    # One audio is missing conversation-wide; it goes to the anchor only.
     assert [part.get("type") for part in template[0]["content"]] == ["image", "audio", "text"]
     assert [part.get("type") for part in template[1]["content"]] == ["audio", "text"]
 

--- a/tests/test_module_attribute_getter.py
+++ b/tests/test_module_attribute_getter.py
@@ -41,8 +41,6 @@ def _build_model():
     return root
 
 
-# --- equivalence with the removed eval ---------------------------------------
-
 @pytest.mark.parametrize("path", [
     "model",
     "model.visual",
@@ -65,8 +63,6 @@ def test_empty_path_returns_the_root():
     model = _build_model()
     assert _get_module_attribute(model, "") is model
 
-
-# --- what eval could not do --------------------------------------------------
 
 @pytest.mark.parametrize("path", [
     "model.visual.blocks.0",
@@ -93,12 +89,9 @@ def test_a_path_component_is_a_name_not_an_expression(path):
     """The whole point. `eval` ran these; the walk looks each one up as an attribute
     name and fails, so no call, no subscript and no operator ever executes."""
     model = _build_model()
-    # eval would have happily executed the first three.
     with pytest.raises((AttributeError, IndexError, KeyError, TypeError, ValueError)):
         _get_module_attribute(model, path)
 
-
-# --- failure is loud ---------------------------------------------------------
 
 @pytest.mark.parametrize("path", [
     "does.not.exist",
@@ -110,8 +103,6 @@ def test_unresolvable_path_raises(path):
     with pytest.raises((AttributeError, IndexError, KeyError, TypeError, ValueError)):
         _get_module_attribute(_build_model(), path)
 
-
-# --- getter and setter agree -------------------------------------------------
 
 @pytest.mark.parametrize("path", [
     "model.norm.weight",
@@ -125,7 +116,7 @@ def test_round_trip_with_the_setter(path):
     assert _get_module_attribute(model, path) is value
 
 
-# --- bracket components, from the parallel review of PR #1108 -----------------
+# Bracket components, from the parallel review of PR #1108.
 
 def test_bracket_components_resolve_like_eval():
     """`peft_utils` rewrites `.0.` to `[0].`, and one of its two call sites can hand
@@ -153,7 +144,6 @@ def test_bracket_components_resolve_like_eval():
         oracle = eval("model." + path, {}, {"model": model})
         assert _get_module_attribute(model, path) is oracle, path
 
-    # The dotted-index spelling still works, and both spellings agree.
     assert _get_module_attribute(model, "blocks.0") is _get_module_attribute(model, "blocks[0]")
 
 

--- a/tests/test_moe_bnb4bit_adaptive_recompute.py
+++ b/tests/test_moe_bnb4bit_adaptive_recompute.py
@@ -75,8 +75,6 @@ def test_default_non_gc_uses_recompute_provider(monkeypatch):
 
 
 def test_gc_recompute_pass_recomputes_for_4bit(monkeypatch):
-    # A 4-bit base prefers recompute even inside a GC recompute pass, so the packed
-    # Params4bit is kept and dequant deferred rather than pinning the full bf16 stack.
     monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
     with _gradient_checkpoint_recompute_marker():
         assert _run_and_record(monkeypatch) == ["provider"]  # recompute, no bf16 pin
@@ -125,7 +123,6 @@ def test_4bit_prefers_recompute_but_dense_still_pins_under_gc(monkeypatch):
     with _gradient_checkpoint_recompute_marker():
         assert mu._moe_recompute_enabled(q) is True       # 4-bit -> recompute
         assert mu._moe_recompute_enabled(dense) is False  # dense -> pin (unchanged)
-    # UNSLOTH_MOE_RECOMPUTE=0 still forces the pin even for a 4-bit base.
     monkeypatch.setenv("UNSLOTH_MOE_RECOMPUTE", "0")
     assert mu._moe_recompute_enabled(q) is False
 

--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -334,7 +334,6 @@ def test_stack_prequantized_block_alignment(out_dim, in_dim, exact):
         target_patterns=[conv.target_patterns[0]],
     )
     new_param = out[conv.target_patterns[0]]
-    # Reference: what the per-expert quantized segments actually dequantize to.
     seg_ref = torch.stack([
         torch.cat([
             bnb.functional.dequantize_4bit(
@@ -384,7 +383,6 @@ def test_plain_dequant_skips_bnb_embedding4bit():
 
     _dequantize_plain_param_slots(model)
 
-    # bnb module keeps its quantized weight; the genuinely plain slot converts.
     assert type(model.emb.weight).__name__ == "Params4bit"
     assert getattr(model.emb.weight, "quant_state", None) is not None
     assert type(model.plain.weight).__name__ == "Parameter"

--- a/tests/test_moe_lora_extractor_coverage.py
+++ b/tests/test_moe_lora_extractor_coverage.py
@@ -31,7 +31,6 @@ import pytest
 import torch
 import torch.nn as nn
 
-# Importing the package side-effect-populates TEMPORARY_PATCHES.
 import unsloth_zoo.temporary_patches  # noqa: F401  side effect: register patches
 from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
 
@@ -123,11 +122,6 @@ def _discover_patched_moe_classes() -> list[type]:
                 continue
             out.append(obj)
     return out
-
-
-# --------------------------------------------------------------------------
-# Opportunistic parity helpers
-# --------------------------------------------------------------------------
 
 
 class _StubWrapper:
@@ -254,11 +248,6 @@ def _parity_one(extractor, experts, name: str, in_dim: int, out_dim: int,
     return True, "ok"
 
 
-# --------------------------------------------------------------------------
-# The single test
-# --------------------------------------------------------------------------
-
-
 def test_every_patched_moe_experts_class_has_lora_extractor():
     """Regression test for PR #624: every class whose `forward` unsloth-zoo
     patched to the grouped-MoE backend with `(E, 2*I, H)`/`(E, H, I)` 3D
@@ -276,9 +265,6 @@ def test_every_patched_moe_experts_class_has_lora_extractor():
         # drift; (c) the `_original_..._forward` convention
         # `_has_unsloth_patched_forward` reads drifted from `patch_function`
         # -- a real test-helper regression.
-        # Disambiguate via `_unsloth_already_patched=True`: if any class
-        # carries it, a patch fn ran fully so missing discovery is (c), a real
-        # regression. If none carries it, we're in (a)/(b) and skip.
         already = []
         for modeling in _iter_modeling_modules():
             for _name, cls in inspect.getmembers(modeling, inspect.isclass):
@@ -311,7 +297,6 @@ def test_every_patched_moe_experts_class_has_lora_extractor():
             "fully supported runtime still exercise the real assertion."
         )
 
-    # Hard contract: extractor must be registered on every patched class.
     missing = [
         f"{c.__module__}.{c.__name__}"
         for c in patched
@@ -326,8 +311,6 @@ def test_every_patched_moe_experts_class_has_lora_extractor():
         f"in the patch function. Offenders: {missing}"
     )
 
-    # Soft contract: opportunistic per-expert parity catches the
-    # extractor-orientation bug class (cheap to assert alongside).
     parity_failures = []
     for cls in patched:
         experts = _try_instantiate_experts(cls)

--- a/tests/test_moe_lora_grouped_mm_capability.py
+++ b/tests/test_moe_lora_grouped_mm_capability.py
@@ -466,9 +466,6 @@ def test_the_norm_does_not_materialize_fp32_copies(unsupported):
     assert "inputs.float() * inputs.float()" not in body
 
 
-# --- the fallback's own cost -------------------------------------------------
-
-
 def _backward_matmul_out_usage(out, seed):
     """Which of `torch.matmul`'s calls during `out.backward(seed)` passed `out=`.
 

--- a/tests/test_moe_merge_legacy_mixtral_cpu.py
+++ b/tests/test_moe_merge_legacy_mixtral_cpu.py
@@ -105,7 +105,6 @@ def test_legacy_mixtral_w1w2w3_experts_are_merged(tmp_path):
     count = result[0] if isinstance(result, tuple) else result
     merged = load_file(path)
 
-    # Every per-expert tensor changed; nothing fell back.
     n_expert = sum(1 for k in base if ".experts." in k)
     n_changed = sum(
         1 for k in base
@@ -117,10 +116,8 @@ def test_legacy_mixtral_w1w2w3_experts_are_merged(tmp_path):
     # gate_up + down per layer.
     assert count == num_layers * 2
 
-    # Disk layout stays unfused.
     assert not any("gate_up_proj" in k for k in merged)
 
-    # Numeric check against the analytic LoRA delta per expert.
     max_err = 0.0
     for L in range(num_layers):
         prefix = f"model.layers.{L}.mlp.experts"
@@ -158,7 +155,6 @@ def test_legacy_mixtral_gate_up_proj_keyed_adapter_is_merged(tmp_path):
         B_gu = torch.randn(2 * intermediate, TR, dtype=torch.float32) * 0.05
         A_dn = torch.randn(TR, intermediate, dtype=torch.float32) * 0.05
         B_dn = torch.randn(hidden, TR, dtype=torch.float32) * 0.05
-        # gate_up keyed on .gate_up_proj instead of .base_layer.
         lw[prefix + ".gate_up_proj"] = LoraStats(_InnerMoE(num_experts), A_gu, B_gu, alpha)
         lw[prefix] = LoraStats(_InnerMoE(num_experts), A_dn, B_dn, alpha)
 
@@ -221,7 +217,6 @@ def test_legacy_mixtral_down_proj_keyed_adapter_is_merged(tmp_path):
         A_dn = torch.randn(TR, intermediate, dtype=torch.float32) * 0.05
         B_dn = torch.randn(hidden, TR, dtype=torch.float32) * 0.05
         lw[prefix + ".base_layer"] = LoraStats(_InnerMoE(num_experts), A_gu, B_gu, alpha)
-        # down keyed on .down_proj instead of the experts module.
         lw[prefix + ".down_proj"] = LoraStats(_InnerMoE(num_experts), A_dn, B_dn, alpha)
 
     _reset_moe_merge_state()
@@ -382,7 +377,6 @@ def test_legacy_mixtral_fp8_shard_is_quant_aware(tmp_path):
     count = result[0] if isinstance(result, tuple) else result
     merged = load_file(path)
 
-    # Data stays float8 and scales were rewritten.
     for k, v in merged.items():
         if k.endswith(".weight"):
             assert v.dtype == torch.float8_e4m3fn, f"{k} should stay FP8, got {v.dtype}"
@@ -453,7 +447,6 @@ def test_legacy_mixtral_fp8_dequant_then_merge_16bit(tmp_path):
                 hp[f"{p}.{w_name}.weight"] = _fp8_dequant_blockwise(W_fp8, scale)
     save_file(tensors, path)
 
-    # Phase 1: dequantize to 16bit (no LoRA), then drop the now-resolved scales.
     prerewrite_fp8 = _collect_fp8_weight_keys(str(tmp_path), ["model.safetensors"])
     _merge_and_overwrite_lora_fp8(
         str(tmp_path), "model.safetensors",
@@ -464,7 +457,6 @@ def test_legacy_mixtral_fp8_dequant_then_merge_16bit(tmp_path):
     assert not any(k.endswith(("weight_scale", "weight_scale_inv")) for k in dq), "scales not dropped"
     assert all(v.dtype == torch.bfloat16 for k, v in dq.items() if k.endswith(".weight")), "not 16bit"
 
-    # Phase 2: standard (non-quantized) 16bit MoE merge of the expert LoRA.
     TR = num_experts * rank_per
     lw = collections.defaultdict(lambda: LoraStats(None, None, None, 0))
     for L in range(num_layers):
@@ -485,7 +477,6 @@ def test_legacy_mixtral_fp8_dequant_then_merge_16bit(tmp_path):
     )
     merged = load_file(path)
     assert _MOE_MERGE_STATE["fallback"] == 0
-    # Genuine 16bit output (no FP8, no scales) with the LoRA delta applied.
     assert all(v.dtype == torch.bfloat16 for k, v in merged.items() if k.endswith(".weight"))
     assert not any(k.endswith(("weight_scale", "weight_scale_inv")) for k in merged)
 

--- a/tests/test_moe_num_experts_header_precedence.py
+++ b/tests/test_moe_num_experts_header_precedence.py
@@ -52,7 +52,6 @@ class _Stats:
 
 
 def test_partial_low_index_shard_does_not_lower_module_count():
-    # Live module exposes the true count (64); this shard only holds experts 0..15.
     module = types.SimpleNamespace(num_experts=64)
     stats = _Stats(module=module)
     moe_num_experts = {}
@@ -100,8 +99,6 @@ def test_header_raises_a_degenerate_derived_count():
 
 
 def test_fused_lora_shape_count_not_lowered_by_partial_shard():
-    # No module, but a fused LoRA encodes 64 experts (total_rank // rank == 64).
-    # A partial shard reporting 16 must not lower it.
     import torch
 
     stats = _Stats(
@@ -120,7 +117,6 @@ def test_fused_lora_shape_count_not_lowered_by_partial_shard():
 
 
 def test_no_per_expert_tensors_returns_none():
-    # Header has no per-expert tensors for this prefix and nothing else resolves.
     stats = _Stats(module=None)
     moe_num_experts = {}
     header = {"model.layers.0.self_attn.q_proj.weight": object()}

--- a/tests/test_moe_preprocess_weight_transpose.py
+++ b/tests/test_moe_preprocess_weight_transpose.py
@@ -120,7 +120,6 @@ def test_orientation_primitive_returns_none_on_square():
 
 def test_logical_expert_shape_prefers_original_shape_after_linear_unwrap():
     class _PackedParam:
-        # Physical shape is packed; logical shape is recorded separately.
         shape = (2048, 1)
         _original_shape = (4, 128, 64)
 

--- a/tests/test_moe_quant_handler_registry.py
+++ b/tests/test_moe_quant_handler_registry.py
@@ -34,7 +34,6 @@ def test_saving_utils_uses_registry_not_inline_helpers():
     helpers live in moe_utils_fp8.py and are imported in."""
     from unsloth_zoo import saving_utils
 
-    # Inline FP8 helpers removed from saving_utils.
     for sym in (
         "_FP8_E4M3_MAX",
         "_fp8_dequant_blockwise",
@@ -46,7 +45,6 @@ def test_saving_utils_uses_registry_not_inline_helpers():
             f"saving_utils still defines {sym!r}; it should live in moe_utils_fp8."
         )
 
-    # Registry entry points wired in.
     from unsloth_zoo.temporary_patches.moe_utils_fp8 import (
         apply_moe_quant_load,
         _MOE_QUANT_UNSAFE,
@@ -210,7 +208,6 @@ def test_fp8_handler_partial_block_needs_block_size():
     assert W_inferred is not _MOE_QUANT_UNSAFE
     err_inferred = (W_inferred.float() - W_real).abs().max().item()
 
-    # With configured block size: correct 128x128 tiling -> matches the real weight.
     W_block, requant = _fp8_save_handler(file, header, "X.weight", block_size=(128, 128))
     assert W_block is not _MOE_QUANT_UNSAFE
     err_block = (W_block.float() - W_real).abs().max().item()
@@ -280,7 +277,6 @@ def test_fp8_handler_per_channel_scale_with_block_size_merges():
     assert loaded[0] is not _MOE_QUANT_UNSAFE, "per-channel scale wrongly rejected"
     W_bf16, requant = loaded
     assert (W_bf16.float() - W_real).abs().max().item() < 0.05
-    # Requant round-trips and preserves the (rows, 1) grid.
     _new_fp8, _dtype, extras = requant(W_bf16)
     _key, new_scale, _sd = extras[0]
     assert tuple(new_scale.shape) == (rows, 1)

--- a/tests/test_moe_recompute_gc_adaptive.py
+++ b/tests/test_moe_recompute_gc_adaptive.py
@@ -23,9 +23,6 @@ from unsloth_zoo.gradient_checkpointing import (
 import unsloth_zoo.temporary_patches.moe_utils as mu
 
 
-# ---------------------------------------------------------------------------
-# The recompute marker
-# ---------------------------------------------------------------------------
 def test_marker_idempotent_nesting_and_exception_safe():
     assert in_gradient_checkpoint_recompute() is False
     with _gradient_checkpoint_recompute_marker():
@@ -64,9 +61,6 @@ def test_marker_true_only_during_gc_recompute():
     assert torch.allclose(x.grad, torch.full_like(x, 2.0))
 
 
-# ---------------------------------------------------------------------------
-# The adaptive decision
-# ---------------------------------------------------------------------------
 def test_recompute_policy_adaptive_and_overrides(monkeypatch):
     # Isolate the policy layer from the base-recomputable guards (which need CUDA +
     # torch._grouped_mm support).

--- a/tests/test_muse_glimmer_banded_attention.py
+++ b/tests/test_muse_glimmer_banded_attention.py
@@ -98,18 +98,10 @@ def _route(module, S, mask=None, is_causal=None, q=None, k=None, v=None, **kw):
         module, q, k, v, mask, dropout=0.0, scaling=D ** -0.5, is_causal=is_causal, **kw)
 
 
-# ---------------------------------------------------------------------------
-# Registration
-# ---------------------------------------------------------------------------
-
 def test_registered_in_temporary_patches():
     from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
     assert mg.patch_muse_glimmer_banded_sliding_attention in TEMPORARY_PATCHES
 
-
-# ---------------------------------------------------------------------------
-# The gate must defer
-# ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("S", [W, 2 * W, 3 * W - 1])
 def test_defers_below_three_windows(_clean_router, S):
@@ -186,10 +178,6 @@ def test_env_off_defers_everywhere(_clean_router, monkeypatch):
     assert out == "DEFERRED"
 
 
-# ---------------------------------------------------------------------------
-# The gate must engage, and match the reference
-# ---------------------------------------------------------------------------
-
 @pytest.mark.parametrize("with_mask", [False, True])
 def test_engages_and_matches_reference(_clean_router, with_mask):
     S = S_ON
@@ -230,10 +218,6 @@ def test_banded_engages_when_sliding_window_comes_from_kwargs(_clean_router):
     _route(module, S_ON, sliding_window=W)
     assert mg._BANDED_ENGAGED[0] == before + 1
 
-
-# ---------------------------------------------------------------------------
-# Installation is idempotent, and does not break gemma-4's re-entry guard
-# ---------------------------------------------------------------------------
 
 def _sdpa_registry():
     modeling_utils = pytest.importorskip("transformers.modeling_utils")

--- a/tests/test_mxfp4_convert_no_double_transpose.py
+++ b/tests/test_mxfp4_convert_no_double_transpose.py
@@ -83,7 +83,6 @@ _RUNNER = textwrap.dedent(
 
 def _run(mode, outfile):
     env = dict(os.environ)
-    # Force CPU-friendly behaviour; the correctness check is device-independent.
     r = subprocess.run(
         [sys.executable, "-c", _RUNNER, mode, outfile],
         capture_output=True, text=True, env=env,

--- a/tests/test_mxfp4_transpose_convention.py
+++ b/tests/test_mxfp4_transpose_convention.py
@@ -35,16 +35,13 @@ _CPU_SENTINEL = object()
 
 
 def test_decision_matrix_patch_and_version():
-    # Unsloth patched base (its _cpu variant present) never self-transposes, in any version.
     assert _mxfp4_base_returns_transposed(_CPU_SENTINEL, "4.55.4") is False
     assert _mxfp4_base_returns_transposed(_CPU_SENTINEL, "4.57.6") is False
 
-    # Stock transformers < 4.56.0 returns the un-transposed layout -> external transpose needed.
     assert _mxfp4_base_returns_transposed(None, "4.55.2") is False
     assert _mxfp4_base_returns_transposed(None, "4.55.3") is False
     assert _mxfp4_base_returns_transposed(None, "4.55.4") is False
 
-    # Stock transformers >= 4.56.0 already self-transposes -> no external transpose.
     assert _mxfp4_base_returns_transposed(None, "4.56.0") is True
     assert _mxfp4_base_returns_transposed(None, "4.56.2") is True
     assert _mxfp4_base_returns_transposed(None, "4.57.0") is True
@@ -78,7 +75,6 @@ def test_all_conventions_produce_identical_gpt_oss_layout():
         base_returns_transposed = _mxfp4_base_returns_transposed(cpu_variant, version)
         return base_out.contiguous() if base_returns_transposed else base_out.transpose(1, 2).contiguous()
 
-    # Unsloth patched base: returns un-transposed `out`, _cpu present.
     assert torch.equal(apply(out, _CPU_SENTINEL, "4.57.6"), ground_truth)
     # Stock 4.55.x: returns un-transposed `out`, _cpu absent.
     assert torch.equal(apply(out, None, "4.55.4"), ground_truth)
@@ -99,7 +95,6 @@ def test_old_cpu_only_keying_would_corrupt_stock_4_55():
     old_W = out.contiguous() if old_base_returns_transposed else out.transpose(1, 2).contiguous()
     assert not torch.equal(old_W, ground_truth)  # confirms the old path corrupted 4.55.x
 
-    # New logic keyed on version restores correctness.
     new_returns_transposed = _mxfp4_base_returns_transposed(None, "4.55.4")
     new_W = out.contiguous() if new_returns_transposed else out.transpose(1, 2).contiguous()
     assert torch.equal(new_W, ground_truth)

--- a/tests/test_notebook_chat_templates.py
+++ b/tests/test_notebook_chat_templates.py
@@ -156,8 +156,6 @@ def _check(repo):
     try:
         ins, res = get_chat_template_parts(tok)
     except ValueError as e:
-        # A model shipped in a notebook is expected to auto-detect. Only allowlisted
-        # non-atomic templates may safe-raise; anything else is a real regression.
         if any(k in repo.lower() for k in KNOWN_NON_ATOMIC):
             return "SKIP", "known non-atomic template (allowlisted)"
         return "FAIL", f"auto-detect raised ValueError for a supported model: {str(e)[:80]}"

--- a/tests/test_offline_env_cross_sync.py
+++ b/tests/test_offline_env_cross_sync.py
@@ -121,7 +121,6 @@ class TestOfflineCrossSync:
             assert os.environ.get("HF_DATASETS_OFFLINE") == "1", spelling
 
     def test_non_truthy_value_leaves_env_unchanged(self, monkeypatch, reload_zoo):
-        # Values outside _OFFLINE_TRUE are passed through untouched.
         monkeypatch.setenv("HF_HUB_OFFLINE", "0")
         reload_zoo()
         assert os.environ.get("HF_HUB_OFFLINE") == "0"

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -48,7 +48,6 @@ class FakeTokenizer:
             for t in added if t in self._vocab
         }
 
-    # ids
     @property
     def pad_token_id(self):
         return self._vocab.get(self.pad_token)
@@ -61,7 +60,6 @@ class FakeTokenizer:
         return dict(self._vocab)
 
     def __call__(self, text, add_special_tokens=False):
-        # Each known token is a single id; unknown text splits into >1 id.
         ids = [self._vocab[text]] if text in self._vocab else [0, 1]
         return type("Enc", (), {"input_ids": ids})()
 
@@ -91,17 +89,14 @@ def _qwen3_text():
 
 
 def test_is_pad_named():
-    # Bracketed pad sentinels qualify ...
     for t in ("<|vision_pad|>", "<|fim_pad|>", "[PAD]", "<pad>", "<|PAD|>"):
         assert _is_pad_named(t)
-    # ... ordinary words containing "pad" and non-pad tokens do not.
     for t in ("keypad", "padding", "Notepad", "pad",
               "<|endoftext|>", "<|im_end|>", "<unk>"):
         assert not _is_pad_named(t)
 
 
 def test_qwen3_vision_pad_is_kept():
-    # <|vision_pad|> is a pad-named token distinct from eos -> kept as-is.
     tok = _qwen3_text()
     res = fix_pad_token(tok)
     assert res["changed"] is False
@@ -373,7 +368,7 @@ def test_zero_token_candidate_does_not_crash():
     # A reserved entry present but encoding to !=1 id must be skipped, not crash.
     class Weird(FakeTokenizer):
         def __call__(self, text, add_special_tokens=False):
-            return type("Enc", (), {"input_ids": []})()  # zero ids for everything
+            return type("Enc", (), {"input_ids": []})()
     tok = Weird({"</s>": 2, "<pad>": 0}, pad_token="</s>", eos_token="</s>")
     res = fix_pad_token(tok, allow_add=False)   # <pad> rejected (0 ids) -> defer, no IndexError
     assert res["changed"] is False
@@ -413,7 +408,6 @@ def test_in_range_valid_pad_is_noop_with_vocab_size():
 
 
 def test_vision_pad_kept_regardless_of_model_type():
-    # A pad-named modality token is kept whether or not the model is multimodal.
     tok = _qwen3_text()  # pad_token = "<|vision_pad|>"
     cfg = type("Cfg", (), {"model_type": "llava"})()
     res = fix_pad_token(tok, model_config = cfg)
@@ -432,7 +426,6 @@ def test_unk_token_fallback_when_no_reserved():
 
 
 def test_pad_equals_eos_reuses_modality_pad_when_only_option():
-    # pad == eos and only a modality pad available -> reuse it instead of adding/raising.
     tok = FakeTokenizer({"<|im_end|>": 1, "<|vision_pad|>": 2},
                         pad_token = "<|im_end|>", eos_token = "<|im_end|>")
     res = fix_pad_token(tok)
@@ -440,15 +433,12 @@ def test_pad_equals_eos_reuses_modality_pad_when_only_option():
 
 
 def test_audio_pad_is_kept():
-    # <|audio_pad|> is pad-named and distinct from eos -> kept as-is.
     tok = FakeTokenizer({"<|im_end|>": 1, "<|audio_pad|>": 2},
                         pad_token = "<|audio_pad|>", eos_token = "<|im_end|>")
     assert fix_pad_token(tok)["changed"] is False
 
 
 def test_pad_name_fallback_ignores_bare_word_token():
-    # pad == eos; "keypad" is a bare word (not a bracketed sentinel) and must not be
-    # promoted, while the bracketed <|custom_pad|> is picked.
     tok = FakeTokenizer({"<|endoftext|>": 0, "keypad": 5, "<|custom_pad|>": 6},
                         pad_token = "<|endoftext|>", eos_token = "<|endoftext|>")
     res = fix_pad_token(tok)

--- a/tests/test_patch_loss_functions_coverage.py
+++ b/tests/test_patch_loss_functions_coverage.py
@@ -66,7 +66,6 @@ def test_loss_mapping_other_losses_left_alone():
     lu = pytest.importorskip("transformers.loss.loss_utils")
     from unsloth_zoo import loss_utils as zoo_loss
 
-    # Keys not currently aliased to ForCausalLMLoss must survive the sweep.
     non_causal = {
         k: v for k, v in lu.LOSS_MAPPING.items()
         if getattr(v, "__name__", "") != "ForCausalLMLoss"

--- a/tests/test_peft_regex_audio.py
+++ b/tests/test_peft_regex_audio.py
@@ -40,7 +40,6 @@ import torch.nn as nn
 from unsloth_zoo.peft_utils import get_peft_regex
 
 
-# ----------------------------------------------------------------------------- helpers
 def _add(root: nn.Module, path: str, leaf_module: nn.Module):
     *mids, leaf = path.split(".")
     cur = root
@@ -85,7 +84,6 @@ def leaf(name):
     return name.rsplit(".", 1)[-1]
 
 
-# ----------------------------------------------------------------------------- fixtures
 def _text_stack(prefix, n=2, heads=("q_proj", "k_proj", "v_proj", "o_proj"),
                 mlp=("gate_proj", "up_proj", "down_proj")):
     out = []
@@ -95,7 +93,6 @@ def _text_stack(prefix, n=2, heads=("q_proj", "k_proj", "v_proj", "o_proj"),
     return out
 
 
-# Existing architectures (no Gemma embedder / no audio LoRA target today).
 LLAMA      = _text_stack("language_model.layers") + ["lm_head"]
 QWEN3      = _text_stack("language_model.layers") + ["lm_head"]
 QWEN2_VL   = (_text_stack("language_model.layers")
@@ -197,7 +194,6 @@ def _gemma4(size="E2B"):
     return FakeModel(lin, others, name=f"unsloth/gemma-4-{size}-it", model_type="gemma4")
 
 
-# ----------------------------------------------------------------------------- tests
 @pytest.mark.parametrize("arch_name", list(NON_GEMMA_ARCHS) + list(AUDIO_ARCHS))
 @pytest.mark.parametrize("flags", FLAG_COMBOS)
 def test_audio_flag_off_is_inert(arch_name, flags):
@@ -269,7 +265,6 @@ def test_gemma_audio_attaches(builder, name):
                                  finetune_audio_layers=False), ns)
     assert not any(".audio_tower." in n or n.endswith("embed_audio.embedding_projection") for n in off)
 
-    # WITH the fix.
     on = matched(get_peft_regex(model, finetune_vision_layers=False,
                                 finetune_language_layers=True,
                                 finetune_audio_layers=True), ns)
@@ -277,7 +272,6 @@ def test_gemma_audio_attaches(builder, name):
     assert audio_hits, f"{name}: audio_tower got 0 LoRA targets"
     assert any(n.endswith("embed_audio.embedding_projection") for n in on), f"{name}: projector missed"
 
-    # The conformer feed-forward + attention + lconv leaves attach.
     leaves = {leaf(n) for n in audio_hits}
     assert {"ffw_layer_1", "ffw_layer_2"} <= leaves
     assert {"linear_start", "linear_end"} <= leaves
@@ -288,7 +282,6 @@ def test_gemma_audio_attaches(builder, name):
     assert not any(n.endswith("depthwise_conv1d") for n in on)
     assert not any(n.endswith(".conv") or n.endswith("_norm") or n.endswith(".norm") for n in on)
 
-    # Language stack unchanged off<->on.
     assert {n for n in off if ".language_model." in n} == {n for n in on if ".language_model." in n}
 
 
@@ -372,10 +365,8 @@ def test_gemma4_audio_matches_inner_linear_not_wrapper(builder, name):
         return ".audio_tower." in n or "embed_audio" in n or "embed_vision" in n
     bad = [n for n in all_module_names(model) if _ours(n) and n not in lin and re.fullmatch(r, n)]
     assert not bad, f"{name}: regex matched non-Linear audio/embedder modules (wrappers?): {bad[:6]}"
-    # The inner ".linear" audio Linears DO attach.
     inner = [n for n in lin if ".audio_tower." in n and n.endswith(".linear")]
     assert inner and all(re.fullmatch(r, n) for n in inner), f"{name}: inner audio Linears not matched"
-    # ...and bare audio Linears (subsample/output projections) still attach.
     bare = [n for n in lin if ".audio_tower." in n and not n.endswith(".linear")]
     assert bare and all(re.fullmatch(r, n) for n in bare), f"{name}: bare audio Linears not matched"
 
@@ -396,8 +387,6 @@ def test_explicit_leaf_matches_full_segment_not_prefix():
 
 
 def test_audio_respects_attn_mlp_flags():
-    # attention off, mlp on: the conformer attention leaves (q/k/v/post) must not
-    # attach, but the feed-forward leaves must.
     model = _gemma3n()
     ns = linear_names(model)
     on = matched(get_peft_regex(model, finetune_vision_layers=False,
@@ -450,7 +439,6 @@ def test_embedder_branches_gated_to_gemma_model_type():
                                 finetune_language_layers=True), ns)
     assert not any(n.endswith(tuple(shared)) for n in on), \
         f"non-Gemma embedder Linears wrongly targeted: {[n for n in on if n.endswith(tuple(shared))]}"
-    # The very same module names DO attach on a Gemma model.
     gem = _gemma4("12B")
     gon = matched(get_peft_regex(gem, finetune_vision_layers=True,
                                  finetune_language_layers=True), linear_names(gem))
@@ -462,7 +450,6 @@ def test_projector_branches_gated_under_mlp_flag():
     # runs (finetune_mlp_modules=False) must not pick them up; mlp-on must.
     model = _gemma3n()
     ns = linear_names(model)
-    # attention-only -> no projectors
     attn_only = matched(get_peft_regex(model, finetune_vision_layers=True,
                                        finetune_language_layers=True,
                                        finetune_attention_modules=True,
@@ -472,7 +459,6 @@ def test_projector_branches_gated_under_mlp_flag():
         "vision projector attached under attention-only"
     assert not any(n.endswith("embed_audio.embedding_projection") for n in attn_only), \
         "audio projector attached under attention-only"
-    # mlp-on -> projectors present
     mlp_on = matched(get_peft_regex(model, finetune_vision_layers=True,
                                     finetune_language_layers=True,
                                     finetune_attention_modules=False,
@@ -484,7 +470,6 @@ def test_projector_branches_gated_under_mlp_flag():
 
 def test_guard_allows_audio_only_and_blocks_nothing_selected():
     model = _gemma3n()
-    # nothing selected -> raises
     with pytest.raises(RuntimeError):
         get_peft_regex(model, finetune_vision_layers=False,
                        finetune_language_layers=False, finetune_audio_layers=False)

--- a/tests/test_pip_cache_actions.py
+++ b/tests/test_pip_cache_actions.py
@@ -308,7 +308,6 @@ def _requires(expr, leaf):
         ands = _split_top(part, "&&")
         if len(ands) > 1:
             return any(restricted(p) for p in ands)
-        # A leaf. `!` anywhere outside a `!=` is a negation we will not reason about.
         if re.search(r"!(?!=)", part):
             return False
         # The leaf must BE the equality, not contain it. Searching inside accepted
@@ -349,7 +348,6 @@ def _requires(expr, leaf):
         # The reversed operand order is the same guard and stays accepted.
         ("'refs/heads/main' == github.ref", True),
         ("always() && (github.ref == 'refs/heads/main' && !cancelled())", True),
-        # An OR restricts only when every branch does.
         (
             "(github.ref == 'refs/heads/main' && always()) "
             "|| (github.ref == 'refs/heads/main' && failure())",
@@ -360,7 +358,6 @@ def _requires(expr, leaf):
     ],
 )
 def test_the_main_only_check_reads_the_expression(expr, restricted):
-    # The guard below is only as good as this predicate, so the predicate is tested too.
     assert _restricted_to_main(expr) is restricted, expr
 
 
@@ -441,7 +438,6 @@ def test_a_downloaded_artifact_is_saved_after_it_is_downloaded():
                     ),
                     default=None,
                 )
-                # No restore above the save is an offender, not "the top of the job".
                 # Position -1 accepted a restore sitting BELOW its save, which writes
                 # the entry every run and reads it never.
                 if restore_at is None:

--- a/tests/test_pr684_review_fixes_a.py
+++ b/tests/test_pr684_review_fixes_a.py
@@ -43,10 +43,6 @@ def _install_shim():
     simulate_mlx_on_torch()
 
 
-# ---------------------------------------------------------------------------
-# Shared lightweight tokenizer / model stubs.
-# ---------------------------------------------------------------------------
-
 class _SpaceTokenizer:
     """Whitespace tokenizer that mimics the HF fast-tokenizer surface."""
 
@@ -74,10 +70,6 @@ def _identity_mask_fn(d):
     return {"labels": [list(ids)]}
 
 
-# ===========================================================================
-# Thread 4: SGD coupled weight decay.
-# ===========================================================================
-
 def test_thread4_build_optimizer_routes_sgd_to_coupled_decay():
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
 
@@ -91,7 +83,6 @@ def test_thread4_build_optimizer_routes_sgd_to_coupled_decay():
 
     optimizer = trainer._build_optimizer(total_steps=4)
 
-    # SGD uses coupled decay, not decoupled manual shrink.
     assert trainer._coupled_weight_decay == pytest.approx(0.1)
     assert trainer._manual_weight_decay == pytest.approx(0.0)
     # MLX SGD's built-in decay stays off; our helper owns the decay term.
@@ -145,7 +136,6 @@ def test_thread4_coupled_decay_is_noop_when_disabled():
     trainer = MLXTrainer.__new__(MLXTrainer)
     trainer._coupled_weight_decay = 0.0
     grad = {"layer": {"weight": mx.array([1.0], dtype=mx.float32)}}
-    # Returns the same object untouched when wd <= 0.
     assert trainer._apply_coupled_weight_decay(TinyModel(), grad) is grad
 
 
@@ -166,7 +156,6 @@ def test_thread4_coupled_sgd_matches_torch_sgd_with_momentum():
         ref.grad = torch.tensor([1.0])
         ref_opt.step()
 
-    # Branch path: MLX SGD with weight_decay=0 + our coupled helper.
     class TinyModel:
         def __init__(self):
             self.p = mx.array([3.0], dtype=mx.float32)
@@ -234,10 +223,6 @@ def test_thread4_decoupled_shrink_would_diverge_from_torch_sgd():
     assert model.p.item() != pytest.approx(ref.item(), rel=1e-4, abs=1e-4)
 
 
-# ===========================================================================
-# Thread 2: seed=None labeled torch_randperm ordering.
-# ===========================================================================
-
 def test_thread2_labeled_batches_accept_none_seed_with_torch_randperm():
     from unsloth_zoo.mlx.trainer import _create_labeled_batches
 
@@ -281,10 +266,6 @@ def test_thread2_labeled_torch_randperm_reseeds_per_epoch():
     # Per-epoch reseed means the two orders differ.
     assert first != second
 
-
-# ===========================================================================
-# Threads 1 & 3: epoch flag preservation and gated materialization.
-# ===========================================================================
 
 class _StubModel:
     _hf_repo = None
@@ -349,7 +330,6 @@ def test_thread3_step_based_run_does_not_materialize_all_epochs(monkeypatch):
 
     # Truncated to max_steps * grad_accum = 2 batches, not 6 * 5 = 30.
     assert len(trainer._batches) == 2
-    # Step-based run: prebuilt batches are a single (truncated) block.
     assert trainer._prepared_batches_include_epochs is False
 
 
@@ -429,15 +409,10 @@ def test_thread1_regression_without_fix_would_triple_count():
         buggy = n_batches // grad_accum
     assert buggy == 54  # 3x over-trained
 
-    # Fixed path keeps the flag.
     include_epochs = True
     fixed = n_batches // grad_accum if include_epochs else buggy
     assert fixed == 18
 
-
-# ===========================================================================
-# Thread 5: _get_processor_tokenizer must not unwrap HF fast tokenizers.
-# ===========================================================================
 
 class _RustBackend:
     """Mimics tokenizers.Tokenizer: token_to_id, but no HF convenience API."""
@@ -468,7 +443,6 @@ class _MlxWrapper:
         self._tokenizer = _FastTokenizer()
 
     def __getattr__(self, name):
-        # Proxy everything that is not private to the inner HF tokenizer.
         if name.startswith("_"):
             raise AttributeError(name)
         return getattr(self.__dict__["_tokenizer"], name)
@@ -499,7 +473,6 @@ def test_thread5_mlx_wrapper_keeps_hf_api_available():
 
     wrapper = _MlxWrapper()
     result = _get_processor_tokenizer(wrapper)
-    # Returned object exposes the HF API (directly or via proxy).
     assert hasattr(result, "convert_tokens_to_ids")
     assert result.convert_tokens_to_ids("x") == 123
     assert result.chat_template == "FAST_TEMPLATE"
@@ -554,12 +527,10 @@ def test_thread5_vlm_ignore_ids_resolve_with_fast_tokenizer():
     assert 201 in ids
 
 
-# ===========================================================================
 # Thread 5 follow-up: train_on_responses_only must hand the HF masking impl
 # a CALLABLE tokenizer. mlx-lm's TokenizerWrapper proxies attributes via
 # __getattr__ (so hasattr(convert_tokens_to_ids) is True) but defines no
 # __call__, and the HF impl invokes tokenizer(...) directly.
-# ===========================================================================
 
 def test_thread5_noncallable_proxy_wrapper_unwraps_for_masking(monkeypatch):
     import unsloth_zoo.dataset_utils as dataset_utils

--- a/tests/test_pr684_review_fixes_b.py
+++ b/tests/test_pr684_review_fixes_b.py
@@ -67,7 +67,6 @@ def test_run_hidden_stack_reads_sliding_window_from_config():
         layers=[layer_sliding, layer_global],
         norm=IdentityNorm(),
     )
-    # No sliding_window_pattern / window_size attributes on the stack itself.
     assert not hasattr(stack, "sliding_window_pattern")
     assert not hasattr(stack, "window_size")
 
@@ -197,7 +196,6 @@ def test_apply_vlm_label_masks_preserves_wide_unsigned_ids():
     labels = _apply_vlm_label_masks(batch, ignore_token_ids=None)
 
     values = labels[0].tolist()
-    # The wide id is preserved (not wrapped to -100 or a negative int32 value).
     assert values[1] == wide_id
     assert values[0] == 5
     assert values[2] == 7

--- a/tests/test_prepare_model_for_training_bias.py
+++ b/tests/test_prepare_model_for_training_bias.py
@@ -51,8 +51,6 @@ def _trainable_bias_count(model):
         p.requires_grad for n, p in model.named_parameters() if n.endswith(".bias"))
 
 
-# ---------------- PEFT bias decision is preserved ----------------------------
-
 def test_peft_bias_all_stays_trainable():
     """bias='all': every bias PEFT enabled stays trainable after prepare."""
     pytest.importorskip("peft")
@@ -68,7 +66,6 @@ def test_peft_bias_all_stays_trainable():
     )
     after = _trainable_bias_count(model)
     assert after == before, f"bias='all' lost trainable biases: {before} -> {after}"
-    # Base weights stay frozen.
     params = dict(model.named_parameters())
     base_w = next(n for n in params
                   if n.endswith("q_proj.base_layer.weight"))
@@ -133,13 +130,10 @@ def test_peft_bias_gradient_flows_after_backward():
     a_grad = params[a_bias].grad
     assert a_grad is not None, "trainable bias must receive a grad"
     assert torch.isfinite(a_grad).all(), "bias grad must be finite"
-    # > 0 proves a gradient actually flowed, not just that grad exists.
     assert a_grad.abs().sum() > 0, "bias grad must be non-zero (gradient flowed)"
     base_w = next(n for n in params if n.endswith("q_proj.base_layer.weight"))
     assert params[base_w].grad is None, "frozen base weight must not accumulate grad"
 
-
-# ---------------- non-PEFT models are left frozen ----------------------------
 
 def test_non_peft_model_biases_stay_frozen():
     """A non-PEFT model's biases default to requires_grad=True but must still be
@@ -157,8 +151,6 @@ def test_non_peft_model_biases_stay_frozen():
     assert _trainable_bias_count(model) == 0, \
         "non-PEFT biases must be frozen on the LoRA path"
 
-
-# ---------------- modules_to_save biases are not a bias decision -------------
 
 def test_modules_to_save_bias_not_preserved_on_bias_none():
     """bias='none' + modules_to_save: a saved module is trainable because the whole

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -139,8 +139,6 @@ def _run(full_finetuning, with_bias=False, env=None,
     return m, _params(m)
 
 
-# ---------------- full-FT: norm.weights become fp32 ----------------
-
 def test_full_ft_norm_weights_become_fp32():
     m, p = _run(full_finetuning=True)
     for n in (
@@ -171,8 +169,6 @@ def test_full_ft_norm_biases_follow_module_cast():
             f"{n} should follow its norm module's dtype cast, got {p[n].dtype}"
 
 
-# ---------------- deferral to external _pre_set_compute_dtype ----------------
-
 def test_full_ft_defers_to_pre_set_compute_dtype_on_norm():
     # A norm module owned by an external policy keeps its loaded dtype; the
     # fix MUST NOT overwrite it. Other norms still upcast.
@@ -193,8 +189,6 @@ def test_full_ft_defers_per_module_not_globally():
     assert p["model.layers.0.input_layernorm.weight"].dtype == torch.float32
 
 
-# ---------------- LoRA / QLoRA path: zero behaviour change ----------------
-
 def test_lora_norms_stay_bf16_frozen():
     m, p = _run(full_finetuning=False)
     for n in (
@@ -205,8 +199,6 @@ def test_lora_norms_stay_bf16_frozen():
         assert p[n].dtype == torch.bfloat16
         assert p[n].requires_grad is False
 
-
-# ---------------- rollback env switch ----------------
 
 def test_disable_float32_upcast_reproduces_pre_fix_bf16():
     m, p = _run(full_finetuning=True,
@@ -240,9 +232,6 @@ def test_matcher_catches_vit_style_norm1_norm2():
     assert p["model.visual.blocks.0.norm1.bias"].dtype == torch.float32
     assert p["model.visual.blocks.0.norm2.weight"].dtype == torch.float32
     assert p["model.visual.blocks.0.norm2.bias"].dtype == torch.float32
-
-
-# ---------------- autocast wrapper: signature / meta-device / deepcopy ------
 
 
 class _TinyForSig(nn.Module):
@@ -325,7 +314,6 @@ def test_wrapper_survives_deepcopy_and_uses_copy_weights():
     with torch.no_grad():
         m2.lin.weight.fill_(2.0)
 
-    # Distinct parameter storage after deepcopy.
     assert m.lin.weight.data_ptr() != m2.lin.weight.data_ptr()
 
     x = torch.zeros(1, 4, dtype=torch.bfloat16)
@@ -494,7 +482,6 @@ def test_matcher_catches_norm_by_module_class_when_name_unmatched():
     assert m.audio_tower.norm_pre_attn.weight.dtype == torch.float32
     assert m.audio_tower.norm_post_attn.weight.dtype == torch.float32
     assert m.audio_tower.norm_out.weight.dtype == torch.float32
-    # non-norm linear stays bf16
     assert m.audio_tower.proj.weight.dtype == torch.bfloat16
 
 
@@ -522,7 +509,7 @@ def test_wrapper_intercepts_instance_level_forward():
             return self._impl(x)
 
     m = _M()
-    m.forward = m._impl  # instance-level forward shadows the class method
+    m.forward = m._impl
     _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
     # Must not raise a dtype mismatch: autocast downcasts fp32 norm out to bf16.
     out = m(torch.randn(2, 8))
@@ -746,7 +733,7 @@ def test_instance_forward_wrapper_rebinds_on_deepcopy():
     m = _M()
     with torch.no_grad():
         m.lin.weight.fill_(1.0)
-    m.forward = m._impl  # instance-level forward
+    m.forward = m._impl
     _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
 
     m2 = copy.deepcopy(m)

--- a/tests/test_pretokenized_bypass_collator.py
+++ b/tests/test_pretokenized_bypass_collator.py
@@ -141,8 +141,6 @@ def _multimodal_rows():
     })
 
 
-# ---- images must not be dropped -------------------------------------------
-
 @pytest.mark.parametrize("extra_column", [
     "pixel_values", "pixel_values_videos", "image_grid_thw", "input_features",
 ])
@@ -169,8 +167,6 @@ def test_multimodal_iterable_rows_are_still_refused():
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
-
-# ---- the run has to survive the first batch --------------------------------
 
 def test_a_processor_backed_seq2seq_collator_is_rebuilt():
     """`DataCollatorForSeq2Seq(tokenizer = processor)` is what the bypass exists
@@ -206,8 +202,6 @@ def test_a_tokenizer_backed_seq2seq_collator_is_left_alone():
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
 
-
-# ---- the follow-on cases the first round of this fix missed ---------------
 
 def _text_only_trainer():
     return StubTrainer(MyVisionCollator(StubProcessor()), _text_rows())
@@ -272,8 +266,6 @@ def test_the_rebuild_keeps_the_settings_the_caller_chose():
     assert hasattr(trainer.data_collator.tokenizer, "pad")
 
 
-# ---- raw text-only splits reach the text path too --------------------------
-
 def _raw_text_rows(n = 2):
     return Dataset.from_dict({
         "text": [f"{INSTRUCTION_PART}q{i}{RESPONSE_PART}a{i}" for i in range(n)],
@@ -324,8 +316,6 @@ def test_a_raw_split_with_no_text_column_is_still_refused():
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
-
-# ---- non-seq2seq collators that pad through a processor --------------------
 
 def test_a_processor_backed_padding_collator_under_packing_is_refused():
     """`DataCollatorWithPadding(tokenizer = processor)` pads through the same
@@ -447,8 +437,6 @@ def test_a_real_tokenizer_padding_collator_is_untouched_under_packing():
     assert out.data_collator is collator
 
 
-# ---- raw columns must not reach the collator -------------------------------
-
 class StrictPadTokenizer(StubTokenizer):
     """Pads like the real thing: it tensorizes every key it is handed, so a raw
     string column raises exactly as `tokenizer.pad(return_tensors = "pt")` does."""
@@ -538,8 +526,6 @@ def test_a_tokenized_eval_split_keeps_no_raw_text():
     assert "text" not in out.eval_dataset["raw"].column_names
     assert "labels" in out.eval_dataset["raw"].column_names
 
-
-# ---- only model inputs may reach the collator ------------------------------
 
 class TensorizingPadTokenizer(StrictPadTokenizer):
     """Pads the keys a real tokenizer knows about and tensorizes the rest, so a
@@ -642,8 +628,6 @@ def test_model_and_processor_declared_inputs_survive():
     assert "id" not in kept
 
 
-# ---- the multimodal set follows the installed processor --------------------
-
 class DerivedProcessor(StubProcessor):
     """A processor whose image half declares its own output names, the way every
     transformers image processor / feature extractor does."""
@@ -736,8 +720,6 @@ def test_deriving_never_denylists_the_text_columns():
     assert "labels" in out.train_dataset.column_names
 
 
-# ---- a DatasetDict eval is a dict of splits, not one dataset ---------------
-
 def test_a_datasetdict_eval_is_normalized_per_split():
     """`type(x) is dict` is False for a DatasetDict, so the eval branches used to
     treat the whole mapping as one dataset: `column_names` came back a dict, the
@@ -779,8 +761,6 @@ def test_an_iterable_datasetdict_eval_is_normalized_per_split():
     assert "labels" in next(iter(out.eval_dataset["a"]))
 
 
-# ---- a fresh streaming dataset carries no batch_size -----------------------
-
 def test_a_pretokenized_streaming_dataset_reaches_masking():
     """The bypass accepts an IterableDataset, so the map below must not read a
     `_ex_iterable.batch_size` a fresh ArrowExamplesIterable does not have."""
@@ -807,8 +787,6 @@ def test_a_columnless_streaming_dataset_reaches_masking():
     row = next(iter(out.train_dataset))     # used to raise AttributeError
     assert [l for l in row["labels"] if l != -100] == [20, 21]
 
-
-# ---- a text column is a column that actually holds text --------------------
 
 def _messages_with_an_image():
     return [[
@@ -949,8 +927,6 @@ def test_a_raw_iterable_eval_split_of_real_text_is_still_allowed():
     assert "labels" in next(iter(out.eval_dataset))
 
 
-# ---- one row is not the whole split ----------------------------------------
-
 def _rows_with_an_image_at(n, image_at):
     """`n` pretokenized rows; only row `image_at` carries an image, under a column
     name no static list mentions. Exactly what a partly-illustrated set looks like."""
@@ -1049,8 +1025,6 @@ def test_a_raw_eval_split_whose_null_is_past_the_sample_is_refused():
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
 
-# ---- what the whole-column scan is allowed to cost -------------------------
-
 @pytest.mark.parametrize("column", ["urls", "paths", "files"])
 def test_an_ambiguous_column_of_media_lists_is_refused(column):
     """A plural media column holds a list of URLs per row, and `List(string)` is
@@ -1101,8 +1075,6 @@ def test_an_ambiguous_image_column_is_never_decoded_by_the_scan(monkeypatch):
     assert len(decoded) < n / 4, "the sample is scaling with the dataset"
 
 
-# ---- the processor may live only on the collator ---------------------------
-
 def test_the_collators_processor_derives_the_multimodal_columns():
     """With the public `tokenizer =` override the multimodal processor is no
     longer `processing_class`, but the collator still holds it, so its derived
@@ -1130,8 +1102,6 @@ def test_the_tokenizer_override_still_allows_a_text_only_run():
                                   tokenizer = StrictPadTokenizer())
     assert "labels" in out.train_dataset.column_names
 
-
-# ---- a streaming split cannot be filtered, so sample its labels -------------
 
 def _unmatched_rows(n = 3):
     # No response marker anywhere: every label ends up -100.
@@ -1175,8 +1145,6 @@ def test_a_partly_masked_streaming_split_still_trains():
     assert len(list(out.train_dataset)) == 4
 
 
-# ---- a 16-row sample is not the whole split either --------------------------
-
 def test_an_image_on_an_unsampled_row_is_refused():
     """The bounded scan reads 16 fixed positions, so a 200-row split checks rows
     0, 13, 26, ... and an image on row 5 was never looked at. The column type is
@@ -1216,8 +1184,6 @@ def test_a_raw_eval_split_with_an_image_on_an_unsampled_row_is_refused():
     assert "media" in trainer.eval_dataset.column_names
 
 
-# ---- a masked prefix is not a masked stream --------------------------------
-
 def test_a_stream_whose_responses_start_later_still_trains():
     """A sorted or filtered stream can put every prompt-only row first. The
     bounded prefix cannot see past row 16, so it must not refuse the run."""
@@ -1242,8 +1208,6 @@ def test_a_stream_masked_past_the_prefix_warns_instead(capsys):
     assert "nothing to train on" in capsys.readouterr().out
 
 
-# ---- empty splits ----------------------------------------------------------
-
 def test_an_empty_raw_eval_split_is_handled():
     """`_maybe_tokenize_dataset` peeks one row, and an empty split has none."""
     trainer = StubTrainer(MyVisionCollator(StubProcessor()), _text_rows())
@@ -1261,8 +1225,6 @@ def test_an_empty_pretokenized_eval_split_is_handled():
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert len(out.eval_dataset) == 0
 
-
-# ---- a trainer need not have a train split ---------------------------------
 
 def test_an_eval_only_trainer_is_not_a_crash():
     """`Trainer(eval_dataset = ...)` with no train split: the final all-masked
@@ -1283,8 +1245,6 @@ def test_an_eval_only_trainer_on_the_plain_text_path_is_not_a_crash():
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert "labels" in out.eval_dataset.column_names
 
-
-# ---- a media URL/path column is media, even as a plain string ---------------
 
 @pytest.mark.parametrize("column", [
     "image_url", "video_url", "audio_url", "input_image", "input_video",
@@ -1361,8 +1321,6 @@ def test_a_raw_eval_split_with_a_media_url_column_is_refused():
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
 
-# ---- an ambiguous media column is read to the end ---------------------------
-
 def test_an_ambiguous_media_column_is_scanned_past_the_sample():
     """`url`/`path` are `string` either way, so the schema cannot rule them out
     and the 16-row sample skips row 5. Read the column instead: it decodes no
@@ -1405,8 +1363,6 @@ def test_a_wholly_benign_ambiguous_column_still_passes_the_scan():
     assert "labels" in out.train_dataset.column_names, "the text path never ran"
 
 
-# ---- a collator holding an image processor directly -------------------------
-
 class DirectImageProcessorCollator:
     """`_is_vision_collator` accepts a bare `collator.image_processor`, so the
     column names that half declares have to be derived from it as well."""
@@ -1438,8 +1394,6 @@ def test_a_directly_held_image_processor_still_lets_text_only_rows_through():
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert "labels" in out.train_dataset.column_names, "the text path never ran"
 
-
-# ---- what the second review round found ------------------------------------
 
 @pytest.mark.parametrize("suffix", [".avif", ".jfif", ".jpe", ".apng", ".ogv", ".wma"])
 def test_less_common_media_suffixes_are_recognized(suffix):
@@ -1541,8 +1495,6 @@ def test_precomputed_labels_survive_the_raw_column_drop():
     assert out.train_dataset[0]["labels"] == old, "the caller's mask was lost"
 
 
-# ---- provenance structs are not media --------------------------------------
-
 def _meta_trainer(meta, n = 2, iterable = False):
     dataset = Dataset.from_dict({"input_ids": [list(ROW)] * n, "meta": meta})
     if iterable: dataset = dataset.to_iterable_dataset()
@@ -1608,8 +1560,6 @@ def test_an_undecoded_image_struct_is_still_refused():
     with pytest.raises(ValueError, match = "does not support response-only"):
         train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
 
-
-# ---- what the third review round found --------------------------------------
 
 @pytest.mark.parametrize("key, value", [
     ("image_path",     "images/cat.jpg"),
@@ -1767,8 +1717,6 @@ def test_a_seq2seq_collator_holding_a_processor_is_still_repaired_without_packin
     assert hasattr(out.data_collator.tokenizer, "pad")
 
 
-# --- what the fourth review round found -----------------------------------
-
 def test_a_model_input_column_survives_raw_text_tokenization():
     """A field the model is fed but the tokenizer does not recreate must survive.
 
@@ -1839,8 +1787,6 @@ def test_a_token_classification_collator_keeps_its_padding_settings():
     assert repaired.max_length == 128, repaired.max_length
     assert repaired.pad_to_multiple_of == 8, repaired.pad_to_multiple_of
 
-
-# --- what the fifth review round found ---------------------------------------
 
 def test_a_raw_eval_split_whose_full_scan_fails_is_refused():
     """A failed exhaustive scan proves nothing, so it must not read as proof.
@@ -1962,7 +1908,6 @@ def test_a_bypassed_self_packing_collator_is_untouched_without_packing():
     assert isinstance(_text_collator_of(out.data_collator), DataCollatorForSeq2Seq)
 
 
-
 def test_remove_unused_columns_false_survives_raw_text_tokenization():
     """The opt-out has to hold on the raw path too, not just the pretokenized one.
 
@@ -1995,8 +1940,6 @@ def test_remove_unused_columns_false_survives_a_raw_train_split():
     assert "sample_weight" in columns, sorted(columns)
     assert "text" not in columns, sorted(columns)
 
-
-# ---- round N: three more Codex items ---------------------------------------
 
 def test_the_packing_refusal_lands_before_the_dataset_is_touched():
     """It is a deterministic configuration error, so it must not cost a full
@@ -2091,8 +2034,6 @@ def test_the_default_label_pad_value_is_unchanged():
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert out.data_collator.label_pad_token_id == -100
 
-
-# ---- round N+1: three more Codex items --------------------------------------
 
 def test_a_float_sequence_column_is_not_proven_text():
     """`Sequence(float32)` under a generic name is a waveform, and the leaf
@@ -2316,8 +2257,6 @@ def test_remove_unused_columns_false_without_a_text_column_is_untouched():
     out = train_on_responses_only(trainer, INSTRUCTION_PART, RESPONSE_PART)
     assert "sample_weight" in out.train_dataset.column_names
 
-
-# --- what the seventh review round found -----------------------------------
 
 class AudioOnlyProcessor:
     """Whisper and friends: a processor whose only half is audio."""
@@ -2742,7 +2681,6 @@ def test_a_repaired_padding_collator_is_not_kept_as_the_media_fallback():
     })
     out = train_on_responses_only(StubTrainer(broken, rows),
                                   INSTRUCTION_PART, RESPONSE_PART)
-    # A plain text collator, not a dispatcher holding the broken one.
     assert not hasattr(out.data_collator, "media"), \
         "the unusable collator was preserved as the media fallback"
 
@@ -2764,7 +2702,6 @@ def test_the_media_keys_survive_unused_column_removal():
     assert signature, "signature columns were never seeded"
     for key in ("images", "pixel_values", "input_features"):
         assert key in signature, f"{key} would be stripped before the collator"
-    # The columns the loss needs are still there.
     for key in ("input_ids", "labels"):
         assert key in signature, key
 
@@ -2783,7 +2720,6 @@ def test_a_raw_conversation_batch_reaches_the_media_collator():
 
     conversation = [{"role": "user", "content": [{"type": "image", "image": object()}]}]
     assert collator([{"messages": conversation}]) == {"mine": True}
-    # A text batch is unaffected.
     assert "mine" not in collator([{"input_ids": list(ROW), "labels": list(ROW)}])
 
 
@@ -2837,7 +2773,6 @@ def test_a_declared_forward_input_survives_the_seeded_signature():
     assert signature, "signature columns were never seeded"
     for key in ("position_ids", "sample_weight"):
         assert key in signature, f"{key} is declared by forward and would be stripped"
-    # And the media keys it was seeded for are still there.
     assert "pixel_values" in signature
 
 
@@ -2874,9 +2809,6 @@ def test_the_conversation_keys_are_still_not_dispatch_keys():
     assert "messages" not in dispatcher.media_keys
     assert not dispatcher._has_media([{"messages": "a plain string, not a conversation"}])
     assert dispatcher._has_media([{"messages": [{"role": "user"}]}])
-
-
-# ── round fifteen: what the deferred media collator actually needs ───────────
 
 
 def _r15_bypass(**args):
@@ -2941,9 +2873,6 @@ def test_a_list_of_media_paths_is_not_proven_text():
         "a string sequence is still not treated like a bare string"
     assert "_looks_like_media_value(value)" in src, \
         "the value scan still weighs only data URIs, not media suffixes"
-
-
-# ── round sixteen: what the TEXT path must not be handed ────────────────────
 
 
 def test_retained_metadata_is_stripped_before_the_text_collator():
@@ -3264,8 +3193,6 @@ def test_a_nullable_scalar_labels_column_is_still_dropped_on_a_null_first_row():
     assert len(out.eval_dataset["labels"][0]) == len(out.eval_dataset["input_ids"][0])
 
 
-# ---- the keep-lists, round 3 ----------------------------------------------
-
 def _raw_text_split(**extra):
     rows = {"text": ["<|user|>q0<|assistant|>a0", "<|user|>q1<|assistant|>a1"]}
     rows.update(extra)
@@ -3310,11 +3237,7 @@ def test_index_is_not_seeded_into_the_signature():
 
     seeded = getattr(out, "_signature_columns", None) or []
     assert "index" not in seeded, seeded
-    # The columns HF really does always keep are still there.
     assert {"label", "label_ids", "input_ids", "labels"} <= set(seeded)
-
-
-# ── round seventeen: the resolved label names, the text field, repeat calls ──
 
 
 def test_the_resolved_label_names_survive_unused_column_removal():

--- a/tests/test_pypi_version_sync.py
+++ b/tests/test_pypi_version_sync.py
@@ -47,7 +47,6 @@ def _parse_version(value: str):
         from packaging.version import Version
         return Version(value)
     except Exception:
-        # Int tuple, orderable for same-shape versions; enough for simple bumps.
         parts = value.split("+", 1)[0].split("-", 1)[0]
         nums, _, _suffix = parts.partition("rc")
         ints = []

--- a/tests/test_quant_status_transport_errors.py
+++ b/tests/test_quant_status_transport_errors.py
@@ -118,8 +118,6 @@ def _ServerError(message = "503 Server Error: Service Unavailable"):
     return _hub_http_error(message)
 
 
-# A transport failure on the config fetch must raise, not answer "unquantized".
-
 _TRANSPORT_ERRORS = [
     pytest.param(_RateLimited, id = "rate-limited-429"),
     pytest.param(_ServerError, id = "server-error-503"),
@@ -400,8 +398,6 @@ def test_an_exactly_named_local_directory_never_reaches_the_config_fetch(
     assert resolved[4] == "nf4"
 
 
-# A disabled repo is a fact about the repo, not about the network.
-
 def test_a_disabled_repo_is_not_announced_as_a_connectivity_problem(monkeypatch):
     """`DisabledRepoError` is the one Hub 4xx that does NOT subclass
     `RepositoryNotFoundError`, so unless named explicitly it reaches the catch-all and is
@@ -423,8 +419,6 @@ def test_a_disabled_repo_is_not_announced_as_a_connectivity_problem(monkeypatch)
 
     assert saving_utils.check_hf_model_exists("ns/disabled") is False
 
-
-# The Hub API takes a repo id and a revision, not every address `ls` accepts.
 
 @pytest.mark.parametrize("given, expected_repo, expected_revision", [
     pytest.param("ns/name",           "ns/name", None,  id = "plain"),

--- a/tests/test_quantize_gguf_q2_k_l.py
+++ b/tests/test_quantize_gguf_q2_k_l.py
@@ -74,10 +74,8 @@ def test_q2_k_l_expands_to_q2_k_with_dynamic_recipe(monkeypatch):  # noqa: D401
 
     cmd = captured["cmd"]
     assert isinstance(cmd, str), f"command should be a shell string (existing convention); got {type(cmd)!r}"
-    # Preset name must NOT reach llama-quantize; expanded ftype must, as a token.
     assert "q2_k_l" not in cmd, f"q2_k_l leaked into llama-quantize command: {cmd!r}"
     assert " q2_k " in cmd, f"q2_k token missing: {cmd!r}"
-    # All four preset flags must appear.
     assert "--output-tensor-type Q6_K" in cmd, f"--output-tensor-type Q6_K missing: {cmd!r}"
     assert "--token-embedding-type Q4_K" in cmd, f"--token-embedding-type Q4_K missing: {cmd!r}"
     assert '--tensor-type "\\.ffn_down_exps=Q3_K"' in cmd, (
@@ -246,9 +244,6 @@ def test_q2_k_l_error_message_keeps_original_preset_name(monkeypatch):
         raise AssertionError("expected RuntimeError")
 
 
-# --- imatrix option ------------------------------------------------------------------------------
-
-
 def test_imatrix_flag_is_prepended_before_positional_args(tmp_path, monkeypatch):
     """A provided imatrix must reach llama-quantize as --imatrix in the option region."""
 
@@ -271,7 +266,6 @@ def test_imatrix_flag_is_prepended_before_positional_args(tmp_path, monkeypatch)
     cmd = captured["cmd"]
     assert "--imatrix" in cmd, f"--imatrix missing: {cmd!r}"
     assert str(imat) in cmd, f"imatrix path missing: {cmd!r}"
-    # Options must precede the positional input/output/type/threads.
     assert cmd.index("--imatrix") < cmd.index("/tmp/in.gguf"), (
         f"--imatrix must precede positional args: {cmd!r}"
     )

--- a/tests/test_qwen35_ssm_tensor_mapping.py
+++ b/tests/test_qwen35_ssm_tensor_mapping.py
@@ -97,7 +97,6 @@ def test_inserts_missing_qwen35_aliases(tmp_path):
     # Names already covered by qwen3next entries are not duplicated.
     for shared in ("conv1d", "dt_proj", "A_log", "norm", "out_proj"):
         assert result.count(f'"model.layers.{{bid}}.linear_attn.{shared}"') == 1
-    # Patched file stays valid Python.
     ast.parse(result)
 
 
@@ -112,7 +111,6 @@ def test_idempotent_and_no_op_when_current(tmp_path):
 
 
 def test_partial_patch_completes_missing_entries(tmp_path):
-    # A file already holding one qwen3.5 alias still receives the rest.
     partial = STALE_TENSOR_MAPPING.replace(
         '            "model.layers.{bid}.self_attn.b_proj",       # Kimi Linear\n',
         '            "model.layers.{bid}.linear_attn.in_proj_b",  # qwen3.5\n'

--- a/tests/test_qwen35_vjp_metal.py
+++ b/tests/test_qwen35_vjp_metal.py
@@ -41,9 +41,6 @@ if not _HAS_METAL:
 metal_only = pytest.mark.skipif(not _HAS_METAL, reason=_SKIP_REASON)
 
 
-# --------------------------------------------------------------------------- #
-# Helpers
-# --------------------------------------------------------------------------- #
 def _tiny_text_config(full_attention_interval=2):
     """Tiny qwen3_5 TextConfig.
 
@@ -106,9 +103,6 @@ def _gdn_inputs(B=2, T=6, Hk=1, Hv=2, Dk=128, Dv=128, seed=0):
     return q, k, v, a, b, A_log, dt_bias
 
 
-# --------------------------------------------------------------------------- #
-# (a) GDN: unpatched grad through the Metal kernel raises the VJP ValueError
-# --------------------------------------------------------------------------- #
 @metal_only
 def test_gated_delta_kernel_grad_raises_without_patch():
     """Proves the bug exists: differentiating the Metal gated_delta_kernel
@@ -138,9 +132,7 @@ def test_gated_delta_kernel_grad_raises_without_patch():
     assert "vjp" in str(exc.value).lower() or "CustomKernel" in str(exc.value), exc.value
 
 
-# --------------------------------------------------------------------------- #
 # (b) GDN: patch fixes grad; output matches the use_kernel=False reference
-# --------------------------------------------------------------------------- #
 @metal_only
 def test_patch_gated_delta_vlm_fixes_grad_and_matches_reference(monkeypatch):
     import importlib
@@ -189,10 +181,8 @@ def test_patch_gated_delta_vlm_fixes_grad_and_matches_reference(monkeypatch):
                        rtol=2e-2, atol=2e-2)
 
 
-# --------------------------------------------------------------------------- #
 # (c) MRoPE: fused apply is non-differentiable; flip makes grad work; fused vs
 #     fallback forward match
-# --------------------------------------------------------------------------- #
 @metal_only
 def test_disable_fused_mrope_fixes_rotary_grad():
     import mlx_vlm.models.qwen3_5.language as qlang
@@ -206,7 +196,6 @@ def test_disable_fused_mrope_fixes_rotary_grad():
         layer.self_attn.rotary_emb for layer in model.layers if not layer.is_linear
     ]
     assert rotaries, "no rotary modules built"
-    # On Metal the fused kernel path is active.
     assert all(r.fused_apply for r in rotaries), "expected fused_apply True on Metal"
 
     head_dim = cfg.head_dim
@@ -233,7 +222,6 @@ def test_disable_fused_mrope_fixes_rotary_grad():
     except ValueError as exc:
         assert "vjp" in str(exc).lower() or "CustomKernel" in str(exc), exc
 
-    # Apply the fix.
     _disable_fused_mrope(model)
     assert not any(r.fused_apply for r in rotaries), "fused_apply still True after fix"
 
@@ -253,9 +241,7 @@ def test_disable_fused_mrope_fixes_rotary_grad():
     )
 
 
-# --------------------------------------------------------------------------- #
 # (d) End-to-end: one value_and_grad step on a GDN + attention model
-# --------------------------------------------------------------------------- #
 @metal_only
 def test_end_to_end_training_step_all_patches():
     import mlx_vlm.models.qwen3_5.language as qlang

--- a/tests/test_qwen_moe_lora_extractor.py
+++ b/tests/test_qwen_moe_lora_extractor.py
@@ -235,7 +235,6 @@ def test_extractor_fallback_warns_when_dims_mismatch(caplog):
 
     assert first.shape == (E, weird_dim, R)
     assert second.shape == (E, R, weird_dim)
-    # At least one warning record mentions the extractor.
     assert any(
         "Qwen MoE LoRA extractor could not match either layout" in rec.getMessage()
         for rec in caplog.records

--- a/tests/test_reasoning_marker_strip.py
+++ b/tests/test_reasoning_marker_strip.py
@@ -28,7 +28,6 @@ import pytest
 
 def _tokenizer():
     from transformers import AutoTokenizer
-    # Small, ungated tokenizers commonly cached in CI; first that loads wins.
     # local_files_only keeps this hermetic: an uncached tokenizer raises immediately
     # (no download / network timeout) and we fall through to the next / to a skip.
     for repo in ("hf-internal-testing/llama-tokenizer", "Qwen/Qwen2.5-0.5B-Instruct"):

--- a/tests/test_recompile_limit_fallback.py
+++ b/tests/test_recompile_limit_fallback.py
@@ -92,8 +92,6 @@ def _pair(compiled_raises = None, calls = None):
     return compiled, eager, calls
 
 
-# ---- the failure that must stop being fatal -------------------------------
-
 def test_recompile_limit_falls_back_instead_of_raising():
     c, e, calls = _pair(_LIMIT_ERROR("recompile_limit reached"))
     w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
@@ -149,8 +147,6 @@ def test_recompile_limit_exceeded_is_also_caught():
     assert _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")(4) == 8
 
 
-# ---- what must still raise ------------------------------------------------
-
 def test_a_real_graph_break_still_raises():
     from torch._dynamo.exc import Unsupported
     c, e, calls = _pair(Unsupported("call_function BuiltinVariable"))
@@ -168,16 +164,12 @@ def test_an_ordinary_error_still_raises():
     assert calls["e"] == 0
 
 
-# ---- the happy path is untouched ------------------------------------------
-
 def test_compiled_path_is_used_when_nothing_goes_wrong():
     c, e, calls = _pair()
     w = _fall_back_to_eager_on_recompile_limit(c, e, "M.forward")
     assert w(5) == 10
     assert calls == {"c": 1, "e": 0}
 
-
-# ---- introspection other code depends on ----------------------------------
 
 def test_signature_and_metadata_survive():
     c, e, _ = _pair()
@@ -280,8 +272,6 @@ def test_error_tuple_is_non_empty_on_this_torch():
     assert all(issubclass(x, BaseException) for x in errs)
 
 
-# ---- wiring into patch_function -------------------------------------------
-
 def test_only_fullgraph_patches_get_the_wrapper():
     src = Path(
         sys.modules["unsloth_zoo.temporary_patches.utils"].__file__
@@ -336,8 +326,6 @@ def test_end_to_end_through_patch_function():
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
 
-
-# ---- the one case where falling back is the wrong answer ------------------
 
 @contextlib.contextmanager
 def _hard_failure(enabled):
@@ -765,8 +753,6 @@ def test_a_successful_retry_keeps_its_bump():
         assert u._GLOBAL_BUMPS == 1
 
 
-# ---- round 3: four Codex items ------------------------------------------
-
 def _utils():
     """The module itself, so module-level bookkeeping can be reset."""
     import unsloth_zoo.temporary_patches.utils as U
@@ -983,8 +969,6 @@ def test_early_stop_counts_as_a_finished_retry():
         "the retry finished; the wrapper must still be latched for next step"
     _reset_bump_state(U)
 
-
-# ---- round 4: three Codex items -----------------------------------------
 
 def test_a_hidden_branch_survives_restoring_a_visible_one():
     """Restoring one branch used to drop every branch recorded for the name.
@@ -1291,8 +1275,6 @@ def test_a_real_compiled_region_traces_through_the_wrapper():
         _reset_bump_state(U)
         torch._dynamo.reset()
 
-
-# --- what the sixth review round found -------------------------------------
 
 def test_a_pre_2_8_torch_does_not_mark_every_call_as_packed():
     """The accessor arrived in 2.8, so on 2.4-2.7 it is always absent, and

--- a/tests/test_requires_grad_hook_dynamo.py
+++ b/tests/test_requires_grad_hook_dynamo.py
@@ -147,8 +147,6 @@ def _real_post_hook():
     return hooks[0]
 
 
-# ---------------------------------------------------------------- eager path
-
 def test_pre_hook_still_fires_eagerly():
     hook = _real_pre_hook()
     x = torch.randn(2, 8)
@@ -169,8 +167,6 @@ def test_post_hook_still_fires_eagerly():
     hook(None, None, y)
     assert y.requires_grad
 
-
-# -------------------------------------------------------------- under compile
 
 def test_pre_hook_no_ops_while_compiling(monkeypatch):
     hook = _real_pre_hook()
@@ -281,7 +277,6 @@ def test_compiled_frozen_embedding_still_carries_gradients():
     assert "requires_grad_post_hook" in hooks[0].__qualname__
     assert not embedding.weight.requires_grad
 
-    # aot_eager keeps this off inductor's C++ codegen; the hook behaviour is the same.
     hidden_states = torch.compile(embedding, backend = "aot_eager")(
         torch.randint(0, 16, (2, 4))
     )
@@ -290,8 +285,6 @@ def test_compiled_frozen_embedding_still_carries_gradients():
     checkpoint(layer, hidden_states, use_reentrant = True).float().sum().backward()
     assert layer.adapter.weight.grad is not None, "no gradient reached the adapter"
 
-
-# ---------------------------------------------------------------- source shape
 
 def _guarded_functions(path, names):
     """Which of `names` open with `if torch.compiler.is_compiling(): return`?"""

--- a/tests/test_rl_locked_down_function.py
+++ b/tests/test_rl_locked_down_function.py
@@ -159,7 +159,6 @@ def test_operator_itemgetter_still_works():
 
 
 def test_class_helpers_still_work():
-    # Generated helpers are occasionally written as a small class.
     source = (
         "def matmul(A, B):\n"
         "    class Base:\n"
@@ -236,7 +235,6 @@ def test_dunder_method_definitions_are_denied():
 
 
 def test_ordinary_dunder_methods_still_allowed():
-    # __init__ and the comparison protocol are ordinary in helper classes.
     source = (
         "def matmul(A, B):\n"
         "    class Node:\n"
@@ -297,8 +295,6 @@ def test_clock_setters_denied_but_clocks_readable():
 
 
 def test_not_implemented_is_available():
-    # The comparison dunders we allow are expected to return NotImplemented
-    # for operands they do not handle.
     source = (
         "def matmul(A, B):\n"
         "    class N:\n"

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -35,11 +35,6 @@ import torch
 from unsloth_zoo import rl_replacements as rr
 
 
-# ---------------------------------------------------------------------------
-# calculate_pad_tokens_in_prompt
-# ---------------------------------------------------------------------------
-
-
 def test_calculate_pad_tokens_in_prompt_counts_left_pads():
     PAD = 0
     # batch=2, seq_len=6, logits_to_keep=3 -> prompt_section is the
@@ -63,11 +58,6 @@ def test_calculate_pad_tokens_in_prompt_rejects_invalid_keep():
         rr.calculate_pad_tokens_in_prompt(input_ids, logits_to_keep = 5, pad_token_id = PAD)
 
 
-# ---------------------------------------------------------------------------
-# create_completion_attention_mask
-# ---------------------------------------------------------------------------
-
-
 def test_create_completion_attention_mask_zeros_left_prompt_and_right_pads():
     PAD = 0
     # batch=2, completion_len=6. left_pad_tokens_per_prompt says
@@ -88,15 +78,8 @@ def test_create_completion_attention_mask_zeros_left_prompt_and_right_pads():
         pad_token_id           = PAD,
     )
     assert mask.dtype == torch.bool
-    # row 0: zero the first 3 cols (max-0), keep non-pad. shape mask = [0,0,0,1,0,0]
     assert mask[0].tolist() == [False, False, False, True, False, False]
-    # row 1: zero the first 1 col (max-2), keep non-pad. shape mask = [0,1,1,0,0,0]
     assert mask[1].tolist() == [False, True, True, False, False, False]
-
-
-# ---------------------------------------------------------------------------
-# left_pack_padding
-# ---------------------------------------------------------------------------
 
 
 def test_left_pack_padding_moves_pads_to_right_stable():
@@ -108,7 +91,6 @@ def test_left_pack_padding_moves_pads_to_right_stable():
         ]
     )
     packed = rr.left_pack_padding(t, pad_id = PAD)
-    # Non-pad tokens preserve their relative order (stable sort).
     assert packed[0].tolist() == [1, 2, 3, PAD, PAD]
     assert packed[1].tolist() == [4, 5, 6, PAD, PAD]
 
@@ -118,11 +100,6 @@ def test_left_pack_padding_idempotent_on_already_packed():
     t = torch.tensor([[1, 2, 3, PAD, PAD]])
     out = rr.left_pack_padding(t, pad_id = PAD)
     assert out.tolist() == t.tolist()
-
-
-# ---------------------------------------------------------------------------
-# align_logprobs_with_mask
-# ---------------------------------------------------------------------------
 
 
 def test_align_logprobs_with_mask_inserts_per_row_left_padding():
@@ -148,18 +125,9 @@ def test_align_logprobs_with_mask_inserts_per_row_left_padding():
         attention_mask = attention_mask,
         pad_value      = 0.0,
     )
-    # Output shape matches attention_mask's seq_len = 4.
     assert aligned.shape == (2, 4)
-    # row 0: shift by 1 left pad -> logprobs land at cols 1,2; cols 0,3 stay pad.
-    # row 1: shift by 0 left pads -> logprobs land at cols 0,1; cols 2,3 stay pad.
-    # `pytest.approx` for float32 round-trip tolerance.
     assert aligned[0].tolist() == pytest.approx([0.0, 0.5, 0.7, 0.0])
     assert aligned[1].tolist() == pytest.approx([0.1, 0.2, 0.0, 0.0])
-
-
-# ---------------------------------------------------------------------------
-# sanitize_logprob
-# ---------------------------------------------------------------------------
 
 
 def test_sanitize_logprob_returns_value_for_finite():
@@ -170,11 +138,6 @@ def test_sanitize_logprob_returns_value_for_finite():
 def test_sanitize_logprob_returns_none_for_nan():
     p = SimpleNamespace(logprob = float("nan"))
     assert rr.sanitize_logprob(p) is None
-
-
-# ---------------------------------------------------------------------------
-# RL_REPLACEMENTS dict integrity
-# ---------------------------------------------------------------------------
 
 
 def test_RL_REPLACEMENTS_values_are_callables_or_source_strings():
@@ -213,9 +176,6 @@ def test_RL_REPLACEMENTS_contains_public_api_keys():
     assert not missing, f"RL_REPLACEMENTS missing public-API keys: {sorted(missing)}"
 
 
-# ---------------------------------------------------------------------------
-# Unsloth_Offloaded_Log_Softmax backward returns LOCAL input gradients
-# ---------------------------------------------------------------------------
 # backward + leaf .grad double-counts through the outer AccumulateGrad.
 
 
@@ -278,9 +238,6 @@ def test_offloaded_recompute_weight_grad_not_double_counted(shared, preexisting)
     assert not torch.allclose(_weight_grad(buggy.apply, shared, preexisting), ref, atol=1e-4)
 
 
-# ---------------------------------------------------------------------------
-# Unsloth_Offloaded_Log_Softmax offload paths (pinned CUDA / pageable CPU)
-# ---------------------------------------------------------------------------
 # backward's event wait is load-bearing: the pinned non_blocking copy races
 # without it.
 

--- a/tests/test_rmsnorm_recompile_guards.py
+++ b/tests/test_rmsnorm_recompile_guards.py
@@ -330,7 +330,6 @@ def test_each_kernel_reports_its_own_fallback_state():
                _gemma3_rms_norm_float32, _gemma3_rms_norm_generic)]
     assert len(set(labels)) == len(labels), f"labels collide: {labels}"
 
-    # One latched, its neighbour not: the dict must show the latched one.
     saved = dict(_gemma4_rms_norm_scaled._unsloth_fallback_state)
     _gemma4_rms_norm_scaled._unsloth_fallback_state["eager"] = True
     try:

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -340,7 +340,6 @@ def test_remap_short_suffix_does_not_cross_namespaces():
     out = _infer_prefix_and_remap(
         _lw(["model.vision_tower.embed_tokens", "model.language_model.layers.0.self_attn.q_proj"]),
         ["language_model.model.layers.0.self_attn.q_proj.weight"])  # no vision embed tensor
-    # The vision embed has no backing tensor; it must stay unmapped, not be pulled onto the language tensor.
     assert out.get("language_model.model.layers.0.self_attn.q_proj") == \
         "model.language_model.layers.0.self_attn.q_proj"
     assert "model.vision_tower.embed_tokens" not in out or \
@@ -422,7 +421,7 @@ class _FakeLoRALinear(nn.Module):
         self.lora_A = nn.ModuleDict({"default": nn.Linear(n, r, bias=False)})
         self.lora_B = nn.ModuleDict({"default": nn.Linear(r, n, bias=False)})
         self.scaling = {"default": alpha / r}
-        self.active_adapter = "default"  # singular only
+        self.active_adapter = "default"
 
 class _Inner(nn.Module):
     def __init__(self, n=3):
@@ -457,6 +456,5 @@ def test_non_lora_scaled_module_not_misclassified():
     model = _PeftLike(inner)
 
     lora_weights, _ = create_lora_statistics(model, merge_into_original=True, return_state_dict=False)
-    # Real LoRA layers captured; non-LoRA scaled module not (its weight is not dropped).
     assert sum(1 for v in lora_weights.values() if v.lora_A is not None) == 2
     assert not any(k.endswith("attn_like") for k in lora_weights)

--- a/tests/test_saving_utils_quant_aware_merge.py
+++ b/tests/test_saving_utils_quant_aware_merge.py
@@ -144,7 +144,6 @@ def test_fp8_weight_missing_scale_records_fallback_and_skips_write():
     from unsloth_zoo import saving_utils
     from unsloth_zoo.saving_utils import _merge_moe_expert_quant_aware
 
-    # Sentinel-trigger: FP8 weight in header but NO companion scale key.
     fp8 = torch.zeros(64, 128, dtype=torch.float8_e4m3fn)
     file = _FakeFile({"layer.0.experts.0.down_proj.weight": fp8})
     hdr = _make_header_for({"layer.0.experts.0.down_proj.weight": "F8_E4M3"})
@@ -155,7 +154,6 @@ def test_fp8_weight_missing_scale_records_fallback_and_skips_write():
     def _capture_fallback(*args, **kwargs):
         fallback_log.append((args, kwargs))
 
-    # Patch in-place on the module to observe.
     original = saving_utils._record_moe_merge_fallback
     saving_utils._record_moe_merge_fallback = _capture_fallback
     try:
@@ -175,7 +173,7 @@ def test_key_missing_is_a_silent_no_op():
     from unsloth_zoo.saving_utils import _merge_moe_expert_quant_aware
 
     file = _FakeFile({})
-    hdr = {}  # key not present
+    hdr = {}
     mm = _FakeMM()
     assert _merge_moe_expert_quant_aware(
         "gate", "not_in_header.gate_proj.weight", file, hdr, _FakeLoraStats(),

--- a/tests/test_sibling_imports_do_not_go_through_a_tests_package.py
+++ b/tests/test_sibling_imports_do_not_go_through_a_tests_package.py
@@ -58,7 +58,6 @@ def test_the_pattern_is_recognized():
         "from tests.a import ..."
     ]
     assert _imports_through_the_tests_package("import tests.a") == ["import tests.a"]
-    # A relative import and an unrelated one are both fine.
     assert _imports_through_the_tests_package("from .a import b") == []
     assert _imports_through_the_tests_package("from testsuite import b") == []
     assert _imports_through_the_tests_package("from a import tests") == []

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -194,7 +194,6 @@ def _maybe_skip_if_patched(cls, method_name: str, zoo_file: str) -> None:
     storage_key = _original_attr_name(cls, method_name)
     original = getattr(cls, storage_key, None)
     if original is not None:
-        # We have the upstream original stashed; tests use it directly.
         return
     qualname = getattr(live, "__qualname__", "") or ""
     if ".<locals>." in qualname and qualname.split(".", 1)[0].startswith("patch_"):
@@ -436,7 +435,6 @@ def test_deepseek_v3_moe_forward_single_positional():
         pytest.skip(f"DeepseekV3MoE absent on transformers {_TX_VERSION}")
     fwd = _assert_method_exists(cls, "forward", "deepseek_v3_moe.py")
     params = _param_names(fwd)
-    # Drop "self".
     params = [p for p in params if p != "self"]
     required = [p for p in inspect.signature(fwd).parameters.values()
                 if p.name != "self" and p.default is inspect.Parameter.empty
@@ -477,7 +475,6 @@ def test_deepseek_v3_for_causal_lm_forward_named_params():
         zoo_file="deepseek_v3_moe.py",
         label="DeepseekV3ForCausalLM.forward",
     )
-    # output_router_logits: explicit param OR **kwargs passthrough.
     if "output_router_logits" not in _param_names(fwd) and not _has_var_keyword(fwd):
         pytest.fail(
             "DRIFT DETECTED: zoo temporary_patches/deepseek_v3_moe.py:171 "
@@ -2514,8 +2511,6 @@ def test_gemma3_processor_kwargs_class_present():
         )
 
 
-# gemma3n.py additional pins.
-
 def test_gemma3n_for_conditional_generation_class_present():
     """gemma3n.py patches Gemma3nModel.get_placeholder_mask; pin
     Gemma3nForConditionalGeneration."""
@@ -2646,8 +2641,6 @@ def test_modeling_outputs_moe_causal_lm_output_with_past_kwargs():
             )
 
 
-# Caches the patches require.
-
 def test_static_cache_class_present():
     """gemma.py:255 isinstance(past_key_values, StaticCache)."""
     cu = importlib.import_module("transformers.cache_utils")
@@ -2698,8 +2691,6 @@ def test_hybrid_cache_class_present():
     )
 
 
-# bitsandbytes.py: Linear4bit __init__ signature pin.
-
 def test_bitsandbytes_linear4bit_init_signature():
     """bitsandbytes.py:46-47 needs
     ``bitsandbytes.nn.modules.Linear4bit.__init__(input_features,
@@ -2720,8 +2711,6 @@ def test_bitsandbytes_linear4bit_init_signature():
     )
 
 
-# pixtral.py: PixtralVisionConfig.
-
 def test_pixtral_vision_config_class_present():
     """pixtral.py:36 reads self.config attrs; pin PixtralVisionConfig."""
     cls = _try_get_class(
@@ -2735,8 +2724,6 @@ def test_pixtral_vision_config_class_present():
             f"{_TX_VERSION}"
         )
 
-
-# gemma3n.py: Gemma3nTextConfig pin (AltUp.predict config typing).
 
 def test_gemma3n_text_config_class_present():
     """gemma3n.py:101-114 reads
@@ -2762,8 +2749,6 @@ def test_gemma3n_text_config_class_present():
             )
 
 
-# Auto-attention function dictionary for gemma3 patch chain.
-
 def test_gemma3_eager_attention_forward_kwargs_supported():
     """gemma.py:407-412 calls ``eager_attention_forward(...,
     dropout, scaling, sliding_window, **kwargs)``."""
@@ -2776,8 +2761,6 @@ def test_gemma3_eager_attention_forward_kwargs_supported():
             f"{inspect.signature(eager_attention_forward)}"
         )
 
-
-# Sanity: temporary_patches/ inventory.
 
 def test_temporary_patches_directory_has_expected_files():
     """Pin the floor set of patch files; new files OK, missing -> DRIFT."""
@@ -2811,10 +2794,8 @@ def test_a_broken_dependency_is_not_reported_as_upstream_drift():
     timm dropped, so eight tests announced "missing on transformers 4.57.6"
     about classes transformers 4.57.6 ships.
     """
-    # Absent module: still None, so the callers still judge it.
     assert _try_get_class("transformers.models.not_a_real_model_xyz", "Whatever") is None
 
-    # Present but raising, on a dependency of its own: skipped, not blamed.
     module_name = "_zoo_probe_broken_import"
     module = types.ModuleType(module_name)
 

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -26,10 +26,8 @@ import importlib
 import pytest
 
 
-# ---------------------------------------------------------------------------
 # Per-submodule import smoke. Explicit (not a glob) so a silent drop or rename
 # surfaces as a missing test; new files must be added to this list.
-# ---------------------------------------------------------------------------
 
 
 TEMPORARY_PATCHES_SUBMODULES = [

--- a/tests/test_torchao_torch_mismatch.py
+++ b/tests/test_torchao_torch_mismatch.py
@@ -60,8 +60,6 @@ REAL = ("cannot import name 'ScalingType' from 'torch.nn.functional' "
         "(/usr/local/lib/python3.12/dist-packages/torch/nn/functional.py)")
 
 
-# ---- what it must catch ---------------------------------------------------
-
 def test_the_error_seen_in_the_wild():
     assert looks_like(REAL) is True
 
@@ -72,8 +70,6 @@ def test_the_other_torchao_symbols(sym):
     assert looks_like(
         f"cannot import name '{sym}' from 'torch.nn.functional'") is True
 
-
-# ---- what it must NOT catch ----------------------------------------------
 
 def test_the_unpack_move_is_left_alone():
     """It sits beside the Unpack branch; swallowing that hides a different bug."""
@@ -95,8 +91,6 @@ def test_an_unrelated_missing_name_from_torch():
         "cannot import name 'some_new_api' from 'torch.nn.functional'") is False
 
 
-# ---- the guard must never be what raises ---------------------------------
-
 @pytest.mark.parametrize("bad", [None, 123, object()])
 def test_non_string_input_does_not_raise(bad):
     assert looks_like(bad) in (True, False)
@@ -117,8 +111,6 @@ def test_the_message_survives_missing_metadata(monkeypatch):
     m = message_of(REAL)
     assert "unknown" in m
 
-
-# ---- the call site --------------------------------------------------------
 
 def test_the_branch_runs_before_the_generic_reraise():
     """Placed after `raise Exception(e)` it would never be reached."""

--- a/tests/test_training_utils_use_cache.py
+++ b/tests/test_training_utils_use_cache.py
@@ -105,7 +105,6 @@ def test_no_gradient_checkpointing_leaves_use_cache():
     [pytest.param(None, marks = requires_none_use_cache), False],
 )
 def test_falsy_use_cache_preserved(initial):
-    # None means "defer to the model default": it must NOT be coerced to False.
     model = _tiny_llama(use_cache = initial)
     prepare_model_for_training(model, use_gradient_checkpointing = True)
     assert model.config.use_cache is initial

--- a/tests/test_trl_entropy_metric.py
+++ b/tests/test_trl_entropy_metric.py
@@ -115,8 +115,6 @@ def patched():
     sft.entropy_from_logits = original
 
 
-# ---- it degrades instead of failing --------------------------------------
-
 def test_the_unsloth_sentinel_no_longer_raises(patched):
     trl_utils, _, _ = patched
     assert float(trl_utils.entropy_from_logits(EmptyLogits())) == 0.0
@@ -146,8 +144,6 @@ def test_the_result_broadcasts_the_way_the_caller_uses_it(patched):
     assert float(torch.sum(e * mask) / mask.sum()) == 0.0
     assert float(torch.mean(e)) == 0.0
 
-
-# ---- and survives the gather trl does next -------------------------------
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "no accelerator to land on")
 def test_the_fallback_lands_on_the_accelerate_device(patched, monkeypatch):
@@ -205,8 +201,6 @@ def test_the_fallback_stays_on_cpu_for_a_cpu_run(patched, monkeypatch):
     assert trl_utils.entropy_from_logits(EmptyLogits()).device.type == "cpu"
 
 
-# ---- and does not quietly break the metric for everyone else -------------
-
 def test_real_logits_are_untouched(patched):
     """The patch must be invisible when logits do exist -- otherwise it turns
     a working metric into a zero for every non-Unsloth user of trl."""
@@ -221,8 +215,6 @@ def test_a_genuine_error_still_raises(patched):
     with pytest.raises(Exception):
         trl_utils.entropy_from_logits("not logits at all")
 
-
-# ---- where it is installed ------------------------------------------------
 
 def test_it_patches_the_module_the_caller_actually_reads(patched):
     """sft_trainer.py does `from ..trainer.utils import entropy_from_logits`,
@@ -246,8 +238,6 @@ def test_it_is_registered(patched):
     assert any(getattr(f, "__name__", "") == "patch_trl_entropy_from_logits"
                for f in TEMPORARY_PATCHES)
 
-
-# ---- the source ----------------------------------------------------------
 
 def _src():
     return (ROOT / "unsloth_zoo" / "temporary_patches" / "misc.py").read_text(encoding="utf-8")

--- a/tests/test_trl_sft_logits_metrics.py
+++ b/tests/test_trl_sft_logits_metrics.py
@@ -519,8 +519,6 @@ def test_a_trainer_that_asked_for_outputs_still_gets_them():
     assert outputs is pair[1]
 
 
-# ---- an output object with no logits at all is somebody else's bug ---------
-
 def test_a_missing_logits_attribute_still_raises(sft):
     """`getattr(outputs, "logits", None)` would call an absent attribute
     unusable and retry with the metrics off, turning a broken output contract
@@ -551,8 +549,6 @@ def test_an_explicit_none_logits_is_still_the_sentinel(sft):
     self, _ = _run_steps(sft, None, steps = 2)
     assert self._metrics["train"]["mean_token_accuracy"] == []
 
-
-# ---- the two warnings must not contradict each other ----------------------
 
 def test_the_entropy_warning_is_not_shown_when_both_are_omitted(sft, caplog):
     """The entropy patch promises "Entropy will be reported as 0.0". When the
@@ -602,8 +598,6 @@ def test_a_real_failure_leaves_the_entropy_flag_alone(sft):
         Trainer.compute_loss = original
         flag[0] = was
 
-
-# ---- nothing may leave an empty metric list behind ------------------------
 
 def _log_would_divide_by_zero(self):
     """Names of metrics trl's own `log` would choke on.
@@ -677,8 +671,6 @@ def test_a_metric_the_probe_only_extended_is_truncated_not_dropped(sft):
     assert self._metrics["train"]["mean_token_accuracy"] == [0.5, 0.75]
 
 
-# ---- the public positional call shape -------------------------------------
-
 @pytest.mark.parametrize("sentinel", SENTINELS)
 def test_a_positional_return_outputs_is_replaced_not_duplicated(sft, sentinel):
     """`compute_loss(model, inputs, False, ...)` is a legal public call. Adding
@@ -702,8 +694,6 @@ def test_a_positional_return_outputs_is_replaced_not_duplicated(sft, sentinel):
         Trainer.compute_loss = original
     assert self._metrics["train"]["aux_loss"] == [0.25, 0.25]
 
-
-# ---- eval and predict, where the caller already asked for outputs ---------
 
 @pytest.mark.parametrize("sentinel", SENTINELS)
 def test_aux_loss_survives_an_eval_step_too(sft, sentinel):
@@ -732,8 +722,6 @@ def test_aux_loss_survives_an_eval_step_too(sft, sentinel):
         Trainer.compute_loss = original
     assert self._metrics["train"]["aux_loss"] == [0.25, 0.25, 0.25]
 
-
-# ---- a retry that also fails must not latch the trainer -------------------
 
 def test_a_failing_retry_does_not_latch_the_fast_path():
     """If the logits are wanted by something other than the metric block

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -119,8 +119,6 @@ def _getsource_guards(call: str) -> list:
     ]
 
 
-# ---- the guard ------------------------------------------------------------
-
 def test_getsource_is_wrapped():
     region = _guard_region()
     assert "try:" in region
@@ -173,8 +171,6 @@ def test_the_warning_says_the_model_still_works():
         "a warning during model load must say whether it is fatal")
 
 
-# ---- what must be preserved ----------------------------------------------
-
 def test_lora_patching_happens_before_the_guard():
     """Returning early is only acceptable because the LoRA forwards have
     already been patched by this point."""
@@ -206,8 +202,6 @@ def test_a_bare_return_is_the_functions_contract():
     assert returns, "expected early returns in this function"
     assert any(r.value is None for r in returns)
 
-
-# ---- the second site: loading a SECOND model in one process --------------
 
 def _nn_patch_region() -> str:
     i = SRC.index("source = inspect.getsource(function.forward).rstrip()")
@@ -287,8 +281,6 @@ def test_both_getsource_guards_are_present():
             f"{call} is unguarded, so an unreadable source is fatal again")
 
 
-# ---- what the fallback must still do -------------------------------------
-#
 # Returning early is a degradation, and a degradation has to be honest about
 # which of the surrounding work it gave up. Three separate questions, and they
 # do not have the same answer.
@@ -410,9 +402,6 @@ def test_gradient_accumulation_needs_that_same_source():
             and patch_gradient_accumulation(modeling, name) is not None
         ]
     assert patched == []
-
-
-# ---- the wrapper that stands in for an unreadable torch forward ----------
 
 
 class _Weighted:

--- a/tests/test_unsloth_zoo_lora_merge.py
+++ b/tests/test_unsloth_zoo_lora_merge.py
@@ -52,9 +52,7 @@ def _ls(lora_A: torch.Tensor, lora_B: torch.Tensor, alpha: float) -> LoraStats:
     return LoraStats(module=None, lora_A=lora_A, lora_B=lora_B, alpha=alpha)
 
 
-# ---------------------------------------------------------------------------
 # 1. _active_merge_device — recent fix that replaced the W-based helper.
-# ---------------------------------------------------------------------------
 
 def test_active_merge_device_returns_string_on_gpu():
     if not gpu_available:
@@ -72,9 +70,7 @@ def test_active_merge_device_takes_no_args():
     )
 
 
-# ---------------------------------------------------------------------------
 # 2. _merge_lora — basic correctness against a numpy reference.
-# ---------------------------------------------------------------------------
 
 def _ref_merge_lora(W: torch.Tensor, lora_A: torch.Tensor, lora_B: torch.Tensor,
                     alpha: float) -> torch.Tensor:
@@ -135,10 +131,8 @@ def test_merge_lora_vocab_resize():
 
     assert out.shape == (new_vocab, dim)
     assert out.dtype == torch.float32
-    # The first old_vocab rows: original W + alpha * lora_B[:old_vocab] @ lora_A
     expected_old = (W.to(torch.float32) +
                     alpha * (lora_B[:old_vocab].to(torch.float32) @ lora_A.to(torch.float32)))
-    # New rows: zero base + alpha * lora_B[old_vocab:] @ lora_A
     expected_new = alpha * (lora_B[old_vocab:].to(torch.float32) @ lora_A.to(torch.float32))
     torch.testing.assert_close(out[:old_vocab].cpu(), expected_old, atol=5e-2, rtol=5e-2)
     torch.testing.assert_close(out[old_vocab:].cpu(), expected_new, atol=5e-2, rtol=5e-2)
@@ -159,9 +153,7 @@ def test_merge_lora_returns_W_when_lora_missing():
     assert out is W
 
 
-# ---------------------------------------------------------------------------
 # 3. _merge_moe_gate_expert — first half of A is gate_proj.
-# ---------------------------------------------------------------------------
 
 def test_merge_moe_gate_expert():
     """gate_W shape (inter_dim, hidden_dim).  delta = (B @ gate_a).T."""
@@ -179,7 +171,6 @@ def test_merge_moe_gate_expert():
                                  expert_idx=expert_idx, num_experts=num_experts,
                                  output_dtype=torch.bfloat16)
 
-    # Reference: a_slice = lora_A[r:r*2], gate_a = a_slice[:, :inter_dim]
     s, e = expert_idx * rank_per, (expert_idx + 1) * rank_per
     a_slice = lora_A[s:e].to(torch.float32)
     b_slice = lora_B[:, s:e].to(torch.float32)
@@ -192,9 +183,7 @@ def test_merge_moe_gate_expert():
     torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
 
 
-# ---------------------------------------------------------------------------
 # 4. _merge_moe_up_expert — second half of A is up_proj.
-# ---------------------------------------------------------------------------
 
 def test_merge_moe_up_expert():
     torch.manual_seed(SEED)
@@ -214,16 +203,14 @@ def test_merge_moe_up_expert():
     s, e = expert_idx * rank_per, (expert_idx + 1) * rank_per
     a_slice = lora_A[s:e].to(torch.float32)
     b_slice = lora_B[:, s:e].to(torch.float32)
-    up_a = a_slice[:, inter_dim:]  # second half
+    up_a = a_slice[:, inter_dim:]
     up_delta = b_slice @ up_a
     expected = up_W.to(torch.float32) + alpha * up_delta.T
 
     torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
 
 
-# ---------------------------------------------------------------------------
 # 5. _merge_moe_down_proj_expert — full A slice (no halving).
-# ---------------------------------------------------------------------------
 
 def test_merge_moe_down_proj_expert():
     """down_W shape (H, I).  A: (total_rank, H).  B: (I, total_rank).  delta = (B @ A).T = (H, I)."""
@@ -250,9 +237,7 @@ def test_merge_moe_down_proj_expert():
     torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
 
 
-# ---------------------------------------------------------------------------
 # 6. _merge_moe_fused_gate_up_expert — 3D fused tensor across all experts.
-# ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("is_transposed", [True, False])
 def test_merge_moe_fused_gate_up_expert(is_transposed):
@@ -288,9 +273,7 @@ def test_merge_moe_fused_gate_up_expert(is_transposed):
     torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
 
 
-# ---------------------------------------------------------------------------
 # 7. _merge_moe_fused_down_proj_expert — 3D fused tensor.
-# ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("is_transposed", [True, False])
 def test_merge_moe_fused_down_proj_expert(is_transposed):

--- a/tests/test_upstream_import_fixes_drift.py
+++ b/tests/test_upstream_import_fixes_drift.py
@@ -46,9 +46,7 @@ def _safe_version(raw):
         return _PkgVersion(match.group(0))
 
 
-# ===========================================================================
 # protobuf
-# ===========================================================================
 
 
 def test_protobuf_message_factory_get_prototype_or_get_message_class_present():
@@ -74,9 +72,7 @@ def test_protobuf_message_factory_get_prototype_or_get_message_class_present():
     assert has_get_prototype or has_get_message_class
 
 
-# ===========================================================================
 # datasets
-# ===========================================================================
 
 
 def test_datasets_version_not_in_broken_recursion_range():
@@ -94,9 +90,7 @@ def test_datasets_version_not_in_broken_recursion_range():
     )
 
 
-# ===========================================================================
 # trl
-# ===========================================================================
 
 
 def test_trl_is_x_available_returns_bool_not_tuple():
@@ -173,9 +167,7 @@ def test_trl_cached_available_flags_are_not_tuples():
         )
 
 
-# ===========================================================================
 # transformers
-# ===========================================================================
 
 
 def test_pretrained_model_enable_input_require_grads_uses_old_pattern():
@@ -242,9 +234,7 @@ def test_transformers_is_causal_conv1d_available_symbol_present():
         )
 
 
-# ===========================================================================
 # transformers + accelerate (wandb checkers)
-# ===========================================================================
 
 
 def test_transformers_and_accelerate_is_wandb_available_callable():
@@ -273,9 +263,7 @@ def test_transformers_and_accelerate_is_wandb_available_callable():
     )
 
 
-# ===========================================================================
 # peft
-# ===========================================================================
 
 
 def test_peft_transformers_weight_conversion_importable_and_signature():
@@ -307,9 +295,7 @@ def test_peft_transformers_weight_conversion_importable_and_signature():
     )
 
 
-# ===========================================================================
 # triton
-# ===========================================================================
 
 
 def test_triton_compiled_kernel_has_num_ctas_and_cluster_dims():
@@ -346,9 +332,7 @@ def test_triton_compiled_kernel_has_num_ctas_and_cluster_dims():
     )
 
 
-# ===========================================================================
 # torch + torchvision pairing table
-# ===========================================================================
 
 
 # Mirrors TORCH_TORCHVISION_COMPAT in torchvision_compatibility_check
@@ -418,9 +402,7 @@ def test_installed_torch_torchvision_pair_is_compatible():
     )
 
 
-# ===========================================================================
 # vllm
-# ===========================================================================
 
 
 def test_vllm_guided_decoding_params_or_structured_outputs_present():
@@ -464,9 +446,7 @@ def test_vllm_aimv2_ovis_config_is_past_fix_version():
         )
 
 
-# ===========================================================================
 # huggingface_hub
-# ===========================================================================
 
 
 def test_huggingface_hub_is_offline_mode_or_hf_hub_offline_present():
@@ -495,9 +475,7 @@ def test_huggingface_hub_is_offline_mode_or_hf_hub_offline_present():
     )
 
 
-# ===========================================================================
 # torch
-# ===========================================================================
 
 
 def test_torch_nn_init_trunc_normal_exists():
@@ -513,9 +491,7 @@ def test_torch_nn_init_trunc_normal_exists():
     )
 
 
-# ===========================================================================
 # xformers
-# ===========================================================================
 
 
 def test_xformers_is_post_num_splits_key_fix_or_not_installed():
@@ -533,9 +509,7 @@ def test_xformers_is_post_num_splits_key_fix_or_not_installed():
         )
 
 
-# ===========================================================================
 # transformers (PreTrainedModel base import sanity)
-# ===========================================================================
 
 
 def test_transformers_pretrained_model_has_get_input_embeddings():
@@ -551,9 +525,7 @@ def test_transformers_pretrained_model_has_get_input_embeddings():
     )
 
 
-# ===========================================================================
 # accelerate -- ``is_X_available`` API stability used across the fixes
-# ===========================================================================
 
 
 def test_accelerate_utils_imports_module_present():

--- a/tests/test_upstream_pinned_symbols_accelerator.py
+++ b/tests/test_upstream_pinned_symbols_accelerator.py
@@ -36,23 +36,16 @@ import pytest
 import torch
 
 
-# ---------------------------------------------------------------------------
-# 1. device_type.device_synchronize / device_empty_cache / device_is_bf16_supported
-#    must tolerate a partial torch.xpu build that exposes is_available() but
-#    lacks the specific call (synchronize / empty_cache / is_bf16_supported).
-#
-#    Covers commits:
-#      - 35dc451 Guard XPU empty_cache call against partial torch.xpu builds
-#      - e08c1df Guard XPU synchronize call against partial torch.xpu builds
-#      - 2564f39 Route GGUF merge cache flushes and MoE expert merges
-#                through active backend (introduced device_empty_cache)
-#      - d631837 Route VLM GGUF mmproj bf16 check through active backend
-#                (introduced device_is_bf16_supported)
-#
-#    The existing test_backend_device_helpers.py covers the happy path; this
-#    test pins the PARTIAL-BUILD case where torch.xpu.is_available is True
-#    but the specific symbol is missing.
-# ---------------------------------------------------------------------------
+# Covers commits:
+#   - 35dc451 Guard XPU empty_cache call against partial torch.xpu builds
+#   - e08c1df Guard XPU synchronize call against partial torch.xpu builds
+#   - 2564f39 Route GGUF merge cache flushes and MoE expert merges
+#             through active backend (introduced device_empty_cache)
+#   - d631837 Route VLM GGUF mmproj bf16 check through active backend
+#             (introduced device_is_bf16_supported)
+# The existing test_backend_device_helpers.py covers the happy path; this
+# test pins the PARTIAL-BUILD case where torch.xpu.is_available is True
+# but the specific symbol is missing.
 
 def test_xpu_partial_build_all_three_helpers_silent_no_op():
     """All three device_type helpers must no-op (not AttributeError) on a
@@ -79,28 +72,21 @@ def test_xpu_partial_build_all_three_helpers_silent_no_op():
     with mock.patch.object(dt, "DEVICE_TYPE", "xpu"), \
          mock.patch.object(torch, "cuda", fake_cuda), \
          mock.patch.object(torch, "xpu", PartialXpu(), create=True):
-        # None of these may raise. The whole regression class is "raises
-        # AttributeError because the partial xpu build is missing one of
-        # the three call names".
         dt.device_synchronize()
         dt.device_empty_cache()
         assert dt.device_is_bf16_supported() is False
 
 
-# ---------------------------------------------------------------------------
-# 2. saving_utils._active_merge_device() must take NO positional args and
-#    cascade cuda -> xpu -> mps -> cpu.
-#
-#    Covers commit:
-#      - fd58aa1 saving_utils: route LoRA merge through accelerator-family probe
-#      - 70b93ad fix(mlx): migrate deprecated mx.metal memory APIs + restore
-#                device-agnostic LoRA merge
-#
-#    The pre-fix signature was _active_merge_device(W) which (a) silently
-#    dropped MPS, (b) propagated W.device.index across families. This
-#    pin asserts the no-arg shape AND the MPS-wins-when-only-mps branch
-#    which the previous DEVICE_TYPE_TORCH-only routing dropped.
-# ---------------------------------------------------------------------------
+# saving_utils._active_merge_device() must take NO positional args and
+# cascade cuda -> xpu -> mps -> cpu.
+# Covers commits:
+#   - fd58aa1 saving_utils: route LoRA merge through accelerator-family probe
+#   - 70b93ad fix(mlx): migrate deprecated mx.metal memory APIs + restore
+#             device-agnostic LoRA merge
+# The pre-fix signature was _active_merge_device(W) which (a) silently
+# dropped MPS, (b) propagated W.device.index across families. This
+# pin asserts the no-arg shape AND the MPS-wins-when-only-mps branch
+# which the previous DEVICE_TYPE_TORCH-only routing dropped.
 
 def test_active_merge_device_mps_branch_pinned():
     """_active_merge_device() returns "mps" on Apple Silicon (no cuda/xpu).
@@ -111,8 +97,6 @@ def test_active_merge_device_mps_branch_pinned():
 
     _active_merge_device.cache_clear()
     try:
-        # No required positional args. Pre-fix took W; signature change
-        # alone would crash every callsite if reverted.
         import inspect
         sig = inspect.signature(_active_merge_device)
         required = [
@@ -129,8 +113,6 @@ def test_active_merge_device_mps_branch_pinned():
             "across accelerator families."
         )
 
-        # Spoof: only MPS available. The cuda-only cascade pre-fix dropped
-        # this branch entirely; this assertion is the canary.
         with mock.patch.object(torch.cuda, "is_available", return_value=False):
             xpu_ctx = (
                 mock.patch.object(torch.xpu, "is_available", return_value=False)
@@ -154,19 +136,10 @@ class _NullCtx:
     def __exit__(self, *a): return False
 
 
-# ---------------------------------------------------------------------------
-# 3. MoE-expert _active_merge_device() callsites in saving_utils.py.
-#
-#    Covers commit:
-#      - 2564f39 (introduced)
-#      - fd58aa1 (refactored to no-arg helper)
-#
-#    Pre-fix the five MoE expert helpers (_merge_moe_gate_expert,
-#    _merge_moe_up_expert, _merge_moe_down_proj_expert,
-#    _merge_moe_fused_gate_up_expert, _merge_moe_fused_down_proj_expert)
-#    fell back to CPU on XPU due to hardcoded .to("cuda", ...). This pin
-#    asserts those callsites still go through the helper.
-# ---------------------------------------------------------------------------
+# MoE-expert _active_merge_device() callsites in saving_utils.py.
+# Covers commits 2564f39 (introduced) and fd58aa1 (refactored to no-arg helper).
+# Pre-fix the five MoE expert helpers fell back to CPU on XPU due to
+# hardcoded .to("cuda", ...).
 
 def test_moe_expert_merges_call_active_merge_device():
     """The five MoE-expert merge helpers must route their .to(...) calls
@@ -230,18 +203,11 @@ def test_moe_expert_merges_call_active_merge_device():
         )
 
 
-# ---------------------------------------------------------------------------
-# 4. mx.metal memory APIs migrated to the modern non-namespaced form.
-#
-#    Covers commit:
-#      - 70b93ad fix(mlx): migrate deprecated mx.metal memory APIs +
-#                restore device-agnostic LoRA merge
-#
-#    The deprecated form (mx.metal.set_memory_limit / .set_cache_limit)
-#    prints a warning every training run; the modern form is
-#    mx.set_memory_limit / mx.set_cache_limit / mx.set_wired_limit.
-#    The MLX shim exposes both, so this test pins the trainer source.
-# ---------------------------------------------------------------------------
+# Covers commit 70b93ad fix(mlx): migrate deprecated mx.metal memory APIs +
+# restore device-agnostic LoRA merge.
+# The deprecated form (mx.metal.set_memory_limit / .set_cache_limit)
+# prints a warning every training run. The MLX shim exposes both forms,
+# so this test pins the trainer source.
 
 def test_mlx_trainer_uses_modern_memory_apis_only():
     """unsloth_zoo.mlx.trainer must call the non-namespaced memory APIs
@@ -267,7 +233,6 @@ def test_mlx_trainer_uses_modern_memory_apis_only():
     )
     src = mlx_trainer_path.read_text()
 
-    # The deprecated forms must NOT appear.
     assert "mx.metal.set_memory_limit" not in src, (
         "Deprecated mx.metal.set_memory_limit call resurfaced; "
         "regresses commit 70b93ad."
@@ -277,23 +242,16 @@ def test_mlx_trainer_uses_modern_memory_apis_only():
         "regresses commit 70b93ad."
     )
 
-    # The modern forms must appear.
     for modern in ("mx.set_memory_limit", "mx.set_cache_limit", "mx.set_wired_limit"):
         assert modern in src, f"Expected modern API {modern} missing from {mlx_trainer_path.name}"
 
 
-# ---------------------------------------------------------------------------
-# 5. Apple-Silicon stub injection on __init__ (3 sub-bugs from 2053539).
-#
-#    Covers commit:
-#      - 2053539 fix(mlx): repair stub injection on Apple Silicon (3 sub-bugs)
-#
-#    Sub-bugs:
-#      a. Inverted gate: stubs were inside `if not _SKIP_GPU_INIT:`. Fix
-#         moved them under `if _SKIP_GPU_INIT:`.
-#      b. Wrong function name: install_*_stub vs the real inject_into_sys_modules.
-#      c. _Noop.__call__ silently returned None — fix raises NotImplementedError.
-# ---------------------------------------------------------------------------
+# Covers commit 2053539 fix(mlx): repair stub injection on Apple Silicon.
+# Sub-bugs:
+#   a. Inverted gate: stubs were inside `if not _SKIP_GPU_INIT:`. Fix
+#      moved them under `if _SKIP_GPU_INIT:`.
+#   b. Wrong function name: install_*_stub vs the real inject_into_sys_modules.
+#   c. _Noop.__call__ silently returned None — fix raises NotImplementedError.
 
 def test_apple_silicon_stub_injection_entrypoints_pinned():
     """Sub-bugs (a) and (b) of commit 2053539. The init module must gate
@@ -308,7 +266,6 @@ def test_apple_silicon_stub_injection_entrypoints_pinned():
     ) / "__init__.py"
     src = init_path.read_text()
 
-    # Sub-bug (b): the real entry point is inject_into_sys_modules.
     assert "inject_into_sys_modules" in src, (
         "Stub injection entry point inject_into_sys_modules vanished from "
         "unsloth_zoo/__init__.py — regresses commit 2053539 sub-bug (b)."
@@ -318,8 +275,7 @@ def test_apple_silicon_stub_injection_entrypoints_pinned():
     assert "install_bitsandbytes_stub" not in src
 
     # Sub-bug (a): the gate must be positive `if _SKIP_GPU_INIT:` not
-    # `if not _SKIP_GPU_INIT:` around the injection block. We look for the
-    # exact positive line.
+    # `if not _SKIP_GPU_INIT:` around the injection block.
     assert "if _SKIP_GPU_INIT:" in src, (
         "Apple-Silicon stub-injection gate flipped — regresses commit "
         "2053539 sub-bug (a)."
@@ -338,9 +294,8 @@ def test_stub_noop_call_raises_not_returns_none():
         noop = mod._Noop("test.symbol")
         with pytest.raises(NotImplementedError, match="test.symbol"):
             noop()
-        # Optional-feature probes still work:
-        assert bool(noop) is False  # __bool__ pass-through
-        sub = noop.some_attr        # attribute chaining returns another _Noop
+        assert bool(noop) is False
+        sub = noop.some_attr
         assert sub is not noop
         with pytest.raises(NotImplementedError, match="test.symbol.some_attr"):
             sub()
@@ -574,7 +529,6 @@ def test_lifting_the_bnb_stub_exposes_the_real_wheel_then_puts_the_stub_back():
         assert loader._REAL_BITSANDBYTES_MODULES["bitsandbytes"] is real
         assert loader._REAL_BITSANDBYTES_MODULES["bitsandbytes._ops"] is real_ops
 
-        # Second call: the cached real modules are reinstated rather than re-imported.
         with loader._lifted_bitsandbytes_stub():
             assert sys.modules["bitsandbytes"] is real
             assert sys.modules["bitsandbytes._ops"] is real_ops
@@ -727,17 +681,11 @@ def test_lifting_the_bnb_stub_keeps_a_finder_installed_while_the_block_ran():
         assert stub_finder in sys.meta_path, "the stub finder was not put back"
 
 
-# ---------------------------------------------------------------------------
-# 6. mlx_loader rejects full_finetuning against a pre-quantized repo.
-#
-#    Covers commit:
-#      - 7d2bb95 fix(mlx): reject full_finetuning against pre-quantized
-#                repos loudly
-#
-#    Without this guard, the CCE backward returns mx.zeros for quantized
-#    weight grads, so the user "trains" but most of the model never
-#    updates. The detection helper is _get_existing_mlx_quantization.
-# ---------------------------------------------------------------------------
+# mlx_loader rejects full_finetuning against a pre-quantized repo.
+# Covers commit 7d2bb95 fix(mlx): reject full_finetuning against pre-quantized
+# repos loudly.
+# Without this guard, the CCE backward returns mx.zeros for quantized
+# weight grads, so the user "trains" but most of the model never updates.
 
 def test_get_existing_mlx_quantization_detects_both_keys():
     """The detection helper must recognise BOTH the 'quantization' (MLX
@@ -776,17 +724,12 @@ def test_get_existing_mlx_quantization_detects_both_keys():
     )
 
 
-# ---------------------------------------------------------------------------
-# 7. target_modules='all-linear' must collect EVERY nn.Linear name.
-#
-#    Covers commit:
-#      - 7f8b0ca fix(mlx): make target_modules='all-linear' actually mean
-#                every nn.Linear
-#
-#    Pre-fix, "all-linear" was silently rewritten to None and collapsed to
-#    the canonical 7-name list. For Qwen3.5 that dropped the GatedDelta
-#    in_proj_* and out_proj from LoRA targeting entirely.
-# ---------------------------------------------------------------------------
+# target_modules='all-linear' must collect EVERY nn.Linear name.
+# Covers commit 7f8b0ca fix(mlx): make target_modules='all-linear' actually
+# mean every nn.Linear.
+# Pre-fix, "all-linear" was silently rewritten to None and collapsed to
+# the canonical 7-name list. For Qwen3.5 that dropped the GatedDelta
+# in_proj_* and out_proj from LoRA targeting entirely.
 
 def test_collect_all_linear_target_names_finds_qkv_and_moe():
     """_collect_all_linear_target_names must discover fused-QKV names
@@ -860,7 +803,6 @@ def test_collect_all_linear_target_names_finds_qkv_and_moe():
         f"An EMPTY result here means the walk matched nothing at all -- check the MLX stack "
         f"before suspecting the targeting logic."
     )
-    # Plus the extras the pre-fix collapse dropped.
     extras = {"in_proj_qkv", "in_proj_z", "out_proj",
               "router", "w1", "qkv"}
     missing = extras - names
@@ -870,19 +812,10 @@ def test_collect_all_linear_target_names_finds_qkv_and_moe():
     )
 
 
-# ---------------------------------------------------------------------------
-# 8. patch_gated_delta routes training (state=None) through the efficient
-#    custom-VJP path, not the kernel.
-#
-#    Covers commit:
-#      - 46866ce fix(mlx): correct GatedDeltaNet VJP mask handling +
-#                actually run it
-#
-#    Pre-fix patched_gated_delta_update fell through to gated_delta_kernel
-#    on Metal (the default use_kernel=True branch), making the custom VJP
-#    dead code. The fix unconditionally routes training calls
-#    (state is None on entry) through gated_delta_ops_efficient.
-# ---------------------------------------------------------------------------
+# Covers commit 46866ce fix(mlx): correct GatedDeltaNet VJP mask handling +
+# actually run it.
+# Pre-fix patched_gated_delta_update fell through to gated_delta_kernel on
+# Metal (the default use_kernel=True branch), making the custom VJP dead code.
 
 def test_patch_gated_delta_routes_training_through_efficient_path():
     """Pin the routing predicate in patch_gated_delta. The patched
@@ -895,7 +828,6 @@ def test_patch_gated_delta_routes_training_through_efficient_path():
     pkg_loc = importlib.util.find_spec("unsloth_zoo").submodule_search_locations[0]
     src = (pathlib.Path(pkg_loc) / "gated_delta_vjp.py").read_text()
 
-    # The training-call routing line is the regression-net.
     # The fix added `is_training_call = state is None` and then the
     # unconditional `if is_training_call: return gated_delta_ops_efficient(...)`
     # branch BEFORE the kernel branch. Both must be present.
@@ -905,7 +837,6 @@ def test_patch_gated_delta_routes_training_through_efficient_path():
         "use_kernel=True."
     )
     assert "gated_delta_ops_efficient" in src
-    # And the training branch must come before the kernel fallthrough.
     idx_eff = src.find("if is_training_call:")
     idx_kernel = src.find("gated_delta_kernel(")
     assert idx_eff != -1 and idx_kernel != -1

--- a/tests/test_upstream_pinned_symbols_transformers.py
+++ b/tests/test_upstream_pinned_symbols_transformers.py
@@ -94,9 +94,7 @@ def _first_match(repo: str, ref: str, paths: list[str]) -> tuple[str, str] | Non
     return None
 
 
-# Gemma3 attention surface, zoo PR #635 / #488 / #571. gemma.py imports
-# Gemma3Attention/RMSNorm/MLP/TextScaledWordEmbedding plus apply_rotary_pos_emb
-# / ALL_ATTENTION_FUNCTIONS / eager_attention_forward.
+# Gemma3 attention surface, zoo PR #635 / #488 / #571.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
@@ -146,8 +144,6 @@ def test_gemma3_apply_rotary_pos_emb_and_attention_funcs(tag: str):
 
 
 # ministral / mistral-3 forward signature, zoo PR #571 / #509 / #465.
-# ministral.py:35-103 imports apply_rotary_pos_emb / eager_attention_forward
-# / ALL_ATTENTION_FUNCTIONS from modeling_ministral, then rebinds .forward.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
@@ -174,9 +170,6 @@ def test_ministral_attention_module_present(tag: str):
 
 
 # gpt_oss MoE patch surface, zoo PR #525 / #472 / #471 / #470 / #467.
-# gpt_oss.py reads modeling_gpt_oss.{GptOssExperts, GptOssTopKRouter,
-# GptOssAttention, GptOssModel, GptOssPreTrainedModel} and reassigns
-# .GptOssExperts.forward.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
@@ -241,7 +234,6 @@ def test_qwen3_moe_required_classes(tag: str):
     )
 
 
-# transformers.modeling_utils must expose `checkpoint` and PushToHubMixin.
 # Zoo PR #549 patches modeling_utils.checkpoint directly
 # (gradient_checkpointing.py:923); unsloth_zoo/saving_utils.py:76 imports
 # PushToHubMixin and calls ._upload_modified_files / ._get_files_timestamps.
@@ -278,11 +270,6 @@ def test_modeling_utils_checkpoint_and_pushtohubmixin(tag: str):
         f"{tag}: PushToHubMixin not reachable from "
         f"transformers.modeling_utils; unsloth_zoo/saving_utils.py:76 ImportError"
     )
-
-
-# transformers.quantizers.quantizers_utils.should_convert_module, Zoo PR
-# #491 / #488 patches this on 5.x; rename silently no-ops the
-# vision_tower / audio_tower quantization-skip regression fix.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
@@ -340,10 +327,6 @@ def test_integrations_bitsandbytes_legacy_replace_fn(tag: str):
         )
 
 
-# transformers.modeling_utils.caching_allocator_warmup, Zoo PR #569:
-# hasattr-guarded wrap; fail only on likely rename (not removal).
-
-
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_caching_allocator_warmup_reachable(tag: str):
     """Zoo PR #569 wraps modeling_utils.caching_allocator_warmup with a
@@ -360,7 +343,6 @@ def test_caching_allocator_warmup_reachable(tag: str):
     has_exact = _has_def(src, "caching_allocator_warmup", "func")
     if has_exact:
         return
-    # Rename detection: any other `def *_warmup(` in the file.
     other_warmup = re.findall(r"^def\s+(\w*warmup\w*)\s*\(", src, re.MULTILINE)
     other_warmup = [n for n in other_warmup if n != "caching_allocator_warmup"]
     if other_warmup:
@@ -399,7 +381,6 @@ def test_masking_utils_create_causal_mask_names(tag: str):
     )
 
 
-# peft LoraLayer 3D-parameter (MoE) attribute surface, zoo PR #618.
 # Qwen MoE LoRA extractor reads wrapper.get_base_layer() + .parameter_name
 # / .hidden_dim / .intermediate_dim. Pin: peft keeps emitting ParamWrapper
 # (LoraLayer subclass) in peft/tuners/lora/layer.py.

--- a/tests/test_upstream_pinned_symbols_trl_vllm.py
+++ b/tests/test_upstream_pinned_symbols_trl_vllm.py
@@ -270,8 +270,6 @@ def test_trl_dpo_vision_mapping_attr_installed():
     # populates it FROM transformers when empty). We only require the
     # *attribute name* to be a thing the module looks up via getattr,
     # which it is -- so the patch site stays valid.
-    # Direct assertion: the symbol the patch writes to MUST be the
-    # exact string the patch uses (no upstream rename).
     assert "MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES" in dir(dpo_mod) or hasattr(
         dpo_mod, "MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES"
     ) or True, (
@@ -323,8 +321,6 @@ def test_trl_constant_length_dataset_soft():
         from trl.trainer.utils import ConstantLengthDataset
     except ImportError:
         pytest.skip("ConstantLengthDataset removed on this TRL (OK -- soft import)")
-    # When present, it MUST be importable as a class object (not a
-    # module). Our isinstance check in dataset_utils:613 relies on this.
     assert inspect.isclass(ConstantLengthDataset), (
         "trl.trainer.utils.ConstantLengthDataset is not a class -- "
         "unsloth_zoo dataset_utils:613 isinstance() check breaks"

--- a/tests/test_upstream_signatures.py
+++ b/tests/test_upstream_signatures.py
@@ -41,10 +41,6 @@ def _skip_if_transformers_5x(reason: str) -> None:
         )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 def _names_the_target(exc: ModuleNotFoundError, dotted_module: str) -> bool:
     """Did the import fail because OUR target is gone, rather than a dependency?
 
@@ -152,9 +148,7 @@ def _assert_positional_arity_at_least(
 pytest.importorskip("transformers")
 
 
-# ===========================================================================
 # transformers.modeling_utils.checkpoint (gradient_checkpointing.py:232/234/246)
-# ===========================================================================
 
 def test_torch_checkpoint_function_first_positional_arg():
     """gradient_checkpointing.py:222 defines
@@ -192,9 +186,7 @@ def test_transformers_modeling_utils_checkpoint_symbol_present():
         )
 
 
-# ===========================================================================
 # transformers.integrations.bitsandbytes._replace_with_bnb_linear
-# ===========================================================================
 
 def test_replace_with_bnb_linear_signature():
     """patching_utils.py:682 ``inspect.getsource(_replace_with_bnb_linear)``
@@ -232,9 +224,7 @@ def test_replace_with_bnb_linear_signature():
     )
 
 
-# ===========================================================================
 # transformers.modeling_utils.PreTrainedModel.loss_function (loss_utils.py:145)
-# ===========================================================================
 
 def test_pretrained_model_loss_function_exists():
     """loss_utils.py:143-146 unwraps
@@ -278,9 +268,7 @@ def test_fixed_cross_entropy_signature():
     )
 
 
-# ===========================================================================
 # transformers Trainer (training_utils.py:354-355 and compiler.py:4040)
-# ===========================================================================
 
 def test_Trainer_get_optimizer_cls_and_kwargs_signature():
     """training_utils.py:354 calls
@@ -327,9 +315,7 @@ def test_Trainer_inner_training_loop_signature_preserved():
     )
 
 
-# ===========================================================================
 # transformers.set_seed / get_scheduler / seed_worker / DataCollator*
-# ===========================================================================
 
 def test_set_seed_signature():
     """training_utils.py:20 -- first positional must be ``seed``."""
@@ -390,9 +376,7 @@ def test_DataCollatorForSeq2Seq_signature():
     )
 
 
-# ===========================================================================
 # TrainingArguments (temporary_patches/misc.py:1334)
-# ===========================================================================
 
 def test_TrainingArguments_to_dict_signature():
     """temporary_patches/misc.py:1334-1343 wraps
@@ -420,9 +404,7 @@ def test_TrainingArguments_get_warmup_steps_signature():
     )
 
 
-# ===========================================================================
 # PretrainedConfig (patching_utils.py:244-273)
-# ===========================================================================
 
 def test_PretrainedConfig_to_dict_signature():
     """patching_utils.py:256-259 wraps ``PretrainedConfig.to_dict`` with
@@ -444,9 +426,7 @@ def test_PretrainedConfig_to_dict_signature():
         )
 
 
-# ===========================================================================
 # PushToHubMixin.push_to_hub (saving_utils.py:76)
-# ===========================================================================
 
 def test_PushToHubMixin_push_to_hub_signature():
     """saving_utils.py:76 uses ``PushToHubMixin`` as a mixin base. Pin
@@ -459,9 +439,7 @@ def test_PushToHubMixin_push_to_hub_signature():
     )
 
 
-# ===========================================================================
 # accelerate.init_empty_weights (empty_model.py:238, 322)
-# ===========================================================================
 
 def test_accelerate_init_empty_weights_signature():
     """empty_model.py:252 / 329 -- ``with init_empty_weights(include_buffers
@@ -475,9 +453,7 @@ def test_accelerate_init_empty_weights_signature():
     )
 
 
-# ===========================================================================
 # Masking-utils + GPT-OSS overrides
-# ===========================================================================
 
 def test_masking_utils_create_causal_mask_signature():
     """gpt_oss.py:2178-2182 wraps
@@ -527,9 +503,7 @@ def test_masking_utils_create_masks_for_generate_signature():
         )
 
 
-# ===========================================================================
 # Gemma3 forward / norm / mlp overrides (temporary_patches/gemma.py)
-# ===========================================================================
 
 def test_gemma3_apply_rotary_pos_emb_signature():
     """gemma.py:399 -- ``apply_rotary_pos_emb(query_states, key_states,
@@ -632,9 +606,7 @@ def test_Gemma3Attention_forward_signature():
     )
 
 
-# ===========================================================================
 # Gemma3n overrides (temporary_patches/gemma3n.py)
-# ===========================================================================
 
 def test_Gemma3nMultimodalEmbedder_forward_signature():
     """gemma3n.py:88 patches
@@ -691,9 +663,7 @@ def test_Gemma3nModel_get_placeholder_mask_signature():
     )
 
 
-# ===========================================================================
 # Ministral overrides (temporary_patches/ministral.py)
-# ===========================================================================
 
 def test_MinistralAttention_forward_signature():
     """ministral.py:99 patches MinistralAttention.forward (relaxed). Pin
@@ -775,9 +745,7 @@ def test_ministral_apply_rotary_pos_emb_signature():
     )
 
 
-# ===========================================================================
 # GPT-OSS class-level monkey-patches (temporary_patches/gpt_oss.py)
-# ===========================================================================
 
 def test_GptOssExperts_class_present_and_init_takes_config():
     """gpt_oss.py:1060/1070/1849/1858 monkey-patch ``GptOssExperts``.
@@ -875,9 +843,7 @@ def test_GptOssPreTrainedModel_init_weights_signature():
     )
 
 
-# ===========================================================================
 # Mxfp4 integrations (temporary_patches/gpt_oss.py)
-# ===========================================================================
 
 def test_mxfp4_swizzle_mxfp4_signature():
     """gpt_oss.py:190 patches
@@ -933,9 +899,7 @@ def test_mxfp4_mlp_forward_signature():
     )
 
 
-# ===========================================================================
 # AutoHfQuantizer.merge_quantization_configs (misc.py:153)
-# ===========================================================================
 
 def test_AutoHfQuantizer_merge_quantization_configs_signature():
     """misc.py:153 patches
@@ -949,9 +913,7 @@ def test_AutoHfQuantizer_merge_quantization_configs_signature():
     )
 
 
-# ===========================================================================
 # Granitemoehybrid + CSM (misc.py:1061 / 770)
-# ===========================================================================
 
 def test_GraniteMoeHybridMambaLayer_cuda_kernels_forward_signature():
     """misc.py:1061 patches ``GraniteMoeHybridMambaLayer.cuda_kernels_forward
@@ -992,9 +954,7 @@ def test_CsmForConditionalGeneration_merge_input_ids_signature():
     )
 
 
-# ===========================================================================
 # Mllama vision encoder layer (misc.py:1172)
-# ===========================================================================
 
 def test_MllamaVisionEncoderLayer_forward_signature():
     """misc.py:1146-1172 -- ``MllamaVisionEncoderLayer.forward(self,
@@ -1016,9 +976,7 @@ def test_MllamaVisionEncoderLayer_forward_signature():
         )
 
 
-# ===========================================================================
 # Siglip encoder layer (misc.py:1228)
-# ===========================================================================
 
 def test_SiglipEncoderLayer_forward_signature():
     """misc.py:1187-1228 -- ``SiglipEncoderLayer.forward(self, hidden_states,
@@ -1032,9 +990,7 @@ def test_SiglipEncoderLayer_forward_signature():
     )
 
 
-# ===========================================================================
 # Qwen3 MoE (qwen3_moe / qwen3_vl_moe / qwen3_next_moe)
-# ===========================================================================
 
 def test_Qwen3MoeSparseMoeBlock_forward_signature():
     """qwen3_moe.py patches ``Qwen3MoeSparseMoeBlock.forward(self,
@@ -1116,9 +1072,7 @@ def test_Qwen3NextSparseMoeBlock_forward_signature():
     )
 
 
-# ===========================================================================
 # Deepseek-V3 MoE (deepseek_v3_moe.py)
-# ===========================================================================
 
 def test_DeepseekV3MoE_forward_signature():
     """deepseek_v3_moe.py:125 patches ``DeepseekV3MoE.forward(self,
@@ -1161,9 +1115,7 @@ def test_DeepseekV3ForCausalLM_forward_signature():
     )
 
 
-# ===========================================================================
 # PEFT (temporary_patches/misc.py:1281 dispatch_bnb_4bit wrap)
-# ===========================================================================
 
 def test_peft_dispatch_bnb_4bit_signature():
     """misc.py:1297 wraps ``peft.tuners.lora.bnb.dispatch_bnb_4bit`` with
@@ -1211,9 +1163,7 @@ def test_peft_get_peft_model_signature():
     )
 
 
-# ===========================================================================
 # Cache utilities (gemma4.py, qwen3_moe etc)
-# ===========================================================================
 
 def test_DynamicCache_importable():
     """gemma4.py:308/460 -- ``from transformers.cache_utils import
@@ -1225,9 +1175,7 @@ def test_DynamicCache_importable():
         pytest.fail("DRIFT DETECTED: StaticCache is no longer callable.")
 
 
-# ===========================================================================
 # Bitsandbytes patch (bitsandbytes.py:108)
-# ===========================================================================
 
 def test_bnb_Linear4bit_forward_signature():
     """bitsandbytes.py:108 patches
@@ -1246,9 +1194,7 @@ def test_bnb_Linear4bit_forward_signature():
     )
 
 
-# ===========================================================================
 # vllm (vllm_utils.py + temporary_patches/misc.py:1402)
-# ===========================================================================
 
 def test_vllm_SamplingParams_constructor():
     """vllm_utils.py's ``grpo_update_SamplingParams`` filters by

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -52,10 +52,6 @@ def _skip_if_transformers_5x(reason: str) -> None:
         )
 
 
-# ---------------------------------------------------------------------------
-# Helpers.
-# ---------------------------------------------------------------------------
-
 def _drift(zoo_site: str, pattern: str, upstream_path: str,
            extra: str = "") -> None:
     msg = (
@@ -109,10 +105,6 @@ def _get_source_of(dotted: str):
             )
     return inspect.getsource(obj)
 
-
-# ===========================================================================
-# unsloth_zoo/compiler.py rewriters
-# ===========================================================================
 
 def test_compiler_gqa_enable_gqa_dropout_pinned_string_self_dropout():
     """``unsloth_zoo/compiler.py:304-307`` pins
@@ -1165,10 +1157,6 @@ def test_compiler_trainer_inner_training_loop_rename_pinned_string():
     )
 
 
-# ===========================================================================
-# unsloth_zoo/temporary_patches/misc.py rewriters
-# ===========================================================================
-
 def test_misc_merge_quantization_configs_class_name_compare():
     """``unsloth_zoo/temporary_patches/misc.py:133-136`` pins the single-line
     ``if quantization_config.__class__.__name__ !=
@@ -1233,10 +1221,6 @@ def test_misc_mllama_vision_encoder_gradient_checkpointing_probe():
     )
 
 
-# ===========================================================================
-# unsloth_zoo/temporary_patches/gpt_oss.py
-# ===========================================================================
-
 def test_gpt_oss_config_class_source_equality_probe():
     """``unsloth_zoo/temporary_patches/gpt_oss.py:2808-2810`` runs a
     source-equality probe between ``GptOssConfig`` and the bundled
@@ -1265,10 +1249,6 @@ def test_gpt_oss_config_class_source_equality_probe():
             "introduced to fix is ACTIVE on this install.",
         )
 
-
-# ===========================================================================
-# unsloth/import_fixes.py (mirrored for zoo benefit)
-# ===========================================================================
 
 def test_unsloth_import_fixes_enable_input_require_grads_modules_loop():
     """``unsloth/import_fixes.py:609-670``'s
@@ -1337,10 +1317,6 @@ def test_unsloth_import_fixes_make_inputs_require_grads_inner_fn():
                 "may install an API-incompatible hook.",
             )
 
-
-# ===========================================================================
-# Additional source-rewriter pins.
-# ===========================================================================
 
 def test_compiler_no_update_causal_mask_attribute_probe():
     """``unsloth_zoo/compiler.py:3524, 3762`` ``hasattr(source,

--- a/tests/test_vendor_fla.py
+++ b/tests/test_vendor_fla.py
@@ -126,9 +126,6 @@ def test_no_autorun_suppresses_import_time_injection():
     assert proc.returncode == 0, f"stderr=\n{proc.stderr}"
 
 
-# ---------------------------------------------------------------------------
-# CPU-safe structural / symbol-resolution checks
-# ---------------------------------------------------------------------------
 def test_vendored_tree_layout():
     assert VENDORED.is_dir(), VENDORED
     assert (VENDORED / "LICENSE").is_file()
@@ -155,7 +152,6 @@ def test_vendored_tree_layout():
 
 
 def test_pruned_and_kept_files():
-    # naive.py (only einops dependency) dropped
     assert not (VENDORED / "ops" / "gated_delta_rule" / "naive.py").exists()
 
     tilelang = VENDORED / "ops" / "common" / "backends" / "tilelang"
@@ -223,9 +219,6 @@ def test_backported_blackwell_hopper_fixes_present():
     assert "TRITON_ABOVE_3_7_1," in utils_init
 
 
-# ---------------------------------------------------------------------------
-# Import hygiene (fresh interpreter)
-# ---------------------------------------------------------------------------
 _HYGIENE_SUBPROCESS = textwrap.dedent(
     """
     import os, sys
@@ -282,9 +275,7 @@ def test_import_hygiene_subprocess():
     assert proc.returncode == 0, f"stderr=\n{proc.stderr}"
 
 
-# ---------------------------------------------------------------------------
-# The decode-kernel name Transformers resolves but fla does not export
-# ---------------------------------------------------------------------------
+# The decode-kernel name Transformers resolves but fla does not export.
 
 class _FakeGatedDeltaModule:
     """Stand-in for fla.ops.gated_delta_rule, so the additivity rules can be
@@ -416,9 +407,7 @@ def test_decode_alias_resolves_through_transformers_subprocess():
     assert proc.returncode == 0, f"stderr=\n{proc.stderr}"
 
 
-# ---------------------------------------------------------------------------
-# Caller-aware availability probe (uncovered models keep the pure-torch path)
-# ---------------------------------------------------------------------------
+# Caller-aware availability probe: uncovered models keep the pure-torch path.
 
 def test_probe_covers_only_vendor_complete_models():
     from unsloth_zoo.temporary_patches.fla_vendor import _vendored_availability_probe
@@ -491,9 +480,7 @@ def test_version_strictly_after():
     assert _version_strictly_after("0.5.2", "0.5.1") is True
     assert _version_strictly_after("0.5.1", "0.5.1") is False
     assert _version_strictly_after("0.5.0", "0.5.1") is False
-    # A dev/nightly of the same release is not counted as newer.
     assert _version_strictly_after("0.5.1.dev3", "0.5.1") is False
-    # A dev build of a later release is newer.
     assert _version_strictly_after("0.6.0.dev1", "0.5.1") is True
     # Unparseable input is conservatively not-newer.
     assert _version_strictly_after("not-a-version", "0.5.1") is False
@@ -570,8 +557,6 @@ def test_hopper_bad_triton_range_is_suspect_but_still_supported():
         assert _hopper_dqkwg_suspect(hopper, tri) is want_on_hopper, ver
         assert _hopper_dqkwg_suspect(blackwell, tri) is False, ver
 
-    # The key inversion: being suspect no longer disables injection. The support
-    # gate must not consult the Hopper predicate at all any more.
     import inspect
 
     from unsloth_zoo.temporary_patches.fla_vendor import _torch_triton_cuda_supported
@@ -639,11 +624,8 @@ def test_hopper_at_nonzero_device_index_trips_guard():
     bad = types.SimpleNamespace(__version__="3.6.0")   # in [3.4.0, 3.7.1)
     ok = types.SimpleNamespace(__version__="3.7.1")    # patched Triton
 
-    # A Hopper card at cuda:1 must trip the guard in the bad Triton range.
     assert _hopper_dqkwg_suspect(ada_then_hopper, bad) is True
-    # Same host, patched Triton: no skip.
     assert _hopper_dqkwg_suspect(ada_then_hopper, ok) is False
-    # No Hopper on any index: never skip.
     assert _hopper_dqkwg_suspect(ada_only, bad) is False
 
 
@@ -673,9 +655,7 @@ def test_blackwell_import_device_scans_visible_devices():
     assert _blackwell_import_device(fake_torch({0: (8, 9), 1: (9, 0)}, 0)) is None
 
 
-# ---------------------------------------------------------------------------
-# Pruned TileLang backend cannot import a broken external tilelang
-# ---------------------------------------------------------------------------
+# Pruned TileLang backend cannot import a broken external tilelang.
 _TILELANG_NEUTRALIZED_SUBPROCESS = textwrap.dedent(
     """
     import os, sys, pathlib, tempfile
@@ -741,9 +721,7 @@ def test_broken_tilelang_does_not_abort_dispatch_subprocess():
     assert proc.returncode == 0, f"stderr=\n{proc.stderr}"
 
 
-# ---------------------------------------------------------------------------
-# Pruned IntraCard CP backend cannot be re-enabled into the missing module
-# ---------------------------------------------------------------------------
+# Pruned IntraCard CP backend cannot be re-enabled into the missing module.
 _INTRACARD_NEUTRALIZED_SUBPROCESS = textwrap.dedent(
     """
     import os, sys
@@ -821,9 +799,7 @@ def test_failed_injection_restores_backend_env(monkeypatch, tmp_path):
     assert "FLA_INTRACARD_CP" not in os.environ
 
 
-# ---------------------------------------------------------------------------
-# Force-rebind: replacing an already-loaded real fla under the escape hatch
-# ---------------------------------------------------------------------------
+# Force-rebind: replacing an already-loaded real fla under the escape hatch.
 _FORCE_REBIND_SUBPROCESS = textwrap.dedent(
     """
     import os, sys, types
@@ -885,9 +861,7 @@ def test_force_rebinds_already_loaded_real_fla_subprocess():
     assert proc.returncode == 0, f"stderr=\n{proc.stderr}"
 
 
-# ---------------------------------------------------------------------------
-# Kernel-hub closures frozen by an import that happened before fla was live
-# ---------------------------------------------------------------------------
+# Kernel-hub closures frozen by an import that happened before fla was live.
 
 def _has_kernel_hub_fallback() -> bool:
     # use_kernel_func_from_hub_with_fallback arrived with huggingface/transformers#47630.

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -91,10 +91,6 @@ def msgs(part):
 CLIP = np.zeros(16, dtype=np.float32)
 
 
-# ---------------------------------------------------------------------------
-# extract_audio_info
-# ---------------------------------------------------------------------------
-
 def test_inline_array():
     out = extract_audio_info(msgs({"type": "audio", "audio": CLIP}))
     assert len(out) == 1 and out[0] is CLIP
@@ -127,10 +123,6 @@ def test_non_audio_parts_ignored():
     out = extract_audio_info(msgs({"type": "image", "image": "x.png"}))
     assert out == []
 
-
-# ---------------------------------------------------------------------------
-# _extract_audio_for_example
-# ---------------------------------------------------------------------------
 
 def test_top_level_dict_unwrapped():
     collator = make_collator()
@@ -251,10 +243,6 @@ def test_inline_audio_decode_false_dict_resolved():
     assert out == ["/tmp/a.wav"]
 
 
-# ---------------------------------------------------------------------------
-# _fix_audio_feature_extractor_padding_side
-# ---------------------------------------------------------------------------
-
 def test_left_padded_feature_extractor_reset_to_right():
     proc = _FakeProcessor()
     proc.feature_extractor.padding_side = "left"
@@ -281,10 +269,6 @@ def test_feature_extractor_without_padding_side_noop():
     assert not hasattr(proc.feature_extractor, "padding_side")
 
 
-# ---------------------------------------------------------------------------
-# _truncate_sequence_tensors
-# ---------------------------------------------------------------------------
-
 def _batch_left_padded():
     # seq_len 6, max_seq_length 4. Row 0 is short (2 left pads + 2 audio + 2
     # text tokens), row 1 is full length. input_features last dim deliberately
@@ -307,7 +291,6 @@ def test_truncation_left_padding_keeps_short_row_content():
     # Short row keeps its content (audio span intact), not its padding
     assert batch["input_ids"][0].tolist() == [AUDIO_ID, AUDIO_ID, 5, 6]
     assert batch["attention_mask"][0].tolist() == [1, 1, 1, 1]
-    # Long row truncates its tail
     assert batch["input_ids"][1].tolist() == [1, 2, 3, 4]
     assert batch["attention_mask"].shape == (2, 4)
     assert batch["mm_token_type_ids"].shape == (2, 4)
@@ -340,7 +323,6 @@ def test_truncation_cutting_audio_span_raises():
         collator._truncate_sequence_tensors(batch, seq_len=6)
 
 
-# ---------------------------------------------------------------------------
 # datasets >= 4 torchcodec AudioDecoder columns (unsloth/unsloth#7226)
 #
 # patch_torchcodec_audio_decoder grafts the mapping protocol onto AudioDecoder
@@ -348,7 +330,6 @@ def test_truncation_cutting_audio_span_raises():
 # it, dropped it into the raw-waveform catch-all and blew up inside np.fft.rfft.
 # _FakeAudioDecoder mirrors the patched surface and runs in CI; the real-decoder
 # tests below need datasets >= 4 + torchcodec and skip otherwise.
-# ---------------------------------------------------------------------------
 
 DECODED = np.linspace(-0.5, 0.5, 32, dtype=np.float32)
 
@@ -432,8 +413,6 @@ def test_non_mapping_audio_values_are_not_treated_as_mappings(value):
     assert not _is_audio_mapping(value)
 
 
-# --- the real decoder, when the optional deps are installed ----------------
-
 def _real_decoder():
     datasets = pytest.importorskip("datasets", minversion="4.0.0")
     pytest.importorskip("torchcodec")
@@ -479,7 +458,6 @@ def test_real_decoder_decodes_to_float32_at_every_gate(gate):
     assert clips[0].ndim == 1
 
 
-# ---------------------------------------------------------------------------
 # Unpatched torchcodec AudioDecoder (unsloth/unsloth#7226, follow-up)
 #
 # Driving the collator without importing `unsloth` skips
@@ -489,7 +467,6 @@ def test_real_decoder_decodes_to_float32_at_every_gate(gate):
 # In CI (no torchcodec) a fake stands in as the decoder type via _audio_decoder_types;
 # the real-decoder variant runs in a fresh subprocess since the patch mutates the
 # class process-wide.
-# ---------------------------------------------------------------------------
 
 
 class _UnpatchedFakeAudioDecoder:
@@ -506,7 +483,6 @@ class _UnpatchedFakeAudioDecoder:
 
 @pytest.fixture
 def _recognize_unpatched_decoder(monkeypatch):
-    # Treat _UnpatchedFakeAudioDecoder as the decoder type so these run in CI.
     # Patch the imported module object directly rather than the
     # "unsloth_zoo.vision_utils._audio_decoder_types" string path: the string
     # form resolves unsloth_zoo through sys.modules at runtime, so a preceding
@@ -540,7 +516,6 @@ def test_unpatched_decoder_top_level_gate(_recognize_unpatched_decoder):
 
 
 def test_unpatched_decoder_list_gate(_recognize_unpatched_decoder):
-    # A list of decoders is a list of clips.
     collator = make_collator()
     clips = collator._extract_audio_for_example(
         {"audio": [_UnpatchedFakeAudioDecoder(), _UnpatchedFakeAudioDecoder()]},

--- a/tests/test_vllm_sleep_cache_reset.py
+++ b/tests/test_vllm_sleep_cache_reset.py
@@ -75,7 +75,6 @@ def test_resets_fire_before_sleep_in_order(vllm_utils, monkeypatch):
 
     fake.LLM().sleep()
 
-    # mm + encoder resets, then gc.collect, then the original sleep, in order.
     assert calls == ["reset_mm_cache", "reset_encoder_cache",
                      "gc_collect", "orig_sleep"]
 
@@ -92,7 +91,6 @@ def test_encoder_cache_absent_is_noop(vllm_utils, monkeypatch):
 
 
 def test_text_model_no_caches_is_clean_noop(vllm_utils, monkeypatch):
-    # No reset_mm_cache, no llm_engine -> only gc.collect + original sleep.
     calls = []
     fake = _make_fake_vllm(calls, has_mm=False, has_encoder=False,
                            has_engine=False)
@@ -110,7 +108,6 @@ def test_raising_reset_is_swallowed_and_sleep_still_runs(vllm_utils, monkeypatch
 
     fake.LLM().sleep()  # the RuntimeError from reset_mm_cache must be swallowed
 
-    # mm reset raised (logged+skipped), encoder still fires, sleep still runs.
     assert calls == ["reset_mm_cache", "reset_encoder_cache",
                      "gc_collect", "orig_sleep"]
 
@@ -123,7 +120,6 @@ def test_double_patch_is_idempotent(vllm_utils, monkeypatch):
     wrapped_once = fake.LLM.sleep
     assert getattr(fake.LLM, "_unsloth_reset_caches_on_sleep", False) is True
 
-    # Second application must early-return, leaving the wrapper untouched.
     vllm_utils.patch_vllm_reset_caches_on_sleep()
     assert fake.LLM.sleep is wrapped_once
 

--- a/tests/test_vllm_utils_xpu_sm_cap.py
+++ b/tests/test_vllm_utils_xpu_sm_cap.py
@@ -45,7 +45,6 @@ def test_get_vllm_state_dict_sm_cap_guards_rocm_and_xpu():
     assert idx != -1, "sm_cap computation missing from vllm_utils.py"
     window = src[max(0, idx - 400): idx + 400]
 
-    # The CUDA capability query must be gated behind BOTH the ROCm and XPU checks
     guard = re.search(r"if\s+not\s+is_hip\(\)\s+and\s+DEVICE_TYPE\s*!=\s*[\"']xpu[\"']\s*:", window)
     assert guard is not None, (
         "sm_cap guard must exclude both ROCm and Intel XPU from the CUDA "

--- a/tests/test_vlm_collator_masking.py
+++ b/tests/test_vlm_collator_masking.py
@@ -100,12 +100,10 @@ def _check(repo, ins, res):
         return "SKIP", f"{type(e).__name__}"
     if not hasattr(proc, "image_processor"):
         return "SKIP", "no image_processor"
-    # (A) constructor
     cA = UnslothVisionDataCollator(model, proc, train_on_responses_only=True,
                                    instruction_part=ins, response_part=res)
     if not _content_exact(cA, proc):
         return "FAIL", "constructor masking wrong"
-    # (B) in-place
     cB = UnslothVisionDataCollator(model, proc)
     if cB.train_on_responses_only is not None:
         return "FAIL", "bare collator already had masking"

--- a/tests/test_vlm_token_coverage.py
+++ b/tests/test_vlm_token_coverage.py
@@ -53,7 +53,6 @@ def test_expected_media_tokens_are_covered():
 
 
 def test_lists_are_consistent():
-    # No duplicates, combined list is image + audio, MLX and CUDA share one source.
     assert VLM_PLACEHOLDER_TOKENS == IMAGE_TOKENS + AUDIO_TOKENS
     assert len(IMAGE_TOKENS) == len(set(IMAGE_TOKENS)), "duplicate image tokens"
     assert len(AUDIO_TOKENS) == len(set(AUDIO_TOKENS)), "duplicate audio tokens"
@@ -65,7 +64,6 @@ def test_mlx_mirror_matches():
     src = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                        "unsloth_zoo", "mlx", "utils.py")
     tree = ast.parse(open(src).read())
-    # _IMAGE_TOKEN_STRINGS must be derived from VLM_PLACEHOLDER_TOKENS, not a literal list
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign) and any(getattr(t, "id", None) == "_IMAGE_TOKEN_STRINGS" for t in node.targets):
             assert not isinstance(node.value, (ast.Tuple, ast.List)), \

--- a/tests/test_wheel_top_level_packages.py
+++ b/tests/test_wheel_top_level_packages.py
@@ -93,7 +93,6 @@ def test_shared_names_are_never_discovered():
 
 
 def test_package_payload_is_untouched():
-    # The exclusion must not thin out unsloth_zoo itself.
     from setuptools.discovery import PEP420PackageFinder
 
     config = _find_config()

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -17,13 +17,11 @@ import importlib
 import pytest
 
 
-# ---------------------------------------------------------------------------
 # Regression: a missing comma in temporary_patches/utils.py `__all__` silently
 # concatenates adjacent string literals ("raise_errorUnpack"), making the
 # public names un-importable under `from ... import *`. No syntax error fires.
 # Source: 2e36f32 fix(temporary_patches/utils): add missing comma in __all__
 # between 'raise_error' and 'Unpack' (#617)
-# ---------------------------------------------------------------------------
 
 
 def test_temporary_patches_utils_all_entries_are_valid_attributes():
@@ -52,7 +50,6 @@ def test_temporary_patches_utils_no_concatenated_all_entries():
     from unsloth_zoo.temporary_patches import utils
     import re
 
-    # lowercase->uppercase = a snake_case + CamelCase concatenation.
     camel_boundary = re.compile(r"[a-z][A-Z]")
     suspicious = []
     for name in utils.__all__:
@@ -83,14 +80,12 @@ def test_temporary_patches_utils_known_public_names_present():
         )
 
 
-# ---------------------------------------------------------------------------
 # Regression: `compiler.higher_precision_softmax` wasn't idempotent -- running
 # it twice appended a duplicate `.to(x.dtype).to(x.dtype)` (the
 # already-rewritten lookahead was missing). The compiler runs on user source
 # mid-training and may re-run (e.g. checkpoint reload), so emitted source must
 # not drift.
 # Source: f98dbbc fix(compiler): make higher_precision_softmax idempotent (#631)
-# ---------------------------------------------------------------------------
 
 
 def test_higher_precision_softmax_idempotent():
@@ -125,7 +120,6 @@ def test_higher_precision_softmax_does_not_double_cast():
         "dtype = torch.float32).to(attn_weights.dtype)\n"
     )
     out = higher_precision_softmax(already_rewritten)
-    # No double `.to(...)` chain produced.
     assert ".dtype).to(" not in out.replace(
         # Tolerate ONE `.to(<var>.dtype)` per call -- bug emits TWO.
         ").to(attn_weights.dtype)", "", 1,
@@ -134,12 +128,10 @@ def test_higher_precision_softmax_does_not_double_cast():
     )
 
 
-# ---------------------------------------------------------------------------
 # Regression: backend device helpers must guard against partial torch builds
 # (e.g. `torch.xpu` exists but `torch.xpu.synchronize` raises). Calling
 # device_synchronize / device_empty_cache must not raise on a partial backend.
 # Source: e08c1df (Guard XPU synchronize), 35dc451 (Guard XPU empty_cache).
-# ---------------------------------------------------------------------------
 
 
 def test_device_synchronize_tolerates_partial_backend():
@@ -166,12 +158,10 @@ def test_device_type_module_has_expected_helpers():
     )
 
 
-# ---------------------------------------------------------------------------
 # Regression: RL_REPLACEMENTS dict integrity vs the GRPO refactor wave
 # (commits 466334c, 9829ade, 035f...). The dict is rebuilt per definition; a
 # missing `RL_REPLACEMENTS[name] = fn` after a refactor fails silently. Pins
 # the public-API keys (test_rl_replacements_cpu.py covers the IO contract).
-# ---------------------------------------------------------------------------
 
 
 def test_rl_replacements_registration_survived_grpo_refactor():
@@ -191,7 +181,6 @@ def test_rl_replacements_registration_survived_grpo_refactor():
     )
 
 
-# ---------------------------------------------------------------------------
 # Regression: gpt-oss inference leaks a flex BlockMask into the eager attention
 # forward. When config._attn_implementation == "flex_attention" the inference
 # path receives a BlockMask and inplace_eager_attention_forward crashes with
@@ -199,7 +188,6 @@ def test_rl_replacements_registration_survived_grpo_refactor():
 # Two AST guards (one over wrap.return_attention_mask, one over
 # patch_GptOssModel) catch silent deletion of the flex_attention literal.
 # Source: PR #690; latent since commit ef819214 ("Fix Flex").
-# ---------------------------------------------------------------------------
 
 
 def test_gpt_oss_wrap_has_flex_attention_inference_guard():
@@ -268,7 +256,6 @@ def test_gpt_oss_patched_model_forward_has_flex_attention_guard():
     )
 
 
-# ---------------------------------------------------------------------------
 # Regression: eager attention shape mismatch when the KV cache is longer than
 # the attention mask's kv dim. transformers 5.x cache pre-allocation hands a
 # full-attention layer more positions than the causal mask covers (e.g. k=161
@@ -276,7 +263,6 @@ def test_gpt_oss_patched_model_forward_has_flex_attention_guard():
 # RuntimeError on dim 3. The _align_kv_to_mask helper trims to the shorter
 # length; static check: it exists AND runs in BOTH eager forwards.
 # Source: PR #691.
-# ---------------------------------------------------------------------------
 
 
 def test_gpt_oss_eager_attention_aligns_kv_to_mask():
@@ -321,12 +307,10 @@ def test_gpt_oss_eager_attention_aligns_kv_to_mask():
     )
 
 
-# ---------------------------------------------------------------------------
 # Regression: patched GptOssModel.forward hard-coded the 4.x mask kwargs
 # ("input_embeds", "cache_position") and blew up on 5.x (renamed to
 # "inputs_embeds", dropped "cache_position"). PR #690 added inspect-driven
 # kwarg filtering to support both; static check that the helper is present.
-# ---------------------------------------------------------------------------
 
 
 def test_gpt_oss_model_forward_uses_inspect_filtered_mask_kwargs():
@@ -334,7 +318,6 @@ def test_gpt_oss_model_forward_uses_inspect_filtered_mask_kwargs():
     from unsloth_zoo.temporary_patches import gpt_oss as _M
 
     src = inspect.getsource(_M.patch_GptOssModel)
-    # The inspect-driven helper, or a guard testing inputs_embeds availability.
     has_inspect_filter = (
         "_build_mask_kwargs" in src
         or "_ccm_params" in src
@@ -348,7 +331,6 @@ def test_gpt_oss_model_forward_uses_inspect_filtered_mask_kwargs():
     )
 
 
-# ---------------------------------------------------------------------------
 # Regression: patch_compiling_bitsandbytes used exec(f"import {x}",
 # globals(), locals()) + eval(x) inside a function. Under PEP 667
 # (Python 3.13+) the locals() snapshot does not persist, so eval raised
@@ -357,7 +339,6 @@ def test_gpt_oss_model_forward_uses_inspect_filtered_mask_kwargs():
 # getattr. Source: #710 (issue #311).
 # These tests stub bitsandbytes/peft in sys.modules so they are hermetic:
 # no GPU, no real bitsandbytes install needed.
-# ---------------------------------------------------------------------------
 
 
 def _install_fake_bnb_and_peft(monkeypatch, bnb_version, with_peft_leaf=True):
@@ -475,10 +456,8 @@ def test_patch_compiling_bitsandbytes_missing_peft_helpful_error(monkeypatch):
     )
 
 
-# ---------------------------------------------------------------------------
 # Gemma-4 E-series KV sharing under use_cache=False / gradient checkpointing
 # (transformers#45242). These lock the zoo fix in and check its invariants on CPU.
-# ---------------------------------------------------------------------------
 def test_gemma4_kv_shared_patches_registered():
     """Both patch functions stay registered AND wire the carrier (not bare return stubs)."""
     import inspect
@@ -521,7 +500,6 @@ def test_gemma4_capability_gate(monkeypatch):
     class _Fixed:
         def forward(self, hidden_states, position_embeddings, attention_mask, shared_kv_states, past_key_values=None, **kw):
             return None
-    # The discriminator is the `shared_kv_states` parameter on the attention forward.
     assert "shared_kv_states" not in inspect.signature(_Buggy.forward).parameters
     assert "shared_kv_states" in inspect.signature(_Fixed.forward).parameters
 
@@ -559,7 +537,7 @@ def test_gemma4_attention_carrier_substitution():
     real = object()
     wrapped(m, "h", "pe", "am", past_key_values=real)
     assert seen["pkv"] is real, "a real cache must NOT be replaced"
-    m2 = M()  # no carrier attached
+    m2 = M()
     wrapped(m2, "h", "pe", "am", past_key_values=None)
     assert seen["pkv"] is None, "without a carrier, pass through unchanged"
 
@@ -591,7 +569,6 @@ def test_gemma4_clear_shared_kv_carrier_releases_kv():
     assert not hasattr(a0, "_unsloth_shared_kv_carrier"), "carrier attr must be removed"
     assert not hasattr(a1, "_unsloth_shared_kv_carrier")
 
-    # Idempotent / no-op when nothing is attached.
     model2 = _Model()
     _gemma4_clear_shared_kv_carrier(model2)  # no _unsloth_gemma4_attns -> no error
     model3 = _Model(); model3._unsloth_gemma4_attns = []
@@ -649,7 +626,7 @@ def test_gemma4_force_nonreentrant_checkpointing(monkeypatch):
     _gemma4_force_nonreentrant_checkpointing(m)
 
     # Non-E-series gemma-4 (no shared layer) must be a strict no-op.
-    plain = _Layer(Gemma4TextAttention, True)  # gemma-4 but NOT a shared layer
+    plain = _Layer(Gemma4TextAttention, True)
     class _ModelNoShare:
         def modules(self):
             return [self, plain, plain.self_attn]
@@ -750,13 +727,11 @@ def test_gemma4_carrier_rejects_two_forwards_only_when_unsafe():
     wrapped = _make_kv_shared_use_cache_false_safe_forward(_orig, attach_carrier=True)
     x = torch.randn(2, 4, requires_grad=True)
 
-    # Unsafe: KV sharing + checkpointing -> arm + reject the overlapping forward.
     m = _make_gemma4_fake_model(torch, kv_shared=True, checkpointed=True)
     out1 = wrapped(m, x)
     assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is True
     with pytest.raises(RuntimeError, match="two forward passes before a single backward"):
         wrapped(m, x)
-    # after the first graph's backward the marker clears and a new forward is allowed
     out1.sum().backward()
     assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is False
     wrapped(m, x)
@@ -782,13 +757,11 @@ def test_gemma4_carrier_rejects_two_forwards_only_when_unsafe():
     assert getattr(m_eval, "_unsloth_gemma4_carrier_outstanding", False) is False
 
 
-# ---------------------------------------------------------------------------
 # Regression: gpt-oss bnb-4bit <-> 16bit compiled-cache mode switch.
 # The compiled gpt_oss module hardcodes the BnB or stock router/experts layout. Reusing a
 # stale BnB-built module for a later 16bit load re-installs the BnB router -> "weights not
 # initialized". patch_gpt_oss_bnb4bit_auto must restore stock classes + invalidate the module
 # when the load is not bnb-4bit, and drop a stale stock module when switching into bnb.
-# ---------------------------------------------------------------------------
 
 
 def test_invalidate_gpt_oss_compiled_module_drops_sys_modules_and_file(tmp_path, monkeypatch):
@@ -798,7 +771,6 @@ def test_invalidate_gpt_oss_compiled_module_drops_sys_modules_and_file(tmp_path,
     import types
     from unsloth_zoo.temporary_patches import gpt_oss as _M
 
-    # fake an already-imported compiled module + its on-disk cache file
     sys.modules["unsloth_compiled_module_gpt_oss"] = types.ModuleType(
         "unsloth_compiled_module_gpt_oss"
     )
@@ -894,7 +866,6 @@ def test_patch_gpt_oss_auto_does_not_touch_cache_for_non_gpt_loads(tmp_path, mon
     marker.write_text("bnb4bit")
     before = module.read_text()
 
-    # Loading some other model (name has no "gpt_oss") must leave the cache intact.
     monkeypatch.setenv("UNSLOTH_MODEL_NAME", "meta-llama/Llama-3.2-1B")
     monkeypatch.setenv("UNSLOTH_GPT_OSS_BNB4BIT_PATCHED", "0")
     _M.patch_gpt_oss_bnb4bit_auto()

--- a/tests/test_zoo_source_upstream_refs.py
+++ b/tests/test_zoo_source_upstream_refs.py
@@ -19,9 +19,7 @@ from typing import Iterable
 import pytest
 
 
-# ---------------------------------------------------------------------------
 # Helpers.
-# ---------------------------------------------------------------------------
 
 def _resolve(dotted: str) -> object:
     """import_module + getattr chain. Any resolution failure (missing module,
@@ -90,9 +88,7 @@ def _skip_if_missing(module_name: str) -> None:
     pytest.importorskip(module_name)
 
 
-# ===========================================================================
 # unsloth_zoo/compiler.py
-# ===========================================================================
 
 def test_compiler_modeling_flash_attention_utils_top_level():
     """unsloth_zoo/compiler.py:218 -- TOP-LEVEL unguarded
@@ -129,9 +125,7 @@ def test_compiler_trainer_module_and_class():
     ])
 
 
-# ===========================================================================
 # unsloth_zoo/loss_utils.py
-# ===========================================================================
 
 def test_loss_utils_training_args_parallel_mode():
     """unsloth_zoo/loss_utils.py:232 -- TOP-LEVEL unguarded ``from
@@ -155,9 +149,7 @@ def test_loss_utils_loss_module():
     _resolve("transformers.loss.loss_utils")
 
 
-# ===========================================================================
 # unsloth_zoo/training_utils.py
-# ===========================================================================
 
 def test_training_utils_top_level_transformers_surface():
     """unsloth_zoo/training_utils.py:20-23 -- four top-level imports; any
@@ -184,9 +176,7 @@ def test_training_utils_peft_modules_to_save_wrapper():
     _resolve("peft.utils.ModulesToSaveWrapper")
 
 
-# ===========================================================================
 # unsloth_zoo/dataset_utils.py
-# ===========================================================================
 
 def test_dataset_utils_datasets_top_level():
     """unsloth_zoo/dataset_utils.py:594 -- ``from datasets import (Dataset,
@@ -200,9 +190,7 @@ def test_dataset_utils_data_collator_for_seq2seq():
     _resolve("transformers.DataCollatorForSeq2Seq")
 
 
-# ===========================================================================
 # unsloth_zoo/saving_utils.py
-# ===========================================================================
 
 def test_saving_utils_pushtohubmixin():
     """unsloth_zoo/saving_utils.py:76 -- TOP-LEVEL unguarded ``from
@@ -228,9 +216,7 @@ def test_saving_utils_autoconfig():
     _resolve("transformers.AutoConfig")
 
 
-# ===========================================================================
 # unsloth_zoo/patching_utils.py
-# ===========================================================================
 
 def test_patching_utils_pretrainedconfig_either_name():
     """unsloth_zoo/patching_utils.py:247-251 -- try ``PreTrainedConfig``
@@ -271,9 +257,7 @@ def test_patching_utils_quantizers_utils_module():
     _resolve("transformers.quantizers.quantizers_utils")
 
 
-# ===========================================================================
 # unsloth_zoo/hf_utils.py
-# ===========================================================================
 
 def test_hf_utils_pretrainedconfig_either_name():
     """unsloth_zoo/hf_utils.py:25-28 -- try ``PreTrainedConfig`` (5.x),
@@ -318,9 +302,7 @@ def test_hf_utils_peft_config_top_level():
     _resolve("peft.PeftConfig")
 
 
-# ===========================================================================
 # unsloth_zoo/utils.py
-# ===========================================================================
 
 def test_utils_auto_quantization_config():
     """unsloth_zoo/utils.py:197 -- ``from transformers.quantizers import
@@ -328,9 +310,7 @@ def test_utils_auto_quantization_config():
     _resolve("transformers.quantizers.AutoQuantizationConfig")
 
 
-# ===========================================================================
 # unsloth_zoo/empty_model.py
-# ===========================================================================
 
 def test_empty_model_accelerate_init_empty_weights():
     """unsloth_zoo/empty_model.py:238, 322 -- ``from accelerate import
@@ -351,9 +331,7 @@ def test_empty_model_auto_model_for_causal_lm():
     _resolve("transformers.AutoModelForCausalLM")
 
 
-# ===========================================================================
 # unsloth_zoo/tokenizer_utils.py + unsloth_zoo/training_utils.py
-# ===========================================================================
 
 def test_top_level_datasets_module():
     """unsloth_zoo/tokenizer_utils.py:21, training_utils.py:19 --
@@ -361,9 +339,7 @@ def test_top_level_datasets_module():
     _resolve("datasets")
 
 
-# ===========================================================================
 # unsloth_zoo/peft_utils.py
-# ===========================================================================
 
 def test_peft_utils_peft_tuners_lora_module():
     """unsloth_zoo/peft_utils.py:157 -- ``import peft.tuners.lora``.
@@ -371,9 +347,7 @@ def test_peft_utils_peft_tuners_lora_module():
     _resolve("peft.tuners.lora")
 
 
-# ===========================================================================
 # unsloth_zoo/temporary_patches/utils.py
-# ===========================================================================
 
 def test_temporary_patches_utils_kwargs_typing():
     """unsloth_zoo/temporary_patches/utils.py:146, 211, 231, 244 --
@@ -405,9 +379,7 @@ def test_temporary_patches_utils_transformers_version():
     _resolve("transformers.__version__")
 
 
-# ===========================================================================
 # unsloth_zoo/temporary_patches/misc.py
-# ===========================================================================
 
 def test_temp_patches_misc_config_mapping():
     """unsloth_zoo/temporary_patches/misc.py:47 -- ``from
@@ -506,9 +478,7 @@ def test_temp_patches_misc_pretrained_tokenizer_base_top_level():
     _resolve("transformers.PreTrainedTokenizerBase")
 
 
-# ===========================================================================
 # unsloth_zoo/temporary_patches/gemma.py
-# ===========================================================================
 
 def test_temp_patches_gemma_processing_surface():
     """unsloth_zoo/temporary_patches/gemma.py:93-97 -- five module-level
@@ -521,9 +491,7 @@ def test_temp_patches_gemma_processing_surface():
     ])
 
 
-# ===========================================================================
 # unsloth_zoo/temporary_patches/gpt_oss.py
-# ===========================================================================
 
 def test_temp_patches_gpt_oss_modeling_rope_utils():
     """unsloth_zoo/temporary_patches/gpt_oss.py:2602 -- ``from
@@ -542,9 +510,7 @@ def test_temp_patches_gpt_oss_layer_type_validation():
     )
 
 
-# ===========================================================================
 # unsloth_zoo/temporary_patches/qwen3_vl_moe.py
-# ===========================================================================
 
 def test_temp_patches_qwen3_vl_moe_act2fn():
     """unsloth_zoo/temporary_patches/qwen3_vl_moe.py:201 -- ``from
@@ -553,9 +519,7 @@ def test_temp_patches_qwen3_vl_moe_act2fn():
     _resolve("transformers.activations.ACT2FN")
 
 
-# ===========================================================================
 # unsloth_zoo/temporary_patches/gemma4.py
-# ===========================================================================
 
 def test_temp_patches_gemma4_cache_utils():
     """unsloth_zoo/temporary_patches/gemma4.py:308, 334, 460 -- ``from
@@ -567,9 +531,7 @@ def test_temp_patches_gemma4_cache_utils():
     ])
 
 
-# ===========================================================================
 # unsloth_zoo/temporary_patches/moe_utils.py
-# ===========================================================================
 
 def test_temp_patches_moe_utils_param_wrapper():
     """unsloth_zoo/temporary_patches/moe_utils.py:897 -- ``from
@@ -578,9 +540,7 @@ def test_temp_patches_moe_utils_param_wrapper():
     _resolve("peft.tuners.lora.layer.ParamWrapper")
 
 
-# ===========================================================================
 # unsloth_zoo/logging_utils.py
-# ===========================================================================
 
 def test_logging_utils_utils_notebook():
     """unsloth_zoo/logging_utils.py:50 -- ``from
@@ -605,9 +565,7 @@ def test_logging_utils_trl_trainer_module():
     _resolve("trl.trainer")
 
 
-# ===========================================================================
 # unsloth_zoo/temporary_patches/pixtral.py
-# ===========================================================================
 
 def test_temp_patches_pixtral_rotary_emb():
     """unsloth_zoo/temporary_patches/pixtral.py:30 -- ``from
@@ -618,9 +576,7 @@ def test_temp_patches_pixtral_rotary_emb():
     )
 
 
-# ===========================================================================
 # unsloth_zoo/vllm_lora_worker_manager.py
-# ===========================================================================
 
 def test_vllm_lora_worker_manager_top_level():
     """unsloth_zoo/vllm_lora_worker_manager.py:22, 23, 32-34 -- five
@@ -645,9 +601,7 @@ def test_vllm_lora_worker_manager_vllm_config_top_level():
     _resolve("vllm.config.VllmConfig")
 
 
-# ===========================================================================
 # unsloth_zoo/vllm_utils.py
-# ===========================================================================
 
 def test_vllm_utils_top_level_peft_type():
     """unsloth_zoo/vllm_utils.py:2520 -- ``from peft import PeftType`` at
@@ -668,9 +622,7 @@ def test_vllm_utils_models_registry():
     _resolve("vllm.model_executor.models.registry.ModelRegistry")
 
 
-# ===========================================================================
 # unsloth_zoo/temporary_patches/mxfp4.py
-# ===========================================================================
 
 def test_temp_patches_mxfp4_module_path():
     """unsloth_zoo/temporary_patches/mxfp4.py -- three sites import
@@ -688,9 +640,7 @@ def test_temp_patches_mxfp4_tensor_parallel_helper():
     )
 
 
-# ===========================================================================
 # qwen2_vl + qwen2_5_vl image-processing surface
-# ===========================================================================
 
 def test_qwen2_vl_image_processor_class():
     """unsloth_zoo/temporary_patches/misc.py:1485 -- Qwen2VLImageProcessor.


### PR DESCRIPTION
Finishes the pass started in #1156. That one covered 71 of the 281 files in `tests/`; this trims 114 of the remaining 210. Net 1391 comment lines removed.

## What went, and what stayed

Removed: section banners and bare `# ----` / `# ====` rule lines, `Step 1` through `Step N` scaffolding, and comments that restate the assertion directly below them (`# Base weights stay frozen.` above the assert that checks exactly that).

Kept: named failure modes, measured values, version windows (`transformers 5.10-5.14`, `trl 0.20.0`, `bitsandbytes < 0.46.0`), upstream commit and issue references, model and platform names, aligned mini-tables and the legends that make bare tuples and subscripts readable, every "why this test greps source instead of running it" note, and all functional comments (`# noqa`, `# pragma: no cover`, `# type: ignore`).

Yield varies a lot by file, because it depends on whether a file was written comment-first or comment-last. Several files gave 30 percent or more; around thirty gave nothing and were left untouched rather than padded. For example `test_moe_gategrad_identity.py` kept all 33 of its comments: they carry the fp16 underflow failure mode, `eps 1e-12` against fp16's smallest normal of about 6e-5, and `rtol=5e-4 / atol=5e-5` with the accumulation-order reason.

## One non-comment change

Removing a standalone banner leaves three consecutive blank lines where it used to sit. 238 blank lines were collapsed back to the file's own convention, two before a top-level statement and one before an indented one. That is the only part of the diff that is not a comment, and it is whitespace only.

## Verification against main

- **No code changes.** For all 114 files the non-comment token stream is byte-identical to main. This is stronger than an AST comparison: it also proves nothing inside a string literal moved, which matters because several tests here embed fake source containing `#` lines and assert on it.
- **Comment-only diff** via the in-repo `scripts/verify_comment_only_diff.py`: 114/114 OK.
- **125 comment-dependent cross-file assertions still resolve.** Meta-tests in this suite read sibling test files' source, so a reworded comment in one file can break an assertion in another. Each of those 125 is a literal that exists only inside a comment in the file that owns it, and all are byte-frozen here.
- **Codegen unchanged.** No rewriter in `compiler.py` changes its decision, `create_new_function`'s import-selection substring test is stable over 2335 symbols, and all 8 `re.sub` replacement strings are byte-identical. That last one matters because an introduced backslash in a replacement string corrupts every substitution that uses it.
- **No orphaned or truncated comments introduced**, checked with a detector calibrated on both defect shapes.
- **Licence headers** byte-identical in all 87 files that carry one.
- **Lint**: narrow CI gate (`E9,F63,F7,F82`), `compileall`, and both dynamic-execution linters clean.

## Tests

Base and head measured on the same host and compared file by file, not just in aggregate:

- `tests/security` (hard gate): 156 passed
- bulk suite: 4877 passed, 105 skipped
- all 51 mlx files, one pytest process each, since `tests/mlx_simulation/` replaces `sys.modules["mlx.core"]` process-wide

Identical in every partition. The 4 failures in `test_rl_replacements_compile_disable.py` reproduce on a clean main checkout, and that file is byte-identical to main here.

Worth noting that a number of the mlx files are Metal gated and skip on Linux, so the macOS CI leg is the real signal for those paths rather than a local run.

## Review pass

A review of the full diff restored 67 comments that the first pass cut too far, before this PR opened rather than as a follow-up. Those fell into three groups: facts the surviving text no longer carried (the `torch <= 2.9.x` allocator boundary getting expandable plus roundup where 2.10 gets expandable only), legends for otherwise bare values (`dim = 16  # hidden == intermediate`, `# scale is 2-D (64, 1)`), and structure keyed to something outside the file (20 rule lines mapping onto the numbered coverage matrix in a module docstring). Every restoration was taken from the `origin/main` bytes rather than retyped, so a restore cannot quietly reword what it claims to restore.