### PR TITLE
fix(mlx): preserve VLM processor and training-path contracts

### DIFF
--- a/tests/test_mlx_save_over_source.py
+++ b/tests/test_mlx_save_over_source.py
@@ -111,6 +111,31 @@ def _mode(path):
     return stat.S_IMODE(os.stat(path).st_mode)
 
 
+@pytest.mark.parametrize("failure", [None, TypeError, AttributeError])
+def test_vlm_processor_failure_preserves_finished_adapter(tmp_path, failure):
+    from pathlib import Path
+    from types import SimpleNamespace
+    import mlx.nn as nn
+    from mlx_lm.tuner.lora import LoRALinear
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    processor = SimpleNamespace()
+    def broken_save(directory):
+        (Path(directory) / "processor_config.json").write_text('{"broken":')
+        raise failure("processor runtime state is not serializable")
+    if failure is not None:
+        processor.save_pretrained = broken_save
+    model = nn.Module()
+    model.q_proj = LoRALinear.from_base(nn.Linear(4, 4, bias=False), r=2, scale=2)
+    model.q_proj.lora_b = mx.ones_like(model.q_proj.lora_b) * 3
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.model, trainer.processor, trainer.tokenizer = model, processor, processor
+    trainer.args = SimpleNamespace(output_dir=str(tmp_path / "saved"), learning_rate=1e-3,
+                                   max_steps=2, max_seq_length=8, use_cce=True)
+    trainer._save_model_impl()
+    saved = Path(trainer.args.output_dir)
+    assert mx.array_equal(mx.load(str(saved / "adapters.safetensors"))["q_proj.lora_b"], model.q_proj.lora_b)
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
 def test_resaving_adapters_keeps_the_targets_permissions(tmp_path, monkeypatch):
     """os.replace() installs a new inode, so the temp file must inherit the mode.

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -5,6 +5,7 @@ import re
 
 import numpy as np
 import pytest
+from PIL import Image
 from pathlib import Path
 from unittest import mock
 
@@ -482,11 +483,11 @@ def test_vlm_prompt_completion_prefers_embedded_images_like_cuda():
     processor = _ConversationalPromptCompletionProcessor()
     _finalized_collate(
         [{
-            "image": "top-level",
+            "image": Image.new("RGB", (8, 8), "red"),
             "prompt": [{
                 "role": "user",
                 "content": [
-                    {"type": "image", "image": "embedded"},
+                    {"type": "image", "image": Image.new("RGB", (8, 8), "blue")},
                     {"type": "text", "text": "Q"},
                 ],
             }],
@@ -497,7 +498,7 @@ def test_vlm_prompt_completion_prefers_embedded_images_like_cuda():
         image_size=16,
     )
 
-    assert processor.images_seen[0] == ["embedded"]
+    assert processor.images_seen[0] == [Image.new("RGB", (8, 8), "blue")]
 
 
 def test_vlm_prompt_completion_uses_top_level_image_for_bare_placeholder():
@@ -505,8 +506,8 @@ def test_vlm_prompt_completion_uses_top_level_image_for_bare_placeholder():
 
     messages = [{"role": "user", "content": [{"type": "image"}]}]
     assert _extract_vlm_pc_images(
-        {"image": "top-level"}, messages, [], image_size=16,
-    ) == ["top-level"]
+        {"image": Image.new("RGB", (8, 8), "red")}, messages, [], image_size=16,
+    ) == [Image.new("RGB", (8, 8), "red")]
 
 
 def test_vlm_collate_passes_studio_top_level_image_to_processor():
@@ -522,24 +523,24 @@ def test_vlm_collate_passes_studio_top_level_image_to_processor():
                     {"type": "text", "text": "Q"},
                 ],
             }],
-            "image": "top-level",
+            "image": Image.new("RGB", (8, 8), "red"),
         }],
         processor,
         max_seq_length=8,
         image_size=16,
     )
 
-    assert processor.images_seen == [["top-level"]]
+    assert processor.images_seen == [[Image.new("RGB", (8, 8), "red")]]
 
 
 def test_vlm_top_level_images_key_still_wins_over_image_key():
     from unsloth_zoo.mlx.utils import _extract_vlm_images
 
     assert _extract_vlm_images(
-        {"images": ["plural"], "image": "singular"},
+        {"images": [Image.new("RGB", (8, 8), "red")], "image": Image.new("RGB", (8, 8), "blue")},
         [],
         image_size=16,
-    ) == ["plural"]
+    ) == [Image.new("RGB", (8, 8), "red")]
 
 
 def test_vlm_top_level_image_key_requires_bare_image_placeholder():
@@ -610,7 +611,7 @@ def test_vlm_prompt_completion_top_level_images_use_cuda_process_shape(monkeypat
     def fake_process_vision_info(conversations, **kwargs):
         seen["conversations"] = conversations
         seen["kwargs"] = kwargs
-        return ["processed"], None, {"fps": []}
+        return [Image.new("RGB", (8, 8), "blue")], None, {"fps": []}
 
     monkeypatch.setattr(
         vision_utils,
@@ -618,9 +619,9 @@ def test_vlm_prompt_completion_top_level_images_use_cuda_process_shape(monkeypat
         fake_process_vision_info,
     )
 
-    assert _extract_vlm_pc_images({"images": ["raw"]}, [], [], image_size=16) == ["processed"]
+    assert _extract_vlm_pc_images({"images": [Image.new("RGB", (8, 8), "red")]}, [], [], image_size=16) == [Image.new("RGB", (8, 8), "blue")]
     assert seen == {
-        "conversations": [{"image": "raw"}],
+        "conversations": [{"image": Image.new("RGB", (8, 8), "red")}],
         "kwargs": {"return_video_kwargs": True},
     }
 
@@ -655,7 +656,7 @@ def test_vlm_render_falls_back_to_content_part_templates():
         def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
             assert tokenize is False
             if messages and all(isinstance(part, dict) and "type" in part for part in messages):
-                return "parts:" + ",".join(part["type"] for part in messages)
+                return "parts:" + ",".join(part["type"] for part in messages) + ":" + "".join(part.get("text", "") for part in messages)
             raise ValueError("expected content parts")
 
     rendered = _render_vlm_messages(
@@ -663,7 +664,7 @@ def test_vlm_render_falls_back_to_content_part_templates():
         [{"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "Q"}]}],
     )
 
-    assert rendered == "parts:image,text"
+    assert rendered == "parts:image,text:Q"
 
 
 def test_vlm_render_falls_back_to_text_templates():
@@ -912,7 +913,7 @@ def test_deepseek_rendering_repairs_missing_image_token():
         chat_template = "deepseek"
 
         def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
-            return "question"
+            return "".join(part.get("text", "") for m in messages for part in m["content"])
 
     text = _render_vlm_messages(
         DeepseekProcessor(),
@@ -5552,7 +5553,6 @@ def test_vlm_component_kwargs_preserve_expansion_and_modality_options(drops_padd
 
     output = _call_vlm_processor(Processor(), (), dict(text=["a#", "bb#"], images=[2, 3], size=4, padding=True))
     assert output == {"input_ids": [[3], [4]], "pixel_values": [8, 12], "padding": True}
-
 @pytest.mark.parametrize("existing_pad", [None, "[UNK]"])
 def test_image_free_vlm_calls_use_the_padded_tokenizer(existing_pad):
     from tokenizers import Tokenizer, models, pre_tokenizers
@@ -5571,7 +5571,6 @@ def test_image_free_vlm_calls_use_the_padded_tokenizer(existing_pad):
     assert tokenizer.pad_token == (existing_pad or "[EOS]")
 
 
-
 @pytest.mark.parametrize("key", ["image_sizes", "images_spatial_crop"])
 def test_nested_size_metadata_preserves_image_and_slice_axes(key):
     from unsloth_zoo.mlx.utils import _normalize_size_tuples, _prepare_vlm_batch_for_compile
@@ -5580,3 +5579,20 @@ def test_nested_size_metadata_preserves_image_and_slice_axes(key):
     batch = _prepare_vlm_batch_for_compile({key: raw}, {}, phase="content")
     assert batch[key] is raw and batch[key].shape == (2, 2, 2)
     assert batch["_unsloth_static_vlm_metadata"][key] == (((2, 3), (4, 5)), ((6, 7), (8, 9)))
+
+
+@pytest.mark.parametrize("image_type", ["image", "image_url", "input_image"])
+@pytest.mark.parametrize("stringify", [False, True])
+def test_vlm_rendering_keeps_image_order_without_stringifying_parts(tmp_path, monkeypatch, image_type, stringify):
+    from types import SimpleNamespace
+    from tokenizers import Tokenizer, models
+    from transformers import PreTrainedTokenizerFast
+    from unsloth_zoo.mlx.utils import _render_vlm_messages
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=Tokenizer(models.WordLevel({"x": 0})))
+    expression = "m['content']" if stringify else "'' + m['content']"
+    tokenizer.chat_template = "{% for m in messages %}{{ " + expression + " }}{% endfor %}"
+    processor = SimpleNamespace(tokenizer=tokenizer, image_token="<|picture|>")
+    messages = [{"role": "user", "content": [
+        {"type": "text", "text": "before"}, {"type": image_type},
+        {"type": "text", "text": "after"}]}]
+    assert _render_vlm_messages(processor, messages) == "before<|picture|>after"

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -5529,3 +5529,26 @@ def test_qwen3_omni_leaves_assistant_turns_alone_without_counts():
 
     assert [part.get("type") for part in template[0]["content"]] == ["text", "audio"]
     assert [part.get("type") for part in template[1]["content"]] == ["audio", "text"]
+
+
+@pytest.mark.parametrize("drops_padding", [False, True])
+def test_vlm_component_kwargs_preserve_expansion_and_modality_options(drops_padding):
+    from unsloth_zoo.mlx.utils import _call_vlm_processor
+    class Tokenizer:
+        def __call__(self, text, padding):
+            return {"input_ids": [[len(t)] for t in text], "padding": padding}
+
+    class Images:
+        def __call__(self, images, size):
+            return {"pixel_values": [i * size for i in images]}
+
+    class Processor:
+        tokenizer, image_processor = Tokenizer(), Images()
+        def __call__(self, text, images, **kwargs):
+            if drops_padding:
+                kwargs.pop("padding")
+            return {**self.image_processor(images, **kwargs),
+                    **self.tokenizer([t.replace("#", "##") for t in text], **kwargs)}
+
+    output = _call_vlm_processor(Processor(), (), dict(text=["a#", "bb#"], images=[2, 3], size=4, padding=True))
+    assert output == {"input_ids": [[3], [4]], "pixel_values": [8, 12], "padding": True}

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2335,10 +2335,13 @@ def test_paligemma_mask_is_left_alone_without_token_types():
     untouched = _paligemma_replace_mask(
         SimpleNamespace(attention_mask_4d=outer_product), None, padding)
     assert untouched.attention_mask_4d is outer_product
-    # Nor when upstream built no mask at all, e.g. a text-only batch.
-    assert _paligemma_replace_mask(
+    text_mask = _paligemma_replace_mask(
         SimpleNamespace(attention_mask_4d=None),
-        mx_.zeros((1, 4), dtype=mx_.int32), padding).attention_mask_4d is None
+        mx_.array([[0, 0, 1, 1], [0, 0, 0, 1]]), mx_.ones((2, 4)),
+    ).attention_mask_4d
+    visible = np.asarray(text_mask).reshape(2, 4, 4)
+    assert visible[0, 0, 1] and visible[1, 0, 2]
+    assert not visible[0, 0, 2] and not visible[1, 2, 3]
     replaced = _paligemma_replace_mask(
         SimpleNamespace(attention_mask_4d=outer_product),
         mx_.array([[0, 0, 1, 1]], dtype=mx_.int32), padding)
@@ -2346,14 +2349,15 @@ def test_paligemma_mask_is_left_alone_without_token_types():
     assert not np.asarray(replaced.attention_mask_4d).reshape(4, 4)[2, 3]
 
 
-def test_paligemma_embedder_wrapper_replaces_the_mask_it_wrapped():
+@pytest.mark.parametrize("has_native_mask", [False, True])
+def test_paligemma_embedder_wrapper_replaces_the_mask_it_wrapped(has_native_mask):
     """The wrapper is what actually reaches a loaded model, so it has to hand the
     token types on rather than return upstream's mask untouched."""
     from types import SimpleNamespace
     from unsloth_zoo.mlx.loader import _paligemma_causal_mask_wrapper
 
     mx_ = _utils_mx()
