### PR TITLE
Reduce comment volume in unsloth_zoo pure-logic modules

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -69,13 +69,11 @@ def _longest_common_sublist(lists):
         """Return (exists, sublist) for a common sublist of `length`."""
         common = set()
         first = lists[0]
-        # All sublists of `length` from the first list
         for i in range(len(first) - length + 1):
             sub = tuple(first[i:i + length])
             common.add(sub)
         pass
 
-        # Keep only sublists also present in every remaining list
         for lst in lists[1:]:
             current = set()
             for i in range(len(lst) - length + 1):
@@ -89,7 +87,6 @@ def _longest_common_sublist(lists):
         return True, list(common.pop())
     pass
 
-    # Binary search on length
     left, right = 1, min_len
     result = []
 
@@ -125,7 +122,6 @@ def _find_common_token_ids(component, tokenizer, force_match = False):
     elif component.startswith("\n"): left_text = "\n"
     stripped = component.strip()
     
-    # Add current pieces and also newlines
     all_input_ids = []
     if not force_match:
         for left in range(3):
@@ -224,7 +220,6 @@ def get_chat_template_parts(tokenizer):
     specials = sorted({str(s) for s in (set(getattr(tok, "all_special_tokens", []) or []) | added) if s}, key = len, reverse = True)
 
     def strip_lead(s, *prefixes):
-        # Remove any of the given leading strings, repeatedly
         changed = True
         while changed:
             changed = False
@@ -233,7 +228,6 @@ def get_chat_template_parts(tokenizer):
         return s
 
     def strip_shared(a, b):
-        # Drop leading special-tokens/whitespace common to both until roles differ
         while True:
             wa, wb = re.match(r"\s+", a), re.match(r"\s+", b)
             if wa and wb and wa.group() == wb.group():
@@ -247,7 +241,6 @@ def get_chat_template_parts(tokenizer):
         return a, b
 
     def gap_mode(from_ends, to_starts):
-        # Most common text between adjacent content blocks
         out = []
         for e in from_ends:
             nxt = [s for s in to_starts if s >= e]
