### PR TITLE
Reduce comment volume in unsloth_zoo/temporary_patches/

### DIFF
--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -520,7 +520,6 @@ def patch_Gemma3ForConditionalGeneration_causal_mask():
             causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
             mask_length = attention_mask.shape[-1]
 
-            # Then apply padding mask (will mask pad tokens)
             padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to(causal_mask.device)
             padding_mask = padding_mask == 0
             causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
@@ -848,7 +847,7 @@ def patch_Gemma3Attention():
                 scale = getattr(self, "scaling", None), # Use self.scaling if defined, else SDPA default
                 enable_gqa = getattr(self, "num_key_value_groups", 1) != 1,
             )
-            attn_weights = None # Defaulting to None
+            attn_weights = None
 
         # 7. Reshape and downcast for output projection.
         # SDPA returns (bsz, heads, q_len, head_dim) needing transpose;
@@ -1098,7 +1097,7 @@ def patch_Gemma3Attention_generic():
                 scale = getattr(self, "scaling", None), # Use self.scaling if defined, else SDPA default
                 enable_gqa = getattr(self, "num_key_value_groups", 1) != 1,
             )
-            attn_weights = None # Defaulting to None
+            attn_weights = None
 
         # 7. Reshape and downcast for output projection.
         # SDPA returns (bsz, heads, q_len, head_dim) needing transpose;

--- a/unsloth_zoo/temporary_patches/gemma3n.py
+++ b/unsloth_zoo/temporary_patches/gemma3n.py
@@ -116,14 +116,13 @@ def patch_Gemma3nTextAltUp_predict():
         # permute hidden_states to [batch_size, num_tokens, hidden_size, altup_num_inputs]
         predictions = torch.matmul(hidden_states.permute(1, 2, 3, 0), all_coefs)
         predictions = predictions.permute(3, 0, 1, 2)  # undo the permute
-        predictions += hidden_states  # add the original input
+        predictions += hidden_states
         return predictions.contiguous().type_as(hidden_states)
     pass
     patch_function(transformers.models.gemma3n.modeling_gemma3n.Gemma3nTextAltUp, "predict", predict, fullgraph = True)
 pass
 
 def patch_Gemma3nConv_Embed_forwards():
-    # helper function to patch both forwards
     try:
         patch_Gemma3nConvNormAct_forward()
         patch_Gemma3nMultimodalEmbedder_forward()

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -465,7 +465,6 @@ def _gemma4_force_nonreentrant_checkpointing(model):
             pass
     for layer in layers:
         try:
-            # Only override when this layer is actually being checkpointed.
             if not getattr(layer, "gradient_checkpointing", False):
                 continue
             # Preserve the layer's existing checkpoint kwargs (preserve_rng_state, context_fn,
@@ -999,7 +998,6 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma4TextMLP)
 
 
-# ============================================================================
 # Gemma-4 vision pooler float16 overflow fix (transformers 5.5.0 - 5.9.x and
 # the yanked 5.10.0; fixed upstream in >= 5.10.1 by PR #46277).
 #
@@ -1025,7 +1023,6 @@ TEMPORARY_PATCHES.append(patch_Gemma4TextMLP)
 # release including the yanked 5.10.0: fixed sources skip, unknown (future
 # drift) sources are left untouched, transformers without gemma4 no-ops via
 # ImportError. The pooler runs eager, so no compiler-cache companion is needed.
