### PR TITLE
Unbreak main against transformers 5.17 and trl 1.13

### DIFF
--- a/tests/test_disable_compile_functions_reach_imported_helpers.py
+++ b/tests/test_disable_compile_functions_reach_imported_helpers.py
@@ -18,12 +18,15 @@
 `called_functions` holds only names the modeling file both calls AND defines, so an
 imported-only helper is imported raw for Dynamo to inline, and the CALLER is demoted."""
 
+import importlib.util
 import inspect
+import json
 import os
 import subprocess
 import sys
 
 import pytest
+import transformers
 
 from unsloth_zoo import compiler as compiler_module
 from unsloth_zoo.compiler import (
@@ -68,18 +71,217 @@ def test_every_fullgraph_emit_site_consults_the_detector():
     )
 
 
-_HAS_VISION_UTILS = False
-try:
-    import transformers.vision_utils  # noqa: F401
-    import transformers.models.minimax_m3_vl  # noqa: F401
+def _run_compiler_child(script, cwd):
+    """Its own interpreter: the rewriter sets `__UNSLOTH_PATCHED__` on the modeling module
+    and swaps the classes it emits back into it, so a compile run is a one-way trip for
+    the process that does it."""
+    # conftest's GPU-free harness does not reach a subprocess.
+    env = dict(os.environ)
+    env["UNSLOTH_ALLOW_CPU"] = "1"
+    env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
+    # Pin the child to THIS checkout, else it reports on the site-packages compiler.py.
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env["PYTHONPATH"] = os.pathsep.join(
+        [repo_root] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
+    )
+    # An inherited UNSLOTH_COMPILE_DISABLE=1 forces disable=True and emits the wrong decorator.
+    env.pop("UNSLOTH_COMPILE_DISABLE", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd = str(cwd),
+        env = env,
+        capture_output = True,
+        text = True,
+        timeout = 1800,
+    )
+    assert result.returncode == 0, result.stdout[-4000:] + result.stderr[-4000:]
+    payload = None
+    for line in result.stdout.splitlines():
+        if line.startswith("@@@"):
+            payload = json.loads(line[3:])
+    assert payload is not None, result.stdout[-4000:]
+    return payload
 
-    _HAS_VISION_UTILS = True
-except Exception:
-    pass
+
+def _decorator_above(generated, function_name):
+    """The emit sites put the decorator immediately above `def <Class>_forward`, so the
+    text after the last `\\n@` is the one that governs this function."""
+    where = generated.find(f"def {function_name}(")
+    assert where != -1, (
+        f"{function_name} is not in the generated cache at all, so its decorator "
+        f"proves nothing.\n" + generated[:2000]
+    )
+    return generated[:where].rsplit("\n@", 1)[-1]
+
+
+# The synthetic fixture owns the end-to-end proof, because no shipped model presents the
+# shape any more (see `_upstream_shape_is_shipped`). It writes a real modeling package to
+# disk so inspect.getsource and linecache behave exactly as they do upstream, hangs it off
+# transformers.models.__path__ so the compiler's own
+# `importlib.import_module(f"transformers.models.{mt}.modeling_{mt}")` finds it, and then
+# drives the real `unsloth_compile_transformers`.
+_SYNTHETIC_CHILD = r'''
+import os, sys, json, importlib, io, contextlib, textwrap
+os.environ["UNSLOTH_COMPILE_LOCATION"] = "unsloth_compiled_cache"
+import torch
+import transformers.models
+from unsloth_zoo.compiler import DISABLE_COMPILE_FUNCTIONS, unsloth_compile_transformers
+
+# Any listed name proves the rule, and index 0 keeps working if the list is re-ordered.
+LISTED   = DISABLE_COMPILE_FUNCTIONS[0]
+MT       = "unsloth_synthetic_vl"
+CALLER   = "SyntheticImportedHelperCaller"
+INNOCENT = "SyntheticPlainBlock"
+
+root = os.path.join(os.getcwd(), "synthetic_transformers_models")
+package = os.path.join(root, MT)
+os.makedirs(package)
+with open(os.path.join(package, "__init__.py"), "w", encoding = "utf-8") as handle:
+    handle.write("")
+
+# The helper lives in a SIBLING module. The caller only imports it, so it never reaches
+# `called_functions`, and the grid_thw.tolist() that makes it untraceable is invisible to
+# every source scan the compiler runs over the modeling file.
+with open(os.path.join(package, "synthetic_vision_utils.py"), "w", encoding = "utf-8") as handle:
+    handle.write(textwrap.dedent(f"""
+        def {LISTED}(grid_thw, spatial_merge_size):
+            sizes = grid_thw.tolist()
+            return grid_thw.new_zeros(len(sizes) * spatial_merge_size)
+    """))
+
+# Neither __init__ mentions nn.Linear or nn.ModuleList, so both modules arrive at the
+# emit site with fullgraph = True and only the DISABLE_COMPILE_FUNCTIONS rule can part them.
+with open(os.path.join(package, f"modeling_{MT}.py"), "w", encoding = "utf-8") as handle:
+    handle.write(textwrap.dedent(f"""
+        import torch
+        import torch.nn as nn
+
+        from .synthetic_vision_utils import {LISTED}
+
+        __all__ = ["{CALLER}", "{INNOCENT}"]
+
+
+        class {CALLER}(nn.Module):
+            def __init__(self, hidden_size = 8, spatial_merge_size = 2):
+                super().__init__()
+                self.scale = nn.Parameter(torch.ones(hidden_size))
+                self.spatial_merge_size = spatial_merge_size
+
+            def forward(self, hidden_states, grid_thw):
+                indices = {LISTED}(grid_thw, self.spatial_merge_size)
+                return hidden_states * self.scale + indices.sum()
+
+
+        class {INNOCENT}(nn.Module):
+            def __init__(self, hidden_size = 8):
+                super().__init__()
+                self.weight = nn.Parameter(torch.ones(hidden_size))
+
+            def forward(self, hidden_states):
+                return hidden_states * self.weight
+    """))
+
+# transformers.models is a real package, so extending its __path__ hands the fixture to
+# the ordinary import machinery rather than faking sys.modules entries around it.
+transformers.models.__path__.append(root)
+location = f"transformers.models.{MT}.modeling_{MT}"
+modeling_file = importlib.import_module(location)
+
+buf = io.StringIO()
+with contextlib.redirect_stdout(buf):
+    unsloth_compile_transformers(
+        model_type = MT, fast_lora_forwards = False, fullgraph = True,
+        import_from_cache = False, disable = False, supports_sdpa = [None],
+    )
+
+generated = open(
+    os.path.join("unsloth_compiled_cache", f"unsloth_compiled_module_{MT}.py"),
+    encoding = "utf-8",
+).read()
+
+print("@@@" + json.dumps({
+    "generated"     : generated,
+    "modeling_file" : modeling_file.__file__,
+    "listed"        : LISTED,
+    "caller"        : CALLER,
+    "innocent"      : INNOCENT,
+    "log"           : buf.getvalue()[-4000:],
+}))
+'''
+
+
+def test_synthetic_imported_helper_demotes_its_caller_and_nothing_else(tmp_path):
+    payload = _run_compiler_child(_SYNTHETIC_CHILD, tmp_path)
+
+    generated = payload["generated"]
+    listed = payload["listed"]
+    caller = payload["caller"]
+    innocent = payload["innocent"]
+
+    # The fixture has to have been the module the compiler actually read, not a
+    # same-named leftover somewhere else on sys.path.
+    assert payload["modeling_file"].startswith(str(tmp_path)), payload["modeling_file"]
+
+    # The precondition the whole rule rests on: the helper is imported, never defined
+    # here, so `called_functions` cannot see it and Dynamo inlines the raw upstream body.
+    assert f"def {listed}(" not in generated, (
+        f"the fixture now defines {listed} itself, which puts it in `called_functions` "
+        f"and makes this test prove nothing."
+    )
+
+    assert "fullgraph = False" in _decorator_above(generated, f"{caller}_forward"), (
+        f"{caller}_forward calls the imported {listed}, whose first line is "
+        f"grid_thw.tolist(); emitting it fullgraph = True kills the first forward with "
+        f"`Backend compiler exception ... aten._local_scalar_dense.default`.\n"
+        + _decorator_above(generated, f"{caller}_forward")
+        + "\n--- compiler log ---\n"
+        + payload["log"]
+    )
+
+    # Demoting everything is not a fix. A module that calls nothing on the list keeps
+    # fullgraph = True, so this test fails a blanket `fullgraph = False` just as loudly.
+    assert "fullgraph = True" in _decorator_above(generated, f"{innocent}_forward"), (
+        f"{innocent}_forward calls nothing in DISABLE_COMPILE_FUNCTIONS, so demoting it "
+        f"gives up fullgraph for every leaf module in every model.\n"
+        + _decorator_above(generated, f"{innocent}_forward")
+        + "\n--- compiler log ---\n"
+        + payload["log"]
+    )
+
+
+_UPSTREAM_MODEL_TYPE = "minimax_m3_vl"
+_UPSTREAM_CLASS = "MiniMaxM3VL3DRotaryEmbedding"
+
+
+def _upstream_shape_is_shipped():
+    """transformers 5.17 renamed this class to MiniMaxM3VLVisionRotaryEmbedding and lifted
+    the get_vision_position_ids call out of it into MiniMaxM3VLVisionModel.forward. That is
+    a PreTrainedModel subclass, which is never compiled, so re-pointing at the new name
+    asserts nothing. Across all of transformers 5.17 the only plain nn.Module left calling
+    the helper is paddleocr_vl's encoder, and paddleocr_vl DEFINES the helper itself.
+
+    Read the source text instead of importing: importing a modeling module here would leak
+    a half-patched transformers into every test that runs after this one."""
+    try:
+        import transformers.vision_utils  # noqa: F401
+
+        spec = importlib.util.find_spec(
+            f"transformers.models.{_UPSTREAM_MODEL_TYPE}.modeling_{_UPSTREAM_MODEL_TYPE}"
+        )
+    except Exception:
+        return False
+    if spec is None or not spec.origin:
+        return False
+    try:
+        with open(spec.origin, encoding = "utf-8") as handle:
+            source = handle.read()
+    except OSError:
+        return False
+    return f"class {_UPSTREAM_CLASS}(" in source
 
 
 # Its own interpreter: the rewriter sets `__UNSLOTH_PATCHED__` on the modeling module.
-_CHILD = r'''
+_UPSTREAM_CHILD = r'''
 import os, sys, json, importlib, io, contextlib
 os.environ["UNSLOTH_COMPILE_LOCATION"] = "unsloth_compiled_cache"
 import torch
@@ -123,48 +325,29 @@ print("@@@" + json.dumps({
 
 
 @pytest.mark.skipif(
-    not _HAS_VISION_UTILS,
-    reason = "needs transformers >= 5.9 (shared vision_utils) with minimax_m3_vl",
+    not _upstream_shape_is_shipped(),
+    reason = (
+        f"transformers {transformers.__version__} no longer ships a compiled leaf module "
+        f"that calls an imported-only DISABLE_COMPILE_FUNCTIONS helper: "
+        f"{_UPSTREAM_CLASS} is gone from modeling_{_UPSTREAM_MODEL_TYPE} (renamed to "
+        f"MiniMaxM3VLVisionRotaryEmbedding, with the get_vision_position_ids call moved "
+        f"into the uncompiled MiniMaxM3VLVisionModel). "
+        f"test_synthetic_imported_helper_demotes_its_caller_and_nothing_else covers the rule."
+    ),
 )
 def test_imported_helper_is_not_inlined_into_a_fullgraph_region(tmp_path):
-    # conftest's GPU-free harness does not reach a subprocess.
-    env = dict(os.environ)
-    env["UNSLOTH_ALLOW_CPU"] = "1"
-    env["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
-    # Pin the child to THIS checkout, else it reports on the site-packages compiler.py.
-    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    env["PYTHONPATH"] = os.pathsep.join(
-        [repo_root] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
-    )
-    # An inherited UNSLOTH_COMPILE_DISABLE=1 forces disable=True and emits the wrong decorator.
-    env.pop("UNSLOTH_COMPILE_DISABLE", None)
-    result = subprocess.run(
-        [sys.executable, "-c", _CHILD],
-        cwd = str(tmp_path),
-        env = env,
-        capture_output = True,
-        text = True,
-        timeout = 1800,
-    )
-    assert result.returncode == 0, result.stdout[-4000:] + result.stderr[-4000:]
-    payload = None
-    for line in result.stdout.splitlines():
-        if line.startswith("@@@"):
-            import json
-
-            payload = json.loads(line[3:])
-    assert payload is not None, result.stdout[-4000:]
+    payload = _run_compiler_child(_UPSTREAM_CHILD, tmp_path)
 
     generated = payload["generated"]
     assert "def get_vision_position_ids(" not in generated, (
         "minimax_m3_vl now defines the helper itself; pick another model type "
         "that only imports it, or this test proves nothing."
     )
-    where = generated.find("def MiniMaxM3VL3DRotaryEmbedding_forward")
-    assert where != -1, "MiniMaxM3VL3DRotaryEmbedding_forward is no longer generated"
+    where = generated.find(f"def {_UPSTREAM_CLASS}_forward")
+    assert where != -1, f"{_UPSTREAM_CLASS}_forward is no longer generated"
     decorators = generated[:where]
     assert "fullgraph = False" in decorators.rsplit("\n@", 1)[-1], (
-        "MiniMaxM3VL3DRotaryEmbedding_forward calls the raw upstream "
+        f"{_UPSTREAM_CLASS}_forward calls the raw upstream "
         "get_vision_position_ids, whose first line is grid_thw.tolist(); "
         "emitting it fullgraph = True kills the first vision forward with "
         "`Backend compiler exception ... aten._local_scalar_dense.default`.\n"

--- a/tests/test_trl_sft_logits_metrics.py
+++ b/tests/test_trl_sft_logits_metrics.py
@@ -28,6 +28,9 @@ branch runs BEFORE the forward and injects forward kwargs, so "pretend liger is
 on" is only safe there if those kwargs are kept out of the model call.
 """
 import collections
