### PR TITLE
Retry the pip bootstrap in the lanes too

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -143,7 +143,7 @@ jobs:
               rc=0
               {
                 "$interpreter" -m venv "$venv" &&
-                "$venv/bin/python" -m pip install --upgrade pip &&
+                retry "$venv/bin/python" -m pip install --upgrade pip &&
                 retry "$venv/bin/pip" install --index-url https://download.pytorch.org/whl/cpu \
                   "torch>=2.4.0,<2.11.0" &&
                 retry "$venv/bin/pip" install -e .[core] &&
@@ -481,7 +481,7 @@ jobs:
             rc=0
             {
               python -m venv .lanes/venv-numerics &&
-              .lanes/venv-numerics/bin/python -m pip install --upgrade pip &&
+              retry .lanes/venv-numerics/bin/python -m pip install --upgrade pip &&
               retry .lanes/venv-numerics/bin/pip install --index-url https://download.pytorch.org/whl/cpu \
                 "torch>=2.4.0,<2.11.0" &&
               retry .lanes/venv-numerics/bin/pip install -e .[core] &&
@@ -502,7 +502,7 @@ jobs:
             rc=0
             {
               python -m venv .lanes/venv-suites &&
-              .lanes/venv-suites/bin/python -m pip install --upgrade pip &&
+              retry .lanes/venv-suites/bin/python -m pip install --upgrade pip &&
               retry .lanes/venv-suites/bin/pip install --index-url https://download.pytorch.org/whl/cpu \
                 "torch>=2.4.0,<2.11.0" &&
               retry .lanes/venv-suites/bin/pip install -e .[core] \
@@ -818,7 +818,7 @@ jobs:
                 spec_p="$(echo "$specs" | sed -n 3p)" &&
                 echo "resolved: $spec_t | $spec_r | $spec_p" &&
                 python -m venv "$venv" &&
-                "$venv/bin/python" -m pip install --upgrade pip &&
+                retry "$venv/bin/python" -m pip install --upgrade pip &&
                 # torchvision: transformers' qwen2_vl / qwen2_5_vl image processors
                 # import it at module top, so without it the existence probes go red
                 # on ModuleNotFoundError rather than on drift. CPU build is plenty.

--- a/tests/test_ci_lane_scripts_parse.py
+++ b/tests/test_ci_lane_scripts_parse.py
@@ -262,13 +262,18 @@ def test_network_bound_installs_are_retried() -> None:
     pip's `--retries` only covers establishing a connection, so a body truncated
     mid-download (ProtocolError / IncompleteRead) is not retried and the install
     dies. The lanes wrap those installs in retry().
+
+    The pip bootstrap used to be excluded here. It is network-bound like the
+    rest, and it runs before anything else in the lane, so a blip there costs the
+    whole lane: `retry` around `pip install -e .[core]` demonstrably saved a lane
+    from an IncompleteRead on 2026-09-09, and there was no reason the line above
+    it should have been the one left unprotected.
     """
     for workflow, job, name, run in _lane_steps():
         for body in _capture_groups(run):
             installs = [
                 stmt for stmt in _statements(body)
                 if "pip" in stmt and " install " in stmt
-                and "--upgrade pip" not in stmt
                 and "--no-deps" not in stmt      # deliberately `|| true`
             ]
             for stmt in installs:


### PR DESCRIPTION
Not a fix for anything currently red, and worth saying so up front.

While reading the `Core drift (3 upstream pins)` log for #1187 I found the `IncompleteRead` in it was a red herring. `retry()` caught it, attempt two succeeded, and the job failed on the drift tests instead:

```
+ .lanes/venv-t4576-trl0latest/bin/pip install -e '.[core]'
  Installing build dependencies: finished with status 'error'
      ERROR: Could not install packages due to an OSError: ('Connection broken: IncompleteRead(48657 bytes read, 534 more expected)', ...)
+ echo 'retry: attempt 1 failed, retrying in 15s: .lanes/venv-t4576-trl0latest/bin/pip install -e .[core]'
```

and then the lane went on to build fine. The mechanism works.

What it does not cover is the line above it. `python -m pip install --upgrade pip` is network-bound like every other install in the lane, runs before anything else so a blip there costs the whole lane, and was the one command left unwrapped. `test_network_bound_installs_are_retried` had an explicit carve-out saying so:

```python
and "--upgrade pip" not in stmt
```

There was no reason for the carve-out beyond it being where the list started, so both are gone. The three lane bootstraps (`core-upstream-matrix`, `python-version-collect`, `mlx-cpu-linux`) are wrapped, and the test now requires it.

Verified the test is real by unwrapping one bootstrap again:

```
AssertionError: consolidated-tests-ci.yml: job 'core-upstream-matrix' step 'Run all three
upstream pins (concurrently)': network-bound install is not wrapped in retry():
    "$venv/bin/python" -m pip install --upgrade pip
```

`test_ci_lane_scripts_parse.py` passes 47/47, and all workflows still parse.

Independent of #1187, but low priority next to it.
