### PR TITLE
Run fullgraph regions eagerly when torch.compile is disabled

### DIFF
--- a/tests/test_compile_dynamo_disabled_fullgraph.py
+++ b/tests/test_compile_dynamo_disabled_fullgraph.py
@@ -150,6 +150,26 @@ def _checkpointed_step(flip_to):
     return w.grad
 
 
+def _checkpointed_wrapper():
+    """One wrapper plus the list of body executions, for multi-step tests."""
+    calls = []
+    src = {}
+    exec("def block(x, w):\n"
+         "    calls.append(1)\n"
+         "    return torch.nn.functional.layer_norm(x @ w, (w.shape[-1],)).sin()\n",
+         {"calls": calls, "torch": torch}, src)
+    return u.torch_compile_with_fallback(fullgraph = True)(src["block"]), calls
+
+
+def _run_checkpointed(wrapped):
+    from torch.utils.checkpoint import checkpoint
+    torch.manual_seed(0)
+    x = torch.randn(4, 8, requires_grad = True)
+    w = torch.randn(8, 8, requires_grad = True)
+    checkpoint(wrapped, x, w, use_reentrant = False).sum().backward()
+    return w.grad
+
+
 @pytest.mark.parametrize("starts_disabled", [True, False])
 def test_a_mid_step_flip_does_not_abort_a_checkpointed_backward(starts_disabled):
     """A flip between a checkpointed forward and its backward keeps its mode.
@@ -207,13 +227,17 @@ def test_the_force_eager_stance_is_left_to_torch():
 
 
 def test_another_regions_pack_does_not_force_this_one_into_the_compiler():
-    # The marker is process-wide, so it says only that SOMETHING compiled. A
-    # wrapper with nothing cached must still go eager, or torch 2.14 raises.
+    # The evidence is per wrapper, not a process-wide marker or a shared
+    # __qualname__: a wrapper with nothing cached must still go eager.
     fn, calls = _counting_fn()
+    other, _ = _counting_fn()
+    other.__qualname__ = fn.__qualname__              # a colliding label
+    compiled_one = u.torch_compile_with_fallback(fullgraph = True)(other)
+    u._PACKED_COMPILED_IN_CHECKPOINT = True           # some other region's pack
+    compiled_one(torch.zeros(3))                      # records the shared label
     wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
     prev = torch._dynamo.config.disable
     torch._dynamo.config.disable = True
-    u._PACKED_COMPILED_IN_CHECKPOINT = True          # some other region's pack
     try:
         del calls[:]
         got = wrapped(torch.zeros(3))
@@ -221,6 +245,43 @@ def test_another_regions_pack_does_not_force_this_one_into_the_compiler():
         torch._dynamo.config.disable = prev
     assert torch.equal(got, torch.ones(3))
     assert len(calls) == 1
+
+
+def test_a_checkpointed_wrapper_compiles_again_on_the_next_step():
+    """Re-enabling must reach a wrapper that is only ever called under one.
+
+    Every checkpoint forward is inside a region, so deferring on "inside a
+    region" rather than "being recomputed" left such a wrapper eager forever.
+    """
+    prev = torch._dynamo.config.disable
+    try:
+        torch._dynamo.config.disable = True
+        wrapped, calls = _checkpointed_wrapper()
+        _run_checkpointed(wrapped)
+        torch._dynamo.config.disable = False
+        _run_checkpointed(wrapped)
+        _run_checkpointed(wrapped)
+    finally:
+        torch._dynamo.config.disable = prev
+    assert wrapped._unsloth_fallback_state["ran_eager_disabled"] is False
+    assert wrapped._unsloth_fallback_state["last_call_compiled"] is True
+
+
+def test_disabling_after_a_completed_checkpointed_step_takes_effect():
+    # The compiled evidence must not outlive the recompute it was for: nothing
+    # inside this package clears a step marker.
+    prev = torch._dynamo.config.disable
+    try:
+        torch._dynamo.config.disable = False
+        wrapped, calls = _checkpointed_wrapper()
+        _run_checkpointed(wrapped)
+        torch._dynamo.config.disable = True
+        del calls[:]
+        _run_checkpointed(wrapped)
+    finally:
+        torch._dynamo.config.disable = prev
+    # Forward plus recompute, each exactly once: eager, and never twice.
+    assert len(calls) == 2
 
 
 def test_dynamo_tracing_disabled_reads_the_live_config():

--- a/tests/test_compile_dynamo_disabled_fullgraph.py
+++ b/tests/test_compile_dynamo_disabled_fullgraph.py
@@ -48,11 +48,11 @@ from unsloth_zoo.temporary_patches import utils as u
 
 @pytest.fixture(autouse = True)
 def clear_checkpoint_markers():
-    # Both are process-wide and only a step boundary clears them, so a test that
-    # packs under a checkpoint would otherwise decide the next test's mode.
+    # Process-wide and only a step boundary clears them, so a test that packs
+    # under a checkpoint would otherwise decide the next test's mode.
     yield
-    u._PACKED_EAGER_IN_CHECKPOINT = False
     u._PACKED_COMPILED_IN_CHECKPOINT = False
+    u._COMPILED_OK_LABELS.clear()
 
 
 @pytest.fixture
@@ -133,43 +133,94 @@ def test_a_real_graph_break_still_raises():
         wrapped(torch.zeros(3))
 
 
-@pytest.mark.parametrize("starts_disabled", [True, False])
-def test_a_mid_step_flip_does_not_abort_a_checkpointed_backward(starts_disabled):
-    """A flip between a checkpointed forward and its backward keeps its mode.
-
-    Non-reentrant checkpointing recomputes the forward during backward and
-    compares what each pass saved, so recomputing a compiled pack eagerly (or
-    the reverse) raises `CheckpointError` and ends the step. The flag is read
-    live, so the mode is held for the rest of the step once activations are
-    packed, and the flip takes effect at the next step boundary.
-    """
+def _checkpointed_step(flip_to):
     from torch.utils.checkpoint import checkpoint
 
     def block(x, w):
         return torch.nn.functional.layer_norm(x @ w, (w.shape[-1],)) * x
 
-    def one_step(flip):
-        torch.manual_seed(0)
-        wrapped = u.torch_compile_with_fallback(fullgraph = True)(block)
-        x = torch.randn(4, 8, requires_grad = True)
-        w = torch.randn(8, 8, requires_grad = True)
-        out = checkpoint(wrapped, x, w, use_reentrant = False)
-        if flip:
-            torch._dynamo.config.disable = not torch._dynamo.config.disable
-        out.sum().backward()
-        return w.grad
+    torch.manual_seed(0)
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(block)
+    x = torch.randn(4, 8, requires_grad = True)
+    w = torch.randn(8, 8, requires_grad = True)
+    out = checkpoint(wrapped, x, w, use_reentrant = False)
+    if flip_to is not None:
+        torch._dynamo.config.disable = flip_to
+    out.sum().backward()
+    return w.grad
 
+
+@pytest.mark.parametrize("starts_disabled", [True, False])
+def test_a_mid_step_flip_does_not_abort_a_checkpointed_backward(starts_disabled):
+    """A flip between a checkpointed forward and its backward keeps its mode.
+
+    Non-reentrant checkpointing recomputes the forward during backward and
+    compares what each pass saved, so recomputing a compiled pack eagerly, or
+    an eager pack compiled, raises `CheckpointError` and ends the step.
+    """
     prev = torch._dynamo.config.disable
     try:
         torch._dynamo.config.disable = starts_disabled
-        want = one_step(flip = False)
-        torch._dynamo.config.disable = starts_disabled
-        u._PACKED_EAGER_IN_CHECKPOINT = False
+        want = _checkpointed_step(flip_to = None)
         u._PACKED_COMPILED_IN_CHECKPOINT = False
-        got = one_step(flip = True)
+        u._COMPILED_OK_LABELS.clear()
+        torch._dynamo.config.disable = starts_disabled
+        got = _checkpointed_step(flip_to = not starts_disabled)
     finally:
         torch._dynamo.config.disable = prev
     assert torch.allclose(want, got, atol = 1e-5)
+
+
+def test_a_nested_wrapper_is_traceable_after_running_eager():
+    # The checkpoint probe reaches a pybind builtin Dynamo refuses to enter, so
+    # an outer fullgraph trace of a wrapper that has run eager must not take it.
+    def inner(x):
+        return x * 2
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(inner)
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = True
+    try:
+        wrapped(torch.zeros(3))
+    finally:
+        torch._dynamo.config.disable = prev
+
+    def outer(x):
+        return wrapped(x) + 1
+    assert torch.equal(
+        torch.compile(outer, fullgraph = True)(torch.zeros(3)), torch.ones(3),
+    )
+
+
+def test_the_force_eager_stance_is_left_to_torch():
+    # torch only raises "found no compiled frames" while the stance is
+    # "default" (torch/_dynamo/eval_frame.py), so force_eager needs nothing.
+    fn, calls = _counting_fn()
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
+    torch.compiler.set_stance("force_eager")
+    try:
+        del calls[:]
+        got = wrapped(torch.zeros(3))
+    finally:
+        torch.compiler.set_stance("default")
+    assert torch.equal(got, torch.ones(3))
+    assert len(calls) == 1
+
+
+def test_another_regions_pack_does_not_force_this_one_into_the_compiler():
+    # The marker is process-wide, so it says only that SOMETHING compiled. A
+    # wrapper with nothing cached must still go eager, or torch 2.14 raises.
+    fn, calls = _counting_fn()
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = True
+    u._PACKED_COMPILED_IN_CHECKPOINT = True          # some other region's pack
+    try:
+        del calls[:]
+        got = wrapped(torch.zeros(3))
+    finally:
+        torch._dynamo.config.disable = prev
+    assert torch.equal(got, torch.ones(3))
+    assert len(calls) == 1
 
 
 def test_dynamo_tracing_disabled_reads_the_live_config():

--- a/tests/test_compile_dynamo_disabled_fullgraph.py
+++ b/tests/test_compile_dynamo_disabled_fullgraph.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""`fullgraph = True` regions when the user has switched Dynamo off.
+"""`fullgraph = True` regions when the user has switched the compiler off.
 
 `TORCH_COMPILE_DISABLE=1` (and `torch._dynamo.config.disable = True`, which is
 the same flag by hand) takes torch.compile out of the picture while debugging.