+import contextlib
+import inspect
+import logging
 import sys
 import warnings
 from pathlib import Path
@@ -117,6 +120,11 @@ def _trainer(sftmod = None):
     self._metrics = {"train": collections.defaultdict(list),
                      "eval": collections.defaultdict(list)}
     self._total_train_tokens = 0
+    # Tensor parallel ranks see the same batch, so trl divides the gathered token
+    # count by this. One process here, so one. `object.__new__` skips the
+    # __init__ that would have set it; see test_the_stub_covers_what_trl_reads
+    # for the guard that catches the next attribute trl adds.
+    self._tp_size = 1
     self.aux_loss_enabled = False
     self.compute_loss_func = None
     return self
@@ -262,6 +270,37 @@ def test_it_is_registered(sft):
     from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
     assert any(getattr(f, "__name__", "") == "patch_trl_sft_logits_metrics"
                for f in TEMPORARY_PATCHES)
+
+
+def _self_reads(func):
+    """Every `self.NAME` this function reads."""
+    import ast, textwrap
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    return {node.attr for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name) and node.value.id == "self"
+            and isinstance(node.ctx, ast.Load)}
+
+
+def test_the_stub_covers_what_trl_reads(sft):
+    """`_trainer` builds an SFTTrainer with `object.__new__` and hand-seeds the
+    instance state, so trl adding one attribute to __init__ breaks every test in
+    this module at once with an AttributeError from deep inside trl. That is what
+    `_tp_size` did on trl 1.13: 29 failures, none of them naming the cause.
+
+    This is the one test that should go red instead. `hasattr` runs against a real
+    SFTTrainer instance, so class attributes and methods answer for themselves --
+    only genuinely new per-instance state trips it, which is exactly the case the
+    stub has to keep up with.
+    """
+    self = _trainer(sft)
+    missing = sorted(name for name in _self_reads(sft.SFTTrainer.compute_loss)
+                     if not hasattr(self, name))
+    assert not missing, (
+        f"trl's SFTTrainer.compute_loss reads self.{{{', '.join(missing)}}}, which "
+        f"`_trainer` does not provide. Seed each one there with the value trl's "
+        f"__init__ would have given it for a single-process CPU run."
+    )
 
 
 # ---- against a stand-in for trl 1.x --------------------------------------
