### PR TITLE
gpt-oss: stop paying for coordinate_descent_tuning to get combo kernels

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1413,22 +1413,13 @@ else:
     device_memory = 0
 use_combo_kernels = False if device_memory/1024/1024/1024 <= 40 else True
 
-# coordinate_descent_tuning used to be driven by use_combo_kernels as well, so asking for
-# combo kernels also bought the tuning. They cost very differently and were measured apart:
+# coordinate_descent_tuning used to be driven by use_combo_kernels too, so asking for combo
+# kernels also bought the tuning. Measured apart on T4/L4/A100/B200: combo kernels are free
+# (decode compile 7.36s vs 7.48s off), the tuning costs +28% on A100 and +32% on L4 decode
+# compile for no measurable gain anywhere. Default it off, opt in to re-measure.
 #
-#   flag                        compile overhead (decode)      step time / decode tok/s
-#   combo_kernels               A100 7.36s vs 7.48s off        within noise on T4/L4/A100/B200
-#   coordinate_descent_tuning   A100 9.55s (+28%)              no measurable benefit anywhere
-#                               L4   9.21s (+32%)
-#
-# So the tuning is the expensive half and had no measured payoff, on either training or
-# decode, on any of T4 16GB, L4 22GB, A100 40GB or B200 180GB. Default it off and let it be
-# turned back on explicitly for anyone who wants to re-measure.
-#
-# Note also that the 40GB test is in GiB: an A100-SXM4-40GB reports 39.49, so it falls BELOW
-# this threshold and combo kernels are off there. Left as-is because combo kernels measured
-# as no-effect on both sides of the boundary, so moving it would change nothing; recorded so
-# the next reader does not assume a 40GB card takes the combo path.
+# The 40GB test above is in GiB, so an A100-SXM4-40GB reports 39.49 and falls BELOW it.
+# Left as-is: combo kernels measured as no-effect on both sides of the boundary.
 use_coordinate_descent = os.environ.get("UNSLOTH_COORDINATE_DESCENT_TUNING", "0") == "1"
 
 fused_torch_compile_options = get_torch_compile_options(

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1412,12 +1412,31 @@ elif DEVICE_TYPE in ("cuda", "hip") and torch.cuda.is_available():
 else:
     device_memory = 0
 use_combo_kernels = False if device_memory/1024/1024/1024 <= 40 else True
+
+# coordinate_descent_tuning used to be driven by use_combo_kernels as well, so asking for
+# combo kernels also bought the tuning. They cost very differently and were measured apart:
+#
+#   flag                        compile overhead (decode)      step time / decode tok/s
+#   combo_kernels               A100 7.36s vs 7.48s off        within noise on T4/L4/A100/B200
+#   coordinate_descent_tuning   A100 9.55s (+28%)              no measurable benefit anywhere
+#                               L4   9.21s (+32%)
+#
+# So the tuning is the expensive half and had no measured payoff, on either training or
+# decode, on any of T4 16GB, L4 22GB, A100 40GB or B200 180GB. Default it off and let it be
+# turned back on explicitly for anyone who wants to re-measure.
+#
+# Note also that the 40GB test is in GiB: an A100-SXM4-40GB reports 39.49, so it falls BELOW
+# this threshold and combo kernels are off there. Left as-is because combo kernels measured
+# as no-effect on both sides of the boundary, so moving it would change nothing; recorded so
+# the next reader does not assume a 40GB card takes the combo path.
+use_coordinate_descent = os.environ.get("UNSLOTH_COORDINATE_DESCENT_TUNING", "0") == "1"
+
 fused_torch_compile_options = get_torch_compile_options(
     epilogue_fusion = True,
     max_autotune = False, # Too slow
     shape_padding = True,
     cudagraphs = True,
-    coordinate_descent_tuning = use_combo_kernels, # Very slow!
+    coordinate_descent_tuning = use_coordinate_descent, # Very slow, and no measured gain
     combo_kernels = use_combo_kernels,
     memory_planning = True,
     multi_kernel = False, # Fails on torch 2.10 nightly
@@ -1429,7 +1448,7 @@ no_combo_fused_torch_compile_options = get_torch_compile_options(
     max_autotune = False, # Too slow
     shape_padding = True,
     cudagraphs = True,
-    coordinate_descent_tuning = use_combo_kernels, # Very slow!
+    coordinate_descent_tuning = use_coordinate_descent, # Very slow, and no measured gain
     combo_kernels = False, # Breaks on attention
     memory_planning = True,
     multi_kernel = False, # Fails on torch 2.10 nightly


### PR DESCRIPTION
`coordinate_descent_tuning` and `combo_kernels` were both driven by `use_combo_kernels`, so any card above the memory threshold got the tuning too. They cost very differently, so this splits them and defaults the expensive one off.

## Measurements

These options feed `moe_forward_inference`, which is reached under `not self.training and qlen == 1`, so decode is the path that matters. Measured there, 3 outer reps, noise floor taken from the combo-off reps of the same GPU:

| GPU | flag | compile overhead | decode tok/s |
|---|---|---|---|
| A100 39.49GB | combo off | 7.48 s | 11.73 |
| | combo on | 7.36 s | 11.87 (+1.19%, inside 2.47% noise) |
| | combo on + coord | **9.55 s (+28%)** | 11.84 (+0.94%, inside noise) |
| L4 22.03GB | combo off | 6.99 s | 12.06 |
| | combo on | 6.93 s | 12.08 (+0.17%, inside 1.49% noise) |
| | combo on + coord | **9.21 s (+32%)** | 12.08 (+0.17%, inside noise) |

Combo kernels are free to compile and make no measurable difference to throughput, on T4 16GB, L4 22GB, A100 40GB and B200 180GB, in both training and decode. The tuning adds 28-32% compile overhead and produced no gain on any of them, which is what its own `# Very slow!` comment already suspected.

Training compile time agrees, comparing warm reps so session cold start does not confound it: A100 39295 / 39243 / 38784 ms and L4 39953 / 39450 / 39309 ms for off / on / on+coord.

## Correctness

Greedy decode output is bit-identical with combo kernels on and off, on both A100 and L4, across every arm. Each arm is also self-consistent across repeats, printable ratio 1.0, longest repeated-token run 1. So this is not trading output quality for anything.

## What changed

`coordinate_descent_tuning` now defaults off and is opt-in via `UNSLOTH_COORDINATE_DESCENT_TUNING=1` for anyone who wants to re-measure it. `combo_kernels` keeps its existing gate and behaviour, since it is free and harmless.

## One thing recorded rather than changed

The gate is `device_memory/1024/1024/1024 > 40`, i.e. GiB. An A100-SXM4-40GB reports **39.49 GiB** and therefore falls below it, so combo kernels are off on a 40GB A100 and only switch on at 80GB and above. I left the threshold alone because combo kernels measured as no-effect on both sides of it, so moving it would change nothing measurable. It is now in a comment so the next reader does not have to rediscover it.

## Verification

```
UNSLOTH_COORDINATE_DESCENT_TUNING=0 -> combo=True coord=False
UNSLOTH_COORDINATE_DESCENT_TUNING=1 -> combo=True coord=True
```
on a 178GB card, with `no_combo_fused_torch_compile_options` keeping `combo_kernels=False` in both cases as before.