-    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_) if has_native_mask else None
     seen = {}
 
     def original(_self, input_ids=None, pixel_values=None, mask=None, **kwargs):
@@ -2370,7 +2374,8 @@ def test_paligemma_embedder_wrapper_replaces_the_mask_it_wrapped():
     assert not np.asarray(got.attention_mask_4d).reshape(4, 4)[2, 3]
 
 
-def test_paligemma_plain_loss_path_also_gets_the_causal_suffix():
+@pytest.mark.parametrize("has_native_mask", [False, True])
+def test_paligemma_plain_loss_path_also_gets_the_causal_suffix(has_native_mask):
     """Upstream's call embeds with a fixed three arguments, dropping the token
     types, so without threading them the `use_cce=False` path keeps leaking."""
     from types import SimpleNamespace
@@ -2380,7 +2385,7 @@ def test_paligemma_plain_loss_path_also_gets_the_causal_suffix():
     )
 
     mx_ = _utils_mx()
-    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_) if has_native_mask else None
     padding = mx_.ones((1, 4), dtype=mx_.int32)
     seen = {}
 
@@ -5545,3 +5550,21 @@ def test_vlm_component_kwargs_preserve_expansion_and_modality_options(drops_padd
 
     output = _call_vlm_processor(Processor(), (), dict(text=["a#", "bb#"], images=[2, 3], size=4, padding=True))
     assert output == {"input_ids": [[3], [4]], "pixel_values": [8, 12], "padding": True}
+
+@pytest.mark.parametrize("existing_pad", [None, "[UNK]"])
+def test_image_free_vlm_calls_use_the_padded_tokenizer(existing_pad):
+    from tokenizers import Tokenizer, models, pre_tokenizers
+    from transformers import PreTrainedTokenizerFast
+    from unsloth_zoo.mlx.utils import _processor_vlm_inputs
+    backend = Tokenizer(models.WordLevel({"[UNK]": 0, "[EOS]": 1, "a": 2, "b": 3}))
+    backend.pre_tokenizer = pre_tokenizers.Whitespace()
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, eos_token="[EOS]",
+                                       unk_token="[UNK]", pad_token=existing_pad, model_input_names=["input_ids", "attention_mask"])
+    processor = mock.Mock(spec=["tokenizer", "image_processor"], tokenizer=tokenizer, image_processor=object())
+    processor.side_effect = AssertionError("image processor must not receive text-only calls")
+    inputs = _processor_vlm_inputs(processor, ["a b", "b"], [[], []], 8)
+    assert inputs["input_ids"].tolist() == [[2, 3], [3, 1 if existing_pad is None else 0]]
+    assert inputs["attention_mask"].tolist() == [[1, 1], [1, 0]]
+    processor.assert_not_called()
+    assert tokenizer.pad_token == (existing_pad or "[EOS]")
+

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -5596,3 +5596,23 @@ def test_vlm_rendering_keeps_image_order_without_stringifying_parts(tmp_path, mo
         {"type": "text", "text": "before"}, {"type": image_type},
         {"type": "text", "text": "after"}]}]
     assert _render_vlm_messages(processor, messages) == "before<|picture|>after"
+
+
+@pytest.mark.parametrize("layout", ["nested", "decoder", "view"])
+@pytest.mark.parametrize("count", [1, 2])
+@pytest.mark.parametrize("use_dora", [False, True])
+def test_decoder_containers_support_lora(layout, count, use_dora):
+    from types import SimpleNamespace as NS
+    import mlx.nn as nn
+    from unsloth_zoo.mlx.loader import linear_to_lora_layers, _fix_gemma3n_altup_batch
+    from unsloth_zoo.mlx.utils import _get_transformer_layers
+    stack = nn.Module()
+    stack.layers = [nn.Module(), nn.Module()]
+    for layer in stack.layers:
+        layer.proj = nn.Linear(4, 4)
+    root = {"nested": NS(model=NS(layers=stack)), "decoder": NS(layers=range(2), model=NS(decoder=stack)),
+            "view": NS(model=stack)}[layout]
+    assert _get_transformer_layers(root) is stack.layers
+    assert not _fix_gemma3n_altup_batch(NS(language_model=root))
+    assert linear_to_lora_layers(root, count, dict(keys=["proj"], rank=2, scale=2, dropout=0, use_dora=use_dora)) == count
+    assert [hasattr(layer.proj, "lora_a") for layer in stack.layers] == [count == 2, True]

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3830,6 +3830,8 @@ def test_compile_preparation_finds_phi4mm_positions_without_token_indices():
     ("image_grid_thw", [[1, 16, 12], [2, 8, 4]]),
     ("video_grid_thw", [[2, 12, 8], [3, 4, 2]]),
     ("spatial_shapes", [[16, 12], [8, 4]]),