@@ -30,10 +30,13 @@ writes the decorator into every generated `unsloth_compiled_cache` module. So a
 user who disables torch.compile on torch 2.14 loses GRPO training at the first
 step, having asked only to turn the compiler off.
 
-The flag is therefore read live, before each call, rather than recovered from
-after one: torch has already run the body by the time it raises, so recovering
-would run it twice, and entering the compiled callable at all makes torch mark
-the code object skipped permanently.
+The flag is read before the call, never recovered from after one: torch has
+already run the body by the time it raises, so recovering would run it twice.
+And it is read at the FIRST call, not at decoration and not on every call. At
+decoration is too early, since a flag set only while modules import would stick
+for the run. Every call is too late to be consistent: a checkpoint's pack and
+its recompute must agree, and by the time a recompute runs the forward that
+packed it is gone.
 
 `TORCHDYNAMO_DISABLE=1` is a different switch, handled inside
 `torch._dynamo.optimize`, which returns the undecorated function. Nothing here
@@ -48,8 +51,10 @@ from unsloth_zoo.temporary_patches import utils as u
 
 @pytest.fixture(autouse = True)
 def clear_checkpoint_markers():
-    # Process-wide and only a step boundary clears them, so a test that packs
-    # under a checkpoint would otherwise decide the next test's mode.
+    # A compiled call under a checkpoint sets these process-wide, and only a
+    # step boundary clears them. Left set, they make the recompile-limit arm
+    # re-raise rather than fall back, in this file's tests and in any that run
+    # after it.
     yield
     u._PACKED_COMPILED_IN_CHECKPOINT = False
     u._COMPILED_OK_LABELS.clear()
@@ -77,6 +82,29 @@ def _counting_fn():
     return src["f"], calls
 
 
+def _checkpointed_wrapper():
+    """One wrapper plus the list of its body executions."""
+    calls = []
+    src = {}
+    exec("def block(x, w):\n"
+         "    calls.append(1)\n"
+         "    return torch.nn.functional.layer_norm(x @ w, (w.shape[-1],)).sin()\n",
+         {"calls": calls, "torch": torch}, src)
+    return u.torch_compile_with_fallback(fullgraph = True)(src["block"]), calls
+
+
+def _pack(wrapped):
+    """One non-reentrant checkpointed forward. Returns (output, weight)."""
+    from torch.utils.checkpoint import checkpoint
+    torch.manual_seed(0)
+    x = torch.randn(4, 8, requires_grad = True)
+    w = torch.randn(8, 8, requires_grad = True)
+    return checkpoint(wrapped, x, w, use_reentrant = False), w
+
+
+# --------------------------------------------------------------- the dispatch
+
+
 def test_decorated_before_disabling_runs_eagerly_and_exactly_once():
     fn, calls = _counting_fn()
     wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
@@ -101,20 +129,22 @@ def test_decorated_while_disabled_runs_eagerly_and_exactly_once(dynamo_off):
     assert len(calls) == 1
 
 
-def test_re_enabling_dynamo_restores_compilation():
-    # Discarding the compiled callable at decoration time made a flag that was
-    # set only during import permanent for the rest of the run.
+def test_a_flag_held_only_over_decoration_does_not_stick():
+    """Disabled while the module imports, restored before the first call.
+
+    Deciding at decoration time pinned such a region to eager for the whole
+    run, which is what reading the flag at the first call instead avoids.
+    """
     fn, _ = _counting_fn()
-    wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
     prev = torch._dynamo.config.disable
     torch._dynamo.config.disable = True
     try:
-        wrapped(torch.zeros(3))
+        wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
     finally:
         torch._dynamo.config.disable = prev
     assert torch.equal(wrapped(torch.zeros(3)), torch.ones(3))
-    state = getattr(wrapped, "_unsloth_fallback_state", {})
-    assert not state.get("eager", False)
+    assert wrapped._unsloth_fallback_state["compiler_off"] is False
+    assert wrapped._unsloth_fallback_state["eager"] is False
 
 
 def test_fullgraph_false_is_untouched(dynamo_off):
@@ -123,92 +153,14 @@ def test_fullgraph_false_is_untouched(dynamo_off):
 
 
 def test_a_real_graph_break_still_raises():
-    # The eager dispatch is keyed on the live flag, not on an error message, so
-    # a genuine fullgraph failure is never absorbed.
+    # The eager dispatch is keyed on the flag, not on an error message, so a
+    # genuine fullgraph failure is never absorbed.
     def breaks(x):
         print("graph break")
         return x + 1
     wrapped = u.torch_compile_with_fallback(fullgraph = True)(breaks)
     with pytest.raises(Exception):
         wrapped(torch.zeros(3))
-
-
-def _checkpointed_step(flip_to):
-    from torch.utils.checkpoint import checkpoint
-
-    def block(x, w):
-        return torch.nn.functional.layer_norm(x @ w, (w.shape[-1],)) * x
-
-    torch.manual_seed(0)
-    wrapped = u.torch_compile_with_fallback(fullgraph = True)(block)
-    x = torch.randn(4, 8, requires_grad = True)
-    w = torch.randn(8, 8, requires_grad = True)
-    out = checkpoint(wrapped, x, w, use_reentrant = False)
-    if flip_to is not None:
-        torch._dynamo.config.disable = flip_to
-    out.sum().backward()
-    return w.grad
-
-
-def _checkpointed_wrapper():
-    """One wrapper plus the list of body executions, for multi-step tests."""
-    calls = []
-    src = {}
-    exec("def block(x, w):\n"
-         "    calls.append(1)\n"
-         "    return torch.nn.functional.layer_norm(x @ w, (w.shape[-1],)).sin()\n",
-         {"calls": calls, "torch": torch}, src)
-    return u.torch_compile_with_fallback(fullgraph = True)(src["block"]), calls
-
-
-def _run_checkpointed(wrapped):
-    from torch.utils.checkpoint import checkpoint
-    torch.manual_seed(0)
-    x = torch.randn(4, 8, requires_grad = True)
-    w = torch.randn(8, 8, requires_grad = True)
-    checkpoint(wrapped, x, w, use_reentrant = False).sum().backward()
-    return w.grad
-
-
-@pytest.mark.parametrize("starts_disabled", [True, False])
-def test_a_mid_step_flip_does_not_abort_a_checkpointed_backward(starts_disabled):
-    """A flip between a checkpointed forward and its backward keeps its mode.
-
-    Non-reentrant checkpointing recomputes the forward during backward and
-    compares what each pass saved, so recomputing a compiled pack eagerly, or
-    an eager pack compiled, raises `CheckpointError` and ends the step.
-    """
-    prev = torch._dynamo.config.disable
-    try:
-        torch._dynamo.config.disable = starts_disabled
-        want = _checkpointed_step(flip_to = None)
-        u._PACKED_COMPILED_IN_CHECKPOINT = False
-        u._COMPILED_OK_LABELS.clear()
-        torch._dynamo.config.disable = starts_disabled
-        got = _checkpointed_step(flip_to = not starts_disabled)
-    finally:
-        torch._dynamo.config.disable = prev
-    assert torch.allclose(want, got, atol = 1e-5)
-
-
-def test_a_nested_wrapper_is_traceable_after_running_eager():
-    # The checkpoint probe reaches a pybind builtin Dynamo refuses to enter, so
-    # an outer fullgraph trace of a wrapper that has run eager must not take it.
-    def inner(x):
-        return x * 2
-    wrapped = u.torch_compile_with_fallback(fullgraph = True)(inner)
-    prev = torch._dynamo.config.disable
-    torch._dynamo.config.disable = True
-    try:
-        wrapped(torch.zeros(3))
-    finally:
-        torch._dynamo.config.disable = prev
-
-    def outer(x):
-        return wrapped(x) + 1
-    assert torch.equal(
-        torch.compile(outer, fullgraph = True)(torch.zeros(3)), torch.ones(3),
-    )
 
 
 def test_the_force_eager_stance_is_left_to_torch():
@@ -226,65 +178,8 @@ def test_the_force_eager_stance_is_left_to_torch():
     assert len(calls) == 1
 
 
