### PR TITLE
Put torch.nn's forwards back after the dtype loop rewrites them

### DIFF
--- a/tests/test_compiler_dynamic_exec.py
+++ b/tests/test_compiler_dynamic_exec.py
@@ -107,6 +107,61 @@ def _unimport_the_compile_folder(monkeypatch):
                 del sys.modules[name]
 
 
+def _own_torch_nn_forwards():
+    """The ``forward`` each ``torch.nn`` class defines in its own ``__dict__``.
+
+    Read off ``vars(cls)`` rather than ``getattr``, so an inherited forward is
+    not recorded as if the class owned one and then installed on it as a real
+    attribute by the restore below.
+    """
+    try:
+        import torch
+    except Exception:
+        return None
+    return {
+        name: vars(obj)["forward"]
+        for name, obj in vars(torch.nn).items()
+        if isinstance(obj, type) and "forward" in vars(obj)
+    }
+
+
+@pytest.fixture(autouse = True)
+def _restore_torch_nn_forwards():
+    """Put ``torch.nn``'s own forwards back after the dtype loop rewrites them.
+
+    ``unsloth_compile_transformers`` patches ``torch.nn.<Module>.forward`` in
+    place, on the real ``torch.nn``, and nothing here undoes it. The wrappers
+    then outlive the test and every later test in the process sees a torch.nn
+    that is already patched.
+
+    That is not theoretical: it fails
+    ``test_compiled_cache_collective.py::test_repeated_dtype_patching_does_not_stack_the_source_rewrite``,
+    which opens by capturing ``pristine = torch.nn.Conv2d.forward`` and then
+    asserts the installed marker carries torch's own forward. Run after this
+    module in one process, what it captures is already a
+    ``_dtype_safe_forward.<locals>.forward``, so the assertion compares a
+    wrapper against the genuine original and fails on a contract that holds.
+    The two files are in different jobs today, `Core drift` and
+    `Repo tests (CPU)`, so CI does not currently put them in one process. That
+    is a scheduling accident and not a property worth relying on.
+
+    Restored by identity against a snapshot rather than by deleting the
+    attribute: several of these classes legitimately define their own forward,
+    and deleting would expose an inherited one instead.
+    """
+    before = _own_torch_nn_forwards()
+    try:
+        yield
+    finally:
+        if not before:
+            return
+        import torch
+        for name, original in before.items():
+            cls = getattr(torch.nn, name, None)
+            if isinstance(cls, type) and vars(cls).get("forward") is not original:
+                cls.forward = original
+
+
 # Model types the zoo compiler drives end-to-end (from its call sites).
 KNOWN_MODEL_TYPES = [
     "llama",


### PR DESCRIPTION
## Summary

The second leak out of `test_compiler_dynamic_exec`, and the one I said in #1172 deserved its own change rather than being folded into a red-CI fix.

`unsloth_compile_transformers` patches `torch.nn.<Module>.forward` in place, on the real `torch.nn`, and nothing in the test undoes it. The wrappers outlive the test, so every later test in the process sees a `torch.nn` that is already patched.

## What it breaks

`tests/test_compiled_cache_collective.py::test_repeated_dtype_patching_does_not_stack_the_source_rewrite` opens by capturing the pristine forward and then asserts the installed marker carries torch's own:

```python
pristine = torch.nn.Conv2d.forward
...
assert installed[0].__unsloth_dtype_original__ is pristine, (
    "the marker must carry torch's own forward, so a later "
    "compile-mode change rebuilds from source rather than a rewrite."
)
```

Run after this module in one process, what it captures is already a `_dtype_safe_forward.<locals>.forward`:

```
E  AssertionError: the marker must carry torch's own forward, so a later compile-mode change rebuilds from source rather than a rewrite.
E  assert <function Conv2d.forward at 0x716e563c9080> is <function forward at 0x71670fe11120>
E   +  where <function Conv2d.forward at 0x716e563c9080> = <function _dtype_safe_forward.<locals>.forward at 0x71670f737f60>.__unsloth_dtype_original__
```

So it compares a wrapper against the genuine original and fails on a contract that actually holds. The victim is fine; the premise it captured was already polluted.

## Why this is not urgent, and why it is still worth fixing

The two files are in different jobs today, `Core drift` and `Repo tests (CPU)` respectively, so CI does not currently run them in one process, and each passes alone. That is a scheduling accident rather than a property worth relying on: any change to either job's file list, or anything that runs the suite as a directory, brings it back. It is also the same class of defect as the `sys.modules` leak in #1172 and the one #1168 fixed before that, out of the same file.

## The fix

Snapshot what each `torch.nn` class defines in its own `__dict__` and restore by identity.

Read off `vars(cls)` rather than `getattr` so an inherited forward is not recorded as if the class owned one and then installed on it as a real attribute by the restore. Restored rather than deleted, because several of these classes legitimately define their own forward and deleting would expose an inherited one instead.

## Verification

Probed it directly rather than inferring from the interaction. A test that drives the compiler, followed by one that checks `torch.nn`:

| | result |
| --- | --- |
| without the fixture | `Conv2d.forward` left carrying `__unsloth_dtype_wrapped__`, probe fails |
| with the fixture | 2 passed |

| suite | before | after |
| --- | --- | --- |
| `dynamic_exec` then `collective` | 1 failed, 132 passed | 133 passed |
| `collective` then `dynamic_exec` | 133 passed | 133 passed |
| `test_compiler_dynamic_exec.py` alone | 83 passed, 2 skipped | unchanged |
| `test_compiled_cache_collective.py` alone | 50 passed | unchanged |

Both CI gate lists on this branch: `Repo tests (CPU)` 1508 passed / 4 skipped, `Core drift` 804 passed / 62 skipped.
