### PR TITLE
fix(mlx): honor processor tokenizer trust and clarify refusals

### DIFF
--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -174,7 +174,9 @@ def test_apply_mlx_distributed_sharding_modes_and_guards():
         _apply_mlx_distributed_sharding(object(), tensor_group=tensor_group, model_name="fake")
 
 
-def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_path):
+@pytest.mark.parametrize("trust", [False, True])
+def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_path, trust):
+    from transformers import AutoTokenizer
     import mlx_lm.utils as mlx_lm_utils
     from unsloth_zoo.mlx.loader import _load_mlx_lm_distributed
 
@@ -227,12 +229,23 @@ def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_
 
     monkeypatch.setattr(mlx_lm_utils, "_download", _download)
     monkeypatch.setattr(mlx_lm_utils, "load_model", _load_model)
-    monkeypatch.setattr(mlx_lm_utils, "load_tokenizer", lambda *_a, **_k: types.SimpleNamespace(name="tok"))
+    (model_path / "tokenizer_config.json").write_text('{"tokenizer_class":"RemoteTokenizer"}')
+    tokenizer_calls = []
+
+    def tokenizer(path, **kwargs):
+        tokenizer_calls.append(kwargs)
+        return types.SimpleNamespace(name="tok")
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(tokenizer))
+    monkeypatch.setattr(
+        mlx_lm_utils, "load_tokenizer",
+        lambda path, *_a, **_k: AutoTokenizer.from_pretrained(path),
+    )
 
     model, tokenizer, config = _load_mlx_lm_distributed(
         "fake/repo",
         "llama",
-        {"return_config": True},
+        {"return_config": True, "tokenizer_config": {"trust_remote_code": trust}},
         pipeline_group=_FakeGroup(name="pipeline"),
     )
 
@@ -245,6 +258,7 @@ def test_load_mlx_lm_distributed_pipeline_filters_quant_shards(monkeypatch, tmp_
     assert ("download", local_shards) in events
     assert ("load", list(local_shards)) in events
     assert all(not path.exists() for path in load_paths)
+    assert tokenizer_calls[0]["trust_remote_code"] is trust
     assert config["eos_token_id"] == 3
     assert config["model_type"] == "llama"
     assert model._unsloth_mlx_distributed_parallel_mode == "pipeline"

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1788,9 +1788,11 @@ def test_vlm_sanitizer_replay_uses_real_model_instances():
     ) == {"visual.proj.weight": "tensor"}
 
 
+@pytest.mark.parametrize("trust", [False, True])
 def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
     monkeypatch,
     tmp_path,
+    trust,
 ):
     import unsloth_zoo.mlx.loader as loader
 
@@ -1809,13 +1811,11 @@ def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
     )
 
     image_processor = object()
-    monkeypatch.setattr(
-        loader,
-        "_build_vlm_image_processor_from_config",
-        lambda model_path, processor_config, preprocessor_config, model_type=None: (
-            image_processor
-        ),
-    )
+    def build_image_processor(*args, **kwargs):
+        assert kwargs["trust_remote_code"] is trust
+        return image_processor
+
+    monkeypatch.setattr(loader, "_build_vlm_image_processor_from_config", build_image_processor)
 
     (tmp_path / "processor_config.json").write_text(
         json.dumps({"processor_class": "FakeProcessor"}),
@@ -1839,6 +1839,7 @@ def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
         degraded,
         tmp_path,
         "glm_ocr",
+        trust_remote_code=trust,
     )
 
     assert isinstance(repaired, FakeProcessor)
@@ -4405,3 +4406,151 @@ def test_tokenizer_load_never_prompts_for_remote_code(monkeypatch, tmp_path):
     with pytest.raises(ValueError, match="custom code"):
         loader._load_mlx_tokenizer(tmp_path)
     assert not prompts, "tokenizer load prompted on stdin for remote code"
