### PR TITLE
gpt-oss: say where the float32 down projection actually comes from

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2004,9 +2004,13 @@ def torch_native_forward(
 
             gated_output = gated_output.to(torch.float32)
             device_type = gated_output.device.type if isinstance(gated_output.device.type, str) and gated_output.device.type != "mps" else "cpu"
-            # Autocast off keeps the adapter matmuls in float32. The down projection itself
-            # is float32 via _pre_set_compute_dtype, set in unsloth's loader, since
-            # bitsandbytes Linear4bit casts to self.compute_dtype whatever autocast says.
+            # Three separate things keep this float32, none of them redundant. A quantized
+            # down_proj computes in float32 via _pre_set_compute_dtype, set in unsloth's
+            # loader; the float32 gated_output is what Linear4bit restores the output to,
+            # since it captures inp_dtype and casts back; and autocast off is what protects
+            # the unquantized fallback, which takes F.linear and ignores compute_dtype.
+            # It does not keep the adapter matmuls in float32 -- the forced-float32 LoRA
+            # path casts those to float16 itself.
             with torch.autocast(device_type=device_type, enabled=False):
                 out = down_proj(gated_output)
             
@@ -2029,8 +2033,9 @@ def torch_native_forward(
         # glu = gate * torch.sigmoid(gate * self.alpha)
         # fused = (up_h + 1) * glu
 
-        # Autocast off for the down projection only. As above, the float32 comes from
-        # _pre_set_compute_dtype, not from this context manager.
+        # Autocast off for the down projection only. As above, it is the unquantized
+        # fallback that needs this; a quantized layer gets float32 from
+        # _pre_set_compute_dtype instead.
         device_type = fused.device.type if isinstance(fused.device.type, str) and fused.device.type != "mps" else "cpu"
         with torch.autocast(device_type=device_type, enabled=False):
             out_list = [
@@ -2044,10 +2049,10 @@ def torch_native_forward(
     pass
 pass
 
-# torch_native_forward has full float32 protection in float16 training: swiglu in float32,
-# autocast disabled around down_proj, and down_proj itself in float32 via
-# _pre_set_compute_dtype (set in unsloth's loader). The last one is what keeps the down
-# projection output out of float16.
+# torch_native_forward protects the down projection three ways in float16 training: swiglu and
+# gated_output in float32, which is also the dtype Linear4bit restores its output to;
+# _pre_set_compute_dtype (set in unsloth's loader) for the quantized compute; and autocast
+# disabled for the unquantized fallback, which ignores compute_dtype.
 GptOssExpertsBnb4bit.forward = torch_native_forward
 
 def patch_gpt_oss_linearized():

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2004,13 +2004,15 @@ def torch_native_forward(
 
             gated_output = gated_output.to(torch.float32)
             device_type = gated_output.device.type if isinstance(gated_output.device.type, str) and gated_output.device.type != "mps" else "cpu"
-            # Three separate things keep this float32, none of them redundant. A quantized
-            # down_proj computes in float32 via _pre_set_compute_dtype, set in unsloth's
-            # loader; the float32 gated_output is what Linear4bit restores the output to,
-            # since it captures inp_dtype and casts back; and autocast off is what protects
-            # the unquantized fallback, which takes F.linear and ignores compute_dtype.
-            # It does not keep the adapter matmuls in float32 -- the forced-float32 LoRA
-            # path casts those to float16 itself.
+            # Three separate things keep this float32, none of them redundant. On the
+            # forced-float32 path only, a quantized down_proj computes in float32 via
+            # _pre_set_compute_dtype, set in unsloth's loader; without that rule the layer
+            # takes the run's ordinary compute dtype, bfloat16 included. The float32
+            # gated_output is what Linear4bit restores the output to, since it captures
+            # inp_dtype and casts back. And autocast off is what protects the unquantized
+            # fallback, which takes F.linear and ignores compute_dtype. It does not keep the
+            # adapter matmuls in float32 -- the forced-float32 LoRA path casts those to
+            # float16 itself.
             with torch.autocast(device_type=device_type, enabled=False):
                 out = down_proj(gated_output)
             
@@ -2034,8 +2036,9 @@ def torch_native_forward(
         # fused = (up_h + 1) * glu
 
         # Autocast off for the down projection only. As above, it is the unquantized
-        # fallback that needs this; a quantized layer gets float32 from
-        # _pre_set_compute_dtype instead.
+        # fallback that needs this; on the forced-float32 path a quantized layer gets
+        # float32 from _pre_set_compute_dtype instead. This branch also runs in bfloat16,
+        # where no float32 rule is registered and the layer stays in bfloat16.
         device_type = fused.device.type if isinstance(fused.device.type, str) and fused.device.type != "mps" else "cpu"
         with torch.autocast(device_type=device_type, enabled=False):
             out_list = [
@@ -2051,8 +2054,9 @@ pass
 
 # torch_native_forward protects the down projection three ways in float16 training: swiglu and
 # gated_output in float32, which is also the dtype Linear4bit restores its output to;
-# _pre_set_compute_dtype (set in unsloth's loader) for the quantized compute; and autocast
-# disabled for the unquantized fallback, which ignores compute_dtype.
+# _pre_set_compute_dtype (registered by unsloth's loader on the forced-float32 path only) for
+# the quantized compute; and autocast disabled for the unquantized fallback, which ignores
+# compute_dtype. A bfloat16 run registers no float32 rule and keeps the layer in bfloat16.
 GptOssExpertsBnb4bit.forward = torch_native_forward
 
 def patch_gpt_oss_linearized():

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2004,7 +2004,15 @@ def torch_native_forward(
 
             gated_output = gated_output.to(torch.float32)
             device_type = gated_output.device.type if isinstance(gated_output.device.type, str) and gated_output.device.type != "mps" else "cpu"
-            with torch.autocast(device_type=device_type, enabled=False): # Force float32
+            # Autocast off so the adapter matmuls stay float32. The float32 down projection
+            # itself comes from elsewhere: unsloth's loader registers a custom dtype rule
+            # setting _pre_set_compute_dtype = torch.float32 on every gpt-oss down_projs
+            # module (and mlp.router) on the forced-float32 path, because bitsandbytes
+            # Linear4bit casts its input to self.compute_dtype whatever autocast says.
+            # Both halves are load-bearing: measured on gpt-oss-20b 4bit QLoRA the output
+            # here peaks around 51800, which is 0.79x of the float16 maximum, so storing it
+            # in float16 would leave only about a quarter of the range as headroom.
+            with torch.autocast(device_type=device_type, enabled=False):
                 out = down_proj(gated_output)
             
             weighted_output = out.to(torch.float32) * routing_weights[token_idx, expert_idx, None].to(torch.float32)
@@ -2026,9 +2034,11 @@ def torch_native_forward(
         # glu = gate * torch.sigmoid(gate * self.alpha)
         # fused = (up_h + 1) * glu
 
-        # Force float32 matrix multiply on down projection only
+        # Autocast off for the down projection only. As in the training branch above, the
+        # float32 comes from _pre_set_compute_dtype on the down_projs modules rather than
+        # from this context manager.
         device_type = fused.device.type if isinstance(fused.device.type, str) and fused.device.type != "mps" else "cpu"
-        with torch.autocast(device_type=device_type, enabled=False): # Force float32
+        with torch.autocast(device_type=device_type, enabled=False):
             out_list = [
                 down_l(fused[e].to(dtype))
                 for e, down_l in enumerate(self.down_projs)
@@ -2040,8 +2050,10 @@ def torch_native_forward(
     pass
 pass
 
-# torch_native_forward has full float32 protection (swiglu in float32, autocast
-# disabled around down_proj) to prevent NaN in fp16 training.
+# torch_native_forward has full float32 protection in float16 training: swiglu in float32,
+# autocast disabled around down_proj, and the down projection itself computing in float32 via
+# _pre_set_compute_dtype. The last of those is what keeps the down projection output out of
+# float16, and it is set in unsloth's loader rather than here.
 GptOssExpertsBnb4bit.forward = torch_native_forward
 
 def patch_gpt_oss_linearized():

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2004,14 +2004,9 @@ def torch_native_forward(
 
             gated_output = gated_output.to(torch.float32)
             device_type = gated_output.device.type if isinstance(gated_output.device.type, str) and gated_output.device.type != "mps" else "cpu"
-            # Autocast off so the adapter matmuls stay float32. The float32 down projection
-            # itself comes from elsewhere: unsloth's loader registers a custom dtype rule
-            # setting _pre_set_compute_dtype = torch.float32 on every gpt-oss down_projs
-            # module (and mlp.router) on the forced-float32 path, because bitsandbytes
-            # Linear4bit casts its input to self.compute_dtype whatever autocast says.
-            # Both halves are load-bearing: measured on gpt-oss-20b 4bit QLoRA the output
-            # here peaks around 51800, which is 0.79x of the float16 maximum, so storing it
-            # in float16 would leave only about a quarter of the range as headroom.
+            # Autocast off keeps the adapter matmuls in float32. The down projection itself
+            # is float32 via _pre_set_compute_dtype, set in unsloth's loader, since
+            # bitsandbytes Linear4bit casts to self.compute_dtype whatever autocast says.
             with torch.autocast(device_type=device_type, enabled=False):
                 out = down_proj(gated_output)
             
@@ -2034,9 +2029,8 @@ def torch_native_forward(
         # glu = gate * torch.sigmoid(gate * self.alpha)
         # fused = (up_h + 1) * glu
 
-        # Autocast off for the down projection only. As in the training branch above, the
-        # float32 comes from _pre_set_compute_dtype on the down_projs modules rather than
-        # from this context manager.
+        # Autocast off for the down projection only. As above, the float32 comes from
+        # _pre_set_compute_dtype, not from this context manager.
         device_type = fused.device.type if isinstance(fused.device.type, str) and fused.device.type != "mps" else "cpu"
         with torch.autocast(device_type=device_type, enabled=False):
             out_list = [
@@ -2051,9 +2045,9 @@ def torch_native_forward(
 pass
 
 # torch_native_forward has full float32 protection in float16 training: swiglu in float32,
-# autocast disabled around down_proj, and the down projection itself computing in float32 via
-# _pre_set_compute_dtype. The last of those is what keeps the down projection output out of
-# float16, and it is set in unsloth's loader rather than here.
+# autocast disabled around down_proj, and down_proj itself in float32 via
+# _pre_set_compute_dtype (set in unsloth's loader). The last one is what keeps the down
+# projection output out of float16.
 GptOssExpertsBnb4bit.forward = torch_native_forward
 
 def patch_gpt_oss_linearized():


### PR DESCRIPTION
Comment-only change to `torch_native_forward`. No behaviour change.

## Why

Three comments around the expert down projection attribute the float32 to the autocast disable:

```python
with torch.autocast(device_type=device_type, enabled=False): # Force float32
    out = down_proj(gated_output)
```

That is not where it comes from. bitsandbytes `Linear4bit` casts its input to `self.compute_dtype` whatever autocast says, so on its own this context manager would leave the projection running in float16. The float32 comes from `unsloth/models/loader.py`, which registers a custom dtype rule setting `_pre_set_compute_dtype = torch.float32` on every gpt-oss `down_projs` module and on `mlp.router` when the forced-float32 path triggers. `patching_utils.py` then casts the rest of the model to float16 and applies those per-module overrides.

So the guard is split across three files, and the comment at the call site points away from the part that matters. The autocast disable is still doing real work, it keeps autocast off the adapter matmuls, but it is not what keeps the output out of float16.

## Why it is worth recording

The protection is load-bearing and easy to remove from outside this file. Anything that walks the model setting `compute_dtype`, or that drops `gpt_oss` from `FORCE_FLOAT32`, silently reverts the projection to a float16 store. Doing exactly that on `unsloth/gpt-oss-20b-unsloth-bnb-4bit` reproduces a clean failure: the loss tracks a bfloat16 reference to step 50, then exactly 2 elements of layer 23's expert output become inf and every later loss is NaN. In that run `over65504` and `nonfinite` are both 2, so the only values past the ceiling are the infs themselves, and the residual is flat across the failure. It is a store overflowing rather than magnitudes drifting up.

The headroom in the shipped configuration is thinner than it looks, which is the number now recorded in the comment. Measured on a B200 over a float16 QLoRA run in the stock configuration, batch 1 x grad accum 4, seq 1024, `HuggingFaceH4/Multilingual-Thinking`:

| | value |
|---|---|
| `UNSLOTH_FORCE_FLOAT32` | 1 |
| embedding dtype | float16 |
| down_projs `compute_dtype` | float32, all 768 |
| peak down projection output | 51848 |
| as a fraction of the float16 maximum | 0.79x |
| values over 65504 | 0 |

So roughly a quarter of the float16 range is left. That is comfortable today and there is nothing to fix, but it is close enough that the reason for the float32 store should be findable from the call site.

## What was considered and rejected

Replacing the float32 compute with `torch.mm(..., out_dtype = torch.float32)`, which gives the same float32 store at float16 GEMM speed. It measures 2.4x to 5.1x cheaper than float32 at these shapes on a T4 at the GEMM level, but it does not survive contact with a real step: the down projections are about 272 GFLOP per step, so the entire theoretical saving is 3.3ms of an 11560ms step on a B200 and about 29ms on a T4 step measured in tens of seconds. Implemented and benchmarked end to end it came out 1.4% slower, since the backward has to dequantize the weight a second time. Not worth the complexity for a tenth of a percent that did not materialise.