-def test_another_regions_pack_does_not_force_this_one_into_the_compiler():
-    # The evidence is per wrapper, not a process-wide marker or a shared
-    # __qualname__: a wrapper with nothing cached must still go eager.
-    fn, calls = _counting_fn()
-    other, _ = _counting_fn()
-    other.__qualname__ = fn.__qualname__              # a colliding label
-    compiled_one = u.torch_compile_with_fallback(fullgraph = True)(other)
-    u._PACKED_COMPILED_IN_CHECKPOINT = True           # some other region's pack
-    compiled_one(torch.zeros(3))                      # records the shared label
-    wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
-    prev = torch._dynamo.config.disable
-    torch._dynamo.config.disable = True
-    try:
-        del calls[:]
-        got = wrapped(torch.zeros(3))
-    finally:
-        torch._dynamo.config.disable = prev
-    assert torch.equal(got, torch.ones(3))
-    assert len(calls) == 1
-
-
-def test_a_checkpointed_wrapper_compiles_again_on_the_next_step():
-    """Re-enabling must reach a wrapper that is only ever called under one.
-
-    Every checkpoint forward is inside a region, so deferring on "inside a
-    region" rather than "being recomputed" left such a wrapper eager forever.
-    """
-    prev = torch._dynamo.config.disable
-    try:
-        torch._dynamo.config.disable = True
-        wrapped, calls = _checkpointed_wrapper()
-        _run_checkpointed(wrapped)
-        torch._dynamo.config.disable = False
-        _run_checkpointed(wrapped)
-        _run_checkpointed(wrapped)
-    finally:
-        torch._dynamo.config.disable = prev
-    assert wrapped._unsloth_fallback_state["ran_eager_disabled"] is False
-    assert wrapped._unsloth_fallback_state["last_call_compiled"] is True
-
-
-def test_disabling_after_a_completed_checkpointed_step_takes_effect():
-    # The compiled evidence must not outlive the recompute it was for: nothing
-    # inside this package clears a step marker.
-    prev = torch._dynamo.config.disable
-    try:
-        torch._dynamo.config.disable = False
-        wrapped, calls = _checkpointed_wrapper()
-        _run_checkpointed(wrapped)
-        torch._dynamo.config.disable = True
-        del calls[:]
-        _run_checkpointed(wrapped)
-    finally:
-        torch._dynamo.config.disable = prev
-    # Forward plus recompute, each exactly once: eager, and never twice.
-    assert len(calls) == 2
-
-
 def test_dynamo_tracing_disabled_reads_the_live_config():
+    # The reader stays live; it is the wrapper that takes one snapshot.
     prev = torch._dynamo.config.disable
     try:
         torch._dynamo.config.disable = True
@@ -293,3 +188,111 @@ def test_dynamo_tracing_disabled_reads_the_live_config():
         assert u.dynamo_tracing_disabled() is False
     finally:
         torch._dynamo.config.disable = prev
+
+
+# ------------------------------------------------- checkpointing consistency
+#
+# Non-reentrant checkpointing recomputes the forward during backward and
+# compares what each pass saved, so a pack and its recompute running in
+# different modes raises CheckpointError and ends the step. Each of these was
+# a live failure of a per-call read of the flag.
+
+
+@pytest.mark.parametrize("disabled", [True, False])
+def test_a_checkpointed_step_runs_with_the_compiler_either_way(disabled):
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = disabled
+    try:
+        wrapped, calls = _checkpointed_wrapper()
+        del calls[:]
+        out, w = _pack(wrapped)
+        out.sum().backward()
+    finally:
+        torch._dynamo.config.disable = prev
+    assert w.grad is not None
+    if disabled:
+        # The forward and its recompute, each exactly once. Compiled, the
+        # recompute replays a graph and never re-enters the Python body.
+        assert len(calls) == 2
+
+
+def test_the_snapshot_survives_a_flip_between_a_forward_and_its_backward():
+    """Re-enabling mid-step must not recompute an eager pack compiled.
+
+    Only this direction is ours. Disabling mid-step over a COMPILED pack is
+    torch's own: it consults `config.disable` whenever it converts a frame, so
+    the recompute's variant is skipped and runs eager whatever we do. That case
+    raises `CheckpointError` identically on `main`.
+    """
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = True
+    try:
+        wrapped, _ = _checkpointed_wrapper()
+        out, w = _pack(wrapped)
+        torch._dynamo.config.disable = False
+        out.sum().backward()
+    finally:
+        torch._dynamo.config.disable = prev
+    assert w.grad is not None
+
+
+def test_two_outstanding_packs_of_one_wrapper_agree():
+    """Two live packs of one wrapper, with a flip between their forwards.
+
+    A mode held per wrapper and updated per call described only the newest
+    pack, so the older one was recomputed in the other mode. Fails on `main`
+    as well, where the second forward is what changes mode.
+    """
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = True
+    try:
+        wrapped, _ = _checkpointed_wrapper()
+        first, w1 = _pack(wrapped)
+        torch._dynamo.config.disable = False
+        second, w2 = _pack(wrapped)
+        (first.sum() + second.sum()).backward()
+    finally:
+        torch._dynamo.config.disable = prev
+    assert w1.grad is not None and w2.grad is not None
+
+
+def test_a_completed_checkpointed_step_leaves_no_state_to_expire():
+    """The decision is the wrapper's own, and it does not drift after a step.
+
+    Nothing in this package calls `apply_pending_eager_fallbacks`, so a mode
+    that had to be expired at a step boundary never would be. Checked away from
+    a checkpoint: whether torch can still run a COMPILED region once the flag
+    is set is torch's own frame-conversion behaviour, unchanged from `main`.
+    """
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = False
+    try:
+        wrapped, _ = _checkpointed_wrapper()
+        out, w = _pack(wrapped)
+        out.sum().backward()
+        assert w.grad is not None
+        torch._dynamo.config.disable = True
+        assert wrapped._unsloth_fallback_state["compiler_off"] is False
+        assert wrapped._unsloth_fallback_state["eager"] is False
+    finally:
+        torch._dynamo.config.disable = prev
+
+
+def test_a_nested_wrapper_is_traceable_after_running_eager():
+    # An outer fullgraph trace must not reach a checkpoint-hook probe: it is a
+    # pybind builtin Dynamo refuses to enter, which is fatal under fullgraph.
+    def inner(x):
+        return x * 2
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(inner)
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = True
+    try:
+        wrapped(torch.zeros(3))
+    finally:
+        torch._dynamo.config.disable = prev
+
+    def outer(x):
+        return wrapped(x) + 1
+    assert torch.equal(
+        torch.compile(outer, fullgraph = True)(torch.zeros(3)), torch.ones(3),
+    )

--- a/tests/test_compile_dynamo_disabled_fullgraph.py
+++ b/tests/test_compile_dynamo_disabled_fullgraph.py
@@ -1,0 +1,108 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""`fullgraph = True` regions when the user has switched Dynamo off.
+
+`TORCHDYNAMO_DISABLE=1` is the documented way to take torch.compile out of the
+picture while debugging. Up to torch 2.13 a `fullgraph = True` region then ran
+eagerly. From torch 2.14 it raises instead:
+
+    RuntimeError: torch.compile with fullgraph=True found no compiled frames.
+    Skipped frames: ... Dynamo tracing is disabled
+
+Every `torch_compile_with_fallback` region inherits that, and there are many:
+`rl_replacements.py` wraps the GRPO loss accumulator in one, and `compiler.py`
+writes the decorator into every generated `unsloth_compiled_cache` module. So a
+user who disables Dynamo on torch 2.14 loses GRPO training at the first step,
+having asked only to turn the compiler off.
+
+Two arms, because the switch can be thrown on either side of decoration:
+
+  * before, which is what the env var does, caught at decoration time;
+  * after, which a test or a notebook does by assigning to the config, caught
+    once at call time and latched.
+"""
+
+import pytest
+import torch
+
+from unsloth_zoo.temporary_patches import utils as u
+
+
+@pytest.fixture
+def dynamo_off():
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = True
+    try:
+        yield
+    finally:
+        torch._dynamo.config.disable = prev
+
+
+def _add_one(x):
+    return x + 1
+
+
+def test_decorating_under_disabled_dynamo_returns_the_plain_function(dynamo_off):
+    # Decorated while disabled: never compiled at all, so nothing can raise.
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(_add_one)
+    assert wrapped is _add_one
+    assert torch.equal(wrapped(torch.zeros(3)), torch.ones(3))
+
+
+def test_disabling_dynamo_after_decoration_falls_back_to_eager():
+    # The env var route cannot reach a wrapper that already exists, which is
+    # exactly the case the runtime arm covers.
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(_add_one)
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = True
+    try:
+        got = wrapped(torch.zeros(3))
+    finally:
+        torch._dynamo.config.disable = prev
+    assert torch.equal(got, torch.ones(3))
+
+
+def test_fullgraph_false_is_untouched(dynamo_off):
+    # Dynamo already falls back by itself there, so the guard must not fire.
+    wrapped = u.torch_compile_with_fallback(fullgraph = False)(_add_one)
+    assert torch.equal(wrapped(torch.zeros(3)), torch.ones(3))
+
+
+@pytest.mark.parametrize(
+    "text,want",
+    [
+        ("torch.compile with fullgraph=True found no compiled frames. "
+         "Skipped frames: Dynamo tracing is disabled", True),
+        # A real fullgraph graph break must still raise.
+        ("Unsupported: call_function BuiltinVariable(print)", False),
+        ("torch.compile with fullgraph=True hit a graph break", False),
+        ("found no compiled frames", False),
+    ],
+)
+def test_the_signature_match_is_narrow(text, want):
+    assert u._is_fullgraph_without_frames(RuntimeError(text)) is want
+
+
+def test_dynamo_tracing_disabled_reads_the_live_config():
+    prev = torch._dynamo.config.disable
+    try:
+        torch._dynamo.config.disable = True
+        assert u.dynamo_tracing_disabled() is True
+        torch._dynamo.config.disable = False
+        assert u.dynamo_tracing_disabled() is False
+    finally:
+        torch._dynamo.config.disable = prev

--- a/tests/test_compile_dynamo_disabled_fullgraph.py
+++ b/tests/test_compile_dynamo_disabled_fullgraph.py
@@ -16,9 +16,10 @@
 
 """`fullgraph = True` regions when the user has switched Dynamo off.
 
