### PR TITLE
MLX: score every TRL DPO loss_type and report the preference metric set

### DIFF
--- a/tests/mlx_simulation/mlx_stub.py
+++ b/tests/mlx_simulation/mlx_stub.py
@@ -497,6 +497,7 @@ def argmin(a, axis=None, keepdims=False, **kw):
     return torch.argmin(a, dim=axis, keepdim=keepdims) if axis is not None else torch.argmin(a)
 
 
+def sort(a, axis=-1, **kw): return torch.sort(a, dim=axis).values
 def argsort(a, axis=-1, **kw): return torch.argsort(a, dim=axis)
 
 

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -160,7 +160,8 @@ class TemplateScriptTokenizer(Tokenizer):
 
 def rows(count=6):
     return [
-        {"prompt": f"question {index}: ", "chosen": "yes", "rejected": "no"}
+        {"prompt": f"question {index}: ",
+         "chosen": f"yes{index}", "rejected": f"no{index}"}
         for index in range(count)
     ]
 
@@ -176,14 +177,15 @@ def policy(kind="dpo", **kwargs):
     return PreferenceLengthPolicy(kind=kind, **options)
 
 
-def build_plan(**kwargs):
+def build_plan(dataset=None, **kwargs):
     from unsloth_zoo.mlx.preference import create_preference_batch_plan
     options = dict(
         batch_size=2, length_policy=policy(), dataset_order="sequential",
         grad_accum=2,
     )
     options.update(kwargs)
-    return create_preference_batch_plan(rows(), Tokenizer(), **options)
+    return create_preference_batch_plan(
+        rows() if dataset is None else dataset, Tokenizer(), **options)
 
 
 def test_configs_are_objective_specific_and_keyword_only():
@@ -192,6 +194,9 @@ def test_configs_are_objective_specific_and_keyword_only():
     assert not hasattr(MLXTrainingConfig(), "beta")
     assert MLXORPOConfig(beta=0.2).beta == 0.2
     assert MLXDPOConfig(beta=0.3, label_smoothing=0.1).reference_free is False
+    default = MLXDPOConfig()
+    assert (default.loss_type, default.loss_weights, default.discopop_tau) == (
+        "sigmoid", None, 0.05)
     with pytest.raises(TypeError):
         MLXORPOConfig(*([None] * 100))
 
@@ -764,7 +769,8 @@ class TinyModel:
 
 @pytest.mark.parametrize("objective", ["orpo", "dpo"])
 def test_microbatch_loss_matches_one_logical_batch(objective):
-    from unsloth_zoo.mlx.preference import make_dpo_loss_fn, make_orpo_loss_fn
+    from unsloth_zoo.mlx.preference import (
+        make_dpo_loss_fn, make_orpo_loss_fn, resolve_preference_objective)
 
     dataset = rows(3)
     from unsloth_zoo.mlx.preference import create_preference_batch_plan
@@ -777,10 +783,12 @@ def test_microbatch_loss_matches_one_logical_batch(objective):
         num_batches=1, grad_accum=1, dataset_order="sequential",
     )
     model = TinyModel()
+    resolved_objective = resolve_preference_objective(
+        objective, beta=0.1, reference_free=True)
     loss_fn = (
-        make_orpo_loss_fn(beta=0.1)
+        make_orpo_loss_fn(resolved_objective)
         if objective == "orpo"
-        else make_dpo_loss_fn(beta=0.1, reference_free=True)
+        else make_dpo_loss_fn(resolved_objective)
     )
     micro_value = sum(float(loss_fn(model, *micro[index])[0]) for index in range(2)) / 2
     whole_value = float(loss_fn(model, *whole[0])[0])
@@ -815,10 +823,236 @@ def test_dpo_label_smoothing_matches_conservative_formula():
         + epsilon * preference._log_sigmoid(-logits)
     ).mean()
     actual, weight, _stats = preference.make_dpo_loss_fn(
-        beta=beta, label_smoothing=epsilon, reference_free=True,
+        preference.resolve_preference_objective(
+            "dpo", beta=beta, label_smoothing=epsilon, reference_free=True),
     )(model, batch, lengths, normalizers)
     assert float(actual) == pytest.approx(float(expected), rel=1e-6)
     assert int(weight) == 1
+
+
+# What TRL 0.23.1's own dpo_loss returns for these pairs at beta 0.3 and
+# discopop_tau 0.2, smoothing 0.15 wherever the variant reads it -- run from its
+# source, not transcribed. The fourth pair carries the difference past 1 / beta
+# where hinge clamps; the first three sort differently from their order.
+_DPO_FIXTURE = dict(
+    chosen=[-1.0, -2.5, -0.4, -0.2], rejected=[-1.8, -0.6, -2.2, -3.6],
+    ref_chosen=[-1.3, -2.0, -0.9, -2.4], ref_rejected=[-1.1, -1.4, -2.6, -1.9],
+)
+_TRL_PAIR_LOSSES = {
+    "sigmoid": (0.5993552, 0.8485404, 0.6827597, 0.4458072),
+    "robust": (0.4900695, 0.9906118, 0.6718311, 0.0195929),
+    "exo_pair": (0.2186689, 0.5223414, 0.3237762, 0.0259403),
+    "hinge": (0.7, 1.39, 0.97, 0.0),
+    "ipo": (0.4444444, 8.8011111, 2.4544444, 4.9877778),
+    "sppo_hard": (2.8022222, 10.7788889, 5.6322222, 0.2855556),
+    "nca_pair": (1.3155638, 1.4916006, 1.3839086, 1.1901117),
+    "aot_pair": (0.5832604, 0.5993552, 0.6827597, 0.568037),
+    "aot": (0.8485404, 0.5755404, 0.527488, 0.5468133),
+    "apo_zero": (0.9252073, 1.0971435, 0.9925342, 0.7159331),
+    "apo_down": (0.9480423, 1.0588529, 1.0299304, 0.8961154),
+    "discopop": (0.7068026, 0.9780284, 0.8352891, 0.3102519),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_TRL_PAIR_LOSSES))
+def test_each_dpo_variant_matches_the_trl_formula(name):
+    import mlx.core as mx
+    from unsloth_zoo.mlx import preference
+
+    assert set(preference._DPO_VARIANTS) == set(_TRL_PAIR_LOSSES)
+    # TRL warns for a narrower set than the one that drops the value.
+    assert "discopop" not in preference._DPO_SMOOTHING_WARNINGS
+    objective = preference.resolve_preference_objective(
+        "dpo", beta=0.3, loss_type=name, discopop_tau=0.2,
+        label_smoothing=(
+            0.0 if name in preference._DPO_SMOOTHING_WARNINGS else 0.15),
+    )
+    arrays = {key: mx.array(value, dtype=mx.float32)
+              for key, value in _DPO_FIXTURE.items()}
+    scored = preference._dpo_pair_loss(objective, preference._DPOTerms(
+        chosen_ratio=arrays["chosen"] - arrays["ref_chosen"],
+        rejected_ratio=arrays["rejected"] - arrays["ref_rejected"],
+        delta=(arrays["chosen"] - arrays["rejected"])
+        - (arrays["ref_chosen"] - arrays["ref_rejected"]), **arrays))
+    assert scored.tolist() == pytest.approx(_TRL_PAIR_LOSSES[name], rel=1e-5)
+
+
+def test_an_objective_is_valid_however_it_was_built():
+    """The invariants belong to the type, so a caller past the resolver still
+    cannot hold an objective its loss would score wrongly."""
+    import dataclasses
+    from unsloth_zoo.mlx.preference import (
+        PreferenceObjective, make_dpo_loss_fn, make_orpo_loss_fn,
+        make_preference_eval_fn, resolve_preference_objective)
+
+    for kind, options, match in (
+        ("cpo", {}, "unknown objective kind"),
+        ("dpo", dict(loss_types=("bco_pair",)), "running mean"),
+        ("dpo", dict(loss_types=("kto_pair",)), "removed it"),
+        ("dpo", dict(loss_types=("sigmoidal",)), "unknown loss_type"),
+        ("dpo", dict(loss_types=(), weights=()), "at least one"),
+        ("dpo", dict(loss_types=["sigmoid", "hinge"], weights=[1.0]),
+         "same length"),
+        ("dpo", dict(loss_types=("sigmoid", "hinge"),
+                     weights=(1.0, float("nan"))), "must all be finite"),
+        ("dpo", dict(beta=float("inf")), "finite and non-negative"),
+        ("orpo", dict(beta=-1.0), "finite and non-negative"),
+        ("dpo", dict(label_smoothing=0.5), r"\[0, 0.5\)"),
+        ("dpo", dict(loss_types=("discopop",), discopop_tau=0.0),
+         "discopop_tau"),
+        ("dpo", dict(loss_types=("aot",), reference_free=True),
+         "reference_free never computes"),
+    ):
+        with pytest.raises(ValueError, match=match):
+            PreferenceObjective(kind=kind, **{"beta": 0.1, **options})
+    with pytest.raises(ValueError, match="unknown objective kind"):
+        resolve_preference_objective("cpo", beta=0.1)
+
+    # A bound binds only where a loss reads the value, and exo_pair's
+    # log(smoothing) has no zero wherever it is named.
+    kept = PreferenceObjective(
+        kind="dpo", beta=0.1, loss_types=["sigmoid", "exo_pair"],
+        weights=[0.0, -1.0], discopop_tau=0.0)
+    assert (kept.loss_types, kept.weights, kept.discopop_tau) == (
+        ("sigmoid", "exo_pair"), (0.0, -1.0), 0.0)
+    assert kept.label_smoothing == pytest.approx(1e-3)
+    assert PreferenceObjective(
+        kind="orpo", beta=0.1, label_smoothing=0.5).label_smoothing == 0.5
+    assert {f.name for f in dataclasses.fields(PreferenceObjective)} == {
+        "kind", "beta", "label_smoothing", "loss_types", "weights",
+        "discopop_tau", "reference_free"}
+
+    # Each factory takes its own kind, so ORPO may carry DPO fields it ignores.
+    dpo = resolve_preference_objective("dpo", beta=0.1)
+    assert (dpo.loss_types, dpo.weights, dpo.label_smoothing) == (
+        ("sigmoid",), (1.0,), 0.0)
+    for build, wrong in ((make_dpo_loss_fn, "orpo"), (make_orpo_loss_fn, "dpo")):
+        with pytest.raises(ValueError, match="objective of kind"):
+            build(resolve_preference_objective(wrong, beta=0.1))
+    for build in (make_dpo_loss_fn, make_preference_eval_fn):
+        with pytest.raises(ValueError, match="scores against a reference"):
+            build(dpo)
+        assert build(dpo, reference_policy=object()) is not None
+
+
+def _ordered(rewards, weights):
+    """TRL's accumulation: one weighted copy of the rewards per list entry."""
+    total = rewards * weights[0]
+    for weight in weights[1:]:
+        total = total + rewards * weight
+    return total
+
+
+def _assert_reported_stats(kind, stats, expected, counts, over):
+    """Every reported slot against a value recomputed here, then the counts it
+    is divided by -- both their totals and which one each metric names."""
+    from unsloth_zoo.mlx import preference
+
+    names = preference.PREFERENCE_EVAL_METRICS[kind]
+    for metric, value in expected.items():
+        assert float(stats[names.index(metric)]) == pytest.approx(
+            float(value), rel=1e-5), metric
+    assert [float(stats[len(names) + at]) for at in range(len(counts))] == [
+        pytest.approx(float(value)) for value in counts]
+    named = preference._PREFERENCE_DENOMINATOR_NAMES[kind]
+    at = preference.PREFERENCE_EVAL_DENOMINATORS[kind]
+    assert {name: named[at[index] - len(names)]
+            for index, name in enumerate(names)} == over
+
+
+def test_the_training_loss_and_its_reported_metrics_follow_the_objective():
+    """The closure scores the named variants at their weights on the ratios TRL
+    derives, accumulates rewards once per entry as TRL does, and named ipo
+    divides policy and reference alike before any variant runs."""
+    import mlx.core as mx
+    from unsloth_zoo.mlx import preference
+
+    # Rows of unlike length, so a count taken from the first row and scaled by
+    # the row count is not the count these rows carry.
+    batch, lengths, normalizers = build_plan([
+        {"prompt": f"question {index}: ", "chosen": "yes " * (index + 1),
+         "rejected": "no " * (2 - index)} for index in range(2)],
+        num_batches=1, grad_accum=1)[0]
+    model = TinyModel()
+    beta, weights = 0.3, [0.1, 0.2, -0.3]
+    pairs = batch.shape[0] // 2
+    # A reference far enough above one pair's rejected row and the other's
+    # chosen row that the two pairs order oppositely whatever the model scores,
+    # which is what the accuracy count below is read against.
+    held = mx.array([0.0, 60.0, 60.0, 0.0])
+    policy = types.SimpleNamespace(forward=lambda *_a: held)
+    resolve = preference.resolve_preference_objective
+    objective = resolve(
+        "dpo", beta=beta, loss_type=["hinge", "apo_down", "sigmoid"],
+        loss_weights=weights)
+    actual, weight, stats = preference.make_dpo_loss_fn(
+        objective, reference_policy=policy)(model, batch, lengths, normalizers)
+
+    logps = preference._response_logps(model, batch, lengths)
+    chosen, rejected = logps[:pairs], logps[pairs:]
+    ref_chosen, ref_rejected = held[:pairs], held[pairs:]
+    terms = preference._DPOTerms(
+        chosen=chosen, rejected=rejected, ref_chosen=ref_chosen,
+        ref_rejected=ref_rejected, chosen_ratio=chosen - ref_chosen,
+        rejected_ratio=rejected - ref_rejected,
+        delta=(chosen - rejected) - (ref_chosen - ref_rejected))
+    expected = None
+    for name, entry in zip(objective.loss_types, weights):
+        term = preference._DPO_VARIANTS[name](objective, terms) * entry
+        expected = term if expected is None else expected + term
+    assert float(actual) == pytest.approx(float(expected.mean()), rel=1e-6)
+    assert int(weight) == 1
+    assert resolve("dpo", beta=beta,
+                   loss_type=["hinge", "sigmoid"]).weights == (1.0, 1.0)
+
+    # These weights cancel, separating TRL's per-entry copies from one copy
+    # scaled by their sum.
+    reward_chosen = _ordered(beta * (chosen - ref_chosen), weights)
+    reward_rejected = _ordered(beta * (rejected - ref_rejected), weights)
+    logits, _ce, mask = preference._preference_forward(model, batch, lengths)
+    rows, vocab = logits.astype(mx.float32).sum(axis=-1), logits.shape[-1]
+    _assert_reported_stats("dpo", stats, {
+        "rewards/chosen": reward_chosen.sum(),
+        "rewards/rejected": reward_rejected.sum(),
+        "rewards/accuracies": (reward_chosen > reward_rejected).sum(),
+        "rewards/margins": (reward_chosen - reward_rejected).sum(),
+        "logps/chosen": chosen.sum(), "logps/rejected": rejected.sum(),
+        "logits/chosen": (rows[:pairs] * mask[:pairs]).sum(),
+        "logits/rejected": (rows[pairs:] * mask[pairs:]).sum(),
+    }, (mask[:pairs].sum() * vocab, mask[pairs:].sum() * vocab, pairs), {
+        "logits/chosen": "chosen_logits", "logits/rejected": "rejected_logits",
+        **{name: "pairs" for name in preference.PREFERENCE_EVAL_METRICS["dpo"]
+           if not name.startswith("logits/")}})
+    for at, side, reference in ((0, chosen, ref_chosen), (1, rejected, ref_rejected)):
+        assert float(stats[at]) != float(
+            (beta * (side - reference) * sum(weights)).sum()), at
+
+    free = resolve("dpo", beta=beta, loss_type=["sigmoid", "ipo"],
+                   reference_free=True)
+    _terms, free_stats = preference._dpo_scores(
+        model, batch, lengths, free, reference_policy=policy)
+    counts = mx.maximum(mask.sum(axis=1), mx.array(1.0))
+    assert float(free_stats[0]) == pytest.approx(float(_ordered(
+        beta * logps[:pairs] / counts[:pairs], (1.0, 1.0)).sum()), rel=1e-6)
+
+    scored, ipo_stats = preference._dpo_scores(
+        model, batch, lengths,
+        resolve("dpo", beta=beta, loss_type=["sigmoid", "ipo"]),
+        reference_policy=policy)
+    scaled, reference = logps / counts, held / counts
+    for got, want in ((scored.chosen, scaled[:pairs]),
+                      (scored.rejected, scaled[pairs:]),
+                      (scored.ref_chosen, reference[:pairs]),
+                      (scored.ref_rejected, reference[pairs:]),
+                      (scored.chosen_ratio, scaled[:pairs] - reference[:pairs]),
+                      (scored.rejected_ratio, scaled[pairs:] - reference[pairs:]),
+                      (scored.delta, (scaled[:pairs] - scaled[pairs:])
+                       - (reference[:pairs] - reference[pairs:]))):
+        assert got.tolist() == pytest.approx(want.tolist(), rel=1e-6)
+    won = [bool(a > b) for a, b in zip(
+        (scored.chosen_ratio).tolist(), (scored.rejected_ratio).tolist())]
+    assert sorted(won) == [False, True]
+    assert float(ipo_stats[2]) == float(sum(won))
 
 
 def test_orpo_nll_covers_the_full_chosen_sequence():
