### PR TITLE
Close the two leaks the teardown audit found, one of them mine

### DIFF
--- a/tests/test_compiler_dynamic_exec.py
+++ b/tests/test_compiler_dynamic_exec.py
@@ -145,21 +145,69 @@ def _restore_torch_nn_forwards():
     `Repo tests (CPU)`, so CI does not currently put them in one process. That
     is a scheduling accident and not a property worth relying on.
 
-    Restored by identity against a snapshot rather than by deleting the
-    attribute: several of these classes legitimately define their own forward,
-    and deleting would expose an inherited one instead.
+    Two directions, because the loop patches by assignment and assignment does
+    not care whether the class had a forward of its own.
+
+    A class that owned one gets it put back by identity rather than deleted:
+    several of these legitimately define their own, and deleting would expose
+    an inherited one instead.
+
+    A class that owned none has to have the attribute deleted, not restored,
+    and this is the half worth stating. ``BatchNorm1d``, ``BatchNorm2d`` and
+    ``BatchNorm3d`` inherit ``forward`` from ``_BatchNorm``, so they are absent
+    from the snapshot; the loop then gives each one a real attribute it never
+    had. Restoring only the recorded names leaves those three rewritten, which
+    is exactly what an audit of what survives teardown found still leaking
+    after the first version of this fixture.
     """
     before = _own_torch_nn_forwards()
     try:
         yield
     finally:
-        if not before:
+        if before is None:
             return
         import torch
-        for name, original in before.items():
-            cls = getattr(torch.nn, name, None)
-            if isinstance(cls, type) and vars(cls).get("forward") is not original:
-                cls.forward = original
+        for name, obj in vars(torch.nn).items():
+            if not isinstance(obj, type):
+                continue
+            current = vars(obj).get("forward")
+            if current is None:
+                continue
+            if name in before:
+                if current is not before[name]:
+                    obj.forward = before[name]
+            else:
+                delattr(obj, "forward")
+
+
+@pytest.fixture(autouse = True)
+def _restore_unsloth_env():
+    """Undo the ``UNSLOTH_*`` variables the compiler sets on its way through.
+
+    ``monkeypatch`` only knows about what the *test* set. The compiler writes
+    to ``os.environ`` itself, and an audit of what survives teardown found
+    three escaping every drive:
+
+        UNSLOTH_FULLGRAPH                 unset -> '1'
+        UNSLOTH_HIGH_PRECISION_LAYERNORM  unset -> '0'
+        UNSLOTH_RETURN_LOGITS             unset -> '0'
+
+    ``UNSLOTH_FULLGRAPH`` in particular changes how later tests compile, and
+    the module that set it is long gone by then. Restoring the whole
+    ``UNSLOTH_*`` namespace to its snapshot is idempotent with respect to
+    ``monkeypatch``, which puts the same original values back whichever of the
+    two finalizers runs first.
+    """
+    before = {k: v for k, v in os.environ.items() if k.startswith("UNSLOTH_")}
+    try:
+        yield
+    finally:
+        for key in [k for k in os.environ if k.startswith("UNSLOTH_")]:
+            if key not in before:
+                del os.environ[key]
+        for key, value in before.items():
+            if os.environ.get(key) != value:
+                os.environ[key] = value
 
 
 # Model types the zoo compiler drives end-to-end (from its call sites).


### PR DESCRIPTION
## Summary

#1173 was incomplete. That was the third leak found out of `test_compiler_dynamic_exec` in as many days, each one discovered because it broke somebody else, so rather than wait for a fourth victim I audited what global state one compiler drive actually mutates and what survives teardown. It found two things still escaping, one of them introduced by my own fix.

## 1. Three classes the snapshot could never have covered

`BatchNorm1d`, `BatchNorm2d` and `BatchNorm3d` inherit `forward` from `_BatchNorm`, so they own none and are absent from the snapshot #1173 takes:

```
BatchNorm1d   owns_forward=False  inherits_from=['_BatchNorm']
BatchNorm2d   owns_forward=False  inherits_from=['_BatchNorm']
BatchNorm3d   owns_forward=False  inherits_from=['_BatchNorm']
Conv2d        owns_forward=True   inherits_from=['Conv2d']
```

The dtype loop patches by assignment, which does not care whether the class had one, so each of those three gains a real attribute it never had. #1173 restores by iterating the snapshot, so it never sees them and all three stayed rewritten after every drive.

The snapshot reasoning was right for classes that own a forward, and I did not handle the symmetric case: a class that *gained* one needs the attribute deleted so the inherited version is exposed again, not restored. Both directions are handled now.

## 2. Environment variables the compiler sets itself

`monkeypatch` only knows about what the *test* set. The compiler writes to `os.environ` on its way through, and those writes outlive the test:

```
UNSLOTH_FULLGRAPH                 unset -> '1'
UNSLOTH_HIGH_PRECISION_LAYERNORM  unset -> '0'
UNSLOTH_RETURN_LOGITS             unset -> '0'
```

`UNSLOTH_FULLGRAPH` in particular changes how later tests compile, and the module that set it is long gone by the time that matters.

Restoring the whole `UNSLOTH_*` namespace to its snapshot is idempotent with respect to `monkeypatch`, which puts the same original values back whichever of the two finalizers runs first, so this does not depend on fixture ordering.

## Verification

Measured on the same probe before and after, driving `qwen3_moe` and reading back what survived teardown:

| leaked through teardown | before | after |
| --- | --- | --- |
| `torch.nn` forwards still rewritten | 3 (`BatchNorm1d/2d/3d`) | 0 |
| `UNSLOTH_*` variables | 3 | 0 |
| bare `sys.modules` entries | 0 | 0 (already fixed by #1172) |

Unchanged elsewhere:

| suite | result |
| --- | --- |
| `test_compiler_dynamic_exec.py` alone | 83 passed, 2 skipped |
| with `test_compiled_cache_collective.py`, both orders | 133 passed, 2 skipped |
| `Repo tests (CPU)` gate list | 1508 passed, 4 skipped |
| `Core drift` gate list | 804 passed, 62 skipped |

## What the audit also showed, and did not need fixing

One drive registers 13 bare names in `sys.modules` (`Conv1d` ... `RMSNorm`, plus `unsloth_compiled_module_qwen3_moe`) and rewrites 12 `torch.nn` forwards. The bare `sys.modules` entries are already cleaned up by #1172, which keys on the compile folder rather than on a name list, so they cost nothing here. Nothing in `torch.nn.functional` is touched, and `sys.path` is left alone.