-`TORCHDYNAMO_DISABLE=1` is the documented way to take torch.compile out of the
-picture while debugging. Up to torch 2.13 a `fullgraph = True` region then ran
-eagerly. From torch 2.14 it raises instead:
+`TORCH_COMPILE_DISABLE=1` (and `torch._dynamo.config.disable = True`, which is
+the same flag by hand) takes torch.compile out of the picture while debugging.
+Up to torch 2.13 a `fullgraph = True` region then ran eagerly. From torch 2.14
+torch runs the body and raises afterwards, out of its post-call bookkeeping:
 
     RuntimeError: torch.compile with fullgraph=True found no compiled frames.
     Skipped frames: ... Dynamo tracing is disabled
@@ -26,14 +27,17 @@ eagerly. From torch 2.14 it raises instead:
 Every `torch_compile_with_fallback` region inherits that, and there are many:
 `rl_replacements.py` wraps the GRPO loss accumulator in one, and `compiler.py`
 writes the decorator into every generated `unsloth_compiled_cache` module. So a
-user who disables Dynamo on torch 2.14 loses GRPO training at the first step,
-having asked only to turn the compiler off.
+user who disables torch.compile on torch 2.14 loses GRPO training at the first
+step, having asked only to turn the compiler off.
 
-Two arms, because the switch can be thrown on either side of decoration:
+The flag is therefore read live, before each call, rather than recovered from
+after one: torch has already run the body by the time it raises, so recovering
+would run it twice, and entering the compiled callable at all makes torch mark
+the code object skipped permanently.
 
-  * before, which is what the env var does, caught at decoration time;
-  * after, which a test or a notebook does by assigning to the config, caught
-    once at call time and latched.
+`TORCHDYNAMO_DISABLE=1` is a different switch, handled inside
+`torch._dynamo.optimize`, which returns the undecorated function. Nothing here
+has to deal with it, and the tests below pin that too.
 """
 
 import pytest
@@ -56,45 +60,68 @@ def _add_one(x):
     return x + 1
 
 
-def test_decorating_under_disabled_dynamo_returns_the_plain_function(dynamo_off):
-    # Decorated while disabled: never compiled at all, so nothing can raise.
-    wrapped = u.torch_compile_with_fallback(fullgraph = True)(_add_one)
-    assert wrapped is _add_one
-    assert torch.equal(wrapped(torch.zeros(3)), torch.ones(3))
+def _counting_fn():
+    """A fresh code object per test: torch skip marks attach to the code."""
+    calls = []
+    src = {}
+    exec("def f(x):\n    calls.append(1)\n    return x + 1\n", {"calls": calls}, src)
+    return src["f"], calls
 
 
-def test_disabling_dynamo_after_decoration_falls_back_to_eager():
-    # The env var route cannot reach a wrapper that already exists, which is
-    # exactly the case the runtime arm covers.
-    wrapped = u.torch_compile_with_fallback(fullgraph = True)(_add_one)
+def test_decorated_before_disabling_runs_eagerly_and_exactly_once():
+    fn, calls = _counting_fn()
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
     prev = torch._dynamo.config.disable
     torch._dynamo.config.disable = True
     try:
+        del calls[:]
         got = wrapped(torch.zeros(3))
     finally:
         torch._dynamo.config.disable = prev
     assert torch.equal(got, torch.ones(3))
+    # 2 here is the torch 2.14 double-run: body, then raise, then eager retry.
+    assert len(calls) == 1
+
+
+def test_decorated_while_disabled_runs_eagerly_and_exactly_once(dynamo_off):
+    fn, calls = _counting_fn()
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
+    del calls[:]
+    got = wrapped(torch.zeros(3))
+    assert torch.equal(got, torch.ones(3))
+    assert len(calls) == 1
+
+
+def test_re_enabling_dynamo_restores_compilation():
+    # Discarding the compiled callable at decoration time made a flag that was
+    # set only during import permanent for the rest of the run.
+    fn, _ = _counting_fn()
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(fn)
+    prev = torch._dynamo.config.disable
+    torch._dynamo.config.disable = True
+    try:
+        wrapped(torch.zeros(3))
+    finally:
+        torch._dynamo.config.disable = prev
+    assert torch.equal(wrapped(torch.zeros(3)), torch.ones(3))
+    state = getattr(wrapped, "_unsloth_fallback_state", {})
+    assert not state.get("eager", False)
 
 
 def test_fullgraph_false_is_untouched(dynamo_off):
-    # Dynamo already falls back by itself there, so the guard must not fire.
     wrapped = u.torch_compile_with_fallback(fullgraph = False)(_add_one)
     assert torch.equal(wrapped(torch.zeros(3)), torch.ones(3))
 
 
-@pytest.mark.parametrize(
-    "text,want",
-    [
-        ("torch.compile with fullgraph=True found no compiled frames. "
-         "Skipped frames: Dynamo tracing is disabled", True),
-        # A real fullgraph graph break must still raise.
-        ("Unsupported: call_function BuiltinVariable(print)", False),
-        ("torch.compile with fullgraph=True hit a graph break", False),
-        ("found no compiled frames", False),
-    ],
-)
-def test_the_signature_match_is_narrow(text, want):
-    assert u._is_fullgraph_without_frames(RuntimeError(text)) is want
+def test_a_real_graph_break_still_raises():
+    # The eager dispatch is keyed on the live flag, not on an error message, so
+    # a genuine fullgraph failure is never absorbed.
+    def breaks(x):
+        print("graph break")
+        return x + 1
+    wrapped = u.torch_compile_with_fallback(fullgraph = True)(breaks)
+    with pytest.raises(Exception):
+        wrapped(torch.zeros(3))
 
 
 def test_dynamo_tracing_disabled_reads_the_live_config():

--- a/tests/test_compile_dynamo_disabled_fullgraph.py
+++ b/tests/test_compile_dynamo_disabled_fullgraph.py
@@ -46,6 +46,15 @@ import torch
 from unsloth_zoo.temporary_patches import utils as u
 
 
+@pytest.fixture(autouse = True)
+def clear_checkpoint_markers():
+    # Both are process-wide and only a step boundary clears them, so a test that
+    # packs under a checkpoint would otherwise decide the next test's mode.
+    yield
+    u._PACKED_EAGER_IN_CHECKPOINT = False
+    u._PACKED_COMPILED_IN_CHECKPOINT = False
+
+
 @pytest.fixture
 def dynamo_off():
     prev = torch._dynamo.config.disable
@@ -122,6 +131,45 @@ def test_a_real_graph_break_still_raises():
     wrapped = u.torch_compile_with_fallback(fullgraph = True)(breaks)
     with pytest.raises(Exception):
         wrapped(torch.zeros(3))
+
+
+@pytest.mark.parametrize("starts_disabled", [True, False])
+def test_a_mid_step_flip_does_not_abort_a_checkpointed_backward(starts_disabled):
+    """A flip between a checkpointed forward and its backward keeps its mode.
+
+    Non-reentrant checkpointing recomputes the forward during backward and
+    compares what each pass saved, so recomputing a compiled pack eagerly (or
+    the reverse) raises `CheckpointError` and ends the step. The flag is read
+    live, so the mode is held for the rest of the step once activations are
+    packed, and the flip takes effect at the next step boundary.
+    """
+    from torch.utils.checkpoint import checkpoint
+
+    def block(x, w):
+        return torch.nn.functional.layer_norm(x @ w, (w.shape[-1],)) * x
+
+    def one_step(flip):
+        torch.manual_seed(0)
+        wrapped = u.torch_compile_with_fallback(fullgraph = True)(block)
+        x = torch.randn(4, 8, requires_grad = True)
+        w = torch.randn(8, 8, requires_grad = True)
+        out = checkpoint(wrapped, x, w, use_reentrant = False)
+        if flip:
+            torch._dynamo.config.disable = not torch._dynamo.config.disable
+        out.sum().backward()
+        return w.grad
+
+    prev = torch._dynamo.config.disable
+    try:
+        torch._dynamo.config.disable = starts_disabled
+        want = one_step(flip = False)
+        torch._dynamo.config.disable = starts_disabled
+        u._PACKED_EAGER_IN_CHECKPOINT = False
+        u._PACKED_COMPILED_IN_CHECKPOINT = False
+        got = one_step(flip = True)
+    finally:
+        torch._dynamo.config.disable = prev
+    assert torch.allclose(want, got, atol = 1e-5)
 
 
 def test_dynamo_tracing_disabled_reads_the_live_config():

--- a/tests/test_compile_dynamo_disabled_fullgraph.py
+++ b/tests/test_compile_dynamo_disabled_fullgraph.py
@@ -163,6 +163,10 @@ def test_a_real_graph_break_still_raises():
         wrapped(torch.zeros(3))
 
 
+@pytest.mark.skipif(
+    not hasattr(getattr(torch, "compiler", None), "set_stance"),
+    reason = "torch.compiler.set_stance is new in torch 2.6; the floor is 2.4",
+)
 def test_the_force_eager_stance_is_left_to_torch():
     # torch only raises "found no compiled frames" while the stance is
     # "default" (torch/_dynamo/eval_frame.py), so force_eager needs nothing.

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1185,41 +1185,32 @@ _DISABLED_HOOK_SIGNATURES = (
 )
 
 
-_NO_COMPILED_FRAMES_SIGNATURE = ("fullgraph=True", "found no compiled frames")
+_DYNAMO_CONFIG = None
 
 
 def dynamo_tracing_disabled():
     """Has the user switched Dynamo off process-wide?
 