@@ -712,7 +705,6 @@ def train_on_responses_only(
     # Keep the original object (may be a VLM processor) so auto-detect can read a
     # chat template that lives only on the processor; the matcher uses the inner one.
     processor = tokenizer
-    # Get non vision tokenizer
     if hasattr(tokenizer, "image_processor") or hasattr(tokenizer, "tokenizer"):
         tokenizer = tokenizer.tokenizer
     if  not hasattr(tokenizer, "_unsloth_input_part") or \
@@ -755,7 +747,6 @@ def train_on_responses_only(
         )
     pass
 
-    # Store some temporary stuff
     A_first = A_must[0]
     len_A_must = len(A_must)
     A_left_reversed = A_left[::-1]
@@ -805,14 +796,11 @@ def train_on_responses_only(
             n_minus_1 = n - 1
             j = 0
 
-            # Collect all (assistant_k, user_j) spans for this sample
             spans = []
             while j < n:
-                # Find <assistant>
                 if (input_ids[j] == A_first) and \
                     (input_ids[j : (k := j + len_A_must)] == A_must):
 
-                    # Extend over optional tokens, backward then forward
                     for optional_left in A_left_reversed:
                         if j < 1: break
                         if optional_left == input_ids[j-1]: j -= 1
@@ -827,13 +815,11 @@ def train_on_responses_only(
                     assistant_k = k
 
                     j = assistant_k
-                    # Find the next <user> (or the final item if assistant is last)
                     while j < n:
                         if (j == n_minus_1) or \
                             ((input_ids[j] == Q_first) and \
                              (input_ids[j : (k := j + len_Q_must)] == Q_must)):
 
-                            # Extend over optional tokens, backward then forward
                             for optional_left in Q_left_reversed:
                                 if j < 1: break
                                 if optional_left == input_ids[j-1]: j -= 1
@@ -845,7 +831,6 @@ def train_on_responses_only(
                                 else: break
                             pass
                             user_j = j
-                            # Account for last item
                             if user_j != n_minus_1:
                                 # user_k = k
                                 # j = user_k
@@ -2307,7 +2292,6 @@ def standardize_data_formats(
                 uniques[key].append(value)
     pass
 
-    # Must be only 2 entries
     assert(len(uniques.keys()) == 2)
 
     keys = list(uniques.keys())
@@ -2315,7 +2299,6 @@ def standardize_data_formats(
     length_second = len(set(uniques[keys[1]]))
 
     if length_first < length_second:
-        # Role is assigned to the first element
         role_key    = keys[0]
         content_key = keys[1]
     else:
@@ -2323,7 +2306,6 @@ def standardize_data_formats(
         content_key = keys[0]
     pass
 
-    # Check roles are in aliases
     all_aliases = set(aliases_for_system + aliases_for_user + aliases_for_assistant)
     roles = set(uniques[role_key])
     leftover_aliases = (all_aliases | roles) - all_aliases
@@ -2333,7 +2315,6 @@ def standardize_data_formats(
         )
     pass
 
-    # Mapping for aliases
     aliases_mapping = {}
     for x in aliases_for_system:    aliases_mapping[x] = "system"
     for x in aliases_for_user:      aliases_mapping[x] = "user"

--- a/unsloth_zoo/device_map_planner.py
+++ b/unsloth_zoo/device_map_planner.py
@@ -161,9 +161,6 @@ class _SearchExhausted(Exception):
     """Internal: the bounded exact-packing search hit its node budget."""
 
 
-# --------------------------------------------------------------------------- #
-# logit transform detection
-# --------------------------------------------------------------------------- #
 def _config_attr(holder, name, default = None):
     """``getattr`` that a hostile config cannot break out of.
 
@@ -326,9 +323,6 @@ def detect_logit_transforms(model_or_config) -> dict:
         return zero
 
 
-# --------------------------------------------------------------------------- #
-# headroom formula
-# --------------------------------------------------------------------------- #
 def logit_headroom_bytes(
     vocab_size: int,
     rows_per_chunk: int,
@@ -384,9 +378,6 @@ def logit_headroom_bytes(
     return int(per_chunk + retained + safety_bytes)
 
 
-# --------------------------------------------------------------------------- #
-# plan object
-# --------------------------------------------------------------------------- #
 @dataclass
 class DeviceMapPlan:
     """Result of :func:`plan_device_map`."""
@@ -440,9 +431,6 @@ class DeviceMapPlan:
         return "\n".join(lines)
 
 
-# --------------------------------------------------------------------------- #
-# introspection helpers (all generic)
-# --------------------------------------------------------------------------- #
 def _parse_size(value: Any) -> int:
     """Accept 12345, "14GiB", "14GB", "500MiB"."""
     if isinstance(value, (int,)) and not isinstance(value, bool):
@@ -891,9 +879,6 @@ def _usable_devices(max_memory: Mapping[Any, Any] | None) -> list[int]:
     return list(range(torch.cuda.device_count()))
 
 
-# --------------------------------------------------------------------------- #
-# the planner
-# --------------------------------------------------------------------------- #
 def plan_device_map(
     model: nn.Module,
     *,
@@ -1618,9 +1603,6 @@ def plan_device_map(
     )
 
 
-# --------------------------------------------------------------------------- #
-# pre-load convenience
-# --------------------------------------------------------------------------- #
 def _runtime_quantization_config(kwargs: dict[str, Any]) -> Any:
     """The quantisation the CALLER asked for, popped out of the loader kwargs.
 

--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -88,19 +88,16 @@ def compare_attributes(original_model, new_model):
         buffer_names = {name for name,_ in original_module.named_buffers(recurse=False)}
 
 
-        # Missing: in original but not in new
         missing_in_new = orig_attrs - new_attrs
         missing_in_new = missing_in_new - {'hf_device_map', 'source_cls'}
         if missing_in_new:
             for attr in sorted(missing_in_new):
                 missing_attrs.append(f"{name}.{attr}")
 
-        # Extra: in new but not in original
         extra_in_new = new_attrs - orig_attrs
         if extra_in_new:
             print(f'Found some extra attributes like: {list(extra_in_new)[:5]}...')
 
-        # Compare common attributes and buffer names
         common_attrs = orig_attrs & new_attrs
         common_buffers = orig_attrs | buffer_names
         for attr in sorted(common_attrs):
@@ -259,7 +256,6 @@ def create_empty_causal_lm(config, dtype = torch.float16):
         if hasattr(config, "model_name"):
             causal_config.model_name = config.model_name
     _set_runtime_dtype(causal_config)
-    # Suppress warning on uninited weights
     old_warn = os.environ.get("UNSLOTH_WARN_UNINITIALIZED", "1")
     os.environ["UNSLOTH_WARN_UNINITIALIZED"] = "0"
     model_name = getattr(causal_config, 'model_name', getattr(config, 'model_name', None))
@@ -308,7 +304,6 @@ def create_empty_causal_lm(config, dtype = torch.float16):
         "linear_conv_kernel_dim": 1,
     })
 
-    # Set attention module head_dim
     head_dim = getattr(causal_config, "head_dim", causal_config.hidden_size // causal_config.num_attention_heads)
     new_config.update({"head_dim" : head_dim})
 
@@ -533,7 +528,6 @@ def create_empty_vision_model(config, dtype = torch.float16):
             traceback.print_exc()
             original_meta_model = None
     finally:
-        # Restore original SiglipVisionModel weight init
         if patched_here and hasattr(SiglipVisionModel, "_original_initialize_weights"):
             SiglipVisionModel._init_weights = SiglipVisionModel._original_initialize_weights
             del SiglipVisionModel._original_initialize_weights
@@ -541,7 +535,6 @@ def create_empty_vision_model(config, dtype = torch.float16):
 
     new_config = deepcopy(config)
 
-    # Common text attributes
     _set_config_attrs(new_config.text_config, {
         "num_attention_heads": 1,
         "num_key_value_heads": 1,
@@ -560,7 +553,6 @@ def create_empty_vision_model(config, dtype = torch.float16):
         "linear_conv_kernel_dim": 1,
     })
 
-    # Common vision attributes
     _set_config_attrs(new_config.vision_config, {
         "hidden_size": 1,
         "intermediate_size": 1,
@@ -1454,7 +1446,6 @@ def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_stat
     layer_counts = get_model_layer_counts(vllm_internals.config)
     num_layers_to_iterate = max(layer_counts.values()) if isinstance(layer_counts, dict) else layer_counts
 
-    # Process layered components
     for kk in range(num_layers_to_iterate):
         for layer_template in all_layered_templates:
             layer_path = layer_template.format(kk=kk)
@@ -1491,7 +1482,6 @@ def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_stat
                     else:
                         print(f"Unsloth: Skipping layer '{layer_path}' of unexpected type: {type(layer_module)}")
 
-    # Extract non-layered vision components
     non_layered_components = layer_config.get('non_layered_components', [])
     for component_path in non_layered_components:
         component = _get_nested_attr(vllm_internals, component_path)
@@ -1504,7 +1494,6 @@ def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_stat
                 quant_state_dict[component_path] = component.data
             elif isinstance(component, torch.nn.Module):
                 for param_name, param in component.named_parameters():
-                    # Skip params extracted separately
                     if param_name.replace('.weight', '') in non_layered_components: continue
                     full_param_path = f"{component_path}.{param_name}"
                     if hasattr(param, 'weight'):

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -125,7 +125,6 @@ def _calculate_n_gradient_checkpoints(
     size = n_layers // n_checkpoints
     sizes = np.full(n_checkpoints, size, dtype = int)
     leftovers = n_layers % n_checkpoints
-    # Append leftovers from the right
     for k in range(leftovers):
         sizes[n_checkpoints-1-k] += 1
     boundaries = np.hstack((0, np.cumsum(sizes)))
@@ -644,7 +643,6 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
             CPU_BUFFERS.append(x)
     pass
 
-    # Allocate one buffer per GPU
     n_gpus = torch.cuda.device_count() if DEVICE_TYPE in ("cuda", "hip") else torch.xpu.device_count()
     NEXT_BUFFER_SLOT = [0] * n_gpus
     try:
@@ -808,7 +806,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                     GPU_BUFFERS_B = None
                         pass
 
-                        # Extend buffer size
                         if CPU_INDEX >= len(CPU_BUFFERS):
                             with _no_inference_mode():
                                 x = torch.empty(new_size, dtype = arg.dtype, device = "cpu", pin_memory = True)
@@ -834,7 +831,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                     GPU_BUFFER.resize_(new_size)
                                 else:
                                     raise
-                        # Resize buffer B when double buffering; disable + free B on OOM
                         if USE_DOUBLE_BUFFER:
                             GPU_BUFFER_B = GPU_BUFFERS_B[device_index]
                             if new_size > GPU_BUFFER_B.numel():
@@ -904,7 +900,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                 " or call .backward() without passing the `inputs` argument."
             )
 
-        # Copy the list to avoid modifying original list.
         inputs = list(ctx.inputs)
         tensor_indices = ctx.tensor_indices
         tensors = ctx.saved_tensors
@@ -916,7 +911,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
             global GPU_BUFFERS_B
             global BUFFER_EVENTS_A
             global BUFFER_EVENTS_B
-            # Select buffer from per-device buffer_slot
             if USE_DOUBLE_BUFFER and buffer_slot == 1:
                 buffer = GPU_BUFFERS_B[device_index][:new_size].view(shape)
             else:
@@ -926,23 +920,19 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
             # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
             if USE_DOUBLE_BUFFER:
-                # Wait for the last compute on THIS buffer to finish
                 event_buffer = BUFFER_EVENTS_B if buffer_slot == 1 else BUFFER_EVENTS_A
                 EXTRA_STREAM.wait_event(event_buffer[device_index])
             else:
-                # Single buffer mode: wait for MAIN_STREAM
                 EXTRA_STREAM.wait_stream(MAIN_STREAM)
 
             # buffer is a normal (non-inference) buffer, so this reload copy_ is safe (unsloth#3828).
             with torch_gpu_stream(EXTRA_STREAM):
                 buffer.copy_(x, non_blocking = True)
         else:
-            # No GPU buffer seen
             if len(tensor_indices) != 0:
                 inputs[tensor_indices[0]] = tensors[0]
         pass
 
-        # Fill in inputs with appropriate saved tensors.
         for i, idx in enumerate(tensor_indices[1:], start = 1):
             inputs[idx] = tensors[i]
         pass
@@ -954,8 +944,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
         global CURRENT_GC_INDEX
         CURRENT_GC_INDEX = 0
 
-        # Stash the surrounding rng state, mimic the forward state, then
-        # restore the surrounding state when done.
         rng_devices = []
         if ctx.preserve_rng_state and ctx.had_device_in_fwd:
             rng_devices = ctx.fwd_devices
@@ -998,7 +986,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
         if isinstance(outputs, torch.Tensor):
             outputs = (outputs,)
 
-        # run backward() with only tensor that requires grad
         outputs_with_grad = []
         args_with_grad = []
         for i in range(len(outputs)):
@@ -1026,7 +1013,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
             inp.grad if isinstance(inp, torch.Tensor) else None
             for inp in detached_inputs
         )
-        # Clear all memory
         for i in range(len(detached_inputs)):
             detached_inputs[i] = None
             inputs[i] = None
@@ -1219,7 +1205,6 @@ def reset_unsloth_gradient_checkpointing_buffers():
     if len(CPU_BUFFERS) == 0:
         return
 
-    # Reset CPU buffers to initial size; free any added during training
     for i in range(len(CPU_BUFFERS)):
         if i < INITIAL_CPU_BUFFER_COUNT:
             if CPU_BUFFERS[i] is not None and hasattr(CPU_BUFFERS[i], "resize_"):
@@ -1230,18 +1215,15 @@ def reset_unsloth_gradient_checkpointing_buffers():
             CPU_BUFFERS[i] = None
     pass
 
-    # Trim the list back to initial count if it grew
     if len(CPU_BUFFERS) > INITIAL_CPU_BUFFER_COUNT:
         del CPU_BUFFERS[INITIAL_CPU_BUFFER_COUNT:]
     pass
 
-    # Reset GPU buffers to initial size
     for i in range(len(GPU_BUFFERS)):
         if GPU_BUFFERS[i] is not None and hasattr(GPU_BUFFERS[i], "resize_"):
             GPU_BUFFERS[i].resize_(INITIAL_GPU_BUFFER_SIZE)
     pass
 
-    # Reset state for a fresh training run
     CPU_INDEX = 0
     BACKWARD_PASS = True
     LAST_GC_INDEX = 0
@@ -1252,7 +1234,6 @@ def reset_unsloth_gradient_checkpointing_buffers():
         for i in range(len(NEXT_BUFFER_SLOT)):
             NEXT_BUFFER_SLOT[i] = 0
 
-    # Reset double buffering if buffer B still exists, or try to re-allocate
     if _double_buffer_disabled():
         if GPU_BUFFERS_B is not None:
             for i in range(len(GPU_BUFFERS_B)):

--- a/unsloth_zoo/hf_cache.py
+++ b/unsloth_zoo/hf_cache.py
@@ -40,7 +40,6 @@ def _expand_env_path(value: str) -> Path:
 
 
 def _is_writable(path: Path) -> bool:
-    # Create the dir and a throwaway file; any failure means not writable.
     # Symlinks are allowed here: users legitimately symlink caches to large
     # volumes. Fallback paths are hardened separately in _is_safe_private_dir.
     try:
@@ -94,7 +93,6 @@ def _safe_user() -> str:
 
 
 def _fallback_bases() -> list[Path]:
-    # Ordered writable candidates used when the default cache is read-only.
     user = _safe_user()
     bases = [Path(tempfile.gettempdir()) / f"huggingface_{user}"]
     try:

--- a/unsloth_zoo/hf_cache_state.py
+++ b/unsloth_zoo/hf_cache_state.py
@@ -185,10 +185,6 @@ def snapshot_dir_has_broken_symlinks(snapshot_dir: Path) -> bool:
     return False
 
 
-# ---------------------------------------------------------------------------
-# Weight-file recognition
-# ---------------------------------------------------------------------------
-
 _WEIGHT_FILE_SUFFIXES = (
     ".safetensors",
     ".bin",
@@ -325,10 +321,6 @@ def _weight_shard_index_complete(index_path: Path) -> bool:
     return True
 
 
-# ---------------------------------------------------------------------------
-# Pattern helpers (normalization + glob detection + HF filtering)
-# ---------------------------------------------------------------------------
-
 _GLOB_CHARS = ("*", "?", "[")
 
 
@@ -425,10 +417,6 @@ def snapshot_has_requested_broken_symlinks(
         return False
     return bool(_filter_paths(broken, allow_patterns, ignore_patterns))
 
-
-# ---------------------------------------------------------------------------
-# The conservative fast-path completeness gate
-# ---------------------------------------------------------------------------
 
 # Canonical root weight filenames a default load reads (the single file or its shard index proves warm).
 _CANONICAL_SINGLE_WEIGHTS = ("model.safetensors", "pytorch_model.bin")
@@ -1189,10 +1177,6 @@ def requested_named_files_present(
             return False
     return True
 
-
-# ---------------------------------------------------------------------------
-# Active-cache enumeration primitives (download-manager / watchdog support)
-# ---------------------------------------------------------------------------
 
 def _iter_snapshot_dirs(repo_dir: Path) -> Iterator[Path]:
     snapshots_dir = repo_dir / "snapshots"

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -710,7 +710,6 @@ def _child_open_incomplete_blobs(pid: int) -> Optional[set]:
         except Exception:
             return None
         return {os.path.basename(f.path) for f in files if f.path.endswith(INCOMPLETE_SUFFIX)}
-    # Linux fallback: read open fds from /proc.
     fd_dir = f"/proc/{pid}/fd"
     try:
         entries = os.listdir(fd_dir)

--- a/unsloth_zoo/logging_utils.py
+++ b/unsloth_zoo/logging_utils.py
@@ -85,18 +85,14 @@ def NotebookProgressCallback_on_log(Trainer_metrics):
     set_Trainer_metrics = frozenset(Trainer_metrics)
 
     def _NotebookProgressCallback_on_log(self, args, state, control, logs = None, **kwargs):
-        # Only for when there is no evaluation
         if args.eval_strategy == IntervalStrategy.NO and "loss" in logs:
             values = {}
 
-            # 1) Pre-extracted metrics, only if present in logs
             for metric in Trainer_metrics:
                 if metric in logs:
                     values[metric.replace("/", " / ")] = logs[metric]
             pass
 
-            # 2) Dynamic per-reward-function metrics (rewards/*): user-defined
-            #    names, so sort for stable column ordering across steps.
             dynamic_reward_keys = sorted(
                 k for k in logs
                 if k.startswith("rewards/") and k not in set_Trainer_metrics
@@ -107,7 +103,6 @@ def NotebookProgressCallback_on_log(Trainer_metrics):
                     values[display_key] = logs[key]
             pass
 
-            # 3) Prepend Training Loss + Step as first columns
             values = {"Training Loss": logs["loss"], **values}
             values[self.first_column] = state.global_step
             self.training_tracker.write_line(values)
@@ -144,17 +139,14 @@ def NotebookTrainingTracker_write_line(Trainer_metrics):
             if len(self.inner_table) > 1:
                 last_values = self.inner_table[-1]
                 if last_values[0] != values[first_column]:
-                    # write new line
                     self.inner_table.append([values[c] if c in values else "" for c in columns])
                 else:
-                    # update last line, preserving existing values for missing keys
                     new_values = values
                     for c in columns:
                         if c not in new_values:
                             new_values[c] = last_values[columns.index(c)]
                     self.inner_table[-1] = [new_values[c] for c in columns]
             else:
-                # First data row (after header)
                 self.inner_table.append([values[c] if c in values else "" for c in columns])
             pass
         pass
@@ -168,7 +160,6 @@ def _PatchRLStatistics(metrics, algorithm):
         if len(metrics) == 0: return
         from transformers.trainer import is_in_notebook
         if is_in_notebook():
-            # Patch DPO notebook printing
             NotebookTrainingTracker.write_line = NotebookTrainingTracker_write_line(metrics)
             from transformers.trainer import DEFAULT_PROGRESS_CALLBACK
             DEFAULT_PROGRESS_CALLBACK.on_train_begin = NotebookProgressCallback_on_train_begin(metrics)
@@ -180,7 +171,6 @@ pass
 
 @functools.cache
 def get_trl_metrics():
-    # Gets metrics so we can output them in notebooks
 
     import trl.trainer
     trainers = dir(trl.trainer)
@@ -240,7 +230,6 @@ def get_trl_metrics():
         left_prefix = 'prefix = "eval_" if train_eval == "eval" else ""' in file
         if left_prefix: metrics += metrics_f
 
-        # Move all eval_ things to the end and reward to the front
         beginning = []
         middle = []
         end = []

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -92,7 +92,6 @@ def patch_loss_functions(_fast_cross_entropy_loss, torch_compile = True):
         return None
     pass
 
-    # Generic cross entropy loss
     def unsloth_fixed_cross_entropy(source, target, num_items_in_batch: int = None, ignore_index: int = -100, **kwargs):
         if ignore_index == -100:
             loss = _fast_cross_entropy_loss(
@@ -116,7 +115,6 @@ def patch_loss_functions(_fast_cross_entropy_loss, torch_compile = True):
         return loss
     pass
     
-    # Causal LM loss
     def UnslothForCausalLMLoss(
         logits, labels, vocab_size: int, num_items_in_batch: int = None, ignore_index: int = -100, **kwargs
     ):
@@ -141,7 +139,6 @@ def patch_loss_functions(_fast_cross_entropy_loss, torch_compile = True):
         )
     pass
 
-    # Now patch the losses!
     import transformers.modeling_utils
     LOSS_MAPPING = transformers.loss.loss_utils.LOSS_MAPPING
     # Patch every key still aliased to the stock ForCausalLMLoss. PreTrainedModel
@@ -287,7 +284,6 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
     batch_samples = []
     num_items_in_batch = None
 
-    # Check if model allows **kwargs
     m = self.model
     if hasattr(m, "get_base_model"):
         # Removes PeftModelForCausalLM and gets internal model
@@ -331,7 +327,6 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
         has_kwargs, is_vlm = ALLOWED_NUM_ITEMS_IN_BATCH[model_name]
     pass
 
-    # Iterate to find all batches
     for _ in range(num_batches):
         try:
             batch_samples += [next(epoch_iterator)]
@@ -339,7 +334,6 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
             break
     pass
 
-    # Get num_items_in_batch
     if has_kwargs and len(batch_samples) > 0 and "labels" in batch_samples[0]:
         try:
             token_counts = []

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -245,7 +245,6 @@ def get_peft_regex(
                 r").*?"   + match_linear_modules
     pass
 
-    # Final check to confirm if matches exist
     check = any(re.search(regex_matcher, name, flags = re.DOTALL) for name in linear_modules)
     if not check and target_modules is not None:
         raise RuntimeError(
@@ -314,7 +313,6 @@ def requires_grad_for_gradient_checkpointing(model):
         pass
     pass
 
-    # Remove all previous forward hooks for gradient checkpointing
     for name, module in model.named_modules():
         if len(module._forward_hooks) != 0:
             register_other_hooks(
@@ -326,7 +324,6 @@ def requires_grad_for_gradient_checkpointing(model):
         pass
     pass
 
-    # Add post forward hook
     def requires_grad_post_hook(module, input, output):
         type_output = type(output)
         if type_output is torch.Tensor:
@@ -407,7 +404,6 @@ def requires_grad_for_gradient_checkpointing(model):
             fallback_name = None
             fallback_module = None
 
-            # Try getting previous parent module
             for j in range(len(name_components)-1, 0, -1):
                 name_curr = name_components[j]
                 name_pre  = "model." + ".".join(name_components[:j])
@@ -475,7 +471,6 @@ def requires_grad_for_gradient_checkpointing(model):
         logger.info(f"Unsloth: Making `{module_name}` require gradients")
 
         still_need_patching = True
-        # Check if input_embeddings exists
         if hasattr(module, "get_input_embeddings"):
             # Use forward hook after Embedding() is called
             try:
@@ -498,7 +493,6 @@ def requires_grad_for_gradient_checkpointing(model):
         pass
 
         if still_need_patching:
-            # Use forward pre hook before module is called
             register_other_hooks(
                 "requires_grad_pre_hook",
                 "requires_grad_pre_hook",

--- a/unsloth_zoo/rl_environments.py
+++ b/unsloth_zoo/rl_environments.py
@@ -268,7 +268,6 @@ def check_signal_escape_patterns(code: str):
             func = node.func
             func_name = None
 
-            # Get the function name for pattern matching
             if isinstance(func, ast.Attribute):
                 # signal.signal(...), signal.setitimer(...), etc.
                 if isinstance(func.value, ast.Name):
@@ -282,10 +281,8 @@ def check_signal_escape_patterns(code: str):
                 if func.id in ("signal", "setitimer", "alarm", "pthread_sigmask"):
                     func_name = func.id
 
-            # Check for signal tampering patterns
             if func_name:
                 if func_name in ("signal.signal", "signal"):
-                    # Check if setting SIGALRM handler
                     if len(node.args) >= 1:
                         arg0 = node.args[0]
                         if _ast_name_matches(arg0, ("SIGALRM", "signal.SIGALRM")):
@@ -296,7 +293,6 @@ def check_signal_escape_patterns(code: str):
                             })
 
                 elif func_name in ("signal.setitimer", "setitimer"):
-                    # Check if disabling ITIMER_REAL
                     if len(node.args) >= 1:
                         arg0 = node.args[0]
                         if _ast_name_matches(arg0, ("ITIMER_REAL", "signal.ITIMER_REAL")):
@@ -329,9 +325,7 @@ def check_signal_escape_patterns(code: str):
                 self.generic_visit(node)
                 return
 
-            # Check for bare except or catching TimeoutError/BaseException inside a loop
             if node.type is None:
-                # Bare except:
                 exception_catching.append({
                     "type": "bare_except_in_loop",
                     "line": node.lineno,
@@ -375,7 +369,6 @@ def check_signal_escape_patterns(code: str):
     visitor = SignalEscapeVisitor()
     visitor.visit(tree)
 
-    # Add warning if signal is imported but no specific tampering found
     if visitor.imports_signal and not signal_tampering:
         warnings.append("Code imports 'signal' module - review manually for safety")
 
@@ -1037,9 +1030,6 @@ class Benchmarker:
         }
 pass
 
-####################
-##### Open Env #####
-####################
 import socket
 import requests
 import random
@@ -1076,13 +1066,10 @@ def _get_openenv_pythonpath(working_directory: str) -> str:
     src_path = os.path.join(working_directory, "src")
 
     if os.path.exists(root_client):
-        # New structure: envs at root + openenv in src
         return f"{working_directory}{os.pathsep}{src_path}"
     elif os.path.exists(src_client):
-        # Old structure: everything in src
         return src_path
     else:
-        # Fallback: try both paths
         return f"{working_directory}{os.pathsep}{src_path}"
 
 
@@ -1095,14 +1082,12 @@ def launch_openenv(
     openenv_class = None,
 ):
     """ Finds a new port or checks if the old open port actually works """
-    # Check if OpenEnv is working first
     assert type(environment) is dict
     assert type(port) is int and port >= 0 and port <= (65535-1)
     assert type(working_directory) is str
     assert openenv_class is not None
     assert type(server) is str
 
-    # Auto-fix PYTHONPATH for OpenEnv compatibility
     correct_pythonpath = _get_openenv_pythonpath(working_directory)
     if environment.get("PYTHONPATH") != correct_pythonpath:
         environment = dict(environment)  # Don't mutate original
@@ -1119,14 +1104,12 @@ def launch_openenv(
                     except: pass
                     process = None
                 else:
-                    # It should work, so simply return the old one!
                     return process
             except:
                 process = None
         return process
     openenv_process = check_openenv_works(openenv_process)
 
-    # Otherwise, find the next port which can be used
     trials = 0
     while openenv_process is None:
         # Port ID must be less than uint16_MAX
@@ -1141,7 +1124,6 @@ def launch_openenv(
             text = True,
             cwd = working_directory,
         )
-        # Wait until port is open
         wait_trials = 0
         while not is_port_open("localhost", port):
             time.sleep(0.01)

--- a/unsloth_zoo/tokenizer_utils.py
+++ b/unsloth_zoo/tokenizer_utils.py
@@ -59,7 +59,6 @@ def mean_of_trained_tokens(model, eps = 1e-16):
     embedding_matrix = model.get_input_embeddings ().weight.clone()
     lm_head_matrix   = model.get_output_embeddings().weight.clone()
 
-    # Get untrained tokens
     indicator_untrained = torch.amax(embedding_matrix, axis = 1) <= eps
     where_untrained = torch.where(indicator_untrained)[0]
     n_untrained = where_untrained.shape[0]
@@ -71,15 +70,12 @@ def mean_of_trained_tokens(model, eps = 1e-16):
     #     )
     # pass
 
-    # Get sum of all items
     sum_embedding = torch.sum(embedding_matrix, dtype = torch.float32, axis = 0)
     sum_lm_head   = torch.sum(lm_head_matrix,   dtype = torch.float32, axis = 0)
 
-    # Remove bad tokens
     sum_embedding -= torch.sum(embedding_matrix[where_untrained], dtype = torch.float32, axis = 0)
     sum_lm_head   -= torch.sum(lm_head_matrix  [where_untrained], dtype = torch.float32, axis = 0)
 
-    # Find correct average by dividing by sum of trained tokens
     mean_embedding = (sum_embedding / n_trained)
     mean_lm_head   = (sum_lm_head   / n_trained)
 
@@ -123,18 +119,15 @@ def add_new_tokens(
     mean_embedding = mean_embedding.to(torch.float32)
     mean_lm_head   = mean_lm_head  .to(torch.float32)
 
-    # Get old lengths
     old_input_embedding  = model.get_input_embeddings ().weight
     old_output_embedding = model.get_output_embeddings().weight
     old_input_length  = old_input_embedding .shape[0]
     old_output_length = old_output_embedding.shape[0]
     old_config_size   = model.config.vocab_size
 
-    # Check for tied weights as well
     is_tied = (old_input_embedding.data_ptr() == old_output_embedding.data_ptr()) \
         or (model.config.tie_word_embeddings)
 
-    # Add tokens!
     old_length = len(tokenizer)
     tokenizer.add_tokens(new_tokens)
     new_vocab_length = len(tokenizer)
@@ -182,11 +175,9 @@ def add_new_tokens(
             mean_embedding_token = embedding_matrix[input_ids].mean(axis = 0, dtype = torch.float32)
             mean_lm_head_token   = lm_head_matrix  [input_ids].mean(axis = 0, dtype = torch.float32)
 
-            # Interpolate
             mean_embedding_token = mean_embedding*(1-interpolation) + mean_embedding_token*interpolation
             mean_lm_head_token   = mean_lm_head  *(1-interpolation) + mean_lm_head_token  *interpolation
 
-            # Set the new vector
             with torch.no_grad():
                 embedding_matrix[old_length+j] = mean_embedding_token
                 lm_head_matrix  [old_length+j] = mean_lm_head_token
@@ -201,7 +192,6 @@ def add_new_tokens(
             lm_head_matrix  [old_length:new_vocab_length] = mean_lm_head
     pass
 
-    # We set a flag to say we need to train embeddings
     internal_model = model
     while hasattr(internal_model, "model"):
         internal_model._need_to_train_embeddings = True
@@ -227,7 +217,6 @@ def add_new_tokens(
     # Otherwise error will occur on saving models ie use save_model
     if is_tied: model.tie_weights()
 
-    # Clear deleted GPU items
     for _ in range(3):
         gc.collect()
         torch.cuda.empty_cache()
@@ -263,7 +252,6 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
     embedding_matrix = embedding_matrix[:min_size]
     lm_head_matrix   = lm_head_matrix  [:min_size]
     
-    # Get untrained tokens
     indicator_untrained1 = torch.amax(embedding_matrix, axis = 1) <= eps
     # Check lm_head as well
 
@@ -287,10 +275,8 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
     indicator_untrained2 = indicator_untrained2 | torch.zeros_like(indicator_untrained2)
     indicator_untrained2[final_bad_lm_head] = True
 
-    # Combine both checks
     indicator_untrained = indicator_untrained1.to("cpu") & indicator_untrained2.to("cpu")
 
-    # Remove pad token and other important token possibilities
     special_tokens = (
         "bos_token",
         "eos_token",
@@ -312,18 +298,15 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
     n_untrained = where_untrained.shape[0]
     n_trained = embedding_matrix.shape[0] - n_untrained
 
-    # Get set and actual tokens
     where_untrained = where_untrained.tolist()
     if len(where_untrained) == 0: return
 
-    # Remove untrained indices where it's longer
     
     where_untrained_set = frozenset(where_untrained)
     actual_bad_tokens = tokenizer.convert_ids_to_tokens(where_untrained)
     # Remove None items in actual_bad_tokens
     actual_bad_tokens = [x for x in actual_bad_tokens if x is not None]
 
-    # Check if tokenizer and training datasets have bad tokens
     if_bad_first  = False
     if_bad_second = False
     # Check tokenizer's chat template for any untrained tokens
@@ -336,7 +319,6 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
         # an indexable dataset
         return
 
-    # Check the first 250, last 250 input_ids
     size_dataset = len(train_dataset)
     size = min(size_dataset, 250)
     for j in range(size):
@@ -351,7 +333,6 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
         pass
     pass
 
-    # Check last 250
     if not if_bad_second:
         left = max(size_dataset-250, 0)
         for j in range(left, size_dataset):
@@ -367,10 +348,8 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
         pass
     pass
 
-    # Check if bad tokens exists!
     if not if_bad_first and not if_bad_second: return
 
-    # Check if lm_head / embed_token are trainable!
     bad_not_trainable = False
     if not embedding_matrix.requires_grad: bad_not_trainable = True
     if not lm_head_matrix  .requires_grad: bad_not_trainable = True
@@ -380,7 +359,6 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
         final_bad_items = []
         which_locations = []
 
-        # Re-check the first 250, last 250 input_ids
         size_dataset = len(train_dataset)
         size = min(size_dataset, 250)
         for j in range(size):
@@ -394,7 +372,6 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
             pass
         pass
 
-        # Re-check last 250
         left = max(size_dataset-250, 0)
         for j in range(left, size_dataset):
             input_ids = train_dataset[j]
@@ -423,7 +400,6 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
                 pass
             pass
 
-            # Re-check last 2000
             left = max(size_dataset-2000, 0)
             for j in range(left, size_dataset):
                 input_ids = train_dataset[j]
@@ -451,7 +427,6 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
         )
     pass
 
-    # Count all the possible bad tokens
     final_counts = np.zeros(max(len(tokenizer), embedding_matrix.shape[0]), dtype = np.int64)
     def mapping(examples):
         input_ids = examples["input_ids"]
@@ -460,19 +435,15 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
     pass
     train_dataset.map(mapping, batched = True, desc = "Counting untrained tokens")
 
-    # Get sum of all items
     sum_embedding = torch.sum(embedding_matrix, dtype = torch.float32, axis = 0)
     sum_lm_head   = torch.sum(lm_head_matrix,   dtype = torch.float32, axis = 0)
 
-    # Remove bad tokens
     sum_embedding -= torch.sum(embedding_matrix[where_untrained], dtype = torch.float32, axis = 0)
     sum_lm_head   -= torch.sum(lm_head_matrix  [where_untrained], dtype = torch.float32, axis = 0)
 
-    # Find correct average by dividing by sum of trained tokens
     mean_embedding = (sum_embedding / n_trained)
     mean_lm_head   = (sum_lm_head   / n_trained)
 
-    # Scale each to be equal to 1/max_frequency. Also set some to 0 if none seen
     scaling = final_counts[where_untrained] / max(final_counts.max(), 1)
     scaling = torch.tensor(scaling, device = mean_embedding.device).unsqueeze(1)
     mean_embedding = mean_embedding.repeat((n_untrained, 1,)) * scaling
@@ -481,7 +452,6 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
     mean_embedding[where_null] = 0
     mean_lm_head  [where_null] = 0
 
-    # Set them to the mean
     print(
         "Unsloth: Setting embed_tokens & lm_head untrained tokens to "\
         "mean(trained) to counteract NaNs during training."
@@ -489,7 +459,6 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
     embedding_matrix[where_untrained] = mean_embedding.to(embedding_matrix.dtype)
     lm_head_matrix  [where_untrained] = mean_lm_head  .to(lm_head_matrix  .dtype)
 
-    # Clean up
     for _ in range(3):
         gc.collect()
         torch.cuda.empty_cache()

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -59,7 +59,6 @@ def fix_zero_training_loss(model, tokenizer, train_dataset):
     row = train_dataset[0]
     if type(row) is dict and "labels" in row:
 
-        # Check the first 100 rows
         seen_bad  = 0
         seen_good = 0
         for i, row in enumerate(train_dataset):
@@ -70,7 +69,6 @@ def fix_zero_training_loss(model, tokenizer, train_dataset):
             if i >= 100: break
         pass
 
-        # Check ratio
         if seen_bad == 0 and seen_good == 0: return
 
         elif seen_bad / (seen_bad + seen_good) == 1:
@@ -600,7 +598,6 @@ def unsloth_train(trainer):
         )
     pass
 
-    # Separate weight decay for parameters
     optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(training_args)
     decay_parameters = frozenset(Trainer.get_decay_parameter_names(None, model))
     yes_decay, no_decay = [], []
@@ -623,7 +620,6 @@ def unsloth_train(trainer):
     total_train_batch_size, max_steps, num_train_epochs = \
         get_max_steps(training_args, n_training_samples, trainer.train_dataset)
 
-    # Get LR scheduler
     lr_scheduler = transformers_get_scheduler(
         name = training_args.lr_scheduler_type,
         optimizer = optimizer,
@@ -632,7 +628,6 @@ def unsloth_train(trainer):
         **getattr(training_args, "lr_scheduler_kwargs", {}),
     )
 
-    # Gradient accumulation and grad norm clipping
     max_grad_norm   = training_args.max_grad_norm
     clip_grad_norm_ = torch.nn.utils.clip_grad_norm_
     bsz = training_args.per_device_train_batch_size
@@ -642,7 +637,6 @@ def unsloth_train(trainer):
     #     torch.FloatTensor([inverse_gradient_accumulation_steps])\
     #     .to(device = "cuda:0", non_blocking = True)[0]
 
-    # Mixed precision scaling
     torch_version = torch.__version__
     config_dtype = dtype_from_config(model.config)
     if config_dtype == torch.float16:
@@ -686,15 +680,12 @@ def unsloth_train(trainer):
         f' "-____-"     Number of trainable parameters = {n_parameters_to_train:,}'
     print(debug_info)
 
-    # Get per epoch counter
     max_iters_per_epoch = math.ceil(n_training_samples / total_train_batch_size)
     leftover_samples = n_training_samples % total_train_batch_size
-    # But also consider leftover steps
     leftover_ga = math.ceil(leftover_samples / bsz)
     if leftover_samples == 0: leftover_ga = ga
 
     logging_steps = training_args.logging_steps
-    # Go through each epoch
     start_time = time.time()
     with ProgressBar(total = max_steps, dynamic_ncols = True) as progress_bar:
         for epoch in range(num_train_epochs):
@@ -716,12 +707,10 @@ def unsloth_train(trainer):
                 n_batches = leftover_ga if j == (max_iters_per_epoch-1) else ga
                 batches = [next(train_dataloader_iterator) for j in range(n_batches)]
 
-                # Count non zeros before loss calc
                 n_items = torch.stack([
                     torch.count_nonzero(x["labels"][..., 1:] != -100) for x in batches
                 ]).sum()
 
-                # Gradient accumulation
                 for batch in batches:
                     input_ids = batch["input_ids"].pin_memory().to(device = "cuda:0", non_blocking = True)
                     labels    = batch["labels"]   .pin_memory().to(device = "cuda:0", non_blocking = True)
@@ -762,7 +751,6 @@ def unsloth_train(trainer):
     print("Unsloth: Finished training!")
     end_time = time.time()
 
-    # Return stats
     trainer_stats = Trainer_Stats(metrics = {"train_runtime" : end_time - start_time})
     return trainer_stats
 pass

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -428,7 +428,6 @@ def fetch_image(
         image = image_obj.convert("RGB")
     else:
         image = image_obj
-    ## resize
     if "resized_height" in ele and "resized_width" in ele:
         resized_height, resized_width = smart_resize(
             ele["resized_height"],
@@ -529,26 +528,22 @@ def calculate_video_frame_range(
     'video_start'/'video_end' (seconds). Raises ValueError on invalid params
     or an inconsistent time range.
     """
-    # Validate essential parameters
     if video_fps <= 0:
         raise ValueError("video_fps must be a positive number")
     if total_frames <= 0:
         raise ValueError("total_frames must be a positive integer")
 
-    # Get start and end time in seconds
     video_start = ele.get("video_start", None)
     video_end = ele.get("video_end", None)
     if video_start is None and video_end is None:
         return 0, total_frames - 1, total_frames
 
     max_duration = total_frames / video_fps
-    # Process start frame
     if video_start is not None:
         video_start_clamped = max(0.0, min(video_start, max_duration))
         start_frame = math.ceil(video_start_clamped * video_fps)
     else:
         start_frame = 0
-    # Process end frame
     if video_end is not None:
         video_end_clamped = max(0.0, min(video_end, max_duration))
         end_frame = math.floor(video_end_clamped * video_fps)
@@ -556,7 +551,6 @@ def calculate_video_frame_range(
     else:
         end_frame = total_frames - 1
 
-    # Validate frame order
     if start_frame >= end_frame:
         raise ValueError(
             f"Invalid time range: Start frame {start_frame} (at {video_start_clamped if video_start is not None else 0}s) "
@@ -1178,7 +1172,6 @@ class UnslothVisionDataCollator:
         for example in examples:
             messages = self._select_messages_or_raw(example)
 
-            # Check if data format is correct for VLMs!
             if len(messages) != 0:
                 messages = self._validate_and_normalize_first_message(messages)
 
@@ -1209,7 +1202,6 @@ class UnslothVisionDataCollator:
             audio = self._extract_audio_for_example(example, messages)
             audios.extend(audio)
 
-        # Tokenize the texts and process the images
         # When audio is present, omit max_length/truncation from the top-level processor
         # call — passing them at top-level causes _merge_kwargs to broadcast them into
         # audio_kwargs, which makes the audio feature extractor truncate the waveform to
@@ -1251,7 +1243,6 @@ class UnslothVisionDataCollator:
         if 'pixel_values_videos' in batch:
             batch = self._cast_pixel_values_dtype_inplace(batch, 'pixel_values_videos')
 
-        # Mask image tokens and pad tokens
         labels = batch["input_ids"].clone()
         padding_ids = self._get_padding_token_ids_on_device(labels.device)
         labels[torch.isin(labels, padding_ids)] = self.ignore_index
@@ -1665,7 +1656,6 @@ class UnslothVisionDataCollator:
         for ex in examples:
             p, c = ex["prompt"], ex["completion"]
 
-            # Determine chat vs plain for each side
             is_p_msgs = isinstance(p, list) and (len(p) == 0 or isinstance(p[0], dict))
             is_c_msgs = isinstance(c, list) and (len(c) == 0 or isinstance(c[0], dict))
 
@@ -1691,7 +1681,6 @@ class UnslothVisionDataCollator:
             else:
                 c_txt = str(c)
 
-            # Images: prefer embedded; else first top-level image; else []
             imgs, vids, vids_kwarg = self._extract_images_for_pc(ex, p if is_p_msgs else None, c if is_c_msgs else None)
             imgs = self._resize_images_inplace(imgs)
 
@@ -1758,7 +1747,6 @@ class UnslothVisionDataCollator:
         else:
             token_type_ids = None
 
-        # Flush to tokenizer default padding side
         pad_id = self._pad_token_id_or_fail()
         flush_side = self._tokenizer_padding_side()
         if token_type_ids is not None:
@@ -1766,13 +1754,11 @@ class UnslothVisionDataCollator:
                 attention_mask, input_ids, flush_side, pad_id, (completion_mask, token_type_ids)
             )
 
-            # Truncate with side awareness
             if self.max_seq_length is not None:
                 input_ids, attention_mask, completion_mask, token_type_ids = self._truncate_by_side(
                     input_ids, attention_mask, completion_mask, flush_side, self.max_seq_length, token_type_ids=token_type_ids
                 )
 
-            # Optional pad-to-multiple-of (manual in PC)
             if self.pad_to_multiple_of and self.pad_to_multiple_of > 1:
                 input_ids, attention_mask, completion_mask, token_type_ids = self._pad_to_multiple(
                     input_ids, attention_mask, completion_mask, flush_side, pad_id, self.pad_to_multiple_of, token_type_ids=token_type_ids
@@ -1782,7 +1768,6 @@ class UnslothVisionDataCollator:
                 attention_mask, input_ids, flush_side, pad_id, (completion_mask,)
             )
 
-            # Truncate with side awareness
             if self.max_seq_length is not None:
                 input_ids, attention_mask, completion_mask = self._truncate_by_side(
                     input_ids, attention_mask, completion_mask, flush_side, self.max_seq_length
@@ -1793,7 +1778,6 @@ class UnslothVisionDataCollator:
                     input_ids, attention_mask, completion_mask, flush_side, pad_id, self.pad_to_multiple_of
                 )
 
-        # Labels: mask attention pads + image/pad tokens; completion-only if requested
         labels = input_ids.clone()
         labels[attention_mask == 0] = self.ignore_index
         padding_ids = self._get_padding_token_ids_on_device(labels.device)


### PR DESCRIPTION
Third batch of the comment reduction pass, after #1156 and #1158 (`tests/`) and #1157 (`unsloth_zoo/mlx/`). This is the first batch over source that `compiler.py` scans, so it is deliberately conservative: **182 comment lines removed across 14 files, deletion only, zero insertions.**

## How scope was set

A read-only safety triage ran over every candidate file before any edit, checking five things per comment: whether a test asserts on its text, whether it sits between two lines a `compiler.py` finder anchors on as consecutive, whether it is inside a string literal, whether it contains `def` above a `def`, and whether the file's source is read at runtime or by a test.

**Excluded outright**, about 7300 comments left untouched:
- `compiler.py`, `saving_utils.py`, `patching_utils.py`, `vllm_utils.py`, `llama_cpp.py`, `rl_replacements.py`
- everything under `temporary_patches/`, which holds every live rewriter firing and all the `find("def")` dedent sites
- `compile_cache.py`, `tiled_mlp.py`, `hf_xet_tuning.py`: triage found 3 to 6 safe lines each and judged the risk not worth it
- `dataset_utils.sft_prepare_dataset`: its source text is consumed by the `unsloth` repo's RL patcher, which is not in this tree. The function documents this itself at `_ccm = 'create_' + 'causal_mask_mapping'`, code deliberately split to defeat a substring scan

## What went, and what stayed

Removed: section banners (`device_map_planner.py` yielded exactly its six 3-line banners and nothing else), `Step 1` scaffolding, and comments restating the line directly below (`# Binary search on length`, `# Get untrained tokens`, `# Allocate one buffer per GPU`).

Kept: everything naming a failure mode, a model, a library version, a measured number, an errno, an upstream filename, an issue, or a security property. In these modules that is nearly all of them. `hf_xet_fallback.py` yields 1 line out of 467 because its short comments are wrapped continuations of measured-threshold comments. `dataset_utils.py` lines 1138 to 2262, about 400 comments, yield none: they record Fuyu `image_patches_indices`, Gemma 3 `num_crops`, Llama 3.2 Vision `num_tiles`, TRL 0.22.2 and costs like 94 seconds per 100k rows.

The editors also kept 22 lines triage had cleared. Several are the deletion-only rule working as intended: a two-line wrapped comment whose second line carries the fact is all or nothing, since salvaging half needs a reword. Others are semantic: `peft_utils.py:307` sits above a line that clears the hook dict, so it states the opposite of the following statement rather than restating it.

## Deletion only, as a rule

No surviving comment was reworded, rewrapped or re-indented. That makes two hazards unbreakable by construction rather than by care:

- **374 literals** that a test asserts against a module's source and that occur only inside a comment. Reflowing one of those blocks so the literal straddles a line break fails the test with every word retained.
- A package-wide scan in `tests/test_hf_xet_tuning.py` that asserts every *quoted* `HF_XET_*` name is a known variable. Deleting a comment can never trip it; rewording one so an env var name ends up in quotes would.

One specific line worth calling out: `empty_model.py:1154` is `# "model.multi_modal_projector.linear_2",` inside a set literal. It is commented-out data whose text a test asserts on, and a pass that treats commented-out code as deletable would take it. It is untouched.

## Verification against main

- **Codegen unchanged.** No rewriter in `compiler.py` changes its decision across 96 files. Unlike the earlier batches this is not a negative control: these files feed `create_new_function`'s `x in new_source` import filter, a plain substring test over text that includes comments, so deleting the last mention of a symbol would have dropped an import. It is stable over 2335 symbols.
- **All 8 `re.sub` replacement strings byte-identical**, and every comment sentinel intact (`_AITER_MARKER`, `_full_license_header`, the versioning header whose line count is parsed positionally, the `# LM Head` slice anchor and its 800 character window).
- **No code changes.** For all 14 files the non-comment token stream is byte-identical to main, which also proves nothing inside a string literal moved.
- **Comment-only diff** via the in-repo `scripts/verify_comment_only_diff.py`: 14/14 OK.
- **Licence headers** byte-identical in all 14, including the LGPL variant in `hf_cache.py`, which differs from its siblings and was left as is rather than normalised.
- **Lint**: the narrow CI gate reports the same 4 pre-existing errors at base and head (`pack_dataset` in the excluded function, two `__all__` names in `peft_utils.py`); `compileall` and both dynamic-execution linters clean.

## Tests

Base and head measured on the same host and compared file by file:

- `tests/security` (hard gate): 156 passed
- bulk suite: 4877 passed, 105 skipped
- all 51 mlx files, one process each

Identical in every partition. The 4 failures in `test_rl_replacements_compile_disable.py` reproduce on a clean main checkout and that file is untouched.

## What this leaves

The remaining comment volume in `unsloth_zoo/` sits in the codegen-critical files and `temporary_patches/`. Those need a different approach from a comment sweep, since in `temporary_patches/` the length of a comment can decide whether a rewriter fires, so I am not proposing them as a follow-up in this form.