@@ -550,11 +589,44 @@ def test_an_explicit_none_logits_is_still_the_sentinel(sft):
     assert self._metrics["train"]["mean_token_accuracy"] == []
 
 
-def test_the_entropy_warning_is_not_shown_when_both_are_omitted(sft, caplog):
+class _Records(logging.Handler):
+    """Reads the warnings off the logger that emits them.
+
+    `caplog` installs its handler on the ROOT logger, so it only sees what
+    propagates there. misc.py borrows a transformers logger, and once `unsloth`
+    is installed and imported that logger no longer propagates -- the warning
+    still reaches the user on stderr, but caplog.text is empty and the test reads
+    as "the warning was not shown". Attaching to the logger itself asks the
+    question the test is actually asking, whatever else configured logging first.
+    """
+
+    def __init__(self):
+        super().__init__(level = logging.WARNING)
+        self.text = ""
+
+    def emit(self, record):
+        self.text += record.getMessage() + "\n"
+
+
+@contextlib.contextmanager
+def _warnings_from(logger):
+    handler = _Records()
+    was_level, was_disabled = logger.level, logger.disabled
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    logger.disabled = False
+    try:
+        yield handler
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(was_level)
+        logger.disabled = was_disabled
+
+
+def test_the_entropy_warning_is_not_shown_when_both_are_omitted(sft):
     """The entropy patch promises "Entropy will be reported as 0.0". When the
     accuracy read then fails, the wrapper reports that BOTH are omitted, so the
     first message is wrong and the user sees two contradictory ones on step 1."""