+    ("image_sizes", [[16, 12], [8, 4]]),
+    ("images_spatial_crop", [[2, 3], [4, 5]]),
 ])
 def test_processor_grid_structure_survives_compile_preparation(array_factory, key, rows):
     from unsloth_zoo.mlx.utils import _prepare_vlm_batch_for_compile
@@ -5568,3 +5570,13 @@ def test_image_free_vlm_calls_use_the_padded_tokenizer(existing_pad):
     processor.assert_not_called()
     assert tokenizer.pad_token == (existing_pad or "[EOS]")
 
+
+
+@pytest.mark.parametrize("key", ["image_sizes", "images_spatial_crop"])
+def test_nested_size_metadata_preserves_image_and_slice_axes(key):
+    from unsloth_zoo.mlx.utils import _normalize_size_tuples, _prepare_vlm_batch_for_compile
+    assert _normalize_size_tuples([[[2, 3], [4, 5]], [[6, 7]]]) == (((2, 3), (4, 5)), ((6, 7),))
+    raw = mx.array([[[2, 3], [4, 5]], [[6, 7], [8, 9]]])
+    batch = _prepare_vlm_batch_for_compile({key: raw}, {}, phase="content")
+    assert batch[key] is raw and batch[key].shape == (2, 2, 2)
+    assert batch["_unsloth_static_vlm_metadata"][key] == (((2, 3), (4, 5)), ((6, 7), (8, 9)))

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3820,32 +3820,25 @@ def test_compile_preparation_finds_phi4mm_positions_without_token_indices():
         [7, image_id, 8, audio_id, 9]
     ]
 
-def _prepared_grid(model_type):
+@pytest.mark.parametrize("array_factory", [mx.array, np.array, tuple])
+@pytest.mark.parametrize("key,rows", [
+    ("image_grid_thw", [[1, 16, 12], [2, 8, 4]]),
+    ("video_grid_thw", [[2, 12, 8], [3, 4, 2]]),
+    ("spatial_shapes", [[16, 12], [8, 4]]),
+])
+def test_processor_grid_structure_survives_compile_preparation(array_factory, key, rows):
     from unsloth_zoo.mlx.utils import _prepare_vlm_batch_for_compile
 
-    # "content" is the phase that fixes the grid form; "positions" needs the
-    # per-family token ids a bare model_type config does not carry.
-    return _prepare_vlm_batch_for_compile({
-        "input_ids": mx.array([[1, 2, 3]], dtype=mx.int32),
-        "attention_mask": mx.array([[1, 1, 1]], dtype=mx.int32),
-        "image_grid_thw": mx.array([[1, 16, 16]], dtype=mx.int32),
-    }, {"model_type": model_type, "vision_config": {"hidden_size": 8}},
-        phase="content")
-
-
-def test_array_grid_families_keep_an_indexable_grid():
-    """These vision towers open with `grid_thw.tolist()`; tuples raise there."""
-    for model_type in ("glm4v", "glm_ocr", "muse_glimmer", "glm5_next"):
-        grid = _prepared_grid(model_type)["image_grid_thw"]
-        assert isinstance(grid, mx.array), model_type
-        assert grid.tolist() == [[1, 16, 16]], model_type
-
-
-def test_compile_patched_families_keep_the_traceable_tuple_grid():
-    """Qwen/Paddle patches trace the grid as static metadata, not an array."""
-    for model_type in ("qwen2_vl", "qwen2_5_vl", "qwen3_vl", "paddleocr_vl"):
-        grid = _prepared_grid(model_type)["image_grid_thw"]
-        assert grid == ((1, 16, 16),), model_type
+    value = array_factory(rows)
+    batch = _prepare_vlm_batch_for_compile({"input_ids": mx.array([[1, 2, 3], [4, 5, 6]]), key: value},
+                                           {"model_type": "new_architecture"}, phase="content")
+    expected = tuple(tuple(row) for row in rows)
+    assert batch["_unsloth_static_vlm_metadata"][key] == expected
+    if array_factory is tuple:
+        assert batch[key] == expected
+    else:
+        assert batch[key] is value
+        assert batch[key].tolist() == rows
 
 
 def _prepared_positions(model_type):

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -5616,3 +5616,21 @@ def test_decoder_containers_support_lora(layout, count, use_dora):
     assert not _fix_gemma3n_altup_batch(NS(language_model=root))
     assert linear_to_lora_layers(root, count, dict(keys=["proj"], rank=2, scale=2, dropout=0, use_dora=use_dora)) == count
     assert [hasattr(layer.proj, "lora_a") for layer in stack.layers] == [count == 2, True]
+
+
+def test_crop_arrays_reach_the_image_tower_without_boolean_conversion(monkeypatch):
+    from collections import defaultdict
+    from types import SimpleNamespace as NS
+    from unsloth_zoo.mlx import compile as patches
+    modules = defaultdict(lambda: NS(**{name: type(name, (), {}) for name in (
+        "Model", "MlpProjector", "VisionEmbeddings", "VisionModel", "InputEmbeddingsFeatures")}))
+    monkeypatch.setattr(patches, "importlib", NS(import_module=lambda name: modules[name]))
+    monkeypatch.setattr(patches, "_PATCHED_ARCHES", set())
+    monkeypatch.setattr(patches, "_patch_method", setattr)
+    patches._install_deepseek_ocr_compile_patches()
+    model = NS(language_model=NS(model=NS(embed_tokens=lambda ids: mx.zeros((1, 2, 4)))),
+               sam_model=mock.Mock(side_effect=RuntimeError("image tower reached")))
+    with pytest.raises(RuntimeError, match="image tower reached"):
+        modules["mlx_vlm.models.deepseekocr.deepseekocr"].Model.get_input_embeddings(
+            model, mx.array([[1, 2]]), (mx.zeros((0, 3, 1, 1)), mx.zeros((2, 3, 1, 1))),
+            images_spatial_crop=mx.array([[1, 1], [2, 1]]))

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -5199,6 +5199,7 @@ def _install_deepseek_ocr_compile_patches():
 
             return InputEmbeddingsFeatures(inputs_embeds=input_embeds)
 
