### PR TITLE
fix(mlx): decouple tokenizer loading from model configs

### DIFF
--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -174,7 +174,9 @@ def test_apply_mlx_distributed_sharding_modes_and_guards():
         _apply_mlx_distributed_sharding(object(), tensor_group=tensor_group, model_name="fake")
 
 
-def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_path):
+@pytest.mark.parametrize("trust", [False, True])
+def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_path, trust):
+    from transformers import AutoTokenizer
     import mlx_lm.utils as mlx_lm_utils
     from unsloth_zoo.mlx.loader import _load_mlx_lm_distributed
 
@@ -227,12 +229,23 @@ def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_
 
     monkeypatch.setattr(mlx_lm_utils, "_download", _download)
     monkeypatch.setattr(mlx_lm_utils, "load_model", _load_model)
-    monkeypatch.setattr(mlx_lm_utils, "load_tokenizer", lambda *_a, **_k: types.SimpleNamespace(name="tok"))
+    (model_path / "tokenizer_config.json").write_text('{"tokenizer_class":"RemoteTokenizer"}')
+    tokenizer_calls = []
+
+    def tokenizer(path, **kwargs):
+        tokenizer_calls.append(kwargs)
+        return types.SimpleNamespace(name="tok")
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(tokenizer))
+    monkeypatch.setattr(
+        mlx_lm_utils, "load_tokenizer",
+        lambda path, *_a, **_k: AutoTokenizer.from_pretrained(path),
+    )
 
     model, tokenizer, config = _load_mlx_lm_distributed(
         "fake/repo",
         "llama",
-        {"return_config": True},
+        {"return_config": True, "tokenizer_config": {"trust_remote_code": trust}},
         pipeline_group=_FakeGroup(name="pipeline"),
     )
 
@@ -245,6 +258,7 @@ def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_
     assert ("download", local_shards) in events
     assert ("load", list(local_shards)) in events
     assert all(not path.exists() for path in load_paths)
+    assert tokenizer_calls[0]["trust_remote_code"] is trust
     assert config["eos_token_id"] == 3
     assert config["model_type"] == "llama"
     assert model._unsloth_mlx_distributed_parallel_mode == "pipeline"

--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -174,9 +174,7 @@ def test_apply_mlx_distributed_sharding_modes_and_guards():
         _apply_mlx_distributed_sharding(object(), tensor_group=tensor_group, model_name="fake")
 
 
-@pytest.mark.parametrize("trust", [False, True])
-def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_path, trust):
-    from transformers import AutoTokenizer
+def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_path):
     import mlx_lm.utils as mlx_lm_utils
     from unsloth_zoo.mlx.loader import _load_mlx_lm_distributed
 
@@ -229,23 +227,12 @@ def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_
 
     monkeypatch.setattr(mlx_lm_utils, "_download", _download)
     monkeypatch.setattr(mlx_lm_utils, "load_model", _load_model)
-    (model_path / "tokenizer_config.json").write_text('{"tokenizer_class":"RemoteTokenizer"}')
-    tokenizer_calls = []
-
-    def tokenizer(path, **kwargs):
-        tokenizer_calls.append(kwargs)
-        return types.SimpleNamespace(name="tok")
-
-    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(tokenizer))
-    monkeypatch.setattr(
-        mlx_lm_utils, "load_tokenizer",
-        lambda path, *_a, **_k: AutoTokenizer.from_pretrained(path),
-    )
+    monkeypatch.setattr(mlx_lm_utils, "load_tokenizer", lambda *_a, **_k: types.SimpleNamespace(name="tok"))
 
     model, tokenizer, config = _load_mlx_lm_distributed(
         "fake/repo",
         "llama",
-        {"return_config": True, "tokenizer_config": {"trust_remote_code": trust}},
+        {"return_config": True},
         pipeline_group=_FakeGroup(name="pipeline"),
     )
 
@@ -258,7 +245,6 @@ def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_
     assert ("download", local_shards) in events
     assert ("load", list(local_shards)) in events
     assert all(not path.exists() for path in load_paths)
-    assert tokenizer_calls[0]["trust_remote_code"] is trust
     assert config["eos_token_id"] == 3
     assert config["model_type"] == "llama"
     assert model._unsloth_mlx_distributed_parallel_mode == "pipeline"

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -4373,3 +4373,32 @@ def test_tokenizer_scope_routes_mlx_lm_and_restores(tmp_path):
         thread.join(timeout=60)
     assert not errors
     assert AutoTokenizer.__dict__["from_pretrained"] is pristine
+
+
+def test_tokenizer_load_never_prompts_for_remote_code(monkeypatch, tmp_path):
+    """transformers reads a missing trust_remote_code as None, and answers None
+    by prompting on stdin for TIME_OUT_REMOTE_CODE seconds. The blank config
+    _load_mlx_tokenizer injects forces has_local_code False, so a remote-code
+    repo lands on that branch: without an explicit default a plain load blocks
+    ~15s on a question nobody asked, in a notebook or a Studio worker."""
+    import unsloth_zoo.mlx.loader as loader
+
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps({
+        "tokenizer_class": "RemoteTokenizer",
+        "auto_map": {"AutoTokenizer": ["tokenization_custom.RemoteTokenizer", None]},
+    }))
+    (tmp_path / "tokenization_custom.py").write_text("class RemoteTokenizer: pass\n")
+
+    # Record rather than raise: resolve_trust_remote_code wraps the prompt in
+    # `except Exception` and rewrites anything raised here into the same
+    # ValueError the passing path produces, which hides the prompt entirely.
+    prompts = []
+
+    def fake_input(*args, **kwargs):
+        prompts.append(args)
+        return "n"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    with pytest.raises(ValueError, match="custom code"):
+        loader._load_mlx_tokenizer(tmp_path)
+    assert not prompts, "tokenizer load prompted on stdin for remote code"

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -4276,10 +4276,8 @@ def test_tokenizer_without_declared_class_keeps_class_default_specials(tmp_path)
     from transformers import PreTrainedTokenizerFast
     import unsloth_zoo.mlx.loader as loader
 
-    # The published gpt2 repo's shape, built locally: a serialized fast
-    # tokenizer, no tokenizer_class, no special_tokens_map.json. Downloading the
-    # real one would make this fail offline or behind a proxy, and this file is
-    # a hard gate in the Repo tests (CPU) lane.
+    # gpt2's published shape, built locally: downloading it fails offline, and
+    # this file is a hard gate in the Repo tests (CPU) lane.
     vocab = {"<|endoftext|>": 0, "hello": 1, "Ġworld": 2}
     backend = Tokenizer(models.BPE(vocab=vocab, merges=[]))
     backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
@@ -4288,8 +4286,7 @@ def test_tokenizer_without_declared_class_keeps_class_default_specials(tmp_path)
     (tmp_path / "tokenizer_config.json").write_text(json.dumps({"model_max_length": 1024}))
     (tmp_path / "config.json").write_text(json.dumps({"model_type": "gpt2"}))
 
-    # The bare backend is what the fast-file branch used to return, and it has
-    # no defaults to fall back on.
+    # What the fast-file branch used to return: no class defaults to fall back on.
     bare = PreTrainedTokenizerFast.from_pretrained(tmp_path)
     assert bare.eos_token is None
 
@@ -4397,9 +4394,8 @@ def test_tokenizer_load_never_prompts_for_remote_code(monkeypatch, tmp_path):
     }))
     (tmp_path / "tokenization_custom.py").write_text("class RemoteTokenizer: pass\n")
 
