### PR TITLE
fix(mlx): complete text-model routing and cache-free training

### DIFF
--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -109,6 +109,22 @@ class _VLMOnlyClass:
     """Stands in for a class only mlx-vlm ships; routing never calls it."""
 
 
+def test_vlm_only_text_routing_checks_remapped_module_presence(monkeypatch):
+    import unsloth_zoo.mlx.loader as loader
+
+    monkeypatch.setattr(loader, "_mlx_lm_module_name", lambda _: "remapped")
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: _VLMOnlyClass)
+    seen = []
+    monkeypatch.setattr(loader.importlib.util, "find_spec", lambda name: seen.append(name))
+    assert loader._mlx_vlm_only_text_model({"model_type": "alias"}, "alias")
+    assert seen == ["mlx_lm.models.remapped"]
+    monkeypatch.setattr(loader.importlib.util, "find_spec", lambda _: object())
+    assert not loader._mlx_vlm_only_text_model({"model_type": "alias"}, "alias")
+    monkeypatch.setattr(loader.importlib.util, "find_spec", lambda _: None)
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: None)
+    assert not loader._mlx_vlm_only_text_model({"model_type": "absent"}, "absent")
+
+
 def test_text_only_vlm_load_stays_on_vlm_path_when_mlx_lm_has_no_model(monkeypatch):
     import unsloth_zoo.mlx.loader as loader
 
