### PR TITLE
Unimport the compile folder after driving the compiler

### DIFF
--- a/tests/test_compiler_dynamic_exec.py
+++ b/tests/test_compiler_dynamic_exec.py
@@ -30,6 +30,7 @@ import ast
 import importlib
 import inspect
 import os
+import sys
 import textwrap
 
 import pytest
@@ -54,6 +55,56 @@ def _compile_disabled(monkeypatch):
     instead. Scoped and undone here, the setting reaches only this module.
     """
     monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "1")
+
+
+@pytest.fixture(autouse = True)
+def _unimport_the_compile_folder(monkeypatch):
+    """Take back out of ``sys.modules`` whatever the compile folder put in.
+
+    Driving ``unsloth_compile_transformers`` writes a generated module and then
+    imports it, and a generated MoE module imports its helpers by bare name --
+    ``moe_utils`` and friends resolve only because the compile folder is on
+    ``sys.path``. Nothing in the installed environment provides that name, so
+    the import IS the swap, and the module it leaves behind outlives the
+    directory it was read from. Every later test in the process that imports it
+    bare then gets a stale copy, and because the generated module swallows that
+    import it loads reporting success with its backend names undefined. That is
+    #1168's failure, arriving here by a second route: it fixed the leak in
+    test_moe_weight_preprocessor_registry_shared.py and added the gate that now
+    catches this one on `Core drift`, where a newer transformers takes the
+    qwen3_moe path that emits the import.
+
+    Keyed on where a module was loaded from rather than on a list of names, so a
+    generated module that starts importing some new helper is covered without
+    anyone remembering to add it here.
+
+    ``monkeypatch`` is requested for its teardown ordering, not for its API:
+    depending on it puts this finalizer ahead of the env being unpatched, so
+    ``get_compile_folder()`` below still resolves the folder the test used.
+    """
+    before = dict(sys.modules)
+    try:
+        yield
+    finally:
+        try:
+            folder, _ = compiler.get_compile_folder()
+            root = os.path.realpath(folder)
+        except Exception:
+            return
+        for name, module in list(sys.modules.items()):
+            path = getattr(module, "__file__", None)
+            if not path:
+                continue
+            try:
+                resolved = os.path.realpath(path)
+            except (OSError, ValueError):
+                continue
+            if resolved != root and not resolved.startswith(root + os.sep):
+                continue
+            if name in before:
+                sys.modules[name] = before[name]
+            else:
+                del sys.modules[name]
 
 
 # Model types the zoo compiler drives end-to-end (from its call sites).


### PR DESCRIPTION
## Summary

`Core drift (3 upstream pins)` is red on main. #1168 fixed one `moe_utils` leak and added a gate that has no exemption for that name. The gate is right, and it has now found a second leak by a different route.

```
AssertionError: tests/test_compiler_dynamic_exec.py::test_unsloth_compile_transformers_emits_parseable_cache[qwen3_moe]
replaced ['moe_utils'] in sys.modules and did not put it back, so every later test in this
process imports the substitute.
```

Failing on main at `0ac8694d` (run 34085390820, job 101628331836) in both the `tlatest5-trl1latest` and `pyproject` lanes.

## What leaks

`test_compiler_dynamic_exec` drives `unsloth_compile_transformers`, which writes a generated module and imports it, and a generated MoE module imports its helpers by bare name. A top-level `moe_utils` resolves only because the compile folder is on `sys.path`, so nothing puts it back: the import IS the swap, and the module it leaves behind outlives the directory it was read from.

That is the same failure #1168 described. Every later test in the process that imports the name bare gets a stale copy, and because the generated module swallows that import it loads reporting success with its backend names undefined.

The test does not write the import; the compiler does. So the cleanup belongs to the test that drove it.

## Why it appears now

Only `qwen3_moe` on a newer transformers takes the path that emits the import, which is why this shows on Core drift's upstream pins and not on the transformers that `pyproject.toml` resolves. It was also behind the `test_compiler_getsource_tokenerror` failure that #1167 cleared, so this is what that suite reaches now that it gets further.

## The fix

An autouse fixture that takes back out of `sys.modules` whatever the compile folder put in, keyed on where a module was loaded from rather than on a list of names. A generated module that starts importing some new helper is covered without anyone remembering to add it here.

`monkeypatch` is requested for its teardown ordering rather than its API: depending on it puts this finalizer ahead of the env being unpatched, so `get_compile_folder()` still resolves the folder the test actually used.

## Verification

Planted the leak rather than waiting for CI. A test that bare-imports a helper out of the compile folder, with the fixture not applied, reproduces the gate's message exactly and fails the following test on the stale module:

```
AssertionError: tests/test_zz_leak_sim.py::test_a_leaks_moe_utils replaced ['moe_utils'] in
sys.modules and did not put it back, ...
AssertionError: LEAKED into the next test
1 failed, 1 passed, 1 error
```

With the fixture applied, both pass.

| suite | result |
| --- | --- |
| `tests/test_compiler_dynamic_exec.py` | 83 passed, 2 skipped |
| Core drift's own 24-file list | 804 passed, 62 skipped, 0 failed |

## One thing I did not fix here

Running `test_compiler_dynamic_exec.py` before `test_compiled_cache_collective.py` in one process fails `test_repeated_dtype_patching_does_not_stack_the_source_rewrite`. It reproduces identically on clean main, so it is not from this change, and the two files are in different jobs (`Core drift` and `Repo tests (CPU)` respectively) so CI never runs them in the same process today. It is a second leak out of the same file, the patched torch.nn forwards rather than `sys.modules`, and it deserves its own change rather than being folded into a red-CI fix.
