### PR TITLE
Fix the two CI failures on main: a leaked moe_utils and a stale dtype probe

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,6 +285,17 @@ def _isolate_xet_health_state(tmp_path_factory, monkeypatch):
 # the same and is already used elsewhere in these files: monkeypatch.setitem, which puts
 # the original back.
 _GUARDED_MODULES = ("bitsandbytes", "bitsandbytes.functional", "bitsandbytes.nn")
+
+# Names that nothing in the installed environment provides. A top-level `moe_utils`
+# only ever resolves because a test put a compile-cache directory on sys.path, so
+# for these the exemption below is wrong in both directions: the import IS the swap,
+# and the module it leaves behind outlives the directory it was read from. Leaving
+# one there makes the bare `from moe_utils import ...` in every generated MoE module
+# resolve to a stale copy, which is invisible because that import is deliberately
+# swallowed -- the module loads reporting success with its backend names undefined.
+# That is exactly how test_compiled_cache_collective.py's recovery test failed on
+# main while passing when run alone.
+_GUARDED_BARE_MODULES = ("moe_utils",)
 _MODULE_SNAPSHOT_KEY = "_unsloth_guarded_module_snapshot"
 
 
@@ -299,7 +310,10 @@ def _is_module_stub(mod):
 def pytest_runtest_setup(item):
     import sys as _sys
 
-    setattr(item, _MODULE_SNAPSHOT_KEY, {n: _sys.modules.get(n) for n in _GUARDED_MODULES})
+    setattr(item, _MODULE_SNAPSHOT_KEY, {
+        n: _sys.modules.get(n)
+        for n in _GUARDED_MODULES + _GUARDED_BARE_MODULES
+    })
 
 
 @_pytest.hookimpl(trylast = True)
@@ -322,6 +336,13 @@ def pytest_runtest_teardown(item, nextitem):
         now = _sys.modules.get(name)
         if now is was:
             continue
+        if was is None and now is not None and name in _GUARDED_BARE_MODULES:
+            # No exemption here: see _GUARDED_BARE_MODULES. Importing one of these
+            # at all requires a sys.path the rest of the session does not have, so
+            # "nothing was there and the test imported the real thing" is precisely
+            # the leak rather than the innocent case it is for a real package.
+            leaked.append(name)
+            continue
         if was is None and not _is_module_stub(now):
             # Nothing was there and the test imported the real thing. That is an
             # import, not a swap, and flagging it would fail every test that touches
@@ -332,5 +353,6 @@ def pytest_runtest_teardown(item, nextitem):
         raise AssertionError(
             f"{item.nodeid} replaced {leaked} in sys.modules and did not put it back, "
             f"so every later test in this process imports the substitute. Use "
-            f"monkeypatch.setitem(sys.modules, ...), which restores on teardown."
+            f"monkeypatch.setitem(sys.modules, ...), which restores on teardown, or "
+            f"save and restore the entry by hand where the import itself installs it."
         )

--- a/tests/test_compiled_cache_collective.py
+++ b/tests/test_compiled_cache_collective.py
@@ -1321,6 +1321,12 @@ def test_direct_recovery_can_still_import_cache_helpers(
         "forward_moe_backend = 'installed'\n", encoding="utf-8",
     )
 
+    # The generated module does a bare `from moe_utils import ...`, so an entry
+    # left in sys.modules by any earlier test wins over the file just written and
+    # this reports a search-path bug that is not there. Isolate it on the way in
+    # as well as on the way out; tests/conftest.py now fails the leaker directly.
+    previous_moe_utils = sys.modules.pop("moe_utils", None)
+
     name = "pr967_recovery_helper"
     real_import = compiler.importlib.import_module
     failed = False
@@ -1350,14 +1356,19 @@ def test_direct_recovery_can_still_import_cache_helpers(
         )
 
         assert getattr(module, f"{name}_fn")(21) == 42