@@ -354,6 +370,7 @@ def test_from_pretrained_distributed_vlm_forwards_normalized_override(monkeypatc
         "install_mlx_compile_patches", "_ensure_vlm_processor_inputs_patched",
         "_ensure_vlm_prompt_utils_patched", "_convert_mlx_dtype",
         "_patch_mixed_precision_set_dtype", "_ensure_minicpmo_mlx_sanitize",
+        "_ensure_native_vlm_weight_names",
         "_ensure_minicpmo_vision_dtype", "_fix_gemma4_kv_sharing",
         "_fix_gemma3_vision_post_layernorm_eps", "_fix_gemma3_vision_attention_fp32_sdpa",
         "_fix_gemma3_vision_encoder_fp32_layernorm", "_fix_gemma3_vision_post_layernorm_fp32",

--- a/tests/test_mlx_gguf_moe_export_metal.py
+++ b/tests/test_mlx_gguf_moe_export_metal.py
@@ -38,6 +38,52 @@ CONFIG = dict(
 )
 
 
+@metal_only
+def test_native_name_sanitizer_preserves_vlm_expert_export(monkeypatch, tmp_path):
+    import inspect
+    from types import SimpleNamespace
+    import mlx.nn as nn
+    from mlx_vlm.models.qwen3_5_moe.qwen3_5_moe import Model
+    from mlx_vlm.models.llava_onevision.llava_onevision import Model as StaticModel
+    from unsloth_zoo.mlx import loader, utils
+
+    model = Model.__new__(Model)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(text_config=SimpleNamespace(
+        tie_word_embeddings=False, num_hidden_layers=2, num_experts=2,
+    ))
+    source = {}
+    for layer in range(2):
+        prefix = f"model.language_model.layers.{layer}.mlp.experts"
+        source[f"{prefix}.gate_up_proj"] = mx.arange(48).reshape(2, 6, 4).astype(mx.float32) + layer * 100
+        source[f"{prefix}.down_proj"] = mx.arange(24).reshape(2, 4, 3).astype(mx.float32) + layer * 100
+    staged = model.sanitize(dict(source))
+    static_model = StaticModel.__new__(StaticModel)
+    owners = [model, static_model]
+    vocabulary = set(utils._mlx_sanitizer_vocabulary(owners))
+    def exported(directory):
+        directory.mkdir()
+        mx.save_safetensors(str(directory / "model.safetensors"), staged)
+        assert utils._prepare_moe_gguf_export_directory(directory, model=model) > 0
+        return mx.load(str(directory / "model.safetensors"))
+
+    expected = exported(tmp_path / "before")
+    assert any(name.endswith("experts.gate_up_proj") for name in expected)
+
+    monkeypatch.setattr(Model, "sanitize", Model.sanitize)
+    monkeypatch.setattr(StaticModel, "sanitize", inspect.getattr_static(StaticModel, "sanitize"))
+    loader._ensure_native_vlm_weight_names("qwen3_5_moe")
+    loader._ensure_native_vlm_weight_names("llava_onevision")
+    for order in (owners, owners[::-1]):
+        assert vocabulary == set(utils._mlx_sanitizer_vocabulary(order))
+    assert utils._mlx_sanitizer_writes_in_place(utils._mlx_moe_sanitizers(model)[0])
+    actual = exported(tmp_path / "after")
+    assert actual.keys() == expected.keys()
+    for name in actual:
+        assert mx.array_equal(actual[name], expected[name]).item()
+        assert mx.array_equal(actual[name], source[name]).item()
+
+
 def _stage_merged_moe_model(path, shards=1):
     from mlx_lm.models import qwen3_moe
 

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -43,6 +43,138 @@ if _METAL:
 MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
 
 
+@metal_only
+@pytest.mark.parametrize("family", ["qwen2_vl", "glm4v"])
+def test_cacheless_text_positions_match_language_wrapper(family):
+    import importlib
+    from types import SimpleNamespace
+
+    configs = importlib.import_module(f"mlx_vlm.models.{family}.config")
+    language = importlib.import_module(f"mlx_vlm.models.{family}.language")
+    args = configs.TextConfig.from_dict(dict(
+        model_type=family, hidden_size=512, num_hidden_layers=2,
+        intermediate_size=128, num_attention_heads=4, num_key_value_heads=2,
+        rms_norm_eps=1e-5, vocab_size=32, max_position_embeddings=128,
+        rope_scaling={"type": "default", "rope_type": "default",
+                      "mrope_section": [8, 12, 12] if family == "glm4v" else [16, 24, 24]},
+    ))
+    config = SimpleNamespace(vision_config=SimpleNamespace(spatial_merge_size=2),
+                             image_token_id=40, video_token_id=41, vision_start_token_id=42)
+    lm = language.LanguageModel(args, config)
+    for rows in ([[2, 3, 4], [5, 6, 7]], [[7, 6], [4, 3]], [[2, 3, 4], [5, 6, 8]]):
+        inputs = mx.array(rows)
+        positions, _ = lm.get_rope_index(inputs)
+        expected = mlx_utils._model_logits(lm(inputs, position_ids=positions))
+        lm._position_ids = mx.full((3, 1, 1), 97)
+        hidden = mlx_utils._forward_text_hidden_states(lm, inputs)
+        actual = lm.lm_head(hidden)
+        mx.eval(actual, expected)
+        assert mx.allclose(actual, expected, atol=1e-5).item()
+        assert lm._position_ids.shape == (3, 1, 1)
+        explicit = positions + mx.array([0, 1, 2])[:, None, None]
+        expected_hidden = lm.model(inputs, position_ids=explicit)
+        actual_hidden = mlx_utils._forward_text_hidden_states(lm, inputs, position_ids=explicit)
+        assert mx.array_equal(actual_hidden, expected_hidden).item()
+
+
+@metal_only
+def test_cached_position_attribute_does_not_imply_multiaxis_rope():
+    from mlx_vlm.models.minimax_m3_vl.config import TextConfig
+    from mlx_vlm.models.minimax_m3_vl.language import LanguageModel
+
+    args = TextConfig(hidden_size=64, intermediate_size=64, dense_intermediate_size=128,
+                      num_hidden_layers=2, num_attention_heads=2, num_key_value_heads=1,
+                      head_dim=32, vocab_size=32, num_local_experts=2, num_experts_per_tok=1,
+                      shared_intermediate_size=64, moe_layer_freq=[0, 0])
+    lm = LanguageModel(args)
+    inputs = mx.array([[2, 3, 4], [5, 6, 7]])
+    expected = lm(inputs).logits
+    actual = lm.lm_head(mlx_utils._forward_text_hidden_states(lm, inputs))
+    assert mx.allclose(actual, expected, atol=1e-5).item()
+
+
+@metal_only
+@pytest.mark.parametrize("static", [False, True])
+def test_native_vlm_names_preserve_source_remaps_and_transforms(monkeypatch, static):
+    import inspect
+    from unsloth_zoo.mlx import loader
+
+    class RenamingModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Linear(3, 3)
+            self.other = nn.Linear(3, 3)
+
+    def sanitize(weights):
+        return {
+            ("decoder." + k if k.startswith("decoder.") else k.replace("source.", "other.")):
+            (v.T if k == "decoder.bias" else v)
+            for k, v in weights.items()
+        }
+
+    RenamingModel.sanitize = staticmethod(sanitize) if static else lambda self, weights: sanitize(weights)
+
+    original_class_call = RenamingModel.sanitize
+    original_signature = inspect.signature(RenamingModel().sanitize)
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: RenamingModel)
+    loader._ensure_native_vlm_weight_names("arbitrary")
+    loader._ensure_native_vlm_weight_names("arbitrary")
+    model = RenamingModel()
+    assert RenamingModel.sanitize is original_class_call
+    assert inspect.signature(model.sanitize) == original_signature
+    weights = {"decoder.weight": mx.ones((3, 3)), "source.weight": mx.zeros((3, 3)),
+               "decoder.scales": mx.ones((3, 1)), "decoder.biases": mx.zeros((3, 1)),
+               "unknown.weight": mx.ones((2, 2)), "decoder.bias": mx.ones((3,))}
+    result = model.sanitize(weights)
+    assert result["decoder.weight"] is weights["decoder.weight"]
+    for key in ("decoder.scales", "decoder.biases"):
+        assert result[key] is weights[key]
+    assert result["other.weight"] is weights["source.weight"]
+    assert result["unknown.weight"] is weights["unknown.weight"]
+    assert "decoder.decoder.bias" in result
+    assert "decoder.bias" not in result
+    if static:
+        assert RenamingModel.sanitize(weights).keys() == sanitize(weights).keys()
+        assert mlx_utils._call_mlx_vlm_sanitize(RenamingModel, {}, weights).keys() == sanitize(weights).keys()
+
+
+@metal_only
+@pytest.mark.parametrize("per_layer", [False, True])
+def test_recurrent_language_layers_receive_one_adapter_each(per_layer):
+    from unsloth_zoo.mlx.loader import linear_to_lora_layers
+    from mlx_lm.tuner.lora import LoRALinear
+
+    class Layer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = nn.Linear(4, 4, bias=False)
+            self.v_proj = nn.Linear(4, 4, bias=False)
+
+    class RecurrentModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.low, self.high = Layer(), Layer()
+
+        @property
+        def layers(self):
+            return [self.low, self.low, self.high, self.low, self.high]
+
+    model = RecurrentModel()
+    config = dict(keys=["q_proj"], rank=2, scale=2, dropout=0)
+    if per_layer:
+        config.update(keys=["q_proj", "v_proj"],
+                      layer_keys=[["q_proj"], ["q_proj"], ["v_proj"], ["q_proj"], ["v_proj"]])
+    assert linear_to_lora_layers(model, 5, config) == 2
+    assert isinstance(model.low.q_proj, LoRALinear)
+    if per_layer:
+        assert isinstance(model.high.v_proj, LoRALinear)
+        assert not isinstance(model.high.q_proj, LoRALinear)
+        assert not isinstance(model.low.v_proj, LoRALinear)
+    else:
+        assert isinstance(model.high.q_proj, LoRALinear)
+        assert model.low.q_proj is not model.high.q_proj
+
+
 def _dataset(n=24):
     return [
         {"text": f"### Question: what is {i} plus {i}?\n### Answer: {2 * i}."}

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -318,8 +318,12 @@ def linear_to_lora_layers(model, num_layers, config):
 
     limit = max(int(num_layers), 0)
     attached = 0
+    visited = set()
     offset = max(len(layers) - limit, 0)
     for index, layer in enumerate(layers[offset:], start=offset):
+        if id(layer) in visited:
+            continue
+        visited.add(id(layer))
         wanted = (set(layer_keys[index]) | shared) if layer_keys else keys
         replacements = []
         for name, module in layer.named_modules():
@@ -2680,6 +2684,64 @@ def _prefer_vlm_loader_for_text(config: dict, model_type: str) -> bool:
         return _resolve_mlx_vlm_model_class(model_type) is not None
 
     return _has_multimodal_strip_sanitize(cls)
+
+
+def _mlx_vlm_only_text_model(config: dict, model_type: str) -> bool:
+    if _is_vlm(config) or not model_type:
+        return False
+    module_name = _mlx_lm_module_name(model_type)
+    try:
+        spec = importlib.util.find_spec(f"mlx_lm.models.{module_name}")
+    except (ImportError, ValueError):
+        return False
+    if spec is not None:
+        return False
+    return _resolve_mlx_vlm_model_class(model_type) is not None
+
+
+class _NativeVLMWeightSanitizer:
+    def __init__(self, original):
+        self.original = original
+
+    def __get__(self, model, owner):
+        sanitize = self.original.__get__(model, owner)
+        # Class calls and export inspection retain the backend's own sanitizer.
+        if model is None:
+            return sanitize
+
+        @wraps(sanitize)
+        def preserving_native_names(weights):
+            from mlx.utils import tree_flatten
+
+            native = dict(tree_flatten(model.parameters()))
+            native.update({
+                key[:-len("weight")] + suffix: None
+                for key in tuple(native) if key.endswith(".weight")
+                for suffix in ("scales", "biases")
+            })
+            sources = {}
+            for key, value in weights.items():
+                if key in native:
+                    sources.setdefault(id(value), []).append(key)
+            sanitized = sanitize(weights)
+            for key, value in list(sanitized.items()):
+                candidates = sources.get(id(value), ())
+                # Undo only unambiguous pure renames of already-native parameters.
+                if key not in native and len(candidates) == 1:
+                    original = candidates[0]
+                    if original not in sanitized:
+                        sanitized[original] = sanitized.pop(key)
+            return sanitized
+
+        return preserving_native_names
+
+
+def _ensure_native_vlm_weight_names(model_type: str) -> None:
+    cls = _resolve_mlx_vlm_model_class(model_type)
+    sanitize = inspect.getattr_static(cls, "sanitize", None)
+    if sanitize is None or isinstance(sanitize, _NativeVLMWeightSanitizer):
+        return
+    cls.sanitize = _NativeVLMWeightSanitizer(sanitize)
 
 
 def _ensure_safe_text_wrapper_sanitize(model_type: str) -> None:
@@ -8250,9 +8312,12 @@ class FastMLXModel:
         is_vlm = False
         force_vlm_text_path = bool(
             text_only is True and _prefer_vlm_loader_for_text(config_data, model_type)
+            or text_only is not False and _mlx_vlm_only_text_model(config_data, model_type)
         )
 
-        if text_only is True and not force_vlm_text_path:
+        if force_vlm_text_path:
+            is_vlm = True
+        elif text_only is True:
             is_vlm = False
         elif text_only is False:
             is_vlm = True
@@ -8298,6 +8363,7 @@ class FastMLXModel:
             _ensure_minicpmo_mlx_sanitize(model_type)
             _ensure_minicpmo_vision_dtype(model_type)
             _ensure_audio_conv_sanitize(model_type)
+            _ensure_native_vlm_weight_names(model_type)
 
             quant_state = _ensure_quantization_compatible(
                 config_data, quantization_spec, model_name,
@@ -8446,7 +8512,7 @@ class FastMLXModel:
             )
             if force_vlm_text_path:
                 print(
-                    "Unsloth: text_only=True requested for a multimodal wrapper; "
+                    "Unsloth: Loading a text model through mlx-vlm; "
                     "keeping the model on the mlx-vlm path and returning its tokenizer."
                 )
                 _mark_text_only_vlm(model, model_type)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1391,6 +1391,25 @@ def _forward_text_hidden_states(model, inputs, inputs_embeds=None, **kwargs):
         if "attention_mask_4d" in kwargs and "mask" not in kwargs:
             kwargs["mask"] = kwargs.pop("attention_mask_4d")
         backbone_kwargs = _filter_backbone_kwargs(backbone, kwargs)
+        rope_args = getattr(tm, "args", getattr(backbone, "config", None))
+        rope_config = (
+            _config_get(rope_args, "rope_parameters")
+            or _config_get(rope_args, "rope_scaling")
+        )
+        if (
+            inputs_embeds is None
+            and backbone_kwargs.get("position_ids") is None
+            and backbone_kwargs.get("cache") is None
+            and hasattr(tm, "_position_ids")
+            and _config_get(rope_config, "mrope_section") is not None
+        ):
+            # Text prefill uses identical sequential positions on all mRoPE axes.
+            position_ids = mx.broadcast_to(
+                mx.arange(inputs.shape[1]), (3, inputs.shape[0], inputs.shape[1]),
+            )
+            backbone_kwargs.update(_filter_backbone_kwargs(
+                backbone, {"position_ids": position_ids},
+            ))
         if inputs_embeds is not None:
             backbone_kwargs[embed_kwarg] = inputs_embeds
         return backbone(inputs, **backbone_kwargs)


### PR DESCRIPTION
Text-only architectures available only in mlx-vlm still failed with `Model type ... not supported` after #1147. Several supported wrappers also failed during cache-free text training, and converted Moondream3 checkpoints failed strict loading because sanitization duplicated native parameter prefixes.

This change completes those loader contracts while preserving #1147's arity and causality checks:

- Route text architectures through mlx-vlm when their remapped mlx-lm module is absent and mlx-vlm resolves the model class. Unknown architectures retain the existing unsupported-model path; an installed but broken mlx-lm module is not treated as absent.
- Supply sequential three-axis positions for cache-free text prefill when the language model declares mRoPE. The hidden-state loss bypasses the language wrapper that normally supplies those positions. Explicit positions, cached calls, and embedded multimodal inputs retain their existing paths.
- Preserve already-native parameter names when sanitization only renames an unchanged tensor to a nonexistent parameter. Source-format conversions and tensor transformations still run. A descriptor preserves original class-level sanitizer calls and export inspection.
- Attach LoRA once per selected physical layer, retaining main's per-layer target selection. HRM exposes recurrent execution entries that refer to the same physical layers.

No model-type allow-list is added. Tokenizer/processor failures and unrelated image collator/save failures remain outside this change.

Validation used materialized tiny checkpoints with the real MLX load and training paths, including adapter movement checks:

- `glm4v`, `glm4v_moe`, `glm_ocr`, `paddleocr_vl`, `qwen2_vl`, and `moondream3` now pass text-only training. The complete regression sweep preserved all 36 previous text-only passes and five intentional refusals.
- All eight mlx-vlm-only text architectures reach the correct backend: Cohere2-MoE, DeepSeek-V4, LongCat-Flash-Sparse, and HRM-Text train; LLaDA2-MoE receives the existing bidirectional-model refusal. Laguna/Mellum still encounter tokenizer configuration errors, and MiniMax-M3 encounters the processor custom-code refusal with `trust_remote_code=False`.
- Audited installed language models' cache reads; the affected decoder paths share the mRoPE prefill contract. Other apparent unguarded reads are normalized or supplied by their outer callers.
- 45 selected tests passed before rebasing, including actual GGUF expert-export equivalence and #1147 probe regressions. Seven targeted production mutations failed their corresponding tests.
- After rebasing onto current main, eight focused Metal cases, 10 loader tests, and all 55 LoRA role-selection tests pass. Mutations removing either recurrent deduplication or per-layer selection fail the strengthened regression test. All six target text-only families pass again, and HRM passes the full load/inference/default-text/text-only step set.

Tested with MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.7.0rc0, and Transformers 5.5.0. Tiny random weights validate loading and training contracts, not output quality.
