### PR TITLE
Let prepare_wy_repr_bwd autotune num_stages on triton 3.6 and up

### DIFF
--- a/tests/test_vendor_fla.py
+++ b/tests/test_vendor_fla.py
@@ -25,6 +25,7 @@ Two parts:
     Triton kernels cannot run (no CUDA / torch<2.7 / triton<3.3).
 """
 
+import ast
 import os
 import sys
 import subprocess
@@ -183,7 +184,9 @@ def test_backported_blackwell_hopper_fixes_present():
 
     wy = (VENDORED / "ops" / "gated_delta_rule" / "wy_fast.py").read_text()
     assert "PREPARE_WY_REPR_BWD_NUM_WARPS = [2] if IS_NVIDIA_BLACKWELL else [2, 4]" in wy
-    assert "PREPARE_WY_REPR_BWD_NUM_STAGES = [4] if IS_NVIDIA_BLACKWELL else [2, 3, 4]" in wy
+    # num_stages is policy-driven (see test_prepare_wy_repr_bwd_num_stages_policy);
+    # the warp pin is the part #1000 actually established, so pin that literally.
+    assert "PREPARE_WY_REPR_BWD_NUM_STAGES = _prepare_wy_repr_bwd_num_stages(" in wy
     assert "for num_warps in PREPARE_WY_REPR_BWD_NUM_WARPS" in wy
     # The fwd recompute kernel keeps its wider space.
     assert "for num_warps in [2, 4, 8]" in wy
@@ -217,6 +220,46 @@ def test_backported_blackwell_hopper_fixes_present():
     assert "TRITON_ABOVE_3_7_1 = " in compat
     utils_init = (VENDORED / "utils" / "__init__.py").read_text()
     assert "TRITON_ABOVE_3_7_1," in utils_init
+
+
+def test_prepare_wy_repr_bwd_num_stages_policy():
+    """fla PR #1000 pinned Blackwell to num_warps=2 AND num_stages=4. Only num_warps
+    was implicated by #999, and that report was on triton 3.3.1, so num_stages is
+    allowed to autotune from triton 3.6 onward and the exact upstream pin is kept
+    below it. The warp pin is never relaxed. No GPU: the policy is a pure function of
+    (is_blackwell, triton_above_3_6_0)."""
+    import importlib.util
+
+    src = VENDORED / "ops" / "gated_delta_rule" / "wy_fast.py"
+    # Load just the helper, without importing fla (which needs torch + triton + CUDA).
+    tree = ast.parse(src.read_text())
+    fn = next(
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_prepare_wy_repr_bwd_num_stages"
+    )
+    ns = {}
+    exec(compile(ast.Module(body=[fn], type_ignores=[]), str(src), "exec"), ns)
+    policy = ns["_prepare_wy_repr_bwd_num_stages"]
+
+    # Blackwell + triton < 3.6 -> the exact upstream pin.
+    assert policy(True, False) == [4]
+    # Blackwell + triton >= 3.6 -> more than one num_stages offered.
+    assert len(policy(True, True)) > 1
+    assert 4 in policy(True, True), "the validated config must stay in the space"
+    # Non-Blackwell is untouched by #1000 on either triton.
+    assert policy(False, False) == [2, 3, 4]
+    assert policy(False, True) == [2, 3, 4]
+
+    # The warp pin is separate and unconditional.
+    wy = src.read_text()
+    assert "PREPARE_WY_REPR_BWD_NUM_WARPS = [2] if IS_NVIDIA_BLACKWELL else [2, 4]" in wy
+    # The gate is wired to the real constant, not left hardcoded.
+    assert "PREPARE_WY_REPR_BWD_NUM_STAGES = _prepare_wy_repr_bwd_num_stages(\n" \
+           "    IS_NVIDIA_BLACKWELL, TRITON_ABOVE_3_6_0,\n)" in wy
+    compat = (VENDORED / "utils" / "_compat.py").read_text()
+    assert 'TRITON_ABOVE_3_6_0 = package_version.parse(triton.__version__) >= ' \
+           'package_version.parse("3.6.0")' in compat
+    assert "TRITON_ABOVE_3_6_0," in (VENDORED / "utils" / "__init__.py").read_text()
 
 
 _HYGIENE_SUBPROCESS = textwrap.dedent(

--- a/unsloth_zoo/_vendored/_licenses.py
+++ b/unsloth_zoo/_vendored/_licenses.py
@@ -118,6 +118,14 @@ modifications =
         * PR #1000 (issue #999) in ops/gated_delta_rule/wy_fast.py: restrict the
           Blackwell prepare_wy_repr_bwd_kernel autotune to the B200-validated
           config (unstable configs can hang / misaligned-address the bwd).
+          Narrowed by Unsloth: PR #1000 pins num_warps=2 AND num_stages=4, but only
+          num_warps was implicated by #999 and the report was on triton 3.3.1, while
+          num_stages=4 is the expensive half. Measured on one B200 (torch 2.12.1+cu130,
+          triton 3.7.1), chunk_gated_delta_rule fwd+bwd B=2 T=8192 H=48 D=128 bf16:
+          the full pin costs 0.733 ms of 5.309 ms and num_stages alone accounts for
+          0.624 ms of that. So the warp pin is kept unconditionally and num_stages is
+          allowed to autotune from triton 3.6 onward; below 3.6 the exact upstream pin
+          is kept, since that is the era #999 was reported against.
         * PR #983 (issue #640) in ops/common/chunk_o.py (+ TRITON_ABOVE_3_7_1 in
           utils/_compat.py and utils/__init__.py): narrow the Hopper gated
           chunk_bwd_dqkwg guard to Triton [3.4.0, 3.7.1); 3.7.1 fixes the bug.

--- a/unsloth_zoo/_vendored/fla/MANIFEST
+++ b/unsloth_zoo/_vendored/fla/MANIFEST
@@ -32,6 +32,14 @@ modifications =
         * PR #1000 (issue #999) in ops/gated_delta_rule/wy_fast.py: restrict the
           Blackwell prepare_wy_repr_bwd_kernel autotune to the B200-validated
           config (unstable configs can hang / misaligned-address the bwd).
+          Narrowed by Unsloth: PR #1000 pins num_warps=2 AND num_stages=4, but only
+          num_warps was implicated by #999 and the report was on triton 3.3.1, while
+          num_stages=4 is the expensive half. Measured on one B200 (torch 2.12.1+cu130,
+          triton 3.7.1), chunk_gated_delta_rule fwd+bwd B=2 T=8192 H=48 D=128 bf16:
+          the full pin costs 0.733 ms of 5.309 ms and num_stages alone accounts for
+          0.624 ms of that. So the warp pin is kept unconditionally and num_stages is
+          allowed to autotune from triton 3.6 onward; below 3.6 the exact upstream pin
+          is kept, since that is the era #999 was reported against.
         * PR #983 (issue #640) in ops/common/chunk_o.py (+ TRITON_ABOVE_3_7_1 in
           utils/_compat.py and utils/__init__.py): narrow the Hopper gated
           chunk_bwd_dqkwg guard to Triton [3.4.0, 3.7.1); 3.7.1 fixes the bug.

--- a/unsloth_zoo/_vendored/fla/ops/gated_delta_rule/wy_fast.py
+++ b/unsloth_zoo/_vendored/fla/ops/gated_delta_rule/wy_fast.py
@@ -12,14 +12,33 @@ import triton.language as tl
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
-from fla.utils import IS_NVIDIA_BLACKWELL, autotune_cache_kwargs, check_shared_mem
+from fla.utils import (
+    IS_NVIDIA_BLACKWELL,
+    TRITON_ABOVE_3_6_0,
+    autotune_cache_kwargs,
+    check_shared_mem,
+)
 
 # Unsloth: backported from fla PR #1000 (issue #999). On Blackwell the autotuner
 # can pick an unstable prepare_wy_repr_bwd_kernel config, causing the gated-delta
 # backward to hang or hit a misaligned address (NCCL watchdog timeout under DDP).
 # Pin to the B200-validated config until the wider space is re-validated.
 PREPARE_WY_REPR_BWD_NUM_WARPS = [2] if IS_NVIDIA_BLACKWELL else [2, 4]
-PREPARE_WY_REPR_BWD_NUM_STAGES = [4] if IS_NVIDIA_BLACKWELL else [2, 3, 4]
+
+
+def _prepare_wy_repr_bwd_num_stages(is_blackwell, triton_above_3_6_0):
+    """Unsloth: PR #1000 pinned Blackwell to num_warps=2 AND num_stages=4, but only
+    num_warps was implicated (validated on triton 3.3.1) and num_stages=4 is the slow
+    half: on a B200 it costs 0.62 ms of a 5.31 ms chunk_gated_delta_rule fwd+bwd at
+    T=8192 H=48. Keep the warp pin, and from triton 3.6 let num_stages autotune."""
+    if is_blackwell and not triton_above_3_6_0:
+        return [4]
+    return [2, 3, 4]
+
+
+PREPARE_WY_REPR_BWD_NUM_STAGES = _prepare_wy_repr_bwd_num_stages(
+    IS_NVIDIA_BLACKWELL, TRITON_ABOVE_3_6_0,
+)
 
 
 @triton.heuristics({

--- a/unsloth_zoo/_vendored/fla/utils/__init__.py
+++ b/unsloth_zoo/_vendored/fla/utils/__init__.py
@@ -11,6 +11,7 @@ from ._compat import (  # noqa: F401
     SUPPORTS_AUTOTUNE_CACHE,
     TRITON_ABOVE_3_4_0,
     TRITON_ABOVE_3_5_1,
+    TRITON_ABOVE_3_6_0,
     TRITON_ABOVE_3_7_1,
     autotune_cache_kwargs,
 )

--- a/unsloth_zoo/_vendored/fla/utils/_compat.py
+++ b/unsloth_zoo/_vendored/fla/utils/_compat.py
@@ -14,6 +14,9 @@ from ._config import FLA_CACHE_RESULTS
 
 TRITON_ABOVE_3_4_0 = package_version.parse(triton.__version__) >= package_version.parse("3.4.0")
 TRITON_ABOVE_3_5_1 = package_version.parse(triton.__version__) >= package_version.parse("3.5.1")
+# Unsloth: added for the fla PR #1000 num_stages relaxation in
+# ops/gated_delta_rule/wy_fast.py.
+TRITON_ABOVE_3_6_0 = package_version.parse(triton.__version__) >= package_version.parse("3.6.0")
 # Unsloth: added for fla PR #983 (issue #640) backport in ops/common/chunk_o.py.
 TRITON_ABOVE_3_7_1 = package_version.parse(triton.__version__) >= package_version.parse("3.7.1")
 


### PR DESCRIPTION
## Summary

The vendored FLA snapshot carries the Blackwell pin from fla PR #1000 on `prepare_wy_repr_bwd_kernel`: `num_warps=2` and `num_stages=4`. Issue #999 only ever implicated the warp count, on triton 3.3.1, and the stage pin turns out to be the expensive half. This PR keeps the warp pin exactly as upstream wrote it and lets `num_stages` autotune on triton 3.6 and newer. Older triton keeps the exact upstream config, and `num_stages=4` stays in the search space so the validated config can still win.

Found while auditing the FLA install removal (unsloth#10487, notebooks#372): the vendored 0.5.1 kernels measured 7 to 12 percent slower than pip 0.5.2 at kernel level. Bisecting each vendored hunk in isolation on a B200 (torch 2.12.1+cu130, triton 3.7.1, `chunk_gated_delta_rule` fwd+bwd, B=2 T=8192 H=48 D=128 bf16):

| revert in isolation | ms | delta |
|---|---|---|
| vendored snapshot | 5.309 | baseline |
| minus the `prepare_wy_repr_bwd` pin | 4.577 | 13.8% faster |
| keep `num_warps=2`, free `num_stages` | 4.686 | 11.7% faster |
| minus the forward-h 2-warp pin | 5.258 | 1.0% faster |
| minus grid-cap flattening or the Hopper step | 5.31 | no change |

`torch.profiler` puts all of it in `prepare_wy_repr_bwd_kernel`: 1443 us pinned, 714 us with stages free. The autotuner picks `num_stages=2` on triton 3.7.1.

## Measurements

Kernel, 7 process runs round-robin on a quiet B200, ms:

| shape (B,T,H,D) | current | this PR | pip 0.5.2 |
|---|---|---|---|
| 2,2048,16,128 | 1.740 | 1.722 | 1.837 |
| 2,2048,48,128 | 1.769 | 1.734 | 1.823 |
| 2,8192,16,128 | 2.090 | 1.866 | 1.946 |
| 2,8192,48,128 | 5.316 | 4.691 | 4.805 |

At the shapes Qwen3.5-2B (H=HV=16) and Qwen3.6-35B-A3B (H=16, HV=32) actually launch, only the long-context 35B shape moves: 2.328 to 2.104 ms at B=1 T=8192. The other three shapes are host-bound at these batch sizes, so the GPU-time gain (present everywhere, all in that one kernel) does not reach the step. Projected onto the 35B at seq 8192 this is about 1 percent of a step; at seq 2048 it is nothing. This is a long-context improvement, not a general one.

Correctness, against the current snapshot and against pip 0.5.2 at T=2048 and 8192, H=48: o, dq, dk, dv and dbeta bit identical; dg max abs 1.5e-7. Repeatability: 20 identical forwards give 1 distinct output at both shapes (pip 0.5.2 gives 10 at T=8192 on this GPU). Triton 3.6.0 with torch 2.11 (a copy of a cu128 venv): relaxation active, 20 of 20 bit identical, 4.943 to 4.613 ms at T=8192 H=48, no hang.

End to end, 30 step LoRA runs of Qwen3.5-2B and Qwen3.6-35B-A3B at seq 2048 (4 repeats) and 8192 (2 repeats): losses inside the same-venv repeat band in every pair, peak memory byte identical, step times within run-to-run noise on the shared GPU.

## Change

- `ops/gated_delta_rule/wy_fast.py`: `PREPARE_WY_REPR_BWD_NUM_STAGES` is now a small pure function of `(is_blackwell, triton_above_3_6_0)`.
- `utils/_compat.py`, `utils/__init__.py`: `TRITON_ABOVE_3_6_0`.
- `tests/test_vendor_fla.py`: asserts Blackwell on triton below 3.6 keeps `[4]`, on 3.6 and up offers more than one stage with 4 still present, and non-Blackwell is untouched; no GPU needed.
- `_licenses.py` and `MANIFEST` move together because a test keeps them byte identical.

This is a deliberate deviation from the upstream pin on evidence upstream did not have. The right follow-up is an fla issue with these measurements so the pin can be narrowed there too.

## Tests

`tests/test_vendor_fla.py`, `test_vendored_license_shipped.py`, `test_fla_hopper_tile.py`: 55 passed, 19 skipped.