+        resolved = getattr(sys.modules.get("moe_utils"), "__file__", None)
         assert getattr(module, "forward_moe_backend", None) == "installed", (
             "the recovered module could not import moe_utils from the compiled "
             "cache, so a generated MoE module would load with its backend names "
-            "undefined and fail at the first forward."
+            "undefined and fail at the first forward. moe_utils resolved to "
+            f"{resolved!r}; the helper written for this test is "
+            f"{str(primary / 'moe_utils.py')!r}."
         )
     finally:
         for alias in (name, f"unsloth_cache_{name}", "moe_utils"):
             sys.modules.pop(alias, None)
+        if previous_moe_utils is not None:
+            sys.modules["moe_utils"] = previous_moe_utils
 
 
 def test_recovered_module_keeps_an_importable_module_identity(

--- a/tests/test_compiler_getsource_tokenerror.py
+++ b/tests/test_compiler_getsource_tokenerror.py
@@ -135,12 +135,102 @@ def test_compile_transformers_survives_tokenerror_from_getsource(tmp_path):
     )
 
 
-def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
-    """Raises only on the generated forward, so the pipeline reaches the dtype patcher."""
+# The markers #967 added to every forward _patch_torch_dtype_modules installs.
+# Dropping them puts a compile-folder forward back in the state the patcher treats
+# as "not mine yet", which is what the rewrite path below needs to be reachable.
+_STRIP_DTYPE_MARKERS = """
+        for _name in compiler._patch_functions:
+            _cls = getattr(torch.nn, _name, None)
+            _fwd = getattr(_cls, "forward", None) if _cls is not None else None
+            if _fwd is None:
+                continue
+            for _marker in (
+                "__unsloth_dtype_wrapped__",
+                "__unsloth_dtype_disable__",
+                "__unsloth_dtype_original__",
+            ):
+                if hasattr(_fwd, _marker):
+                    delattr(_fwd, _marker)
+"""
+
+
+def test_a_second_pass_does_not_read_its_own_generated_forward(tmp_path):
+    """#967's idempotence guarantee, which is what makes the probe below artificial.
+
+    The warm-up leaves every patched torch.nn forward served out of the compile
+    folder AND marked `__unsloth_dtype_wrapped__`. A second pass must recognise its
+    own output and skip it, because re-reading it would stack a second dtype
+    prologue and return a bf16 activation as fp32. Measured on this tree: 12 of 12
+    generated forwards are marked, so the second pass calls getsource on none.
+    """
     proc = _run(
         """
         import torch
 
+        generated = [
+            name for name in compiler._patch_functions
+            if getattr(getattr(getattr(torch.nn, name, None), "forward", None),
+                       "__code__", None) is not None
+            and getattr(torch.nn, name).forward.__code__.co_filename.startswith(CACHE)
+        ]
+        marked = [
+            name for name in generated
+            if getattr(torch.nn.__dict__[name].forward,
+                       "__unsloth_dtype_wrapped__", False)
+        ]
+
+        real_getsource = compiler.inspect.getsource
+        hits = []
+
+        def record_generated(obj, *args, **kwargs):
+            code = getattr(obj, "__code__", None)
+            if code is not None and code.co_filename.startswith(CACHE):
+                hits.append(code.co_filename)
+            return real_getsource(obj, *args, **kwargs)
+
+        compiler.inspect.getsource = record_generated
+
+        fresh_llama()
+        compiler.unsloth_compile_transformers("llama", disable=True)
+
+        print("RESULT " + json.dumps({
+            "generated": len(generated),
+            "marked": len(marked),
+            "hits": len(hits),
+        }))
+        """,
+        tmp_path / "cache_idempotent",
+    )
+    out = _result(proc, "second-pass-skips-own-output")
+
+    assert out["generated"] > 0, (
+        "no torch.nn forward was served out of the compile folder after a "
+        "warm-up compile, so this probe proves nothing about a second pass"
+    )
+    assert out["marked"] == out["generated"], (
+        f"{out['generated'] - out['marked']} generated forwards carry no "
+        f"__unsloth_dtype_wrapped__ marker, so a second pass would rewrite them "
+        f"again and stack a dtype prologue"
+    )
+    assert out["hits"] == 0, (
+        f"a second pass called inspect.getsource on {out['hits']} compile-folder "
+        f"forwards, so it is reading back its own generated output"
+    )
+
+
+def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
+    """The handler itself: getsource raising on a compile-folder forward must not fail the load.
+
+    The markers are stripped first. Before #967 a second pass reached this on its
+    own, which is how the case was found; #967 closed that route deliberately, so
+    reproducing the state has to be explicit now. The handler is still live for a
+    forward built by exec or one whose file has gone, and the contract it owes is
+    unchanged: wrap rather than skip, so the casts survive without the source.
+    """
+    proc = _run(
+        """
+        import torch
+        """ + _STRIP_DTYPE_MARKERS + """
         generated = sorted({
             code.co_filename
             for code in (
@@ -165,10 +255,15 @@ def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
 
         fresh_llama()
         compiler.unsloth_compile_transformers("llama", disable=True)
+        compiler.inspect.getsource = real_getsource
+
+        # Skipping instead of wrapping would only move the failure here.
+        ran = tuple(torch.nn.LayerNorm(4)(torch.randn(2, 4)).shape) == (2, 4)
 
         print("RESULT " + json.dumps({
             "generated": len(generated),
             "hits": len(hits),
+            "forward_runs": ran,
         }))
         """,
         tmp_path / "cache_generated",
@@ -182,7 +277,13 @@ def test_dtype_patcher_survives_tokenerror_on_its_generated_forward(tmp_path):
     )
     assert out["hits"] > 0, (
         "no getsource call resolved into the compile folder, so the dtype "
-        "patcher's TokenError handler was never exercised"
+        "patcher's TokenError handler was never exercised. If the marker names "
+        "in _STRIP_DTYPE_MARKERS have drifted from compiler.py, this is what "
+        "that looks like"
+    )
+    assert out["forward_runs"], (
+        "a torch.nn forward stopped working after getsource raised, so the "
+        "handler skipped the module instead of wrapping it"
     )
 
 