-    # Record rather than raise: resolve_trust_remote_code wraps the prompt in
-    # `except Exception` and rewrites anything raised here into the same
-    # ValueError the passing path produces, which hides the prompt entirely.
+    # Record, never raise: resolve_trust_remote_code catches Exception and
+    # rewrites it into the ValueError the passing path also produces.
     prompts = []
 
     def fake_input(*args, **kwargs):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -4272,24 +4272,32 @@ def test_tokenizer_without_declared_class_keeps_class_default_specials(tmp_path)
     special_tokens_map.json: bos/eos/unk come from the tokenizer class's
     __init__ defaults. Loading the bare backend drops them, and an eos_token of
     None leaves mlx-lm generation with no stop token."""
-    import transformers
+    from tokenizers import Tokenizer, decoders, models, pre_tokenizers
+    from transformers import PreTrainedTokenizerFast
     import unsloth_zoo.mlx.loader as loader
 
-    tokenizer = transformers.AutoTokenizer.from_pretrained("openai-community/gpt2")
-    tokenizer.save_pretrained(tmp_path)
-    # save_pretrained writes a tokenizer_class the published repo does not have.
-    config_path = tmp_path / "tokenizer_config.json"
-    metadata = json.loads(config_path.read_text())
-    metadata.pop("tokenizer_class", None)
-    config_path.write_text(json.dumps(metadata))
-    (tmp_path / "special_tokens_map.json").unlink(missing_ok=True)
+    # The published gpt2 repo's shape, built locally: a serialized fast
+    # tokenizer, no tokenizer_class, no special_tokens_map.json. Downloading the
+    # real one would make this fail offline or behind a proxy, and this file is
+    # a hard gate in the Repo tests (CPU) lane.
+    vocab = {"<|endoftext|>": 0, "hello": 1, "Ġworld": 2}
+    backend = Tokenizer(models.BPE(vocab=vocab, merges=[]))
+    backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+    backend.decoder = decoders.ByteLevel()
+    backend.save(str(tmp_path / "tokenizer.json"))
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps({"model_max_length": 1024}))
     (tmp_path / "config.json").write_text(json.dumps({"model_type": "gpt2"}))
 
+    # The bare backend is what the fast-file branch used to return, and it has
+    # no defaults to fall back on.
+    bare = PreTrainedTokenizerFast.from_pretrained(tmp_path)
+    assert bare.eos_token is None
+
     loaded = loader._load_mlx_tokenizer(tmp_path)
-    assert loaded.eos_token == tokenizer.eos_token
-    assert loaded.eos_token_id == tokenizer.eos_token_id
-    assert loaded.bos_token == tokenizer.bos_token
-    assert loaded("hello world")["input_ids"] == tokenizer("hello world")["input_ids"]
+    assert loaded.eos_token == "<|endoftext|>"
+    assert loaded.bos_token == "<|endoftext|>"
+    assert loaded.eos_token_id == 0
+    assert loaded("hello world")["input_ids"] == bare("hello world")["input_ids"]
 
 
 def test_model_type_lookup_never_builds_a_model_config(monkeypatch, tmp_path):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -4407,6 +4407,64 @@ def test_mlx_lm_tokenizer_loader_forwards_trust(monkeypatch, tmp_path, trust):
     assert calls[0]["trust_remote_code"] is trust
 
 
+def test_tokenizer_without_declared_class_keeps_class_default_specials(tmp_path):
+    """gpt2 and friends declare no tokenizer_class and ship no
+    special_tokens_map.json: bos/eos/unk come from the tokenizer class's
+    __init__ defaults. Loading the bare backend drops them, and an eos_token of
+    None leaves mlx-lm generation with no stop token."""
+    import json
+    import transformers
+    import unsloth_zoo.mlx.loader as loader
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained("openai-community/gpt2")
+    tokenizer.save_pretrained(tmp_path)
+    # save_pretrained writes a tokenizer_class the published repo does not have.
+    config_path = tmp_path / "tokenizer_config.json"
+    metadata = json.loads(config_path.read_text())
+    metadata.pop("tokenizer_class", None)
+    config_path.write_text(json.dumps(metadata))
+    (tmp_path / "special_tokens_map.json").unlink(missing_ok=True)
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "gpt2"}))
+
+    loaded = loader._load_mlx_tokenizer(tmp_path)
+    assert loaded.eos_token == tokenizer.eos_token
+    assert loaded.eos_token_id == tokenizer.eos_token_id
+    assert loaded.bos_token == tokenizer.bos_token
+    assert loaded("hello world")["input_ids"] == tokenizer("hello world")["input_ids"]
+
+
+def test_model_type_lookup_never_builds_a_model_config(monkeypatch, tmp_path):
+    """The recovery above must not reintroduce the validation this PR removes."""
+    import json
+    import transformers
+    import unsloth_zoo.mlx.loader as loader
+
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "gpt2"}))
+    monkeypatch.setattr(
+        transformers.AutoConfig, "from_pretrained",
+        staticmethod(lambda *a, **k: pytest.fail("model config must not be resolved")),
+    )
+    assert loader._tokenizer_class_for_model_type(tmp_path) is not None
+
+
+@pytest.mark.parametrize("bad", [
+    {},                                  # no model_type at all
+    {"model_type": "not_a_real_model"},  # unknown to transformers
+])
+def test_model_type_lookup_returns_none_when_unresolvable(tmp_path, bad):
+    import json
+    import unsloth_zoo.mlx.loader as loader
+
+    (tmp_path / "config.json").write_text(json.dumps(bad))
+    assert loader._tokenizer_class_for_model_type(tmp_path) is None
+
+
+def test_model_type_lookup_tolerates_missing_config(tmp_path):
+    import unsloth_zoo.mlx.loader as loader
+
+    assert loader._tokenizer_class_for_model_type(tmp_path) is None
+
+
 @pytest.mark.parametrize("trust", [False, True])
 def test_image_processor_builder_forwards_trust(monkeypatch, tmp_path, trust):
     import transformers
@@ -4414,12 +4472,37 @@ def test_image_processor_builder_forwards_trust(monkeypatch, tmp_path, trust):
 
     processor, calls = object(), []
 
-    def from_pretrained(path, **kwargs):
+    def record(path, **kwargs):
         calls.append(kwargs["trust_remote_code"])
         return processor
 
-    monkeypatch.setattr(transformers.AutoImageProcessor, "from_pretrained", staticmethod(from_pretrained))
+    class FakeAutoImageProcessor:
+        from_pretrained = staticmethod(record)
+
+    # Replace the NAME the builder imports, never an attribute OF the real class:
+    # without torchvision, transformers 5.x hands out AutoImageProcessor as a
+    # backend-gated placeholder that raises ImportError on every attribute read,
+    # and setattr reads the old value first. torchvision is not a dependency of
+    # this package, so that is the configuration the MLX path runs in.
+    monkeypatch.setattr(transformers, "AutoImageProcessor", FakeAutoImageProcessor)
     assert loader._build_vlm_image_processor_from_config(
         tmp_path, {}, {}, trust_remote_code=trust,
     ) is processor
     assert calls == [trust]
+
+
+def test_image_processor_builder_degrades_when_backend_is_gated(monkeypatch, tmp_path):
+    """The caller treats None as "no image processor", so a gated
+    AutoImageProcessor has to degrade instead of raising out of the loader."""
+    import transformers
+    import unsloth_zoo.mlx.loader as loader
+
+    class GatedAutoImageProcessor:
+        @staticmethod
+        def from_pretrained(path, **kwargs):
+            raise ImportError("requires the Torchvision library")
+
+    monkeypatch.setattr(transformers, "AutoImageProcessor", GatedAutoImageProcessor)
+    assert loader._build_vlm_image_processor_from_config(
+        tmp_path, {}, {}, trust_remote_code=False,
+    ) is None

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1788,9 +1788,11 @@ def test_vlm_sanitizer_replay_uses_real_model_instances():
     ) == {"visual.proj.weight": "tensor"}
 
 
+@pytest.mark.parametrize("trust", [False, True])
 def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
     monkeypatch,
     tmp_path,
+    trust,
 ):
     import unsloth_zoo.mlx.loader as loader
 
@@ -1809,13 +1811,11 @@ def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
     )
 
     image_processor = object()
-    monkeypatch.setattr(
-        loader,
-        "_build_vlm_image_processor_from_config",
-        lambda model_path, processor_config, preprocessor_config, model_type=None: (
-            image_processor
-        ),
-    )
+    def build_image_processor(*args, **kwargs):
+        assert kwargs["trust_remote_code"] is trust
+        return image_processor
+
+    monkeypatch.setattr(loader, "_build_vlm_image_processor_from_config", build_image_processor)
 
     (tmp_path / "processor_config.json").write_text(
         json.dumps({"processor_class": "FakeProcessor"}),
@@ -1839,6 +1839,7 @@ def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
         degraded,
         tmp_path,
         "glm_ocr",
+        trust_remote_code=trust,
     )
 
     assert isinstance(repaired, FakeProcessor)
@@ -4232,3 +4233,193 @@ def test_moe_gguf_export_splits_a_tensor_a_sanitizer_fused_from_a_named_group(tm
     rewritten = _staged_tensors(path)
     assert sorted(rewritten) == sorted(model.checkpoint)
     assert all(rewritten[n].tolist() == v.tolist() for n, v in model.checkpoint.items())
+
+
+def test_tokenizer_load_bypasses_model_config_and_preserves_sidecars(monkeypatch, tmp_path):
+    from tokenizers import Tokenizer, models, pre_tokenizers
+    from transformers import AutoConfig, PreTrainedTokenizerFast
+    import unsloth_zoo.mlx.loader as loader
+
+    backend = Tokenizer(models.WordLevel({"[UNK]": 0, "hello": 1, "world": 2}, unk_token="[UNK]"))
+    backend.pre_tokenizer = pre_tokenizers.Whitespace()
+    expected = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]", eos_token="[END]")
+    expected.add_tokens(["extra_one", "extra_two"])
+    expected.chat_template = "{% for m in messages %}{{ m['content'] }}{% endfor %}"
+    expected.save_pretrained(tmp_path)
+    (tmp_path / "config.json").write_text(json.dumps({
+        "model_type": "unregistered", "rope_scaling": {"type": "longrope"},
+    }))
+
+    def reject_config(*args, **kwargs):
+        raise AssertionError("tokenizer must not resolve model config")
+
+    monkeypatch.setattr(AutoConfig, "from_pretrained", reject_config)
+    actual = loader._load_mlx_tokenizer(tmp_path)
+    assert actual.get_vocab() == expected.get_vocab()
+    assert actual.special_tokens_map == expected.special_tokens_map
+    assert actual.get_added_vocab() == expected.get_added_vocab()
+    assert actual.chat_template == expected.chat_template
+    for text in ("hello extra_two", "extra_one world"):
+        ids = expected.encode(text)
+        assert actual.encode(text) == ids
+        assert actual.decode(ids) == expected.decode(ids)
+
+
+def test_tokenizer_fast_file_precedes_remote_tiktoken(monkeypatch, tmp_path):
+    from tokenizers import Tokenizer, models
+    from transformers import AutoTokenizer
+    import unsloth_zoo.mlx.loader as loader
+
+    Tokenizer(models.WordLevel({"hello": 0})).save(str(tmp_path / "tokenizer.json"))
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps({
+        "tokenizer_class": "TiktokenTokenizerWrapper",
+        "auto_map": {"AutoTokenizer": ["tiktoken.TiktokenTokenizerWrapper", None]},
+    }))
+
+    def reject_remote(*args, **kwargs):
+        raise AssertionError("serialized tokenizer must not execute remote code")
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", reject_remote)
+    for trust in (False, True):
+        assert loader._load_mlx_tokenizer(tmp_path, trust_remote_code=trust).encode("hello") == [0]
+
+
+def test_tokenizer_scope_forwards_trust_without_model_config_and_restores(monkeypatch, tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+    from transformers import AutoTokenizer, PretrainedConfig
+    import unsloth_zoo.mlx.loader as loader
+
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps({
+        "tokenizer_class": "RemoteTokenizer",
+        "auto_map": {"AutoTokenizer": ["tokenization_custom.RemoteTokenizer", None]},
+    }))
+    calls = []
+
+    def remote_tokenizer(path, **kwargs):
+        calls.append(kwargs)
+        if not kwargs.get("trust_remote_code"):
+            raise ValueError("custom code requires trust_remote_code=True")
+        return "remote"
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(remote_tokenizer))
+    with loader._mlx_tokenizer_loading_scope(True):
+        assert AutoTokenizer.from_pretrained(tmp_path, trust_remote_code=False) == "remote"
+        assert isinstance(calls[-1]["config"], PretrainedConfig)
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            assert pool.submit(AutoTokenizer.from_pretrained, tmp_path, trust_remote_code=True).result() == "remote"
+        assert "config" not in calls[-1]
+        with loader._mlx_tokenizer_loading_scope():
+            with pytest.raises(ValueError, match=r"tokenization_custom.py.*trust_remote_code=True"):
+                AutoTokenizer.from_pretrained(tmp_path, trust_remote_code=True)
+        assert AutoTokenizer.from_pretrained(tmp_path) == "remote"
+    assert AutoTokenizer.from_pretrained is remote_tokenizer
+    with pytest.raises(RuntimeError):
+        with loader._mlx_tokenizer_loading_scope():
+            raise RuntimeError("failed processor")
+    assert AutoTokenizer.from_pretrained is remote_tokenizer
+
+
+@pytest.mark.parametrize("failure_mode", ["processor", "tokenizer", "swallowed"])
+@pytest.mark.parametrize("native_available", [False, True])
+def test_processor_remote_refusal_names_file_and_trust_reaches_nested_tokenizer(
+    monkeypatch, tmp_path, failure_mode, native_available,
+):
+    from transformers import AutoTokenizer
+    import unsloth_zoo.mlx.loader as loader
+
+    (tmp_path / "config.json").write_text(json.dumps({
+        "model_type": "custom_vlm",
+        "auto_map": {"AutoProcessor": "processing_custom.CustomProcessor"},
+    }))
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps({
+        "tokenizer_class": "RemoteTokenizer",
+        "auto_map": {"AutoTokenizer": ["tokenization_custom.RemoteTokenizer", None]},
+    }))
+    calls = []
+
+    class RemoteProcessor:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            calls.append(kwargs["trust_remote_code"])
+            if not kwargs["trust_remote_code"]:
+                if failure_mode != "processor":
+                    try:
+                        AutoTokenizer.from_pretrained(path)
+                    except ValueError:
+                        if failure_mode == "swallowed":
+                            raise ValueError("Unrecognized processing class")
+                        raise
+                raise ValueError("contains custom code which must be executed; trust_remote_code=True")
+            return AutoTokenizer.from_pretrained(path)
+
+    def tokenizer(path, **kwargs):
+        if not kwargs["trust_remote_code"]:
+            raise ValueError("custom code requires trust_remote_code=True")
+        return "processor-tokenizer"
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(tokenizer))
+    monkeypatch.setitem(globals(), "AutoProcessor", RemoteProcessor)
+    monkeypatch.setitem(globals(), "load_processor", _test_bound_load_processor)
+    monkeypatch.setattr(loader, "_ensure_vlm_detokenizer_copy", lambda: None)
+    native = object()
+    monkeypatch.setattr(
+        loader, "_load_declared_mlx_vlm_processor",
+        lambda *_a, **_k: native if native_available else None,
+    )
+    default = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    if native_available:
+        assert default(tmp_path) is native
+    else:
+        code_file = "processing_custom" if failure_mode == "processor" else "tokenization_custom"
+        with pytest.raises(ValueError, match=rf"{code_file}.py.*trust_remote_code=True"):
+            default(tmp_path)
+    trusted = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load, allow_remote_code=True)
+    assert trusted(tmp_path) == "processor-tokenizer"
+    assert calls == [False, True]
+
+
+@pytest.mark.parametrize("trust", [False, True])
+def test_mlx_lm_tokenizer_loader_forwards_trust(monkeypatch, tmp_path, trust):
+    from transformers import AutoTokenizer
+    import mlx_lm.utils as lm_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    (tmp_path / "tokenizer_config.json").write_text('{"tokenizer_class":"RemoteTokenizer"}')
+    calls = []
+
+    def tokenizer(path, **kwargs):
+        calls.append(kwargs)
+        return "tokenizer"
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(tokenizer))
+    monkeypatch.setattr(lm_utils, "_download", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(lm_utils, "load_model", lambda *a, **k: ("model", {"eos_token_id": 7}))
+
+    def load_tokenizer(path, config, eos_token_ids):
+        assert eos_token_ids == 7
+        return AutoTokenizer.from_pretrained(path)
+
+    monkeypatch.setattr(lm_utils, "load_tokenizer", load_tokenizer)
+    result = loader._load_mlx_lm_with_strict_fallback(
+        tmp_path, "custom", None, {"tokenizer_config": {"trust_remote_code": trust}},
+    )
+    assert result == ("model", "tokenizer")
+    assert calls[0]["trust_remote_code"] is trust
+
+
+@pytest.mark.parametrize("trust", [False, True])
+def test_image_processor_builder_forwards_trust(monkeypatch, tmp_path, trust):
+    import transformers
+    import unsloth_zoo.mlx.loader as loader
+
+    processor, calls = object(), []
+
+    def from_pretrained(path, **kwargs):
+        calls.append(kwargs["trust_remote_code"])
+        return processor
+
+    monkeypatch.setattr(transformers.AutoImageProcessor, "from_pretrained", staticmethod(from_pretrained))
+    assert loader._build_vlm_image_processor_from_config(
+        tmp_path, {}, {}, trust_remote_code=trust,
+    ) is processor
+    assert calls == [trust]

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1788,11 +1788,9 @@ def test_vlm_sanitizer_replay_uses_real_model_instances():
     ) == {"visual.proj.weight": "tensor"}
 
 
-@pytest.mark.parametrize("trust", [False, True])
 def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
     monkeypatch,
     tmp_path,
-    trust,
 ):
     import unsloth_zoo.mlx.loader as loader
 
@@ -1811,11 +1809,13 @@ def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
     )
 
     image_processor = object()
-    def build_image_processor(*args, **kwargs):
-        assert kwargs["trust_remote_code"] is trust
-        return image_processor
-
-    monkeypatch.setattr(loader, "_build_vlm_image_processor_from_config", build_image_processor)
+    monkeypatch.setattr(
+        loader,
+        "_build_vlm_image_processor_from_config",
+        lambda model_path, processor_config, preprocessor_config, model_type=None: (
+            image_processor
+        ),
+    )
 
     (tmp_path / "processor_config.json").write_text(
         json.dumps({"processor_class": "FakeProcessor"}),
@@ -1839,7 +1839,6 @@ def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
         degraded,
         tmp_path,
         "glm_ocr",
-        trust_remote_code=trust,
     )
 
     assert isinstance(repaired, FakeProcessor)
@@ -4236,6 +4235,9 @@ def test_moe_gguf_export_splits_a_tensor_a_sanitizer_fused_from_a_named_group(tm
 
 
 def test_tokenizer_load_bypasses_model_config_and_preserves_sidecars(monkeypatch, tmp_path):
+    """transformers 5.x resolves the model config before tokenizing and only
+    catches ValueError/OSError from it, so a config raising AttributeError or
+    KeyError takes a loadable tokenizer down with it."""
     from tokenizers import Tokenizer, models, pre_tokenizers
     from transformers import AutoConfig, PreTrainedTokenizerFast
     import unsloth_zoo.mlx.loader as loader
@@ -4265,154 +4267,11 @@ def test_tokenizer_load_bypasses_model_config_and_preserves_sidecars(monkeypatch
         assert actual.decode(ids) == expected.decode(ids)
 
 
-def test_tokenizer_fast_file_precedes_remote_tiktoken(monkeypatch, tmp_path):
-    from tokenizers import Tokenizer, models
-    from transformers import AutoTokenizer
-    import unsloth_zoo.mlx.loader as loader
-
-    Tokenizer(models.WordLevel({"hello": 0})).save(str(tmp_path / "tokenizer.json"))
-    (tmp_path / "tokenizer_config.json").write_text(json.dumps({
-        "tokenizer_class": "TiktokenTokenizerWrapper",
-        "auto_map": {"AutoTokenizer": ["tiktoken.TiktokenTokenizerWrapper", None]},
-    }))
-
-    def reject_remote(*args, **kwargs):
-        raise AssertionError("serialized tokenizer must not execute remote code")
-
-    monkeypatch.setattr(AutoTokenizer, "from_pretrained", reject_remote)
-    for trust in (False, True):
-        assert loader._load_mlx_tokenizer(tmp_path, trust_remote_code=trust).encode("hello") == [0]
-
-
-def test_tokenizer_scope_forwards_trust_without_model_config_and_restores(monkeypatch, tmp_path):
-    from concurrent.futures import ThreadPoolExecutor
-    from transformers import AutoTokenizer, PretrainedConfig
-    import unsloth_zoo.mlx.loader as loader
-
-    (tmp_path / "tokenizer_config.json").write_text(json.dumps({
-        "tokenizer_class": "RemoteTokenizer",
-        "auto_map": {"AutoTokenizer": ["tokenization_custom.RemoteTokenizer", None]},
-    }))
-    calls = []
-
-    def remote_tokenizer(path, **kwargs):
-        calls.append(kwargs)
-        if not kwargs.get("trust_remote_code"):
-            raise ValueError("custom code requires trust_remote_code=True")
-        return "remote"
-
-    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(remote_tokenizer))
-    with loader._mlx_tokenizer_loading_scope(True):
-        assert AutoTokenizer.from_pretrained(tmp_path, trust_remote_code=False) == "remote"
-        assert isinstance(calls[-1]["config"], PretrainedConfig)
-        with ThreadPoolExecutor(max_workers=1) as pool:
-            assert pool.submit(AutoTokenizer.from_pretrained, tmp_path, trust_remote_code=True).result() == "remote"
-        assert "config" not in calls[-1]
-        with loader._mlx_tokenizer_loading_scope():
-            with pytest.raises(ValueError, match=r"tokenization_custom.py.*trust_remote_code=True"):
-                AutoTokenizer.from_pretrained(tmp_path, trust_remote_code=True)
-        assert AutoTokenizer.from_pretrained(tmp_path) == "remote"
-    assert AutoTokenizer.from_pretrained is remote_tokenizer
-    with pytest.raises(RuntimeError):
-        with loader._mlx_tokenizer_loading_scope():
-            raise RuntimeError("failed processor")
-    assert AutoTokenizer.from_pretrained is remote_tokenizer
-
-
-@pytest.mark.parametrize("failure_mode", ["processor", "tokenizer", "swallowed"])
-@pytest.mark.parametrize("native_available", [False, True])
-def test_processor_remote_refusal_names_file_and_trust_reaches_nested_tokenizer(
-    monkeypatch, tmp_path, failure_mode, native_available,
-):
-    from transformers import AutoTokenizer
-    import unsloth_zoo.mlx.loader as loader
-
-    (tmp_path / "config.json").write_text(json.dumps({
-        "model_type": "custom_vlm",
-        "auto_map": {"AutoProcessor": "processing_custom.CustomProcessor"},
-    }))
-    (tmp_path / "tokenizer_config.json").write_text(json.dumps({
-        "tokenizer_class": "RemoteTokenizer",
-        "auto_map": {"AutoTokenizer": ["tokenization_custom.RemoteTokenizer", None]},
-    }))
-    calls = []
-
-    class RemoteProcessor:
-        @classmethod
-        def from_pretrained(cls, path, **kwargs):
-            calls.append(kwargs["trust_remote_code"])
-            if not kwargs["trust_remote_code"]:
-                if failure_mode != "processor":
-                    try:
-                        AutoTokenizer.from_pretrained(path)
-                    except ValueError:
-                        if failure_mode == "swallowed":
-                            raise ValueError("Unrecognized processing class")
-                        raise
-                raise ValueError("contains custom code which must be executed; trust_remote_code=True")
-            return AutoTokenizer.from_pretrained(path)
-
-    def tokenizer(path, **kwargs):
-        if not kwargs["trust_remote_code"]:
-            raise ValueError("custom code requires trust_remote_code=True")
-        return "processor-tokenizer"
-
-    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(tokenizer))
-    monkeypatch.setitem(globals(), "AutoProcessor", RemoteProcessor)
-    monkeypatch.setitem(globals(), "load_processor", _test_bound_load_processor)
-    monkeypatch.setattr(loader, "_ensure_vlm_detokenizer_copy", lambda: None)
-    native = object()
-    monkeypatch.setattr(
-        loader, "_load_declared_mlx_vlm_processor",
-        lambda *_a, **_k: native if native_available else None,
-    )
-    default = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
-    if native_available:
-        assert default(tmp_path) is native
-    else:
-        code_file = "processing_custom" if failure_mode == "processor" else "tokenization_custom"
-        with pytest.raises(ValueError, match=rf"{code_file}.py.*trust_remote_code=True"):
-            default(tmp_path)
-    trusted = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load, allow_remote_code=True)
-    assert trusted(tmp_path) == "processor-tokenizer"
-    assert calls == [False, True]
-
-
-@pytest.mark.parametrize("trust", [False, True])
-def test_mlx_lm_tokenizer_loader_forwards_trust(monkeypatch, tmp_path, trust):
-    from transformers import AutoTokenizer
-    import mlx_lm.utils as lm_utils
-    import unsloth_zoo.mlx.loader as loader
-
-    (tmp_path / "tokenizer_config.json").write_text('{"tokenizer_class":"RemoteTokenizer"}')
-    calls = []
-
-    def tokenizer(path, **kwargs):
-        calls.append(kwargs)
-        return "tokenizer"
-
-    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(tokenizer))
-    monkeypatch.setattr(lm_utils, "_download", lambda *a, **k: tmp_path)
-    monkeypatch.setattr(lm_utils, "load_model", lambda *a, **k: ("model", {"eos_token_id": 7}))
-
-    def load_tokenizer(path, config, eos_token_ids):
-        assert eos_token_ids == 7
-        return AutoTokenizer.from_pretrained(path)
-
-    monkeypatch.setattr(lm_utils, "load_tokenizer", load_tokenizer)
-    result = loader._load_mlx_lm_with_strict_fallback(
-        tmp_path, "custom", None, {"tokenizer_config": {"trust_remote_code": trust}},
-    )
-    assert result == ("model", "tokenizer")
-    assert calls[0]["trust_remote_code"] is trust
-
-
 def test_tokenizer_without_declared_class_keeps_class_default_specials(tmp_path):
-    """gpt2 and friends declare no tokenizer_class and ship no
+    """gpt2 and its relatives declare no tokenizer_class and ship no
     special_tokens_map.json: bos/eos/unk come from the tokenizer class's
     __init__ defaults. Loading the bare backend drops them, and an eos_token of
     None leaves mlx-lm generation with no stop token."""
