### PR TITLE
attention_metal was running against the shim, not real MLX

### DIFF
--- a/tests/test_mlx_attention_metal.py
+++ b/tests/test_mlx_attention_metal.py
@@ -25,6 +25,31 @@ import pytest
 mx = pytest.importorskip("mlx.core")
 pytest.importorskip("mlx_lm")
 
+# "Is mlx importable" is not "is this real mlx", and this file needs the second.
+# simulate_mlx_on_torch() installs process-wide and one sibling module calls it
+# while being IMPORTED (test_mlx_arrays_cache_advance.py, which sorts just before
+# this one), so collection alone is enough to make the importorskip above succeed
+# against the shim. These tests then run against a simulation that refuses the
+# operation they are built on:
+#
+#     NotImplementedError: mlx-shim: mx.quantize is not implemented in the
+#     simulation. Use real MLX on a Mac to produce quantized weights.
+#
+# 40 failures, every one of them on a box that simply has no MLX. That is the
+# trap test_mlx_real_detection_is_order_independent.py documents; it guards the
+# find_spec spellings of it, and importorskip is a third spelling that lies the
+# same way. Alone this file skips and passes, which is why it stayed hidden here
+# while failing unsloth's Core job, the one place that runs this suite as a
+# whole directory rather than a curated list.
+from mlx_simulation import mlx_is_simulated  # noqa: E402
+
+if mlx_is_simulated():
+    pytest.skip(
+        "needs real MLX: these compare a fused Metal kernel against the "
+        "runtime's own path, and the shim implements neither",
+        allow_module_level = True,
+    )
+
 from unsloth_zoo.mlx.attention import (
     _PATCH_FLAG,
     _PATCH_TARGETS,

--- a/tests/test_mlx_real_detection_is_order_independent.py
+++ b/tests/test_mlx_real_detection_is_order_independent.py
@@ -253,3 +253,64 @@ def test_a_gate_evaluates_to_false_under_the_shim(path: Path, names: list):
         f"`and` belongs, or a probe evaluated before this module installs its own shim. "
         f"Tests behind that gate will run against a stub whose ops raise on CALL."
     )
+
+
+# `importorskip` is a third spelling of the same mistake, and the one that got
+# through: the rule above reads find_spec calls, and test_mlx_attention_metal.py
+# had none. It gated on `pytest.importorskip("mlx.core")` succeeding, which the
+# shim satisfies just as happily as find_spec does, and ran 40 tests against a
+# simulation that refuses the operation they are built on.
+#
+# Flagging every importorskip("mlx") module would be wrong: 12 of the 14 are
+# fine, because the shim implements what they use. What separates the two that
+# are not is that they call an operation the shim REFUSES, so that is the
+# question asked here, and the refused set is read off the shim rather than
+# listed, so a new refusal widens this automatically.
+
+
+def _shim_refused_ops() -> set:
+    """Public ``mx.*`` names whose shim body raises NotImplementedError."""
+    stub = _TESTS / "mlx_simulation" / "mlx_stub.py"
+    tree = ast.parse(stub.read_text(encoding="utf-8"))
+    refused = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+            continue
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Raise):
+                continue
+            exc = sub.exc
+            name = (exc.func.id if isinstance(exc, ast.Call)
+                    and isinstance(exc.func, ast.Name) else getattr(exc, "id", ""))
+            if name == "NotImplementedError":
+                refused.add(node.name)
+    return refused
+
+
+def _consults_the_simulation(source: str) -> bool:
+    """Either spelling of the order-independent question is accepted.
+
+    ``mlx_is_simulated()`` is the helper; test_mlx_quantized_optimizer_state.py
+    open-codes the same check against ``mx.__file__`` and is equally correct.
+    """
+    return "mlx_is_simulated" in source or "mlx_simulation" in source
+
+
+@pytest.mark.parametrize("path", _test_modules(), ids=lambda p: p.name)
+def test_a_module_calling_an_op_the_shim_refuses_asks_whether_it_is_real(path: Path):
+    source = path.read_text(encoding="utf-8")
+    if 'importorskip("mlx' not in source and "importorskip('mlx" not in source:
+        return
+    called = sorted(op for op in _shim_refused_ops() if f"mx.{op}" in source)
+    if not called or _consults_the_simulation(source):
+        return
+    pytest.fail(
+        f"{path.name} gates on importorskip('mlx...') alone but calls "
+        f"mx.{', mx.'.join(called)}, which the shim raises NotImplementedError "
+        f"for. A sibling module installs the shim while being imported, so "
+        f"collection order alone decides whether this file runs against real "
+        f"MLX or against a stub that refuses the operation it is built on. Add:\n"
+        f"    from mlx_simulation import mlx_is_simulated\n"
+        f"    if mlx_is_simulated():\n"
+        f"        pytest.skip(..., allow_module_level = True)"
+    )