@@ -849,10 +1083,33 @@ def test_orpo_nll_covers_the_full_chosen_sequence():
     response_nll = (
         ce[:pairs] * response_mask[:pairs]
     ).sum() / response_mask[:pairs].sum()
-    actual, _weight, _stats = preference.make_orpo_loss_fn(beta)(
+    actual, _weight, stats = preference.make_orpo_loss_fn(
+        preference.resolve_preference_objective("orpo", beta=beta))(
         model, batch, lengths, normalizers,
     )
     assert float(actual) == pytest.approx(float(full_nll + beta * odds), rel=1e-6)
+
+    chosen_lp, rejected_lp = response_logp[:pairs], response_logp[pairs:]
+    # TRL's odds, written out rather than taken from the helper under test.
+    odds_of = lambda logp: logp - mx.log(1.0 - mx.exp(logp))
+    log_odds = odds_of(chosen_lp) - odds_of(rejected_lp)
+    raw = preference._model_logits(model(batch[:, :-1]))
+    rows, half = raw.astype(mx.float32).sum(axis=-1), math.prod(raw.shape) // 2
+    _assert_reported_stats("orpo", stats, {
+        "rewards/chosen": beta * chosen_lp.sum(),
+        "rewards/rejected": beta * rejected_lp.sum(),
+        "rewards/accuracies": (chosen_lp > rejected_lp).sum(),
+        "rewards/margins": beta * (chosen_lp - rejected_lp).sum(),
+        "logps/chosen": chosen_lp.sum(), "logps/rejected": rejected_lp.sum(),
+        "logits/chosen": rows[:pairs].sum(), "logits/rejected": rows[pairs:].sum(),
+        "nll_loss": (ce[:pairs] * full_mask).sum(),
+        "log_odds_ratio": -mx.log1p(mx.exp(-log_odds)).sum(),
+        "log_odds_chosen": log_odds.sum(),
+    }, (half, half, full_mask.sum(), pairs), {
+        "logits/chosen": "chosen_logits", "logits/rejected": "rejected_logits",
+        "nll_loss": "nll_tokens",
+        **{name: "pairs" for name in preference.PREFERENCE_EVAL_METRICS["orpo"]
+           if not name.startswith("logits/") and name != "nll_loss"}})
     assert not math.isclose(
         float(actual), float(response_nll + beta * odds), rel_tol=1e-4,
     )
@@ -1137,6 +1394,68 @@ def test_preference_trainer_runs_through_shared_training_loop(
     assert result["trained_tokens"] > 0
 
 
+def _window_mean(model, plan, indices, metric="logps/chosen"):
+    """What a window covering these micro-batches reports for one metric."""
+    from unsloth_zoo.mlx import preference
+
+    loss_fn = preference.make_dpo_loss_fn(preference.resolve_preference_objective(
+        "dpo", beta=0.1, reference_free=True))
+    at = preference.PREFERENCE_EVAL_METRICS["dpo"].index(metric)
+    scored = [loss_fn(model, *plan[index])[2] for index in indices]
+    return (sum(float(stats[at]) for stats in scored)
+            / sum(float(stats[-1]) for stats in scored))
+
+
+class _StopMidWindow:
+    """on_substep_end fires off the accumulation boundary, so its second call
+    lands mid-window and mid-epoch: the only partial window there is to abandon."""
+
+    def __init__(self):
+        self.substeps = 0
+
+    def on_substep_end(self, args, state, control, **kwargs):
+        self.substeps += 1
+        if self.substeps == 2:
+            control.should_epoch_stop = True
+        return control
+
+
+@pytest.mark.parametrize("logging_steps,steps,epochs,stop,windows", [
+    (1, 2, 1, False, ((0, 1), (2, 3))),
+    (2, 2, 1, False, ((0, 1, 2, 3),)),
+    (1, 3, 2, True, ((0, 1), (0, 1), (2, 3))),
+])
+def test_a_logged_window_holds_its_own_metrics_and_nothing_earlier(
+    logging_steps, steps, epochs, stop, windows, monkeypatch, tmp_path,
+):
+    """Each log line covers the window that produced it: not its first
+    micro-batch, not one already reported, and not one whose gradient was
+    discarded, whose rows the optimizer never saw."""
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    model = _tiny_model()
+    trainer = MLXDPOTrainer(model, Tokenizer(), rows(6), args=MLXDPOConfig(
+        **_generation_common(
+            tmp_path, reference_free=True, beta=0.1, max_steps=steps,
+            num_train_epochs=epochs, per_device_train_batch_size=1,
+            logging_steps=logging_steps, generate_during_eval=False,
+            eval_steps=0, preserve_dataset_order=True)),
+        callbacks=[_StopMidWindow()] if stop else [])
+    plan, _ = trainer._prepare_data(False)
+    _run_generation_trainer(trainer, monkeypatch, [])
+
+    # The stubbed optimizer never moves the weights, so the plan rescores the
+    # same numbers after the run.
+    logged = [entry["logps/chosen"] for entry in trainer.state.log_history
+              if "logps/chosen" in entry]
+    assert len(logged) == len(windows)
+    for value, window in zip(logged, windows):
+        assert value == pytest.approx(_window_mean(model, plan, window), rel=1e-5)
+    if stop:
+        assert logged[1] != pytest.approx(
+            _window_mean(model, plan, (2, 0, 1)), rel=1e-9)
+
+
 def test_referenced_dpo_freezes_accidental_norm_before_reference_validation(
     monkeypatch, tmp_path,
 ):
@@ -1239,7 +1558,8 @@ def test_final_loss_averages_logical_updates_with_ragged_epoch_tail(
     import mlx.core as mx
     import mlx.nn as nn
     from mlx.utils import tree_map
-    from unsloth_zoo.mlx.preference import make_orpo_loss_fn
+    from unsloth_zoo.mlx.preference import (
+        make_orpo_loss_fn, resolve_preference_objective)
     from unsloth_zoo.mlx.trainer import MLXORPOConfig, MLXORPOTrainer
 
     def value_and_grad_with_aux(model, fn):
@@ -1259,7 +1579,8 @@ def test_final_loss_averages_logical_updates_with_ragged_epoch_tail(
     model = _tiny_model()
     trainer = MLXORPOTrainer(model, Tokenizer(), rows(5), args=config)
     plan, _ = trainer._prepare_data(False)
-    objective = make_orpo_loss_fn(config.beta)
+    objective = make_orpo_loss_fn(
+        resolve_preference_objective("orpo", beta=config.beta))
     values = [float(objective(model, *plan[index])[0]) for index in range(3)]
     expected = ((values[0] + values[1]) / 2 + values[2]) / 2
     trainer._build_optimizer = lambda _steps: types.SimpleNamespace(
@@ -1469,28 +1790,27 @@ def _run_generation_trainer(trainer, monkeypatch, calls, generate_batch=None):
     return trainer.train()
 
 
-def test_generation_fields_stay_appended_for_a_wholesale_config_copy():
-    """A config round-tripped without the generation fields is still a copy.
-
-    An unregistered field flips the copy detection, letting a copied default
-    warmup_steps override an explicit warmup_ratio.
-    """
+@pytest.mark.parametrize("config_cls_name", ["MLXDPOConfig", "MLXORPOConfig"])
+def test_a_preference_field_a_dump_predates_still_reads_as_a_wholesale_copy(
+        config_cls_name):
+    """Every field these configs add arrived after some release whose dumps are
+    still accepted, so an unregistered one flips the copy detection and lets a
+    copied default warmup_steps override an explicit warmup_ratio."""
     import dataclasses
-    from unsloth_zoo.mlx.trainer import MLXDPOConfig
+    from unsloth_zoo.mlx import trainer as trainer_module
 
-    generation_fields = {
-        "generate_during_eval", "num_generation_prompts",
-        "generation_max_tokens", "generation_temperature",
-    }
-    baseline = MLXDPOConfig()
-    provided = {
-        field.name: getattr(baseline, field.name)
-        for field in dataclasses.fields(MLXDPOConfig)
-        if field.name not in generation_fields
-    }
-    provided["warmup_ratio"] = 0.25
-    config = MLXDPOConfig(**provided)
-    assert config._unsloth_mlx_warmup_steps_explicit is False
+    config_cls = getattr(trainer_module, config_cls_name)
+    fields = dataclasses.fields(config_cls)
+    shared = {f.name for f in dataclasses.fields(trainer_module.MLXTrainingConfig)}
+    baseline = config_cls()
+    appended = [f.name for f in fields if f.name not in shared]
+    assert appended
+    for dropped in appended:
+        config = config_cls(warmup_ratio=0.25, **{
+            f.name: getattr(baseline, f.name)
+            for f in fields if f.name not in (dropped, "warmup_ratio")})
+        assert config._unsloth_mlx_warmup_steps_explicit is False, dropped
+        assert config.warmup_ratio == 0.25, dropped
 
 
 def test_callback_requested_eval_samples_without_a_step_cadence(
@@ -1825,7 +2145,18 @@ def test_evaluation_reports_the_trl_metric_set(objective, tmp_path, monkeypatch)
     from unsloth_zoo.mlx.preference import PREFERENCE_EVAL_METRICS
     from unsloth_zoo.mlx.trainer import (
         MLXDPOConfig, MLXDPOTrainer, MLXORPOConfig, MLXORPOTrainer,
+        _preference_metric_values,
     )
+
+    # Each metric is a window sum over the denominator it names; TRL averages
+    # per-batch means instead.
+    batches = [[4.0, 9.0, 2.0, 3.0], [1.0, 1.0, 1.0, 1.0]]
+    summed = [sum(column) for column in zip(*batches)]
+    weighted = _preference_metric_values(("a", "b"), {0: 2, 1: 3}, summed)
+    assert weighted == {"a": 5 / 3, "b": 10 / 4}
+    assert weighted["a"] != pytest.approx((4 / 2 + 1 / 1) / 2)
+    assert set(_preference_metric_values(
+        ("a", "b"), {0: 2, 1: 3}, [0.0] * 4).values()) == {0.0}
 
     cls, config = ((MLXORPOTrainer, MLXORPOConfig) if objective == "orpo"
                    else (MLXDPOTrainer, MLXDPOConfig))
@@ -1843,11 +2174,41 @@ def test_evaluation_reports_the_trl_metric_set(objective, tmp_path, monkeypatch)
     assert any("eval_loss" in entry for entry in trainer.state.log_history)
 
 
+def test_the_config_carries_every_objective_field_into_the_run(tmp_path,
+                                                               monkeypatch):
+    """A run that dropped any of these would still train, on a different
+    objective, and evaluation would rank its checkpoints by another again."""
+    from unsloth_zoo.mlx import trainer as trainer_module
+    from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
+
+    captured = {}
+    for name in ("make_dpo_loss_fn", "make_preference_eval_fn"):
+        build = getattr(trainer_module, name)
+        monkeypatch.setattr(trainer_module, name, (
+            lambda objective, build=build, name=name, **kwargs: (
+                captured.setdefault(name, objective),
+                build(objective, **kwargs))[1]))
+    common = _generation_common(
+        tmp_path, max_steps=1, eval_steps=1, generate_during_eval=False,
+        reference_free=True, loss_type=["sigmoid", "robust"],
+        loss_weights=[0.25, 0.5], discopop_tau=0.2, label_smoothing=0.2)
+    trainer = MLXDPOTrainer(_tiny_model(), Tokenizer(), rows(4),
+                            eval_dataset=rows(3), args=MLXDPOConfig(**common))
+    _run_generation_trainer(trainer, monkeypatch, [])
+    objective = captured["make_dpo_loss_fn"]
+    assert (objective.loss_types, objective.weights) == (
+        ("sigmoid", "robust"), (0.25, 0.5))
+    assert (objective.discopop_tau, objective.label_smoothing) == (0.2, 0.2)
+    assert objective.reference_free
+    assert captured["make_preference_eval_fn"] == objective
+
+
 def test_eval_loss_weights_every_pair_once_across_a_ragged_tail():
     """Three rows at batch_size 2 leave a one-pair tail. Weighting each batch
     equally would give that tail the same say as the two pairs before it."""
     from unsloth_zoo.mlx.preference import (
         create_preference_batch_plan, make_preference_eval_fn,
+        resolve_preference_objective,
     )
 
     options = dict(length_policy=resolved(max_seq_length=64), num_epochs=1,
@@ -1858,7 +2219,8 @@ def test_eval_loss_weights_every_pair_once_across_a_ragged_tail():
         rows(3), Tokenizer(), batch_size=3, **options)
     assert len(split) == 2 and len(whole) == 1
     model = TinyModel()
-    eval_fn = make_preference_eval_fn("dpo", beta=0.1, reference_free=True)
+    eval_fn = make_preference_eval_fn(resolve_preference_objective(
+        "dpo", beta=0.1, reference_free=True))
     total, weight = 0.0, 0
     for index in range(len(split)):
         loss, pairs, _stats = eval_fn(model, *split[index])
@@ -2174,6 +2536,7 @@ def test_evaluation_accepts_a_wrapped_model_output(objective):
     the same forward the training loss does, so it has to accept both."""
     from unsloth_zoo.mlx.preference import (
         create_preference_batch_plan, make_preference_eval_fn,
+        resolve_preference_objective,
     )
 
     class Wrapped(TinyModel):
@@ -2187,7 +2550,8 @@ def test_evaluation_accepts_a_wrapped_model_output(objective):
         rows(2), Tokenizer(), batch_size=2,
         length_policy=resolved(max_seq_length=64),
         num_epochs=1, grad_accum=1, preserve_dataset_order=True)
-    eval_fn = make_preference_eval_fn(objective, beta=0.1, reference_free=True)
+    eval_fn = make_preference_eval_fn(resolve_preference_objective(
+        objective, beta=0.1, reference_free=True))
 
     bare = TinyModel()
     wrapped = Wrapped()

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -1870,12 +1870,11 @@ def test_eval_loss_weights_every_pair_once_across_a_ragged_tail():
 
 
 def test_the_orpo_logit_sum_is_accumulated_in_float32():
-    """ORPO reduces raw logits, so the accumulator dtype is the model's own.
+    """Both objectives reduce raw logits wider than the logits are stored.
 
     mx.sum does not promote, and a batch holds millions of logits: in bf16 the
-    running sum stops registering addends long before the end, and the cast in
-    mx.stack lands after the damage. DPO is safe by construction -- its float32
-    response mask promotes the multiply before the reduction.
+    running sum stops registering addends long before the end, and a cast of the
+    result lands after the damage.
 
     This shim runs in float32, so the assertion is on the dtype rather than on
     the value; only a real-mlx run reproduces the drift itself.

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -789,12 +789,12 @@ def test_microbatch_loss_matches_one_logical_batch(objective):
 
 def test_orpo_odds_term_is_finite_for_perfect_float16_logp():
     import mlx.core as mx
-    from unsloth_zoo.mlx.preference import _orpo_terms
+    from unsloth_zoo.mlx.preference import _log_sigmoid, _orpo_log_odds
 
-    value = _orpo_terms(
+    value = -_log_sigmoid(_orpo_log_odds(
         mx.array([0.0], dtype=mx.float16),
         mx.array([-1.0], dtype=mx.float16),
-    )
+    ))
     assert math.isfinite(float(value[0]))
     assert value.dtype == mx.float32
 
@@ -814,7 +814,7 @@ def test_dpo_label_smoothing_matches_conservative_formula():
         (1 - epsilon) * preference._log_sigmoid(logits)
         + epsilon * preference._log_sigmoid(-logits)
     ).mean()
-    actual, weight = preference.make_dpo_loss_fn(
+    actual, weight, _stats = preference.make_dpo_loss_fn(
         beta=beta, label_smoothing=epsilon, reference_free=True,
     )(model, batch, lengths, normalizers)
     assert float(actual) == pytest.approx(float(expected), rel=1e-6)
@@ -841,15 +841,15 @@ def test_orpo_nll_covers_the_full_chosen_sequence():
     response_logp = -(ce * response_mask).sum(axis=1) / mx.maximum(
         response_mask.sum(axis=1), mx.array(1.0),
     )
-    odds = preference._orpo_terms(
+    odds = -preference._log_sigmoid(preference._orpo_log_odds(
         response_logp[:pairs], response_logp[pairs:],
-    ).mean()
+    )).mean()
     full_mask = (steps < lengths[:pairs, 1:]).astype(mx.float32)
     full_nll = (ce[:pairs] * full_mask).sum() / full_mask.sum()
     response_nll = (
         ce[:pairs] * response_mask[:pairs]
     ).sum() / response_mask[:pairs].sum()
-    actual, _ = preference.make_orpo_loss_fn(beta)(
+    actual, _weight, _stats = preference.make_orpo_loss_fn(beta)(
         model, batch, lengths, normalizers,
     )
     assert float(actual) == pytest.approx(float(full_nll + beta * odds), rel=1e-6)

--- a/tests/test_mlx_preference.py
+++ b/tests/test_mlx_preference.py
@@ -830,10 +830,8 @@ def test_dpo_label_smoothing_matches_conservative_formula():
     assert int(weight) == 1
 
 
-# What TRL 0.23.1's own dpo_loss returns for these pairs at beta 0.3 and
-# discopop_tau 0.2, smoothing 0.15 wherever the variant reads it -- run from its
-# source, not transcribed. The fourth pair carries the difference past 1 / beta
-# where hinge clamps; the first three sort differently from their order.
+# Run from TRL 0.23.1's own dpo_loss, not transcribed. The fourth pair pushes
+# past 1 / beta where hinge clamps; the first three sort out of their order.
 _DPO_FIXTURE = dict(
     chosen=[-1.0, -2.5, -0.4, -0.2], rejected=[-1.8, -0.6, -2.2, -3.6],
     ref_chosen=[-1.3, -2.0, -0.9, -2.4], ref_rejected=[-1.1, -1.4, -2.6, -1.9],
@@ -860,7 +858,6 @@ def test_each_dpo_variant_matches_the_trl_formula(name):
     from unsloth_zoo.mlx import preference
 
     assert set(preference._DPO_VARIANTS) == set(_TRL_PAIR_LOSSES)
-    # TRL warns for a narrower set than the one that drops the value.
     assert "discopop" not in preference._DPO_SMOOTHING_WARNINGS
     objective = preference.resolve_preference_objective(
         "dpo", beta=0.3, loss_type=name, discopop_tau=0.2,
@@ -878,8 +875,6 @@ def test_each_dpo_variant_matches_the_trl_formula(name):
 
 
 def test_an_objective_is_valid_however_it_was_built():
-    """The invariants belong to the type, so a caller past the resolver still
-    cannot hold an objective its loss would score wrongly."""
     import dataclasses
     from unsloth_zoo.mlx.preference import (
         PreferenceObjective, make_dpo_loss_fn, make_orpo_loss_fn,
@@ -908,8 +903,7 @@ def test_an_objective_is_valid_however_it_was_built():
     with pytest.raises(ValueError, match="unknown objective kind"):
         resolve_preference_objective("cpo", beta=0.1)
 
-    # A bound binds only where a loss reads the value, and exo_pair's
-    # log(smoothing) has no zero wherever it is named.
+    # A bound binds only where a loss reads the value.
     kept = PreferenceObjective(
         kind="dpo", beta=0.1, loss_types=["sigmoid", "exo_pair"],
         weights=[0.0, -1.0], discopop_tau=0.0)
@@ -922,7 +916,6 @@ def test_an_objective_is_valid_however_it_was_built():
         "kind", "beta", "label_smoothing", "loss_types", "weights",
         "discopop_tau", "reference_free"}
 
-    # Each factory takes its own kind, so ORPO may carry DPO fields it ignores.
     dpo = resolve_preference_objective("dpo", beta=0.1)
     assert (dpo.loss_types, dpo.weights, dpo.label_smoothing) == (
         ("sigmoid",), (1.0,), 0.0)
@@ -944,8 +937,6 @@ def _ordered(rewards, weights):
 
 
 def _assert_reported_stats(kind, stats, expected, counts, over):
-    """Every reported slot against a value recomputed here, then the counts it
-    is divided by -- both their totals and which one each metric names."""
     from unsloth_zoo.mlx import preference
 
     names = preference.PREFERENCE_EVAL_METRICS[kind]
@@ -961,14 +952,10 @@ def _assert_reported_stats(kind, stats, expected, counts, over):
 
 
 def test_the_training_loss_and_its_reported_metrics_follow_the_objective():
-    """The closure scores the named variants at their weights on the ratios TRL
-    derives, accumulates rewards once per entry as TRL does, and named ipo
-    divides policy and reference alike before any variant runs."""
     import mlx.core as mx
     from unsloth_zoo.mlx import preference
 
-    # Rows of unlike length, so a count taken from the first row and scaled by
-    # the row count is not the count these rows carry.
+    # Rows of unlike length, so a count scaled from the first row is wrong.
     batch, lengths, normalizers = build_plan([
         {"prompt": f"question {index}: ", "chosen": "yes " * (index + 1),
          "rejected": "no " * (2 - index)} for index in range(2)],
@@ -976,9 +963,7 @@ def test_the_training_loss_and_its_reported_metrics_follow_the_objective():
     model = TinyModel()
     beta, weights = 0.3, [0.1, 0.2, -0.3]
     pairs = batch.shape[0] // 2
-    # A reference far enough above one pair's rejected row and the other's
-    # chosen row that the two pairs order oppositely whatever the model scores,
-    # which is what the accuracy count below is read against.
+    # Far enough out that the two pairs order oppositely whatever the model scores.
     held = mx.array([0.0, 60.0, 60.0, 0.0])
     policy = types.SimpleNamespace(forward=lambda *_a: held)
     resolve = preference.resolve_preference_objective
@@ -1005,8 +990,7 @@ def test_the_training_loss_and_its_reported_metrics_follow_the_objective():
     assert resolve("dpo", beta=beta,
                    loss_type=["hinge", "sigmoid"]).weights == (1.0, 1.0)
 
-    # These weights cancel, separating TRL's per-entry copies from one copy
-    # scaled by their sum.
+    # Weights summing to zero separate TRL's per-entry copies from one scaled copy.
     reward_chosen = _ordered(beta * (chosen - ref_chosen), weights)
     reward_rejected = _ordered(beta * (rejected - ref_rejected), weights)
     logits, _ce, mask = preference._preference_forward(model, batch, lengths)
@@ -1395,7 +1379,6 @@ def test_preference_trainer_runs_through_shared_training_loop(
 
 
 def _window_mean(model, plan, indices, metric="logps/chosen"):
-    """What a window covering these micro-batches reports for one metric."""
     from unsloth_zoo.mlx import preference
 
     loss_fn = preference.make_dpo_loss_fn(preference.resolve_preference_objective(
@@ -1407,8 +1390,7 @@ def _window_mean(model, plan, indices, metric="logps/chosen"):
 
 
 class _StopMidWindow:
-    """on_substep_end fires off the accumulation boundary, so its second call
-    lands mid-window and mid-epoch: the only partial window there is to abandon."""
+    """on_substep_end fires off the accumulation boundary, so call two is mid-window."""
 
     def __init__(self):
         self.substeps = 0
@@ -1428,9 +1410,7 @@ class _StopMidWindow:
 def test_a_logged_window_holds_its_own_metrics_and_nothing_earlier(
     logging_steps, steps, epochs, stop, windows, monkeypatch, tmp_path,
 ):
-    """Each log line covers the window that produced it: not its first
-    micro-batch, not one already reported, and not one whose gradient was
-    discarded, whose rows the optimizer never saw."""
+    """Each log line covers its own window, not one already reported or dropped."""
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
 
     model = _tiny_model()
@@ -1444,8 +1424,7 @@ def test_a_logged_window_holds_its_own_metrics_and_nothing_earlier(
     plan, _ = trainer._prepare_data(False)
     _run_generation_trainer(trainer, monkeypatch, [])
 
-    # The stubbed optimizer never moves the weights, so the plan rescores the
-    # same numbers after the run.
+    # The stubbed optimizer never moves the weights, so the plan rescores equal.
     logged = [entry["logps/chosen"] for entry in trainer.state.log_history
               if "logps/chosen" in entry]
     assert len(logged) == len(windows)
@@ -1793,9 +1772,7 @@ def _run_generation_trainer(trainer, monkeypatch, calls, generate_batch=None):
 @pytest.mark.parametrize("config_cls_name", ["MLXDPOConfig", "MLXORPOConfig"])
 def test_a_preference_field_a_dump_predates_still_reads_as_a_wholesale_copy(
         config_cls_name):
-    """Every field these configs add arrived after some release whose dumps are
-    still accepted, so an unregistered one flips the copy detection and lets a
-    copied default warmup_steps override an explicit warmup_ratio."""
+    """An unregistered appended field flips the copy detection, losing warmup_ratio."""
     import dataclasses
     from unsloth_zoo.mlx import trainer as trainer_module
 
@@ -2148,8 +2125,7 @@ def test_evaluation_reports_the_trl_metric_set(objective, tmp_path, monkeypatch)
         _preference_metric_values,
     )
 
-    # Each metric is a window sum over the denominator it names; TRL averages
-    # per-batch means instead.
+    # A window sum over the denominator it names; TRL averages per-batch means.
     batches = [[4.0, 9.0, 2.0, 3.0], [1.0, 1.0, 1.0, 1.0]]
     summed = [sum(column) for column in zip(*batches)]
     weighted = _preference_metric_values(("a", "b"), {0: 2, 1: 3}, summed)
@@ -2176,8 +2152,6 @@ def test_evaluation_reports_the_trl_metric_set(objective, tmp_path, monkeypatch)
 
 def test_the_config_carries_every_objective_field_into_the_run(tmp_path,
                                                                monkeypatch):
-    """A run that dropped any of these would still train, on a different
-    objective, and evaluation would rank its checkpoints by another again."""
     from unsloth_zoo.mlx import trainer as trainer_module
     from unsloth_zoo.mlx.trainer import MLXDPOConfig, MLXDPOTrainer
 
@@ -2232,15 +2206,7 @@ def test_eval_loss_weights_every_pair_once_across_a_ragged_tail():
 
 
 def test_the_orpo_logit_sum_is_accumulated_in_float32():
-    """Both objectives reduce raw logits wider than the logits are stored.
-
-    mx.sum does not promote, and a batch holds millions of logits: in bf16 the
-    running sum stops registering addends long before the end, and a cast of the
-    result lands after the damage.
-
-    This shim runs in float32, so the assertion is on the dtype rather than on
-    the value; only a real-mlx run reproduces the drift itself.
-    """
+    """mx.sum does not promote; this shim is float32, so assert on the dtype."""
     import mlx.core as mx
     from unsloth_zoo.mlx import preference as pref
 

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -1219,7 +1219,8 @@ def test_every_text_loss_accepts_a_wrapped_model_output():
     feeds a model call to cross-entropy has to accept both."""
     import mlx.core as mx
 
-    from unsloth_zoo.mlx.preference import make_dpo_loss_fn, make_orpo_loss_fn
+    from unsloth_zoo.mlx.preference import (
+        make_dpo_loss_fn, make_orpo_loss_fn, resolve_preference_objective)
     from unsloth_zoo.mlx.utils import make_baseline_loss_fn
 
     vocab = 8
@@ -1239,8 +1240,9 @@ def test_every_text_loss_accepts_a_wrapped_model_output():
         return _LanguageModelOutput(logits)
 
     baseline = make_baseline_loss_fn()
-    orpo = make_orpo_loss_fn(beta=0.1)
-    dpo = make_dpo_loss_fn(beta=0.1, reference_free=True)
+    orpo = make_orpo_loss_fn(resolve_preference_objective("orpo", beta=0.1))
+    dpo = make_dpo_loss_fn(resolve_preference_objective(
+        "dpo", beta=0.1, reference_free=True))
     # Chosen and rejected rows differ, so an unwrap that reordered the batch
     # axis would reverse the preference signal instead of comparing equal.
     rejected_ids = mx.array([[1, 5, 6, 7]], dtype=mx.int32)
@@ -1440,3 +1442,18 @@ def test_gather_qmm_guard_never_breaks_a_working_call(failing, monkeypatch,
         **kw) == "result"
     assert seen["sorted_indices"] is True
     assert mlx_utils._MLX_GATHER_QMM_UNREADABLE is True   # warns once, not per call
+
+
+@metal_only
+@pytest.mark.parametrize("dtype", ["bfloat16", "float16"], ids=["bf16", "fp16"])
+def test_the_logit_sum_holds_the_widest_vocabulary_in_float16(dtype):
+    """float16 is the recommended dtype on M1 and M2 and stops at 65504, far
+    below the 1e9 a wide row of large logits sums to. The contraction has to
+    scale the accumulation into range rather than reporting an infinity the
+    response mask then turns into NaN."""
+    from unsloth_zoo.mlx.preference import _row_logit_sum
+
+    wide = mx.full((1, 2, 262144), 4000.0, dtype=getattr(mx, dtype))
+    rows = _row_logit_sum(wide)
+    assert bool(mx.all(mx.isfinite(rows))), "the scale does not cover 256K"
+    assert float(rows[0, 0]) == pytest.approx(262144 * 4000.0, rel=1e-3)

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -1447,10 +1447,7 @@ def test_gather_qmm_guard_never_breaks_a_working_call(failing, monkeypatch,
 @metal_only
 @pytest.mark.parametrize("dtype", ["bfloat16", "float16"], ids=["bf16", "fp16"])
 def test_the_logit_sum_holds_the_widest_vocabulary_in_float16(dtype):
-    """float16 is the recommended dtype on M1 and M2 and stops at 65504, far
-    below the 1e9 a wide row of large logits sums to. The contraction has to
-    scale the accumulation into range rather than reporting an infinity the
-    response mask then turns into NaN."""
+    """float16 stops at 65504, far below the 1e9 a wide row of logits sums to."""
     from unsloth_zoo.mlx.preference import _row_logit_sum
 
     wide = mx.full((1, 2, 262144), 4000.0, dtype=getattr(mx, dtype))

--- a/unsloth_zoo/mlx/preference.py
+++ b/unsloth_zoo/mlx/preference.py
@@ -866,9 +866,28 @@ def _orpo_log_odds(chosen, rejected):
     return chosen_odds - rejected_odds
 
 
-def make_orpo_loss_fn(beta=0.1):
+def _require_kind(objective, kind):
+    if objective.kind != kind:
+        raise ValueError(
+            f"Unsloth MLX preference: the {kind.upper()} loss needs an "
+            f"objective of kind '{kind}', not '{objective.kind}'."
+        )
+
+
+def _require_reference(objective, reference_policy):
+    if objective.kind == "dpo" and not objective.reference_free \
+            and reference_policy is None:
+        raise ValueError(
+            "Unsloth MLX DPO: this objective scores against a reference "
+            "policy, but none was given. Pass one as reference_policy, or "
+            "build the objective with reference_free=True."
+        )
+
+
+def make_orpo_loss_fn(objective):
     """Create an ORPO loss with exact logical-window normalization."""
-    beta = float(beta)
+    _require_kind(objective, "orpo")
+    beta = objective.beta
 
     def loss_fn(model, batch, lengths, normalizers):
         nll_sum, _batch_nll_tokens, ratio, stats = _orpo_scores(
@@ -983,22 +1002,305 @@ def _response_logps(model, batch, lengths):
     return -(ce * _response_mask(targets, lengths)).sum(axis=1)
 
 
-def make_dpo_loss_fn(
-    *, beta=0.1, label_smoothing=0.0, reference_policy=None, reference_free=False,
+# TRL's own warning list, narrower than the set that drops the value: discopop
+# drops it silently.
+_DPO_SMOOTHING_WARNINGS = frozenset({
+    "hinge", "ipo", "bco_pair", "sppo_hard", "nca_pair", "apo_zero", "apo_down",
+})
+
+# These read the reference log probabilities themselves rather than the ratios,
+# so a reference-free run, which never computes them, leaves them nothing to
+# score. TRL computes the reference regardless and does not notice.
+_DPO_NEEDS_REFERENCE = frozenset({
+    "sppo_hard", "nca_pair", "aot_pair", "aot", "discopop",
+})
+
+_DPO_REFUSED = {
+    "bco_pair": (
+        "it subtracts a running mean of rewards carried across optimizer steps, "
+        "so its value would depend on micro-batch order and on what a "
+        "checkpoint happened to hold"
+    ),
+    "kto_pair": "TRL removed it from DPO training in favour of a KTO trainer",
+}
+
+
+@dataclass(frozen=True)
+class _DPOTerms:
+    """The four log probabilities a variant reads, and the ratios TRL derives.
+
+    ``delta`` groups its subtraction as TRL does rather than the equivalent
+    ``chosen_ratio - rejected_ratio``, which is not the same in float32.
+    """
+
+    chosen: object
+    rejected: object
+    ref_chosen: object
+    ref_rejected: object
+    chosen_ratio: object
+    rejected_ratio: object
+    delta: object
+
+
+def _dpo_smoothed_sigmoid(objective, delta):
+    scaled = objective.beta * delta
+    epsilon = objective.label_smoothing
+    return -(
+        (1.0 - epsilon) * _log_sigmoid(scaled) + epsilon * _log_sigmoid(-scaled)
+    )
+
+
+def _dpo_robust(objective, terms):
+    scaled = objective.beta * terms.delta
+    epsilon = objective.label_smoothing
+    return (
+        -_log_sigmoid(scaled) * (1.0 - epsilon) + _log_sigmoid(-scaled) * epsilon
+    ) / (1.0 - 2.0 * epsilon)
+
+
+def _dpo_exo_pair(objective, terms):
+    scaled = objective.beta * terms.delta
+    epsilon = objective.label_smoothing
+    return (
+        mx.sigmoid(scaled) * (_log_sigmoid(scaled) - math.log(1.0 - epsilon))
+        + mx.sigmoid(-scaled) * (_log_sigmoid(-scaled) - math.log(epsilon))
+    )
+
+
+def _dpo_hinge(objective, terms):
+    value = 1.0 - objective.beta * terms.delta
+    return mx.maximum(value, mx.array(0.0, dtype=value.dtype))
+
+
+def _dpo_ipo(objective, terms):
+    return (terms.delta - 1.0 / (2.0 * objective.beta)) ** 2
+
+
+def _dpo_sppo_hard(objective, terms):
+    half = 0.5 / objective.beta
+    return (terms.chosen_ratio - half) ** 2 + (terms.rejected_ratio + half) ** 2
+
+
+def _dpo_nca_pair(objective, terms):
+    chosen_rewards = terms.chosen_ratio * objective.beta
+    rejected_rewards = terms.rejected_ratio * objective.beta
+    return (
+        -_log_sigmoid(chosen_rewards)
+        - 0.5 * _log_sigmoid(-chosen_rewards)
+        - 0.5 * _log_sigmoid(-rejected_rewards)
+    )
+
+
+def _dpo_aot_pair(objective, terms):
+    return _dpo_smoothed_sigmoid(objective, (
+        mx.sort(terms.chosen_ratio, axis=0)
+        - mx.sort(terms.rejected_ratio, axis=0)
+    ))
+
+
+def _dpo_aot(objective, terms):
+    return _dpo_smoothed_sigmoid(objective, (
+        mx.sort(terms.chosen - terms.rejected, axis=0)
+        - mx.sort(terms.ref_chosen - terms.ref_rejected, axis=0)
+    ))
+
+
+def _dpo_apo_zero(objective, terms):
+    return (
+        1.0 - mx.sigmoid(objective.beta * terms.chosen_ratio)
+        + mx.sigmoid(objective.beta * terms.rejected_ratio)
+    )
+
+
+def _dpo_apo_down(objective, terms):
+    return (
+        mx.sigmoid(objective.beta * terms.chosen_ratio)
+        + 1.0 - mx.sigmoid(
+            objective.beta * (terms.chosen_ratio - terms.rejected_ratio)
+        )
+    )
+
+
+def _dpo_discopop(objective, terms):
+    scaled = objective.beta * terms.delta
+    modulation = mx.sigmoid(scaled / objective.discopop_tau)
+    return (
+        -_log_sigmoid(scaled) * (1.0 - modulation)
+        + mx.exp(-scaled) * modulation
+    )
+
+
+_DPO_VARIANTS = {
+    "sigmoid": lambda objective, terms: _dpo_smoothed_sigmoid(
+        objective, terms.delta,
+    ),
+    "robust": _dpo_robust,
+    "exo_pair": _dpo_exo_pair,
+    "hinge": _dpo_hinge,
+    "ipo": _dpo_ipo,
+    "sppo_hard": _dpo_sppo_hard,
+    "nca_pair": _dpo_nca_pair,
+    "aot_pair": _dpo_aot_pair,
+    "aot": _dpo_aot,
+    "apo_zero": _dpo_apo_zero,
+    "apo_down": _dpo_apo_down,
+    "discopop": _dpo_discopop,
+}
+
+
+@dataclass(frozen=True)
+class PreferenceObjective:
+    """What a preference run optimizes, resolved once and scored everywhere."""
+
+    kind: str
+    beta: float
+    label_smoothing: float = 0.0
+    loss_types: tuple = ("sigmoid",)
+    weights: tuple = (1.0,)
+    discopop_tau: float = 0.05
+    reference_free: bool = False
+
+    def __post_init__(self):
+        # Frozen stops rebinding, not editing what a list holds.
+        object.__setattr__(self, "loss_types", tuple(self.loss_types))
+        object.__setattr__(self, "weights", tuple(self.weights))
+        if self.kind not in ("dpo", "orpo"):
+            raise ValueError(
+                f"Unsloth MLX preference: unknown objective kind '{self.kind}'."
+            )
+        if not math.isfinite(self.beta) or self.beta < 0:
+            raise ValueError(
+                "Unsloth MLX preference: beta must be finite and non-negative, "
+                f"not {self.beta}."
+            )
+        if self.kind != "dpo":
+            # ORPO reads beta and nothing below, and each loss takes only its
+            # own kind, so nothing else here reaches a reader that would mind.
+            return
+        if len(self.weights) != len(self.loss_types):
+            raise ValueError(
+                f"Unsloth MLX DPO: loss_weights has {len(self.weights)} entries "
+                f"for {len(self.loss_types)} loss types; they must be the same "
+                "length."
+            )
+        if not self.loss_types:
+            raise ValueError(
+                "Unsloth MLX DPO: loss_type must name at least one loss."
+            )
+        if not all(math.isfinite(weight) for weight in self.weights):
+            # A NaN or infinite weight carries into every pair of the step.
+            raise ValueError(
+                f"Unsloth MLX DPO: loss_weights must all be finite, not "
+                f"{list(self.weights)}."
+            )
+        for name in self.loss_types:
+            if name in _DPO_REFUSED:
+                raise ValueError(
+                    f"Unsloth MLX DPO: loss_type '{name}' is not supported "
+                    f"because {_DPO_REFUSED[name]}."
+                )
+            if name not in _DPO_VARIANTS:
+                raise ValueError(
+                    f"Unsloth MLX DPO: unknown loss_type '{name}'. Supported: "
+                    f"{', '.join(sorted(_DPO_VARIANTS))}."
+                )
+        if not 0 <= self.label_smoothing < 0.5:
+            # The range the parameter is defined over, and the one bound to
+            # state: robust divides by 1 - 2 * it, exo_pair logs 1 - it.
+            raise ValueError(
+                "Unsloth MLX DPO: label_smoothing must be in [0, 0.5), not "
+                f"{self.label_smoothing}."
+            )
+        if self.label_smoothing == 0 and "exo_pair" in self.loss_types:
+            # exo_pair takes log(label_smoothing), which has no answer at
+            # zero. TRL applies this floor from inside exo_pair's own branch,
+            # so anything listed ahead of it misses it on the first
+            # micro-batch only; the value is the same, the timing is not.
+            object.__setattr__(self, "label_smoothing", 1e-3)
+        if "discopop" in self.loss_types and not 0 < self.discopop_tau < math.inf:
+            # discopop divides by it, and the delta is zero while the
+            # reference still matches the policy, so zero is NaN, not sharper.
+            raise ValueError(
+                "Unsloth MLX DPO: discopop_tau must be finite and above zero, "
+                f"not {self.discopop_tau}."
+            )
+        unscorable = [
+            name for name in self.loss_types if name in _DPO_NEEDS_REFERENCE
+        ]
+        if self.reference_free and unscorable:
+            raise ValueError(
+                f"Unsloth MLX DPO: {', '.join(unscorable)} score against the "
+                "reference log probabilities themselves, which reference_free "
+                "never computes. Set reference_free=False, or pick a loss_type "
+                "that only reads the policy-minus-reference difference."
+            )
+
+    @property
+    def length_normalized(self):
+        """IPO scores per-token log probabilities. TRL divides before any
+        variant runs, so naming it anywhere moves the rest of the list."""
+        return "ipo" in self.loss_types
+
+
+def resolve_preference_objective(
+    kind, *, beta, label_smoothing=0.0, loss_type="sigmoid",
+    loss_weights=None, discopop_tau=0.05, reference_free=False,
 ):
-    """Create sigmoid DPO with conservative preference-label smoothing."""
+    """Normalize a preference configuration into the objective both paths score.
+
+    Only the configuration's own spellings are resolved here; every setting a
+    loss depends on is established by the objective, so a caller that builds one
+    directly gets the same. The reference policy is a model rather than a
+    setting, so the factories take it separately.
+    """
     beta = float(beta)
-    epsilon = float(label_smoothing)
+    if kind == "orpo":
+        return PreferenceObjective(kind="orpo", beta=beta)
+    names = (loss_type,) if isinstance(loss_type, str) else tuple(loss_type)
+    if loss_weights is None:
+        weights = (1.0,) * len(names)
+    else:
+        weights = tuple(float(weight) for weight in loss_weights)
+    objective = PreferenceObjective(
+        kind=kind, beta=beta, label_smoothing=float(label_smoothing),
+        loss_types=names, weights=weights,
+        discopop_tau=float(discopop_tau), reference_free=bool(reference_free),
+    )
+    ignored = [name for name in names if name in _DPO_SMOOTHING_WARNINGS]
+    if float(label_smoothing) > 0 and ignored:
+        warnings.warn(
+            f"Unsloth MLX DPO: {', '.join(ignored)} ignore label_smoothing; "
+            "pass label_smoothing=0.0 to silence this.",
+            RuntimeWarning,
+        )
+    return objective
+
+
+def _weighted_rewards(rewards, weights):
+    total = rewards * weights[0]
+    for weight in weights[1:]:
+        total = total + rewards * weight
+    return total
+
+
+def _dpo_pair_loss(objective, terms):
+    total = None
+    for name, weight in zip(objective.loss_types, objective.weights):
+        term = _DPO_VARIANTS[name](objective, terms) * weight
+        total = term if total is None else total + term
+    return total
+
+
+def make_dpo_loss_fn(objective, *, reference_policy=None):
+    """Create the DPO loss for a resolved objective."""
+    _require_kind(objective, "dpo")
+    _require_reference(objective, reference_policy)
 
     def loss_fn(model, batch, lengths, normalizers):
-        margin, stats = _dpo_scores(
-            model, batch, lengths, beta=beta,
-            reference_policy=reference_policy, reference_free=reference_free,
+        terms, stats = _dpo_scores(
+            model, batch, lengths, objective, reference_policy=reference_policy,
         )
-        pair_loss = -(
-            (1.0 - epsilon) * _log_sigmoid(margin)
-            + epsilon * _log_sigmoid(-margin)
-        )
+        pair_loss = _dpo_pair_loss(objective, terms)
         _, window_pairs, window_microbatches = normalizers
         loss = window_microbatches.astype(mx.float32) * pair_loss.sum() / mx.maximum(
             window_pairs, mx.array(1),
@@ -1206,43 +1508,53 @@ def _orpo_scores(model, batch, lengths, beta):
     return nll_sum, nll_tokens, ratio, stats
 
 
-def _dpo_scores(model, batch, lengths, *, beta, reference_policy, reference_free):
-    """Score one DPO batch: the preference margin, then the metrics for the log."""
+def _dpo_scores(model, batch, lengths, objective, *, reference_policy):
+    """Score one DPO batch: the variants' terms, then the metrics for the log."""
     logits, ce, mask = _preference_forward(model, batch, lengths)
     pairs = batch.shape[0] // 2
     logps = -(ce * mask).sum(axis=1)
-    if reference_free:
+    if objective.reference_free:
         reference = mx.zeros(logps.shape, dtype=logps.dtype)
     else:
         reference = reference_policy.forward(model, batch, lengths)
+    if objective.length_normalized:
+        counts = mx.maximum(mask.sum(axis=1), mx.array(1.0))
+        logps = logps / counts
+        reference = reference / counts
+    beta = objective.beta
     chosen, rejected = logps[:pairs], logps[pairs:]
-    chosen_rewards = beta * (chosen - reference[:pairs])
-    rejected_rewards = beta * (rejected - reference[pairs:])
-    margin = beta * (
-        (chosen - rejected) - (reference[:pairs] - reference[pairs:])
-    )
+    ref_chosen, ref_rejected = reference[:pairs], reference[pairs:]
+    # TRL adds the rewards up once per entry, so a two-entry list reports twice
+    # what a one-entry list does. In its order, not scaled by the summed
+    # weights, which is a different float32 number.
     stats = _preference_stats(
         "dpo", logits, mask,
         chosen=chosen, rejected=rejected,
-        chosen_rewards=chosen_rewards, rejected_rewards=rejected_rewards,
+        chosen_rewards=_weighted_rewards(
+            beta * (chosen - ref_chosen), objective.weights),
+        rejected_rewards=_weighted_rewards(
+            beta * (rejected - ref_rejected), objective.weights),
     )
-    return margin, stats
+    terms = _DPOTerms(
+        chosen=chosen, rejected=rejected,
+        ref_chosen=ref_chosen, ref_rejected=ref_rejected,
+        chosen_ratio=chosen - ref_chosen,
+        rejected_ratio=rejected - ref_rejected,
+        delta=(chosen - rejected) - (ref_chosen - ref_rejected),
+    )
+    return terms, stats
 
 
-def make_preference_eval_fn(
-    kind, *, beta=0.1, label_smoothing=0.0,
-    reference_policy=None, reference_free=False,
-):
+def make_preference_eval_fn(objective, *, reference_policy=None):
     """Score one preference batch as ``(loss, pairs, stats)``.
 
     ``stats`` holds a numerator per metric in ``PREFERENCE_EVAL_METRICS[kind]``
     order, then the denominators ``PREFERENCE_EVAL_DENOMINATORS[kind]`` names.
-    Nothing is a per-batch mean: summing the vector across batches and dividing
-    each numerator by its own total averages the eval set exactly, however
-    unlike the batches are.
+    Nothing is a per-batch mean, so the eval set averages exactly.
     """
-    beta = float(beta)
-    epsilon = float(label_smoothing)
+    _require_reference(objective, reference_policy)
+    kind = objective.kind
+    beta = objective.beta
 
     def eval_fn(model, batch, lengths, _normalizers=None):
         pairs = batch.shape[0] // 2
@@ -1255,14 +1567,11 @@ def make_preference_eval_fn(
                 - beta * ratio.mean()
             )
         else:
-            margin, stats = _dpo_scores(
-                model, batch, lengths, beta=beta,
-                reference_policy=reference_policy, reference_free=reference_free,
+            terms, stats = _dpo_scores(
+                model, batch, lengths, objective,
+                reference_policy=reference_policy,
             )
-            loss = -(
-                (1.0 - epsilon) * _log_sigmoid(margin)
-                + epsilon * _log_sigmoid(-margin)
-            ).mean()
+            loss = _dpo_pair_loss(objective, terms).mean()
         return loss, mx.array(pairs, dtype=mx.int32), stats
 
     eval_fn._unsloth_preference_metrics = PREFERENCE_EVAL_METRICS[kind]

--- a/unsloth_zoo/mlx/preference.py
+++ b/unsloth_zoo/mlx/preference.py
@@ -866,41 +866,27 @@ def _orpo_log_odds(chosen, rejected):
     return chosen_odds - rejected_odds
 
 
-def _orpo_terms(chosen, rejected):
-    return -_log_sigmoid(_orpo_log_odds(chosen, rejected))
-
-
 def make_orpo_loss_fn(beta=0.1):
     """Create an ORPO loss with exact logical-window normalization."""
     beta = float(beta)
 
     def loss_fn(model, batch, lengths, normalizers):
-        targets = batch[:, 1:]
-        ce = nn.losses.cross_entropy(
-            _model_logits(model(batch[:, :-1])), targets, reduction="none",
-        ).reshape(targets.shape)
-        mask = _response_mask(targets, lengths)
-        response_logp = -(ce * mask).sum(axis=1) / mx.maximum(
-            mask.sum(axis=1), mx.array(1.0),
+        nll_sum, _batch_nll_tokens, ratio, stats = _orpo_scores(
+            model, batch, lengths, beta,
         )
-        pairs = batch.shape[0] // 2
-        nll_mask = (
-            mx.arange(1, targets.shape[1] + 1) < lengths[:pairs, 1:]
-        ).astype(mx.float32)
-        nll_sum = (ce[:pairs] * nll_mask).sum()
-        odds_sum = _orpo_terms(
-            response_logp[:pairs], response_logp[pairs:],
-        ).sum()
         nll_tokens, window_pairs, window_microbatches = normalizers
         loss = window_microbatches.astype(mx.float32) * (
             nll_sum / mx.maximum(nll_tokens, mx.array(1)).astype(mx.float32)
-            + beta * odds_sum / mx.maximum(
+            - beta * ratio.sum() / mx.maximum(
                 window_pairs, mx.array(1),
             ).astype(mx.float32)
         )
-        return loss, mx.array(1, dtype=mx.int32)
+        return loss, mx.array(1, dtype=mx.int32), stats
 
     loss_fn._unsloth_supervised_tokens = _supervised_tokens
+    loss_fn._unsloth_preference_metrics = PREFERENCE_EVAL_METRICS["orpo"]
+    loss_fn._unsloth_preference_denominators = PREFERENCE_EVAL_DENOMINATORS["orpo"]
+    loss_fn._unsloth_preference_stats_width = PREFERENCE_EVAL_STATS_WIDTH["orpo"]
     return loss_fn
 
 
@@ -1005,27 +991,24 @@ def make_dpo_loss_fn(
     epsilon = float(label_smoothing)
 
     def loss_fn(model, batch, lengths, normalizers):
-        policy = _response_logps(model, batch, lengths)
-        pairs = batch.shape[0] // 2
-        if reference_free:
-            reference = mx.zeros(policy.shape, dtype=policy.dtype)
-        else:
-            reference = reference_policy.forward(model, batch, lengths)
-        logits = beta * (
-            (policy[:pairs] - policy[pairs:])
-            - (reference[:pairs] - reference[pairs:])
+        margin, stats = _dpo_scores(
+            model, batch, lengths, beta=beta,
+            reference_policy=reference_policy, reference_free=reference_free,
         )
         pair_loss = -(
-            (1.0 - epsilon) * _log_sigmoid(logits)
-            + epsilon * _log_sigmoid(-logits)
+            (1.0 - epsilon) * _log_sigmoid(margin)
+            + epsilon * _log_sigmoid(-margin)
         )
         _, window_pairs, window_microbatches = normalizers
         loss = window_microbatches.astype(mx.float32) * pair_loss.sum() / mx.maximum(
             window_pairs, mx.array(1),
         ).astype(mx.float32)
-        return loss, mx.array(1, dtype=mx.int32)
+        return loss, mx.array(1, dtype=mx.int32), stats
 
     loss_fn._unsloth_supervised_tokens = _supervised_tokens
+    loss_fn._unsloth_preference_metrics = PREFERENCE_EVAL_METRICS["dpo"]
+    loss_fn._unsloth_preference_denominators = PREFERENCE_EVAL_DENOMINATORS["dpo"]
+    loss_fn._unsloth_preference_stats_width = PREFERENCE_EVAL_STATS_WIDTH["dpo"]
     return loss_fn
 
 
@@ -1088,19 +1071,101 @@ def _orpo_logit_sum(logits):
     return _row_logit_sum(logits).sum(), mx.array(float(math.prod(logits.shape)))
 
 
-# Metric index -> index of the stats entry it is divided by. Anything absent is
-# a per-pair sum over the pair count. These are means over tokens, which no pair
-# count recovers once batches hold different numbers of them.
+# The denominators summed alongside the metrics, in the order appended.
+_PREFERENCE_DENOMINATOR_NAMES = {
+    "dpo": ("chosen_logits", "rejected_logits", "pairs"),
+    "orpo": ("chosen_logits", "rejected_logits", "nll_tokens", "pairs"),
+}
+
+# The metrics that are token means; the pair count recovers every other one.
+# These three are also the ones that can disagree with a CUDA log, which they do
+# once a window's batches carry unlike tokens per pair: TRL weights its
+# per-micro-batch means equally, so its number moves with
+# per_device_train_batch_size on identical data -- 13% across batch sizes 1 to 16
+# in one measured window. Summing numerators over the window and dividing by the
+# tokens they cover does not, and is what both paths report here.
+_PREFERENCE_TOKEN_DENOMINATORS = {
+    "dpo": {
+        "logits/chosen": "chosen_logits",
+        "logits/rejected": "rejected_logits",
+    },
+    "orpo": {
+        "logits/chosen": "chosen_logits",
+        "logits/rejected": "rejected_logits",
+        "nll_loss": "nll_tokens",
+    },
+}
+
+
+def _preference_denominators(kind):
+    """Metric index -> index of the stats entry it is divided by.
+
+    Derived rather than written out: the indices are positions in a vector whose
+    length changes with the objective, and a hand-maintained map would rot the
+    first time a metric moved.
+    """
+    names = PREFERENCE_EVAL_METRICS[kind]
+    offsets = {
+        name: len(names) + offset
+        for offset, name in enumerate(_PREFERENCE_DENOMINATOR_NAMES[kind])
+    }
+    token_means = _PREFERENCE_TOKEN_DENOMINATORS[kind]
+    return {
+        index: offsets[token_means.get(name, "pairs")]
+        for index, name in enumerate(names)
+    }
+
+
 PREFERENCE_EVAL_DENOMINATORS = {
-    "dpo": {6: 8, 7: 9},
-    "orpo": {6: 11, 7: 12, 8: 13},
+    kind: _preference_denominators(kind) for kind in PREFERENCE_EVAL_METRICS
 }
 
 # Reported metrics, then the denominators the trainer sums alongside them.
 PREFERENCE_EVAL_STATS_WIDTH = {
-    kind: len(names) + len(PREFERENCE_EVAL_DENOMINATORS[kind])
+    kind: len(names) + len(_PREFERENCE_DENOMINATOR_NAMES[kind])
     for kind, names in PREFERENCE_EVAL_METRICS.items()
 }
+
+
+def _preference_stats(
+    kind, logits, mask, *, chosen, rejected, chosen_rewards, rejected_rewards,
+    extra=(), extra_denominators=(),
+):
+    """One batch's metric numerators, then the denominators they divide by.
+
+    Every entry is a sum, so summing over a window and dividing each numerator
+    by the entry its index names averages that window exactly.
+    """
+    pairs = chosen.shape[0]
+    # TRL is inconsistent between its trainers: DPOTrainer averages its logit
+    # metric over completion positions, ORPOTrainer over the whole sequence.
+    if kind == "orpo":
+        chosen_logits, chosen_count = _orpo_logit_sum(logits[:pairs])
+        rejected_logits, rejected_count = _orpo_logit_sum(logits[pairs:])
+    else:
+        chosen_logits, chosen_count = _masked_logit_sum(
+            logits[:pairs], mask[:pairs])
+        rejected_logits, rejected_count = _masked_logit_sum(
+            logits[pairs:], mask[pairs:])
+    values = [
+        chosen_rewards.sum(),
+        rejected_rewards.sum(),
+        (chosen_rewards > rejected_rewards).astype(mx.float32).sum(),
+        (chosen_rewards - rejected_rewards).sum(),
+        chosen.sum(),
+        rejected.sum(),
+        chosen_logits,
+        rejected_logits,
+        *extra,
+        chosen_count,
+        rejected_count,
+        *extra_denominators,
+        mx.array(float(pairs)),
+    ]
+    # Reported, never trained on: the loss is the only path to the gradient.
+    return mx.stop_gradient(
+        mx.stack([value.astype(mx.float32) for value in values])
+    )
 
 
 def _preference_forward(model, batch, lengths):
@@ -1111,6 +1176,57 @@ def _preference_forward(model, batch, lengths):
         logits, targets, reduction="none",
     ).reshape(targets.shape)
     return logits, ce, _response_mask(targets, lengths)
+
+
+def _orpo_scores(model, batch, lengths, beta):
+    """Score one ORPO batch as ``(nll_sum, nll_tokens, ratio, stats)``.
+
+    Unreduced: training normalizes over its window, evaluation over the batch.
+    """
+    logits, ce, mask = _preference_forward(model, batch, lengths)
+    pairs = batch.shape[0] // 2
+    response_logp = -(ce * mask).sum(axis=1) / mx.maximum(
+        mask.sum(axis=1), mx.array(1.0),
+    )
+    chosen, rejected = response_logp[:pairs], response_logp[pairs:]
+    nll_mask = (
+        mx.arange(1, batch.shape[1]) < lengths[:pairs, 1:]
+    ).astype(mx.float32)
+    nll_tokens = nll_mask.sum()
+    nll_sum = (ce[:pairs] * nll_mask).sum()
+    log_odds = _orpo_log_odds(chosen, rejected)
+    ratio = _log_sigmoid(log_odds)
+    stats = _preference_stats(
+        "orpo", logits, mask,
+        chosen=chosen, rejected=rejected,
+        chosen_rewards=beta * chosen, rejected_rewards=beta * rejected,
+        extra=(nll_sum, ratio.sum(), log_odds.sum()),
+        extra_denominators=(nll_tokens,),
+    )
+    return nll_sum, nll_tokens, ratio, stats
+
+
+def _dpo_scores(model, batch, lengths, *, beta, reference_policy, reference_free):
+    """Score one DPO batch: the preference margin, then the metrics for the log."""
+    logits, ce, mask = _preference_forward(model, batch, lengths)
+    pairs = batch.shape[0] // 2
+    logps = -(ce * mask).sum(axis=1)
+    if reference_free:
+        reference = mx.zeros(logps.shape, dtype=logps.dtype)
+    else:
+        reference = reference_policy.forward(model, batch, lengths)
+    chosen, rejected = logps[:pairs], logps[pairs:]
+    chosen_rewards = beta * (chosen - reference[:pairs])
+    rejected_rewards = beta * (rejected - reference[pairs:])
+    margin = beta * (
+        (chosen - rejected) - (reference[:pairs] - reference[pairs:])
+    )
+    stats = _preference_stats(
+        "dpo", logits, mask,
+        chosen=chosen, rejected=rejected,
+        chosen_rewards=chosen_rewards, rejected_rewards=rejected_rewards,
+    )
+    return margin, stats
 
 
 def make_preference_eval_fn(
@@ -1129,70 +1245,25 @@ def make_preference_eval_fn(
     epsilon = float(label_smoothing)
 
     def eval_fn(model, batch, lengths, _normalizers=None):
-        logits, ce, mask = _preference_forward(model, batch, lengths)
         pairs = batch.shape[0] // 2
-        logps = -(ce * mask).sum(axis=1)
-        # TRL is not consistent between its trainers: DPOTrainer averages its
-        # logit metric over the completion positions only, ORPOTrainer over the
-        # whole sequence. Follow each, so either compares against its own run.
         if kind == "orpo":
-            chosen_logits, chosen_logit_count = _orpo_logit_sum(logits[:pairs])
-            rejected_logits, rejected_logit_count = _orpo_logit_sum(logits[pairs:])
+            nll_sum, nll_tokens, ratio, stats = _orpo_scores(
+                model, batch, lengths, beta,
+            )
+            loss = (
+                nll_sum / mx.maximum(nll_tokens, mx.array(1.0))
+                - beta * ratio.mean()
+            )
         else:
-            chosen_logits, chosen_logit_count = _masked_logit_sum(
-                logits[:pairs], mask[:pairs])
-            rejected_logits, rejected_logit_count = _masked_logit_sum(
-                logits[pairs:], mask[pairs:])
-        if kind == "orpo":
-            logps = logps / mx.maximum(mask.sum(axis=1), mx.array(1.0))
-        chosen, rejected = logps[:pairs], logps[pairs:]
-        if kind == "orpo":
-            nll_mask = (
-                mx.arange(1, batch.shape[1]) < lengths[:pairs, 1:]
-            ).astype(mx.float32)
-            nll_tokens = nll_mask.sum()
-            nll_sum = (ce[:pairs] * nll_mask).sum()
-            nll = nll_sum / mx.maximum(nll_tokens, mx.array(1.0))
-            log_odds = _orpo_log_odds(chosen, rejected)
-            ratio = _log_sigmoid(log_odds)
-            loss = nll - beta * ratio.mean()
-            chosen_rewards = beta * chosen
-            rejected_rewards = beta * rejected
-            extra = [nll_sum, ratio.sum(), log_odds.sum()]
-            denominators = [
-                chosen_logit_count, rejected_logit_count, nll_tokens,
-            ]
-        else:
-            if reference_free:
-                reference = mx.zeros(logps.shape, dtype=logps.dtype)
-            else:
-                reference = reference_policy.forward(model, batch, lengths)
-            margin = beta * (
-                (chosen - rejected) - (reference[:pairs] - reference[pairs:])
+            margin, stats = _dpo_scores(
+                model, batch, lengths, beta=beta,
+                reference_policy=reference_policy, reference_free=reference_free,
             )
             loss = -(
                 (1.0 - epsilon) * _log_sigmoid(margin)
                 + epsilon * _log_sigmoid(-margin)
             ).mean()
-            chosen_rewards = beta * (chosen - reference[:pairs])
-            rejected_rewards = beta * (rejected - reference[pairs:])
-            extra = []
-            denominators = [chosen_logit_count, rejected_logit_count]
-        stats = [
-            chosen_rewards.sum(),
-            rejected_rewards.sum(),
-            (chosen_rewards > rejected_rewards).astype(mx.float32).sum(),
-            (chosen_rewards - rejected_rewards).sum(),
-            chosen.sum(),
-            rejected.sum(),
-            chosen_logits,
-            rejected_logits,
-        ] + extra + denominators
-        return (
-            loss,
-            mx.array(pairs, dtype=mx.int32),
-            mx.stack([value.astype(mx.float32) for value in stats]),
-        )
+        return loss, mx.array(pairs, dtype=mx.int32), stats
 
     eval_fn._unsloth_preference_metrics = PREFERENCE_EVAL_METRICS[kind]
     eval_fn._unsloth_preference_denominators = PREFERENCE_EVAL_DENOMINATORS[kind]

--- a/unsloth_zoo/mlx/preference.py
+++ b/unsloth_zoo/mlx/preference.py
@@ -1050,24 +1050,42 @@ PREFERENCE_EVAL_METRICS = {
 }
 
 
+# Contracted against instead of ones: a matmul returns the input dtype, and a
+# float16 vocabulary row sum runs past 65504 to infinity, which the mask then
+# turns into NaN. The smallest power of two still normal in float16, so undoing
+# it is exact; a 262144-entry vocabulary uses up its headroom near logits of 4096.
+_LOGIT_SUM_SCALE = 2.0 ** -14
+
+
+def _row_logit_sum(logits):
+    """Logit sum at each position, accumulated wider than the logits are stored.
+
+    mx.sum accumulates in the input dtype, which can overflow float16 at a real
+    vocabulary and loses mantissa in bf16. Casting first fixes both but
+    materializes a float32 copy of the largest tensor in the step -- 1.6 GB at
+    batch 4, sequence 2048, vocabulary 49152, since MLX does not fuse the cast
+    into the reduction. Contracting accumulates in float32 inside the matmul
+    instead, for the cost of the per-position result alone, which is then rounded
+    once to the logits' own mantissa.
+    """
+    weights = mx.full(
+        (logits.shape[-1], 1), _LOGIT_SUM_SCALE, dtype = logits.dtype,
+    )
+    return (logits @ weights).astype(mx.float32).squeeze(-1) / _LOGIT_SUM_SCALE
+
+
 def _masked_logit_sum(logits, mask):
     """Logit sum over the response positions, and the count it divides by.
 
     Separate so the eval set's mean is taken over all of its positions at once.
     """
     kept = mask.sum() * logits.shape[-1]
-    # The float32 mask promotes the product, so this reduction is already exact.
-    return (logits * mask[..., None]).sum(), kept
+    return (_row_logit_sum(logits) * mask).sum(), kept
 
 
 def _orpo_logit_sum(logits):
-    """Logit sum over every position, and the count it divides by.
-
-    Cast before reducing: mx.sum accumulates in the input dtype, and a bf16
-    batch holds millions of logits, far past where an 8-bit mantissa stops
-    registering the next addend. Casting the result would already be too late.
-    """
-    return logits.astype(mx.float32).sum(), mx.array(float(math.prod(logits.shape)))
+    """Logit sum over every position, and the count it divides by."""
+    return _row_logit_sum(logits).sum(), mx.array(float(math.prod(logits.shape)))
 
 
 # Metric index -> index of the stats entry it is divided by. Anything absent is

--- a/unsloth_zoo/mlx/preference.py
+++ b/unsloth_zoo/mlx/preference.py
@@ -1002,15 +1002,12 @@ def _response_logps(model, batch, lengths):
     return -(ce * _response_mask(targets, lengths)).sum(axis=1)
 
 
-# TRL's own warning list, narrower than the set that drops the value: discopop
-# drops it silently.
+# TRL's own warning list, narrower than the set that drops the value.
 _DPO_SMOOTHING_WARNINGS = frozenset({
     "hinge", "ipo", "bco_pair", "sppo_hard", "nca_pair", "apo_zero", "apo_down",
 })
 
-# These read the reference log probabilities themselves rather than the ratios,
-# so a reference-free run, which never computes them, leaves them nothing to
-# score. TRL computes the reference regardless and does not notice.
+# These rebuild from the raw reference logps, bypassing TRL's reference_free mask.
 _DPO_NEEDS_REFERENCE = frozenset({
     "sppo_hard", "nca_pair", "aot_pair", "aot", "discopop",
 })
@@ -1027,11 +1024,7 @@ _DPO_REFUSED = {
 
 @dataclass(frozen=True)
 class _DPOTerms:
-    """The four log probabilities a variant reads, and the ratios TRL derives.
-
-    ``delta`` groups its subtraction as TRL does rather than the equivalent
-    ``chosen_ratio - rejected_ratio``, which is not the same in float32.
-    """
+    """``delta`` uses TRL's subtraction grouping; regrouping shifts it in float32."""
 
     chosen: object
     rejected: object
@@ -1150,8 +1143,6 @@ _DPO_VARIANTS = {
 
 @dataclass(frozen=True)
 class PreferenceObjective:
-    """What a preference run optimizes, resolved once and scored everywhere."""
-
     kind: str
     beta: float
     label_smoothing: float = 0.0
@@ -1161,7 +1152,6 @@ class PreferenceObjective:
     reference_free: bool = False
 
     def __post_init__(self):
-        # Frozen stops rebinding, not editing what a list holds.
         object.__setattr__(self, "loss_types", tuple(self.loss_types))
         object.__setattr__(self, "weights", tuple(self.weights))
         if self.kind not in ("dpo", "orpo"):
@@ -1174,8 +1164,6 @@ class PreferenceObjective:
                 f"not {self.beta}."
             )
         if self.kind != "dpo":
-            # ORPO reads beta and nothing below, and each loss takes only its
-            # own kind, so nothing else here reaches a reader that would mind.
             return
         if len(self.weights) != len(self.loss_types):
             raise ValueError(
@@ -1188,7 +1176,6 @@ class PreferenceObjective:
                 "Unsloth MLX DPO: loss_type must name at least one loss."
             )
         if not all(math.isfinite(weight) for weight in self.weights):
-            # A NaN or infinite weight carries into every pair of the step.
             raise ValueError(
                 f"Unsloth MLX DPO: loss_weights must all be finite, not "
                 f"{list(self.weights)}."
@@ -1205,21 +1192,18 @@ class PreferenceObjective:
                     f"{', '.join(sorted(_DPO_VARIANTS))}."
                 )
         if not 0 <= self.label_smoothing < 0.5:
-            # The range the parameter is defined over, and the one bound to
-            # state: robust divides by 1 - 2 * it, exo_pair logs 1 - it.
+            # robust divides by 1 - 2 * it, so 0.5 is a division by zero.
             raise ValueError(
                 "Unsloth MLX DPO: label_smoothing must be in [0, 0.5), not "
                 f"{self.label_smoothing}."
             )
         if self.label_smoothing == 0 and "exo_pair" in self.loss_types:
-            # exo_pair takes log(label_smoothing), which has no answer at
-            # zero. TRL applies this floor from inside exo_pair's own branch,
-            # so anything listed ahead of it misses it on the first
-            # micro-batch only; the value is the same, the timing is not.
+            # exo_pair logs label_smoothing, undefined at zero. Floored here at
+            # config time; TRL mutates self.label_smoothing inside exo_pair's own
+            # branch, a state change that leaks into the other losses in the list.
             object.__setattr__(self, "label_smoothing", 1e-3)
         if "discopop" in self.loss_types and not 0 < self.discopop_tau < math.inf:
-            # discopop divides by it, and the delta is zero while the
-            # reference still matches the policy, so zero is NaN, not sharper.
+            # discopop divides by it, and delta is zero at init, so 0 is NaN.
             raise ValueError(
                 "Unsloth MLX DPO: discopop_tau must be finite and above zero, "
                 f"not {self.discopop_tau}."
@@ -1237,8 +1221,7 @@ class PreferenceObjective:
 
     @property
     def length_normalized(self):
-        """IPO scores per-token log probabilities. TRL divides before any
-        variant runs, so naming it anywhere moves the rest of the list."""
+        """TRL divides before any variant runs, so ipo normalizes the whole list."""
         return "ipo" in self.loss_types
 
 
@@ -1246,13 +1229,6 @@ def resolve_preference_objective(
     kind, *, beta, label_smoothing=0.0, loss_type="sigmoid",
     loss_weights=None, discopop_tau=0.05, reference_free=False,
 ):
-    """Normalize a preference configuration into the objective both paths score.
-
-    Only the configuration's own spellings are resolved here; every setting a
-    loss depends on is established by the objective, so a caller that builds one
-    directly gets the same. The reference policy is a model rather than a
-    setting, so the factories take it separately.
-    """
     beta = float(beta)
     if kind == "orpo":
         return PreferenceObjective(kind="orpo", beta=beta)
@@ -1292,7 +1268,6 @@ def _dpo_pair_loss(objective, terms):
 
 
 def make_dpo_loss_fn(objective, *, reference_policy=None):
-    """Create the DPO loss for a resolved objective."""
     _require_kind(objective, "dpo")
     _require_reference(objective, reference_policy)
 
@@ -1335,24 +1310,13 @@ PREFERENCE_EVAL_METRICS = {
 }
 
 
-# Contracted against instead of ones: a matmul returns the input dtype, and a
-# float16 vocabulary row sum runs past 65504 to infinity, which the mask then
-# turns into NaN. The smallest power of two still normal in float16, so undoing
-# it is exact; a 262144-entry vocabulary uses up its headroom near logits of 4096.
+# An unscaled float16 vocabulary row sum overflows to inf, which the mask then
+# turns into NaN. This is the smallest normal float16, so undoing it is exact.
 _LOGIT_SUM_SCALE = 2.0 ** -14
 
 
 def _row_logit_sum(logits):
-    """Logit sum at each position, accumulated wider than the logits are stored.
-
-    mx.sum accumulates in the input dtype, which can overflow float16 at a real
-    vocabulary and loses mantissa in bf16. Casting first fixes both but
-    materializes a float32 copy of the largest tensor in the step -- 1.6 GB at
-    batch 4, sequence 2048, vocabulary 49152, since MLX does not fuse the cast
-    into the reduction. Contracting accumulates in float32 inside the matmul
-    instead, for the cost of the per-position result alone, which is then rounded
-    once to the logits' own mantissa.
-    """
+    """Logit sum per position, accumulated in float32 by the matmul, not mx.sum."""
     weights = mx.full(
         (logits.shape[-1], 1), _LOGIT_SUM_SCALE, dtype = logits.dtype,
     )
@@ -1369,23 +1333,16 @@ def _masked_logit_sum(logits, mask):
 
 
 def _orpo_logit_sum(logits):
-    """Logit sum over every position, and the count it divides by."""
     return _row_logit_sum(logits).sum(), mx.array(float(math.prod(logits.shape)))
 
 
-# The denominators summed alongside the metrics, in the order appended.
 _PREFERENCE_DENOMINATOR_NAMES = {
     "dpo": ("chosen_logits", "rejected_logits", "pairs"),
     "orpo": ("chosen_logits", "rejected_logits", "nll_tokens", "pairs"),
 }
 
-# The metrics that are token means; the pair count recovers every other one.
-# These three are also the ones that can disagree with a CUDA log, which they do
-# once a window's batches carry unlike tokens per pair: TRL weights its
-# per-micro-batch means equally, so its number moves with
-# per_device_train_batch_size on identical data -- 13% across batch sizes 1 to 16
-# in one measured window. Summing numerators over the window and dividing by the
-# tokens they cover does not, and is what both paths report here.
+# Token means, unlike TRL, which weights per-micro-batch means equally and so
+# reports a number that moves with per_device_train_batch_size.
 _PREFERENCE_TOKEN_DENOMINATORS = {
     "dpo": {
         "logits/chosen": "chosen_logits",
@@ -1400,12 +1357,6 @@ _PREFERENCE_TOKEN_DENOMINATORS = {
 
 
 def _preference_denominators(kind):
-    """Metric index -> index of the stats entry it is divided by.
-
-    Derived rather than written out: the indices are positions in a vector whose
-    length changes with the objective, and a hand-maintained map would rot the
-    first time a metric moved.
-    """
     names = PREFERENCE_EVAL_METRICS[kind]
     offsets = {
         name: len(names) + offset
@@ -1433,11 +1384,7 @@ def _preference_stats(
     kind, logits, mask, *, chosen, rejected, chosen_rewards, rejected_rewards,
     extra=(), extra_denominators=(),
 ):
-    """One batch's metric numerators, then the denominators they divide by.
-
-    Every entry is a sum, so summing over a window and dividing each numerator
-    by the entry its index names averages that window exactly.
-    """
+    """Numerators then denominators, all sums, so a window average is exact."""
     pairs = chosen.shape[0]
     # TRL is inconsistent between its trainers: DPOTrainer averages its logit
     # metric over completion positions, ORPOTrainer over the whole sequence.
@@ -1464,7 +1411,6 @@ def _preference_stats(
         *extra_denominators,
         mx.array(float(pairs)),
     ]
-    # Reported, never trained on: the loss is the only path to the gradient.
     return mx.stop_gradient(
         mx.stack([value.astype(mx.float32) for value in values])
     )
@@ -1481,10 +1427,7 @@ def _preference_forward(model, batch, lengths):
 
 
 def _orpo_scores(model, batch, lengths, beta):
-    """Score one ORPO batch as ``(nll_sum, nll_tokens, ratio, stats)``.
-
-    Unreduced: training normalizes over its window, evaluation over the batch.
-    """
+    """Unreduced: training normalizes over its window, evaluation over the batch."""
     logits, ce, mask = _preference_forward(model, batch, lengths)
     pairs = batch.shape[0] // 2
     response_logp = -(ce * mask).sum(axis=1) / mx.maximum(
@@ -1509,7 +1452,6 @@ def _orpo_scores(model, batch, lengths, beta):
 
 
 def _dpo_scores(model, batch, lengths, objective, *, reference_policy):
-    """Score one DPO batch: the variants' terms, then the metrics for the log."""
     logits, ce, mask = _preference_forward(model, batch, lengths)
     pairs = batch.shape[0] // 2
     logps = -(ce * mask).sum(axis=1)
@@ -1524,9 +1466,8 @@ def _dpo_scores(model, batch, lengths, objective, *, reference_policy):
     beta = objective.beta
     chosen, rejected = logps[:pairs], logps[pairs:]
     ref_chosen, ref_rejected = reference[:pairs], reference[pairs:]
-    # TRL adds the rewards up once per entry, so a two-entry list reports twice
-    # what a one-entry list does. In its order, not scaled by the summed
-    # weights, which is a different float32 number.
+    # TRL adds the rewards once per loss entry, so a two-entry list reports twice
+    # a one-entry list; summed in its order, not scaled by the summed weights.
     stats = _preference_stats(
         "dpo", logits, mask,
         chosen=chosen, rejected=rejected,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -617,6 +617,7 @@ from .preference import (
     make_dpo_loss_fn,
     make_orpo_loss_fn,
     make_preference_eval_fn,
+    resolve_preference_objective,
     resolve_preference_length_policy,
 )
 from .compile import (
@@ -1339,6 +1340,9 @@ class MLXTrainingConfig:
             "num_generation_prompts",
             "generation_max_tokens",
             "generation_temperature",
+            "loss_type",
+            "loss_weights",
+            "discopop_tau",
         }
         _field_names = {field.name for field in config_fields}
         copied_all_fields = (_field_names - _appended_fields) <= set(provided)
@@ -1427,6 +1431,10 @@ class MLXDPOConfig(MLXTrainingConfig):
     beta: float = field(default=0.1, kw_only=True)
     reference_free: bool = field(default=False, kw_only=True)
     label_smoothing: float = field(default=0.0, kw_only=True)
+    # A DPOConfig collapses a one-entry list back to a string, so both arrive.
+    loss_type: str | list[str] = field(default="sigmoid", kw_only=True)
+    loss_weights: list[float] | None = field(default=None, kw_only=True)
+    discopop_tau: float = field(default=0.05, kw_only=True)
     disable_dropout: bool = field(default=True, kw_only=True)
     max_length: int | None = field(default=1024, kw_only=True)
     max_prompt_length: int | None = field(default=512, kw_only=True)
@@ -5396,12 +5404,22 @@ class MLXTrainer:
         preference_eval_fn = None
         if preference_kind:
             if preference_kind == "orpo":
-                loss_fn = make_orpo_loss_fn(beta=args.beta)
+                objective = resolve_preference_objective("orpo", beta=args.beta)
+                loss_fn = make_orpo_loss_fn(objective)
                 self._preference_reference_provenance = {
                     "kind": "orpo_no_reference"
                 }
                 _main_print(f"Unsloth: Using ORPO loss (beta={args.beta}).")
             else:
+                objective = resolve_preference_objective(
+                    "dpo",
+                    beta=args.beta,
+                    label_smoothing=args.label_smoothing,
+                    loss_type=args.loss_type,
+                    loss_weights=args.loss_weights,
+                    discopop_tau=args.discopop_tau,
+                    reference_free=bool(args.reference_free),
+                )
                 reference_policy, provenance = build_reference_policy(
                     model,
                     reference_free=bool(args.reference_free),
@@ -5416,23 +5434,19 @@ class MLXTrainer:
                 # the same ones the loss does. NEFTune is already off in eval.
                 _sampling_reference = reference_policy
                 loss_fn = make_dpo_loss_fn(
-                    beta=args.beta,
-                    label_smoothing=args.label_smoothing,
-                    reference_policy=reference_policy,
-                    reference_free=bool(args.reference_free),
+                    objective, reference_policy=reference_policy,
                 )
-                _main_print(f"Unsloth: Using DPO loss (beta={args.beta}).")
+                _main_print(
+                    f"Unsloth: Using DPO loss (beta={args.beta}, "
+                    f"loss_type={list(objective.loss_types)})."
+                )
             self._preference_run_context = PreferenceRunContext(
                 model, enabled=bool(getattr(args, "disable_dropout", True)),
             )
             # Not the training loss: that one normalizes across an accumulation
             # window, where this one normalizes over the split it is given.
             preference_eval_fn = make_preference_eval_fn(
-                preference_kind,
-                beta=args.beta,
-                label_smoothing=getattr(args, "label_smoothing", 0.0),
-                reference_policy=_sampling_reference,
-                reference_free=bool(getattr(args, "reference_free", False)),
+                objective, reference_policy=_sampling_reference,
             )
 
         self.callback_handler.optimizer = optimizer

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -5426,7 +5426,7 @@ class MLXTrainer:
                 model, enabled=bool(getattr(args, "disable_dropout", True)),
             )
             # Not the training loss: that one normalizes across an accumulation
-            # window, and reports none of these metrics.
+            # window, where this one normalizes over the split it is given.
             preference_eval_fn = make_preference_eval_fn(
                 preference_kind,
                 beta=args.beta,
@@ -6294,6 +6294,10 @@ class MLXTrainer:
         supervised_tokens = 0
         pending_supervised_tokens = 0
         pending_steps = 0
+        # The preference metric sums, split the same way; None until a loss
+        # that reports them runs, which an SFT or VLM objective never does.
+        metric_stats = None
+        pending_stats = None
         trained_tokens = 0
         train_time = 0
         # Wall clock for the PENDING window, split like the loss/token counters
@@ -6379,6 +6383,7 @@ class MLXTrainer:
             on_log fires on every rank and self-gates on is_world_process_zero.
             """
             nonlocal losses, n_tokens, supervised_tokens, steps, train_time, trained_tokens
+            nonlocal metric_stats
             # Nothing accumulated since the last log: a callback can force
             # should_log again on a step that already logged, and the accumulators
             # are plain-int 0 after a reset, so .item() below would raise and a real
@@ -6462,6 +6467,17 @@ class MLXTrainer:
             }
             if grad_norm_val is not None:
                 logs["grad_norm"] = grad_norm_val
+            if metric_stats is not None:
+                # TRL's preference trainers log these beside the loss every step.
+                summed_stats = self._distributed_all_sum(
+                    metric_stats, stream=mx.cpu,
+                )
+                mx.eval(summed_stats)
+                logs.update(_preference_metric_values(
+                    loss_fn._unsloth_preference_metrics,
+                    loss_fn._unsloth_preference_denominators,
+                    summed_stats.tolist(),
+                ))
             # HF's Trainer.log stamps the epoch onto every payload, so a persisted
             # log_history entry keeps it after state.epoch has moved on.
             if self.state.epoch is not None:
@@ -6485,6 +6501,7 @@ class MLXTrainer:
             n_tokens = 0
             supervised_tokens = 0
             steps = 0
+            metric_stats = None
             train_time = 0
 
         def _sample_generations(current_step):
@@ -7380,6 +7397,10 @@ class MLXTrainer:
             pending_n_tokens += toks
             pending_supervised_tokens += supervised_toks
             pending_steps += 1
+            if stats is not None:
+                pending_stats = (
+                    stats if pending_stats is None else pending_stats + stats
+                )
             if do_update:
                 # Window applied: fold pending into committed and reset pending.
                 # Evaluating the committed accumulators here materializes the folded
@@ -7399,6 +7420,13 @@ class MLXTrainer:
                 pending_supervised_tokens = 0
                 pending_steps = 0
                 _metric_eval = (losses, n_tokens, supervised_tokens)
+                if pending_stats is not None:
+                    metric_stats = (
+                        pending_stats if metric_stats is None
+                        else metric_stats + pending_stats
+                    )
+                    pending_stats = None
+                    _metric_eval = (*_metric_eval, metric_stats)
             else:
                 # Substep: only the pending window changed; committed is unchanged
                 # (already materialized at its last fold). Both are always arrays at
@@ -7406,6 +7434,8 @@ class MLXTrainer:
                 _metric_eval = (
                     pending_losses, pending_n_tokens, pending_supervised_tokens,
                 )
+                if pending_stats is not None:
+                    _metric_eval = (*_metric_eval, pending_stats)
             # One evaluation boundary: the reported norm (when present) is
             # evaluated together with model/optimizer state and metric
             # accumulators, never as a separate earlier graph execution.
@@ -7520,6 +7550,7 @@ class MLXTrainer:
                         pending_losses = 0
                         pending_n_tokens = 0
                         pending_supervised_tokens = 0
+                        pending_stats = None
                         pending_steps = 0
                         # Drop the abandoned window's time with its tokens, else
                         # the next window's tokens/s is deflated by it.

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1987,6 +1987,19 @@ def _resolve_training_steps(args, batches, batch_iter, *, includes_epochs=False)
     raise ValueError("max_steps must be > 0 when using streaming mode.")
 
 
+def _preference_metric_values(names, denominators, summed):
+    """Window means from summed numerators and the denominators they name.
+
+    ``summed`` holds every numerator followed by every denominator, so a window
+    or an eval set is averaged exactly however unlike its batches are.
+    """
+    values = {}
+    for index, name in enumerate(names):
+        divisor = summed[denominators[index]]
+        values[name] = summed[index] / divisor if divisor > 0 else 0.0
+    return values
+
+
 class MLXTrainer:
     """MLX-native trainer for Apple Silicon, mirroring SFTTrainer's constructor API."""
 
@@ -4022,13 +4035,10 @@ class MLXTrainer:
                 if metric_names is None:
                     metrics[f"{prefix}perplexity"] = math.exp(min(value, 100))
                 elif total > 0:
-                    summed = stats.tolist()
-                    for index, name in enumerate(metric_names):
-                        over = metric_denominators.get(index)
-                        divisor = total if over is None else summed[over]
-                        metrics[f"{prefix}{name}"] = (
-                            summed[index] / divisor if divisor > 0 else 0.0
-                        )
+                    for name, metric in _preference_metric_values(
+                        metric_names, metric_denominators, stats.tolist(),
+                    ).items():
+                        metrics[f"{prefix}{name}"] = metric
                 return value
 
             if isinstance(eval_batches, dict):
@@ -5715,24 +5725,34 @@ class MLXTrainer:
                 )
             return grad, toks_f
 
+        def _scored(batch_data):
+            """Loss, its weight, and the metric sums a preference loss reports.
+
+            ``stats`` is None for every objective that reports no metrics of its
+            own, which is every SFT and VLM loss.
+            """
+            scored, grad = _loss_and_grad(batch_data)
+            stats = scored[2] if len(scored) > 2 else None
+            return scored[0], scored[1], stats, grad
+
         def _local_grad_step(batch_data, prev_state):
             """Local loss/grad accumulation step, safe to compile under DDP."""
-            (lvalue, toks), grad = _loss_and_grad(batch_data)
+            lvalue, toks, stats, grad = _scored(batch_data)
             toks_f = toks.astype(mx.float32)
             grad, toks_f = _accumulate_weighted_grad(grad, toks_f, prev_state)
             # Carried as state across loop iterations, or reduced eagerly
             # outside mx.compile under DDP.
             grad = tree_map(mx.stop_gradient, grad)
             toks_f = mx.stop_gradient(toks_f)
-            return lvalue, toks, (grad, toks_f)
+            return lvalue, toks, stats, (grad, toks_f)
 
         # Unified step for VLM (dict batch) and text (tuple batch) training.
         def step_fn(batch_data, prev_state, do_update):
-            (lvalue, toks), grad = _loss_and_grad(batch_data)
+            lvalue, toks, stats, grad = _scored(batch_data)
 
             if _direct_single_step_update:
                 grad_norm = _apply_update_direct(grad, toks.astype(mx.float32))
-                return lvalue, toks, None, grad_norm
+                return lvalue, toks, stats, None, grad_norm
 
             toks_f = toks.astype(mx.float32)
             grad_norm = mx.array(0.0, dtype=mx.float32)
@@ -5740,11 +5760,11 @@ class MLXTrainer:
 
             if do_update:
                 grad_norm = _apply_update(grad, toks_f)
-                return lvalue, toks, None, grad_norm
+                return lvalue, toks, stats, None, grad_norm
 
             grad = tree_map(mx.stop_gradient, grad)
             toks_f = mx.stop_gradient(toks_f)
-            return lvalue, toks, (grad, toks_f), None
+            return lvalue, toks, stats, (grad, toks_f), None
 
         _compile_decision = getattr(self, "_compile_decision", None)
         _use_compile = (
@@ -5827,8 +5847,10 @@ class MLXTrainer:
         _ddp_update_outside_step = distributed_world_size > 1
 
         def _ddp_eager_local_step_fn(batch_data, prev_state, do_update):
-            lvalue, toks, local_state = _local_grad_step(batch_data, prev_state)
-            return lvalue, toks, local_state, None
+            lvalue, toks, stats, local_state = _local_grad_step(
+                batch_data, prev_state,
+            )
+            return lvalue, toks, stats, local_state, None
 
         if _use_compile:
             _uncompiled_step_fn = step_fn
@@ -5885,8 +5907,8 @@ class MLXTrainer:
 
                 def _ddp_compiled_step_fn(batch_data, prev_state, do_update):
                     try:
-                        lvalue, toks, local_state = _compiled_local_grad_step(
-                            batch_data, prev_state,
+                        lvalue, toks, stats, local_state = (
+                            _compiled_local_grad_step(batch_data, prev_state)
                         )
                         mx.eval(
                             _compile_state,
@@ -5894,12 +5916,13 @@ class MLXTrainer:
                             toks,
                             local_state[0],
                             local_state[1],
+                            *(() if stats is None else (stats,)),
                         )
                     except Exception as e:
                         if _is_compile_exception(e):
                             raise _DDPCompiledLocalGradError(str(e)) from e
                         raise
-                    return lvalue, toks, local_state, None
+                    return lvalue, toks, stats, local_state, None
 
                 if _use_compile:
                     step_fn = _ddp_compiled_step_fn
@@ -6975,11 +6998,12 @@ class MLXTrainer:
             nonlocal _compile_fallback_reason
 
             def _eval_local_result(step_result):
-                lvalue, toks, local_state, _grad_norm = step_result
+                lvalue, toks, stats, local_state, _grad_norm = step_result
+                extra = () if stats is None else (stats,)
                 if local_state is not None:
-                    mx.eval(lvalue, toks, local_state[0], local_state[1])
+                    mx.eval(lvalue, toks, local_state[0], local_state[1], *extra)
                 else:
-                    mx.eval(lvalue, toks)
+                    mx.eval(lvalue, toks, *extra)
 
             local_error = None
             compile_error = None
@@ -7298,7 +7322,7 @@ class MLXTrainer:
                 self._distributed_should_stop()
 
             if _ddp_update_outside_step:
-                lvalue, toks, grad_accum_state, grad_norm = _run_ddp_local_step(
+                lvalue, toks, stats, grad_accum_state, grad_norm = _run_ddp_local_step(
                     batch_data, grad_accum_state, do_update,
                 )
                 if do_update:
@@ -7312,7 +7336,7 @@ class MLXTrainer:
                 if _use_compile and not _ddp_compile_local_grad:
                     rng_state_before = _mlx_rng_key()
                 try:
-                    lvalue, toks, grad_accum_state, grad_norm = step_fn(
+                    lvalue, toks, stats, grad_accum_state, grad_norm = step_fn(
                         batch_data, grad_accum_state, do_update,
                     )
                 except (ValueError, RuntimeError, TypeError) as e:
@@ -7336,7 +7360,7 @@ class MLXTrainer:
                             batch_data = batches[scheduled_index]
                         _restore_mlx_rng_key(rng_state_before)
                         state = [model.state, optimizer.state, mx.random.state]
-                        lvalue, toks, grad_accum_state, grad_norm = step_fn(
+                        lvalue, toks, stats, grad_accum_state, grad_norm = step_fn(
                             batch_data, grad_accum_state, do_update,
                         )
                     else:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1996,11 +1996,7 @@ def _resolve_training_steps(args, batches, batch_iter, *, includes_epochs=False)
 
 
 def _preference_metric_values(names, denominators, summed):
-    """Window means from summed numerators and the denominators they name.
-
-    ``summed`` holds every numerator followed by every denominator, so a window
-    or an eval set is averaged exactly however unlike its batches are.
-    """
+    """``summed`` is every numerator then every denominator; the mean is exact."""
     values = {}
     for index, name in enumerate(names):
         divisor = summed[denominators[index]]
@@ -5486,8 +5482,7 @@ class MLXTrainer:
             self._preference_run_context = PreferenceRunContext(
                 model, enabled=bool(getattr(args, "disable_dropout", True)),
             )
-            # Not the training loss: that one normalizes across an accumulation
-            # window, where this one normalizes over the split it is given.
+            # Not the training loss: that one normalizes across a window.
             preference_eval_fn = make_preference_eval_fn(
                 objective, reference_policy=_sampling_reference,
             )
@@ -5783,11 +5778,7 @@ class MLXTrainer:
             return grad, toks_f
 
         def _scored(batch_data):
-            """Loss, its weight, and the metric sums a preference loss reports.
-
-            ``stats`` is None for every objective that reports no metrics of its
-            own, which is every SFT and VLM loss.
-            """
+            """``stats`` is None for every SFT and VLM loss, which report none."""
             scored, grad = _loss_and_grad(batch_data)
             stats = scored[2] if len(scored) > 2 else None
             return scored[0], scored[1], stats, grad
@@ -6351,8 +6342,7 @@ class MLXTrainer:
         supervised_tokens = 0
         pending_supervised_tokens = 0
         pending_steps = 0
-        # The preference metric sums, split the same way; None until a loss
-        # that reports them runs, which an SFT or VLM objective never does.
+        # Preference metric sums, split like the loss counters; None for SFT/VLM.
         metric_stats = None
         pending_stats = None
         trained_tokens = 0
@@ -6525,7 +6515,6 @@ class MLXTrainer:
             if grad_norm_val is not None:
                 logs["grad_norm"] = grad_norm_val
             if metric_stats is not None:
-                # TRL's preference trainers log these beside the loss every step.
                 summed_stats = self._distributed_all_sum(
                     metric_stats, stream=mx.cpu,
                 )


### PR DESCRIPTION
## What this changes

MLX DPO and ORPO now compute what the CUDA path computes and report what it reports, per step.

Before this change, MLX DPO scored one fixed sigmoid loss regardless of `loss_type`, so a run configured for `ipo`, `hinge`, `apo_zero` or any other variant trained on a different objective than it asked for — silently. Neither trainer reported the preference metrics at all, so a run could not be compared against the CUDA run it mirrors, and evaluation ranked checkpoints by a number the training log never showed.

Three things arrive together:

**The twelve stateless TRL DPO variants**, per pair: `sigmoid`, `robust`, `exo_pair`, `hinge`, `ipo`, `sppo_hard`, `nca_pair`, `aot_pair`, `aot`, `apo_zero`, `apo_down`, `discopop`. A run may name one or several; `loss_weights` scales each entry's contribution. Rewards accumulate one weighted copy per entry in TRL's own order, which is not the same float32 number as scaling once by the summed weights. Evaluation scores whatever the run trains on.

`bco_pair` and `kto_pair` are refused by name with the reason. `bco_pair` carries a running mean across optimizer steps, so its value would depend on micro-batch order and on what a checkpoint happened to hold; TRL removed `kto_pair` from DPO training.

**The metric set both trainers report**: `rewards/chosen`, `rewards/rejected`, `rewards/accuracies`, `rewards/margins`, `logps/chosen`, `logps/rejected`, `logits/chosen`, `logits/rejected`, plus ORPO's `nll_loss`, `log_odds_ratio` and `log_odds_chosen`. They reach the training log and evaluation alike.

**A frozen `PreferenceObjective`** that both the training loss and the eval scorer are built from, so the two cannot diverge. It establishes its own validity — kind, beta, the smoothing range the parameter is defined over, the loss names, finite weights matching the loss count, `discopop_tau` where `discopop` divides by it, and the `exo_pair` smoothing floor TRL applies from inside its own branch. A reference-free run naming one of the five variants that read the reference log probabilities themselves is refused, since that mode never computes them.

## The averaging convention, and where it differs from TRL

Three metrics are token means: `logits/chosen`, `logits/rejected`, and ORPO's `nll_loss`. TRL averages per-micro-batch means with equal weight, so its own number for them moves with `per_device_train_batch_size` on identical data:

| metric | spread across `per_device_train_batch_size` 1 → 16 |
|---|---|
| `logits/chosen` | 13% |
| `nll_loss` | 10% |

Parity for these three is therefore not a well-defined target: it can only be matched at one batching configuration. This change sums each numerator over the accumulation window and divides by the tokens that numerator covers, which is invariant to batch shape. Under the length-sorted default the divergence from a TRL log is 10.3% mean and 60% max on `logits/chosen`, 1.4% mean on `nll_loss`. Every pair-denominated metric agrees with TRL except in a window holding a short tail batch.

## Behaviour change worth noting in a release

The reported logit metrics shift by about 1.7e-4 relative. The DPO and ORPO logit metrics used to reduce the logits through a float32 mask product or a float32 cast, either of which materializes a second, wider copy of the largest tensor in the step — 1.6 GB at batch 4, sequence 2048, vocabulary 49152. They now contract against a scaled weight vector, so the accumulation happens inside the matmul and costs only the per-position result.

For scale, that 1.7e-4 is smaller than the variation the same number already carries from batch shape alone (6e-4 between batch sizes 1 and 2), and two to three orders of magnitude smaller than the averaging divergence above. The loss is unaffected; only the reported metrics move.

A default DPO configuration produces bit-for-bit the same loss as before this change.

## Risks and tradeoffs

- The weight vector is `2**-14`, the smallest power of two still normal in float16, chosen so a plain ones vector cannot overflow float16 on a wide vocabulary: a real row sums past 3e5 while float16 stops at 65504, and the overflow reaches the log as NaN once the response mask multiplies it. It leaves headroom a 262144-entry vocabulary uses up near logits of 4096.
- Each position's sum is now rounded to the logits' own mantissa rather than accumulated in float32. That error is correlated rather than self-cancelling, but on realistic logits it stays within 1e-4 relative of the exact mean.
- `ipo` length-normalizes the log probabilities before any variant runs, on both the policy and the reference, so every reported number is per-token whenever it is listed.
- `MLXDPOConfig` gains `loss_type`, `loss_weights` and `discopop_tau`. They join the fields a wholesale config copy may omit, so a dump from a release predating them still counts as a copy rather than letting a copied default `warmup_steps` override an explicit `warmup_ratio`.

Out of scope, deliberately: `rpo_alpha` and the `sft` loss type, the MoE router auxiliary loss, `ld_alpha`, `use_weighting`, `f_divergence_type`, reference-model options, and VLM preference training.

## Validation

All twelve variants were checked against TRL 0.23.1's own `dpo_loss`, lifted from its source and run on the same inputs:

```
worst relative error across all twelve variants: 8.128e-07
```

Test suites:

```
420 passed   tests/test_mlx_preference.py
             tests/test_mlx_trainer_internals.py
             tests/test_mlx_training_e2e_metal.py
```

Mutation testing over the change, 86 mutants in two sets, all killed: 62 covering the objective (loss selection, weights, the domain checks, the refusals) and 24 covering the metric pipeline (which branch each slot reports, the direction of each comparison, the count each metric is averaged over, the float16 scale, and the accumulation window's reset and threading). The two float16 scale mutants are killed on Metal rather than under the simulation shim, since only real hardware reproduces the overflow.