-    import json
     import transformers
     import unsloth_zoo.mlx.loader as loader
 
@@ -4434,8 +4293,7 @@ def test_tokenizer_without_declared_class_keeps_class_default_specials(tmp_path)
 
 
 def test_model_type_lookup_never_builds_a_model_config(monkeypatch, tmp_path):
-    """The recovery above must not reintroduce the validation this PR removes."""
-    import json
+    """The recovery above must not reintroduce the validation this fix removes."""
     import transformers
     import unsloth_zoo.mlx.loader as loader
 
@@ -4452,7 +4310,6 @@ def test_model_type_lookup_never_builds_a_model_config(monkeypatch, tmp_path):
     {"model_type": "not_a_real_model"},  # unknown to transformers
 ])
 def test_model_type_lookup_returns_none_when_unresolvable(tmp_path, bad):
-    import json
     import unsloth_zoo.mlx.loader as loader
 
     (tmp_path / "config.json").write_text(json.dumps(bad))
@@ -4465,44 +4322,54 @@ def test_model_type_lookup_tolerates_missing_config(tmp_path):
     assert loader._tokenizer_class_for_model_type(tmp_path) is None
 
 
-@pytest.mark.parametrize("trust", [False, True])
-def test_image_processor_builder_forwards_trust(monkeypatch, tmp_path, trust):
-    import transformers
+def test_tokenizer_scope_routes_mlx_lm_and_restores(tmp_path):
+    """mlx_lm.utils.load_tokenizer calls AutoTokenizer.from_pretrained directly,
+    so the scope is the only way to reach it; it must restore on exit and after
+    an exception, and leave other threads alone."""
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+    from transformers import AutoTokenizer
     import unsloth_zoo.mlx.loader as loader
 
