### PR TITLE
Fix the flex-attention backward shared-memory gate missing every num_stages=1 GPU

### DIFF
--- a/tests/test_flex_attention_bwd_shmem_gate.py
+++ b/tests/test_flex_attention_bwd_shmem_gate.py
@@ -38,20 +38,43 @@ flex = pytest.importorskip("unsloth_zoo.temporary_patches.flex_attention_bwd")
 torch = pytest.importorskip("torch")
 
 
-def _staged(block, stages, head_dim, dtype_size):
-    """The formula this module shipped with, kept here as the floor it must not go under."""
-    return stages * block * head_dim * dtype_size * 2 + flex._SHMEM_OVERHEAD
+def _dtypes():
+    """Every dtype the backward is reached with, including any float8 this torch has."""
+    out = [torch.bfloat16, torch.float16, torch.float32]
+    for name in ("float8_e4m3fn", "float8_e5m2"):
+        dt = getattr(torch, name, None)
+        if dt is not None:
+            out.append(dt)
+    return out
+
+
+def _staged(block, stages, head_dim, dtype):
+    """The formula this module shipped with, dtype rule included.
+
+    Its rule answers 4 for anything that is not bf16 or fp16, which is four times a
+    float8's real width. Reproduced faithfully rather than corrected, because this is
+    the floor the estimate must not drop below, not a model of the hardware.
+    """
+    size = 2 if dtype in (torch.bfloat16, torch.float16) else 4
+    return stages * block * head_dim * size * 2 + flex._SHMEM_OVERHEAD
 
 
 class TestTheEstimateIsNeverLowerThanItWas:
-    """Whatever else changes, no GPU may stop being covered."""
+    """Whatever else changes, no GPU may stop being covered.
+
+    The float8 rows are the ones that caught a real slip: correcting the element width
+    to its true 1 byte dropped the estimate for an fp8 kernel to well under what the
+    shipped formula produced, which would have closed the gate on a case it opens today.
+    Each term now keeps its own dtype rule so the maximum is a floor for every dtype.
+    """
 
     @pytest.mark.parametrize("block", [16, 32, 64, 128])
     @pytest.mark.parametrize("stages", [1, 2, 3])
     @pytest.mark.parametrize("head_dim", [64, 128, 192, 256])