-    `TORCHDYNAMO_DISABLE=1` is the documented way to take torch.compile out of
-    the picture while debugging, and torch reads it into `config.disable` when
-    `torch._dynamo` is imported. `torch._dynamo.config.disable = True` is the
-    same switch set by hand.
+    `TORCH_COMPILE_DISABLE=1` is the switch torch reads into `config.disable`
+    at import; `torch._dynamo.config.disable = True` is the same thing set by
+    hand. Read live, never cached: notebooks and test fixtures flip it mid-run.
+
+    `TORCHDYNAMO_DISABLE=1` is NOT this flag. `torch._dynamo.optimize` checks
+    that env var itself and hands back the undecorated function, so it never
+    reaches a compiled callable and needs nothing from us.
     """
-    try:
-        import torch._dynamo
-        return bool(torch._dynamo.config.disable)
-    except Exception:
-        return False
-
-
-def _is_fullgraph_without_frames(exc):
-    """Did a `fullgraph = True` region refuse because tracing is disabled?
-
-    From torch 2.14 a compiled region whose frames were all skipped raises
-
-        RuntimeError: torch.compile with fullgraph=True found no compiled
-        frames. Skipped frames: ... Dynamo tracing is disabled
-
-    where earlier torch quietly ran the function eagerly. Disabling Dynamo is a
-    request for eager, so this is not a defect to surface; matched on the
-    signature so any other RuntimeError still raises.
-    """
-    try:
-        text = str(exc)
-    except Exception:
-        return False
-    return all(part in text for part in _NO_COMPILED_FRAMES_SIGNATURE)
+    global _DYNAMO_CONFIG
+    config = _DYNAMO_CONFIG
+    if config is None:
+        try:
+            import torch._dynamo
+            config = _DYNAMO_CONFIG = torch._dynamo.config
+        except Exception:
+            return False
+    # The module object is cached, the flag is not: this runs on every call
+    # into a compiled region, where the `import` statement alone cost about as
+    # much as a small torch op.
+    return bool(config.disable)
 
 
 def _is_our_own_disabled_hook(exc):
@@ -1785,19 +1776,6 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             f"apart from speed.",
         )
 
-    def _give_up_on_disabled_dynamo(e, args, kwargs, marker_before):
-        """Dynamo was switched off after this wrapper was built.
-
-        Same bare eager flip as the disabled-hook arm: nothing ever compiled,
-        so there is no pack that a later recompute could disagree with.
-        """
-        return _give_up_at_compile_time(
-            e, args, kwargs, marker_before,
-            f"Unsloth: Dynamo tracing is disabled, so {label} cannot be "
-            f"compiled; running it eagerly from here. Training is unaffected "
-            f"apart from speed.",
-        )
-
     def _is_backend_refusal_we_handle(e):
         """The gate the wrapper's own backend arm applies, in one place."""
         if _wants_hard_backend_failure():
@@ -1911,6 +1889,18 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     def wrapper(*args, **kwargs):
         if state["eager"]:
             return eager_func(*args, **kwargs)
+        if dynamo_tracing_disabled():
+            # Checked BEFORE the call, not recovered from afterwards. Torch runs
+            # the body and only then raises "found no compiled frames" from its
+            # post-call bookkeeping (torch/_dynamo/eval_frame.py), so catching
+            # that and re-running eager executes the body twice, consuming RNG
+            # twice and repeating any mutation it made.
+            #
+            # Not latched either: entering the compiled callable while tracing
+            # is off makes torch mark the code object skipped for good, so this
+            # is also what keeps the region compilable once the user switches
+            # Dynamo back on.
+            return eager_func(*args, **kwargs)
         marker_before = _PACKED_COMPILED_IN_CHECKPOINT
         try:
             _note_packed_under_checkpoint()
@@ -1966,15 +1956,6 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             if not _is_our_own_disabled_hook(e):
                 raise
             return _give_up_on_disabled_hook(e, args, kwargs, marker_before)
-        except RuntimeError as e:
-            # Last arm on purpose: every typed class above gets first refusal,
-            # and several of them are RuntimeError subclasses. Only torch
-            # 2.14's "found no compiled frames" lands here, which happens when
-            # Dynamo was switched off after this wrapper was built. The
-            # decoration-time guard cannot see that, so catch it once and latch.
-            if not _is_fullgraph_without_frames(e):
-                raise
-            return _give_up_on_disabled_dynamo(e, args, kwargs, marker_before)
         else:
             # The compiled callable returned, so anything it packed under a
             # checkpoint is packed compiled. Only `_give_up_on_backend` reads
@@ -2110,12 +2091,6 @@ def torch_compile_with_fallback(fullgraph = False, **compile_kwargs):
     """
     def _decorate(func):
         func = unwrap_already_compiled(func)
-        if fullgraph and dynamo_tracing_disabled():
-            # Nothing can be traced, so from torch 2.14 the compiled callable
-            # raises instead of running eagerly. Hand back the plain function:
-            # that is what disabling Dynamo asked for, and it keeps the region
-            # working on every torch version.
-            return func
         compiled = torch.compile(func, fullgraph = fullgraph, **compile_kwargs)
         if not fullgraph:
             return compiled

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -1185,6 +1185,43 @@ _DISABLED_HOOK_SIGNATURES = (
 )
 
 
+_NO_COMPILED_FRAMES_SIGNATURE = ("fullgraph=True", "found no compiled frames")
+
+
+def dynamo_tracing_disabled():
+    """Has the user switched Dynamo off process-wide?
+
+    `TORCHDYNAMO_DISABLE=1` is the documented way to take torch.compile out of
+    the picture while debugging, and torch reads it into `config.disable` when
+    `torch._dynamo` is imported. `torch._dynamo.config.disable = True` is the
+    same switch set by hand.
+    """
+    try:
+        import torch._dynamo
+        return bool(torch._dynamo.config.disable)
+    except Exception:
+        return False
+
+
+def _is_fullgraph_without_frames(exc):
+    """Did a `fullgraph = True` region refuse because tracing is disabled?
+
+    From torch 2.14 a compiled region whose frames were all skipped raises
+
+        RuntimeError: torch.compile with fullgraph=True found no compiled
+        frames. Skipped frames: ... Dynamo tracing is disabled
+
+    where earlier torch quietly ran the function eagerly. Disabling Dynamo is a
+    request for eager, so this is not a defect to surface; matched on the
+    signature so any other RuntimeError still raises.
+    """
+    try:
+        text = str(exc)
+    except Exception:
+        return False
+    return all(part in text for part in _NO_COMPILED_FRAMES_SIGNATURE)
+
+
 def _is_our_own_disabled_hook(exc):
     """Did we break our own graph with our own `torch.compiler.disable`?
 
@@ -1748,6 +1785,19 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             f"apart from speed.",
         )
 
+    def _give_up_on_disabled_dynamo(e, args, kwargs, marker_before):
+        """Dynamo was switched off after this wrapper was built.
+
+        Same bare eager flip as the disabled-hook arm: nothing ever compiled,
+        so there is no pack that a later recompute could disagree with.
+        """
+        return _give_up_at_compile_time(
+            e, args, kwargs, marker_before,
+            f"Unsloth: Dynamo tracing is disabled, so {label} cannot be "
+            f"compiled; running it eagerly from here. Training is unaffected "
+            f"apart from speed.",
+        )
+
     def _is_backend_refusal_we_handle(e):
         """The gate the wrapper's own backend arm applies, in one place."""
         if _wants_hard_backend_failure():
@@ -1916,6 +1966,15 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             if not _is_our_own_disabled_hook(e):
                 raise
             return _give_up_on_disabled_hook(e, args, kwargs, marker_before)
+        except RuntimeError as e:
+            # Last arm on purpose: every typed class above gets first refusal,
+            # and several of them are RuntimeError subclasses. Only torch
+            # 2.14's "found no compiled frames" lands here, which happens when
+            # Dynamo was switched off after this wrapper was built. The
+            # decoration-time guard cannot see that, so catch it once and latch.
+            if not _is_fullgraph_without_frames(e):
+                raise
+            return _give_up_on_disabled_dynamo(e, args, kwargs, marker_before)
         else:
             # The compiled callable returned, so anything it packed under a
             # checkpoint is packed compiled. Only `_give_up_on_backend` reads