-    processor, calls = object(), []
+    pristine = AutoTokenizer.__dict__["from_pretrained"]
+    with loader._mlx_tokenizer_loading_scope():
+        assert AutoTokenizer.__dict__["from_pretrained"] is not pristine
+        # A thread that never entered the scope keeps ordinary behaviour.
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            assert pool.submit(
+                lambda: getattr(loader._TOKENIZER_LOAD_STATE, "active", False)
+            ).result() is False
+    assert AutoTokenizer.__dict__["from_pretrained"] is pristine
 
-    def record(path, **kwargs):
-        calls.append(kwargs["trust_remote_code"])
-        return processor
+    try:
+        with loader._mlx_tokenizer_loading_scope():
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert AutoTokenizer.__dict__["from_pretrained"] is pristine
 
-    class FakeAutoImageProcessor:
-        from_pretrained = staticmethod(record)
+    # Nested scopes restore only at the outermost exit.
+    with loader._mlx_tokenizer_loading_scope():
+        with loader._mlx_tokenizer_loading_scope():
+            pass
+        assert AutoTokenizer.__dict__["from_pretrained"] is not pristine
+    assert AutoTokenizer.__dict__["from_pretrained"] is pristine
 
-    # Replace the NAME the builder imports, never an attribute OF the real class:
-    # without torchvision, transformers 5.x hands out AutoImageProcessor as a
-    # backend-gated placeholder that raises ImportError on every attribute read,
-    # and setattr reads the old value first. torchvision is not a dependency of
-    # this package, so that is the configuration the MLX path runs in.
-    monkeypatch.setattr(transformers, "AutoImageProcessor", FakeAutoImageProcessor)
-    assert loader._build_vlm_image_processor_from_config(
-        tmp_path, {}, {}, trust_remote_code=trust,
-    ) is processor
-    assert calls == [trust]
+    # Concurrent scopes must not capture each other's patch as the original.
+    errors = []
 