-    def test_it_never_drops_below_the_original_formula(self, block, stages, head_dim):
-        got = flex._estimate_shmem(block, stages, head_dim, torch.bfloat16)
-        assert got >= _staged(block, stages, head_dim, 2), (
+    @pytest.mark.parametrize("dtype", _dtypes(), ids = lambda d: str(d).replace("torch.", ""))
+    def test_it_never_drops_below_the_original_formula(self, block, stages, head_dim, dtype):
+        got = flex._estimate_shmem(block, stages, head_dim, dtype)
+        assert got >= _staged(block, stages, head_dim, dtype), (
             "an estimate below the original one would close the gate on a GPU where it "
             "fires today, which is a silent failure to compile"
         )
@@ -75,7 +98,7 @@ class TestTheMeasuredRequirementIsCovered:
         """The exact config GB10 was handed, against the limit Triton enforces."""
         assert flex._estimate_shmem(64, 1, 256, torch.bfloat16) > 101376
         # And the old formula, which is why it slipped: 1 * 64 * 256 * 2 * 2 + 10240.
-        assert _staged(64, 1, 256, 2) == 75776
+        assert _staged(64, 1, 256, torch.bfloat16) == 75776
 
     def test_a_head_dim_that_fits_still_fits(self):
         """head_dim 128 compiles on GB10 today, so the gate must stay shut for it."""

--- a/tests/test_flex_attention_bwd_shmem_gate.py
+++ b/tests/test_flex_attention_bwd_shmem_gate.py
@@ -1,0 +1,168 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""The shared-memory gate in `temporary_patches.flex_attention_bwd`.
+
+The patch appends smaller backward configs when the ones Inductor picked cannot fit
+in shared memory. Everything here turns on the estimate that decides WHETHER it
+fires, and the failure mode is one-sided: an over-estimate offers a few candidates
+the autotuner discards, while an under-estimate means the gate stays shut, the
+offending config is handed back untouched, and the compile dies with "No valid
+triton configs".
+
+It stayed shut on exactly the GPUs this patch was written for. The original formula
+scales with num_stages, and it was fitted on an sm8x part whose head_dim >= 128
+entry uses num_stages=2. sm10x, sm11x and sm12x all use num_stages=1 there, which
+halves the estimate: on GB10, head_dim 256 bf16 block 64 was scored 75,776 against a
+102,400 limit and passed, while Triton reported `Required: 114688 Hardware limit:
+101376` and refused it.
+
+Measured, by forcing single configs on GB10 (sm_121, torch 2.14, Triton 3.8) and
+reading Triton's own "Required:": block 64 -> 114,688, block 128 -> 229,376, and
+IDENTICAL for num_stages 1 and 2.
+
+GPU-free: the arithmetic is exercised directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+flex = pytest.importorskip("unsloth_zoo.temporary_patches.flex_attention_bwd")
+torch = pytest.importorskip("torch")
+
+
+def _staged(block, stages, head_dim, dtype_size):
+    """The formula this module shipped with, kept here as the floor it must not go under."""
+    return stages * block * head_dim * dtype_size * 2 + flex._SHMEM_OVERHEAD
+
+
+class TestTheEstimateIsNeverLowerThanItWas:
+    """Whatever else changes, no GPU may stop being covered."""
+
+    @pytest.mark.parametrize("block", [16, 32, 64, 128])
+    @pytest.mark.parametrize("stages", [1, 2, 3])
+    @pytest.mark.parametrize("head_dim", [64, 128, 192, 256])
+    def test_it_never_drops_below_the_original_formula(self, block, stages, head_dim):
+        got = flex._estimate_shmem(block, stages, head_dim, torch.bfloat16)
+        assert got >= _staged(block, stages, head_dim, 2), (
+            "an estimate below the original one would close the gate on a GPU where it "
+            "fires today, which is a silent failure to compile"
+        )
+
+
+class TestTheMeasuredRequirementIsCovered:
+    """The numbers Triton itself reported on GB10, head_dim 256 bf16."""
+
+    # (block, num_stages, what Triton said it Required)
+    MEASURED = [(64, 1, 114688), (64, 2, 114688), (128, 1, 229376)]
+
+    @pytest.mark.parametrize("block, stages, required", MEASURED)
+    def test_the_estimate_reaches_the_real_requirement(self, block, stages, required):
+        got = flex._estimate_shmem(block, stages, 256, torch.bfloat16)
+        assert got >= required, (
+            f"block {block}/stages {stages} really needs {required}; estimating {got} "
+            "leaves the gate shut and the config is returned as-is"
+        )
+
+    def test_the_stage_one_case_that_slipped_through(self):
+        """The exact config GB10 was handed, against the limit Triton enforces."""
+        assert flex._estimate_shmem(64, 1, 256, torch.bfloat16) > 101376
+        # And the old formula, which is why it slipped: 1 * 64 * 256 * 2 * 2 + 10240.
+        assert _staged(64, 1, 256, 2) == 75776
+
+    def test_a_head_dim_that_fits_still_fits(self):
+        """head_dim 128 compiles on GB10 today, so the gate must stay shut for it."""
+        assert flex._estimate_shmem(64, 1, 128, torch.bfloat16) <= 101376
+
+    def test_a_large_shared_memory_gpu_is_untouched(self):
+        """A100 opt-in is 166,912, so nothing here fires and autotune time is unchanged."""
+        assert flex._estimate_shmem(64, 2, 256, torch.bfloat16) <= 166912
+
+
+class TestTheLimitIsTheOneTritonEnforces:
+    def test_the_smaller_of_the_two_is_taken(self, monkeypatch):
+        class Props:
+            shared_memory_per_block_optin = 101376
+            shared_memory_per_multiprocessor = 102400
+
+        monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _d: Props())
+        assert flex._shmem_limit(0) == 101376, (
+            "Triton refuses on the per-block opt-in maximum; the 1KB above it is enough "
+            "to bless a config it then rejects"
+        )
+
+    def test_an_older_torch_without_the_optin_attribute_still_answers(self, monkeypatch):
+        class Props:
+            shared_memory_per_multiprocessor = 102400
+
+        monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _d: Props())
+        assert flex._shmem_limit(0) == 102400
+
+    def test_no_usable_attribute_reports_zero_rather_than_guessing(self, monkeypatch):
+        monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _d: object())
+        assert flex._shmem_limit(0) == 0
+
+
+class TestTheFallbackLadder:
+    """The estimate decides whether to intervene; it does not also decide what survives.
+
+    Inductor catches OutOfResources per candidate and keeps the ones that compile, so
+    offering a config that does not fit costs one discarded candidate.
+    """
+
+    class FakeConfig:
+        def __init__(self, bm1, bn1, bm2, bn2, num_stages, num_warps):
+            self.block_m1, self.block_n1 = bm1, bn1
+            self.block_m2, self.block_n2 = bm2, bn2
+            self.num_stages, self.num_warps = num_stages, num_warps
+
+        def __eq__(self, other):
+            return vars(self) == vars(other)
+
+    def _blocks(self, configs):
+        return sorted({c.block_m1 for c in configs}, reverse = True)
+
+    def test_every_block_below_the_offending_one_is_offered(self):
+        configs = flex._generate_safe_configs(
+            self.FakeConfig, 101376, 256, torch.bfloat16, worst_block = 64,
+        )
+        assert self._blocks(configs) == [32, 16], (
+            "the offending block was 64, so 32 and 16 are the candidates that remain"
+        )
+
+    def test_a_larger_offending_block_yields_a_longer_ladder(self):
+        configs = flex._generate_safe_configs(
+            self.FakeConfig, 101376, 256, torch.bfloat16, worst_block = 128,
+        )
+        assert self._blocks(configs) == [64, 32, 16]
+
+    def test_the_smallest_fallback_is_always_present(self):
+        for worst in (0, 32, 64, 128):
+            configs = flex._generate_safe_configs(
+                self.FakeConfig, 101376, 256, torch.bfloat16, worst_block = worst,
+            )
+            assert any(c.block_m1 == 16 and c.num_stages == 1 for c in configs), (
+                f"worst_block={worst} produced no 16/1 fallback"
+            )
+
+
+class TestThePatchIsSafeToApplyTwice:
+    def test_a_second_call_does_not_wrap_the_wrapper(self):
+        if not torch.cuda.is_available():
+            pytest.skip("the patch returns early without CUDA")
+        from torch._inductor.template_heuristics import triton as th  # noqa: PLC0415
+
+        flex.patch_flex_attention_bwd_configs()
+        first = th.CUDAConfigHeuristic().get_flex_attn_bwd_configs(256, torch.bfloat16)
+        flex.patch_flex_attention_bwd_configs()
+        second = th.CUDAConfigHeuristic().get_flex_attn_bwd_configs(256, torch.bfloat16)
+        assert len(first) == len(second), (
+            "the second call wrapped the wrapper, so the ladder is being appended twice"
+        )