-# ============================================================================
 
 def _gemma4_vision_pooler_status(pooler_cls):
     """Classify Gemma4VisionPooler.forward source: "buggy" (dtype-preserving

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -498,7 +498,7 @@ def patch_gpt_oss():
                     blocks.device.type != "meta"
                     and scales.device.type != "meta"
                     and blocks.numel() > 0
-                    and blocks.any()  # At least some non-zero values
+                    and blocks.any()
                 )
                 if blocks_valid:
                     # need it for ep
@@ -536,7 +536,6 @@ def patch_gpt_oss():
                         PrecisionConfig(weight_scale=weight_scale, flex_ctx=FlexCtx(rhs_data=InFlexData())),
                     )
 
-                    # delete blocks and scales
                     delattr(module, scales_attr)
                     delattr(module, blocks_attr)
                     # setattr(module, blocks_attr, torch.nn.Parameter(triton_weight_tensor.storage.data, requires_grad=False))
@@ -1191,7 +1190,6 @@ def patch_gpt_oss_bnb4bit():
     except Exception as e:
         return raise_error("transformers.models.gpt_oss.modeling_gpt_oss", e)
 
-    # Store original classes for restoration
     if not hasattr(transformers.models.gpt_oss.modeling_gpt_oss, '_original_GptOssExperts'):
         transformers.models.gpt_oss.modeling_gpt_oss._original_GptOssExperts = \
             transformers.models.gpt_oss.modeling_gpt_oss.GptOssExperts
@@ -1315,7 +1313,6 @@ def _invalidate_gpt_oss_compiled_module():
                         os.remove(_pyc)
                 except Exception:
                     pass
-        # Forget any cached finder/directory state for these paths.
         try:
             importlib.invalidate_caches()
         except Exception:
@@ -1441,7 +1438,6 @@ no_combo_fused_torch_compile_options = get_torch_compile_options(
 @_torch_compile(dynamic=None, fullgraph=True, options=fused_torch_compile_options)
 def moe_forward_inference(self, hidden_states):
     """Torch compile for forward inference path only with CUDAGraphs"""
-    # Router
     router_out = self.router(hidden_states)
     if isinstance(router_out, tuple) and len(router_out) == 3:
         _, router_scores, router_indices = router_out
@@ -2583,7 +2579,6 @@ def patch_GptOssModel():
 
     pass
 
-    # RMSNorm forward
     def rms_layernorm_forward(self, hidden_states):
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
@@ -2940,7 +2935,6 @@ def encode_conversations_with_harmony(
 
     convos = []
 
-    # Create system message
     import datetime
 
     today = datetime.datetime.today().strftime("%Y-%m-%d")
@@ -2954,7 +2948,6 @@ def encode_conversations_with_harmony(
     )
     convos.append(system)
 
-    # Developer message and tool calling
     dev = DeveloperContent.new()
     if developer_instructions is not None: dev = dev.with_instructions(developer_instructions)
     if tool_calls is not None:
@@ -3001,7 +2994,6 @@ def encode_conversations_with_harmony(
             convos.append(x)
     pass
 
-    # Create Harmony conversations
     convos = Conversation.from_messages(convos)
     if add_generation_prompt:
         harmony_input_ids = harmony_encoding.render_conversation_for_completion(convos, Role.ASSISTANT)
@@ -3347,7 +3339,6 @@ def patch_gpt_oss_for_grpo(phase="post_compile"):
             RETURN_HIDDEN_STATES = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
 
             if not RETURN_HIDDEN_STATES:
-                # Normal forward pass
                 return _original_causal_lm_forward(
                     self,
                     input_ids=input_ids,

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -132,7 +132,6 @@ def patch_merge_quantization_configs():
     except Exception as e:
         return raise_error("transformers.quantizers.auto.AutoHfQuantizer.merge_quantization_configs", e)
 
-    # Fast return if already patched
     unique_name = _get_unique_storage_name(transformers.quantizers.auto.AutoHfQuantizer, "merge_quantization_configs")
     if hasattr(transformers.quantizers.auto.AutoHfQuantizer, unique_name): return
 
@@ -149,7 +148,6 @@ def patch_merge_quantization_configs():
 
     exec("from transformers.quantizers.auto import (" + ",".join(x for x in items if x in source) + ")", globals())
     source = dedent(source)
-    # Remove cls if classmethod
     is_classmethod = source.startswith("@classmethod")
     source = source[source.find("def"):]
     if is_classmethod:
@@ -348,7 +346,6 @@ def patch_CsmForConditionalGeneration_forward():
         depth_decoder_loss = None
         depth_decoder_outputs = None
         if labels is not None:
-            # select first codebook as labels for the backbone model
             backbone_labels = labels[:, :, 0]
             backbone_loss = self.loss_function(
                 logits=backbone_logits, labels=backbone_labels, vocab_size=self.config.vocab_size, **kwargs
@@ -961,7 +958,7 @@ def patch_causal_conv1d_cuda_probe():
     pass
 
     if causal_conv1d_fn is None:
-        return  # Already nullified
+        return
     pass
 
     if not torch.cuda.is_available():
@@ -1790,11 +1787,9 @@ def patch_trl_vision_model_mapping():
         import transformers.models.auto.modeling_auto as auto_mod
     except ImportError:
         return
-    # If the old name already exists and is populated, nothing to do
     existing = getattr(auto_mod, "MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES", None)
     if existing is not None and len(existing) > 0:
         return
-    # Inject the old name as alias of the new name
     new_mapping = getattr(auto_mod, "MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES", None)
     if new_mapping is not None:
         auto_mod.MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES = new_mapping
@@ -1909,7 +1904,6 @@ def patch_qwen2vl_image_processor_pixel_attrs():
     except ImportError:
         return
 
-    # Only add shims if not already present as a class-level descriptor
     if not isinstance(Qwen2VLImageProcessor.__dict__.get("max_pixels"), property):
         @property
         def _max_pixels(self):

--- a/unsloth_zoo/temporary_patches/moe_bnb.py
+++ b/unsloth_zoo/temporary_patches/moe_bnb.py
@@ -245,7 +245,6 @@ class MoeExperts4bit(nn.Module):
             current_hidden_states = self.act_fn(gate) * up
             current_hidden_states = self._matmul_4bit(current_hidden_states, down_weight)
 
-            # Apply routing weights and scatter back
             current_hidden_states = current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
             final_hidden_states.index_add_(
                 0, token_idx, current_hidden_states
@@ -274,7 +273,6 @@ class MoeExperts4bit(nn.Module):
                 down_4bit.data if keep_vars else down_4bit.data.detach()
             )
 
-            # Save quant state components
             if hasattr(gate_up_4bit, 'quant_state') and gate_up_4bit.quant_state is not None:
                 for k, v in gate_up_4bit.quant_state.as_dict(packed=True).items():
                     destination[f"{gate_up_prefix}weight.{k}"] = v if keep_vars else v.detach()
@@ -309,7 +307,6 @@ def replace_with_bnb_moe_experts(
 
     has_been_replaced = False
 
-    # Default quantization settings
     compute_dtype = torch.bfloat16
     compress_statistics = True
     quant_type = "nf4"
@@ -321,13 +318,12 @@ def replace_with_bnb_moe_experts(
         quant_type = getattr(quantization_config, 'bnb_4bit_quant_type', 'nf4')
         quant_storage = getattr(quantization_config, 'bnb_4bit_quant_storage', torch.uint8)
 
-    # Find all MoE expert modules
     for module_name, module in list(model.named_modules()):
         if hasattr(module, 'experts') and hasattr(module.experts, 'gate_up_proj'):
             experts = module.experts
 
             if getattr(experts, '_is_bnb_4bit', False):
-                continue  # already quantized
+                continue
 
             gate_up_proj = experts.gate_up_proj
             num_experts = gate_up_proj.shape[0]
@@ -404,7 +400,6 @@ def quantize_moe_experts_inplace(model: nn.Module, verbose: bool = True) -> int:
             if verbose:
                 print(f"Unsloth: Quantizing {name}.experts to 4-bit...")
 
-            # Create new quantized module and copy weights
             new_experts = quantized_cls(
                 num_experts=experts.gate_up_proj.shape[0],
                 hidden_dim=experts.gate_up_proj.shape[2],

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1731,7 +1731,6 @@ def forward_native_grouped_mm(
         gate = _grouped_mm_with_backward_fix(permuted_input, w1, offsets)
         up = _grouped_mm_with_backward_fix(permuted_input, w3, offsets)
 
-        # Add LoRA for w1 and w3 separately if present.
         if use_separated_lora:
             if _has_lora_adapters(self.w1):
                 w1_lora = _extract_lora_weights(self.w1, experts_module=self)
@@ -1759,7 +1758,6 @@ def forward_native_grouped_mm(
     else:
         raise AttributeError("MoE layer must have 'gate_up_proj' or 'w1'/'w3'.")
 
-    # Activation
     if "GptOssExperts" in self.__class__.__name__:
         # Custom GptOss activation.
         limit = getattr(self, "limit", 7.0)
@@ -1845,7 +1843,6 @@ def forward_native_grouped_mm(
             try:
                 lora_delta = _grouped_mm_with_backward_fix(lora_out, second_weight, offsets)
             except RuntimeError:
-                # Manual loop fallback.
                 lora_delta = torch.empty(
                     (lora_out.shape[0], second_weight.shape[-1]),
                     dtype=lora_out.dtype,
@@ -1885,7 +1882,6 @@ def forward_native_grouped_mm(
     else:
         raise AttributeError("MoE layer must have 'down_proj' or 'w2'.")
 
-    # Apply routing weights and scatter-add (reduce).
     if _gategrad:
         # Gate grad comes from the identity; detach so the multiply does not pin Y.
         mm2_out = mm2_out * permuted_weights.detach().unsqueeze(-1)
@@ -1957,7 +1953,6 @@ def forward_triton_grouped_gemm(
     if self._unsloth_moe_configs is None:
         intermediate_dim = self.gate_up_proj.shape[1] // 2
 
-        # Autotune first GEMM.
         gemm1_configs = get_or_autotune_moe_kernels(
             num_experts=self.num_experts,
             hidden_dim=hidden_dim,
@@ -1992,7 +1987,6 @@ def forward_triton_grouped_gemm(
     else:
         w1 = self.gate_up_proj.transpose(-2, -1).contiguous()
 
-    # First grouped GEMM: gate_up projection.
     first_gemm_output = grouped_gemm(
         X=hidden_states,
         W=w1,
@@ -2026,14 +2020,12 @@ def forward_triton_grouped_gemm(
         )
         first_gemm_output = first_gemm_output + gate_up_lora_delta
 
-    # Activation + gate*up.
     if hasattr(self, 'act_fn') and callable(self.act_fn):
         gate, up = first_gemm_output.chunk(2, dim=-1)
         intermediate = self.act_fn(gate) * up
     else:
         intermediate = _silu_and_mul(first_gemm_output)
 
-    # Grouped GEMM 2: down projection.
     down_lora = None
     if getattr(self, "_unsloth_lora_down_proj", None) is not None:
         down_lora = self._unsloth_lora_down_proj[:3]
@@ -2148,7 +2140,6 @@ def forward_native_moe_loop(
             _down_scaling,
         )
 
-    # Expert mask -> which experts have tokens.
     with torch.no_grad():
         expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts)
         expert_mask = expert_mask.permute(2, 1, 0)  # (num_experts, top_k, n_tokens)
@@ -2202,7 +2193,6 @@ def forward_native_moe_loop(
         else:
             current_hidden_states = F.silu(gate) * up
 
-        # down projection for this expert.
         if hasattr(self, "down_proj"):
             down_weight = self.down_proj[expert_idx]
             # Mirror gate_up: prefer the flag over the shape heuristic (unsafe at square dims).

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -60,9 +60,7 @@ __all__ = [
 ]
 
 
-# ============================================================================
 # Detection
-# ============================================================================
 
 def _is_bnb4bit_param(param) -> bool:
     """True iff `param` is a Params4bit with a populated quant_state."""
@@ -92,9 +90,7 @@ def _is_expert_module(module: nn.Module) -> bool:
     )
 
 
-# ============================================================================
 # Dequantization
-# ============================================================================
 
 def _dequantize_bnb4bit_expert_weights(weight, target_dtype: torch.dtype):
     """Dequantize a packed Params4bit MoE expert to its logical 3D shape at