+    def worker():
+        try:
+            for _ in range(10):
+                with loader._mlx_tokenizer_loading_scope():
+                    pass
+        except BaseException as error:  # pragma: no cover - failure path
+            errors.append(error)
 
-def test_image_processor_builder_degrades_when_backend_is_gated(monkeypatch, tmp_path):
-    """The caller treats None as "no image processor", so a gated
-    AutoImageProcessor has to degrade instead of raising out of the loader."""
-    import transformers
-    import unsloth_zoo.mlx.loader as loader
-
-    class GatedAutoImageProcessor:
-        @staticmethod
-        def from_pretrained(path, **kwargs):
-            raise ImportError("requires the Torchvision library")
-
-    monkeypatch.setattr(transformers, "AutoImageProcessor", GatedAutoImageProcessor)
-    assert loader._build_vlm_image_processor_from_config(
-        tmp_path, {}, {}, trust_remote_code=False,
-    ) is None
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+    assert not errors
+    assert AutoTokenizer.__dict__["from_pretrained"] is pristine

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -4353,7 +4353,6 @@ def test_tokenizer_scope_routes_mlx_lm_and_restores(tmp_path):
         pass
     assert AutoTokenizer.__dict__["from_pretrained"] is pristine
 
-    # Nested scopes restore only at the outermost exit.
     with loader._mlx_tokenizer_loading_scope():
         with loader._mlx_tokenizer_loading_scope():
             pass

--- a/tests/test_upstream_pinned_symbols_transformers.py
+++ b/tests/test_upstream_pinned_symbols_transformers.py
@@ -381,6 +381,38 @@ def test_masking_utils_create_causal_mask_names(tag: str):
     )
 
 
+@pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
+def test_tokenization_auto_symbols_for_mlx_loader(tag: str):
+    """Zoo PR #1170: unsloth_zoo/mlx/loader.py:_load_mlx_tokenizer and
+    _tokenizer_class_for_model_type import get_tokenizer_config,
+    tokenizer_class_from_name and TOKENIZER_MAPPING_NAMES from
+    transformers.models.auto.tokenization_auto. None of the three is public
+    API, and losing one breaks every MLX tokenizer load with an ImportError
+    at call time rather than at import time."""
+    src = _fetch_text(
+        "huggingface/transformers",
+        tag,
+        "src/transformers/models/auto/tokenization_auto.py",
+    )
+    if src is None:
+        pytest.skip(f"{tag}: tokenization_auto.py not present")
+    missing = [
+        name for name in ("get_tokenizer_config", "tokenizer_class_from_name")
+        if not _has_def(src, name, "func")
+    ]
+    assert not missing, (
+        f"{tag}: transformers.models.auto.tokenization_auto {missing} missing; "
+        f"unsloth_zoo/mlx/loader.py::_load_mlx_tokenizer raises ImportError and "
+        f"every MLX tokenizer load fails"
+    )
+    assert re.search(r"^TOKENIZER_MAPPING_NAMES\s*=", src, re.MULTILINE), (
+        f"{tag}: TOKENIZER_MAPPING_NAMES missing from tokenization_auto; "
+        f"_tokenizer_class_for_model_type can no longer recover the tokenizer "
+        f"class for repos that declare none (gpt2 and relatives), so their "
+        f"bos/eos/unk silently become None"
+    )
+
+
 # Qwen MoE LoRA extractor reads wrapper.get_base_layer() + .parameter_name
 # / .hidden_dim / .intermediate_dim. Pin: peft keeps emitting ParamWrapper
 # (LoraLayer subclass) in peft/tuners/lora/layer.py.

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -722,7 +722,7 @@ def _materialize_mlx_vlm_config_override(
                     supports_list_extra_special_tokens=supports_list_extra_special_tokens,
                 )
             )
-        if not allow_tokenizer_remote_code and os.path.isfile(os.path.join(local_path, "tokenizer.json")):
+        if not allow_tokenizer_remote_code:
             auto_map = patched_tokenizer_config.get("auto_map")
             if isinstance(auto_map, dict) and auto_map:
                 patched_tokenizer_config = dict(patched_tokenizer_config)
@@ -804,34 +804,6 @@ def _remote_code_reference(metadata, auto_class):
     return reference if isinstance(reference, str) else None
 
 