--- a/unsloth_zoo/temporary_patches/flex_attention_bwd.py
+++ b/unsloth_zoo/temporary_patches/flex_attention_bwd.py
@@ -63,9 +63,22 @@ _SHMEM_TILE_FACTOR = 3.5
 def _dtype_size(dtype):
     if dtype in (torch.bfloat16, torch.float16):
         return 2
+    # getattr, because the float8 dtypes do not exist on every supported torch.
     if dtype in (getattr(torch, "float8_e4m3fn", None), getattr(torch, "float8_e5m2", None)):
         return 1
     return 4
+
+
+def _staged_dtype_size(dtype):
+    """The dtype rule the staged formula was fitted with, kept exactly as it was.
+
+    It answers 4 for anything that is not bf16 or fp16, which includes the float8
+    dtypes -- four times their real width. That is wrong as physics and right as a
+    floor: correcting it here would drop the staged estimate for an fp8 kernel below
+    what this patch has been using, and the whole point of keeping this term is that
+    it can only ever raise the answer.
+    """
+    return 2 if dtype in (torch.bfloat16, torch.float16) else 4
 
 
 def _estimate_shmem(block_size, num_stages, head_dim, dtype):
@@ -76,10 +89,14 @@ def _estimate_shmem(block_size, num_stages, head_dim, dtype):
     on sm_121 it measurably does not. Neither formula is safe alone, so take whichever
     is larger -- an over-estimate costs a few discarded autotune candidates, while an
     under-estimate silently returns a config that cannot compile.