@@ -109,9 +105,7 @@ def _dequantize_bnb4bit_expert_weights(weight, target_dtype: torch.dtype):
     return dequant.to(target_dtype)
 
 
-# ============================================================================
 # Forward dispatcher
-# ============================================================================
 
 _LOGGED_BACKENDS = set()
 

--- a/unsloth_zoo/temporary_patches/moe_utils_fp8.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_fp8.py
@@ -792,12 +792,10 @@ def forward_moe_backend_fp8(self, hidden_states, top_k_index, top_k_weights):
     return _forward_native_fp8_expert_loop(self, hidden_states, top_k_index, top_k_weights)
 
 
-# ============================================================================
 # Save-side hooks: dequant base FP8 weights before LoRA merge, requant after.
 # saving_utils.py consults `_MOE_QUANT_HANDLERS` for every expert weight key
 # it reads, so the FP8 plumbing stays local to this file instead of polluting
 # the generic save path.
-# ============================================================================
 
 # FP8 e4m3 max representable magnitude — matches transformers' Fp8Quantize.convert
 # (finegrained_fp8.py:838-859) and compressed-tensors' fp8 encode path.
@@ -965,10 +963,7 @@ def apply_moe_quant_load(file, header_metadata, key, block_size = None):
     return file.get_tensor(key), None
 
 