### PR DESCRIPTION
## Summary

`unsloth`'s `Core` job is red. Run `34092010393`, job `101648610970`, at `fb9bb4ea`:

```
40 failed, 1326 passed
```

Every one of the 40 is in `tests/test_mlx_attention_metal.py`:

```
tests/test_mlx_attention_metal.py:45: in _quant
    return mx.quantize(mx.random.normal(shape).astype(dtype), group_size, bits)
tests/mlx_simulation/mlx_stub.py:990: in quantize
E   NotImplementedError: mlx-shim: mx.quantize is not implemented in the simulation.
    Use real MLX on a Mac to produce quantized weights, then dequantize in the
    simulation via mx.dequantize.
```

## What happens

`tests/test_mlx_arrays_cache_advance.py` calls `simulate_mlx_on_torch()` while being **imported**:

```python
if importlib.util.find_spec("mlx") is None:
    from mlx_simulation import simulate_mlx_on_torch
    simulate_mlx_on_torch()
```

That installs the shim process-wide with no teardown, and the file sorts immediately before this one. The `pytest.importorskip("mlx.core")` at the top of `test_mlx_attention_metal.py` then succeeds against the shim rather than skipping, and 40 tests built on quantized attention run against a simulation that refuses to quantize.

Running just those two files together reproduces all 40 exactly:

```
python -m pytest tests/test_mlx_arrays_cache_advance.py tests/test_mlx_attention_metal.py -q
40 failed, 20 passed
```

## This is a known trap with a known answer

`tests/test_mlx_real_detection_is_order_independent.py` documents it in full and guards the `find_spec` spellings. `importorskip` is a third spelling that lies in exactly the same way, and there was no rule for it.

`tests/test_mlx_quantized_optimizer_state.py` already handles it, and says so:

```python
# importorskip alone is not enough: another test module may have installed the
if "mlx_simulation" in (getattr(mx, "__file__", "") or ""):
    pytest.skip(_SKIP, allow_module_level=True)
```

So the pattern existed. This file just did not follow it.

## Why it stayed hidden

Alone, the file skips and passes. Zoo's own `Repo tests (CPU)` runs a curated file list that does not include it. `unsloth`'s `Core` is the one job that runs this suite as a whole directory, so it was failing only there, on a repo where the change that caused it does not live.

## The fix

Ask the order-independent question and skip at module level. On a Mac with real MLX, `mlx_is_simulated()` is False and nothing changes.

## The new gate is scoped by measurement, not assumption

14 modules use `importorskip("mlx...")`. Flagging all of them would be wrong, so I ran each one behind the leaked shim first:

| | count |
| --- | --- |
| unaffected (the shim implements what they use) | 12 |
| broken by it | 2 |

What separates the two is that they call an operation the shim **refuses**, so that is what the new check asks. The refused set is read off `mlx_stub.py` rather than listed, so a new refusal widens the gate on its own. It currently derives `dequantize`, `quantize`, `quantized_matmul`.

## Verification

| | result |
| --- | --- |
| the failing pair | 40 failed -> **19 passed, 1 skipped** |
| `test_mlx_attention_metal.py` alone | 1 skipped, unchanged |
| full `tests/` directory, the shape `Core` runs | 44 failed -> **4 failed, 6652 passed, 399 skipped** |
| `test_mlx_real_detection_is_order_independent.py` | 537 passed, no false positives |
| new gate with the fix reverted | fails, naming `mx.dequantize, mx.quantize` |

The 4 remaining are `test_rl_replacements_compile_disable.py`. They fail identically on clean `main` on this box and pass in CI, so they are local to a torch/torchao mismatch here and unrelated to this change.