@@ -206,3 +307,22 @@ def test_the_probe_sets_cpu_mode_itself_rather_than_inheriting_it():
         "the child must keep pinning this checkout, or it validates a "
         "different compiler.py than the one under review"
     )
+
+
+def test_the_stripped_markers_are_the_ones_compiler_sets():
+    """A rename in compiler.py must fail here, not quietly disarm the probe above.
+
+    Stripping names nothing sets would leave every forward marked, the second pass
+    would skip them all, and the TokenError test would go back to reporting zero
+    hits -- the exact failure this file was carrying on main.
+    """
+    compiler_source = (ROOT / "unsloth_zoo" / "compiler.py").read_text(encoding="utf-8")
+    for marker in (
+        "__unsloth_dtype_wrapped__",
+        "__unsloth_dtype_disable__",
+        "__unsloth_dtype_original__",
+    ):
+        assert marker in _STRIP_DTYPE_MARKERS, f"{marker} is not stripped by the probe"
+        assert marker in compiler_source, (
+            f"{marker} is stripped by the probe but compiler.py no longer sets it"
+        )

--- a/tests/test_moe_weight_preprocessor_registry_shared.py
+++ b/tests/test_moe_weight_preprocessor_registry_shared.py
@@ -100,14 +100,24 @@ def test_bare_moe_utils_copy_shares_the_registry(cache_copy, monkeypatch):
     # A third copy: compiler.py puts the compile location on sys.path, so the bare
     # `from moe_utils import ...` generated modules do is its own module too.
     monkeypatch.syspath_prepend(os.environ["UNSLOTH_COMPILE_LOCATION"])