+
+    Each term keeps its own dtype rule so the maximum is a true floor over the
+    original: the staged one because it was fitted that way, the linear one because
+    it is the measured relationship and wants the real element width.
     """
-    tile = block_size * head_dim * _dtype_size(dtype)
-    staged = num_stages * tile * 2 + _SHMEM_OVERHEAD
-    linear = _SHMEM_TILE_FACTOR * tile
+    tile = block_size * head_dim
+    staged = num_stages * tile * _staged_dtype_size(dtype) * 2 + _SHMEM_OVERHEAD
+    linear = _SHMEM_TILE_FACTOR * tile * _dtype_size(dtype)
     return int(max(staged, linear))
 
 

--- a/unsloth_zoo/temporary_patches/flex_attention_bwd.py
+++ b/unsloth_zoo/temporary_patches/flex_attention_bwd.py
@@ -21,10 +21,27 @@ On GPUs with limited shared memory per SM (RTX 3090/4090/5090, RTX PRO 6000,
 ~100KB), the backward configs can exceed the limit for large head_dims (e.g.
 256 in Gemma3): the default BLOCK=64, num_stages=2 needs ~141KB vs ~101KB.
 
-We intercept backward config selection and add safe fallbacks estimated via
-    shmem ~ num_stages * max_block * head_dim * dtype_size * 2 + OVERHEAD
-(OVERHEAD ~10KB from Triton; validated 141,312 estimated vs 140,800 actual).
-Fallbacks are only added when a config is estimated to exceed the limit.
+We intercept backward config selection and add safe fallbacks. Fallbacks are only
+added when a config is estimated to exceed the limit, so a GPU with room to spare
+keeps exactly the configs upstream chose and pays no extra autotune time.
+
+The estimate is the maximum of two formulas, because each was fitted on a different
+GPU and neither generalises on its own:
+    staged ~ num_stages * max_block * head_dim * dtype_size * 2 + OVERHEAD
+    linear ~ 3.5 * max_block * head_dim * dtype_size
+The first was validated on a ~100KB-per-SM sm8x part (141,312 estimated vs 140,800
+actual, BLOCK=64/num_stages=2/head_dim=256). The second was measured on GB10
+(sm_121, torch 2.14, Triton 3.8) by forcing single configs and reading Triton's own
+"Required:": BLOCK 64 -> 114,688 and BLOCK 128 -> 229,376, IDENTICAL for num_stages
+1 and 2. So the requirement is linear in block size and, on that part, independent
+of num_stages.
+
+Taking the maximum matters in both directions. Under-estimating is fatal and silent:
+the gate does not fire, the offending config is returned untouched, and the compile
+dies with "No valid triton configs". Over-estimating only offers configs that
+Inductor discards. So the estimate is deliberately biased high, and it is never
+lower than the original formula, which means every GPU where this patch fires today
+still gets it.
 
 No-op on torch < 2.10 (no FlexBwDConfig).
 """