-class _MLXRemoteCodeError(ValueError):
-    pass
-
-
-def _raise_mlx_remote_code_refusal(model_path, error, *, tokenizer_only=False):
-    if "trust_remote_code" not in str(error) and "custom code" not in str(error):
-        return
-    for filename, auto_class in (
-        ("processor_config.json", "AutoProcessor"),
-        ("preprocessor_config.json", "AutoProcessor"),
-        ("config.json", "AutoProcessor"),
-        ("tokenizer_config.json", "AutoTokenizer"),
-        ("preprocessor_config.json", "AutoImageProcessor"),
-    ):
-        if tokenizer_only and auto_class != "AutoTokenizer":
-            continue
-        reference = _remote_code_reference(
-            _read_json_file(os.path.join(str(model_path), filename)), auto_class,
-        )
-        if reference:
-            code_file = reference.split("--")[-1].rsplit(".", 1)[0] + ".py"
-            raise _MLXRemoteCodeError(
-                f"Unsloth: loading {model_path} requires {code_file} "
-                f"(declared in {filename}). Pass trust_remote_code=True "
-                "to allow this repository's custom code."
-            ) from error
-
-
 def _tokenizer_class_for_model_type(model_path):
     """Resolve the tokenizer class from config.json's model_type STRING.
 
@@ -857,13 +829,19 @@ def _tokenizer_class_for_model_type(model_path):
 
 
 def _load_mlx_tokenizer(model_path, *args, _auto_loader=None, **kwargs):
+    """Load a tokenizer without letting AutoTokenizer resolve the model config.
+
+    transformers 5.x resolves the model config before tokenization and only
+    catches ValueError/OSError from it, so published configs that raise
+    AttributeError or KeyError (Phi-4 multimodal, Nemotron NAS/H, DeepSeek
+    V3.2, MiniCPM3) take an otherwise loadable tokenizer down with them.
+    """
     from transformers import AutoTokenizer, PretrainedConfig, PreTrainedTokenizerFast
     from transformers.models.auto.tokenization_auto import (
         get_tokenizer_config, tokenizer_class_from_name,
     )
 
     auto_loader = _auto_loader or AutoTokenizer.from_pretrained
-    kwargs.setdefault("trust_remote_code", False)
     metadata = get_tokenizer_config(model_path, **kwargs)
     class_name = metadata.get("tokenizer_class")
     remote = _remote_code_reference(metadata, "AutoTokenizer")
@@ -874,27 +852,25 @@ def _load_mlx_tokenizer(model_path, *args, _auto_loader=None, **kwargs):
             tokenizer_class = tokenizer_class_from_name(class_name)
     if tokenizer_class is None and not remote:
         tokenizer_class = _tokenizer_class_for_model_type(model_path)
-    has_fast_file = (Path(model_path) / "tokenizer.json").is_file()
-    if has_fast_file and (
-        not remote or "tiktoken" in (str(class_name) + str(remote)).lower()
-    ):
+    if not remote and (Path(model_path) / "tokenizer.json").is_file():
         if tokenizer_class is None or not issubclass(tokenizer_class, PreTrainedTokenizerFast):
             tokenizer_class = PreTrainedTokenizerFast
         return tokenizer_class.from_pretrained(model_path, *args, **kwargs)
     # Tokenizer metadata selects the class; model validators have no role here.
     if class_name or remote:
         kwargs["config"] = PretrainedConfig()
-    try:
-        return auto_loader(model_path, *args, **kwargs)
-    except ValueError as error:
-        if not kwargs["trust_remote_code"]:
-            _raise_mlx_remote_code_refusal(model_path, error, tokenizer_only=True)
-        raise
+    return auto_loader(model_path, *args, **kwargs)
 
 
 @contextmanager
-def _mlx_tokenizer_loading_scope(trust_remote_code=False):
-    """Cover nested processor tokenizer loads without changing other threads."""
+def _mlx_tokenizer_loading_scope():
+    """Route mlx-lm's internal AutoTokenizer call through _load_mlx_tokenizer.
+
+    mlx_lm.utils.load_tokenizer calls AutoTokenizer.from_pretrained directly, so
+    the only way to reach it is to patch the class. The active flag is
+    thread-local, so other threads keep ordinary behaviour, and the lock keeps
+    two scopes from capturing each other's patch as the original.
+    """
     from transformers import AutoTokenizer
 
     with _TOKENIZER_LOAD_LOCK:
@@ -904,24 +880,15 @@ def _mlx_tokenizer_loading_scope(trust_remote_code=False):
         _TOKENIZER_LOAD_STATE.active = True
         _TOKENIZER_LOAD_STATE.original = original
 
-        refusals = []
-
         @classmethod
         def load(cls, model_path, *args, **kwargs):
             if not getattr(_TOKENIZER_LOAD_STATE, "active", False):
                 return original(model_path, *args, **kwargs)
-            kwargs["trust_remote_code"] = bool(trust_remote_code)
-            try:
-                return _load_mlx_tokenizer(
-                    model_path, *args, _auto_loader=original, **kwargs,
-                )
-            except _MLXRemoteCodeError as error:
-                refusals.append(error)
-                raise
+            return _load_mlx_tokenizer(model_path, *args, _auto_loader=original, **kwargs)
 
         AutoTokenizer.from_pretrained = load
         try:
-            yield refusals
+            yield
         finally:
             AutoTokenizer.from_pretrained = original_descriptor
             _TOKENIZER_LOAD_STATE.active = previous
@@ -977,7 +944,7 @@ def _load_mlx_lm_with_strict_fallback(
             model_config=model_config,
         )
 
-    with _mlx_tokenizer_loading_scope(tokenizer_config.get("trust_remote_code", False)):
+    with _mlx_tokenizer_loading_scope():
         tokenizer = load_tokenizer(
             model_path,
             tokenizer_config,
@@ -1174,7 +1141,7 @@ def _load_mlx_lm_distributed(
         cleanup_final_model_path = True
 
         try:
-            with _mlx_tokenizer_loading_scope(tokenizer_config.get("trust_remote_code", False)):
+            with _mlx_tokenizer_loading_scope():
                 tokenizer = load_tokenizer(
                     final_model_path,
                     tokenizer_config,
@@ -1508,11 +1475,10 @@ def _load_declared_mlx_vlm_processor(model_path, model_type, **kwargs):
             allow_tokenizer_remote_code=False,
         )
     try:
-        with _mlx_tokenizer_loading_scope(kwargs.get("trust_remote_code", False)):
-            return scoped_processor_class.from_pretrained(
-                processor_load_path,
-                **kwargs,
-            )
+        return scoped_processor_class.from_pretrained(
+            processor_load_path,
+            **kwargs,
+        )
     finally:
         if str(processor_load_path) != str(model_path):
             shutil.rmtree(processor_load_path, ignore_errors=True)
@@ -1521,8 +1487,6 @@ def _load_declared_mlx_vlm_processor(model_path, model_type, **kwargs):
 def _is_mlx_vlm_processor_resolution_error(error):
     """Return whether AutoProcessor failed before native MLX construction."""
 
-    if isinstance(error, _MLXRemoteCodeError):
-        return True
     message = str(error).lower()
     if isinstance(error, ValueError):
         return any(
@@ -1598,35 +1562,30 @@ def _bind_mlx_vlm_processor_loader(load_callable, *, allow_remote_code=False):
                         config_data,
                         allow_tokenizer_remote_code=False,
                     )
-            with _mlx_tokenizer_loading_scope(allow_remote_code) as refusals:
+            try:
                 try:
-                    try:
-                        return original_auto_processor.from_pretrained(
-                            processor_load_path,
-                            *args,
-                            **call_kwargs,
-                        )
-                    except Exception as error:
-                        if not _is_mlx_vlm_processor_resolution_error(error):
-                            raise
-                        config_data = _read_json_file(
-                            os.path.join(str(processor_load_path), "config.json")
-                        )
-                        processor = _load_declared_mlx_vlm_processor(
-                            processor_load_path,
-                            config_data.get("model_type"),
-                            **call_kwargs,
-                        )
-                        if processor is None:
-                            if refusals:
-                                raise refusals[-1] from error
-                            if not allow_remote_code:
-                                _raise_mlx_remote_code_refusal(model_path, error)
-                            raise
-                        return processor
-                finally:
-                    if str(processor_load_path) != str(model_path):
-                        shutil.rmtree(processor_load_path, ignore_errors=True)
+                    return original_auto_processor.from_pretrained(
+                        processor_load_path,
+                        *args,
+                        **call_kwargs,
+                    )
+                except Exception as error:
+                    if not _is_mlx_vlm_processor_resolution_error(error):
+                        raise
+                    config_data = _read_json_file(
+                        os.path.join(str(processor_load_path), "config.json")
+                    )
+                    processor = _load_declared_mlx_vlm_processor(
+                        processor_load_path,
+                        config_data.get("model_type"),
+                        **call_kwargs,
+                    )
+                    if processor is None:
+                        raise
+                    return processor
+            finally:
+                if str(processor_load_path) != str(model_path):
+                    shutil.rmtree(processor_load_path, ignore_errors=True)
 
     processor_globals = dict(processor_loader.__globals__)
     processor_globals["AutoProcessor"] = ScopedAutoProcessor
@@ -1822,7 +1781,6 @@ def get_class_predicate(p, m):
 
 def _build_vlm_image_processor_from_config(
     model_path, processor_config, preprocessor_config, model_type=None,
-    *, trust_remote_code=False,
 ):
     """Recreate the image processor from saved processor sidecar configs."""
     image_config = processor_config.get("image_processor")
@@ -1859,9 +1817,7 @@ def _build_vlm_image_processor_from_config(
 
     try:
         from transformers import AutoImageProcessor
-        return AutoImageProcessor.from_pretrained(
-            model_path, trust_remote_code=trust_remote_code,
-        )
+        return AutoImageProcessor.from_pretrained(model_path)
     except Exception:
         return None
 
@@ -1921,7 +1877,6 @@ def _repair_degraded_vlm_processor(
 
     image_processor = _build_vlm_image_processor_from_config(
         model_path, processor_config, preprocessor_config, model_type,
-        trust_remote_code=trust_remote_code,
     )
     if image_processor is None:
         return processor
@@ -8411,9 +8366,11 @@ class FastMLXModel:
         else:
             is_vlm = _is_vlm(config_data)
 
-        extra_kwargs = {"trust_remote_code": bool(trust_remote_code)}
+        extra_kwargs = {}
         if token:
             extra_kwargs["token"] = token
+        if trust_remote_code:
+            extra_kwargs["trust_remote_code"] = True
 
         if is_vlm:
             # VLM path via mlx-vlm

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -842,11 +842,9 @@ def _load_mlx_tokenizer(model_path, *args, _auto_loader=None, **kwargs):
     )
 
     auto_loader = _auto_loader or AutoTokenizer.from_pretrained
-    # Not a default for its own sake: transformers treats a missing
-    # trust_remote_code as None, and resolve_trust_remote_code answers None by
-    # prompting on stdin for TIME_OUT_REMOTE_CODE seconds. The blank config
-    # below forces has_local_code False, so a remote-code repo reaches exactly
-    # that branch and a plain load blocks ~15s on a question nobody asked.
+    # None != False here: transformers answers a missing trust_remote_code by
+    # prompting on stdin, and the blank config below forces has_local_code
+    # False, so a remote-code repo blocks ~15s on a question nobody asked.
     kwargs.setdefault("trust_remote_code", False)
     metadata = get_tokenizer_config(model_path, **kwargs)
     class_name = metadata.get("tokenizer_class")

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -832,6 +832,30 @@ def _raise_mlx_remote_code_refusal(model_path, error, *, tokenizer_only=False):
             ) from error
 
 
+def _tokenizer_class_for_model_type(model_path):
+    """Resolve the tokenizer class from config.json's model_type STRING.
+
+    gpt2 and its relatives declare no tokenizer_class and ship no
+    special_tokens_map.json: their bos/eos/unk live in the tokenizer class's
+    __init__ defaults, so loading the bare backend silently drops them and
+    eos_token becomes None. The model_type is read as plain JSON and never
+    instantiated, so no model config validator runs.
+    """
+    from transformers.models.auto.tokenization_auto import (
+        TOKENIZER_MAPPING_NAMES, tokenizer_class_from_name,
+    )
+
+    model_type = _read_json_file(
+        os.path.join(str(model_path), "config.json"),
+    ).get("model_type")
+    if not model_type:
+        return None
+    mapped = TOKENIZER_MAPPING_NAMES.get(model_type)
+    if isinstance(mapped, (list, tuple)):
+        mapped = next((item for item in reversed(mapped) if item), None)
+    return tokenizer_class_from_name(mapped) if mapped else None
+
+
 def _load_mlx_tokenizer(model_path, *args, _auto_loader=None, **kwargs):
     from transformers import AutoTokenizer, PretrainedConfig, PreTrainedTokenizerFast
     from transformers.models.auto.tokenization_auto import (
@@ -848,6 +872,8 @@ def _load_mlx_tokenizer(model_path, *args, _auto_loader=None, **kwargs):
         tokenizer_class = tokenizer_class_from_name(class_name.removesuffix("Fast") + "Fast")
         if tokenizer_class is None:
             tokenizer_class = tokenizer_class_from_name(class_name)
+    if tokenizer_class is None and not remote:
+        tokenizer_class = _tokenizer_class_for_model_type(model_path)
     has_fast_file = (Path(model_path) / "tokenizer.json").is_file()
     if has_fast_file and (
         not remote or "tiktoken" in (str(class_name) + str(remote)).lower()

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -842,6 +842,12 @@ def _load_mlx_tokenizer(model_path, *args, _auto_loader=None, **kwargs):
     )
 
     auto_loader = _auto_loader or AutoTokenizer.from_pretrained
+    # Not a default for its own sake: transformers treats a missing
+    # trust_remote_code as None, and resolve_trust_remote_code answers None by
+    # prompting on stdin for TIME_OUT_REMOTE_CODE seconds. The blank config
+    # below forces has_local_code False, so a remote-code repo reaches exactly
+    # that branch and a plain load blocks ~15s on a question nobody asked.
+    kwargs.setdefault("trust_remote_code", False)
     metadata = get_tokenizer_config(model_path, **kwargs)
     class_name = metadata.get("tokenizer_class")
     remote = _remote_code_reference(metadata, "AutoTokenizer")

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -722,7 +722,7 @@ def _materialize_mlx_vlm_config_override(
                     supports_list_extra_special_tokens=supports_list_extra_special_tokens,
                 )
             )
-        if not allow_tokenizer_remote_code:
+        if not allow_tokenizer_remote_code and os.path.isfile(os.path.join(local_path, "tokenizer.json")):
             auto_map = patched_tokenizer_config.get("auto_map")
             if isinstance(auto_map, dict) and auto_map:
                 patched_tokenizer_config = dict(patched_tokenizer_config)
@@ -790,6 +790,119 @@ def _materialize_mlx_vlm_config_override(
     return override_dir, patched_config
 
 
+_TOKENIZER_LOAD_LOCK = threading.RLock()
+_TOKENIZER_LOAD_STATE = threading.local()
+
+
+def _remote_code_reference(metadata, auto_class):
+    auto_map = metadata.get("auto_map", {})
+    reference = auto_map.get(auto_class) if isinstance(auto_map, dict) else (
+        auto_map if auto_class == "AutoTokenizer" else None
+    )
+    if isinstance(reference, (list, tuple)):
+        reference = next((item for item in reversed(reference) if item), None)
+    return reference if isinstance(reference, str) else None
+
+
+class _MLXRemoteCodeError(ValueError):
+    pass
+
+
+def _raise_mlx_remote_code_refusal(model_path, error, *, tokenizer_only=False):
+    if "trust_remote_code" not in str(error) and "custom code" not in str(error):
+        return
+    for filename, auto_class in (
+        ("processor_config.json", "AutoProcessor"),
+        ("preprocessor_config.json", "AutoProcessor"),
+        ("config.json", "AutoProcessor"),
+        ("tokenizer_config.json", "AutoTokenizer"),
+        ("preprocessor_config.json", "AutoImageProcessor"),
+    ):
+        if tokenizer_only and auto_class != "AutoTokenizer":
+            continue
+        reference = _remote_code_reference(
+            _read_json_file(os.path.join(str(model_path), filename)), auto_class,
+        )
+        if reference:
+            code_file = reference.split("--")[-1].rsplit(".", 1)[0] + ".py"
+            raise _MLXRemoteCodeError(
+                f"Unsloth: loading {model_path} requires {code_file} "
+                f"(declared in {filename}). Pass trust_remote_code=True "
+                "to allow this repository's custom code."
+            ) from error
+
+
+def _load_mlx_tokenizer(model_path, *args, _auto_loader=None, **kwargs):
+    from transformers import AutoTokenizer, PretrainedConfig, PreTrainedTokenizerFast
+    from transformers.models.auto.tokenization_auto import (
+        get_tokenizer_config, tokenizer_class_from_name,
+    )
+
+    auto_loader = _auto_loader or AutoTokenizer.from_pretrained
+    kwargs.setdefault("trust_remote_code", False)
+    metadata = get_tokenizer_config(model_path, **kwargs)
+    class_name = metadata.get("tokenizer_class")
+    remote = _remote_code_reference(metadata, "AutoTokenizer")
+    tokenizer_class = None
+    if class_name:
+        tokenizer_class = tokenizer_class_from_name(class_name.removesuffix("Fast") + "Fast")
+        if tokenizer_class is None:
+            tokenizer_class = tokenizer_class_from_name(class_name)
+    has_fast_file = (Path(model_path) / "tokenizer.json").is_file()
+    if has_fast_file and (
+        not remote or "tiktoken" in (str(class_name) + str(remote)).lower()
+    ):
+        if tokenizer_class is None or not issubclass(tokenizer_class, PreTrainedTokenizerFast):
+            tokenizer_class = PreTrainedTokenizerFast
+        return tokenizer_class.from_pretrained(model_path, *args, **kwargs)
+    # Tokenizer metadata selects the class; model validators have no role here.
+    if class_name or remote:
+        kwargs["config"] = PretrainedConfig()
+    try:
+        return auto_loader(model_path, *args, **kwargs)
+    except ValueError as error:
+        if not kwargs["trust_remote_code"]:
+            _raise_mlx_remote_code_refusal(model_path, error, tokenizer_only=True)
+        raise
+
+
+@contextmanager
+def _mlx_tokenizer_loading_scope(trust_remote_code=False):
+    """Cover nested processor tokenizer loads without changing other threads."""
+    from transformers import AutoTokenizer
+
+    with _TOKENIZER_LOAD_LOCK:
+        original_descriptor = AutoTokenizer.__dict__["from_pretrained"]
+        original = getattr(_TOKENIZER_LOAD_STATE, "original", AutoTokenizer.from_pretrained)
+        previous = getattr(_TOKENIZER_LOAD_STATE, "active", False)
+        _TOKENIZER_LOAD_STATE.active = True
+        _TOKENIZER_LOAD_STATE.original = original
+
+        refusals = []
+
+        @classmethod
+        def load(cls, model_path, *args, **kwargs):
+            if not getattr(_TOKENIZER_LOAD_STATE, "active", False):
+                return original(model_path, *args, **kwargs)
+            kwargs["trust_remote_code"] = bool(trust_remote_code)
+            try:
+                return _load_mlx_tokenizer(
+                    model_path, *args, _auto_loader=original, **kwargs,
+                )
+            except _MLXRemoteCodeError as error:
+                refusals.append(error)
+                raise
+
+        AutoTokenizer.from_pretrained = load
+        try:
+            yield refusals
+        finally:
+            AutoTokenizer.from_pretrained = original_descriptor
+            _TOKENIZER_LOAD_STATE.active = previous
+            if not previous:
+                del _TOKENIZER_LOAD_STATE.original
+
+
 def _load_mlx_lm_with_strict_fallback(
     model_name,
     model_type,
@@ -838,11 +951,12 @@ def _load_mlx_lm_with_strict_fallback(
             model_config=model_config,
         )
 
-    tokenizer = load_tokenizer(
-        model_path,
-        tokenizer_config,
-        eos_token_ids=config.get("eos_token_id", None),
-    )
+    with _mlx_tokenizer_loading_scope(tokenizer_config.get("trust_remote_code", False)):
+        tokenizer = load_tokenizer(
+            model_path,
+            tokenizer_config,
+            eos_token_ids=config.get("eos_token_id", None),
+        )
     if want_config:
         return model, tokenizer, config
     return model, tokenizer
@@ -1034,11 +1148,12 @@ def _load_mlx_lm_distributed(
         cleanup_final_model_path = True
 
         try:
-            tokenizer = load_tokenizer(
-                final_model_path,
-                tokenizer_config,
-                eos_token_ids=config.get("eos_token_id", None),
-            )
+            with _mlx_tokenizer_loading_scope(tokenizer_config.get("trust_remote_code", False)):
+                tokenizer = load_tokenizer(
+                    final_model_path,
+                    tokenizer_config,
+                    eos_token_ids=config.get("eos_token_id", None),
+                )
             model, _config = load_model(
                 final_model_path,
                 lazy=True,
@@ -1367,10 +1482,11 @@ def _load_declared_mlx_vlm_processor(model_path, model_type, **kwargs):
             allow_tokenizer_remote_code=False,
         )
     try:
-        return scoped_processor_class.from_pretrained(
-            processor_load_path,
-            **kwargs,
-        )
+        with _mlx_tokenizer_loading_scope(kwargs.get("trust_remote_code", False)):
+            return scoped_processor_class.from_pretrained(
+                processor_load_path,
+                **kwargs,
+            )
     finally:
         if str(processor_load_path) != str(model_path):
             shutil.rmtree(processor_load_path, ignore_errors=True)
@@ -1379,6 +1495,8 @@ def _load_declared_mlx_vlm_processor(model_path, model_type, **kwargs):
 def _is_mlx_vlm_processor_resolution_error(error):
     """Return whether AutoProcessor failed before native MLX construction."""
 
+    if isinstance(error, _MLXRemoteCodeError):
+        return True
     message = str(error).lower()
     if isinstance(error, ValueError):
         return any(
@@ -1454,30 +1572,35 @@ def _bind_mlx_vlm_processor_loader(load_callable, *, allow_remote_code=False):
                         config_data,
                         allow_tokenizer_remote_code=False,
                     )
-            try:
+            with _mlx_tokenizer_loading_scope(allow_remote_code) as refusals:
                 try:
-                    return original_auto_processor.from_pretrained(
-                        processor_load_path,
-                        *args,
-                        **call_kwargs,
-                    )
-                except Exception as error:
-                    if not _is_mlx_vlm_processor_resolution_error(error):
-                        raise
-                    config_data = _read_json_file(
-                        os.path.join(str(processor_load_path), "config.json")
-                    )
-                    processor = _load_declared_mlx_vlm_processor(
-                        processor_load_path,
-                        config_data.get("model_type"),
-                        **call_kwargs,
-                    )
-                    if processor is None:
-                        raise
-                    return processor
-            finally:
-                if str(processor_load_path) != str(model_path):
-                    shutil.rmtree(processor_load_path, ignore_errors=True)
+                    try:
+                        return original_auto_processor.from_pretrained(
+                            processor_load_path,
+                            *args,
+                            **call_kwargs,
+                        )
+                    except Exception as error:
+                        if not _is_mlx_vlm_processor_resolution_error(error):
+                            raise
+                        config_data = _read_json_file(
+                            os.path.join(str(processor_load_path), "config.json")
+                        )
+                        processor = _load_declared_mlx_vlm_processor(
+                            processor_load_path,
+                            config_data.get("model_type"),
+                            **call_kwargs,
+                        )
+                        if processor is None:
+                            if refusals:
+                                raise refusals[-1] from error
+                            if not allow_remote_code:
+                                _raise_mlx_remote_code_refusal(model_path, error)
+                            raise
+                        return processor
+                finally:
+                    if str(processor_load_path) != str(model_path):
+                        shutil.rmtree(processor_load_path, ignore_errors=True)
 
     processor_globals = dict(processor_loader.__globals__)
     processor_globals["AutoProcessor"] = ScopedAutoProcessor
@@ -1673,6 +1796,7 @@ def get_class_predicate(p, m):
 
 def _build_vlm_image_processor_from_config(
     model_path, processor_config, preprocessor_config, model_type=None,
+    *, trust_remote_code=False,
 ):
     """Recreate the image processor from saved processor sidecar configs."""
     image_config = processor_config.get("image_processor")
@@ -1709,7 +1833,9 @@ def _build_vlm_image_processor_from_config(
 
     try:
         from transformers import AutoImageProcessor
-        return AutoImageProcessor.from_pretrained(model_path)
+        return AutoImageProcessor.from_pretrained(
+            model_path, trust_remote_code=trust_remote_code,
+        )
     except Exception:
         return None
 
@@ -1769,6 +1895,7 @@ def _repair_degraded_vlm_processor(
 
     image_processor = _build_vlm_image_processor_from_config(
         model_path, processor_config, preprocessor_config, model_type,
+        trust_remote_code=trust_remote_code,
     )
     if image_processor is None:
         return processor
@@ -1776,11 +1903,10 @@ def _repair_degraded_vlm_processor(
     tokenizer = getattr(processor, "tokenizer", None) or processor
     if tokenizer is None or not hasattr(tokenizer, "save_pretrained"):
         try:
-            from transformers import AutoTokenizer
             tokenizer_kwargs = {"trust_remote_code": trust_remote_code}
             if token:
                 tokenizer_kwargs["token"] = token
-            tokenizer = AutoTokenizer.from_pretrained(model_path, **tokenizer_kwargs)
+            tokenizer = _load_mlx_tokenizer(model_path, **tokenizer_kwargs)
         except Exception:
             return processor
 
@@ -5070,7 +5196,7 @@ def _dequantize_bnb_to_tempdir(source, *, token, trust_remote_code):
     with _BNB_IMPORT_LOCK, _lifted_bitsandbytes_stub():
         import bitsandbytes  # noqa: F401 — real wheel; ImportError => fall back
         import torch
-        from transformers import AutoModelForCausalLM, AutoTokenizer
+        from transformers import AutoModelForCausalLM
 
         device = "mps" if torch.backends.mps.is_available() else "cpu"
 
@@ -5114,7 +5240,7 @@ def _dequantize_bnb_to_tempdir(source, *, token, trust_remote_code):
                 pass
             model.save_pretrained(tmpdir, safe_serialization=True)
             # Needed by the downstream mlx-lm load.
-            AutoTokenizer.from_pretrained(
+            _load_mlx_tokenizer(
                 source, token=token, trust_remote_code=trust_remote_code,
             ).save_pretrained(tmpdir)
         except BaseException:
@@ -8259,11 +8385,9 @@ class FastMLXModel:
         else:
             is_vlm = _is_vlm(config_data)
 
-        extra_kwargs = {}
+        extra_kwargs = {"trust_remote_code": bool(trust_remote_code)}
         if token:
             extra_kwargs["token"] = token
-        if trust_remote_code:
-            extra_kwargs["trust_remote_code"] = True
 
         if is_vlm:
             # VLM path via mlx-vlm


### PR DESCRIPTION
Transformers 5.5 can fail to load an otherwise usable tokenizer because `AutoTokenizer.from_pretrained` constructs the model config first. Published configs for Phi-4 multimodal, EXAONE, DeepSeek V3.2, Step 3.5, LongCat Flash Ngram, Nemotron NAS/H, MiniCPM3 and DBRX trigger unsupported-model or config-validation errors before tokenization.

Load serialized fast tokenizers from their tokenizer metadata and files, preserving chat templates and special/added tokens. Declared remote tokenizer classes use a neutral config so their selection also avoids model validation. Keep mlx-lm's tokenizer wrapper, detokenizer selection and EOS handling intact.

Propagate the caller's `trust_remote_code` choice, defaulting to `False`, through ordinary and distributed text loads, nested VLM tokenizer loads, processor recovery and image-processor recovery. Prefer a serialized fast tokenizer for tiktoken wrappers when available. Remote-only refusals name the Python file and opt-in flag, including refusals swallowed by mlx-vlm's processor dispatch. A successful native processor fallback still takes precedence. Nested tokenizer dispatch is scoped to the loading thread, serialized with a reentrant lock, and restored on exit. Studio already forwards the flag and requires no change.

### Validation

- 29 focused loader regressions passed on transformers 5.5.0 after rebasing onto current `main`; 11 tokenizer/processor regressions passed on 4.51.3 with compatible dependencies.
- 14 isolated mutation checks failed their intended test selections, covering config resolution, fast-tokenizer preference, trust propagation in both directions, distributed loading, native fallback precedence and refusal preservation.
- Tested published tokenizer/config files with tiny random checkpoints and no substitute tokenizers or downloaded model weights. All nine config-failure families passed tokenizer and model loading; eight generated. Of 18 remote-code families, 17 passed tokenizer/processor loading with explicit trust and 16 completed model loading and generation.

```bash
python -m pytest tests/test_mlx_save_export_regressions.py tests/test_mlx_distributed_loader.py -q -k 'tokenizer or processor or distributed or strict_fallback'
```

### Scope and remaining failures

The [published DBRX repo](https://huggingface.co/mlx-community/dbrx-instruct-4bit/tree/main) has no `tokenizer.json`, so its `tiktoken.py` wrapper still requires explicit trust. Native Kimi K3 and Plamo2VL processors avoid repository code and remain usable without that opt-in.

This does not claim complete family support: Nemotron NAS reaches an mlx-lm cache failure after tokenization; Plamo2VL reaches an existing layer-indexing fixup failure; Youtu VL's published remote image processor imports the removed `DefaultFastImageProcessorKwargs`. Direct mlx-vlm reproductions also retain ERNIE's missing `.vocab` detokenizer failure and VoiceChat's missing generic processor. Backend model-config parsing and post-tokenizer model behavior are unchanged; no dependency source patches or family-specific shims are included.
