### PR TITLE
Do not report the compile folder's own moe_utils as a leak

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -374,6 +374,7 @@ jobs:
             tests/test_sibling_imports_do_not_go_through_a_tests_package.py \
             tests/test_hip_bf16_offload_dtype.py \
             tests/test_disabled_hook_checkpoint_guard.py \
+            tests/test_conftest_module_leak_gate.py \
             tests/test_compiled_cache_collective.py \
             tests/test_compiled_cache_collective_gloo.py \
             -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,9 +371,17 @@ def pytest_runtest_teardown(item, nextitem):
             continue
         leaked.append(name)
     if leaked:
+        # Naming the file is the whole diagnosis for the bare names: whether the copy
+        # is a leak or the compile folder doing its job is a question about where it
+        # was read from, and without this the report is the same either way.
+        where = ", ".join(
+            f"{n} from {getattr(_sys.modules.get(n), '__file__', None)!r}"
+            for n in leaked
+        )
         raise AssertionError(
-            f"{item.nodeid} replaced {leaked} in sys.modules and did not put it back, "
+            f"{item.nodeid} replaced {leaked} in sys.modules and did not put it back "
+            f"({where}), "
             f"so every later test in this process imports the substitute. Use "
-            f"monkeypatch.setitem(sys.modules, ...), which restores on teardown, or "
+            f"monkeypatch.setitem(sys.modules, ...), which restores on teardown, or"
             f"save and restore the entry by hand where the import itself installs it."
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,15 +287,36 @@ def _isolate_xet_health_state(tmp_path_factory, monkeypatch):
 _GUARDED_MODULES = ("bitsandbytes", "bitsandbytes.functional", "bitsandbytes.nn")
 
 # Names that nothing in the installed environment provides. A top-level `moe_utils`
-# only ever resolves because a test put a compile-cache directory on sys.path, so
-# for these the exemption below is wrong in both directions: the import IS the swap,
-# and the module it leaves behind outlives the directory it was read from. Leaving
-# one there makes the bare `from moe_utils import ...` in every generated MoE module
-# resolve to a stale copy, which is invisible because that import is deliberately
+# only ever resolves because something put a compile-cache directory on sys.path.
+# Leaving one behind makes the bare `from moe_utils import ...` in every generated
+# MoE module resolve to it, which is invisible because that import is deliberately
 # swallowed -- the module loads reporting success with its backend names undefined.
-# That is exactly how test_compiled_cache_collective.py's recovery test failed on
-# main while passing when run alone.
+# That is how test_compiled_cache_collective.py's recovery test failed on main while
+# passing when run alone.
+#
+# Flagged only when the copy came out of a pytest temp directory, and that
+# qualification is load-bearing rather than caution. Compiling a MoE architecture
+# imports moe_utils out of the real unsloth_compiled_cache as ordinary production
+# behaviour, and that copy stays valid for the rest of the session; a rule without
+# the qualification fails test_compiler_dynamic_exec.py for doing its job. A copy
+# read from a tmp_path_factory directory is the opposite: it outlives the directory
+# and is a different module from the one the next test means to import.
 _GUARDED_BARE_MODULES = ("moe_utils",)
+
+
+def _is_from_pytest_tmp(mod):
+    import pathlib
+
+    path = getattr(mod, "__file__", None)
+    if not path:
+        return False
+    # Matched on the "pytest-of-<user>" element tmp_path_factory always creates,
+    # rather than on a basetemp looked up from the config: --basetemp overrides it,
+    # xdist gives each worker its own, and a stale entry can outlive the fixture
+    # that made it. The directory name is the stable part.
+    return any(
+        part.startswith("pytest-of-") for part in pathlib.Path(path).parts
+    )
 _MODULE_SNAPSHOT_KEY = "_unsloth_guarded_module_snapshot"
 
 
@@ -336,12 +357,12 @@ def pytest_runtest_teardown(item, nextitem):
         now = _sys.modules.get(name)
         if now is was:
             continue
-        if was is None and now is not None and name in _GUARDED_BARE_MODULES:
-            # No exemption here: see _GUARDED_BARE_MODULES. Importing one of these
-            # at all requires a sys.path the rest of the session does not have, so
-            # "nothing was there and the test imported the real thing" is precisely
-            # the leak rather than the innocent case it is for a real package.
-            leaked.append(name)
+        if name in _GUARDED_BARE_MODULES:
+            # See _GUARDED_BARE_MODULES: for these the import itself can be the
+            # swap, so the exemption below does not apply. Narrowed to the copies
+            # that go stale, which are the ones a later test can be misled by.
+            if _is_from_pytest_tmp(now):
+                leaked.append(name)
             continue
         if was is None and not _is_module_stub(now):
             # Nothing was there and the test imported the real thing. That is an

--- a/tests/test_conftest_module_leak_gate.py
+++ b/tests/test_conftest_module_leak_gate.py
@@ -1,0 +1,74 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Which `moe_utils` the sys.modules leak gate in conftest.py treats as a leak.
+
+The gate has to separate two things that look identical in sys.modules. Compiling a
+MoE architecture imports moe_utils out of the compile folder as ordinary production
+behaviour, and CI points that folder at `$PWD/.lanes/compiled-<id>`, which lives for
+the whole job. A test that loads a copy from tmp_path_factory leaves behind a module
+whose directory is deleted underneath it, and every later bare `from moe_utils import
+...` silently resolves to that copy.
+
+Getting this backwards is not hypothetical in either direction: a rule with no
+qualification failed test_compiler_dynamic_exec.py for compiling a MoE model, and no
+rule at all is what let the tmp_path copy from
+test_moe_weight_preprocessor_registry_shared.py break the recovery test in
+test_compiled_cache_collective.py.
+"""
+
+from __future__ import annotations
+
+import types
+
+from conftest import _GUARDED_BARE_MODULES, _is_from_pytest_tmp
+
+
+def _module(path):
+    module = types.ModuleType("moe_utils")
+    if path is not None:
+        module.__file__ = path
+    return module
+
+
+def test_moe_utils_is_the_guarded_bare_name():
+    assert "moe_utils" in _GUARDED_BARE_MODULES
+
+
+def test_a_copy_from_a_pytest_temp_directory_is_a_leak(tmp_path_factory):
+    # The real thing rather than a hand-written path, so this keeps tracking
+    # pytest's layout if it ever changes.
+    real = tmp_path_factory.mktemp("compile_location") / "moe_utils.py"
+    assert _is_from_pytest_tmp(_module(str(real)))
+
+
+def test_the_ci_lane_compile_folder_is_not_a_leak():
+    # consolidated-tests-ci.yml: UNSLOTH_COMPILE_LOCATION="$PWD/.lanes/compiled-$id".
+    # This copy stays valid for the whole job, and flagging it fails every test that
+    # compiles a MoE architecture.
+    assert not _is_from_pytest_tmp(
+        _module("/home/runner/work/unsloth-zoo/unsloth-zoo/.lanes/compiled-pyproject/moe_utils.py")
+    )
+
+
+def test_the_default_compiled_cache_is_not_a_leak():
+    assert not _is_from_pytest_tmp(_module("unsloth_compiled_cache/moe_utils.py"))
+
+
+def test_a_module_with_no_file_is_not_reported():
+    # A namespace package or a bare ModuleType substitute: nothing to go stale.
+    assert not _is_from_pytest_tmp(_module(None))
+    assert not _is_from_pytest_tmp(None)


### PR DESCRIPTION
Follow-up to #1168, which took `Core drift` red on main. The two test fixes in that PR are correct and `Repo tests (CPU)` went green; the sys.modules gate I added with them was too strict.

## What broke

The guard flagged any test that left a top-level `moe_utils` in `sys.modules`. But compiling a MoE architecture imports `moe_utils` out of the compile folder as ordinary production behaviour, so `test_compiler_dynamic_exec.py::test_unsloth_compile_transformers_emits_parseable_cache[qwen3_moe]` failed at teardown for doing its job:

```
AssertionError: ...[qwen3_moe] replaced ['moe_utils'] in sys.modules and did not put it back
```

## The distinction the gate was missing

The two cases differ in where the copy came from, not in whether one exists.

- `consolidated-tests-ci.yml` sets `UNSLOTH_COMPILE_LOCATION="$PWD/.lanes/compiled-<id>"`. That folder lives as long as the job, and a copy read from it stays valid for every later test.
- The leak #1168 fixed came from `tmp_path_factory`. That directory is deleted underneath the module that outlives it, and every later bare `from moe_utils import ...` silently resolves to the stale copy.

Narrowed to the second: a copy whose path carries pytest's `pytest-of-<user>` element. Matched on that element rather than a basetemp read from the config, because `--basetemp` overrides it, xdist gives each worker its own, and a stale entry can outlive the fixture that produced it.

## Pinning it

`tests/test_conftest_module_leak_gate.py` checks both directions rather than leaving them to the comment: a `tmp_path_factory` copy is a leak, the CI lane folder and the default `unsloth_compiled_cache` are not.

## What I verified, and what I did not

Verified locally: reverting the #1082 fix still makes the gate name the leaking test, and the narrowed gate is silent on the fixed version.

Not verified locally: the false positive itself does not reproduce on this box, which resolves a different transformers and never imports `moe_utils` in that test. The exoneration rests on the compile location the workflow sets, which is repo-local and carries no `pytest-of-` element, rather than on a local run reproducing the failure.