### PR TITLE
Update the getsource guard tests to the pinned forward from #967

### DIFF
--- a/tests/test_compiled_cache_collective.py
+++ b/tests/test_compiled_cache_collective.py
@@ -1317,6 +1317,10 @@ def test_direct_recovery_can_still_import_cache_helpers(
     primary, temp = cache_dirs
     _stub_compile_folders(monkeypatch, compiler, primary, temp)
     monkeypatch.setattr(compiler, "UNSLOTH_COMPILE_LOCATION", str(primary))
+    # An earlier test that imported a bare moe_utils from its own scratch cache
+    # would satisfy the import below from sys.modules and never touch the
+    # search path this test exists to check. Start from an empty slot.
+    monkeypatch.delitem(sys.modules, "moe_utils", raising=False)
     (primary / "moe_utils.py").write_text(
         "forward_moe_backend = 'installed'\n", encoding="utf-8",
     )

--- a/tests/test_compiler_getsource_tokenerror.py
+++ b/tests/test_compiler_getsource_tokenerror.py
@@ -188,6 +188,74 @@ def test_the_dtype_patcher_never_reads_its_own_generated_forward(tmp_path):
     )
 
 
+def test_a_mode_change_rebuilds_from_the_pristine_forward(tmp_path):
+    """A same-mode second pass continues before touching the pin, so only a
+    mode change exercises it: the rebuild must come from torch's own forward,
+    read nothing out of the compile folder, and not stack a wrapper."""
+    proc = _run(
+        """
+        import torch
+
+        real_getsource = compiler.inspect.getsource
+        hits = []
+
+        def raise_on_generated(obj, *args, **kwargs):
+            code = getattr(obj, "__code__", None)
+            if code is not None and code.co_filename.startswith(CACHE):
+                hits.append(code.co_filename)
+                raise tokenize.TokenError("EOF in multi-line statement", (1, 0))
+            return real_getsource(obj, *args, **kwargs)
+
+        compiler.inspect.getsource = raise_on_generated
+        # The compiled global F.layer_norm is not what this exercises.
+        import unsloth_zoo.patch_torch_functions as ptf
+        ptf.patch_torch_functions = lambda: None
+
+        mod = fresh_llama()
+        compiler._patch_torch_dtype_modules(
+            "transformers.models.llama.modeling_llama",
+            dir(mod),
+            compiler.get_torch_compile_options(),
+            True,
+            False,
+            None,
+        )
+
+        rebuilt = []
+        stacked = []
+        from_cache = []
+        for name in compiler._patch_functions:
+            if not hasattr(torch.nn, name):
+                continue
+            fwd = getattr(torch.nn, name).forward
+            if not getattr(fwd, "__unsloth_dtype_wrapped__", False):
+                continue
+            original = fwd.__unsloth_dtype_original__
+            rebuilt.append([name, fwd.__unsloth_dtype_disable__])
+            if getattr(original, "__unsloth_dtype_wrapped__", False):
+                stacked.append(name)
+            code = getattr(original, "__code__", None)
+            if code is not None and code.co_filename.startswith(CACHE):
+                from_cache.append(name)
+
+        print("RESULT " + json.dumps({
+            "hits": hits,
+            "rebuilt": rebuilt,
+            "stacked": stacked,
+            "from_cache": from_cache,
+        }))
+        """,
+        tmp_path / "cache_mode_change",
+    )
+    out = _result(proc, "mode-change-rebuild")
+
+    assert out["rebuilt"], "no torch.nn forward was rebuilt, so the mode change never reached the loop"
+    assert all(disable is False for _, disable in out["rebuilt"]), out["rebuilt"]
+    assert out["hits"] == [], f"the rebuild read a generated forward through getsource: {out['hits']}"
+    assert out["stacked"] == [], f"a wrapper was rebuilt on top of a wrapper: {out['stacked']}"
+    assert out["from_cache"] == [], f"the pin points at a generated forward: {out['from_cache']}"
+
+
 def test_the_probe_sets_cpu_mode_itself_rather_than_inheriting_it():
     """The subprocess must not depend on conftest for its own importability.
 

--- a/tests/test_compiler_getsource_tokenerror.py
+++ b/tests/test_compiler_getsource_tokenerror.py
@@ -135,8 +135,12 @@ def test_compile_transformers_survives_tokenerror_from_getsource(tmp_path):
     )
 
 
-def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
-    """Raises only on the generated forward, so the pipeline reaches the dtype patcher."""
+def test_the_dtype_patcher_never_reads_its_own_generated_forward(tmp_path):
+    """After a warm-up, the torch.nn forwards are the patcher's own generated
+    ones. A second pass must not call getsource on them: it pins the pristine
+    forward before any rewrite and rebuilds from that (#967), which is what
+    removed the mid-rewrite TokenError this file was written for. A getsource
+    that does resolve into the compile folder is that path coming back."""
     proc = _run(
         """
         import torch
@@ -168,7 +172,7 @@ def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
 
         print("RESULT " + json.dumps({
             "generated": len(generated),
-            "hits": len(hits),
+            "hits": hits,
         }))
         """,
         tmp_path / "cache_generated",
@@ -177,12 +181,12 @@ def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
 
     assert out["generated"] > 0, (
         "no torch.nn forward was served out of the compile folder after a "
-        "warm-up compile, so this probe does not cover the concurrent-rewrite "
-        "case it exists for"
+        "warm-up compile, so this probe does not cover the second-pass case "
+        "it exists for"
     )
-    assert out["hits"] > 0, (
-        "no getsource call resolved into the compile folder, so the dtype "
-        "patcher's TokenError handler was never exercised"
+    assert out["hits"] == [], (
+        f"the dtype patcher read its own generated forward back through "
+        f"getsource: {out['hits']}"
     )
 
 

--- a/tests/test_compiler_getsource_tokenerror.py
+++ b/tests/test_compiler_getsource_tokenerror.py
@@ -136,11 +136,9 @@ def test_compile_transformers_survives_tokenerror_from_getsource(tmp_path):
 
 
 def test_the_dtype_patcher_never_reads_its_own_generated_forward(tmp_path):
-    """After a warm-up, the torch.nn forwards are the patcher's own generated
-    ones. A second pass must not call getsource on them: it pins the pristine
-    forward before any rewrite and rebuilds from that (#967), which is what
-    removed the mid-rewrite TokenError this file was written for. A getsource
-    that does resolve into the compile folder is that path coming back."""
+    """A second pass pins the pristine forward and rebuilds from it (#967), so
+    it must never getsource its own generated forward; a hit is the
+    mid-rewrite TokenError path coming back."""
     proc = _run(
         """
         import torch

--- a/tests/test_moe_weight_preprocessor_registry_shared.py
+++ b/tests/test_moe_weight_preprocessor_registry_shared.py
@@ -100,9 +100,13 @@ def test_bare_moe_utils_copy_shares_the_registry(cache_copy, monkeypatch):
     # A third copy: compiler.py puts the compile location on sys.path, so the bare
     # `from moe_utils import ...` generated modules do is its own module too.
     monkeypatch.syspath_prepend(os.environ["UNSLOTH_COMPILE_LOCATION"])
-    monkeypatch.delitem(sys.modules, "moe_utils", raising=False)
+    # Record the slot BEFORE the import fills it. setitem after the import
+    # remembers the bare copy as the value to restore, so the scratch copy
+    # outlived this test in sys.modules and every later bare `from moe_utils
+    # import ...` in the process resolved to it instead of its own cache.
+    monkeypatch.setitem(sys.modules, "moe_utils", None)
+    del sys.modules["moe_utils"]
     import moe_utils as bare
-    monkeypatch.setitem(sys.modules, "moe_utils", bare)
     assert bare is not moe_utils and bare is not cache_copy
     key = "unit_test_registry_shared_arch_bare"
     fn = lambda weight, proj_type, hidden_dim: weight

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -203,9 +203,8 @@ def test_a_bare_return_is_the_functions_contract():
     assert any(r.value is None for r in returns)
 
 
-# The dtype patcher reads `original_forward`, pinned from `function.forward`
-# before any rewrite (#967), so a second pass never reads its own generated
-# output back through getsource.
+# Pinned from `function.forward` before any rewrite (#967), so a second pass
+# never reads its own generated output back.
 NN_FORWARD_GETSOURCE = "source = inspect.getsource(original_forward).rstrip()"
 
 
@@ -486,9 +485,8 @@ def test_the_unreadable_forward_is_wrapped_rather_than_dropped():
 
 
 def test_the_forward_is_pinned_before_it_is_read():
-    """The pristine forward is captured before any rewrite and every branch
-    installs from it, or the second pass (loader.py prepends "siglip", so
-    vision loads patch torch.nn twice) reads its own output back."""
+    """Captured before any rewrite, or the second pass (vision loads patch
+    torch.nn twice) reads its own output back."""
     region = _nn_patch_region()
     pin = region.index("original_forward = function.forward")
     assert pin < region.index(NN_FORWARD_GETSOURCE)

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -203,8 +203,14 @@ def test_a_bare_return_is_the_functions_contract():
     assert any(r.value is None for r in returns)
 
 
+# The dtype patcher reads `original_forward`, pinned from `function.forward`
+# before any rewrite (#967), so a second pass never reads its own generated
+# output back through getsource.
+NN_FORWARD_GETSOURCE = "source = inspect.getsource(original_forward).rstrip()"
+
+
 def _nn_patch_region() -> str:
-    i = SRC.index("source = inspect.getsource(function.forward).rstrip()")
+    i = SRC.index(NN_FORWARD_GETSOURCE)
     return SRC[max(0, i - 1600):i + 1400]
 
 
@@ -222,7 +228,7 @@ def test_the_nn_forward_patch_loop_is_guarded():
     forward is unreadable -- both measured, not assumed. This guards a state
     we have observed rather than encoding a theory about how it arises.
     """
-    guards = _getsource_guards("inspect.getsource(function.forward)")
+    guards = _getsource_guards("inspect.getsource(original_forward)")
     assert guards, "the forward getsource is no longer inside a try"
     for caught in guards:
         assert _catches(caught, "OSError") and _catches(caught, "TypeError"), (
@@ -242,7 +248,7 @@ def test_an_unreadable_forward_is_skipped_not_fatal():
     # Exactly the try whose body IS this assignment -- several other blocks
     # also call getsource on a forward, and their handlers legitimately do
     # something else.
-    target = "source = inspect.getsource(function.forward).rstrip()"
+    target = NN_FORWARD_GETSOURCE
     handlers = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Try) or len(node.body) != 1:
@@ -272,7 +278,7 @@ def test_the_compiler_config_check_is_kept():
 def test_both_getsource_guards_are_present():
     """Two distinct sites, two distinct failures. Fixing only the first one
     just moves the crash later, which is exactly what happened."""
-    sites = {"inspect.getsource(modeling_file)", "inspect.getsource(function.forward)"}
+    sites = {"inspect.getsource(modeling_file)", "inspect.getsource(original_forward)"}
     for call in sites:
         guards = _getsource_guards(call)
         assert guards and all(
@@ -477,6 +483,15 @@ def test_the_wrapper_is_marked_so_it_is_not_wrapped_twice():
 def test_the_unreadable_forward_is_wrapped_rather_than_dropped():
     region = _nn_patch_region()
     assert "_dtype_safe_forward(" in region
+
+
+def test_the_forward_is_pinned_before_it_is_read():
+    """The pristine forward is captured before any rewrite and every branch
+    installs from it, or the second pass (loader.py prepends "siglip", so
+    vision loads patch torch.nn twice) reads its own output back."""
+    region = _nn_patch_region()
+    pin = region.index("original_forward = function.forward")
+    assert pin < region.index(NN_FORWARD_GETSOURCE)
 
 
 def test_the_tensor_may_arrive_by_keyword():

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -203,13 +203,36 @@ def test_a_bare_return_is_the_functions_contract():
     assert any(r.value is None for r in returns)
 
 
-# Pinned from `function.forward` before any rewrite (#967), so a second pass
-# never reads its own generated output back.
-NN_FORWARD_GETSOURCE = "source = inspect.getsource(original_forward).rstrip()"
+def _nn_forward_getsource() -> tuple:
+    """``(assignment, call, variable)`` for the getsource read in the dtype patcher.
+
+    Found on the parse of ``_patch_torch_dtype_modules`` rather than by spelling: #967
+    renamed the variable from ``function.forward`` to the pinned ``original_forward`` and
+    every anchor here went red on a correct change.
+    """
+    tree = ast.parse(SRC)
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_patch_torch_dtype_modules"
+    )
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        # `inspect.getsource(x).rstrip()`: the getsource call is the receiver.
+        inner = call.func.value if isinstance(call.func, ast.Attribute) else None
+        if not isinstance(inner, ast.Call) or ast.unparse(inner.func) != "inspect.getsource":
+            continue
+        if len(inner.args) == 1 and isinstance(inner.args[0], ast.Name):
+            return ast.unparse(node), ast.unparse(inner), inner.args[0].id
+    raise AssertionError("no `source = inspect.getsource(<forward>).rstrip()` in _patch_torch_dtype_modules")
+
+
+NN_FORWARD_ASSIGN, NN_FORWARD_CALL, NN_FORWARD_VAR = _nn_forward_getsource()
 
 
 def _nn_patch_region() -> str:
-    i = SRC.index(NN_FORWARD_GETSOURCE)
+    i = SRC.index(NN_FORWARD_ASSIGN)
     return SRC[max(0, i - 1600):i + 1400]
 
 
@@ -227,7 +250,7 @@ def test_the_nn_forward_patch_loop_is_guarded():
     forward is unreadable -- both measured, not assumed. This guards a state
     we have observed rather than encoding a theory about how it arises.
     """
-    guards = _getsource_guards("inspect.getsource(original_forward)")
+    guards = _getsource_guards(NN_FORWARD_CALL)
     assert guards, "the forward getsource is no longer inside a try"
     for caught in guards:
         assert _catches(caught, "OSError") and _catches(caught, "TypeError"), (
@@ -247,7 +270,7 @@ def test_an_unreadable_forward_is_skipped_not_fatal():
     # Exactly the try whose body IS this assignment -- several other blocks
     # also call getsource on a forward, and their handlers legitimately do
     # something else.
-    target = NN_FORWARD_GETSOURCE
+    target = NN_FORWARD_ASSIGN
     handlers = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Try) or len(node.body) != 1:
@@ -277,7 +300,7 @@ def test_the_compiler_config_check_is_kept():
 def test_both_getsource_guards_are_present():
     """Two distinct sites, two distinct failures. Fixing only the first one
     just moves the crash later, which is exactly what happened."""
-    sites = {"inspect.getsource(modeling_file)", "inspect.getsource(original_forward)"}
+    sites = {"inspect.getsource(modeling_file)", NN_FORWARD_CALL}
     for call in sites:
         guards = _getsource_guards(call)
         assert guards and all(
@@ -487,9 +510,10 @@ def test_the_unreadable_forward_is_wrapped_rather_than_dropped():
 def test_the_forward_is_pinned_before_it_is_read():
     """Captured before any rewrite, or the second pass (vision loads patch
     torch.nn twice) reads its own output back."""
+    assert NN_FORWARD_VAR != "function", "the read is not pinned: it goes through function.forward"
     region = _nn_patch_region()
-    pin = region.index("original_forward = function.forward")
-    assert pin < region.index(NN_FORWARD_GETSOURCE)
+    pin = region.index(f"{NN_FORWARD_VAR} = function.forward")
+    assert pin < region.index(NN_FORWARD_ASSIGN)
 
 
 def test_the_tensor_may_arrive_by_keyword():


### PR DESCRIPTION
## Summary

Main went red on `tests/test_unreadable_modeling_source.py` and `tests/test_compiler_getsource_tokenerror.py` after #967 merged. That PR pins the pristine torch.nn forward as `original_forward` before any rewrite and reads the source from that, so a second pass never reads its own generated output back through `inspect.getsource`. The tests still anchored on the old spelling, and one asserted the very read the pin removes.

This updates the tests to the merged behaviour. No change to `unsloth_zoo/compiler.py`.

- Six anchors move from `inspect.getsource(function.forward)` to `inspect.getsource(original_forward)`, through one `NN_FORWARD_GETSOURCE` constant.
- A new test asserts the pin (`original_forward = function.forward`) precedes the read.
- `test_dtype_patcher_survives_tokenerror_on_its_generated_forward` becomes `test_the_dtype_patcher_never_reads_its_own_generated_forward`: after a warm-up, the generated forwards are present and no `getsource` call resolves into the compile folder. Reverting the early `continue` on the wrapped forward makes it fail, naming the twelve generated files it read.

## Verification

```
python -m pytest tests/test_unreadable_modeling_source.py tests/test_compiler_getsource_tokenerror.py -q
36 passed
```

Same two files on main: 7 failed, 28 passed. This is also what fails the `Core` job on every unsloth PR since #967, for example unslothai/unsloth#10183 run 34073805739.