+
+
+def test_tokenizer_scope_forwards_trust_without_model_config_and_restores(monkeypatch, tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+    from transformers import AutoTokenizer, PretrainedConfig
+    import unsloth_zoo.mlx.loader as loader
+
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps({
+        "tokenizer_class": "RemoteTokenizer",
+        "auto_map": {"AutoTokenizer": ["tokenization_custom.RemoteTokenizer", None]},
+    }))
+    calls = []
+
+    def remote_tokenizer(path, **kwargs):
+        calls.append(kwargs)
+        if not kwargs.get("trust_remote_code"):
+            raise ValueError("custom code requires trust_remote_code=True")
+        return "remote"
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(remote_tokenizer))
+    with loader._mlx_tokenizer_loading_scope(True):
+        assert AutoTokenizer.from_pretrained(tmp_path, trust_remote_code=False) == "remote"
+        assert isinstance(calls[-1]["config"], PretrainedConfig)
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            assert pool.submit(AutoTokenizer.from_pretrained, tmp_path, trust_remote_code=True).result() == "remote"
+        assert "config" not in calls[-1]
+        with loader._mlx_tokenizer_loading_scope():
+            with pytest.raises(ValueError, match=r"tokenization_custom.py.*trust_remote_code=True"):
+                AutoTokenizer.from_pretrained(tmp_path, trust_remote_code=True)
+        assert AutoTokenizer.from_pretrained(tmp_path) == "remote"
+    assert AutoTokenizer.from_pretrained is remote_tokenizer
+    with pytest.raises(RuntimeError):
+        with loader._mlx_tokenizer_loading_scope():
+            raise RuntimeError("failed processor")
+    assert AutoTokenizer.from_pretrained is remote_tokenizer
+
+
+
+@pytest.mark.parametrize("failure_mode", ["processor", "tokenizer", "swallowed"])
+@pytest.mark.parametrize("native_available", [False, True])
+def test_processor_remote_refusal_names_file_and_trust_reaches_nested_tokenizer(
+    monkeypatch, tmp_path, failure_mode, native_available,
+):
+    from transformers import AutoTokenizer
+    import unsloth_zoo.mlx.loader as loader
+
+    (tmp_path / "config.json").write_text(json.dumps({
+        "model_type": "custom_vlm",
+        "auto_map": {"AutoProcessor": "processing_custom.CustomProcessor"},
+    }))
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps({
+        "tokenizer_class": "RemoteTokenizer",
+        "auto_map": {"AutoTokenizer": ["tokenization_custom.RemoteTokenizer", None]},
+    }))
+    calls = []
+
+    class RemoteProcessor:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            calls.append(kwargs["trust_remote_code"])
+            if not kwargs["trust_remote_code"]:
+                if failure_mode != "processor":
+                    try:
+                        AutoTokenizer.from_pretrained(path)
+                    except ValueError:
+                        if failure_mode == "swallowed":
+                            raise ValueError("Unrecognized processing class")
+                        raise
+                raise ValueError("contains custom code which must be executed; trust_remote_code=True")
+            return AutoTokenizer.from_pretrained(path)
+
+    def tokenizer(path, **kwargs):
+        if not kwargs["trust_remote_code"]:
+            raise ValueError("custom code requires trust_remote_code=True")
+        return "processor-tokenizer"
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(tokenizer))
+    monkeypatch.setitem(globals(), "AutoProcessor", RemoteProcessor)
+    monkeypatch.setitem(globals(), "load_processor", _test_bound_load_processor)
+    monkeypatch.setattr(loader, "_ensure_vlm_detokenizer_copy", lambda: None)
+    native = object()
+    monkeypatch.setattr(
+        loader, "_load_declared_mlx_vlm_processor",
+        lambda *_a, **_k: native if native_available else None,
+    )
+    default = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    if native_available:
+        assert default(tmp_path) is native
+    else:
+        code_file = "processing_custom" if failure_mode == "processor" else "tokenization_custom"
+        with pytest.raises(ValueError, match=rf"{code_file}.py.*trust_remote_code=True"):
+            default(tmp_path)
+    trusted = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load, allow_remote_code=True)
+    assert trusted(tmp_path) == "processor-tokenizer"
+    assert calls == [False, True]
+
+
+
+@pytest.mark.parametrize("trust", [False, True])
+def test_mlx_lm_tokenizer_loader_forwards_trust(monkeypatch, tmp_path, trust):
+    from transformers import AutoTokenizer
+    import mlx_lm.utils as lm_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    (tmp_path / "tokenizer_config.json").write_text('{"tokenizer_class":"RemoteTokenizer"}')
+    calls = []
+
+    def tokenizer(path, **kwargs):
+        calls.append(kwargs)
+        return "tokenizer"
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(tokenizer))
+    monkeypatch.setattr(lm_utils, "_download", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(lm_utils, "load_model", lambda *a, **k: ("model", {"eos_token_id": 7}))
+
+    def load_tokenizer(path, config, eos_token_ids):
+        assert eos_token_ids == 7
+        return AutoTokenizer.from_pretrained(path)
+
+    monkeypatch.setattr(lm_utils, "load_tokenizer", load_tokenizer)
+    result = loader._load_mlx_lm_with_strict_fallback(
+        tmp_path, "custom", None, {"tokenizer_config": {"trust_remote_code": trust}},
+    )
+    assert result == ("model", "tokenizer")
+    assert calls[0]["trust_remote_code"] is trust
+
+
+
+@pytest.mark.parametrize("trust", [False, True])
+def test_image_processor_builder_forwards_trust(monkeypatch, tmp_path, trust):
+    import transformers
+    import unsloth_zoo.mlx.loader as loader
+
+    processor, calls = object(), []
+
+    def record(path, **kwargs):
+        calls.append(kwargs["trust_remote_code"])
+        return processor
+
+    class FakeAutoImageProcessor:
+        from_pretrained = staticmethod(record)
+
+    # The real class is a gated placeholder when torchvision is absent.
+    monkeypatch.setattr(transformers, "AutoImageProcessor", FakeAutoImageProcessor)
+    assert loader._build_vlm_image_processor_from_config(
+        tmp_path, {}, {}, trust_remote_code=trust,
+    ) is processor
+    assert calls == [trust]

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -793,7 +793,7 @@ def _materialize_mlx_vlm_config_override(
                     supports_list_extra_special_tokens=supports_list_extra_special_tokens,
                 )
             )