-# ============================================================================
 # Hook FP8 experts dispatch + relax HF Trainer FP8 guard
-# ============================================================================
-#
 # transformers swaps a model's experts class with FP8Experts at load time when
 # the checkpoint is FP8 (compressed-tensors / finegrained_fp8). The per-arch
 # patch (patch_qwen3_moe etc.) targets the original Qwen3MoeExperts class, so

--- a/unsloth_zoo/temporary_patches/mxfp4.py
+++ b/unsloth_zoo/temporary_patches/mxfp4.py
@@ -111,7 +111,6 @@ def patch_convert_moe_packed_tensors():
         rows_per_chunk: int = 32768 * 1024,
     ) -> torch.Tensor:
         """Dequantize mxfp4 weights into GPT_OSS-compatible form (GPU path)."""
-        # Move CPU tensors to GPU if available.
         if not blocks.is_cuda and torch.cuda.is_available():
             blocks = blocks.cuda()
             scales = scales.cuda()
@@ -275,7 +274,6 @@ def patch_convert_moe_packed_tensors():
         rows_per_chunk default 1M rows; per-chunk memory at B=128: 8192 ~22 MB,
         1M ~2.6 GB, 32M ~90 GB.
         """
-        # Force tensors onto CPU.
         if blocks.is_cuda:
             blocks = blocks.cpu()
         if scales.is_cuda:

--- a/unsloth_zoo/temporary_patches/qwen3_vl_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_vl_moe.py
@@ -104,7 +104,6 @@ def patch_qwen3_vl_moe():
                 device=hidden_states.device,
             )
 
-            # One-hot encode selected experts into an expert mask
             expert_mask = torch.nn.functional.one_hot(
                 selected_experts, num_classes=self.num_experts
             ).permute(2, 1, 0)
@@ -159,7 +158,6 @@ def patch_qwen3_vl_moe():
                 device=hidden_states.device,
             )
 
-            # Loop over all available experts
             for expert_idx in range(self.num_experts):
                 expert_layer = self.experts[expert_idx]
                 token_idx, _ = torch.where(selected_experts == expert_idx)
@@ -376,7 +374,6 @@ def patch_qwen3_vl_moe():
             )
 
             if not RETURN_HIDDEN_STATES:
-                # Normal forward pass
                 return _original_causal_lm_forward(
                     self,
                     input_ids=input_ids,

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -60,7 +60,6 @@ from .common import UNSLOTH_ENABLE_LOGGING, UNSLOTH_COMPILE_DISABLE, torch_compi
 EMPTY = inspect._empty
 
 def raise_error(f: str, exception: Any = None):
-    # Raises error only if logging is on
     if UNSLOTH_ENABLE_LOGGING:
         logger.error(
             f"==================\n"\
@@ -86,7 +85,6 @@ def process_return(
             return_dict = {key : return_dict[key] for key in chosen_keys}
         return output_class(**return_dict)
     except:
-        # We inspect the argument then only allow those arguments
         return_dict_keys = return_dict.keys()
         allowed_keys = set(inspect.signature(output_class).parameters.keys())
         chosen_keys  = allowed_keys & return_dict_keys
@@ -389,7 +387,6 @@ def process_output_options(
     output_hidden_states = (
         output_hidden_states if output_hidden_states is not None else getattr(self.config, "output_hidden_states", False)
     )
-    # Move to kwargs
     kwargs["output_attentions"]    = output_attentions
     kwargs["output_hidden_states"] = output_hidden_states
     return kwargs
@@ -448,7 +445,6 @@ except:
         )
 pass
 
-# Get Cache
 Cache = t.Any
 try: from transformers.cache_utils import Cache
 except: pass
@@ -586,7 +582,6 @@ def get_function_fingerprint(func: Callable) -> List[Dict[str, Any]]:
         param_kind = param.kind.value # 4 is type VAR_KEYWORD **kwargs
         annotation = param.annotation
 
-        # Canonicalize any **kwargs name to "kwargs".
         if "kwargs" in param_name.lower():
             param_name = "kwargs"
             # Default the annotation when untyped.
@@ -607,7 +602,7 @@ def get_function_fingerprint(func: Callable) -> List[Dict[str, Any]]:
         fingerprint.append({
             'name': param_name,
             'kind': param_kind,
-            'is_required': param.default is EMPTY, # True = required
+            'is_required': param.default is EMPTY,
             'annotation' : canonicalize_annotation(annotation),
         })
     return fingerprint
@@ -703,7 +698,6 @@ def can_safely_patch(
         if new_param['is_required'] and not old_param['is_required']:
             return False, f"Parameter '{new_param['name']}' changed from optional to required"
 
-        # Strict matching also compares type annotations.
         if match_level == "strict" and old_param['annotation'] != new_param['annotation']:
             return False, \
             f"Parameter '{old_param['name']}' type annotation changed from:\n"\
@@ -2188,7 +2182,6 @@ def patch_function(
 
     original_func = getattr(target_obj, attr_name)
 
-    # torch.compile if requested.
     if fullgraph is not None and type(fullgraph) is bool and not UNSLOTH_COMPILE_DISABLE:
         # Unwrap already-compiled functions. The shared helper rather than a
         # bare `.__wrapped__`: a carrier without one (an `OptimizedModule`, say)
@@ -2286,7 +2279,6 @@ def patch_function_past_key_values(
         except Exception as e:
             error = str(e)
             continue
-        # Check if either is provided
         for key in ("past_key_value", "past_key_values",):
             if key in new_keys and key in old_keys:
                 try:


### PR DESCRIPTION
## Summary

Removes 66 comment lines and 7 trailing comments across 12 files in `unsloth_zoo/temporary_patches/` (2,030 to 1,964 comments). The yield is deliberately small: these files are recompiled by compiler.py at runtime and most of their comments carry dtype, shape, version, or failure-mode evidence. What goes is restatements (`# Router`, `# Store original classes for restoration`, `# Move CPU tensors to GPU if available.`) and bare separator rules around section titles; the titles themselves stay.

Files touched: gemma.py, gemma3n.py, gemma4.py, gpt_oss.py, misc.py, moe_bnb.py, moe_utils.py, moe_utils_bnb4bit.py, moe_utils_fp8.py, mxfp4.py, qwen3_vl_moe.py, utils.py. Untouched on purpose: ministral.py (its comment length decides whether the attention dtype rewriter fires), the verbatim upstream mirrors in misc.py, `Old_GptOssConfig` in gpt_oss.py (compared byte-exact to upstream at runtime), and the 23 files where triage found nothing safe.

## Why this needed more care than the earlier batches

This module rewrites Python source at runtime, so a comment is not automatically inert: several finders anchor on consecutive lines or read a fixed character window, comments inside string literals are emitted into generated modules, and a number of comment lines are asserted by tests against the module source. Before any edit, every comment in the codegen-critical set (compiler.py, saving_utils.py, temporary_patches/, 4,751 comments in total) was deleted one at a time, and then all at once per file, and all five compiler.py rewriters (higher precision softmax, higher precision layernorms, attention dtype consistency, residual stream, AMD aiter SDPA) were rerun and their decisions compared to the unmodified file. Exactly two comment lines change a rewriter decision, both in temporary_patches/ministral.py, and both are untouched.

Excluded from the pass, by construction:

- test-asserted literals whose only occurrence in the module is a comment line
- comments inside string literals (re.sub replacement bodies, emitted licence and versioning headers, generated helper source)
- the idempotency sentinels (`_AITER_MARKER`, `_full_license_header`) and the positionally parsed versioning header
- licence headers and the in-function `All Unsloth Zoo code licensed under LGPLv3` and `licensed under AGPL3` markers
- class bodies read back with `inspect.getsource` and compared to upstream, and verbatim upstream mirrors
- commented-out code, numbered step series that other comments refer to, and anything naming a model, version, symbol, number, or failure mode

Edits are deletion only: a whole comment line is removed, or a trailing comment is stripped leaving the code bytes unchanged. No surviving comment was reworded or rewrapped.

## Verification

| Check | Result |
|---|---|
| `scripts/verify_comment_only_diff.py --base origin/main` | OK, AST identical after docstring strip |
| Token stream (comments and layout tokens dropped) vs main | identical |
| Generated-module snapshot over 96 files | 0 differences |
| Rewriter decisions vs main, fixpoint on a second pass, import selection over 2,335 symbols, 8 re.sub replacement strings | 0 changes |
| Sentinels and frozen test anchors | 9 of 9 intact |
| Comments containing `def` above a def or class | 0 new |
| Licence headers | byte-identical |
| `tests/security` | 156 passed |
| Full CPU suite excluding mlx | 4 failed, 4877 passed, 105 skipped, the same 4 pre-existing failures as main |

The suite numbers above are for all three codegen-critical PRs applied together; the three touch disjoint files.