-    import logging
     from unsloth_zoo.temporary_patches.misc import logger as misc_logger
     import trl.trainer.utils as trl_utils
     flag = getattr(trl_utils.entropy_from_logits, "_unsloth_warned", None)
@@ -563,9 +635,9 @@ def test_the_entropy_warning_is_not_shown_when_both_are_omitted(sft, caplog):
     was = flag[0]
     flag[0] = False
     try:
-        with caplog.at_level(logging.WARNING, logger = misc_logger.name):
+        with _warnings_from(misc_logger) as records:
             _run_steps(sft, EmptyLogits(), steps = 2)
-        text = caplog.text
+        text = records.text
     finally:
         flag[0] = was
     assert "Both will be omitted" in text

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -52,6 +52,25 @@ def _skip_if_transformers_5x(reason: str) -> None:
         )
 
 
+def _zoo_site(symbol: str) -> str:
+    """``unsloth_zoo/compiler.py:LINE (symbol)``, resolved now rather than typed
+    in. The hand-written pins in this file have gone stale twice -- the three
+    cross_entropy finders were still cited at :1508 / :1599 / :1683 long after
+    they moved past :2500 -- and a drift report that names the wrong line sends
+    the next reader to unrelated code."""
+    import pathlib
+
+    import unsloth_zoo.compiler as _compiler
+
+    path = pathlib.Path(_compiler.__file__)
+    for number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if line.startswith(f"{symbol} = "):
+            return f"unsloth_zoo/compiler.py:{number} ({symbol})"
+    return f"unsloth_zoo/compiler.py ({symbol}, definition not found)"
+
+
 def _drift(zoo_site: str, pattern: str, upstream_path: str,
            extra: str = "") -> None:
     msg = (
@@ -340,7 +359,7 @@ def test_compiler_cross_entropy_lm_head_pattern_present():
             break
     if not found:
         _drift(
-            "unsloth_zoo/compiler.py:1508 (cross_entropy_find_1)",
+            _zoo_site("cross_entropy_find_1"),
             needle,
             "any ForCausalLM among " + ", ".join(candidate_classes),
             "The fused linear cross-entropy rewriter pins this line; "
@@ -385,17 +404,76 @@ def test_compiler_cross_entropy_find_2_loss_function_signature():
         if needle in src:
             return
     _drift(
-        "unsloth_zoo/compiler.py:1599 (cross_entropy_find_2)",
+        _zoo_site("cross_entropy_find_2"),
         "self.loss_function(...)",
         "any ForCausalLM among " + ", ".join(candidate_classes),
     )
 
 
-def test_compiler_cross_entropy_find_3_shift_logits_pattern():
-    """``unsloth_zoo/compiler.py:1683-1700`` (cross_entropy_find_3) pins
-    ``shift_logits = logits[..., :-1, :]`` / ``shift_labels = labels[..., 1:]``
-    in VLM ForConditionalGeneration forwards."""
+# The gemma3 VLM forward as transformers 4.57.6 wrote it, reduced to the block
+# cross_entropy_find_3 matches. Frozen on purpose: upstream moved gemma3 to
+# `self.loss_function` in 5.17, and without a fixture the shift-logits branch
+# would stop being exercised the moment no shipped model used it -- which is
+# exactly when a change to the pattern would go unnoticed.
+_LEGACY_VLM_SHIFT_FORWARD = '''
+def forward(self, input_ids = None, labels = None, **loss_kwargs):
+    outputs = self.model(input_ids = input_ids)
+    logits = outputs.logits
+    loss = None
+    if labels is not None:
+        logits = logits.float()
+        shift_logits = logits[..., :-1, :]
+        shift_labels = labels[..., 1:]
+        if attention_mask is not None:
+            shift_attention_mask = attention_mask[:, -shift_logits.shape[1]:]
+            shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
+            shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
+        else:
+            shift_logits = shift_logits.contiguous()
+            shift_labels = shift_labels.contiguous()
+        loss_fct = nn.CrossEntropyLoss()
+        shift_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
+        shift_labels = shift_labels.view(-1)
+        shift_labels = shift_labels.to(shift_logits.device)
+        loss = loss_fct(shift_logits, shift_labels)
+    return loss
+'''
+
+
+def test_compiler_cross_entropy_find_3_still_matches_its_own_shape():
+    """cross_entropy_find_3 pins ``shift_logits = logits[..., :-1, :]`` /
+    ``shift_labels = labels[..., 1:]`` in VLM ForConditionalGeneration forwards.
+
+    Against a frozen fixture, so this fails when the *pattern* breaks rather than
+    when upstream stops using the shape."""
+    apply_fused_lm_head = pytest.importorskip(
+        "unsloth_zoo.compiler"
+    ).apply_fused_lm_head
+    _, applied = apply_fused_lm_head(_LEGACY_VLM_SHIFT_FORWARD)
+    if not applied:
+        _drift(
+            _zoo_site("cross_entropy_find_3"),
+            "shift_logits = logits[..., :-1, :] / shift_labels = labels[..., 1:]",
+            "the frozen transformers 4.57.6 gemma3 VLM forward in this file",
+            "The pattern no longer matches the shape it was written for, so the "
+            "fused cross-entropy rewrite is a no-op for every VLM still using it.",
+        )
+
+
+def test_the_fused_cross_entropy_rewrite_still_reaches_gemma3():
+    """The contract that actually matters: whatever shape upstream's gemma3
+    forward has this week, one of the cross_entropy finders matches it.
+
+    Asserting a literal string instead is what broke here. transformers 5.17
+    replaced gemma3's hand-written shift with ``self.loss_function(...,
+    **lm_kwargs)`` -- a shape cross_entropy_find_2 was written for, except its
+    ``$KWARGS$`` only accepted ``loss_kwargs`` / ``kwargs``. A no-match is a
+    silent no-op (compiler.py returns the forward untouched), so the only symptom
+    was Gemma 3 quietly losing fused linear cross entropy."""
     pytest.importorskip("transformers")
+    apply_fused_lm_head = pytest.importorskip(
+        "unsloth_zoo.compiler"
+    ).apply_fused_lm_head
     try:
         from transformers.models.gemma3.modeling_gemma3 import (
             Gemma3ForConditionalGeneration,
@@ -406,17 +484,23 @@ def test_compiler_cross_entropy_find_3_shift_logits_pattern():
         src = inspect.getsource(Gemma3ForConditionalGeneration.forward)
     except OSError:
         pytest.skip("Gemma3ForConditionalGeneration.forward source unavailable")
-    needles = (
-        "shift_logits = logits[..., :-1, :]",
-        "shift_labels = labels[..., 1:]",
-    )
-    for needle in needles:
-        if needle not in src:
-            _drift(
-                "unsloth_zoo/compiler.py:1683-1700 (cross_entropy_find_3)",
-                needle,
-                "transformers.models.gemma3.modeling_gemma3.Gemma3ForConditionalGeneration.forward",
-            )
+
+    new_source, applied = apply_fused_lm_head(src)
+    if not applied:
+        _drift(
+            _zoo_site("cross_entropy_find_2")
+            + " / "
+            + _zoo_site("cross_entropy_find_3"),
+            "any cross_entropy finder",
+            "transformers.models.gemma3.modeling_gemma3."
+            "Gemma3ForConditionalGeneration.forward",
+            f"transformers {_TX_VERSION} writes the loss in a shape no finder "
+            "matches, and a finder that does not match is a silent no-op: the "
+            "model trains, using the memory the fused path exists to save.",
+        )
+    assert new_source != src, "reported applied but returned the source unchanged"
+    # A rewrite that does not parse is worse than one that does not fire.
+    ast.parse(textwrap.dedent(new_source))
 
 
 _QWEN2_VL_NEEDLE_4X = (

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2875,7 +2875,13 @@ def apply_fused_lm_head(forward, module=None):
                 r"self\.config\.get_text_config\(\)\.vocab_size"
                 ")",
             )
-            .replace("$KWARGS$", r"(?:, \*\*(loss_kwargs|kwargs))?")
+            # Any identifier, not a list of the two names we had seen. transformers
+            # 5.17 renamed gemma3's to `lm_kwargs`, and because a finder that does
+            # not match is a silent no-op, the only symptom was Gemma 3 quietly
+            # losing fused linear cross entropy. One capture group either way, and
+            # the replacements splice the captured NAME in, so a new spelling
+            # works without being enumerated here.
+            .replace("$KWARGS$", r"(?:, \*\*([A-Za-z_]\w*))?")
             .replace("$LOGITSUPCAST$", r"(?:logits = logits\.float\(\))?")
             .replace("$LABELSDEVICE$", r"(?:labels = labels\.to\([^\)]{1,}\))?")
             .replace(


### PR DESCRIPTION
`Core drift (3 upstream pins)` has been red on main since 2026-09-09, and it takes unsloth's `Core (HF=latest + TRL=latest)` down with it, since that job clones zoo main and runs this suite. Three failures, all from upstream releases published that afternoon.

`transformers` 5.17.0 went to PyPI at 15:39Z. Nothing we merged is involved: unsloth-zoo #1183 landed about four hours earlier and touches only the runtime eager-fallback wrapper, not the source-generation path.

## Gemma 3 stopped getting fused linear cross entropy

This is the one worth reading. 5.17 rewrote `Gemma3ForConditionalGeneration.forward` to delegate the loss:

```python
loss = self.loss_function(
    logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs
)
```

That is `cross_entropy_find_2`'s shape, so the rewrite should still have fired. It did not, because `$KWARGS$` expanded to `(?:, \*\*(loss_kwargs|kwargs))?` and gemma3's is spelled `lm_kwargs`.

A finder that does not match is a silent no-op. `apply_fused_lm_head` returns the forward untouched, prints nothing outside `UNSLOTH_ENABLE_LOGGING=1`, and the model trains correctly while using the memory the fused path exists to save. The only thing that noticed was the drift test, and it reported the missing string rather than the consequence.

`$KWARGS$` now captures any identifier. The replacements splice the captured name in, so the next spelling upstream picks needs no change here. Measured on transformers 5.17.0:

| class | before | after |
| --- | --- | --- |
| Gemma3ForConditionalGeneration | applied=False | applied=True |
| Gemma3ForCausalLM | applied=True | applied=True |
| Qwen2_5_VLForConditionalGeneration | applied=True | applied=True |
| Gemma2ForCausalLM | applied=True | applied=True |
| LlavaForConditionalGeneration | applied=True | applied=True |
| PaliGemmaForConditionalGeneration | applied=True | applied=True |

One case flips, nothing regresses, and every applied rewrite still parses.

`test_compiler_cross_entropy_find_3_shift_logits_pattern` was asserting a literal string in upstream's source, which is why it reported drift instead of the no-op it caused. It is now two tests:

- `test_the_fused_cross_entropy_rewrite_still_reaches_gemma3` runs the real rewriter against the installed forward and requires it to apply and to `ast.parse`. Whatever shape upstream picks next, the contract is that some finder matches it.
- `test_compiler_cross_entropy_find_3_still_matches_its_own_shape` keeps `cross_entropy_find_3` covered against a frozen 4.57.6 fixture, so the pattern stays guarded even though no shipped model uses that shape any more.

Both fail when the fix is reverted.

The zoo-site line numbers in the drift messages are now resolved at runtime. They had gone stale twice, still citing `:1508` / `:1599` / `:1683` for finders that had moved past `:2500`, which sends the next reader to unrelated code.

## MiniMaxM3VL3DRotaryEmbedding is gone

5.17 renamed it to `MiniMaxM3VLVisionRotaryEmbedding` and lifted the `get_vision_position_ids` call out of it into `MiniMaxM3VLVisionModel.forward`.

Re-pointing the test at the new class would assert nothing. `MiniMaxM3VLVisionModel` is a `PreTrainedModel` subclass and is never compiled, so no `_forward` is emitted for it at all. I checked the rest of 5.17 too: of the 41 classes that call the helper, 40 are `PreTrainedModel` subclasses, and the single plain `nn.Module`, paddleocr_vl's encoder, defines the helper itself and so fails the test's own precondition. No shipped model presents this shape any more.

So the end to end proof moves to a synthetic fixture. It writes a real modeling package to disk (so `inspect.getsource` and `linecache` behave as they do upstream), hangs it off `transformers.models.__path__` so the compiler's own `importlib.import_module` finds it, and drives the real `unsloth_compile_transformers`. One leaf module calls an imported-only listed helper and must come out `fullgraph = False`; a second calls nothing listed and must stay `fullgraph = True`, so a blanket demotion fails it just as loudly. Verified by breaking `calls_disable_compile_function` in both directions.

The upstream case is kept and skips with a message naming the transformers version and the missing class, so it still runs on anything below 5.17.

## trl's `_tp_size`

29 failures in `test_trl_sft_logits_metrics.py`:

```
trl/trainer/sft_trainer.py:1872: self._total_train_tokens += num_tokens_in_batch // self._tp_size
AttributeError: 'SFTTrainer' object has no attribute '_tp_size'. Did you mean: 'get_tp_size'?
```

Not a rename, despite the hint. `get_tp_size` is an unrelated `transformers.Trainer` method. trl 1.13's `SFTTrainer.__init__` sets `_tp_size` itself, so real users are fine; the test builds its trainer with `object.__new__` and hand-seeds the instance state, and never picked the new attribute up. No unsloth or zoo code reads `_tp_size`, so there is nothing to migrate.

Seeded, and `test_the_stub_covers_what_trl_reads` now compares the attributes `compute_loss` reads against what the stub provides. The next attribute trl adds fails one test that names it, instead of 29 that do not.

## One more, uncovered by fixing that

`test_the_entropy_warning_is_not_shown_when_both_are_omitted` was failing for the `_tp_size` reason, and would have kept failing for a second one underneath it.

It read the warning through `caplog`, which installs its handler on the root logger. `misc.py` borrows a transformers logger, and once `unsloth` is installed and imported (which every lane does) that logger stops propagating to root. The warning still reached the user on stderr, so the test was reporting "not shown" about a message that was shown. It now attaches to the logger that emits it.

## Verification

Against transformers 5.17.0, trl 1.13.0, peft 0.20.0, torch 2.10 CPU, with `unsloth` installed as the lanes do:

```
616 passed, 57 skipped
```

across `test_compiler_dynamic_exec`, `test_compiler_rewriter_exhaustive`, `test_upstream_source_patterns`, `test_upstream_signatures`, `test_temporary_patches_exhaustive`, `test_zoo_source_upstream_refs`, `test_trl_sft_logits_metrics`, `test_disable_compile_functions_reach_imported_helpers`, `test_ci_lane_scripts_parse`, `test_upstream_pinned_symbols_transformers` and `test_extended_dep_api_pins`. Three consecutive runs, same result each time.

Merging this also clears `Core (HF=latest + TRL=latest)` on unslothai/unsloth, which is currently red for exactly these three reasons.
