### PR TITLE
Add float16 matmul emulation, off by default

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -350,6 +350,7 @@ jobs:
             tests/test_mlx_trainer_internals.py \
             tests/test_mlx_arrays_cache_advance.py \
             tests/test_mlx_quantized_optimizer_routing.py \
+            tests/test_fp16_emulation.py \
             tests/test_check_hf_model_exists_transport_errors.py \
             tests/test_hub_transport_errors_single_segment.py \
             tests/test_quant_status_transport_errors.py \

--- a/tests/test_fp16_emulation.py
+++ b/tests/test_fp16_emulation.py
@@ -34,7 +34,7 @@ from unsloth_zoo.fp16_emulation import (  # noqa: E402
     fp16_split_matmul,
     fp16_split_mm,
     pow2_scale,
-    pow2_scale_tensor,
+    pow2_exponent,
     split_terms,
 )
 
@@ -234,13 +234,13 @@ def test_round_to_actually_rounds_under_compile():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
-def test_pow2_scale_tensor_matches_pow2_scale_at_extremes():
-    """float32 cannot hold the scale for max|x| near 2**-114, where it is 2**128, so the
-    exported helper is float64. pow2_scale returns a finite Python float there and the two
-    must still agree."""
+def test_pow2_exponent_applies_cleanly_at_extremes():
+    """A materialised scale is unusable here however it is stored: 2**128 overflows float32,
+    and a 0-dim float64 scale still promotes down to float32 when applied. ldexp does not."""
     x = torch.tensor([2.0 ** -114])
-    assert pow2_scale_tensor(x).item() == pow2_scale(x)
-    assert torch.isfinite(pow2_scale_tensor(x))
+    n = pow2_exponent(x)
+    assert 2.0 ** n.item() == pow2_scale(x)
+    assert torch.ldexp(x, n).item() == 2.0 ** 14
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
@@ -254,13 +254,14 @@ def test_round_to_does_not_alias_when_dtype_matches():
     fp16_split_mm(A, A, dtype = torch.float32)      # used to raise an aliasing error
 
 
-def test_pow2_scale_tensor_matches_pow2_scale():
-    """The sync-free scale must be the same number, not merely a similar one."""
+def test_pow2_exponent_matches_pow2_scale():
+    """The sync-free form must give the same number, not merely a similar one. Runs on CPU:
+    it is device-independent, and the CPU gate executes this file."""
     for mag in (1e-6, 1e-3, 0.1, 1.0, 1e3):
-        x = torch.randn(256, 256, device = "cuda") * mag
-        assert pow2_scale_tensor(x).item() == pow2_scale(x)
-    zero = torch.zeros(8, 8, device = "cuda")
-    assert pow2_scale_tensor(zero).item() == pow2_scale(zero) == 1.0
+        x = torch.randn(256, 256) * mag
+        assert 2.0 ** pow2_exponent(x).item() == pow2_scale(x)
+    zero = torch.zeros(8, 8)
+    assert 2.0 ** pow2_exponent(zero).item() == pow2_scale(zero) == 1.0
 
 
 # ---------------------------------------------------------------- degenerate operands

--- a/tests/test_fp16_emulation.py
+++ b/tests/test_fp16_emulation.py
@@ -32,6 +32,7 @@ from unsloth_zoo.fp16_emulation import (  # noqa: E402
     fp16_split_matmul,
     fp16_split_mm,
     pow2_scale,
+    pow2_scale_tensor,
     split_terms,
 )
 
@@ -44,6 +45,14 @@ def _rel_l2(actual, reference):
 
 def _reference(A, B):
     return torch.mm(A.double(), B.double())
+
+
+def _pair(m, k, n, mag = 0.02, device = "cuda"):
+    """Operand pair at a magnitude typical of LLM weights, which is below float16's
+    normal-range floor of 0.125 and therefore depends on the scaling to work at all."""
+    torch.manual_seed(3407)
+    return (torch.randn(m, k, device = device) * mag,
+            torch.randn(k, n, device = device) * mag)
 
 
 def _fp16_direct(A, B):
@@ -179,3 +188,54 @@ def test_bf16_control_reproduces_upstream_relationship():
         fp16_split_mm(A, B, dtype = torch.bfloat16, terms = 3, products = 9, scale = False), ref
     )
     assert bf16x3 < _rel_l2(torch.mm(A, B), ref) * 2.0
+
+
+# ---------------------------------------------------------------- torch.compile
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_compiles_fullgraph():
+    """fullgraph is the real bar: it proves no host sync survives in the hot path."""
+    A, B = _pair(512, 512, 512, mag = 0.02)
+    out = torch.compile(fp16_split_mm, fullgraph = True)(A, B)
+    assert torch.isfinite(out).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_compiled_keeps_float32_accuracy():
+    """The regression that matters, and the reason _round_to is a custom op.
+
+    Without the opaque-op barrier Inductor fuses the float16 round trip away, the residual
+    becomes exactly 0, and this lands at plain-float16 error (~2.9e-04) while running
+    faster. Compiled output must stay at float32 parity, not merely be finite.
+    """
+    A, B = _pair(2048, 2048, 2048, mag = 0.02)
+    ref = A.double() @ B.double()
+    rel = lambda t: ((t.double() - ref).norm() / ref.norm()).item()
+    fp32_err = rel(torch.mm(A, B))
+    compiled_err = rel(torch.compile(fp16_split_mm)(A, B))
+    fp16_err = rel(torch.mm(A.half(), B.half()).float())
+    assert compiled_err < 10 * fp32_err, f"compiled {compiled_err:.2e} vs fp32 {fp32_err:.2e}"
+    assert compiled_err < fp16_err / 50, f"compiled {compiled_err:.2e} near fp16 {fp16_err:.2e}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_round_to_actually_rounds_under_compile():
+    """Directly pin the mechanism: a non-zero residual is what the split IS."""
+    def split(x):
+        return split_terms(x, torch.float16, 2)[1]
+    x = torch.randn(1024, 1024, device = "cuda") * 0.02
+    head = split_terms(x, torch.float16, 2)[0]
+    residual = x - head.float()
+    assert residual.norm().item() > 0
+    assert torch.compile(lambda t: t - split_terms(t, torch.float16, 2)[0].float())(x) \
+        .norm().item() > 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_pow2_scale_tensor_matches_pow2_scale():
+    """The sync-free scale must be the same number, not merely a similar one."""
+    for mag in (1e-6, 1e-3, 0.1, 1.0, 1e3):
+        x = torch.randn(256, 256, device = "cuda") * mag
+        assert pow2_scale_tensor(x).item() == pow2_scale(x)
+    zero = torch.zeros(8, 8, device = "cuda")
+    assert pow2_scale_tensor(zero).item() == pow2_scale(zero) == 1.0

--- a/tests/test_fp16_emulation.py
+++ b/tests/test_fp16_emulation.py
@@ -1,8 +1,9 @@
-# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -12,6 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Tests for the dormant float16 matmul emulation.
 
 The important test here is not that the scaled split is accurate, it is that the UNSCALED
@@ -239,3 +241,80 @@ def test_pow2_scale_tensor_matches_pow2_scale():
         assert pow2_scale_tensor(x).item() == pow2_scale(x)
     zero = torch.zeros(8, 8, device = "cuda")
     assert pow2_scale_tensor(zero).item() == pow2_scale(zero) == 1.0