-        if not allow_tokenizer_remote_code:
+        if not allow_tokenizer_remote_code and os.path.isfile(os.path.join(local_path, "tokenizer.json")):
             auto_map = patched_tokenizer_config.get("auto_map")
             if isinstance(auto_map, dict) and auto_map:
                 patched_tokenizer_config = dict(patched_tokenizer_config)
@@ -875,6 +875,34 @@ def _remote_code_reference(metadata, auto_class):
     return reference if isinstance(reference, str) else None
 
 
+class _MLXRemoteCodeError(ValueError):
+    pass
+
+
+def _raise_mlx_remote_code_refusal(model_path, error, *, tokenizer_only=False):
+    if "trust_remote_code" not in str(error) and "custom code" not in str(error):
+        return
+    for filename, auto_class in (
+        ("processor_config.json", "AutoProcessor"),
+        ("preprocessor_config.json", "AutoProcessor"),
+        ("config.json", "AutoProcessor"),
+        ("tokenizer_config.json", "AutoTokenizer"),
+        ("preprocessor_config.json", "AutoImageProcessor"),
+    ):
+        if tokenizer_only and auto_class != "AutoTokenizer":
+            continue
+        reference = _remote_code_reference(
+            _read_json_file(os.path.join(str(model_path), filename)), auto_class,
+        )
+        if reference:
+            code_file = reference.split("--")[-1].rsplit(".", 1)[0] + ".py"
+            raise _MLXRemoteCodeError(
+                f"Unsloth: loading {model_path} requires {code_file} "
+                f"(declared in {filename}). Pass trust_remote_code=True "
+                "to allow this repository's custom code."
+            ) from error
+
+
 def _tokenizer_class_for_model_type(model_path):
     """Resolve the tokenizer class from config.json's model_type STRING.
 
@@ -934,18 +962,17 @@ def _load_mlx_tokenizer(model_path, *args, _auto_loader=None, **kwargs):
     # Tokenizer metadata selects the class; model validators have no role here.
     if class_name or remote:
         kwargs["config"] = PretrainedConfig()
-    return auto_loader(model_path, *args, **kwargs)
+    try:
+        return auto_loader(model_path, *args, **kwargs)
+    except ValueError as error:
+        if not kwargs["trust_remote_code"]:
+            _raise_mlx_remote_code_refusal(model_path, error, tokenizer_only=True)
+        raise
 
 
 @contextmanager
-def _mlx_tokenizer_loading_scope():
-    """Route mlx-lm's internal AutoTokenizer call through _load_mlx_tokenizer.
-
-    mlx_lm.utils.load_tokenizer calls AutoTokenizer.from_pretrained directly, so
-    the only way to reach it is to patch the class. The active flag is
-    thread-local, so other threads keep ordinary behaviour, and the lock keeps
-    two scopes from capturing each other's patch as the original.
-    """
+def _mlx_tokenizer_loading_scope(trust_remote_code=False):
+    """Cover nested processor tokenizer loads without changing other threads."""
     from transformers import AutoTokenizer
 
     with _TOKENIZER_LOAD_LOCK:
@@ -955,15 +982,24 @@ def _mlx_tokenizer_loading_scope():
         _TOKENIZER_LOAD_STATE.active = True
         _TOKENIZER_LOAD_STATE.original = original
 
+        refusals = []
+
         @classmethod
         def load(cls, model_path, *args, **kwargs):
             if not getattr(_TOKENIZER_LOAD_STATE, "active", False):
                 return original(model_path, *args, **kwargs)
-            return _load_mlx_tokenizer(model_path, *args, _auto_loader=original, **kwargs)
+            kwargs["trust_remote_code"] = bool(trust_remote_code)
+            try:
+                return _load_mlx_tokenizer(
+                    model_path, *args, _auto_loader=original, **kwargs,
+                )
+            except _MLXRemoteCodeError as error:
+                refusals.append(error)
+                raise
 
         AutoTokenizer.from_pretrained = load
         try:
-            yield
+            yield refusals
         finally:
             AutoTokenizer.from_pretrained = original_descriptor
             _TOKENIZER_LOAD_STATE.active = previous
@@ -1019,7 +1055,7 @@ def _load_mlx_lm_with_strict_fallback(
             model_config=model_config,
         )
 
-    with _mlx_tokenizer_loading_scope():
+    with _mlx_tokenizer_loading_scope(tokenizer_config.get("trust_remote_code", False)):
         tokenizer = load_tokenizer(
             model_path,
             tokenizer_config,
@@ -1216,7 +1252,7 @@ def _load_mlx_lm_distributed(
         cleanup_final_model_path = True
 
         try:
-            with _mlx_tokenizer_loading_scope():
+            with _mlx_tokenizer_loading_scope(tokenizer_config.get("trust_remote_code", False)):
                 tokenizer = load_tokenizer(
                     final_model_path,
                     tokenizer_config,
@@ -1550,10 +1586,11 @@ def _load_declared_mlx_vlm_processor(model_path, model_type, **kwargs):
             allow_tokenizer_remote_code=False,
         )
     try:
-        return scoped_processor_class.from_pretrained(
-            processor_load_path,
-            **kwargs,
-        )
+        with _mlx_tokenizer_loading_scope(kwargs.get("trust_remote_code", False)):
+            return scoped_processor_class.from_pretrained(
+                processor_load_path,
+                **kwargs,
+            )
     finally:
         if str(processor_load_path) != str(model_path):
             shutil.rmtree(processor_load_path, ignore_errors=True)
@@ -1562,6 +1599,8 @@ def _load_declared_mlx_vlm_processor(model_path, model_type, **kwargs):
 def _is_mlx_vlm_processor_resolution_error(error):
     """Return whether AutoProcessor failed before native MLX construction."""
 
+    if isinstance(error, _MLXRemoteCodeError):
+        return True
     message = str(error).lower()
     if isinstance(error, ValueError):
         return any(
@@ -1637,30 +1676,35 @@ def _bind_mlx_vlm_processor_loader(load_callable, *, allow_remote_code=False):
                         config_data,
                         allow_tokenizer_remote_code=False,
                     )
-            try:
+            with _mlx_tokenizer_loading_scope(allow_remote_code) as refusals:
                 try:
-                    return original_auto_processor.from_pretrained(
-                        processor_load_path,
-                        *args,
-                        **call_kwargs,
-                    )
-                except Exception as error:
-                    if not _is_mlx_vlm_processor_resolution_error(error):
-                        raise
-                    config_data = _read_json_file(
-                        os.path.join(str(processor_load_path), "config.json")
-                    )
-                    processor = _load_declared_mlx_vlm_processor(
-                        processor_load_path,
-                        config_data.get("model_type"),
-                        **call_kwargs,
-                    )
-                    if processor is None:
-                        raise
-                    return processor
-            finally:
-                if str(processor_load_path) != str(model_path):
-                    shutil.rmtree(processor_load_path, ignore_errors=True)
+                    try:
+                        return original_auto_processor.from_pretrained(
+                            processor_load_path,
+                            *args,
+                            **call_kwargs,
+                        )
+                    except Exception as error:
+                        if not _is_mlx_vlm_processor_resolution_error(error):
+                            raise
+                        config_data = _read_json_file(
+                            os.path.join(str(processor_load_path), "config.json")
+                        )
+                        processor = _load_declared_mlx_vlm_processor(
+                            processor_load_path,
+                            config_data.get("model_type"),
+                            **call_kwargs,
+                        )
+                        if processor is None:
+                            if refusals:
+                                raise refusals[-1] from error
+                            if not allow_remote_code:
+                                _raise_mlx_remote_code_refusal(model_path, error)
+                            raise
+                        return processor
+                finally:
+                    if str(processor_load_path) != str(model_path):
+                        shutil.rmtree(processor_load_path, ignore_errors=True)
 
     processor_globals = dict(processor_loader.__globals__)
     processor_globals["AutoProcessor"] = ScopedAutoProcessor
@@ -1856,6 +1900,7 @@ def get_class_predicate(p, m):
 
 def _build_vlm_image_processor_from_config(
     model_path, processor_config, preprocessor_config, model_type=None,
+    *, trust_remote_code=False,
 ):
     """Recreate the image processor from saved processor sidecar configs."""
     image_config = processor_config.get("image_processor")
@@ -1892,7 +1937,9 @@ def _build_vlm_image_processor_from_config(
 
     try:
         from transformers import AutoImageProcessor
-        return AutoImageProcessor.from_pretrained(model_path)
+        return AutoImageProcessor.from_pretrained(
+            model_path, trust_remote_code=trust_remote_code,
+        )
     except Exception:
         return None
 
@@ -1952,6 +1999,7 @@ def _repair_degraded_vlm_processor(
 
     image_processor = _build_vlm_image_processor_from_config(
         model_path, processor_config, preprocessor_config, model_type,
+        trust_remote_code=trust_remote_code,
     )
     if image_processor is None:
         return processor
@@ -8441,11 +8489,9 @@ class FastMLXModel:
         else:
             is_vlm = _is_vlm(config_data)
 
-        extra_kwargs = {}
+        extra_kwargs = {"trust_remote_code": bool(trust_remote_code)}
         if token:
             extra_kwargs["token"] = token
-        if trust_remote_code:
-            extra_kwargs["trust_remote_code"] = True
 
         if is_vlm:
             # VLM path via mlx-vlm


### PR DESCRIPTION
The native mlx-vlm GOT processor hardcodes `trust_remote_code=True` for its tokenizer, so `FastMLXModel.from_pretrained(..., trust_remote_code=False)` can still execute the repository's tokenizer code. Image-processor recovery also omits the caller's trust flag. This follow-up carries the caller's choice through nested tokenizer construction and image-processor recovery, keeping the default `False`.

This is the standalone follow-up [requested during #1170's review](https://github.com/unslothai/unsloth-zoo/pull/1170#issuecomment-5583825157). It preserves the merged tokenizer selection, special-token handling and config-decoupling implementation. It does not restore the unproven tiktoken fast-file preference.

Remote-code refusals now name the required Python file and `trust_remote_code=True`. The loader retains an actual tokenizer refusal when mlx-vlm replaces it with a generic processor-resolution error, while still allowing a successful native processor fallback. Remote-only tokenizer metadata is retained so those diagnostics remain available. The existing thread-local tokenizer scope carries the flag and restores dispatch on exit; standard and distributed text paths preserve their existing explicit opt-in behavior.

Validation on real MLX with published tokenizer files and tiny random checkpoints, comparing current main with this change:

| Case | Main | This PR |
|---|---|---|
| GOT, explicit `False` | Loads remote tokenizer despite the flag | Refuses, naming `tokenization_qwen.py` |
| GOT, explicit `True` | Loads | Loads with identical token IDs |
| DBRX, explicit `True` | Loads | Loads with identical token IDs |
| LLM-jp VL, explicit `True` | Loads | Loads with identical token IDs |
| DBRX / LLM-jp VL, `False` | Repository-level refusal | Names `tiktoken.py` / `processing_llmjpvl.py` and the opt-in flag |

GOT, DBRX, LLM-jp VL and Phi-4 multimodal also passed load and generation checks, including image inference for the VLMs. No model weights were downloaded or dependency sources patched. These are separate real-runtime checks from the unit tests' MLX simulation shim.

- 31 focused loader tests passed on transformers 5.5.0; 16 relevant trust/refusal cases passed on 4.51.3.
- 12 isolated mutation checks failed their intended tests, covering both trust directions, nested scopes, direct/swallowed refusals, native fallback precedence, distributed loading and image-processor recovery.

```bash
python -m pytest tests/test_mlx_save_export_regressions.py tests/test_mlx_distributed_loader.py -q -k 'tokenizer or processor or distributed or strict_fallback'
```