@@ -2051,6 +2110,12 @@ def torch_compile_with_fallback(fullgraph = False, **compile_kwargs):
     """
     def _decorate(func):
         func = unwrap_already_compiled(func)
+        if fullgraph and dynamo_tracing_disabled():
+            # Nothing can be traced, so from torch 2.14 the compiled callable
+            # raises instead of running eagerly. Hand back the plain function:
+            # that is what disabling Dynamo asked for, and it keeps the region
+            # working on every torch version.
+            return func
         compiled = torch.compile(func, fullgraph = fullgraph, **compile_kwargs)
         if not fullgraph:
             return compiled

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -902,11 +902,6 @@ def _in_non_reentrant_checkpoint():
 # eagerly in backward -- an abort, or wrong gradients when the shapes line up.
 _PACKED_COMPILED_IN_CHECKPOINT = False
 
-# The mirror of the above for the disabled-compiler dispatch: activations packed
-# EAGER because the flag was set, so re-enabling the compiler mid-step must not
-# recompute them compiled. Cleared at the same step boundaries.
-_PACKED_EAGER_IN_CHECKPOINT = False
-
 
 def _dynamo_is_tracing():
     """True while Dynamo is compiling the caller, across the supported torches."""
@@ -1521,7 +1516,10 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     # every step boundary. See that set for why the answer has to be per step
     # rather than per wrapper.
     state = {"warned": False, "eager": label in _LATCHED_EAGER_LABELS,
-             "pending_eager": label in _PENDING_EAGER_LABELS, "bumps": 0}
+             "pending_eager": label in _PENDING_EAGER_LABELS, "bumps": 0,
+             # Set the first time the disabled-compiler branch runs, cleared the
+             # first time it is safe to compile again. See the wrapper.
+             "ran_eager_disabled": False}
 
     def _warn(message):
         if not state["warned"]:
@@ -1894,9 +1892,9 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     def wrapper(*args, **kwargs):
         if state["eager"]:
             return eager_func(*args, **kwargs)
-        global _PACKED_EAGER_IN_CHECKPOINT
-        if (dynamo_tracing_disabled() or _PACKED_EAGER_IN_CHECKPOINT) and \
-            not _PACKED_COMPILED_IN_CHECKPOINT:
+        if dynamo_tracing_disabled() and not (
+            _PACKED_COMPILED_IN_CHECKPOINT and label in _COMPILED_OK_LABELS
+        ):
             # Checked BEFORE the call, not recovered from afterwards. Torch runs
             # the body and only then raises "found no compiled frames" from its
             # post-call bookkeeping (torch/_dynamo/eval_frame.py), so catching
@@ -1908,22 +1906,35 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             # is also what keeps the region compilable once the user switches
             # the compiler back on.
             #
-            # The marker defers a flip made mid-step, exactly as the
-            # recompile-limit arm below does. Something already packed compiled
+            # The two markers defer a flip made mid-step, exactly as the
+            # recompile-limit arm below does. THIS wrapper packed compiled
             # activations under a non-reentrant checkpoint this step, so going
             # eager now would recompute that pack in the other mode and abort
             # the backward with `CheckpointError`. Staying compiled is safe
             # precisely because it packed: torch reads `config.disable` when it
             # converts a frame, not when it runs code it has already compiled.
-            # `apply_pending_eager_fallbacks` clears the marker at the step
-            # boundary and the flip takes effect from the next step.
+            # Both are per step and `apply_pending_eager_fallbacks` clears them,
+            # so the flip takes effect from the next step.
             #
-            # `_PACKED_EAGER_IN_CHECKPOINT` is the same deferral mirrored: a
-            # flip the other way, mid-step, would recompute an eager pack
-            # compiled and abort the same backward.
-            if _in_non_reentrant_checkpoint():
-                _PACKED_EAGER_IN_CHECKPOINT = True
+            # `_PACKED_COMPILED_IN_CHECKPOINT` alone is not enough: it is
+            # process-wide, so another region's pack would send a wrapper with
+            # nothing cached into `compiled_func` and back to the error above.
+            state["ran_eager_disabled"] = True
             return eager_func(*args, **kwargs)
+        if state["ran_eager_disabled"]:
+            # Re-enabled after this wrapper ran eager. Asked at the point it
+            # matters rather than latched: a region that packed eager is
+            # recomputed INSIDE that region during backward, so being in one
+            # here is the signal that a pack is still owed, and compiling now
+            # would abort it with `CheckpointError`. Outside one there is
+            # nothing to disagree with, so honour the flag and stop asking.
+            # `_dynamo_is_tracing` first: the probe reaches a pybind builtin
+            # Dynamo refuses to enter, fatal under `fullgraph = True`, the same
+            # guard `_note_packed_under_checkpoint` carries.
+            if not _dynamo_is_tracing() and \
+                _in_non_reentrant_checkpoint() is True:
+                return eager_func(*args, **kwargs)
+            state["ran_eager_disabled"] = False
         marker_before = _PACKED_COMPILED_IN_CHECKPOINT
         try:
             _note_packed_under_checkpoint()
@@ -2144,12 +2155,7 @@ def apply_pending_eager_fallbacks() -> int:
     # and made `_give_up` re-raise for a later call nowhere near a checkpoint.
     # Cleared first, before any early return below.
     global _PACKED_COMPILED_IN_CHECKPOINT, _CHECKPOINT_PROBE_MISSES
-    global _PACKED_EAGER_IN_CHECKPOINT
     _PACKED_COMPILED_IN_CHECKPOINT = False
-    # Only here, not in `_restore_recompile_limits`: that runs mid-step whenever
-    # the last bump goes back, and clearing this one there would let a
-    # half-packed region recompute compiled.
-    _PACKED_EAGER_IN_CHECKPOINT = False
     _CHECKPOINT_PROBE_MISSES = 0             # a new step, a new probe budget
     _COMPILED_OK_LABELS.clear()              # and a new compiled-pack history
     _settled = _settle_abandoned_checkpoint_generator()

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -902,6 +902,11 @@ def _in_non_reentrant_checkpoint():
 # eagerly in backward -- an abort, or wrong gradients when the shapes line up.
 _PACKED_COMPILED_IN_CHECKPOINT = False
 
+# The mirror of the above for the disabled-compiler dispatch: activations packed
+# EAGER because the flag was set, so re-enabling the compiler mid-step must not
+# recompute them compiled. Cleared at the same step boundaries.
+_PACKED_EAGER_IN_CHECKPOINT = False
+
 
 def _dynamo_is_tracing():
     """True while Dynamo is compiling the caller, across the supported torches."""
@@ -1889,7 +1894,9 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     def wrapper(*args, **kwargs):
         if state["eager"]:
             return eager_func(*args, **kwargs)
-        if dynamo_tracing_disabled():
+        global _PACKED_EAGER_IN_CHECKPOINT
+        if (dynamo_tracing_disabled() or _PACKED_EAGER_IN_CHECKPOINT) and \
+            not _PACKED_COMPILED_IN_CHECKPOINT:
             # Checked BEFORE the call, not recovered from afterwards. Torch runs
             # the body and only then raises "found no compiled frames" from its
             # post-call bookkeeping (torch/_dynamo/eval_frame.py), so catching
@@ -1899,7 +1906,23 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             # Not latched either: entering the compiled callable while tracing
             # is off makes torch mark the code object skipped for good, so this
             # is also what keeps the region compilable once the user switches
-            # Dynamo back on.
+            # the compiler back on.
+            #
+            # The marker defers a flip made mid-step, exactly as the
+            # recompile-limit arm below does. Something already packed compiled
+            # activations under a non-reentrant checkpoint this step, so going
+            # eager now would recompute that pack in the other mode and abort
+            # the backward with `CheckpointError`. Staying compiled is safe
+            # precisely because it packed: torch reads `config.disable` when it
+            # converts a frame, not when it runs code it has already compiled.
+            # `apply_pending_eager_fallbacks` clears the marker at the step
+            # boundary and the flip takes effect from the next step.
+            #
+            # `_PACKED_EAGER_IN_CHECKPOINT` is the same deferral mirrored: a
+            # flip the other way, mid-step, would recompute an eager pack
+            # compiled and abort the same backward.
+            if _in_non_reentrant_checkpoint():
+                _PACKED_EAGER_IN_CHECKPOINT = True
             return eager_func(*args, **kwargs)
         marker_before = _PACKED_COMPILED_IN_CHECKPOINT
         try:
@@ -2121,7 +2144,12 @@ def apply_pending_eager_fallbacks() -> int:
     # and made `_give_up` re-raise for a later call nowhere near a checkpoint.
     # Cleared first, before any early return below.
     global _PACKED_COMPILED_IN_CHECKPOINT, _CHECKPOINT_PROBE_MISSES
+    global _PACKED_EAGER_IN_CHECKPOINT
     _PACKED_COMPILED_IN_CHECKPOINT = False
+    # Only here, not in `_restore_recompile_limits`: that runs mid-step whenever
+    # the last bump goes back, and clearing this one there would let a
+    # half-packed region recompute compiled.
+    _PACKED_EAGER_IN_CHECKPOINT = False
     _CHECKPOINT_PROBE_MISSES = 0             # a new step, a new probe budget
     _COMPILED_OK_LABELS.clear()              # and a new compiled-pack history
     _settled = _settle_abandoned_checkpoint_generator()

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -858,6 +858,34 @@ def _is_checkpoint_pack_hook(pack):
                 ("_checkpoint_hook", "_recomputation_hook")))
 
 
+def _in_checkpoint_recompute():
+    """Is a non-reentrant region being RECOMPUTED right now, definitely?
+
+    The two hooks separate the pack from the recompute:
+    `_checkpoint_hook...pack_hook` during the forward,
+    `_recomputation_hook...pack_hook` during backward. Verified identical on
+    2.9.1 and 2.14.0, and the qualnames are unchanged from 2.6.
+
+    A recompute is the only place a mode flip can strand a pack, so this is what
+    the disabled-compiler dispatch defers on. Being merely inside a region is
+    NOT enough: a fresh forward is inside one too, and holding there kept a
+    checkpointed wrapper eager for every later step.
+
+    Definite answers only. Without the accessor (before 2.8) it says False, so
+    the deferral simply does not engage on a torch that cannot raise the error
+    it exists for.
+    """
+    top = _saved_tensor_hook_accessor()
+    if top is None: return False
+    try:
+        hooks = top(True)                       # ignore_is_tracing
+    except Exception:
+        return False
+    if not hooks or hooks is _UNKNOWN: return False
+    return getattr(hooks[0], "__module__", "") == "torch.utils.checkpoint" and \
+        getattr(hooks[0], "__qualname__", "").startswith("_recomputation_hook")
+
+
 def _in_non_reentrant_checkpoint():
     """Are we inside a `use_reentrant = False` region? None when torch cannot say.
 
