### PR TITLE
perf(mlx): fuse quantized MoE gate and up projections

### DIFF
--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -164,6 +164,11 @@ def test_falsey_defaults_are_not_silently_replaced(monkeypatch):
             raise ValueError("body")
 
 def _record_cache_calls(monkeypatch, *, has_clear_cache=True):
+    for name in (
+        "mlx_lm.generate", "mlx_vlm.generate", "mlx_vlm.generate.dispatch",
+        "mlx_vlm.generate.ar", "mlx_vlm.speculative.common",
+    ):
+        monkeypatch.setitem(sys.modules, name, types.SimpleNamespace())
     events = []
     monkeypatch.setattr(
         "mlx.core.synchronize",

--- a/tests/test_mlx_moe_metal.py
+++ b/tests/test_mlx_moe_metal.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+from mlx_simulation import mlx_is_simulated
+
+if mlx_is_simulated():
+    pytest.skip("Requires native MLX", allow_module_level = True)
+pytestmark = pytest.mark.skipif(not mx.metal.is_available(), reason = "Requires Metal")
+
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+from mlx_lm.models import switch_layers as lm
+from mlx_vlm.models import switch_layers as vlm
+from unsloth_zoo.mlx.inference import fused_moe_gate_up
+
+
+def _model(native, dtype = mx.bfloat16, dims = (2048, 512), bits = 8, activation = None, bias = True):
+    mx.random.seed(19)
+    kwargs = {} if activation is None else {"activation": activation}
+    model = native.SwitchGLU(*dims, 8, bias = bias, **kwargs)
+    model.set_dtype(dtype)
+    nn.quantize(model, bits = bits, group_size = 64)
+    model.eval()
+    model.freeze()
+    mx.eval(model.parameters())
+    return model
+
+
+def _equal(a, b):
+    assert np.array_equal(np.array(a.view(mx.uint8)), np.array(b.view(mx.uint8)))
+
+
+def _sample(width = 2048):
+    return (
+        mx.random.normal((1, 2, width)).astype(mx.bfloat16),
+        mx.array([[[7, 2, 0, 5], [6, 4, 1, 3]]]),
+    )
+
+
+@pytest.mark.parametrize("native", [lm, vlm])
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("dims", [(2048, 512), (4096, 1408)])
+def test_fusion_preserves_outputs_parameters_and_native_class(native, dtype, dims, monkeypatch):
+    model = _model(native, dtype, dims)
+    original_call = native.SwitchGLU.__call__
+    names = {name for name, _ in tree_flatten(model.parameters())}
+    samples = []
+    for batch, length in [(1, 1), (2, 1), (1, 8), (1, 64), (1, 256)]:
+        x = mx.random.normal((batch, length, dims[0])).astype(dtype)
+        indices = mx.random.randint(0, 8, (batch, length, 8))
+        expected = model(x, indices)
+        mx.eval(x, indices, expected)
+        samples.append((x, indices, expected))
+    gather_qmm = mx.gather_qmm
+    calls = []
+
+    def counted(*args, **kwargs):
+        calls.append(None)
+        return gather_qmm(*args, **kwargs)
+
+    monkeypatch.setattr(mx, "gather_qmm", counted)
+    with fused_moe_gate_up(model):
+        assert type(model) is not native.SwitchGLU
+        assert native.SwitchGLU.__call__ is original_call
+        assert {name for name, _ in tree_flatten(model.parameters())} == names
+        for x, indices, expected in samples:
+            calls.clear()
+            _equal(model(x, indices), expected)
+            assert len(calls) == 2
+    assert type(model) is native.SwitchGLU
+    assert {name for name, _ in tree_flatten(model.parameters())} == names
+
+
+@pytest.mark.parametrize("native", [lm, vlm])
+def test_nested_scopes_restore_all_modules_after_exception(native):
+    first, second = _model(native), _model(native)
+    root = nn.Sequential(first, second)
+    root.eval()
+    before = [set(module.__dict__) for module in (first, second)]
+    x, indices = _sample()
+    expected = [module(x, indices) for module in (first, second)]
+    mx.eval(expected)
+    with pytest.raises(RuntimeError, match = "injected"):
+        with fused_moe_gate_up(root):
+            outer_classes = [type(module) for module in (first, second)]
+            assert all(cls is not native.SwitchGLU for cls in outer_classes)
+            with fused_moe_gate_up(root):
+                assert [type(module) for module in (first, second)] == outer_classes
+            assert [type(module) for module in (first, second)] == outer_classes
+            for module, answer in zip((first, second), expected):
+                _equal(module(x, indices), answer)
+            raise RuntimeError("injected")
+    for module, keys, answer in zip((first, second), before, expected):
+        assert type(module) is native.SwitchGLU
+        assert set(module.__dict__) == keys
+        _equal(module(x, indices), answer)
+
+
+@pytest.mark.parametrize("native", [lm, vlm])
+@pytest.mark.parametrize("first_exit", [0, 1])
+def test_overlapping_scopes_keep_shared_modules_patched(native, first_exit):
+    modules = [_model(native), _model(native)]
+    root = nn.Sequential(*modules)
+    root.eval()
+    x, indices = _sample()
+    expected = [module(x, indices) for module in modules]
+    mx.eval(expected)
+    scopes = [fused_moe_gate_up(root), fused_moe_gate_up(modules[1])]
+    active = []
+    try:
+        for scope in scopes:
+            scope.__enter__()
+            active.append(scope)
+        bound_call = modules[1].__call__
+        active.remove(scopes[first_exit])
+        scopes[first_exit].__exit__(None, None, None)
+        for index, module in enumerate(modules):
+            still_active = first_exit == 1 or index == 1
+            assert (type(module) is not native.SwitchGLU) == still_active
+            assert hasattr(module, "_unsloth_moe_gate_up") == still_active
+            _equal(module(x, indices), expected[index])
+        _equal(bound_call(x, indices), expected[1])
+    finally:
+        for scope in reversed(active):
+            scope.__exit__(None, None, None)
+    for module, answer in zip(modules, expected):
+        assert type(module) is native.SwitchGLU
+        assert not hasattr(module, "_unsloth_moe_gate_up")
+        _equal(module(x, indices), answer)
+
+
+def test_fusion_does_not_clear_the_global_allocator(monkeypatch):
+    model = _model(lm)
+    clears = []
+    monkeypatch.setattr(mx, "clear_cache", lambda: clears.append(None))
+    with fused_moe_gate_up(model):
+        assert type(model) is not lm.SwitchGLU
+    assert clears == []
+
+
+@pytest.mark.parametrize("native", [lm, vlm])
+def test_inplace_edits_between_scopes_are_used(native):
+    model = _model(native)
+    x, indices = _sample()
+    with fused_moe_gate_up(model):
+        before = model(x, indices)
+        mx.eval(before)
+    for projection in (model.gate_proj, model.up_proj):
+        weight = projection.weight
+        weight[-1, -64:, :] = 0
+        projection.scales[-2, :, :] *= 1.5
+        projection.bias[-1, :] += 0.25
+        assert projection.weight is weight
+        expected = model(x, indices)
+        mx.eval(expected)
+        assert not np.array_equal(
+            np.array(before.view(mx.uint8)), np.array(expected.view(mx.uint8)),
+        )
+        with fused_moe_gate_up(model):
+            _equal(model(x, indices), expected)
+        _equal(model(x, indices), expected)
+        before = expected
+
+
+@pytest.mark.parametrize("native", [lm, vlm])
+def test_training_replacement_and_adapters_use_native_path(native, monkeypatch):
+    model = _model(native)
+    x, indices = _sample()
+    original_call = native.SwitchGLU.__call__
+    gather_qmm = mx.gather_qmm
+    calls = []
+
+    def counted(*args, **kwargs):
+        calls.append(None)
+        return gather_qmm(*args, **kwargs)
+
+    class AdaptedProjection(nn.Module):
+        def __init__(self, base):
+            super().__init__()
+            self.base = base
+
+        def __call__(self, inputs, indices, sorted_indices = False):
+            return self.base(inputs, indices, sorted_indices = sorted_indices) + 0.5
+
+    monkeypatch.setattr(mx, "gather_qmm", counted)
+    with fused_moe_gate_up(model):
+        model.train()
+        calls.clear()
+        actual = model(x, indices)
+        assert len(calls) == 3
+        _equal(actual, original_call(model, x, indices))
+        model.eval()
+        model.gate_proj.scales = model.gate_proj.scales * 1.25
+        calls.clear()
+        actual = model(x, indices)
+        assert len(calls) == 3
+        _equal(actual, original_call(model, x, indices))
+    with fused_moe_gate_up(model):
+        model.up_proj = AdaptedProjection(model.up_proj)
+        calls.clear()
+        actual = model(x, indices)
+        assert len(calls) == 3
+        _equal(actual, original_call(model, x, indices))
+
+
+@pytest.mark.parametrize("reason", ["4bit", "custom", "training", "trainable", "distributed"])
+def test_ineligible_models_stay_native(reason):
+    model = _model(vlm, bits = 4 if reason == "4bit" else 8)
+    if reason == "custom":
+        class CustomSwitch(vlm.SwitchGLU):
+            pass
+        model.__class__ = CustomSwitch
+    elif reason == "training":
+        model.train()
+    elif reason == "trainable":
+        model.up_proj.unfreeze()
+    elif reason == "distributed":
+        model._unsloth_mlx_distributed_parallel_mode = "tensor"
+    original_class = type(model)
+    with fused_moe_gate_up(model):
+        assert type(model) is original_class
+
+
+def test_generation_mode_applies_fusion_and_restores_training():
+    from unsloth_zoo.mlx.generate import generation_mode
+
+    model = _model(lm)
+    x, indices = _sample()
+    expected = model(x, indices)
+    mx.eval(expected)
+    model.train()
+    with generation_mode(model):
+        assert type(model) is not lm.SwitchGLU
+        assert not model.training
+        _equal(model(x, indices), expected)
+    assert type(model) is lm.SwitchGLU
+    assert model.training
+
+
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("family", ["gemma", "gpt_oss"])
+@pytest.mark.parametrize("bias", [False, True])
+def test_family_activation_is_preserved(dtype, family, bias):
+    if family == "gemma":
+        from mlx_vlm.models.gemma4.language import GeGLU
+        activation, dims = GeGLU(), (2816, 704)
+    else:
+        from mlx_lm.models.gpt_oss import SwiGLU
+        activation, dims = SwiGLU(), (2880, 2880)
+    model = _model(vlm, dtype, dims, activation = activation, bias = bias)
+    samples = []
+    for batch, length in [(1, 1), (2, 1), (1, 32)]:
+        x = mx.random.normal((batch, length, dims[0])).astype(dtype)
+        indices = mx.random.randint(0, 8, (batch, length, 8))
+        expected = model(x, indices)
+        mx.eval(x, indices, expected)
+        samples.append((x, indices, expected))
+    with fused_moe_gate_up(model):
+        assert type(model) is not vlm.SwitchGLU
+        for x, indices, expected in samples:
+            _equal(model(x, indices), expected)

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -932,7 +932,9 @@ def generation_mode(model):
         _require_evaluable(model)()
         _GENERATION_MODE_DEPTH += 1
         entered = True
-        yield model
+        from .inference import fused_moe_gate_up
+        with fused_moe_gate_up(model):
+            yield model
     except BaseException as exc:
         active_error = exc
         raise

--- a/unsloth_zoo/mlx/inference.py
+++ b/unsloth_zoo/mlx/inference.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Scoped MLX quantized MoE gate and up projection fusion."""
+
+import sys
+from contextlib import contextmanager
+from threading import RLock
+
+import mlx.core as mx
+
+
+_MOE_PROJECTION_FIELDS = ("weight", "scales", "biases", "bias")
+
+
+_MOE_GATE_UP_CLASSES = {}
+_MOE_GATE_UP_LOCK = RLock()
+
+
+def _moe_switch_specs():
+    specs = {}
+    for path in ("mlx_lm.models.switch_layers", "mlx_vlm.models.switch_layers"):
+        native = sys.modules.get(path)
+        if native is not None and hasattr(native, "QuantizedSwitchLinear"):
+            specs[native.SwitchGLU] = (
+                native.QuantizedSwitchLinear, native._gather_sort, native._scatter_unsort,
+            )
+    return specs
+
+
+def _moe_gate_up_eligible(module, projection_type):
+    gate, up = module.gate_proj, module.up_proj
+    if type(gate) is not projection_type or type(up) is not projection_type:
+        return False
+    if (module.training or gate.training or up.training
+            or gate.trainable_parameters() or up.trainable_parameters()):
+        return False
+    if gate.bits != 8 or gate.mode != "affine" or up.mode != "affine":
+        return False
+    if (gate.group_size, gate.bits) != (up.group_size, up.bits):
+        return False
+    for name in _MOE_PROJECTION_FIELDS:
+        a, b = gate.get(name), up.get(name)
+        if (a is None) != (b is None):
+            return False
+        if a is not None and (
+            not isinstance(a, mx.array)
+            or not isinstance(b, mx.array)
+            or a.shape != b.shape
+            or a.dtype != b.dtype
+        ):
+            return False
+    if gate.weight.ndim != 3 or gate.scales.ndim != 3 or gate.biases is None:
+        return False
+    return all(
+        gate[name].shape[:-1] == gate.weight.shape[:-1] for name in ("scales", "biases")
+    ) and (gate.get("bias") is None or gate.bias.shape == gate.weight.shape[:-1])
+
+
+class _PackedMoEGateUp:
+    def __init__(self, module):
+        gate, up = module.gate_proj, module.up_proj
+        self.original_class = type(module)
+        self.active_scopes = 0
+        self.gate, self.up = gate, up
+        self.metadata = (gate.group_size, gate.bits, gate.mode)
+        self.arrays = {
+            name: mx.concatenate([gate[name], up[name]], axis = -1 if name == "bias" else -2)
+            for name in _MOE_PROJECTION_FIELDS
+            if gate.get(name) is not None
+        }
+        mx.eval(list(self.arrays.values()))
+        self.views = {
+            name: mx.split(array, 2, axis = -1 if name == "bias" else -2)
+            for name, array in self.arrays.items()
+        }
+        mx.eval([view for pair in self.views.values() for view in pair])
+
+    def attach(self):
+        for name, (gate_view, up_view) in self.views.items():
+            setattr(self.gate, name, gate_view)
+            setattr(self.up, name, up_view)
+
+    def matches(self, module):
+        if module.gate_proj is not self.gate or module.up_proj is not self.up:
+            return False
+        for projection in (self.gate, self.up):
+            if (
+                projection.training
+                or projection.trainable_parameters()
+                or (projection.group_size, projection.bits, projection.mode) != self.metadata
+            ):
+                return False
+        for name in _MOE_PROJECTION_FIELDS:
+            expected = self.views.get(name, (None, None))
+            if self.gate.get(name) is not expected[0] or self.up.get(name) is not expected[1]:
+                return False
+        return True
+
+    def project(self, x, indices, sorted_indices):
+        group_size, bits, mode = self.metadata
+        result = mx.gather_qmm(
+            x,
+            self.arrays["weight"],
+            self.arrays["scales"],
+            self.arrays["biases"],
+            rhs_indices = indices,
+            transpose = True,
+            group_size = group_size,
+            bits = bits,
+            mode = mode,
+            sorted_indices = sorted_indices,
+        )
+        if "bias" in self.arrays:
+            result = result + mx.expand_dims(self.arrays["bias"][indices], -2)
+        return mx.split(result, 2, axis = -1)
+
+
+def _fused_moe_gate_up_class(original_class, gather_sort, scatter_unsort):
+    if original_class not in _MOE_GATE_UP_CLASSES:
+
+        def fused_call(self, x, indices):
+            packed = self._unsloth_moe_gate_up
+            if self.training or not packed.matches(self):
+                return original_class.__call__(self, x, indices)
+            x = mx.expand_dims(x, (-2, -3))
+            do_sort = indices.size >= 64
+            idx = indices
+            inv_order = None
+            if do_sort:
+                x, idx, inv_order = gather_sort(x, indices)
+            x_gate, x_up = packed.project(x, idx, do_sort)
+            x = self.down_proj(self.activation(x_up, x_gate), idx, sorted_indices = do_sort)
+            if do_sort:
+                x = scatter_unsort(x, inv_order, indices.shape)
+            return x.squeeze(-2)
+
+        _MOE_GATE_UP_CLASSES[original_class] = type(
+            f"_FusedMoEGateUp{original_class.__name__}", (original_class,), {"__call__": fused_call}
+        )
+    return _MOE_GATE_UP_CLASSES[original_class]
+
+
+@contextmanager
+def fused_moe_gate_up(model):
+    """Fuse quantized MoE gate and up projections while their weights stay fixed.
+
+    Repacking at entry makes weight edits between scopes visible. Overlapping scopes
+    share packing until the last exit; training or custom projections retain native calls.
+    """
+    patched = []
+    try:
+        with _MOE_GATE_UP_LOCK:
+            if not getattr(model, "_unsloth_mlx_distributed_parallel_mode", None):
+                specs = _moe_switch_specs()
+                modules = model.named_modules() if hasattr(model, "named_modules") else ()
+                for _, module in modules:
+                    packed = getattr(module, "_unsloth_moe_gate_up", None)
+                    if (isinstance(packed, _PackedMoEGateUp)
+                            and type(module) is _MOE_GATE_UP_CLASSES.get(packed.original_class)):
+                        original, fused = packed.original_class, type(module)
+                    else:
+                        original = type(module)
+                        spec = specs.get(original)
+                        if spec is None or not _moe_gate_up_eligible(module, spec[0]):
+                            continue
+                        packed = _PackedMoEGateUp(module)
+                        fused = _fused_moe_gate_up_class(original, spec[1], spec[2])
+                    packed.active_scopes += 1
+                    patched.append((module, original, fused, packed))
+                    if type(module) is not fused:
+                        module._unsloth_moe_gate_up = packed
+                        packed.attach()
+                        module.__class__ = fused
+        yield model
+    finally:
+        with _MOE_GATE_UP_LOCK:
+            for module, original, fused, packed in reversed(patched):
+                packed.active_scopes -= 1
+                if packed.active_scopes:
+                    continue
+                if type(module) is fused:
+                    module.__class__ = original
+                if getattr(module, "_unsloth_moe_gate_up", None) is packed:
+                    del module._unsloth_moe_gate_up

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -55,6 +55,7 @@ from .compile import (
     trace_compile_application,
 )
 from .attention import install_quantized_attention
+from .inference import fused_moe_gate_up
 
 _vlm_model_types_cache = None
 _VLM_MODALITY_CONFIG_FIELDS = ("vision_config", "audio_config", "dflash_config")
@@ -6485,26 +6486,26 @@ def _mlx_generate_vlm(self, *args, **kwargs):
 
     generated_ids = []
     last_generation_tokens = None
-    for response in stream_generate(
-        self,
-        processor,
-        "",
-        max_tokens=max_tokens,
-        **batch,
-    ):
-        token_id = _mlx_token_to_int(getattr(response, "token", None))
-        if token_id is None:
-            continue
-        generation_tokens = getattr(response, "generation_tokens", None)
-        if (
-            generation_tokens is not None
-            and generation_tokens == last_generation_tokens
+    with fused_moe_gate_up(self):
+        for response in stream_generate(
+            self,
+            processor,
+            "",
+            max_tokens=max_tokens,
+            **batch,
         ):
-            continue
-        last_generation_tokens = generation_tokens
-        generated_ids.append(token_id)
-        _mlx_put_streamer_tokens(streamer, [token_id])
-
+            token_id = _mlx_token_to_int(getattr(response, "token", None))
+            if token_id is None:
+                continue
+            generation_tokens = getattr(response, "generation_tokens", None)
+            if (
+                generation_tokens is not None
+                and generation_tokens == last_generation_tokens
+            ):
+                continue
+            last_generation_tokens = generation_tokens
+            generated_ids.append(token_id)
+            _mlx_put_streamer_tokens(streamer, [token_id])
     if streamer is not None:
         streamer.end()
     return _mlx_generate_output(prompt_ids, generated_ids)
@@ -6608,21 +6609,22 @@ def _mlx_generate(self, *args, **kwargs):
     generated_ids = []
     eos_restore_state = _mlx_override_tokenizer_eos_ids(tokenizer, eos_token_id)
     try:
-        for response in stream_generate(
-            self,
-            tokenizer,
-            prompt_ids,
-            max_tokens=max_tokens,
-            sampler=sampler,
-            logits_processors=logits_processors,
-            **stream_kwargs,
-        ):
-            token = getattr(response, "token", None)
-            token_id = _mlx_token_to_int(token)
-            if token_id is None:
-                continue
-            generated_ids.append(token_id)
-            _mlx_put_streamer_tokens(streamer, [token_id])
+        with fused_moe_gate_up(self):
+            for response in stream_generate(
+                self,
+                tokenizer,
+                prompt_ids,
+                max_tokens=max_tokens,
+                sampler=sampler,
+                logits_processors=logits_processors,
+                **stream_kwargs,
+            ):
+                token = getattr(response, "token", None)
+                token_id = _mlx_token_to_int(token)
+                if token_id is None:
+                    continue
+                generated_ids.append(token_id)
+                _mlx_put_streamer_tokens(streamer, [token_id])
     finally:
         _mlx_restore_tokenizer_eos_ids(tokenizer, eos_restore_state)
 


### PR DESCRIPTION
Eligible inference-only 8-bit affine MoE blocks currently launch separate gate and up projection gathers. Pack matching gate/up weights and quantization metadata into one projection, split its output, and preserve the native activation, expert sorting, down projection, and output order. The scoped helper uses shared packed views instead of retaining duplicate original weight storage, respects weight replacement, and restores module classes after the last overlapping scope exits. A short entry/exit lock protects per-module ownership; no lock spans generation. Fusion does not clear the global allocator cache; existing generation hygiene retains responsibility for draining streams before its own clears. Training, distributed models, and incompatible or custom projections keep native calls. Loader and generation hooks activate the helper for inference.

33 native Metal tests and 77 generation tests pass. Coverage includes exact projection results, sorted and unsorted expert paths, bias handling, eligibility fallbacks, scope restoration, and weight updates. HTTP tests compare this branch alone against baseline Zoo with identical Studio integration code.

```bash
python -m pytest tests/test_mlx_moe_metal.py tests/test_mlx_generate.py -q
```

### HTTP benchmark

Six fixed paired repetitions per case, balanced AB/BA; 512 generated tokens, greedy seed 42, identical snapshot/native context and unquantized KV within pairs. M3 Max / 128 GiB, MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.7.0, Transformers 5.5.0. Loading, unloading and generation all use HTTP. Warmups and conditioning are excluded; MoE variants load one at a time. Qwen 0.8B is BF16, Gemma E2B mixed 4/8-bit QAT, both large MoEs 8-bit.

| Case | Metric | Valid pairs | Median baseline → candidate | Paired change (95% CI) | CV baseline / candidate | Result |
|---|---|---:|---:|---:|---:|---|
| moe-gemma26 | prefill (tokens/s) | 2/6 | 914.11 → 998.68 | 9.54% (-55.63% to 170.42%) | 7.22% / 0.12% | Inconclusive: repeatability gate not met |
| moe-gemma26 | decode (tokens/s) | 2/6 | 56.73 → 57.87 | 2.00% (1.75% to 2.26%) | 0.01% / 0.03% | Inconclusive: repeatability gate not met |
| moe-qwen35-soaked | prefill (tokens/s) | 2/6 | 1018.65 → 1040.72 | 2.17% (-0.42% to 4.81%) | 0.07% / 0.14% | Inconclusive: repeatability gate not met |
| moe-qwen35-soaked | decode (tokens/s) | 2/6 | 58.12 → 60.31 | 3.78% (0.24% to 7.44%) | 0.40% / 0.13% | Inconclusive: repeatability gate not met |
| moe-qwen35 | prefill (tokens/s) | 4/6 | 1022.84 → 1075.50 | 3.21% (-1.86% to 8.55%) | 2.47% / 3.56% | Inconclusive: repeatability gate not met |
| moe-qwen35 | decode (tokens/s) | 5/6 | 59.36 → 60.28 | 3.23% (0.92% to 5.60%) | 1.82% / 1.66% | Inconclusive: repeatability gate not met |

Changes are geometric mean paired speed ratios with Student-t 95% intervals on paired log ratios. Stable requires ≥4 valid pairs and both variant CV ≤1%; improvement additionally requires a positive lower confidence bound. No throughput-based rejection or adaptive extension. Intervals describe this session, not cross-day reproducibility.

Physical checks: nominal OS thermal pressure, ≤75°C admission and ≤3°C paired start difference, zero new global pageouts/swapouts, equal output text/token counts. Prefill and decode independently require phase-clock matching/drift ≤1% and telemetry coverage ≥90%. Prefill telemetry includes HTTP/CPU/first-token overhead. Warm TTFT is too short for reliable per-phase clock sampling and uses shared checks only. Matching GPU clocks does not prove an otherwise idle system.

Copy uses an 8K reused prefix; its primary metric is warm TTFT (positive speed ratio means faster, not the same percentage as latency reduction). Prefill/MoE/integration use 4K cold prompts (the explicitly labelled Gemma 8K prefill case is a separate longer-window experiment); recurrent decode 1K. Zoo comparisons hold Studio integration constant, with only the named Zoo optimization present. Integration alone uses baseline Zoo; Gemma E2B decode is a no-op control. Gains are not additive.

The separately labelled Qwen MoE conditioned series adds a five-minute HTTP conditioning period before six fixed-prompt pairs using the original first request. Every arm reloads the worker/model, and all twelve outputs and zero cache-hit counts are checked. It was declared after observing rate variation and a rising fan-speed trajectory in the original series. Both series are reported; changing both conditioning and prompt variation does not establish the cause of earlier variability or cross-session reproducibility.

The MoE and decode Zoo PRs are independently based on main and introduce the same `inference.py` module; merging both requires combining their exports. Studio activation is provided by https://github.com/unslothai/unsloth/pull/10733.

<details>
<summary>All measured primary-metric pairs and exclusions</summary>


| Case / metric | A→B values (tokens/s; TTFT in seconds) | Accepted | Reasons |
|---|---|---|---|
| moe-gemma26 / prefill / 1 (AB) | 1023.6225 → 1049.2140 | no | counts-or-host, baseline Pageouts +50 pages, candidate Pageouts +5 pages |
| moe-gemma26 / prefill / 2 (BA) | 1025.8040 → 1056.4609 | no | temperature-gap |
| moe-gemma26 / prefill / 3 (AB) | 980.0838 → 999.8521 | yes | — |
| moe-gemma26 / prefill / 4 (BA) | 980.2937 → 1002.9801 | no | temperature-gap |
| moe-gemma26 / prefill / 5 (AB) | 979.9610 → 1000.8441 | no | temperature-gap |
| moe-gemma26 / prefill / 6 (BA) | 848.1412 → 997.5131 | yes | — |

moe-gemma26 prefill: all-pair estimate 4.78% (95% CI -1.27% to 11.20%; baseline/candidate CV 6.09% / 2.45%); accepted AB 2.02%, BA 17.61%.


| Case / metric | A→B values (tokens/s; TTFT in seconds) | Accepted | Reasons |
|---|---|---|---|
| moe-gemma26 / decode / 1 (AB) | 59.8436 → 60.8697 | no | counts-or-host, baseline Pageouts +50 pages, candidate Pageouts +5 pages |
| moe-gemma26 / decode / 2 (BA) | 56.4585 → 60.5607 | no | temperature-gap |
| moe-gemma26 / decode / 3 (AB) | 56.7362 → 57.8840 | yes | — |
| moe-gemma26 / decode / 4 (BA) | 56.6636 → 57.9784 | no | temperature-gap |
| moe-gemma26 / decode / 5 (AB) | 56.6276 → 57.8774 | no | temperature-gap |
| moe-gemma26 / decode / 6 (BA) | 56.7236 → 57.8481 | yes | — |

moe-gemma26 decode: all-pair estimate 2.90% (95% CI 0.72% to 5.13%; baseline/candidate CV 2.09% / 2.26%); accepted AB 2.02%, BA 1.98%.


| Case / metric | A→B values (tokens/s; TTFT in seconds) | Accepted | Reasons |
|---|---|---|---|
| moe-qwen35-soaked / prefill / 1 (AB) | 1015.6454 → 1037.0578 | no | temperature-gap |
| moe-qwen35-soaked / prefill / 2 (BA) | 1019.3218 → 1039.3061 | yes | — |
| moe-qwen35-soaked / prefill / 3 (AB) | 1017.9775 → 1042.1249 | yes | — |
| moe-qwen35-soaked / prefill / 4 (BA) | 1018.1137 → 1041.8109 | no | counts-or-host, baseline Pageouts +1069 pages |
| moe-qwen35-soaked / prefill / 5 (AB) | 1024.3035 → 1038.1127 | no | counts-or-host, baseline Pageouts +137 pages |
| moe-qwen35-soaked / prefill / 6 (BA) | 1024.7645 → 1046.7941 | no | counts-or-host, candidate Pageouts +1 pages |

moe-qwen35-soaked prefill: all-pair estimate 2.04% (95% CI 1.65% to 2.44%; baseline/candidate CV 0.33% / 0.31%); accepted AB 2.37%, BA 1.96%.


| Case / metric | A→B values (tokens/s; TTFT in seconds) | Accepted | Reasons |
|---|---|---|---|
| moe-qwen35-soaked / decode / 1 (AB) | 58.1201 → 60.2169 | no | temperature-gap |
| moe-qwen35-soaked / decode / 2 (BA) | 57.8845 → 60.2346 | yes | — |
| moe-qwen35-soaked / decode / 3 (AB) | 58.3485 → 60.3865 | yes | — |
| moe-qwen35-soaked / decode / 4 (BA) | 48.6507 → 60.1568 | no | counts-or-host, baseline Pageouts +1069 pages |
| moe-qwen35-soaked / decode / 5 (AB) | 59.3587 → 60.4796 | no | counts-or-host, baseline Pageouts +137 pages |
| moe-qwen35-soaked / decode / 6 (BA) | 59.1934 → 60.2730 | no | counts-or-host, candidate Pageouts +1 pages |

moe-qwen35-soaked decode: all-pair estimate 6.16% (95% CI -1.90% to 14.88%; baseline/candidate CV 6.57% / 0.18%); accepted AB 3.49%, BA 4.06%.


| Case / metric | A→B values (tokens/s; TTFT in seconds) | Accepted | Reasons |
|---|---|---|---|
| moe-qwen35 / prefill / 1 (AB) | 1022.7339 → 1046.5000 | yes | — |
| moe-qwen35 / prefill / 2 (BA) | 956.5901 → 1049.1161 | no | prefill-clock-gap |
| moe-qwen35 / prefill / 3 (AB) | 1009.8296 → 1032.9349 | no | counts-or-host, temperature-gap, candidate Pageouts +79 pages |
| moe-qwen35 / prefill / 4 (BA) | 1013.9765 → 1016.6440 | yes | — |
| moe-qwen35 / prefill / 5 (AB) | 1022.9532 → 1104.6148 | yes | — |
| moe-qwen35 / prefill / 6 (BA) | 1078.2024 → 1104.5030 | yes | — |

moe-qwen35 prefill: all-pair estimate 4.11% (95% CI 0.29% to 8.07%; baseline/candidate CV 3.48% / 3.20%); accepted AB 5.12%, BA 1.35%.


| Case / metric | A→B values (tokens/s; TTFT in seconds) | Accepted | Reasons |
|---|---|---|---|
| moe-qwen35 / decode / 1 (AB) | 59.3558 → 60.2837 | yes | — |
| moe-qwen35 / decode / 2 (BA) | 59.3783 → 60.1741 | yes | — |
| moe-qwen35 / decode / 3 (AB) | 58.0029 → 59.5399 | no | counts-or-host, temperature-gap, candidate Pageouts +79 pages |
| moe-qwen35 / decode / 4 (BA) | 56.8887 → 59.3381 | yes | — |
| moe-qwen35 / decode / 5 (AB) | 58.4849 → 61.8927 | yes | — |
| moe-qwen35 / decode / 6 (BA) | 59.9602 → 61.8747 | yes | — |

moe-qwen35 decode: all-pair estimate 3.13% (95% CI 1.37% to 4.93%; baseline/candidate CV 1.74% / 1.69%); accepted AB 3.67%, BA 2.94%.


</details>

<details>
<summary>Checkpoint revisions and context limits</summary>

| Alias | Model | Revision | Checkpoint dtype | Context |
|---|---|---|---|---:|
| gemma26 | mlx-community/gemma-4-26b-a4b-it-8bit | `33c6d23798a0af159529890f79329206dbfbd73c` | 8-bit | 262144 |
| qwen35 | mlx-community/Qwen3.6-35B-A3B-8bit | `e06a74e6236a60c8367e1a3214e83d8b61b637b0` | 8-bit | 262144 |

</details>

Measured candidate `77272308fade38085ebb60e1198850fbb582b8b9` against `a7eadfb1c16532b78b5fd8ea1a8bf91d635d71cf`.

The HTTP measurements above predate the scope-ownership and allocator-clear fixes. Projection arithmetic is unchanged; the lifecycle fixes were validated with targeted regression tests, not a new throughput benchmark.