+        patched_deepseekocr_get_input_embeddings._unsloth_static_vlm_metadata = ("images_spatial_crop",)
         _patch_method(
             deepseekocr_module.Model,
             "get_input_embeddings",
@@ -5308,6 +5309,7 @@ def _install_deepseek_ocr_compile_patches():
 
         return InputEmbeddingsFeatures2(inputs_embeds=input_embeds)
 
+    patched_deepseekocr2_get_input_embeddings._unsloth_static_vlm_metadata = ("images_spatial_crop",)
     _patch_method(
         deepseekocr2_module.Model,
         "get_input_embeddings",
@@ -5550,6 +5552,7 @@ def _install_negative_image_placeholder_patches():
 
         return txt_embeds
 
+    patched_phi3_get_input_embeddings._unsloth_static_vlm_metadata = ("image_sizes",)
     _patch_method(phi3_module.Model, "get_input_embeddings", patched_phi3_get_input_embeddings)
     _patch_method(phi3_vision_module.VisionModel, "__call__", patched_phi3_vision_call)
     _PATCHED_ARCHES.add("phi3_v")

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -2184,6 +2184,8 @@ def _explicit_position_embedding_adapter(original, replacement):
             return original(self, input_ids, pixel_values, **kwargs)
         return replacement(self, input_ids, pixel_values, **kwargs)
 
+    patched._unsloth_static_vlm_metadata = ("image_grid_thw", "video_grid_thw")
+    patched._unsloth_static_metadata_with_positions = True
     return patched
 
 
@@ -2869,6 +2871,10 @@ def _qwen3_batch_embedding_adapter(
                 )
         return features
 
+    patched._unsloth_static_vlm_metadata = (
+        ("image_grid_thw", "video_grid_thw") if replacement is not None else ()
+    )
+    patched._unsloth_static_metadata_with_positions = True
     patched._unsloth_qwen3_batch_visual_state = True
     patched._unsloth_qwen3_replaces_visual_inference = bool(
         replacement is not None
@@ -4175,6 +4181,9 @@ def _install_paddleocr_vl_compile_patches():
     _patch_method(vision_module.Attention, "__call__", patched_paddle_attention)
     _patch_method(vision_module.VisionModel, "rot_pos_emb", patched_paddle_rot_pos_emb)
     _patch_method(vision_module.VisionModel, "__call__", patched_paddle_vision_call)
+    patched_paddle_get_input_embeddings._unsloth_static_vlm_metadata = (
+        "image_grid_thw", "video_grid_thw",
+    )
     _patch_method(module.Model, "get_input_embeddings", patched_paddle_get_input_embeddings)
     _PATCHED_ARCHES.add("paddleocr_vl")
 
@@ -5688,6 +5697,7 @@ def _install_phi4_multimodal_patches():
             )
             return InputEmbeddingsFeatures(inputs_embeds=outputs)
 
+        patched_phi4_siglip_get_input_embeddings._unsloth_static_vlm_metadata = ("spatial_shapes",)
         _patch_method(
             phi4_siglip_module.Model,
             "get_input_embeddings",
@@ -5803,6 +5813,7 @@ def _install_phi4_multimodal_patches():
         return InputEmbeddingsFeatures(inputs_embeds=outputs)
 
     _patch_method(phi4mm_vision_module.VisionTower, "__call__", patched_phi4mm_vision_tower_call)
+    patched_phi4mm_get_input_embeddings._unsloth_static_vlm_metadata = ("spatial_shapes",)
     _patch_method(phi4mm_module.Model, "get_input_embeddings", patched_phi4mm_get_input_embeddings)
     _PATCHED_ARCHES.add("phi4mm")
 

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -5086,7 +5086,7 @@ def _install_deepseek_ocr_compile_patches():
             seq_features = []
             patch_idx = 0
 
-            for image_idx, crop_shape in enumerate(images_spatial_crop or ()):
+            for image_idx, crop_shape in enumerate(() if images_spatial_crop is None else images_spatial_crop):
                 width_crop_num, height_crop_num = (int(crop_shape[0]), int(crop_shape[1]))
                 has_crops = width_crop_num > 1 or height_crop_num > 1
                 num_patches = width_crop_num * height_crop_num if has_crops else 0

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -351,9 +351,9 @@ def _mlx_lora_from_base(module, config, *, specs, path=None):
 
 
 def _mlx_language_layers(model):
-    if hasattr(model, "layers"):
-        return model.layers
-    return model.model.layers
+    from .utils import _get_transformer_layers
+    layers = _get_transformer_layers(model)
+    return layers if layers is not None else ()
 
 
 def linear_to_lora_layers(model, num_layers, config):
@@ -361,6 +361,14 @@ def linear_to_lora_layers(model, num_layers, config):
     from mlx.utils import tree_unflatten
 
     layers = _mlx_language_layers(model)
+    root = model
+    seen = set()
+    while not all(callable(getattr(root, name, None)) for name in ("named_modules", "update_modules")):
+        if root is None or id(root) in seen:
+            root = None
+            break
+        seen.add(id(root))
+        root = getattr(root, "model", None)
     type_specs = _mlx_lora_type_specs()
     keys = set(config.get("keys") or ())
     # A generic name is attention beside a qkv and MLP beside an fc1, so the
@@ -385,7 +393,7 @@ def linear_to_lora_layers(model, num_layers, config):
             for name, module in layer.named_modules():
                 if name in wanted:
                     _mlx_dora_wrapper_type(module, name)
-        for name, module in model.named_modules():
+        for name, module in (root.named_modules() if root is not None else ()):
             if name in shared:
                 _mlx_dora_wrapper_type(module, name)
     attached = 0
@@ -413,11 +421,11 @@ def linear_to_lora_layers(model, num_layers, config):
     # `shared`, not `keys`: a layer-local `ff_proj` can name a root module too.
     root_replacements = [
         (name, _mlx_lora_from_base(module, config, specs=type_specs, path=name))
-        for name, module in model.named_modules()
+        for name, module in (root.named_modules() if root is not None else ())
         if name in shared
     ]
     if root_replacements:
-        model.update_modules(tree_unflatten(root_replacements))
+        root.update_modules(tree_unflatten(root_replacements))
         attached += len(root_replacements)
 
     return attached
@@ -2587,8 +2595,8 @@ def _fix_gemma3n_altup_batch(model=None):
     outright. Upstream repaired this in mlx-vlm 0.5.0, so this only ever runs
     against older releases, whose source no longer changes.
     """
-    layers = getattr(getattr(getattr(model, "language_model", None), "model", None),
-                     "layers", None)
+    from .utils import _get_transformer_layers
+    layers = _get_transformer_layers(model)
     altup = getattr(layers[0], "altup", None) if layers else None
     if altup is None:
         return False

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2643,7 +2643,7 @@ def _paligemma_replace_mask(features, token_type_ids, attention_mask):
     Without token types there is no prefix boundary to derive, so upstream's mask
     is left as it is rather than guessed at.
     """
-    if token_type_ids is None or features.attention_mask_4d is None:
+    if token_type_ids is None:
         return features
     features.attention_mask_4d = _paligemma_prefix_lm_mask(
         token_type_ids, attention_mask,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -7986,6 +7986,8 @@ class MLXTrainer:
             model_type=model_type,
             strict=False,
         )
+        from .utils import _ensure_vlm_pad_token
+        _ensure_vlm_pad_token(processor)
         self.processor = processor
         return processor
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8610,33 +8610,25 @@ class MLXTrainer:
                 save_lora_adapters(
                     self.model, output_dir, adapter_config=adapter_config,
                 )
-            # VLM processors include the inner tokenizer; skip the separate
-            # tokenizer save when the processor will cover it.
             _processor = self.processor or getattr(self.model, "_processor", None)
-            _processor_saves_tokenizer = (
-                _processor is not None and hasattr(_processor, "save_pretrained")
+            sources = (
+                getattr(self.model, "_config_src_path", None),
+                getattr(self.model, "_src_path", None),
             )
-            if not _processor_saves_tokenizer:
+            if _processor is not None:
+                from .utils import _save_vlm_processor_assets
+                _save_vlm_processor_assets(_processor, output_dir, sources)
+            else:
                 self.tokenizer.save_pretrained(output_dir)
+                src_path = next((source for source in sources if source is not None), None)
+                if src_path is not None:
+                    import shutil
+                    from pathlib import Path
+                    src_config = Path(src_path) / "config.json"
+                    dst_config = Path(output_dir) / "config.json"
+                    if src_config.exists() and not dst_config.exists():
+                        shutil.copy(str(src_config), str(dst_config))
 
-            # Copy base config.json so the checkpoint is loadable. Prefer the
-            # mlx-vlm patched dir when materialized (e.g. DeepSeek OCR): _src_path
-            # holds the original snapshot, whose unpatched model_type/auto_map
-            # would break mlx-vlm routing on the saved adapter's reload.
-            src_path = (
-                getattr(self.model, "_config_src_path", None)
-                or getattr(self.model, "_src_path", None)
-            )
-            if src_path is not None:
-                import shutil
-                from pathlib import Path
-                src_config = Path(src_path) / "config.json"
-                dst_config = Path(output_dir) / "config.json"
-                if src_config.exists() and not dst_config.exists():
-                    shutil.copy(str(src_config), str(dst_config))
-
-            if _processor_saves_tokenizer:
-                _processor.save_pretrained(output_dir)
             print(f"Unsloth: LoRA adapters saved to {output_dir}")
         else:
             save_merged_model(self.model, self.tokenizer, output_dir)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1234,7 +1234,7 @@ def _identify_vlm_embedding_module(model):
             embed_result = model.get_input_embeddings(ids, None)
         except TypeError:
             embed_result = model.get_input_embeddings(ids)
-        merged, _ = _unpack_embed_result(embed_result, model)
+        merged, _ = _unpack_embed_result(embed_result, model, input_ids=ids)
     except Exception:
         return None
     finally:
@@ -2727,6 +2727,7 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
             and not k.startswith("_unsloth_")
             and v is not None
         }
+        _apply_static_vlm_metadata(model, batch_dict, fwd_kwargs)
         fwd_kwargs = _trim_sequence_aligned_vlm_kwargs(fwd_kwargs, inputs.shape[1])
         # Always sent: 13 families declare `mask` without a default. None lets
         # them build the mask they would use for generation.
@@ -2751,7 +2752,9 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
                 **{k: v for k, v in fwd_kwargs.items()
                    if k not in ("mask", "cache")},
             )
-            merged_embeds, embed_kwargs = _unpack_embed_result(embed_result, model)
+            merged_embeds, embed_kwargs = _unpack_embed_result(
+                embed_result, model, input_ids=inputs, attention_mask=attention_mask,
+            )
             scaled_embeds = _apply_vlm_embed_scale(model, inputs, merged_embeds)
             # per_layer_inputs and friends: the merge produced them, and
             # recomputing from ids inside the stack would redo the work.
@@ -2824,7 +2827,20 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
     return loss_fn
 
 
-def _unpack_embed_result(embed_result, model):
+def _apply_static_vlm_metadata(model, batch_dict, kwargs):
+    embedder = getattr(model, "get_input_embeddings", None)
+    keys = getattr(embedder, "_unsloth_static_vlm_metadata", ())
+    if getattr(embedder, "_unsloth_static_metadata_with_positions", False) and (
+        not getattr(model, "training", False) or kwargs.get("position_ids") is None
+    ):
+        return
+    static = batch_dict.get("_unsloth_static_vlm_metadata", {})
+    for key in keys:
+        if key in static:
+            kwargs[key] = static[key]
+
+
+def _unpack_embed_result(embed_result, model, input_ids=None, attention_mask=None):
     """Unpack get_input_embeddings result into embeds + backbone kwargs.
 
     Handles plain mx.array returns and the InputEmbeddingsFeatures dataclass
@@ -2862,33 +2878,15 @@ def _unpack_embed_result(embed_result, model):
     else:
         merged_embeds = embed_result
 
-    # Qwen-VL family: some get_input_embeddings paths stash position_ids on the
-    # language model wrapper; the inner backbone needs them explicitly.
-    # Do not override position_ids explicitly returned by InputEmbeddingsFeatures
-    # (for example when the collator passed CUDA-parity mRoPE IDs through the
-    # embedder).
-    # When no position_ids were stashed (e.g. text-only samples or simple
-    # images without grid_thw), generate sequential ones so the backbone
-    # doesn't crash accessing cache.offset with cache=None.
     lm = getattr(model, "language_model", None)
     if lm is not None and "position_ids" not in backbone_kwargs:
-        _MISSING = object()
-        pos_ids = getattr(lm, "_position_ids", _MISSING)
-        if pos_ids is not _MISSING and pos_ids is not None:
+        pos_ids = getattr(lm, "_position_ids", None)
+        if pos_ids is not None:
             backbone_kwargs["position_ids"] = pos_ids
-        elif pos_ids is None:
-            # Fallback: sequential position_ids. Correct for text-only and
-            # single-image samples. For multi-image with spatial m-RoPE
-            # (Qwen VL), the per-axis positions should differ for image
-            # regions — but grid_thw metadata is unavailable here so we
-            # use sequential as an approximation.
-            seq_len = merged_embeds.shape[1]
-            pos_ids = mx.arange(seq_len).reshape(1, -1)
-            pos_ids = mx.broadcast_to(pos_ids, (merged_embeds.shape[0], seq_len))
-            # Qwen VL m-RoPE uses 3 axes: temporal, height, width
-            MROPE_AXES = 3
-            pos_ids = mx.expand_dims(pos_ids, axis=0)
-            pos_ids = mx.tile(pos_ids, (MROPE_AXES, 1, 1))
+        elif (hasattr(lm, "_position_ids") and input_ids is not None
+              and callable(getattr(lm, "get_rope_index", None))):
+            # The model owns the positional axes; a cached field alone says nothing about rank.
+            pos_ids, _ = lm.get_rope_index(input_ids, attention_mask=attention_mask)
             backbone_kwargs["position_ids"] = pos_ids
 
     return merged_embeds, backbone_kwargs
@@ -2943,6 +2941,7 @@ def _vlm_cce_forward(model, batch_dict, image_token_ids=None,
         and not k.startswith("_unsloth_")
         and v is not None
     }
+    _apply_static_vlm_metadata(model, batch_dict, extra_kwargs)
     extra_kwargs = _trim_sequence_aligned_vlm_kwargs(extra_kwargs, inputs.shape[1])
 
     embed_result = model.get_input_embeddings(
@@ -2951,7 +2950,9 @@ def _vlm_cce_forward(model, batch_dict, image_token_ids=None,
         mask=fwd_attn_mask,
         **extra_kwargs,
     )
-    merged_embeds, backbone_kwargs = _unpack_embed_result(embed_result, model)
+    merged_embeds, backbone_kwargs = _unpack_embed_result(
+        embed_result, model, input_ids=inputs, attention_mask=attention_mask,
+    )
     merged_embeds = _apply_vlm_embed_scale(model, inputs, merged_embeds)
     # Prefer collator-built mRoPE IDs when present. Qwen/GLM collators build
     # CUDA-parity full-sequence positions; recomputing inside the embedder moved
@@ -3097,24 +3098,6 @@ def _mlx_vlm_canonical_model_type(model_type):
     except Exception:
         pass
     return name.replace("-", "_")
-
-
-# Families whose mlx-vlm code indexes the vision grid as an array (`.tolist()`,
-# `.prod()`, `[:, 1:]`). Everything else keeps the tuple the Qwen/Paddle compile
-# patches trace: an array becomes a tracer under mx.compile and `.tolist()` raises.
-_VLM_ARRAY_GRID_MODEL_TYPES = frozenset({
-    "glm4v",
-    "glm_ocr",
-    # Not compile-patched, and opens with `grid_thw.tolist()`.
-    "muse_glimmer",
-    "glm5_next",
-})
-
-
-def _grid_thw_to_mx_array(grid_thw):
-    if grid_thw is None:
-        return None
-    return mx.array(grid_thw, dtype=mx.int32)
 
 
 def _normalize_size_tuples(values):
@@ -3795,23 +3778,19 @@ def _prepare_vlm_batch_for_compile(batch_dict, config, phase=None):
     spatial_shapes = _normalize_size_tuples(batch_dict.get("spatial_shapes"))
     images_spatial_crop = _normalize_size_tuples(batch_dict.get("images_spatial_crop"))
     audio_embed_sizes = _normalize_int_tuple(batch_dict.get("audio_embed_sizes"))
-    # Resolved, not raw: an aliased config is routed to the canonical family's tower,
-    # so the grid form has to follow it there.
-    grid_as_array = (
-        _mlx_vlm_canonical_model_type(model_type) in _VLM_ARRAY_GRID_MODEL_TYPES
-    )
-    if image_grid_thw is not None:
-        batch_dict["image_grid_thw"] = (
-            _grid_thw_to_mx_array(image_grid_thw) if grid_as_array else image_grid_thw
-        )
-    if video_grid_thw is not None:
-        batch_dict["video_grid_thw"] = (
-            _grid_thw_to_mx_array(video_grid_thw) if grid_as_array else video_grid_thw
-        )
+    static_metadata = {}
+    for key, normalized in (
+        ("image_grid_thw", image_grid_thw),
+        ("video_grid_thw", video_grid_thw),
+        ("spatial_shapes", spatial_shapes),
+    ):
+        if normalized is not None:
+            value = batch_dict[key]
+            batch_dict[key] = value if isinstance(value, (mx.array, np.ndarray)) else normalized
+            static_metadata[key] = normalized
+    batch_dict["_unsloth_static_vlm_metadata"] = static_metadata
     if image_sizes is not None:
         batch_dict["image_sizes"] = image_sizes
-    if spatial_shapes is not None:
-        batch_dict["spatial_shapes"] = spatial_shapes
     if images_spatial_crop is not None:
         batch_dict["images_spatial_crop"] = images_spatial_crop
     if audio_embed_sizes is not None:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -16690,6 +16690,106 @@ _MODEL_WEIGHT_SUFFIXES = (
 _MODEL_SIDECAR_SUFFIXES = (".json", ".jinja", ".model", ".txt", ".py")
 
 
+def _save_vlm_processor_assets(processor, path, sources=()):
+    path = Path(path)
+    failures = []
+    saved = set()
+    asset_names = set()
+
+    def valid_asset(file):
+        try:
+            if not file.is_file():
+                return False
+            if file.suffix == ".json":
+                json.loads(file.read_text())
+            return True
+        except (OSError, ValueError):
+            return False
+
+    def copy_assets(source, overwrite=False, source_only=False, complete=True):
+        for file in Path(source).rglob("*"):
+            relative = file.relative_to(source)
+            if not file.is_file() or file.suffix in _MODEL_WEIGHT_SUFFIXES:
+                continue
+            if any(part.startswith(".") for part in relative.parts):
+                continue
+            if file.resolve().is_relative_to(path.resolve()):
+                continue
+            if file.name in _CORE_SAVE_FILENAMES or file.name == "adapter_config.json":
+                continue
+            if file.name.startswith(("model-", "pytorch_model")):
+                continue
+            if source_only and file.suffix not in _MODEL_SIDECAR_SUFFIXES and file.name not in asset_names:
+                continue
+            if not complete and file.suffix != ".json":
+                continue
+            target = path / relative
+            if relative in saved or (
+                not overwrite and target.suffix == ".json" and valid_asset(target)
+            ):
+                continue
+            try:
+                if file.suffix == ".json":
+                    json.loads(file.read_text())
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(file, target)
+                saved.add(relative)
+            except Exception as error:
+                failures.append(f"{relative}: {error}")
+
+    def save_component(component, overwrite=True):
+        vocab_files = getattr(component, "vocab_files_names", None)
+        if isinstance(vocab_files, dict):
+            asset_names.update(Path(name).name for name in vocab_files.values() if isinstance(name, str))
+        save = getattr(component, "save_pretrained", None)
+        if not callable(save):
+            return False
+        success = True
+        try:
+            with tempfile.TemporaryDirectory() as staging:
+                try:
+                    save(staging)
+                except Exception as error:
+                    failures.append(f"{type(component).__name__}: {error}")
+                    success = False
+                # Only JSON can be validated after an interrupted writer.
+                copy_assets(staging, overwrite=overwrite, complete=success)
+        except Exception as error:
+            failures.append(f"{type(component).__name__}: {error}")
+            success = False
+        return success
+
+    if not save_component(processor, overwrite=True):
+        if not failures:
+            failures.append(f"{type(processor).__name__} has no save_pretrained")
+    # Some processors' save methods omit components or are entirely no-ops.
+    names = ("tokenizer", "image_processor", "feature_extractor")
+    names += tuple(getattr(processor, "attributes", ()) or ())
+    seen = {id(processor)}
+    for name in names:
+        component = getattr(processor, name, None)
+        if component is not None and id(component) not in seen:
+            seen.add(id(component))
+            save_component(component)
+
+    for source in sources:
+        if source is None:
+            continue
+        try:
+            source = Path(source)
+            copy_assets(source, source_only=True)
+            config = source / "config.json"
+            target = path / "config.json"
+            if config.is_file() and not valid_asset(target):
+                json.loads(config.read_text())
+                shutil.copy2(config, target)
+        except Exception as error:
+            failures.append(f"processor source: {error}")
+    if failures:
+        print("Unsloth: Adapter saved; processor assets recovered where available: "
+              + "; ".join(dict.fromkeys(failures)))
+
+
 def _copy_source_sidecars(src_path, path):
     """Copy non-weight source sidecars that tokenizer/model saves may omit."""
     copied = 0

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -4308,8 +4308,18 @@ def normalize_mlx_chat_template(
         setattr(target, "_unsloth_model_type", model_type)
 
     tokenizer = _get_processor_tokenizer(target)
-    if is_vlm and not _has_chat_template(target) and _has_chat_template(tokenizer):
-        target.chat_template = tokenizer.chat_template
+    if is_vlm and not _has_chat_template(target):
+        if not _has_chat_template(tokenizer):
+            for source in (getattr(target, "_unsloth_model_name", None),
+                           getattr(tokenizer, "name_or_path", None)):
+                if not source or not Path(source).is_dir():
+                    continue
+                template_path = Path(source) / "chat_template.jinja"
+                if template_path.is_file():
+                    tokenizer.chat_template = template_path.read_text(encoding="utf-8")
+                    break
+        if not _has_chat_template(target) and _has_chat_template(tokenizer):
+            target.chat_template = tokenizer.chat_template
 
     template_target = target if is_vlm else tokenizer
     if strict and not _has_chat_template(template_target):
@@ -4509,6 +4519,9 @@ def _normalize_mlx_messages(messages, *, is_vlm=False):
                         parts.append({"type": "text", "text": part})
                     elif isinstance(part, dict):
                         clean = _clean_vlm_none_keys(part)
+                        for key in ("input_image", "image_url"):
+                            if key in clean:
+                                clean.setdefault("image", clean.pop(key))
                         # Gemma 3n's template renders a placeholder for
                         # "audio" alone, so a part left under an alias carries
                         # a clip with nothing behind it, and an untyped one
@@ -4520,6 +4533,8 @@ def _normalize_mlx_messages(messages, *, is_vlm=False):
                                 clean["type"] = "image"
                             elif any(alias in clean for alias in _AUDIO_PART_TYPES):
                                 clean["type"] = "audio"
+                        elif clean["type"] in ("image_url", "input_image"):
+                            clean["type"] = "image"
                         elif clean["type"] in _AUDIO_PART_TYPES:
                             clean["type"] = "audio"
                         parts.append(clean)
@@ -4559,7 +4574,7 @@ def _collapse_vlm_assistant_content(messages):
     return collapsed
 
 
-def _flatten_vlm_content_for_text_template(messages):
+def _flatten_vlm_content_for_text_template(messages, image_token=None):
     """Render list-style VLM content as text for text-only chat templates."""
     flattened = copy.deepcopy(messages)
     for message in flattened:
@@ -4570,6 +4585,8 @@ def _flatten_vlm_content_for_text_template(messages):
         for part in content:
             if isinstance(part, dict) and part.get("type") == "text":
                 texts.append(str(part.get("text", "")))
+            elif isinstance(part, dict) and part.get("type") == "image" and image_token:
+                texts.append(image_token)
             elif isinstance(part, str):
                 texts.append(part)
         message["content"] = "".join(texts)
@@ -4608,24 +4625,35 @@ def _count_vlm_image_parts(messages):
     return count
 
 
-def _repair_deepseek_rendered_image_tokens(processor, text, messages):
+def _vlm_image_token(processor):
+    for owner in (processor, _get_processor_tokenizer(processor)):
+        for name in ("image_token", "boi_token"):
+            token = getattr(owner, name, None)
+            if isinstance(token, str) and token:
+                return token
+    module = sys.modules.get(type(processor).__module__)
+    for name in ("DEFAULT_IMAGE_TOKEN", "IMAGE_TOKEN", "IMAGE_PLACEHOLDER"):
+        token = getattr(module, name, None)
+        if isinstance(token, str) and token:
+            return token
+    return None
+
+
+def _vlm_render_preserves_content(text, messages):
     if not isinstance(text, str) or not text.strip():
-        return text
-    marker = (
-        f"{processor.__class__.__module__}.{processor.__class__.__name__}"
-    ).lower()
-    if "deepseek" not in marker:
-        return text
-    image_count = _count_vlm_image_parts(messages)
-    if image_count <= 0:
-        return text
-    image_token = getattr(processor, "image_token", None)
-    if not image_token:
-        return text
-    missing = image_count - text.count(image_token)
-    if missing <= 0:
-        return text
-    return (image_token * missing) + text
+        return False
+    normalized = " ".join(text.split())
+    for message in messages:
+        content = message.get("content", "")
+        if isinstance(content, list):
+            if content and str(content) in text:
+                return False
+            parts = [p.get("text", "") if isinstance(p, dict) else p for p in content]
+        else:
+            parts = [content]
+        if any(" ".join(str(part).split()) not in normalized for part in parts):
+            return False
+    return True
 
 
 def _processor_accepts_assistant_list_content(processor):
@@ -4661,63 +4689,55 @@ def _render_vlm_messages(
     *,
     add_generation_prompt=False,
 ):
-    normalize_vlm_processor_chat_template(processor, strict=True)
     if isinstance(messages, str):
         return messages
+    messages = _normalize_vlm_messages(messages)
+    normalize_vlm_processor_chat_template(processor, strict=False)
+    tokenizer = _get_processor_tokenizer(processor)
+    renderer = processor if callable(getattr(processor, "apply_chat_template", None)) else tokenizer
+    image_token = _vlm_image_token(processor)
+    flat_messages = _flatten_vlm_content_for_text_template(messages, image_token)
+    if not _has_chat_template(renderer):
+        return "\n".join(message.get("content", "") for message in flat_messages)
 
     render_messages = messages
-    if not _processor_accepts_assistant_list_content(processor):
+    if not _processor_accepts_assistant_list_content(renderer):
         render_messages = _collapse_vlm_assistant_content(render_messages)
-
-    first_error = None
-    second_error = None
-    third_error = None
-
-    try:
-        text = processor.apply_chat_template(
-            render_messages,
-            tokenize=False,
-            add_generation_prompt=add_generation_prompt,
-        )
-        text = _repair_deepseek_rendered_image_tokens(processor, text, messages)
-        if isinstance(text, str) and text.strip():
+    marked_messages = copy.deepcopy(render_messages)
+    if image_token:
+        for message in marked_messages:
+            content = message.get("content", "")
+            if isinstance(content, list):
+                message["content"] = [
+                    {"type": "text", "text": image_token}
+                    if isinstance(part, dict) and part.get("type") == "image" else part
+                    for part in content
+                ]
+    image_count = _count_vlm_image_parts(messages)
+    image_tokens = {token for token in (image_token, getattr(processor, "boi_token", None),
+                                        getattr(tokenizer, "boi_token", None)) if token}
+    error = None
+    for candidate in (render_messages, marked_messages, flat_messages,
+                      _flatten_vlm_messages_to_content_parts(marked_messages)):
+        try:
+            text = renderer.apply_chat_template(
+                candidate,
+                tokenize=False,
+                add_generation_prompt=add_generation_prompt,
+            )
+            if not all(_vlm_render_preserves_content(text, source) for source in (messages, candidate)):
+                continue
+            if image_tokens and max(text.count(token) for token in image_tokens) < image_count:
+                continue
             return text
-    except Exception as exc:
-        first_error = exc
-
-    try:
-        text = processor.apply_chat_template(
-            _flatten_vlm_messages_to_content_parts(messages),
-            tokenize=False,
-            add_generation_prompt=add_generation_prompt,
-        )
-        text = _repair_deepseek_rendered_image_tokens(processor, text, messages)
-        if isinstance(text, str) and text.strip():
-            return text
-    except Exception as exc:
-        second_error = exc
-
-    try:
-        text = processor.apply_chat_template(
-            _flatten_vlm_content_for_text_template(render_messages),
-            tokenize=False,
-            add_generation_prompt=add_generation_prompt,
-        )
-        text = _repair_deepseek_rendered_image_tokens(processor, text, messages)
-        if isinstance(text, str) and text.strip():
-            return text
-    except Exception as exc:
-        third_error = exc
-
-    if first_error is not None:
-        raise RuntimeError(
-            "Unsloth MLX VLM: failed to render chat messages with this "
-            "processor chat_template. Check that the dataset roles/content "
-            "schema matches the model family, or pass a formatting_func that "
-            "returns pre-rendered text."
-        ) from (third_error or second_error or first_error)
-
-    return ""
+        except Exception as exc:
+            error = exc
+    raise RuntimeError(
+        "Unsloth MLX VLM: failed to render chat messages with this "
+        "processor chat_template. Check that the dataset roles/content "
+        "schema matches the model family, or pass a formatting_func that "
+        "returns pre-rendered text."
+    ) from error
 
 
 def _looks_like_mlx_chat_messages(value):
@@ -6166,6 +6186,22 @@ def _resize_vlm_images(images, image_size):
     target = (image_size, image_size) if isinstance(image_size, int) else image_size
     resized = []
     for image in images:
+        if isinstance(image, (bytes, dict, str, os.PathLike)):
+            from io import BytesIO
+            if isinstance(image, dict):
+                image = image.get("bytes") or image.get("path") or image.get("url")
+            if isinstance(image, str) and image.startswith(("http://", "https://")):
+                from unsloth_zoo.vision_utils import fetch_remote_media_bytes
+                image = fetch_remote_media_bytes(image)
+            elif isinstance(image, str) and image.startswith("data:image"):
+                from base64 import b64decode
+                image = b64decode(image.split("base64,", 1)[1])
+            elif isinstance(image, str) and image.startswith("file://"):
+                from unsloth_zoo.vision_utils import resolve_file_uri_to_path
+                image = resolve_file_uri_to_path(image)
+            if isinstance(image, bytes):
+                image = BytesIO(image)
+            image = Image.open(image)
         if isinstance(image, Image.Image):
             image = image.convert("RGB")
             if _is_vlm_no_resize_image_size(image_size):
@@ -6242,6 +6278,10 @@ def _extract_vlm_images(
                 if isinstance(part, dict) and part.get("type") == "image":
                     image = part.get("image")
                     if image is not None:
+                        if any(key in part for key in ("resized_height", "resized_width", "min_pixels", "max_pixels")):
+                            from unsloth_zoo.vision_utils import fetch_image
+                            image = _resize_vlm_images([image], None)[0]
+                            image = fetch_image({**part, "image": image})
                         images.append(image)
 
     if (

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -7859,12 +7859,64 @@ def _convert_vlm_processor_output(value, return_tensors):
     return value
 
 
+_VLM_COMPONENT_KWARGS = contextvars.ContextVar("vlm_component_kwargs", default={})
+
+
+def _scope_vlm_component_call(component):
+    cls = type(component)
+    original = cls.__call__
+    if getattr(original, "_unsloth_vlm_component_kwargs", False):
+        return
+
+    @wraps(original)
+    def scoped(self, *args, **kwargs):
+        options = _VLM_COMPONENT_KWARGS.get().get(id(self))
+        if options is not None:
+            excluded, defaults = options
+            kwargs = {**defaults, **kwargs}
+            kwargs = {k: v for k, v in kwargs.items() if k not in excluded}
+        return original(self, *args, **kwargs)
+
+    scoped._unsloth_vlm_component_kwargs = True
+    try:
+        cls.__call__ = scoped
+    except (TypeError, AttributeError):
+        # Native callables cannot be patched and keep their own dispatch.
+        pass
+
+
+def _invoke_vlm_processor(processor_call, args, kwargs):
+    processor = args[0] if args and hasattr(args[0], "image_processor") else processor_call
+    tokenizer = getattr(processor, "tokenizer", None)
+    image_processor = getattr(processor, "image_processor", None)
+    if not callable(tokenizer) or not callable(image_processor):
+        return processor_call(*args, **kwargs)
+    from transformers.processing_utils import ImagesKwargs, TextKwargs
+
+    text_keys = set(TextKwargs.__annotations__)
+    image_keys = set(ImagesKwargs.__annotations__)
+    _scope_vlm_component_call(tokenizer)
+    _scope_vlm_component_call(image_processor)
+    # Keep component identity/state, and isolate options from other calls/threads.
+    options = dict(_VLM_COMPONENT_KWARGS.get())
+    options[id(image_processor)] = (text_keys - image_keys, {})
+    options[id(tokenizer)] = (
+        image_keys - text_keys,
+        {"padding": kwargs["padding"]} if "padding" in kwargs else {},
+    )
+    token = _VLM_COMPONENT_KWARGS.set(options)
+    try:
+        return processor_call(*args, **kwargs)
+    finally:
+        _VLM_COMPONENT_KWARGS.reset(token)
+
+
 def _call_vlm_processor(processor_call, args, kwargs):
-    """Retry only the Transformers fast-processor PyTorch output contract."""
+    """Scope modality options and negotiate PyTorch-only processor output."""
 
     return_tensors = kwargs.get("return_tensors")
     try:
-        return processor_call(*args, **kwargs)
+        return _invoke_vlm_processor(processor_call, args, kwargs)
     except ValueError as error:
         if (
             return_tensors not in {"mlx", "np"}
@@ -7874,7 +7926,7 @@ def _call_vlm_processor(processor_call, args, kwargs):
 
     retry_kwargs = dict(kwargs)
     retry_kwargs["return_tensors"] = "pt"
-    output = processor_call(*args, **retry_kwargs)
+    output = _invoke_vlm_processor(processor_call, args, retry_kwargs)
     return _convert_vlm_processor_output(output, return_tensors)
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -767,13 +767,20 @@ def apply_gather_qmm_nax_guard() -> bool:
 
 
 def _get_transformer_layers(model):
-    """Find transformer layers, unwrapping VLM wrappers if needed.
-
-    VLMs: model.language_model.model.layers; text: model.(model.)layers.
-    """
-    m = getattr(model, 'language_model', model)
-    m = getattr(m, 'model', m)
-    return getattr(m, 'layers', None)
+    pending = collections.deque([getattr(model, "language_model", model)])
+    seen = set()
+    while pending:
+        module = pending.popleft()
+        if module is None or id(module) in seen:
+            continue
+        seen.add(id(module))
+        for name in ("layers", "blocks"):
+            layers = getattr(module, name, None)
+            if isinstance(layers, (list, tuple)):
+                return layers
+        for name in ("decoder", "model", "transformer", "layers", "blocks"):
+            pending.append(getattr(module, name, None))
+    return None
 
 
 def _get_vision_encoder_layers(model):
@@ -2916,6 +2923,13 @@ def _filter_backbone_kwargs(backbone, kwargs):
         params = inspect.signature(backbone.__call__).parameters
     except (TypeError, ValueError):
         return kwargs
+    cache = params.get("cache")
+    if (
+        cache is not None and cache.default is inspect.Parameter.empty
+        and cache.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        and "cache" not in kwargs
+    ):
+        kwargs = {**kwargs, "cache": None}
     if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()):
         return kwargs
     allowed = set(params)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3108,17 +3108,11 @@ def _mlx_vlm_canonical_model_type(model_type):
 def _normalize_size_tuples(values):
     if values is None:
         return None
-    if isinstance(values, mx.array):
+    if hasattr(values, "tolist"):
         values = values.tolist()
-    elif hasattr(values, "tolist"):
-        values = values.tolist()
-
-    normalized = []
-    for item in values:
-        if hasattr(item, "tolist"):
-            item = item.tolist()
-        normalized.append(tuple(int(x) for x in item))
-    return tuple(normalized)
+    if isinstance(values, (list, tuple)):
+        return tuple(_normalize_size_tuples(item) for item in values)
+    return int(values)
 
 
 def _normalize_int_tuple(values):
@@ -3788,16 +3782,14 @@ def _prepare_vlm_batch_for_compile(batch_dict, config, phase=None):
         ("image_grid_thw", image_grid_thw),
         ("video_grid_thw", video_grid_thw),
         ("spatial_shapes", spatial_shapes),
+        ("image_sizes", image_sizes),
+        ("images_spatial_crop", images_spatial_crop),
     ):
         if normalized is not None:
             value = batch_dict[key]
             batch_dict[key] = value if isinstance(value, (mx.array, np.ndarray)) else normalized
             static_metadata[key] = normalized
     batch_dict["_unsloth_static_vlm_metadata"] = static_metadata
-    if image_sizes is not None:
-        batch_dict["image_sizes"] = image_sizes
-    if images_spatial_crop is not None:
-        batch_dict["images_spatial_crop"] = images_spatial_crop
     if audio_embed_sizes is not None:
         # The model calls .item() on each entry, so hand over an array; the
         # tuple above is only for this function's span arithmetic.

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2449,6 +2449,8 @@ def _stage_vlm_label_mask_np(inputs, ignore_token_ids=None, labels=None):
         if attention_np.dtype == np.float64:
             attention_np = attention_np.astype(np.float32)
         mask = mask | (attention_np.astype(np.int32) == 0)
+    if inputs.get("_unsloth_suffix_only_loss", False):
+        mask = mask | (np.asarray(inputs["token_type_ids"]) == 0)
     return mask
 
 def _reject_mlx_valued_vlm(context):
@@ -2629,6 +2631,9 @@ def _apply_vlm_label_masks(batch_dict, labels=None, ignore_token_ids=None,
     if attention_mask is not None:
         ignore = mx.array(ignore_index, dtype=labels.dtype)
         labels = mx.where(attention_mask == 0, ignore, labels)
+    if batch_dict.get("_unsloth_suffix_only_loss", False):
+        labels = mx.where(batch_dict["token_type_ids"] == 0,
+                          mx.array(ignore_index, dtype=labels.dtype), labels)
     return labels
 
 
@@ -8037,6 +8042,15 @@ def _drop_unsupported_processor_kwargs(processor, kwargs):
     return {k: v for k, v in kwargs.items() if k in params}
 
 
+def _ensure_vlm_pad_token(processor):
+    tokenizer = _get_processor_tokenizer(processor)
+    if getattr(tokenizer, "pad_token_id", None) is None:
+        eos = getattr(tokenizer, "eos_token", None)
+        if eos is not None:
+            tokenizer.pad_token = eos
+    return tokenizer
+
+
 def _processor_vlm_inputs(
     processor,
     texts,
@@ -8047,6 +8061,12 @@ def _processor_vlm_inputs(
     padding_side=None,
     all_audio=None,
 ):
+    tokenizer = _ensure_vlm_pad_token(processor)
+    images = _format_vlm_images_for_processor(all_images, processor=processor)
+    audio = _format_vlm_audio_for_processor(all_audio, processor=processor)
+    text_only = images is None and audio is None and callable(tokenizer)
+    if text_only:
+        processor = tokenizer
     base_kwargs = dict(
         text=texts,
         padding=True,
@@ -8054,7 +8074,6 @@ def _processor_vlm_inputs(
         add_special_tokens=False,
     )
     base_kwargs = _drop_unsupported_processor_kwargs(processor, base_kwargs)
-    audio = _format_vlm_audio_for_processor(all_audio, processor=processor)
     audio_kwarg = None
     if audio is not None:
         audio_kwarg = _vlm_processor_audio_kwarg(processor)
@@ -8093,7 +8112,6 @@ def _processor_vlm_inputs(
             ))
     if padding_side is not None:
         base_kwargs["padding_side"] = padding_side
-    images = _format_vlm_images_for_processor(all_images, processor=processor)
     if images is not None:
         image_layouts = (
             ("nested", "flat")
@@ -8103,7 +8121,12 @@ def _processor_vlm_inputs(
     else:
         image_layouts = (None,)
     if suffixes is not None and any(suffix is not None for suffix in suffixes):
-        base_kwargs["suffix"] = [suffix or "" for suffix in suffixes]
+        base_kwargs["text_pair" if text_only else "suffix"] = [
+            (suffix or "") + (getattr(tokenizer, "eos_token", None) or "")
+            if text_only else (suffix or "") for suffix in suffixes
+        ]
+        if text_only:
+            base_kwargs["return_token_type_ids"] = True
     if _vlm_processor_requests_mm_token_type_ids(processor):
         base_kwargs["return_mm_token_type_ids"] = True
 
@@ -8176,7 +8199,14 @@ def _processor_vlm_inputs(
         raise first_error
 
     if audio_kwarg is None:
-        return _run_layouts()
+        inputs = _run_layouts()
+        if text_only and "text_pair" in base_kwargs:
+            inputs["labels"] = np.where(
+                np.asarray(inputs["token_type_ids"]) == 0, -100,
+                np.asarray(inputs["input_ids"]),
+            )
+            inputs["_unsloth_suffix_only_loss"] = True
+        return inputs
 
     def _run_audio_layouts():
         return _repair_audio_batch(


### PR DESCRIPTION
Several MLX vision-language processors and decoder wrappers violate assumptions in the training path: tokenizer options leak into strict image processors, grid arrays become tuples, image-less rows are sent to image processors, and nested crop metadata is flattened. Template and decoder-interface mismatches can prevent training from starting, while processor serialization can raise after adapter training has already succeeded.

This fixes those shared contracts through component kwargs, array types and ranks, available attributes, and callable signatures:

- Separate tokenizer and image-processor options while preserving native multimodal token expansion.
- Preserve processor-emitted grid/spatial arrays and nested image-size metadata, with static metadata supplied only to compile consumers that require it. Obtain positional axes from the native model contract.
- Tokenize media-free rows directly, establish padding, and preserve suffix labels and attention masks.
- Recover source chat templates, fall back to tokenizer rendering, and preserve declared image markers, content order, and image preprocessing across supported payload forms.
- Persist adapters before optional processor assets; recover independently serializable components and source metadata when native serialization is incomplete or unavailable.
- Find decoder block lists through wrapper structures, unwrap module views before LoRA conversion and DoRA preflight, and supply `cache=None` when the backbone requires it.
- Avoid boolean evaluation of multi-element crop arrays during DeepSeek OCR image inference.

No new architecture allowlists are introduced. The changes are split into eight commits, one per mechanism.

### Validation

- 185 focused VLM/collator/save and supplemental checks passed, plus six LoRA integration checks.
- All 16 previously passing image-training families still pass after rebasing onto current `main`.
- Reran 39 training checks across 33 affected families: 29 pass; the remaining ten reach separate failures described below.
- All six processor-save families complete text training and final save; five also complete image training.
- DeepSeek OCR image inference passes, with a same-checkpoint negative proof for the original crop-array boolean.
- Diffusion Gemma attention-only DoRA completes the real load/train/save path with all 23 language adapters updating. Reverting the preflight integration fix reproduces the decoder-view attribute error; six additional container cases also fail under that mutation.

Validation uses random tiny checkpoints with real cached processor/tokenizer metadata and the actual load, forward/backward, adapter-update, and save paths. It checks structural compatibility and training data flow, not trained-model output quality. Each mechanism has a regression in the existing VLM collator or save test file that fails with the covered behavior reverted or weakened.

### Scope

This does not address numerical CE/CCE divergence, the phi3small Metal fault, or all remaining architecture-specific training interfaces. Processor-asset recovery reports optional serialization failures after adapter persistence; adapter tensor writes remain strict.

Remaining failures are non-updating vision adapters in Llava, Llava Next, Granite Vision, DeepSeek-VL2, DeepSeek OCR, GOT, and Unlimited OCR; Moondream3 attention-mask dtype compatibility; Nemotron Parse requiring image encoder inputs; and Diffusion Gemma CCE supplying unsupported `inputs_embeds`. Standard CE training succeeds for Diffusion Gemma. These are not claimed fixed by this PR.