@@ -1519,7 +1547,11 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
              "pending_eager": label in _PENDING_EAGER_LABELS, "bumps": 0,
              # Set the first time the disabled-compiler branch runs, cleared the
              # first time it is safe to compile again. See the wrapper.
-             "ran_eager_disabled": False}
+             "ran_eager_disabled": False,
+             # How this wrapper's LAST call ran. Per wrapper, not a label
+             # another function may share, and per call rather than per step:
+             # what a recompute has to agree with is the pack that produced it.
+             "last_call_compiled": False}
 
     def _warn(message):
         if not state["warned"]:
@@ -1831,6 +1863,10 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         anything is half-packed, and for the same reason.
         """
         global _PACKED_COMPILED_IN_CHECKPOINT
+        # Every caller reaches here after `compiled_func` returned, which is
+        # what the disabled-compiler branch reads to decide whether a recompute
+        # of THIS wrapper would disagree with its pack.
+        state["last_call_compiled"] = True
         # The marker FIRST, because it is a plain global read and everything
         # below it can cost a full stack walk. Written as one `and` it read
         # `_in_non_reentrant_checkpoint() is False and not marker`, and Python
@@ -1892,9 +1928,7 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     def wrapper(*args, **kwargs):
         if state["eager"]:
             return eager_func(*args, **kwargs)
-        if dynamo_tracing_disabled() and not (
-            _PACKED_COMPILED_IN_CHECKPOINT and label in _COMPILED_OK_LABELS
-        ):
+        if dynamo_tracing_disabled():
             # Checked BEFORE the call, not recovered from afterwards. Torch runs
             # the body and only then raises "found no compiled frames" from its
             # post-call bookkeeping (torch/_dynamo/eval_frame.py), so catching
@@ -1906,33 +1940,32 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
             # is also what keeps the region compilable once the user switches
             # the compiler back on.
             #
-            # The two markers defer a flip made mid-step, exactly as the
-            # recompile-limit arm below does. THIS wrapper packed compiled
-            # activations under a non-reentrant checkpoint this step, so going
-            # eager now would recompute that pack in the other mode and abort
-            # the backward with `CheckpointError`. Staying compiled is safe
-            # precisely because it packed: torch reads `config.disable` when it
+            # One exception, and it is narrow on purpose: THIS wrapper packed
+            # compiled and that pack is being recomputed right now, so going
+            # eager would recompute it in the other mode and abort the backward
+            # with `CheckpointError`. Staying compiled is safe precisely
+            # because it packed -- torch reads `config.disable` when it
             # converts a frame, not when it runs code it has already compiled.
-            # Both are per step and `apply_pending_eager_fallbacks` clears them,
-            # so the flip takes effect from the next step.
             #
-            # `_PACKED_COMPILED_IN_CHECKPOINT` alone is not enough: it is
-            # process-wide, so another region's pack would send a wrapper with
-            # nothing cached into `compiled_func` and back to the error above.
-            state["ran_eager_disabled"] = True
-            return eager_func(*args, **kwargs)
-        if state["ran_eager_disabled"]:
-            # Re-enabled after this wrapper ran eager. Asked at the point it
-            # matters rather than latched: a region that packed eager is
-            # recomputed INSIDE that region during backward, so being in one
-            # here is the signal that a pack is still owed, and compiling now
-            # would abort it with `CheckpointError`. Outside one there is
-            # nothing to disagree with, so honour the flag and stop asking.
+            # Both halves are per wrapper and asked live, so nothing has to
+            # expire them: a process-wide marker would drag a wrapper with
+            # nothing cached into `compiled_func`, and any marker that outlived
+            # the recompute would go on ignoring the flag, with no caller
+            # inside this package to clear it.
+            if not (state["last_call_compiled"] and
+                    not _dynamo_is_tracing() and _in_checkpoint_recompute()):
+                state["ran_eager_disabled"] = True
+                state["last_call_compiled"] = False
+                return eager_func(*args, **kwargs)
+        elif state["ran_eager_disabled"]:
+            # Re-enabled after this wrapper ran eager. The mirror of the above,
+            # and only a recompute counts here too: a fresh checkpoint forward
+            # is inside a region as well, and holding on that kept a wrapper
+            # used only under checkpointing eager for every later step.
             # `_dynamo_is_tracing` first: the probe reaches a pybind builtin
             # Dynamo refuses to enter, fatal under `fullgraph = True`, the same
             # guard `_note_packed_under_checkpoint` carries.
-            if not _dynamo_is_tracing() and \
-                _in_non_reentrant_checkpoint() is True:
+            if not _dynamo_is_tracing() and _in_checkpoint_recompute():
                 return eager_func(*args, **kwargs)
             state["ran_eager_disabled"] = False
         marker_before = _PACKED_COMPILED_IN_CHECKPOINT

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -858,34 +858,6 @@ def _is_checkpoint_pack_hook(pack):
                 ("_checkpoint_hook", "_recomputation_hook")))
 
 
-def _in_checkpoint_recompute():
-    """Is a non-reentrant region being RECOMPUTED right now, definitely?
-
-    The two hooks separate the pack from the recompute:
-    `_checkpoint_hook...pack_hook` during the forward,
-    `_recomputation_hook...pack_hook` during backward. Verified identical on
-    2.9.1 and 2.14.0, and the qualnames are unchanged from 2.6.
-
-    A recompute is the only place a mode flip can strand a pack, so this is what
-    the disabled-compiler dispatch defers on. Being merely inside a region is
-    NOT enough: a fresh forward is inside one too, and holding there kept a
-    checkpointed wrapper eager for every later step.
-
-    Definite answers only. Without the accessor (before 2.8) it says False, so
-    the deferral simply does not engage on a torch that cannot raise the error
-    it exists for.
-    """
-    top = _saved_tensor_hook_accessor()
-    if top is None: return False
-    try:
-        hooks = top(True)                       # ignore_is_tracing
-    except Exception:
-        return False
-    if not hooks or hooks is _UNKNOWN: return False
-    return getattr(hooks[0], "__module__", "") == "torch.utils.checkpoint" and \
-        getattr(hooks[0], "__qualname__", "").startswith("_recomputation_hook")
-
-
 def _in_non_reentrant_checkpoint():
     """Are we inside a `use_reentrant = False` region? None when torch cannot say.
 
@@ -1221,7 +1193,8 @@ def dynamo_tracing_disabled():
 
     `TORCH_COMPILE_DISABLE=1` is the switch torch reads into `config.disable`
     at import; `torch._dynamo.config.disable = True` is the same thing set by
-    hand. Read live, never cached: notebooks and test fixtures flip it mid-run.
+    hand. Reads the live value, so a caller that wants a snapshot takes one:
+    `_fall_back_to_eager_on_recompile_limit` asks once, at its first call.
 
     `TORCHDYNAMO_DISABLE=1` is NOT this flag. `torch._dynamo.optimize` checks
     that env var itself and hands back the undecorated function, so it never
@@ -1526,6 +1499,18 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
 
     That leaves one mixed step, the one during which the latch flips. See
     `force_eager_fallback` below, which unsloth uses to close it.
+
+    The same reasoning decides the disabled-compiler branch, which asks
+    `dynamo_tracing_disabled()` once, on the first call, and keeps the answer.
+    `TORCH_COMPILE_DISABLE=1` is a process-level switch, and per-call reads of
+    it collide with checkpointing in every direction: a wrapper's pack and its
+    recompute must agree, and by the time a recompute runs, the forward that
+    packed it is long gone -- so the flag cannot be honoured mid-flight without
+    tracking a mode per outstanding pack, which torch exposes no handle for.
+    Deciding once removes the question. A flip made after the first call is
+    ignored, exactly as it is on a plain `torch.compile` region whose code is
+    already cached, and `apply_pending_eager_fallbacks` remains the supported
+    way to move a live wrapper to eager at a step boundary.
     """
     errors = _recompile_limit_errors()
     graph_break_errors = _disabled_hook_graph_break_error()
@@ -1545,13 +1530,9 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     # rather than per wrapper.
     state = {"warned": False, "eager": label in _LATCHED_EAGER_LABELS,
              "pending_eager": label in _PENDING_EAGER_LABELS, "bumps": 0,
-             # Set the first time the disabled-compiler branch runs, cleared the
-             # first time it is safe to compile again. See the wrapper.
-             "ran_eager_disabled": False,
-             # How this wrapper's LAST call ran. Per wrapper, not a label
-             # another function may share, and per call rather than per step:
-             # what a recompute has to agree with is the pack that produced it.
-             "last_call_compiled": False}
+             # Was the compiler switched off when this wrapper was FIRST called?
+             # None until then. Decided once, deliberately: see the wrapper.
+             "compiler_off": None}
 
     def _warn(message):
         if not state["warned"]:
@@ -1863,10 +1844,6 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
         anything is half-packed, and for the same reason.
         """
         global _PACKED_COMPILED_IN_CHECKPOINT