@@ -38,25 +55,68 @@ __all__ = ["patch_flex_attention_bwd_configs"]
 _SHMEM_OVERHEAD = 10240  # 10KB, slightly conservative
 
 
+# Measured on GB10 (sm_121) against Triton's reported "Required:", and stage-independent
+# there. See the module docstring for why both this and the staged formula are kept.
+_SHMEM_TILE_FACTOR = 3.5
+
+
+def _dtype_size(dtype):
+    if dtype in (torch.bfloat16, torch.float16):
+        return 2
+    if dtype in (getattr(torch, "float8_e4m3fn", None), getattr(torch, "float8_e5m2", None)):
+        return 1
+    return 4
+
+
 def _estimate_shmem(block_size, num_stages, head_dim, dtype):
-    """Estimate shared memory for a backward config.
+    """Estimate shared memory for a backward config, biased high on purpose.
 
-    The kernel pipelines two tensor loads (qT+dO or kT+vT), num_stages copies
-    each in shared memory.
+    The kernel pipelines two tensor loads (qT+dO or kT+vT). How many copies it keeps
+    live is not the same across architectures: on sm8x it scales with num_stages, and
+    on sm_121 it measurably does not. Neither formula is safe alone, so take whichever
+    is larger -- an over-estimate costs a few discarded autotune candidates, while an
+    under-estimate silently returns a config that cannot compile.
     """
-    dtype_size = 2 if dtype in (torch.bfloat16, torch.float16) else 4
-    return num_stages * block_size * head_dim * dtype_size * 2 + _SHMEM_OVERHEAD
+    tile = block_size * head_dim * _dtype_size(dtype)
+    staged = num_stages * tile * 2 + _SHMEM_OVERHEAD
+    linear = _SHMEM_TILE_FACTOR * tile
+    return int(max(staged, linear))
 
 
-def _generate_safe_configs(FlexBwDConfig, shmem_limit, head_dim, dtype):
-    """Generate FlexBwDConfig candidates estimated to fit within shared memory."""
+def _shmem_limit(device):
+    """The limit Triton actually enforces.
+
+    It refuses a kernel on the per-block opt-in maximum, which is SMALLER than the
+    per-SM figure on recent parts (101,376 vs 102,400 on GB10) -- and the 1KB between
+    them is enough to bless a config Triton then rejects. Take the smaller of the two,
+    and tolerate either attribute being absent on older torch.
+    """
+    props = torch.cuda.get_device_properties(device)
+    limits = [
+        getattr(props, name, None)
+        for name in ("shared_memory_per_block_optin", "shared_memory_per_multiprocessor")
+    ]
+    limits = [x for x in limits if isinstance(x, int) and x > 0]
+    return min(limits) if limits else 0
+
+
+def _generate_safe_configs(FlexBwDConfig, shmem_limit, head_dim, dtype, worst_block = 0):
+    """Candidates to offer alongside the ones upstream chose.
+
+    Every block strictly smaller than the offending one is offered, rather than only
+    those the estimate blesses. The estimate decides WHETHER to intervene, but it is a
+    model of somebody else's kernel and it should not also decide what survives:
+    Inductor's autotuner catches OutOfResources per candidate and keeps the ones that
+    compile, so offering a config that does not fit costs one discarded candidate,
+    while failing to offer one that does is the whole bug.
+    """
     configs = []
-    for block in [128, 64, 32, 16]:
-        for stages in [3, 2, 1]:
-            est = _estimate_shmem(block, stages, head_dim, dtype)
-            if est <= shmem_limit:
-                for warps in [4, 8]:
-                    configs.append(FlexBwDConfig(block, block, block, block, stages, warps))
+    block = worst_block if worst_block else 256
+    while block > 16:
+        block //= 2
+        for stages in [2, 1]:
+            for warps in [4, 8]:
+                configs.append(FlexBwDConfig(block, block, block, block, stages, warps))
     # Always include the smallest safe fallback
     fallback = FlexBwDConfig(16, 16, 16, 16, 1, 4)
     if fallback not in configs:
@@ -96,35 +156,48 @@ def patch_flex_attention_bwd_configs():
         def make_patched(orig):
             def patched_get_flex_attn_bwd_configs(self, head_dim, dtype):
                 # Per-device limit so heterogeneous multi-GPU setups work.
-                device = torch.cuda.current_device()
-                shmem_limit = torch.cuda.get_device_properties(device).shared_memory_per_multiprocessor
+                try:
+                    shmem_limit = _shmem_limit(torch.cuda.current_device())
+                except Exception:
+                    shmem_limit = 0
 
                 try:
                     configs = list(orig(self, head_dim, dtype))
                 except Exception:
                     configs = []
 
+                if not shmem_limit:
+                    return configs
+
                 # Patch only if some original config exceeds shared memory.
                 needs_patch = False
+                worst_block = 0
                 for c in configs:
                     max_block = max(c.block_m1, c.block_n1, c.block_m2, c.block_n2)
                     est = _estimate_shmem(max_block, c.num_stages, head_dim, dtype)
                     if est > shmem_limit:
                         needs_patch = True
-                        break
+                        worst_block = max(worst_block, max_block)
 
                 if not needs_patch and configs:
                     return configs
 
                 # Add safe fallback configs for this GPU / head_dim / dtype
-                safe = _generate_safe_configs(FlexBwDConfig, shmem_limit, head_dim, dtype)
+                safe = _generate_safe_configs(
+                    FlexBwDConfig, shmem_limit, head_dim, dtype, worst_block,
+                )
                 for c in safe:
                     if c not in configs:
                         configs.append(c)
 
                 return configs
+            patched_get_flex_attn_bwd_configs._unsloth_flex_bwd = True
             return patched_get_flex_attn_bwd_configs
 
+        # Calling this twice would otherwise wrap the wrapper, so every later call
+        # would walk two copies of the same logic.
+        if getattr(original_method, "_unsloth_flex_bwd", False):
+            continue
         cls.get_flex_attn_bwd_configs = make_patched(original_method)
 
     return True


### PR DESCRIPTION
The flex-attention backward shared-memory patch has been a silent no-op on Blackwell-class GPUs. On a GB10 (sm_121, 40 SMs) a default LoRA run on Gemma-3 (head_dim 256) dies on a cold Inductor cache with this patch loaded and active:

```
InductorError: RuntimeError: No valid triton configs. OutOfMemoryError: out of resource:
triton_tem_fused_flex_attention_backward Required: 114688 Hardware limit: 101376
```

## Why it did not fire

`CUDAConfigHeuristic.get_flex_attn_bwd_configs` returns exactly one config for `head_dim >= 128` on this part: block 64, `num_stages=1`. Three separate things then went wrong, and each on its own is enough to keep the gate shut.

**1. The estimate scales with `num_stages`.** It was fitted on an sm8x part, whose `head_dim >= 128` entry uses `num_stages=2`. `sm10x`, `sm11x` and `sm12x` all use `num_stages=1` there, which halves the estimate. head_dim 256 bf16 block 64 scored `1 * 64 * 256 * 2 * 2 + 10240 = 75776`, comfortably under the limit, so `needs_patch` stayed `False` and the failing config was returned untouched.

Measured on GB10 (torch 2.14.0+cu134, Triton 3.8.0) by forcing single configs and reading Triton's own `Required:`:

| block | num_stages | Required |
| --- | --- | --- |
| 64 | 1 | 114688 |
| 64 | 2 | 114688 |
| 128 | 1 | 229376 |

So on that part the requirement is linear in block size and independent of `num_stages`.

**2. The limit was the wrong one.** Triton refuses on `shared_memory_per_block_optin` (101376 here), not `shared_memory_per_multiprocessor` (102400). Those 1024 bytes are enough to bless a config Triton then rejects, and they are exactly the gap between the two numbers in the error above.

**3. The fallback ladder asked the same broken estimate** which blocks to offer, so a wrong estimate both failed to open the gate and then chose the replacements.

## The fix

The two formulas disagree and neither generalises. The original sm8x measurement (`141312` estimated against `140800` actual) implies a tile factor near 4.3; GB10 measures 3.5. Rather than pick one, take the maximum of both.

The direction matters and is not symmetric. An over-estimate offers a few extra candidates that the autotuner discards. An under-estimate is a silent failure to compile. A maximum is also never below the formula that ships today, so every GPU where this patch fires now still gets it, and the change can only add coverage.

The limit is now `min(shared_memory_per_block_optin, shared_memory_per_multiprocessor)`, tolerating either attribute being absent on older torch.

The estimate now decides only *whether* to intervene. Every block strictly below the offending one is offered, rather than only those the estimate blesses. Inductor's autotuner catches `OutOfResources` per candidate and keeps what compiles, so offering a config that does not fit costs one discarded candidate, while failing to offer one that does is the whole bug. Verified directly: a forced list of `[block 64 (OOMs), block 16 (fits)]` compiles cold and produces gradients matching the good-only run.

Finally, `patch_flex_attention_bwd_configs()` wrapped whatever was already installed, so calling it twice walked two copies of the ladder. It is now guarded.

## Verification

On GB10, cold Inductor cache, torch 2.14.0+cu134 / Triton 3.8.0:

- `flex_attention` backward at head_dim 256 bf16 **FAILS** with the shipped patch and **PASSES** with this one, producing real gradients.
- head_dim 32, 64 and 128 keep exactly one config, so nothing else pays autotune time.
- A large-shared-memory part never reaches the gate: 114688 is below A100's 166912 opt-in.
- LoRA on `unsloth/gemma-3-270m-it` trains on the default flex path at 4.4 steps/s, with the loss curve tracking the eager path to three digits.
- Existing suites: `test_temporary_patches_imports.py` and `test_temporary_patches_exhaustive.py`, 146 passed, 13 skipped.
- New `tests/test_flex_attention_bwd_shmem_gate.py`, 253 passed, GPU-free. (61 when this
  was first written; keeping the float8 rows a floor for every dtype widened the
  parametrisation.)

No-op behaviour is unchanged for torch < 2.10 (no `FlexBwDConfig`), for non-CUDA, and for ROCm classes.

## One note for anyone reproducing this

It looks intermittent and it is not. `unsloth_zoo/patching_utils.py` pops `TORCHINDUCTOR_CACHE_DIR` during `import unsloth`, so every run shares one cache directory and setting that variable beforehand does nothing. Once any process has compiled a working backward graph, later runs hit the FX-graph cache and never consult the config heuristic at all, so the same command passes or fails depending only on what some earlier run left behind. Set the cache directory *after* the import to get a genuinely cold run.

That popping is worth revisiting on its own, since it silently overrides an explicit user choice, but it is left alone here.



## Confirmed independently on a second Blackwell part

Re-run on a B200 (sm_100, torch 2.13.0+cu130) after merging this branch with current
`main`, which merges clean:

| block | num_stages | head_dim | old estimate | new estimate | Triton's measured requirement |
| --- | --- | --- | --- | --- | --- |
| 64 | 1 | 256 | 75,776 | 114,688 | 114,688 |
| 128 | 1 | 256 | 141,312 | 229,376 | 229,376 |
| 64 | 2 | 256 | 141,312 | 141,312 | - |

The new estimate reproduces the figures measured on GB10 exactly, on different silicon,
which is the part of the fix that had only one hardware witness before.

B200 reports 233,472 bytes per SM, so the gate stays shut for all of these and the configs
Inductor picked are returned untouched. That is the intended no-op: a part with headroom
pays no extra autotune time. It also means B200 cannot witness the failure itself, and this
does not claim otherwise; the GB10 evidence above is still the only end-to-end reproduction.

`tests/test_flex_attention_bwd_shmem_gate.py` passes 253 on that merged tree.
