### PR TITLE
Follow the dtype loop's rename, and stop the tests spelling the operand out

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -542,15 +542,61 @@ jobs:
           .lanes/venv-suites/bin/python -c "import mlx_vlm, mlx_lm; print('mlx-vlm', mlx_vlm.__version__)"
           # If the joint resolution missed the transformers cap, this job is
           # gating an environment the package forbids.
+          #
+          # Read the cap off our own installed metadata rather than repeating it
+          # as a literal. A literal here says "<=5.5.0" and means "whatever
+          # pyproject pins": the moment pyproject legitimately moves the cap the
+          # gate reports drift that does not exist, which is exactly how #1144
+          # went red. It also only ever checked the ceiling, so a resolution
+          # landing on one of the excluded releases (4.57.4, 5.0.0, ...) passed.
+          # The whole specifier set is the contract, so assert the whole thing.
           .lanes/venv-suites/bin/python - <<'PY'
-          from importlib.metadata import version
+          from importlib.metadata import requires, version
+          from packaging.requirements import Requirement
           from packaging.version import Version
-          transformers = Version(version("transformers"))
-          assert transformers <= Version("5.5.0"), (
-              f"transformers {transformers} exceeds the cap this package pins; "
-              "the MLX packages were resolved without it"
+
+          specifiers = {
+              str(req.specifier)
+              for raw in (requires("unsloth_zoo") or [])
+              for req in [Requirement(raw)]
+              if req.name.lower().replace("_", "-") == "transformers"
+          }
+          assert specifiers, (
+              "unsloth_zoo declares no transformers requirement, so this gate is "
+              "checking nothing. Did the dependency move out of pyproject.toml?"
           )
-          print("transformers", transformers, "within the pinned cap")
+          assert len(specifiers) == 1, (
+              f"unsloth_zoo pins transformers inconsistently across extras: "
+              f"{sorted(specifiers)}. Pick one before this gate can mean anything."
+          )
+          pinned = Requirement(f"transformers{specifiers.pop()}").specifier
+          transformers = Version(version("transformers"))
+          assert transformers in pinned, (
+              f"transformers {transformers} is outside the range this package "
+              f"pins ({pinned}); the MLX packages were resolved without it"
+          )
+          print("transformers", transformers, "within the pinned range", pinned)
+
+          # The ceiling is a deliberate policy choice, not an incidental number,
+          # so state it here as well and on purpose. mlx-vlm >= 0.6.9 requires
+          # transformers >= 5.14, and we are not taking that jump yet; the cap is
+          # what keeps the joint MLX resolution off it. Checking only "matches
+          # pyproject" above would let an automated dependency bump raise the cap
+          # and quietly opt the whole project in -- which is exactly what #1144
+          # did. Raising this is a decision: change CEILING in the same commit
+          # that changes pyproject.toml, deliberately.
+          CEILING = Version("5.5.0")
+          declared = [
+              Version(str(s.version)) for s in pinned if s.operator == "<="
+          ]
+          assert declared and max(declared) <= CEILING, (
+              f"pyproject.toml pins transformers <= {max(declared) if declared else None}, "
+              f"above the {CEILING} ceiling this project holds on purpose. "
+              "mlx-vlm >= 0.6.9 needs transformers >= 5.14 and we are not "
+              "following it yet. If raising it is intended, raise CEILING here "
+              "in the same commit and say why."
+          )
+          print("declared ceiling", max(declared), "at or below the policy ceiling", CEILING)
           PY
 
       - name: pytest tests/test_mlx_quantized_optimizer_state.py (HARD GATE)

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -57,13 +57,30 @@ COMPILER = ROOT / "unsloth_zoo" / "compiler.py"
 SRC = COMPILER.read_text(encoding="utf-8")
 
 
+def _require_index(anchor: str, what: str) -> int:
+    """`SRC.index`, but a miss says which contract broke.
+
+    A bare `.index` raises `ValueError: substring not found` and names neither
+    the anchor nor the test's subject, which is how #967's rename showed up:
+    six tests failed pointing at the test file's own line rather than at the
+    production edit that moved the text out from under them.
+    """
+    i = SRC.find(anchor)
+    assert i != -1, (
+        f"{what}: no `{anchor}` in compiler.py. Either the guard is gone, or "
+        f"it was renamed and this anchor needs to follow it.")
+    return i
+
+
 def _guard_region() -> str:
     """The modeling-file guard and its handler.
 
     Anchored on the call, not on "except (OSError, TypeError)": the torch
     forward guard uses the same clause and is defined earlier in the file.
     """
-    i = SRC.index("full_source = inspect.getsource(modeling_file)")
+    i = _require_index(
+        "full_source = inspect.getsource(modeling_file)",
+        "the modeling-file guard")
     return SRC[max(0, i - 400):i + 2200]
 
 
@@ -174,14 +191,18 @@ def test_the_warning_says_the_model_still_works():
 def test_lora_patching_happens_before_the_guard():
     """Returning early is only acceptable because the LoRA forwards have
     already been patched by this point."""
-    lora = SRC.index("patch_lora_forwards(torch_compile_options)")
-    guard = SRC.index("full_source = inspect.getsource(modeling_file)")
+    lora = _require_index(
+        "patch_lora_forwards(torch_compile_options)", "the LoRA forward patch")
+    guard = _require_index(
+        "full_source = inspect.getsource(modeling_file)", "the modeling-file guard")
     assert lora < guard
 
 
 def test_the_patched_marker_is_set_before_the_guard():
-    marker = SRC.index("modeling_file.__UNSLOTH_PATCHED__ = True")
-    guard = SRC.index("full_source = inspect.getsource(modeling_file)")
+    marker = _require_index(
+        "modeling_file.__UNSLOTH_PATCHED__ = True", "the patched marker")
+    guard = _require_index(
+        "full_source = inspect.getsource(modeling_file)", "the modeling-file guard")
     assert marker < guard, (
         "an early return must not leave the module looking unpatched, or a "
         "later pass would try again and fail again")
@@ -203,9 +224,80 @@ def test_a_bare_return_is_the_functions_contract():
     assert any(r.value is None for r in returns)
 
 
+def _nn_forward_read() -> tuple:
+    """The torch.nn forward read, discovered rather than spelled out.
+
+    Returns `(name, statement)` where `name` is whatever local the loop reads
+    the forward's source from and `statement` is the assignment as written.
+
+    Discovered because the spelling is not the contract. #967 renamed this
+    operand from `function.forward` to `original_forward` -- a strictly better
+    version of the same read, pinning the pristine forward so a second pass
+    cannot consume its own generated output -- and six tests here reported it
+    as the guard having been deleted. A test that fails on a correct rename is
+    reporting on the test, not on compiler.py.
+
+    Matched on shape: an assignment to `source` of `inspect.getsource(<Name>)
+    .rstrip()`. The name is then held to its real contract by
+    `test_the_forward_source_is_read_from_the_pinned_original` below, so this
+    stays a rename-tolerant search and not a weaker assertion.
+    """
+    found = []
+    for node in ast.walk(ast.parse(SRC)):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not (isinstance(target, ast.Name) and target.id == "source"):
+            continue
+        call = node.value
+        if not (isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "rstrip"):
+            continue
+        inner = call.func.value
+        if not (isinstance(inner, ast.Call)
+                and ast.unparse(inner.func) == "inspect.getsource"
+                and len(inner.args) == 1
+                and isinstance(inner.args[0], ast.Name)):
+            continue
+        found.append((inner.args[0].id, ast.unparse(node)))
+
+    assert found, (
+        "no `source = inspect.getsource(<name>).rstrip()` in compiler.py at "
+        "all. The torch.nn forward patch loop no longer reads the forward's "
+        "source the way every test below assumes.")
+    assert len({name for name, _ in found}) == 1, (
+        f"several forward-source reads with different operands: {sorted(found)}. "
+        "These tests assume one site and would guard an arbitrary one of them.")
+    return found[0]
+
+
+NN_FORWARD_NAME, NN_FORWARD_READ = _nn_forward_read()
+NN_FORWARD_GETSOURCE = f"inspect.getsource({NN_FORWARD_NAME})"
+
+
 def _nn_patch_region() -> str:
-    i = SRC.index("source = inspect.getsource(original_forward).rstrip()")
+    i = _require_index(NN_FORWARD_READ, "the torch.nn forward patch loop")
     return SRC[max(0, i - 1600):i + 1400]
+
+
+def test_the_forward_source_is_read_from_the_pinned_original():
+    """The operand is discovered, so pin what it must BE.
+
+    Either it is `function.forward` itself, or it is a local assigned from
+    `function.forward` in the same loop -- #967's pin, which is what makes the
+    read idempotent across the two passes a vision load performs. Without this,
+    `_nn_forward_read` would happily latch onto a rename to something that is
+    not the forward at all and every test below would still pass.
+    """
+    if NN_FORWARD_NAME == "function":
+        pytest.skip("read directly off `function.forward`, nothing to pin")
+    pin = f"{NN_FORWARD_NAME} = function.forward"
+    i = _require_index(pin, "the pristine-forward pin")
+    read = _require_index(NN_FORWARD_READ, "the forward source read")
+    assert i < read, (
+        f"`{pin}` must precede `{NN_FORWARD_READ}`, or the loop is not reading "
+        "the forward it pinned")
 
 
 def test_the_nn_forward_patch_loop_is_guarded():
@@ -222,8 +314,8 @@ def test_the_nn_forward_patch_loop_is_guarded():
     forward is unreadable -- both measured, not assumed. This guards a state
     we have observed rather than encoding a theory about how it arises.
     """
-    guards = _getsource_guards("inspect.getsource(original_forward)")
-    assert guards, "the forward getsource is no longer inside a try"
+    guards = _getsource_guards(NN_FORWARD_GETSOURCE)
+    assert guards, f"`{NN_FORWARD_GETSOURCE}` is no longer inside a try"
     for caught in guards:
         assert _catches(caught, "OSError") and _catches(caught, "TypeError"), (
             f"the forward guard stopped catching one of them: {sorted(caught)}")
@@ -242,7 +334,7 @@ def test_an_unreadable_forward_is_skipped_not_fatal():
     # Exactly the try whose body IS this assignment -- several other blocks
     # also call getsource on a forward, and their handlers legitimately do
     # something else.
-    target = "source = inspect.getsource(original_forward).rstrip()"
+    target = NN_FORWARD_READ
     handlers = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Try) or len(node.body) != 1:
@@ -272,7 +364,7 @@ def test_the_compiler_config_check_is_kept():
 def test_both_getsource_guards_are_present():
     """Two distinct sites, two distinct failures. Fixing only the first one
     just moves the crash later, which is exactly what happened."""
-    sites = {"inspect.getsource(modeling_file)", "inspect.getsource(original_forward)"}
+    sites = {"inspect.getsource(modeling_file)", NN_FORWARD_GETSOURCE}
     for call in sites:
         guards = _getsource_guards(call)
         assert guards and all(
@@ -541,7 +633,8 @@ def test_a_rebuild_wraps_the_original_not_the_wrapper():
 
 def test_the_loop_rebuilds_on_a_mode_change():
     region = _nn_patch_region()
-    i = SRC.index('__unsloth_dtype_wrapped__", False)')
+    i = _require_index(
+        '__unsloth_dtype_wrapped__", False)', "the already-wrapped check")
     window = SRC[i:i + 800]
     assert "__unsloth_dtype_disable__" in window, (
         "a wrapper built for the other compile mode must not be reused")

--- a/tests/test_unreadable_modeling_source.py
+++ b/tests/test_unreadable_modeling_source.py
@@ -204,7 +204,7 @@ def test_a_bare_return_is_the_functions_contract():
 
 
 def _nn_patch_region() -> str:
-    i = SRC.index("source = inspect.getsource(function.forward).rstrip()")
+    i = SRC.index("source = inspect.getsource(original_forward).rstrip()")
     return SRC[max(0, i - 1600):i + 1400]
 
 
@@ -222,7 +222,7 @@ def test_the_nn_forward_patch_loop_is_guarded():
     forward is unreadable -- both measured, not assumed. This guards a state
     we have observed rather than encoding a theory about how it arises.
     """
-    guards = _getsource_guards("inspect.getsource(function.forward)")
+    guards = _getsource_guards("inspect.getsource(original_forward)")
     assert guards, "the forward getsource is no longer inside a try"
     for caught in guards:
         assert _catches(caught, "OSError") and _catches(caught, "TypeError"), (
@@ -242,7 +242,7 @@ def test_an_unreadable_forward_is_skipped_not_fatal():
     # Exactly the try whose body IS this assignment -- several other blocks
     # also call getsource on a forward, and their handlers legitimately do
     # something else.
-    target = "source = inspect.getsource(function.forward).rstrip()"
+    target = "source = inspect.getsource(original_forward).rstrip()"
     handlers = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Try) or len(node.body) != 1:
@@ -272,7 +272,7 @@ def test_the_compiler_config_check_is_kept():
 def test_both_getsource_guards_are_present():
     """Two distinct sites, two distinct failures. Fixing only the first one
     just moves the crash later, which is exactly what happened."""
-    sites = {"inspect.getsource(modeling_file)", "inspect.getsource(function.forward)"}
+    sites = {"inspect.getsource(modeling_file)", "inspect.getsource(original_forward)"}
     for call in sites:
         guards = _getsource_guards(call)
         assert guards and all(


### PR DESCRIPTION
## Summary

Six source contracts in `tests/test_unreadable_modeling_source.py` have failed since #967, and they are the last of that fallout still on main. #1168 took the other three failures; this takes these, and then fixes the reason they broke rather than only the anchors.

No production code changes.

## What happened

#967 pinned the pristine forward into a local before any rewrite:

```python
original_forward = function.forward
try:
    source = inspect.getsource(original_forward).rstrip()
except (OSError, TypeError, tokenize.TokenError):
```

Same exception tuple, same wrap-rather-than-drop behaviour, and the pin is the improvement the commit was making, so a second pass cannot read its own generated output back. The tests were still searching for `inspect.getsource(function.forward)` and reported it as the guard having been removed:

```
FAILED test_the_nn_forward_patch_loop_is_guarded - AssertionError: the forward getsource is no longer inside a try
FAILED test_both_getsource_guards_are_present - AssertionError: inspect.getsource(function.forward) is unguarded, so an unreadable source is fatal again
FAILED test_the_compiler_config_check_is_kept - ValueError: substring not found
```

`ValueError: substring not found` names neither the anchor nor the production edit that moved it, which is most of why this took a while to read.

## Effect

This is red on `unslothai/unsloth`'s `Core (HF=default + TRL=default)`, `Core (HF=latest + TRL=latest)` and `Core (HF=4.57.6 + TRL<1)`. That job clones `unsloth_zoo@main` and runs this suite, so it fails on unsloth's `main` and on every open unsloth PR regardless of that PR's diff, including several that touch no Python at all.

## The fix, in two parts

**1. Follow the rename.** Four anchors move to `original_forward`. The other two `function.forward` references in the file, the `get_compiler_config` `hasattr` and the `__unsloth_dtype_wrapped__` `getattr`, still match `compiler.py` exactly and are left alone.

**2. Stop spelling the operand out.** A correct rename should not fail six tests, so `_nn_forward_read()` now finds the read by shape off the parse, an assignment to `source` of `inspect.getsource(<Name>).rstrip()`, and the anchors derive from what it finds.

Discovery on its own would weaken these tests, since a rename to something that is not the forward at all would still pass. So `test_the_forward_source_is_read_from_the_pinned_original` holds the discovered name to its contract: it is `function.forward`, or a local assigned from it before the read. That is #967's guarantee, pinned directly.

Bare `SRC.index` calls go through `_require_index`, which names the broken contract instead of raising `ValueError`.

## Verification

```
python -m pytest tests/test_unreadable_modeling_source.py tests/test_compiler_getsource_tokenerror.py -q
38 passed
```

Same two files on main: 6 failed, 31 passed.

Mutated `compiler.py` in three directions rather than assuming the new form still bites:

| mutation | expected | result |
| --- | --- | --- |
| rename `original_forward` to `pristine_forward` | pass | 32 passed |
| delete the `try`/`except` around the read | fail | 3 failed |
| point the pin at something other than `function.forward` | fail | 1 failed, the new test |

The full CI gate list from `Repo tests (CPU)`, 37 files, is 1508 passed / 4 skipped / 0 failed on this branch.

## Also: the MLX lane had the same defect

`consolidated-tests-ci.yml` re-stated the transformers cap as the literal `"5.5.0"` while its own comment said it meant whatever `pyproject.toml` pins. When #1144 raised that cap the gate failed reporting `transformers 5.15.1 exceeds the cap this package pins`, which was not true: the PR had raised the cap, so the install did match the pin.

It now asks the two questions separately.

**Does the resolution match what we declare?** Read off our own metadata, so a deliberate cap change no longer produces a phantom failure. It also checks the whole specifier set rather than only the ceiling, so a resolution landing on an excluded release such as 4.57.4 or 5.0.0 no longer passes silently, which the old `<= 5.5.0` never caught.

**Is the declared ceiling still the one we chose?** Metadata alone would let an automated bump raise the cap unnoticed, which is the one thing the literal was accidentally catching. So 5.5.0 stays as a separate, deliberate assertion with its reason written down: mlx-vlm >= 0.6.9 requires transformers >= 5.14, and raising the cap frees pip to resolve mlx-vlm 0.6.17 and take that jump as a side effect. Raising it is now a decision made in the same commit, not a consequence.

Behaviour of the new gate:

| scenario | result |
| --- | --- |
| main today, cap `<=5.5.0`, env 4.57.6 | pass |
| cap raised to `<=5.15.1` as in #1144 | fail, naming the ceiling and why |
| resolution drifts to 5.15.1, cap unchanged | fail |
| resolution lands on excluded 4.57.4 | fail, new coverage |
| transformers requirement removed entirely | fail, instead of passing vacuously |

## Note on the third failure

The earlier version of this description said `test_compiler_getsource_tokenerror.py` was left alone because it needed a decision about intent. #1168 has since made that decision and split it in two, keeping the TokenError handler genuinely exercised by stripping the markers first. Nothing is owed here. #1166, which covered the same ground, is closed as superseded.