-        # Every caller reaches here after `compiled_func` returned, which is
-        # what the disabled-compiler branch reads to decide whether a recompute
-        # of THIS wrapper would disagree with its pack.
-        state["last_call_compiled"] = True
         # The marker FIRST, because it is a plain global read and everything
         # below it can cost a full stack walk. Written as one `and` it read
         # `_in_non_reentrant_checkpoint() is False and not marker`, and Python
@@ -1928,46 +1905,15 @@ def _fall_back_to_eager_on_recompile_limit(compiled_func, eager_func, label):
     def wrapper(*args, **kwargs):
         if state["eager"]:
             return eager_func(*args, **kwargs)
-        if dynamo_tracing_disabled():
+        if state["compiler_off"] is None:
+            state["compiler_off"] = dynamo_tracing_disabled()
+        if state["compiler_off"]:
             # Checked BEFORE the call, not recovered from afterwards. Torch runs
             # the body and only then raises "found no compiled frames" from its
             # post-call bookkeeping (torch/_dynamo/eval_frame.py), so catching
             # that and re-running eager executes the body twice, consuming RNG
             # twice and repeating any mutation it made.
-            #
-            # Not latched either: entering the compiled callable while tracing
-            # is off makes torch mark the code object skipped for good, so this
-            # is also what keeps the region compilable once the user switches
-            # the compiler back on.
-            #
-            # One exception, and it is narrow on purpose: THIS wrapper packed
-            # compiled and that pack is being recomputed right now, so going
-            # eager would recompute it in the other mode and abort the backward
-            # with `CheckpointError`. Staying compiled is safe precisely
-            # because it packed -- torch reads `config.disable` when it
-            # converts a frame, not when it runs code it has already compiled.
-            #
-            # Both halves are per wrapper and asked live, so nothing has to
-            # expire them: a process-wide marker would drag a wrapper with
-            # nothing cached into `compiled_func`, and any marker that outlived
-            # the recompute would go on ignoring the flag, with no caller
-            # inside this package to clear it.
-            if not (state["last_call_compiled"] and
-                    not _dynamo_is_tracing() and _in_checkpoint_recompute()):
-                state["ran_eager_disabled"] = True
-                state["last_call_compiled"] = False
-                return eager_func(*args, **kwargs)
-        elif state["ran_eager_disabled"]:
-            # Re-enabled after this wrapper ran eager. The mirror of the above,
-            # and only a recompute counts here too: a fresh checkpoint forward
-            # is inside a region as well, and holding on that kept a wrapper
-            # used only under checkpointing eager for every later step.
-            # `_dynamo_is_tracing` first: the probe reaches a pybind builtin
-            # Dynamo refuses to enter, fatal under `fullgraph = True`, the same
-            # guard `_note_packed_under_checkpoint` carries.
-            if not _dynamo_is_tracing() and _in_checkpoint_recompute():
-                return eager_func(*args, **kwargs)
-            state["ran_eager_disabled"] = False
+            return eager_func(*args, **kwargs)
         marker_before = _PACKED_COMPILED_IN_CHECKPOINT
         try:
             _note_packed_under_checkpoint()


### PR DESCRIPTION
## Summary

`TORCH_COMPILE_DISABLE=1` (and `torch._dynamo.config.disable = True`, the same flag set by hand) takes `torch.compile` out of the picture while debugging. Up to torch 2.13 a `fullgraph = True` region then ran eagerly. From torch 2.14 torch runs the body and raises afterwards, out of its post-call bookkeeping:

```
RuntimeError: torch.compile with fullgraph=True found no compiled frames.
Skipped frames: ... Dynamo tracing is disabled
```

Every `torch_compile_with_fallback` region inherits that, and there are many. `rl_replacements.py` wraps the GRPO loss accumulator in one, and `compiler.py` writes the decorator into every generated `unsloth_compiled_cache` module. So on torch 2.14 a user who disables the compiler loses GRPO training at the first step, having asked only to turn the compiler off.

`TORCHDYNAMO_DISABLE=1` is a different switch and is not affected: `torch._dynamo.optimize` checks that env var itself and returns the undecorated function, so it never reaches a compiled callable.

Found while checking #890 across torch 2.6.0 through 2.14.0. It reproduces on `main` with no patch of mine applied, so it is not specific to that change.

## Reproducer

On torch 2.14.0, against `main`, with `TORCH_COMPILE_DISABLE=1` set:

```python
import torch
from unsloth_zoo import rl_replacements as rr

B, T, V = 4, 5, 11
g = torch.Generator().manual_seed(1)
new = torch.randn(B, T, generator = g, dtype = torch.float64).requires_grad_(True)
old = new.detach() + 0.05
ref = new.detach() + 0.05
kwargs = dict(
    loss_type = "grpo", num_items_in_batch = 20.0, num_processes = 1,
    current_gradient_accumulation_steps = 1, max_completion_length = T,
)
rr.UnslothEfficientGRPO.apply(
    new, old, ref, None, torch.randn(V, 3, dtype = torch.float64),
    torch.randint(0, V, (B, T), generator = g), torch.ones(B, T, dtype = torch.float64),
    torch.randn(B, generator = g, dtype = torch.float64), 0.04, None, 1, kwargs,
)
```

raises the `RuntimeError` above. On this branch it returns `0.10886901617050171`, which is the value torch 2.9.1 returns for the same inputs.

## Fix

The wrapper asks `dynamo_tracing_disabled()` once, at its first call, and runs the eager function whenever the answer was yes.

Reading it before the call rather than recovering from the error afterwards is the whole point. Torch runs the body and only then raises, from the `finally` in `torch/_dynamo/eval_frame.py`, so an exception handler that re-runs eager executes the function twice for one call: two draws from the RNG, and any mutation the body made repeated. Measured on 2.14.0, an earlier revision of this branch ran the body twice; `test_decorated_before_disabling_runs_eagerly_and_exactly_once` pins it at one.

Reading it at the first call rather than at decoration matters because a flag held only while modules import would otherwise stick for the whole run. The first call is after imports, so `TORCH_COMPILE_DISABLE=1` and a `config.disable` set before training both take effect, and a scoped patch that is restored does not.

Reading it once rather than on every call is what keeps it consistent with activation checkpointing. Non-reentrant checkpointing recomputes the forward during backward and compares what each pass saved, so a pack and its recompute running in different modes raises `CheckpointError` and ends the step. A per-call read cannot stay consistent: by the time a recompute runs, the forward that packed it is gone, and one wrapper can have several packs outstanding at once, which torch exposes no handle to tell apart. A flip made after the first call is therefore ignored, which is what a plain `torch.compile` region does anyway once its code is cached. `apply_pending_eager_fallbacks` remains the supported way to move a live wrapper to eager at a step boundary.

Two mid-step cases are torch's and are unchanged from `main` either way: it consults `config.disable` whenever it converts a frame, so a recompute that needs a new guard variant is skipped and runs eager no matter what this wrapper decides. The tests state that rather than claiming otherwise.

`torch.compiler.set_stance("force_eager")` needs no handling: torch raises only while the stance is `"default"`, which is what that check in `eval_frame.py` is for. Verified on 2.9.1 and 2.14.0.

Keying on the flag rather than on the error message also means no fullgraph failure is ever absorbed. Torch emits the same "found no compiled frames" text for skipfile and dispatch-mode refusals, which are genuine failures and still raise.

`fullgraph = False` is untouched, since Dynamo already falls back by itself there.

Cost: one dict read on the call path of a compiled region after the first call, against 24 us for a minimal call through this wrapper.

## Verification

`tests/test_compile_dynamo_disabled_fullgraph.py`: disabled before decoration and disabled at decoration, exactly one body execution in each, a flag held only over decoration not sticking, a checkpointed step under either setting, a flip between a forward and its backward, two outstanding packs of one wrapper straddling a flip, a completed checkpointed step leaving nothing to expire, a nested wrapper still traceable after running eager, the `force_eager` stance left to torch, `fullgraph = False` untouched, a real graph break still raising, and the flag reader itself still live.

| | torch 2.9.1 | torch 2.14.0 |
|---|---|---|
| new test file, on `main` | 3 failed, 10 passed | 9 failed, 4 passed |
| new test file, on this branch | 13 passed | 13 passed |
| GRPO reproducer under a disabled compiler, on `main` | passes | fails |
| GRPO reproducer under a disabled compiler, on this branch | passes | passes |


On 2.9.1, `main` fails three of them. One is only the absent helper. The other two assert wrapper state this change introduces, so they cannot pass there; 2.9.1 never raised the error itself, which is why the rest pass.

No regressions across the compile, checkpoint, fallback and recompile suites: 153 passed and 2 skipped on torch 2.14.0, and a wider sweep on torch 2.9.1 over every compile, fallback, checkpoint, GRPO, `rl_replacements` and patching test in the repo at 1737 passed, 84 skipped. The four `tests/test_checkpoint_compile_mix.py` failures seen on 2.14.0 are identical with and without this change and predate it.