+
+
+# ---------------------------------------------------------------- degenerate operands
+#
+# Each of these returned something silently wrong before: a NaN, a zero, or an exception,
+# where torch.mm returns the right answer. The emulation advertises itself as a float32
+# matmul stand-in, so "wrong but fast" is the one outcome it must not have.
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_out_dtype_probe_finds_cuda_support():
+    """aten::mm.dtype is CUDA-only. Probing it on CPU raises NotImplementedError, which
+    subclasses RuntimeError, so a CPU probe would cache False and disable the tensor-core
+    path the module exists for."""
+    from unsloth_zoo.fp16_emulation import _has_out_dtype
+    assert _has_out_dtype() is True
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_infinite_operand_matches_torch_mm():
+    A = torch.tensor([[float("inf")]], device = "cuda")
+    B = torch.tensor([[1.0]], device = "cuda")
+    assert torch.isinf(fp16_split_mm(A, B)).all()      # was NaN: inf - inf in the residual
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_scale_that_would_overflow_float32():
+    """max|x| below about 2**-113 makes the scale itself larger than float32 can hold."""
+    A = torch.full((2, 2), 2.0 ** -114, device = "cuda")
+    B = torch.full((2, 2), 2.0 ** 114, device = "cuda")
+    assert torch.allclose(fp16_split_mm(A, B).double(), A.double() @ B.double(), rtol = 1e-5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_scale_product_overflows_but_operands_do_not():
+    """Each scale is representable at 2**69; only sA * sB overflows, so the division is
+    done one scale at a time."""
+    A = torch.tensor([[2.0 ** -55]], device = "cuda")
+    B = torch.tensor([[2.0 ** -55]], device = "cuda")
+    assert torch.allclose(fp16_split_mm(A, B).double(), A.double() @ B.double(), rtol = 1e-5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_within_tensor_range_wider_than_float16():
+    """One per-tensor scale cannot hold a range this wide, so the small entries would round
+    to zero. Falls back to float32 rather than returning an all-zero matrix."""
+    A = torch.diag(torch.tensor([1.0, 2.0 ** -39], device = "cuda"))
+    B = torch.diag(torch.tensor([1.0, 2.0 ** 39], device = "cuda"))
+    assert torch.allclose(fp16_split_mm(A, B).diagonal(), torch.ones(2, device = "cuda"))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_empty_dimension_matches_torch_mm():
+    """MoE routing hands out empty expert partitions; torch.mm accepts them, max() does not."""
+    A = torch.zeros(0, 8, device = "cuda")
+    B = torch.zeros(8, 4, device = "cuda")
+    assert fp16_split_mm(A, B).shape == (0, 4)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_float32_accumulate_survives_autocast():
+    """torch.mm is autocast-eligible, so .float() operands alone do not keep the fallback in
+    float32 inside an autocast region."""
+    A, B = _pair(512, 512, 512, mag = 0.02)
+    ref = A.double() @ B.double()
+    with torch.autocast(device_type = "cuda", dtype = torch.float16):
+        out = fp16_split_mm(A, B)
+    assert out.dtype == torch.float32
+    rel = ((out.double() - ref).norm() / ref.norm()).item()
+    assert rel < 1e-5, f"autocast degraded the emulation to {rel:.2e}"
+
+
+@pytest.mark.parametrize("kwargs", [{"terms": 0}, {"products": 0}, {"products": -1}])
+def test_non_positive_counts_rejected(kwargs):
+    """products=-1 used to slice the full product list and silently run a different scheme."""
+    A, B = _pair(4, 4, 4, device = "cpu")
+    with pytest.raises(ValueError):
+        fp16_split_mm(A, B, **kwargs)

--- a/tests/test_fp16_emulation.py
+++ b/tests/test_fp16_emulation.py
@@ -1,0 +1,181 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for the dormant float16 matmul emulation.
+
+The important test here is not that the scaled split is accurate, it is that the UNSCALED
+split collapses at small magnitudes. float16's 5-bit exponent is the whole difficulty, and a
+split implementation that quietly stopped splitting would still pass an accuracy test run at
+magnitude 1.0. test_unscaled_underflows_at_small_magnitude fails if the cliff is absent.
+"""
+import os
+import sys
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from unsloth_zoo.fp16_emulation import (  # noqa: E402
+    fp16_emulation_enabled,
+    fp16_split_matmul,
+    fp16_split_mm,
+    pow2_scale,
+    split_terms,
+)
+
+
+def _rel_l2(actual, reference):
+    diff = actual.double() - reference
+    denom = torch.linalg.vector_norm(reference)
+    return (torch.linalg.vector_norm(diff) / denom).item()
+
+
+def _reference(A, B):
+    return torch.mm(A.double(), B.double())
+
+
+def _fp16_direct(A, B):
+    """float16 operands with float32 accumulate, i.e. what a tensor core actually does.
+
+    Not torch.mm(A.half(), B.half()), which also accumulates in float16 and is a different
+    and much worse baseline. The question here is the precision of the stored operands.
+    """
+    return torch.mm(A.half().float(), B.half().float())
+
+
+def test_disabled_by_default():
+    """Nothing in Unsloth enables this, and importing it must not turn anything on."""
+    os.environ.pop("UNSLOTH_FP16_EMULATION", None)
+    assert fp16_emulation_enabled() is False
+    os.environ["UNSLOTH_FP16_EMULATION"] = "1"
+    try:
+        assert fp16_emulation_enabled() is True
+    finally:
+        os.environ.pop("UNSLOTH_FP16_EMULATION", None)
+
+
+def test_pow2_scale_is_exact():
+    """The scale must be a power of two, otherwise it injects error into an error measurement."""
+    for mag in (1e-6, 1e-3, 1.0, 1e3):
+        x = torch.randn(64, 64) * mag
+        s = pow2_scale(x)
+        assert s > 0 and torch.tensor(s).log2().item().is_integer()
+        # Scaling by a power of two is lossless, so scaling and unscaling round-trips exactly.
+        assert torch.equal((x * s) / s, x)
+
+
+def test_pow2_scale_handles_degenerate_input():
+    assert pow2_scale(torch.zeros(8, 8)) == 1.0
+    assert pow2_scale(torch.full((8, 8), float("inf"))) == 1.0
+
+
+def test_split_terms_reconstructs():
+    x = torch.randn(128, 128)
+    terms = split_terms(x, torch.float16, 3)
+    assert len(terms) == 3
+    total = sum(t.float() for t in terms)
+    # Three float16 terms carry ~33 significand bits, comfortably more than float32's 24.
+    assert _rel_l2(total, x.double()) < 1e-6
+
+
+@pytest.mark.parametrize("magnitude", [1e-6, 1e-3, 0.1, 1.0, 1e3])
+def test_scaled_split_holds_ieee_parity(magnitude):
+    """Scaled, the split should track IEEE float32 across the whole sweep."""
+    torch.manual_seed(3407)
+    A = torch.randn(256, 256) * magnitude
+    B = torch.randn(256, 256) * magnitude
+    ref = _reference(A, B)
+
+    ieee = _rel_l2(torch.mm(A, B), ref)
+    split = _rel_l2(fp16_split_mm(A, B, scale = True), ref)
+    direct = _rel_l2(_fp16_direct(A, B), ref)
+
+    # Within 2x of IEEE, and far better than plain float16.
+    assert split < ieee * 2.0, f"scaled split {split:.3e} vs ieee {ieee:.3e}"
+    assert split < direct / 10.0, f"scaled split {split:.3e} vs float16 {direct:.3e}"
+
+
+def test_unscaled_underflows_at_small_magnitude():
+    """The cliff below |x| = 0.125 must be reproducible.
+
+    If this passes trivially, the split is not actually splitting. At 1e-6 the low term is
+    entirely subnormal or zero, so the unscaled split should be no better than plain float16,
+    while the scaled split stays at IEEE parity.
+    """
+    torch.manual_seed(3407)
+    A = torch.randn(256, 256) * 1e-6
+    B = torch.randn(256, 256) * 1e-6
+    ref = _reference(A, B)
+
+    unscaled = _rel_l2(fp16_split_mm(A, B, scale = False), ref)
+    scaled = _rel_l2(fp16_split_mm(A, B, scale = True), ref)
+    direct = _rel_l2(_fp16_direct(A, B), ref)
+
+    assert unscaled > 1e-3, f"expected the unscaled split to collapse, got {unscaled:.3e}"
+    assert unscaled == pytest.approx(direct, rel = 0.5), (
+        f"unscaled {unscaled:.3e} should match plain float16 {direct:.3e}: "
+        f"the low term has underflowed and the split no longer exists"
+    )
+    assert scaled < unscaled / 100.0
+
+
+def test_outlier_distribution():
+    """The LLM-realistic case: mostly small values with a few large ones."""
+    torch.manual_seed(3407)
+    def outlier(m, n):
+        x = torch.randn(m, n) * 0.02
+        return torch.where(torch.rand(m, n) < 0.001, x * 500.0, x)
+    A, B = outlier(256, 256), outlier(256, 256)
+    ref = _reference(A, B)
+    assert _rel_l2(fp16_split_mm(A, B), ref) < _rel_l2(torch.mm(A, B), ref) * 3.0
+
+
+def test_rejects_bad_shapes_and_products():
+    with pytest.raises(ValueError):
+        fp16_split_mm(torch.randn(2, 3, 4), torch.randn(4, 4))
+    with pytest.raises(ValueError):
+        fp16_split_mm(torch.randn(4, 4), torch.randn(4, 4), terms = 2, products = 5)
+
+
+def test_autograd_matches_float32_matmul():
+    """Gradients must be emulated too, not silently dropped to plain float16."""
+    torch.manual_seed(3407)
+    A = (torch.randn(64, 96) * 0.02).requires_grad_(True)
+    B = (torch.randn(96, 32) * 0.02).requires_grad_(True)
+    A_ref = A.detach().clone().requires_grad_(True)
+    B_ref = B.detach().clone().requires_grad_(True)
+
+    fp16_split_matmul(A, B).sum().backward()
+    torch.mm(A_ref, B_ref).sum().backward()
+
+    assert torch.allclose(A.grad, A_ref.grad, rtol = 1e-3, atol = 1e-6)
+    assert torch.allclose(B.grad, B_ref.grad, rtol = 1e-3, atol = 1e-6)
+
+
+def test_bf16_control_reproduces_upstream_relationship():
+    """bf16x3 9-product needs no scaling, because bfloat16 has float32's exponent range.
+
+    This is the control that validates the rig: it should track IEEE closely even unscaled,
+    which is the property that makes the upstream bfloat16 scheme work and the float16 port
+    require scaling.
+    """
+    torch.manual_seed(3407)
+    A = torch.randn(256, 256) * 1e-6
+    B = torch.randn(256, 256) * 1e-6
+    ref = _reference(A, B)
+    bf16x3 = _rel_l2(
+        fp16_split_mm(A, B, dtype = torch.bfloat16, terms = 3, products = 9, scale = False), ref
+    )
+    assert bf16x3 < _rel_l2(torch.mm(A, B), ref) * 2.0

--- a/tests/test_fp16_emulation.py
+++ b/tests/test_fp16_emulation.py
@@ -250,12 +250,23 @@ def test_pow2_scale_tensor_matches_pow2_scale():
 # matmul stand-in, so "wrong but fast" is the one outcome it must not have.
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
-def test_out_dtype_probe_finds_cuda_support():
+def test_out_dtype_probe_matches_a_direct_call():
     """aten::mm.dtype is CUDA-only. Probing it on CPU raises NotImplementedError, which
     subclasses RuntimeError, so a CPU probe would cache False and disable the tensor-core
-    path the module exists for."""
+    path the module exists for.
+
+    Asserted against a direct attempt rather than against True: pyproject allows torch>=2.4,
+    and out_dtype only landed in 2.8, so False is the correct answer on a supported older
+    install and this must not fail there.
+    """
     from unsloth_zoo.fp16_emulation import _has_out_dtype
-    assert _has_out_dtype() is True
+    zero = torch.zeros(1, 1, dtype = torch.float16, device = "cuda")
+    try:
+        torch.mm(zero, zero, out_dtype = torch.float32)
+        supported = True
+    except (TypeError, RuntimeError):
+        supported = False
+    assert _has_out_dtype() is supported
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
@@ -280,6 +291,25 @@ def test_scale_product_overflows_but_operands_do_not():
     A = torch.tensor([[2.0 ** -55]], device = "cuda")
     B = torch.tensor([[2.0 ** -55]], device = "cuda")
     assert torch.allclose(fp16_split_mm(A, B).double(), A.double() @ B.double(), rtol = 1e-5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_large_times_small_does_not_overflow_intermediately():
+    """2**114 @ 2**-113 is 2.0. Applying the inverse scales one at a time passes through inf
+    in either order, so the combined exponent goes on in a single ldexp."""
+    A = torch.tensor([[2.0 ** 114]], device = "cuda")
+    B = torch.tensor([[2.0 ** -113]], device = "cuda")
+    assert torch.allclose(fp16_split_mm(A, B).double(), A.double() @ B.double(), rtol = 1e-5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_ordinary_tensors_are_not_diverted_to_the_fallback():
+    """The dynamic-range guard is a catastrophe guard. A tighter bound would fire on ordinary
+    randn operands, whose hi/lo runs past 2**23 on any near-zero entry, and would quietly
+    replace the emulation with float32 mm on the workload it exists for."""
+    from unsloth_zoo.fp16_emulation import _split_can_represent
+    A, B = _pair(1024, 1024, 1024, mag = 0.02)
+    assert _split_can_represent(A) and _split_can_represent(B)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")

--- a/tests/test_fp16_emulation.py
+++ b/tests/test_fp16_emulation.py
@@ -234,6 +234,26 @@ def test_round_to_actually_rounds_under_compile():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_pow2_scale_tensor_matches_pow2_scale_at_extremes():
+    """float32 cannot hold the scale for max|x| near 2**-114, where it is 2**128, so the
+    exported helper is float64. pow2_scale returns a finite Python float there and the two
+    must still agree."""
+    x = torch.tensor([2.0 ** -114])
+    assert pow2_scale_tensor(x).item() == pow2_scale(x)
+    assert torch.isfinite(pow2_scale_tensor(x))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+def test_round_to_does_not_alias_when_dtype_matches():
+    """.to(dtype) returns the input itself when the dtype already matches, and a custom op
+    declaring no aliasing may not return one of its inputs."""
+    A = torch.randn(8, 8, device = "cuda")
+    terms = split_terms(A, torch.float32, 2)
+    assert terms[0] is not A
+    assert torch.equal(terms[0], A)
+    fp16_split_mm(A, A, dtype = torch.float32)      # used to raise an aliasing error
+
+
 def test_pow2_scale_tensor_matches_pow2_scale():
     """The sync-free scale must be the same number, not merely a similar one."""
     for mag in (1e-6, 1e-3, 0.1, 1.0, 1e3):

--- a/unsloth_zoo/fp16_emulation.py
+++ b/unsloth_zoo/fp16_emulation.py
@@ -1,8 +1,9 @@
-# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -12,6 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Emulate float32 matmul accuracy using split float16 terms.
 
 NOT ENABLED ANYWHERE. Nothing in Unsloth calls this module, and importing it changes no
@@ -81,6 +83,13 @@ change to get there, both load-bearing:
     stops existing and lands at plain-float16 error while running faster. Guarded by
     test_compiled_keeps_float32_accuracy.
 
+Degenerate operands fall back to plain float32 mm rather than returning something wrong: a
+non-finite entry (the residual would compute inf - inf and NaN the result), a magnitude so
+small the scale overflows float32, and a within-tensor dynamic range wider than float16's
+normal window, which one per-tensor scale cannot hold and which would round the small entries
+to zero. The check reads tensor values, so it is skipped under torch.compile, where a host
+read breaks the graph and the operands are the ordinary finite ones anyway.
+
 So: numerically sound, not currently worth enabling. Kept for the case where a large
 float32 GEMM appears on hardware without bfloat16 tensor cores.
 """
@@ -111,16 +120,34 @@ _HAS_OUT_DTYPE = None
 
 
 def _has_out_dtype() -> bool:
-    """torch.mm(..., out_dtype = ) landed in torch 2.8. Probed once, not assumed."""
+    """torch.mm(..., out_dtype = ) landed in torch 2.8. Probed once, not assumed.
+
+    Probed on CUDA, because `aten::mm.dtype` is CUDA-only: a CPU probe raises
+    NotImplementedError, which subclasses RuntimeError and so would be caught below and cache
+    False forever, silently costing the tensor-core path this module exists for.
+    """
     global _HAS_OUT_DTYPE
     if _HAS_OUT_DTYPE is None:
-        try:
-            zero = torch.zeros(1, 1, dtype = torch.float16)
-            torch.mm(zero, zero, out_dtype = torch.float32)
-            _HAS_OUT_DTYPE = True
-        except (TypeError, RuntimeError):
+        if not torch.cuda.is_available():
             _HAS_OUT_DTYPE = False
+        else:
+            try:
+                zero = torch.zeros(1, 1, dtype = torch.float16, device = "cuda")
+                torch.mm(zero, zero, out_dtype = torch.float32)
+                _HAS_OUT_DTYPE = True
+            except (TypeError, RuntimeError):
+                _HAS_OUT_DTYPE = False
     return _HAS_OUT_DTYPE
+
+
+def _mm_float32(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Plain float32 matmul that autocast cannot downcast.
+
+    `.float()` on the operands is not enough: torch.mm is autocast-eligible, so inside an
+    autocast region it is re-cast to float16 and the result stops being float32-accumulated.
+    """
+    with torch.autocast(device_type = a.device.type, enabled = False):
+        return torch.mm(a.float(), b.float())
 
 
 def _mm_f32_accumulate(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
@@ -131,7 +158,7 @@ def _mm_f32_accumulate(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     """
     if _has_out_dtype() and a.is_cuda:
         return torch.mm(a, b, out_dtype = torch.float32)
-    return torch.mm(a.float(), b.float())
+    return _mm_float32(a, b)
 
 
 def pow2_scale(x: torch.Tensor, target_exp: int = 14) -> float:
@@ -158,6 +185,8 @@ def pow2_scale_tensor(x: torch.Tensor, target_exp: int = 14) -> torch.Tensor:
     expression"). frexp gives the exponent on device instead. frexp returns
     m = mantissa * 2**exp with mantissa in [0.5, 1), so floor(log2(m)) == exp - 1.
     """
+    if x.numel() == 0:
+        return torch.ones((), device = x.device, dtype = torch.float32)
     m = x.abs().max()
     _, exp = torch.frexp(m)
     scale = torch.exp2((target_exp - (exp - 1)).float())
@@ -194,6 +223,37 @@ def split_terms(x: torch.Tensor, dtype: torch.dtype, terms: int) -> list:
     return out
 
 
+# hi/lo window in which BOTH split terms stay normal in float16. The high term lands at
+# 2**target_exp = 2**14 and the low term sits about 2**-11 below it, so an entry more than
+# 2**28 under the maximum has already fallen through float16's normal floor.
+_SPLIT_RANGE_LIMIT = 2.0 ** 28
+
+
+def _split_can_represent(x: torch.Tensor, s: torch.Tensor) -> bool:
+    """Whether one per-tensor power-of-two scale can actually carry this operand.
+
+    Three ways the split silently returns something wrong, all of which plain float32 mm gets
+    right: a non-finite entry, whose residual computes inf - inf and poisons everything to NaN;
+    a magnitude so small the scale itself overflows float32; and a within-tensor dynamic range
+    wider than float16's normal window, which rounds the small entries to zero. A single scale
+    taken from the maximum cannot serve the last case at all.
+
+    Reads tensor values, so it syncs and is skipped under torch.compile, where a host read
+    breaks the graph. The compiled path is for the ordinary finite, normal-range operands the
+    module is meant for.
+    """
+    if torch.compiler.is_compiling():
+        return True
+    absx = x.abs()
+    hi = absx.max()
+    if not bool(torch.isfinite(hi)) or not bool(torch.isfinite(s)):
+        return False
+    lo = torch.where(absx == 0, torch.full_like(absx, float("inf")), absx).min()
+    if not bool(torch.isfinite(lo)):
+        return True         # all zeros: nothing to lose
+    return bool(hi / lo <= _SPLIT_RANGE_LIMIT)
+
+
 def fp16_split_mm(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -213,13 +273,23 @@ def fp16_split_mm(
     """
     if A.ndim != 2 or B.ndim != 2:
         raise ValueError(f"fp16_split_mm expects 2D operands, got {A.shape} and {B.shape}")
+    if terms < 1 or products < 1:
+        raise ValueError(f"terms and products must be positive, got terms={terms} products={products}")
     if products > terms * terms:
         raise ValueError(f"products={products} exceeds terms*terms={terms * terms}")
 
     A32, B32 = A.float(), B.float()
+    # torch.mm accepts a zero-sized dimension; the max() reduction in the scale does not, and
+    # an empty expert partition is an ordinary outcome of MoE routing.
+    if A32.numel() == 0 or B32.numel() == 0:
+        return _mm_float32(A32, B32)
+
     one = torch.ones((), device = A32.device, dtype = torch.float32)
     sA = pow2_scale_tensor(A32) if scale else one
     sB = pow2_scale_tensor(B32) if scale else one
+    if not _split_can_represent(A32, sA) or not _split_can_represent(B32, sB):
+        return _mm_float32(A32, B32)
+
     a_terms = split_terms(A32 * sA, dtype, terms)
     b_terms = split_terms(B32 * sB, dtype, terms)
 
@@ -228,7 +298,9 @@ def fp16_split_mm(
     for i, j in pairs[:products]:
         part = _mm_f32_accumulate(a_terms[i], b_terms[j])
         acc = part if acc is None else acc + part
-    return acc / (sA * sB)
+    # Divided one scale at a time: sA * sB overflows to inf for two individually representable
+    # small operands (2**-55 each gives 2**69 apiece), which would zero a good result.
+    return acc / sA / sB
 
 
 class _FP16SplitMatmul(torch.autograd.Function):

--- a/unsloth_zoo/fp16_emulation.py
+++ b/unsloth_zoo/fp16_emulation.py
@@ -186,8 +186,13 @@ def pow2_scale_tensor(x: torch.Tensor, target_exp: int = 14) -> torch.Tensor:
     torch.compile(fullgraph = True) it is a hard error ("could not guard on data-dependent
     expression"). frexp gives the exponent on device instead. frexp returns
     m = mantissa * 2**exp with mantissa in [0.5, 1), so floor(log2(m)) == exp - 1.
+
+    Materialised in float64 to keep the documented equivalence with `pow2_scale`, which returns
+    a Python float. For max|x| near 2**-114 the scale is 2**128, which float32 cannot hold and
+    would silently hand back inf while `pow2_scale` returns a perfectly good 3.4e38. The main
+    path does not use this at all; it carries `pow2_exponent` and applies it with ldexp.
     """
-    return torch.exp2(pow2_exponent(x, target_exp).float())
+    return torch.exp2(pow2_exponent(x, target_exp).double())
 
 
 def pow2_exponent(x: torch.Tensor, target_exp: int = 14) -> torch.Tensor:
@@ -217,7 +222,10 @@ _HAS_CUSTOM_OP = hasattr(torch.library, "custom_op")
 if _HAS_CUSTOM_OP:
     @torch.library.custom_op("unsloth_zoo::fp16_emulation_round", mutates_args = ())
     def _round_to(x: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
-        return x.to(dtype)
+        # Cloned when the dtype already matches: .to() returns the input itself there, and a
+        # custom op declaring no aliasing may not return one of its inputs. Without this,
+        # split_terms(x, x.dtype, ...) raises instead of splitting.
+        return x.clone() if x.dtype == dtype else x.to(dtype)
 
     @_round_to.register_fake
     def _(x, dtype):

--- a/unsloth_zoo/fp16_emulation.py
+++ b/unsloth_zoo/fp16_emulation.py
@@ -76,19 +76,20 @@ torch.compile. `fp16_split_mm` compiles fullgraph and compiling it is worth 1.5-
 torch 2.14), which turns square-4096 from 1.24x into 3.25x against float32. Two things had to
 change to get there, both load-bearing:
 
-  - the scale must not call `.item()`, which syncs and breaks fullgraph. `pow2_scale_tensor`
-    uses frexp instead and returns the identical number.
+  - the scale must not call `.item()`, which syncs and breaks fullgraph. `pow2_exponent`
+    uses frexp instead and is applied with ldexp.
   - the float16 rounding must go through an opaque custom op. Inductor otherwise fuses
     `.to(float16).to(float32)` away, leaving a residual of exactly 0, so the split silently
     stops existing and lands at plain-float16 error while running faster. Guarded by
     test_compiled_keeps_float32_accuracy.
 
 Degenerate operands fall back to plain float32 mm rather than returning something wrong: a
-non-finite entry (the residual would compute inf - inf and NaN the result), a magnitude so
-small the scale overflows float32, and a within-tensor dynamic range wider than float16's
-normal window, which one per-tensor scale cannot hold and which would round the small entries
-to zero. The check reads tensor values, so it is skipped under torch.compile, where a host
-read breaks the graph and the operands are the ordinary finite ones anyway.
+non-finite entry, whose residual would compute inf - inf and NaN the result, and a within-tensor
+dynamic range wider than float16's normal window, which one per-tensor scale cannot hold and
+which would round the small entries to zero. The check reads tensor values, so it is skipped
+under torch.compile, where a host read breaks the graph and the operands are the ordinary finite
+ones anyway. Extreme magnitudes need no fallback: the scaling is an exponent applied with ldexp,
+so nothing is materialised that could overflow.
 
 So: numerically sound, not currently worth enabling. Kept for the case where a large
 float32 GEMM appears on hardware without bfloat16 tensor cores.
@@ -104,7 +105,7 @@ import torch
 __all__ = [
     "fp16_emulation_enabled",
     "pow2_scale",
-    "pow2_scale_tensor",
+    "pow2_exponent",
     "split_terms",
     "fp16_split_mm",
     "fp16_split_matmul",
@@ -170,8 +171,8 @@ def pow2_scale(x: torch.Tensor, target_exp: int = 14) -> float:
     its own. That matters when the entire purpose is to measure error. target_exp = 14 puts
     the maximum an octave below the float16 ceiling of 65504.
 
-    Returns a Python float, so it syncs. `pow2_scale_tensor` is the torch.compile-safe form;
-    this one is kept because it is the readable definition and is what the tests assert on.
+    Returns a Python float, so it syncs. `pow2_exponent` is the torch.compile-safe form.
+    This one is kept because it is the readable definition and is what the tests assert on.
     """
     m = x.abs().max().item()
     if m == 0 or not math.isfinite(m):
@@ -179,30 +180,20 @@ def pow2_scale(x: torch.Tensor, target_exp: int = 14) -> float:
     return 2.0 ** (target_exp - math.floor(math.log2(m)))
 
 
-def pow2_scale_tensor(x: torch.Tensor, target_exp: int = 14) -> torch.Tensor:
-    """`pow2_scale` without the host sync, returning a 0-dim tensor.
-
-    `.item()` is a data-dependent host read: it forces a device sync, and under
-    torch.compile(fullgraph = True) it is a hard error ("could not guard on data-dependent
-    expression"). frexp gives the exponent on device instead. frexp returns
-    m = mantissa * 2**exp with mantissa in [0.5, 1), so floor(log2(m)) == exp - 1.
-
-    Materialised in float64 to keep the documented equivalence with `pow2_scale`, which returns
-    a Python float. For max|x| near 2**-114 the scale is 2**128, which float32 cannot hold and
-    would silently hand back inf while `pow2_scale` returns a perfectly good 3.4e38. The main
-    path does not use this at all; it carries `pow2_exponent` and applies it with ldexp.
-    """
-    return torch.exp2(pow2_exponent(x, target_exp).double())
-
-
 def pow2_exponent(x: torch.Tensor, target_exp: int = 14) -> torch.Tensor:
-    """The exponent n behind `pow2_scale_tensor`, i.e. the scale is 2**n.
+    """The exponent n such that the scale is 2**n.
 
-    Carried as an exponent rather than a scale so the scaling and its inverse can be applied
-    with ldexp, which cannot overflow on the way to a representable answer. Materialising 2**n
-    breaks in both directions: 2**n itself overflows float32 below about 2**-113, and for a
-    large-times-small pair like 2**114 @ 2**-113 (which is just 2.0) dividing by one scale
-    before the other passes through inf.
+    There is deliberately no tensor-valued *scale* helper. One existed and was removed: a 0-dim
+    tensor follows scalar promotion, so multiplying a float32 operand by a float64 scale stays
+    in float32, and at max|x| near 2**-114 the scale of 2**128 overflows to inf on the way in
+    however the scale itself is stored. `torch.ldexp(x, pow2_exponent(x))` has no such edge and
+    is what this module uses throughout: it cannot overflow on the way to a representable
+    answer, in either direction. For a large-times-small pair like 2**114 @ 2**-113, which is
+    just 2.0, dividing by one materialised scale before the other passes through inf.
+
+    frexp gives the exponent on device, avoiding the `.item()` host read that would sync and
+    break torch.compile(fullgraph = True). frexp returns m = mantissa * 2**exp with mantissa in
+    [0.5, 1), so floor(log2(m)) == exp - 1.
     """
     if x.numel() == 0:
         return torch.zeros((), device = x.device, dtype = torch.int32)

--- a/unsloth_zoo/fp16_emulation.py
+++ b/unsloth_zoo/fp16_emulation.py
@@ -70,6 +70,17 @@ T4 itself measured 9.06e-7 against IEEE 2.61e-7, i.e. 3.5x IEEE rather than the 
 B200, still 324x better than plain float16. That B200/T4 gap is unexplained; plausibly
 different tensor-core accumulate behaviour, but that is a guess and is recorded as one.
 
+torch.compile. `fp16_split_mm` compiles fullgraph and compiling it is worth 1.5-2.2x (B200,
+torch 2.14), which turns square-4096 from 1.24x into 3.25x against float32. Two things had to
+change to get there, both load-bearing:
+
+  - the scale must not call `.item()`, which syncs and breaks fullgraph. `pow2_scale_tensor`
+    uses frexp instead and returns the identical number.
+  - the float16 rounding must go through an opaque custom op. Inductor otherwise fuses
+    `.to(float16).to(float32)` away, leaving a residual of exactly 0, so the split silently
+    stops existing and lands at plain-float16 error while running faster. Guarded by
+    test_compiled_keeps_float32_accuracy.
+
 So: numerically sound, not currently worth enabling. Kept for the case where a large
 float32 GEMM appears on hardware without bfloat16 tensor cores.
 """
@@ -84,6 +95,7 @@ import torch
 __all__ = [
     "fp16_emulation_enabled",
     "pow2_scale",
+    "pow2_scale_tensor",
     "split_terms",
     "fp16_split_mm",
     "fp16_split_matmul",
@@ -128,6 +140,9 @@ def pow2_scale(x: torch.Tensor, target_exp: int = 14) -> float:
     A power of two is exact in binary floating point, so the scaling contributes no error of
     its own. That matters when the entire purpose is to measure error. target_exp = 14 puts
     the maximum an octave below the float16 ceiling of 65504.
+
+    Returns a Python float, so it syncs. `pow2_scale_tensor` is the torch.compile-safe form;
+    this one is kept because it is the readable definition and is what the tests assert on.
     """
     m = x.abs().max().item()
     if m == 0 or not math.isfinite(m):
@@ -135,11 +150,45 @@ def pow2_scale(x: torch.Tensor, target_exp: int = 14) -> float:
     return 2.0 ** (target_exp - math.floor(math.log2(m)))
 
 
+def pow2_scale_tensor(x: torch.Tensor, target_exp: int = 14) -> torch.Tensor:
+    """`pow2_scale` without the host sync, returning a 0-dim tensor.
+
+    `.item()` is a data-dependent host read: it forces a device sync, and under
+    torch.compile(fullgraph = True) it is a hard error ("could not guard on data-dependent
+    expression"). frexp gives the exponent on device instead. frexp returns
+    m = mantissa * 2**exp with mantissa in [0.5, 1), so floor(log2(m)) == exp - 1.
+    """
+    m = x.abs().max()
+    _, exp = torch.frexp(m)
+    scale = torch.exp2((target_exp - (exp - 1)).float())
+    return torch.where(torch.isfinite(m) & (m > 0), scale, torch.ones_like(scale))
+
+
+# Rounding to low precision has to survive Inductor, and by default it does not: it fuses
+# `x.to(float16).to(float32)` into a no-op, keeping the value in a float32 register and never
+# rounding. The residual is then exactly 0, the low term vanishes and the split silently
+# degrades to a plain float16 matmul, measured at 2.93e-04 against eager's 4.86e-06 while
+# looking 5.8x faster. An opaque custom op is the barrier that forces a real round trip.
+_HAS_CUSTOM_OP = hasattr(torch.library, "custom_op")
+
+if _HAS_CUSTOM_OP:
+    @torch.library.custom_op("unsloth_zoo::fp16_emulation_round", mutates_args = ())
+    def _round_to(x: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+        return x.to(dtype)
+
+    @_round_to.register_fake
+    def _(x, dtype):
+        return torch.empty_like(x, dtype = dtype)
+else:
+    def _round_to(x: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+        return x.to(dtype)
+
+
 def split_terms(x: torch.Tensor, dtype: torch.dtype, terms: int) -> list:
     """Split a float32 tensor into `terms` low-precision terms, residual by residual."""
     out, residual = [], x
     for _ in range(terms):
-        head = residual.to(dtype)
+        head = _round_to(residual, dtype)
         out.append(head)
         residual = residual - head.float()
     return out
@@ -168,8 +217,9 @@ def fp16_split_mm(
         raise ValueError(f"products={products} exceeds terms*terms={terms * terms}")
 
     A32, B32 = A.float(), B.float()
-    sA = pow2_scale(A32) if scale else 1.0
-    sB = pow2_scale(B32) if scale else 1.0
+    one = torch.ones((), device = A32.device, dtype = torch.float32)
+    sA = pow2_scale_tensor(A32) if scale else one
+    sB = pow2_scale_tensor(B32) if scale else one
     a_terms = split_terms(A32 * sA, dtype, terms)
     b_terms = split_terms(B32 * sB, dtype, terms)
 

--- a/unsloth_zoo/fp16_emulation.py
+++ b/unsloth_zoo/fp16_emulation.py
@@ -156,7 +156,9 @@ def _mm_f32_accumulate(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     The fallback is numerically equivalent for this use because the operands are already
     exactly representable in the low precision, so widening them loses nothing.
     """
-    if _has_out_dtype() and a.is_cuda:
+    # Device first: probing allocates a CUDA tensor and initialises a CUDA context, which a
+    # CPU-only call must not pay for, least of all in a forked worker that cannot touch CUDA.
+    if a.is_cuda and _has_out_dtype():
         return torch.mm(a, b, out_dtype = torch.float32)
     return _mm_float32(a, b)
 
@@ -185,12 +187,24 @@ def pow2_scale_tensor(x: torch.Tensor, target_exp: int = 14) -> torch.Tensor:
     expression"). frexp gives the exponent on device instead. frexp returns
     m = mantissa * 2**exp with mantissa in [0.5, 1), so floor(log2(m)) == exp - 1.
     """
+    return torch.exp2(pow2_exponent(x, target_exp).float())
+
+
+def pow2_exponent(x: torch.Tensor, target_exp: int = 14) -> torch.Tensor:
+    """The exponent n behind `pow2_scale_tensor`, i.e. the scale is 2**n.
+
+    Carried as an exponent rather than a scale so the scaling and its inverse can be applied
+    with ldexp, which cannot overflow on the way to a representable answer. Materialising 2**n
+    breaks in both directions: 2**n itself overflows float32 below about 2**-113, and for a
+    large-times-small pair like 2**114 @ 2**-113 (which is just 2.0) dividing by one scale
+    before the other passes through inf.
+    """
     if x.numel() == 0:
-        return torch.ones((), device = x.device, dtype = torch.float32)
+        return torch.zeros((), device = x.device, dtype = torch.int32)
     m = x.abs().max()
     _, exp = torch.frexp(m)
-    scale = torch.exp2((target_exp - (exp - 1)).float())
-    return torch.where(torch.isfinite(m) & (m > 0), scale, torch.ones_like(scale))
+    n = target_exp - (exp - 1)
+    return torch.where(torch.isfinite(m) & (m > 0), n, torch.zeros_like(n))
 
 
 # Rounding to low precision has to survive Inductor, and by default it does not: it fuses
@@ -223,20 +237,31 @@ def split_terms(x: torch.Tensor, dtype: torch.dtype, terms: int) -> list:
     return out
 
 
-# hi/lo window in which BOTH split terms stay normal in float16. The high term lands at
-# 2**target_exp = 2**14 and the low term sits about 2**-11 below it, so an entry more than
-# 2**28 under the maximum has already fallen through float16's normal floor.
+# hi/lo window beyond which the smallest entries lose their second term entirely and the
+# split degrades to plain float16 for them.
+#
+# This is deliberately a catastrophe guard, not a precision guard. Reserving the ~11 bits the
+# residual needs would put the limit at 2**17, but ordinary tensors exceed that routinely --
+# randn(256) * 0.02 measures 2**23.9, randn(4096) * 0.02 measures 2**24.4 -- because a matrix
+# only needs one near-zero entry to blow up hi/lo. At 2**17 the guard fires on the exact
+# workload this module is for and silently replaces the emulation with float32 mm.
+#
+# What is left is a real limitation of per-tensor scaling, recorded rather than papered over:
+# an output element that depends only on entries far below the tensor maximum can carry much
+# larger relative error than the aggregate figures in the docstring. diag([a, b*2**-27])
+# against its reciprocal returns 0.999844 rather than 1.0. Per-row or per-block scaling is the
+# fix if that case ever matters; a tighter global limit is not.
 _SPLIT_RANGE_LIMIT = 2.0 ** 28
 
 
-def _split_can_represent(x: torch.Tensor, s: torch.Tensor) -> bool:
+def _split_can_represent(x: torch.Tensor) -> bool:
     """Whether one per-tensor power-of-two scale can actually carry this operand.
 
-    Three ways the split silently returns something wrong, all of which plain float32 mm gets
+    Two ways the split silently returns something wrong, both of which plain float32 mm gets
     right: a non-finite entry, whose residual computes inf - inf and poisons everything to NaN;
-    a magnitude so small the scale itself overflows float32; and a within-tensor dynamic range
-    wider than float16's normal window, which rounds the small entries to zero. A single scale
-    taken from the maximum cannot serve the last case at all.
+    and a within-tensor dynamic range wider than the window above, which leaves the small
+    entries' residuals subnormal or zero. A single scale taken from the maximum cannot serve
+    the second case at all.
 
     Reads tensor values, so it syncs and is skipped under torch.compile, where a host read
     breaks the graph. The compiled path is for the ordinary finite, normal-range operands the
@@ -246,7 +271,7 @@ def _split_can_represent(x: torch.Tensor, s: torch.Tensor) -> bool:
         return True
     absx = x.abs()
     hi = absx.max()
-    if not bool(torch.isfinite(hi)) or not bool(torch.isfinite(s)):
+    if not bool(torch.isfinite(hi)):
         return False
     lo = torch.where(absx == 0, torch.full_like(absx, float("inf")), absx).min()
     if not bool(torch.isfinite(lo)):
@@ -284,23 +309,24 @@ def fp16_split_mm(
     if A32.numel() == 0 or B32.numel() == 0:
         return _mm_float32(A32, B32)
 
-    one = torch.ones((), device = A32.device, dtype = torch.float32)
-    sA = pow2_scale_tensor(A32) if scale else one
-    sB = pow2_scale_tensor(B32) if scale else one
-    if not _split_can_represent(A32, sA) or not _split_can_represent(B32, sB):
+    if not _split_can_represent(A32) or not _split_can_represent(B32):
         return _mm_float32(A32, B32)
 
-    a_terms = split_terms(A32 * sA, dtype, terms)
-    b_terms = split_terms(B32 * sB, dtype, terms)
+    zero = torch.zeros((), device = A32.device, dtype = torch.int32)
+    eA = pow2_exponent(A32) if scale else zero
+    eB = pow2_exponent(B32) if scale else zero
+    a_terms = split_terms(torch.ldexp(A32, eA), dtype, terms)
+    b_terms = split_terms(torch.ldexp(B32, eB), dtype, terms)
 
     pairs = sorted(itertools.product(range(terms), repeat = 2), key = lambda ij: ij[0] + ij[1])
     acc = None
     for i, j in pairs[:products]:
         part = _mm_f32_accumulate(a_terms[i], b_terms[j])
         acc = part if acc is None else acc + part
-    # Divided one scale at a time: sA * sB overflows to inf for two individually representable
-    # small operands (2**-55 each gives 2**69 apiece), which would zero a good result.
-    return acc / sA / sB
+    # One ldexp with the combined exponent. Neither sA * sB nor a division per scale works: the
+    # product overflows for two small operands, and dividing in either order passes through inf
+    # for a large-times-small pair whose answer is perfectly representable.
+    return torch.ldexp(acc, -(eA + eB))
 
 
 class _FP16SplitMatmul(torch.autograd.Function):

--- a/unsloth_zoo/fp16_emulation.py
+++ b/unsloth_zoo/fp16_emulation.py
@@ -1,0 +1,223 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Emulate float32 matmul accuracy using split float16 terms.
+
+NOT ENABLED ANYWHERE. Nothing in Unsloth calls this module, and importing it changes no
+behaviour. It is kept because it is correct and measured, so a future workload that needs
+float32-accuracy matmuls on hardware without bfloat16 tensor cores can switch it on rather
+than rediscover it. Enable explicitly with UNSLOTH_FP16_EMULATION=1, or just call
+`fp16_split_mm` directly.
+
+Background. pytorch/pytorch#195301 added `fp32_precision="bfx9"`: split each float32
+operand into three bfloat16 terms and accumulate nine bfloat16 tensor-core products in
+float32. That works because bfloat16 has 8 significand bits (3 terms covers float32's 24)
+AND 8 exponent bits, the same range as float32, so the split is lossless across the whole
+dynamic range.
+
+Porting it to float16 is not a relabel, because float16 has 11 significand bits but only 5
+exponent bits:
+
+  - 2 terms give about 22 bits, 2 short of float32. 3 terms give 33, which is wasteful.
+  - Normal float16 spans [6.104e-5, 65504]. In a 2-term split the low term is about 2^-11
+    of the high term, so both stay normal only for |x| in [0.125, 65504], roughly 19 binary
+    decades against float32's 277.
+
+Typical LLM weights and activations live at 1e-3 to 1e-1, which is BELOW that floor, so the
+low term underflows to subnormal or zero and the split silently degrades to plain float16
+while still costing three matmuls. Power-of-two per-tensor scaling is therefore not an
+optimisation here, it is load-bearing. `scale = False` exists so the failure can be shown
+rather than asserted.
+
+Measured, B200, median relative L2 against a float64 reference over a magnitude sweep:
+
+    method                    1e-6      1e-3       0.1       1.0       1e3
+    float32 IEEE            2.12e-7   2.11e-7   2.11e-7   2.11e-7   2.12e-7
+    fp16x2 3-product scaled 2.16e-7   2.17e-7   2.17e-7   2.17e-7   2.17e-7
+    fp16x2 3-product plain  2.44e-2   2.43e-5   3.22e-7   2.18e-7   2.17e-7
+    float16 direct          2.44e-2   2.93e-4   2.94e-4   2.93e-4   2.94e-4
+
+Scaled, it holds IEEE parity across six orders of magnitude, including on an outlier-heavy
+distribution. Unscaled at 1e-6 it is bit-identical to plain float16: the low term has fully
+underflowed and the split has ceased to exist. The rig was validated with a bf16x3 9-product
+control at 0.9x IEEE, reproducing the relationship the upstream PR published.
+
+Why it is off. On a real T4 (Kaggle T4x2, torch 2.10+cu128, sm75) the emulation only pays on
+large square GEMMs, and loses badly on the small ones that dominate a QLoRA step:
+
+    shape          float32    float16      fp16x2 3-product
+    square-4096    33.54 ms   6.74 ms      27.13 ms   (1.24x vs float32)
+    square-2048     4.40 ms   0.91 ms       4.69 ms   (0.94x)
+    gemma3-QK^T     0.46 ms   0.19 ms       1.33 ms   (0.35x)
+    gemma3-PV       0.41 ms   0.23 ms       1.73 ms   (0.24x)
+
+and in a stock T4 QLoRA step every GEMM is already float16-in, so there is nothing to
+accelerate: NF4 dequant plus base projection, the LoRA addmm, the lm_head, and attention.
+The one genuine float32 target, Gemma3/Gemma4 attention under UNSLOTH_FORCE_FLOAT32, is
+exactly the small-shape regime where this is 3-4x SLOWER than plain float32. Accuracy on the
+T4 itself measured 9.06e-7 against IEEE 2.61e-7, i.e. 3.5x IEEE rather than the 1.0x seen on
+B200, still 324x better than plain float16. That B200/T4 gap is unexplained; plausibly
+different tensor-core accumulate behaviour, but that is a guess and is recorded as one.
+
+So: numerically sound, not currently worth enabling. Kept for the case where a large
+float32 GEMM appears on hardware without bfloat16 tensor cores.
+"""
+from __future__ import annotations
+
+import itertools
+import math
+import os
+
+import torch
+
+__all__ = [
+    "fp16_emulation_enabled",
+    "pow2_scale",
+    "split_terms",
+    "fp16_split_mm",
+    "fp16_split_matmul",
+]
+
+
+def fp16_emulation_enabled() -> bool:
+    """Opt-in switch. Default off; nothing in Unsloth consults this today."""
+    return os.environ.get("UNSLOTH_FP16_EMULATION", "0") == "1"
+
+
+_HAS_OUT_DTYPE = None
+
+
+def _has_out_dtype() -> bool:
+    """torch.mm(..., out_dtype = ) landed in torch 2.8. Probed once, not assumed."""
+    global _HAS_OUT_DTYPE
+    if _HAS_OUT_DTYPE is None:
+        try:
+            zero = torch.zeros(1, 1, dtype = torch.float16)
+            torch.mm(zero, zero, out_dtype = torch.float32)
+            _HAS_OUT_DTYPE = True
+        except (TypeError, RuntimeError):
+            _HAS_OUT_DTYPE = False
+    return _HAS_OUT_DTYPE
+
+
+def _mm_f32_accumulate(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Low-precision inputs with float32 accumulate, which is what a tensor core does.
+
+    The fallback is numerically equivalent for this use because the operands are already
+    exactly representable in the low precision, so widening them loses nothing.
+    """
+    if _has_out_dtype() and a.is_cuda:
+        return torch.mm(a, b, out_dtype = torch.float32)
+    return torch.mm(a.float(), b.float())
+
+
+def pow2_scale(x: torch.Tensor, target_exp: int = 14) -> float:
+    """Power-of-two scale bringing max|x| to about 2**target_exp.
+
+    A power of two is exact in binary floating point, so the scaling contributes no error of
+    its own. That matters when the entire purpose is to measure error. target_exp = 14 puts
+    the maximum an octave below the float16 ceiling of 65504.
+    """
+    m = x.abs().max().item()
+    if m == 0 or not math.isfinite(m):
+        return 1.0
+    return 2.0 ** (target_exp - math.floor(math.log2(m)))
+
+
+def split_terms(x: torch.Tensor, dtype: torch.dtype, terms: int) -> list:
+    """Split a float32 tensor into `terms` low-precision terms, residual by residual."""
+    out, residual = [], x
+    for _ in range(terms):
+        head = residual.to(dtype)
+        out.append(head)
+        residual = residual - head.float()
+    return out
+
+
+def fp16_split_mm(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    dtype: torch.dtype = torch.float16,
+    terms: int = 2,
+    products: int = 3,
+    scale: bool = True,
+) -> torch.Tensor:
+    """Split-term emulation of a float32 matmul. Returns float32.
+
+    `products` keeps only the most significant cross terms: for a 2-term split, 3 products
+    means hi*hi + hi*lo + lo*hi and drops the negligible lo*lo. Terms are ordered by
+    term-index sum, which tracks magnitude.
+
+    On float16, `scale` must stay True for any tensor whose magnitudes fall below 0.125,
+    which is nearly all LLM weights and activations. See the module docstring.
+    """
+    if A.ndim != 2 or B.ndim != 2:
+        raise ValueError(f"fp16_split_mm expects 2D operands, got {A.shape} and {B.shape}")
+    if products > terms * terms:
+        raise ValueError(f"products={products} exceeds terms*terms={terms * terms}")
+
+    A32, B32 = A.float(), B.float()
+    sA = pow2_scale(A32) if scale else 1.0
+    sB = pow2_scale(B32) if scale else 1.0
+    a_terms = split_terms(A32 * sA, dtype, terms)
+    b_terms = split_terms(B32 * sB, dtype, terms)
+
+    pairs = sorted(itertools.product(range(terms), repeat = 2), key = lambda ij: ij[0] + ij[1])
+    acc = None
+    for i, j in pairs[:products]:
+        part = _mm_f32_accumulate(a_terms[i], b_terms[j])
+        acc = part if acc is None else acc + part
+    return acc / (sA * sB)
+
+
+class _FP16SplitMatmul(torch.autograd.Function):
+    """Autograd wrapper so the emulation can stand in for a float32 matmul in training.
+
+    Both input gradients are emulated the same way, keeping the backward at the same
+    accuracy as the forward rather than silently dropping to plain float16.
+    """
+    @staticmethod
+    def forward(ctx, A, B, dtype, terms, products, scale):
+        ctx.save_for_backward(A, B)
+        ctx.config = (dtype, terms, products, scale)
+        return fp16_split_mm(A, B, dtype, terms, products, scale)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        A, B = ctx.saved_tensors
+        dtype, terms, products, scale = ctx.config
+        grad_A = grad_B = None
+        if ctx.needs_input_grad[0]:
+            grad_A = fp16_split_mm(
+                grad_output.contiguous(), B.t().contiguous(), dtype, terms, products, scale,
+            ).to(A.dtype)
+        if ctx.needs_input_grad[1]:
+            grad_B = fp16_split_mm(
+                A.t().contiguous(), grad_output.contiguous(), dtype, terms, products, scale,
+            ).to(B.dtype)
+        return grad_A, grad_B, None, None, None, None
+    pass
+pass
+
+
+def fp16_split_matmul(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    dtype: torch.dtype = torch.float16,
+    terms: int = 2,
+    products: int = 3,
+    scale: bool = True,
+) -> torch.Tensor:
+    """Differentiable form of `fp16_split_mm`."""
+    return _FP16SplitMatmul.apply(A, B, dtype, terms, products, scale)


### PR DESCRIPTION
Adds `unsloth_zoo/fp16_emulation.py`. Nothing calls it, importing it changes no behaviour, and it is off unless `UNSLOTH_FP16_EMULATION=1` or the functions are called directly. It is here so a future workload that needs float32-accuracy matmuls without bfloat16 tensor cores can switch it on rather than rediscover it.

## What it is

pytorch/pytorch#195301 added `fp32_precision="bfx9"`: split each float32 operand into three bfloat16 terms and accumulate nine bfloat16 tensor-core products in float32. This is the float16 port.

It is not a relabel. bfloat16 carries float32's 8 exponent bits, so the split is lossless across the whole dynamic range. float16 has 5:

- 2 terms give about 22 bits, 2 short of float32. 3 terms give 33, which is wasteful.
- Normal float16 spans [6.104e-5, 65504]. In a 2-term split the low term is about 2^-11 of the high term, so both stay normal only for `|x|` in [0.125, 65504], roughly 19 binary decades against float32's 277.

Typical weights and activations sit at 1e-3 to 1e-1, which is **below** that floor. The low term underflows and the split silently degrades to plain float16 while still paying for three matmuls. Power-of-two per-tensor scaling is therefore load-bearing, not an optimisation, and `scale = False` is kept so the failure can be demonstrated rather than asserted.

## Accuracy

B200, median relative L2 against a float64 reference computed from the same float32 inputs:

| method | 1e-6 | 1e-3 | 0.1 | 1.0 | 1e3 |
|---|---|---|---|---|---|
| float32 IEEE | 2.12e-7 | 2.11e-7 | 2.11e-7 | 2.11e-7 | 2.12e-7 |
| fp16x2 3-product, scaled | 2.16e-7 | 2.17e-7 | 2.17e-7 | 2.17e-7 | 2.17e-7 |
| fp16x2 3-product, unscaled | 2.44e-2 | 2.43e-5 | 3.22e-7 | 2.18e-7 | 2.17e-7 |
| float16 direct | 2.44e-2 | 2.93e-4 | 2.94e-4 | 2.93e-4 | 2.94e-4 |

Scaled, it holds IEEE parity across six orders of magnitude and on an outlier-heavy distribution. Unscaled at 1e-6 it is indistinguishable from plain float16: the low term has fully underflowed and the split has ceased to exist. The rig was validated with a bf16x3 9-product control at 0.9x IEEE, reproducing the relationship the upstream PR published.

## Why it is not enabled

On a real T4 (Kaggle T4x2, sm75) it only pays on large square GEMMs:

| shape | float32 | float16 | fp16x2 3-product |
|---|---|---|---|
| square-4096 | 33.54 ms | 6.74 ms | 27.13 ms (1.24x vs float32) |
| square-2048 | 4.40 ms | 0.91 ms | 4.69 ms (0.94x) |
| gemma3 QK^T | 0.46 ms | 0.19 ms | 1.33 ms (0.35x) |
| gemma3 PV | 0.41 ms | 0.23 ms | 1.73 ms (0.24x) |

An earlier FLOP-ratio estimate of 2.67x was wrong: measured float16:float32 on a T4 is about 5x rather than 8x, and the split adds four elementwise passes, two `abs().max()` reductions, three launches and two `[M, N]` adds.

More to the point, a stock T4 QLoRA step is already float16-in at every GEMM (NF4 dequant plus base projection, the LoRA addmm, the lm_head, attention), so there is nothing to accelerate. The one genuine float32 target, Gemma3/Gemma4 attention under `UNSLOTH_FORCE_FLOAT32`, forced precisely on GPUs without bfloat16, is exactly the small-shape regime where this is 3-4x slower than plain float32.

One thing I cannot explain and have recorded as unexplained: accuracy measured on the T4 itself is 9.06e-7 against IEEE 2.61e-7, i.e. 3.5x IEEE rather than the 1.0x seen on B200. Still 324x better than plain float16. Plausibly different tensor-core accumulate behaviour, but that is a guess.

## Tests

14 tests. The one that matters is `test_unscaled_underflows_at_small_magnitude`: an implementation that quietly stopped splitting would still pass an accuracy test run at magnitude 1.0, so the test asserts the cliff is present and that the unscaled split degrades to exactly plain float16. `test_bf16_control_reproduces_upstream_relationship` validates the rig against the scheme that is known to work.

Note the float16 baseline in the tests is float16 operands with float32 accumulate, which is what a tensor core does. `torch.mm(A.half(), B.half())` also accumulates in float16 and is a different, much worse baseline.