-    monkeypatch.delitem(sys.modules, "moe_utils", raising=False)
-    import moe_utils as bare
-    monkeypatch.setitem(sys.modules, "moe_utils", bare)
-    assert bare is not moe_utils and bare is not cache_copy
+    # Restored by hand rather than through monkeypatch, and that is not a style
+    # choice. delitem() on a name that is absent records nothing, and by the time
+    # setitem() runs the import below has already put `bare` in sys.modules, so
+    # setitem records `bare` as the value to restore. The undo then REINSTATES it
+    # and every later test in the process resolves `moe_utils` to this copy --
+    # loaded from a tmp_path_factory directory that is deleted at session end.
+    # That is what broke test_compiled_cache_collective.py's recovery test, whose
+    # generated module does exactly the bare `from moe_utils import ...` above.
+    previous = sys.modules.pop("moe_utils", None)
     key = "unit_test_registry_shared_arch_bare"
     fn = lambda weight, proj_type, hidden_dim: weight
-    moe_utils.register_weight_preprocessor(key, fn)
     try:
+        import moe_utils as bare
+        assert bare is not moe_utils and bare is not cache_copy
+        moe_utils.register_weight_preprocessor(key, fn)
         assert bare.get_weight_preprocessor(key) is fn
     finally:
         moe_utils._WEIGHT_PREPROCESSORS.pop(key, None)
+        sys.modules.pop("moe_utils", None)
+        if previous is not None:
+            sys.modules["moe_utils"] = previous


### PR DESCRIPTION
Main is red on two tests. Neither is a production bug, and both trace back to #967 landing without its CI run completing.

## `test_direct_recovery_can_still_import_cache_helpers` (#967)

Passes alone, fails in the suite, which is the signature of test-order pollution. The polluter is `test_moe_weight_preprocessor_registry_shared.py` (#1082):

```python
monkeypatch.delitem(sys.modules, "moe_utils", raising=False)
import moe_utils as bare
monkeypatch.setitem(sys.modules, "moe_utils", bare)
```

`delitem` on a name that is absent records nothing, and the `import` installs `bare` before `setitem` runs, so `setitem` records `bare` as the value to restore. The undo reinstates it. Every later test in the process then resolves a bare `moe_utils` to a copy read out of a `tmp_path_factory` directory.

The #967 test's generated module does exactly that bare import. It bound the stale copy, the deliberate `except Exception: pass` swallowed the mismatch, and the module loaded reporting success with `forward_moe_backend` undefined, which is precisely the failure the test exists to catch. Saved and restored by hand, since monkeypatch cannot express this ordering.

The recovery test now also isolates `moe_utils` on entry rather than only in `finally`, and names what the module actually resolved to when it fails.

## `tests/conftest.py` leak gate

The gate missed this twice: `moe_utils` was not guarded, and its "nothing was there and the test imported the real thing" exemption would have waved it through regardless. For a bare name that only resolves because a test put a compile-cache directory on `sys.path`, the import IS the swap, and the module outlives the directory it came from. Guarded separately with no exemption.

Verified by reverting the fix and re-running: the gate names the leaking test directly.

## `test_dtype_patcher_survives_tokenerror_on_its_generated_forward` (#1149)

This one asserted a precondition #967 correctly removed. It reached the TokenError handler only because a second pass used to re-read its own generated output through `inspect.getsource`. #967 marks what it installs and skips it, because re-reading stacks a second dtype prologue and returns a bf16 activation as fp32.

Measured on this tree: 12 of 12 generated forwards carry `__unsloth_dtype_wrapped__`, so the second pass calls `getsource` on none of them and `hits` was 0. The production change is right; the probe was stale.

Split in two rather than deleted:

- a new test pins #967's guarantee directly, that every generated forward is marked and a second pass reads none of them
- the original keeps its subject by stripping the markers first, so the patcher genuinely re-enters the rewrite. It now also asserts a `torch.nn` forward still runs afterwards, which is the contract the handler owes: wrap, do not skip
- a third pins the stripped marker names against `compiler.py`, so a rename fails loudly instead of silently disarming the probe

## Scope

No production code changed. Across all 24 test files that touch `moe_utils`, this removes one failure and adds none.