### PR TITLE
Make the undefined-name lint gate, and fix the two real bugs it was reporting

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -498,6 +498,11 @@ jobs:
           # pins: measured 5.5.0 -> 5.14.1. Together, pip honours the cap and lands
           # on the newest mlx-vlm that fits, which is the 0.6.4 ceiling the audio
           # gate records.
+          #
+          # The <0.7.0 bound is repeated here because pyproject's copy is marker-gated
+          # to darwin + arm64 and so constrains nothing on this Linux lane. Without it
+          # the lane resolved mlx-vlm 0.7.0 the moment the transformers cap moved,
+          # gating a combination pyproject forbids.
           (
             rc=0
             {
@@ -506,7 +511,7 @@ jobs:
               retry .lanes/venv-suites/bin/pip install --index-url https://download.pytorch.org/whl/cpu \
                 "torch>=2.4.0,<2.11.0" &&
               retry .lanes/venv-suites/bin/pip install -e .[core] \
-                "mlx>=0.22.0" mlx-cpu "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4" &&
+                "mlx>=0.22.0" mlx-cpu "mlx-lm>=0.31.2" "mlx-vlm>=0.4.4,<0.7.0" &&
               { .lanes/venv-suites/bin/pip install --no-deps \
                 "unsloth @ git+https://github.com/unslothai/unsloth@main" || true; } &&
               retry .lanes/venv-suites/bin/pip install pytest==9.0.3

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -379,6 +379,7 @@ jobs:
             tests/test_conftest_module_leak_gate.py \
             tests/test_compiled_cache_collective.py \
             tests/test_compiled_cache_collective_gloo.py \
+            tests/test_undefined_name_gate.py \
             -v
 
       - name: pytest MLX adapter-filter gate (HARD GATE)

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -67,10 +67,14 @@ jobs:
 
       - name: Python ruff check (narrow gate)
         # E9 / F63 / F7 / F82: syntax errors, broken comparisons, undefined names.
-        # continue-on-error during CI bootstrap: first run on main surfaced 13
-        # latent findings (rl_replacements.py L1128 F821). The gpt_oss match-on-3.9
-        # one is fixed; the rest still need clearing before this can gate.
-        continue-on-error: true
+        # The 13 findings that kept this on continue-on-error are cleared, so it gates.
+        # Two of them were real: rl_replacements called nullcontext() without importing
+        # it, and peft_utils listed two names in __all__ that had moved to saving_utils.
+        # The rest are names an exec(source, globals()) defines a line earlier, and carry
+        # an inline noqa saying so.
+        #
+        # Leaving it non-gating was not free. It still annotated every run red, which is
+        # what a real failure on a PR then had to be picked out of.
         run: |
           ruff check --select E9,F63,F7,F82 unsloth_zoo tests scripts
 

--- a/tests/test_undefined_name_gate.py
+++ b/tests/test_undefined_name_gate.py
@@ -1,0 +1,92 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The two real defects the narrow ruff gate had been reporting into a muted step.
+
+`Source lint` ran `ruff check --select E9,F63,F7,F82` under `continue-on-error: true`
+because 13 findings predated it. Eleven were names an `exec(source, globals())` defines a
+line earlier. Two were not, and both are reachable from ordinary use, so they are pinned
+here as behaviour rather than left to the linter alone.
+"""
+
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_the_float32_grpo_path_can_build_its_autocast_context():
+    """`grpo_accumulated_loss` takes `nullcontext()` whenever the trainer has no autocast
+    dtype, which is exactly what `UNSLOTH_FORCE_FLOAT32=1` sets. The name was never
+    imported, so that branch raised `NameError` instead of running unautocast."""
+    import unsloth_zoo.rl_replacements as rl
+
+    assert hasattr(rl, "nullcontext"), (
+        "rl_replacements calls nullcontext() on the UNSLOTH_FORCE_FLOAT32 path; "
+        "without the import that branch is a NameError"
+    )
+    with rl.nullcontext():
+        pass
+
+
+def test_peft_utils_exports_only_names_it_has():
+    """`merge_and_overwrite_lora` and `merge_and_dequantize_lora` stayed in `__all__` after
+    moving to `saving_utils`, so a star import raised AttributeError and named neither."""
+    import unsloth_zoo.peft_utils as peft_utils
+
+    missing = [name for name in peft_utils.__all__ if not hasattr(peft_utils, name)]
+    assert not missing, f"__all__ names that do not exist: {missing}"
+
+
+def test_a_star_import_of_peft_utils_succeeds():
+    """The failure mode itself, in a subprocess because a star import needs module scope."""
+    result = subprocess.run(
+        [sys.executable, "-c", "from unsloth_zoo.peft_utils import *"],
+        capture_output = True,
+        text = True,
+        cwd = REPO,
+        timeout = 600,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+
+
+@pytest.mark.skipif(
+    subprocess.run(
+        [sys.executable, "-m", "ruff", "--version"], capture_output = True
+    ).returncode != 0,
+    reason = "needs ruff",
+)
+def test_the_narrow_gate_is_clean_so_it_can_stay_gating():
+    """`Source lint` gates on this now. A new undefined name should fail here too, rather
+    than only in CI, and an exec-defined one should carry the inline noqa that says so."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "ruff", "check",
+            "--select", "E9,F63,F7,F82",
+            "--output-format", "concise",
+            "unsloth_zoo", "tests", "scripts",
+        ],
+        capture_output = True,
+        text = True,
+        cwd = REPO,
+        timeout = 600,
+    )
+    assert result.returncode == 0, result.stdout[-4000:]

--- a/tests/test_undefined_name_gate.py
+++ b/tests/test_undefined_name_gate.py
@@ -35,16 +35,31 @@ REPO = Path(__file__).resolve().parents[1]
 
 def test_the_float32_grpo_path_can_build_its_autocast_context():
     """`grpo_accumulated_loss` takes `nullcontext()` whenever the trainer has no autocast
-    dtype, which is exactly what `UNSLOTH_FORCE_FLOAT32=1` sets. The name was never
-    imported, so that branch raised `NameError` instead of running unautocast."""
+    dtype, which is exactly what `UNSLOTH_FORCE_FLOAT32=1` sets. The name was never bound,
+    so that branch raised `NameError` instead of running unautocast.
+
+    Asserted against the FUNCTION SOURCE in a bare namespace, because that is the shape the
+    production path has: this function is copied into the generated `UnslothGRPOTrainer`
+    cache without unsloth_zoo's module imports, as the comment beside the PrefixGrouper
+    import in its body says. A module-level import satisfies `import unsloth_zoo` and still
+    leaves the generated trainer raising, so checking the module would pass while the path
+    users actually run stayed broken.
+    """
+    import inspect
+
     import unsloth_zoo.rl_replacements as rl
 
-    assert hasattr(rl, "nullcontext"), (
-        "rl_replacements calls nullcontext() on the UNSLOTH_FORCE_FLOAT32 path; "
-        "without the import that branch is a NameError"
+    source = inspect.getsource(rl.grpo_accumulated_loss)
+    namespace = {"torch": rl.torch, "os": rl.os}
+    exec(compile(source, "<generated-trainer>", "exec"), namespace)
+    rebuilt = namespace["grpo_accumulated_loss"]
+
+    # A name bound by an import inside the body is a LOCAL; one that relies on the module
+    # is a global, and a global is exactly what the generated trainer does not carry.
+    assert "nullcontext" in rebuilt.__code__.co_varnames, (
+        "nullcontext resolves as a global, so the generated UnslothGRPOTrainer raises "
+        "NameError on the UNSLOTH_FORCE_FLOAT32 path; bind it inside the function body"
     )
-    with rl.nullcontext():
-        pass
 
 
 def test_peft_utils_exports_only_names_it_has():

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -5889,7 +5889,8 @@ def unsloth_compile_transformers(
         "False",
     )
     exec(inner_training_loop, globals())
-    Trainer._inner_training_loop = _fast_inner_training_loop
+    # Defined by the exec(inner_training_loop, globals()) directly above.
+    Trainer._inner_training_loop = _fast_inner_training_loop  # noqa: F821
 
     # All other functions
     if compile_function_calls:

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -2624,7 +2624,9 @@ def sft_prepare_dataset(
     if packing:
         # Use TRL's pack_dataset if available
         try:
-            pack_dataset
+            # A presence probe, not a use: TRL exports pack_dataset only on some
+            # versions, and the bare name is what the except below is for.
+            pack_dataset  # noqa: F821
         except:
             print("Unsloth: Hugging Face's packing is currently buggy - we're disabling it for now!")
             return dataset
@@ -2633,7 +2635,7 @@ def sft_prepare_dataset(
             raise ValueError("When packing is enabled, `max_seq_length` can't be `None`.")
 
         if use_desc: map_kwargs["desc"] = f"Unsloth: Packing {dataset_name} dataset"
-        dataset = pack_dataset(
+        dataset = pack_dataset(  # noqa: F821 -- reached only past the probe above.
             dataset.select_columns(used_column_names),
             max_seq_length,
             getattr(args, "packing_strategy", "bfd"),

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -657,7 +657,8 @@ def patch_compiled_autograd():
     good_items = [x for x in all_items if x in source]
     exec("from torch._dynamo.compiled_autograd import (" + ", ".join(x for x in good_items) + ")", globals())
     exec(source, globals())
-    torch._dynamo.compiled_autograd.AutogradCompilerInstance.end_capture = unsloth_end_capture
+    # Defined by the exec(source, globals()) directly above.
+    torch._dynamo.compiled_autograd.AutogradCompilerInstance.end_capture = unsloth_end_capture  # noqa: F821
 
     # From https://github.com/pytorch/pytorch/pull/135795/files
     try:
@@ -683,7 +684,8 @@ def patch_compiled_autograd():
     good_items = [x for x in all_items if x in source]
     exec("from torch._dynamo.variables.misc import (" + ", ".join(x for x in good_items) + ")", globals())
     exec(source, globals())
-    torch._dynamo.variables.misc.AutogradEngineVariable.call_method = unsloth_call_method
+    # Defined by the exec(source, globals()) directly above.
+    torch._dynamo.variables.misc.AutogradEngineVariable.call_method = unsloth_call_method  # noqa: F821
     return
 pass
 
@@ -841,7 +843,8 @@ if _transformers_bnb is not None and \
     source = re.sub(pattern, add_score_code, source, flags=re.MULTILINE)
 
     exec(source, globals())
-    _transformers_bnb._replace_with_bnb_linear = _unsloth_replace_with_bnb_linear
+    # Defined by the exec(source, globals()) directly above.
+    _transformers_bnb._replace_with_bnb_linear = _unsloth_replace_with_bnb_linear  # noqa: F821
 pass
 
 # Patch for transformers 5.x: should_convert_module uses re.match + endswith

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -14,10 +14,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+# merge_and_overwrite_lora and merge_and_dequantize_lora were listed here after they had
+# already moved to saving_utils, which made `from unsloth_zoo.peft_utils import *` raise
+# AttributeError rather than import anything.
 __all__ = [
     "get_peft_regex",
-    "merge_and_overwrite_lora",
-    "merge_and_dequantize_lora",
     "SKIP_QUANTIZATION_MODULES",
     "get_lora_layer_modules",
     "requires_grad_for_gradient_checkpointing",

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -23,6 +23,7 @@ import inspect
 import os
 import math
 import logging
+from contextlib import nullcontext
 from typing import Union, Callable, Optional, List, Dict
 from .device_type import DEVICE_TYPE, device_synchronize
 from unsloth_zoo.temporary_patches.common import (
@@ -1745,21 +1746,6 @@ def grpo_accumulated_loss(
     os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "0"
 
     return loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1, completion_mask
-    # Old non-efficient code path (dead).
-    new_logits = torch.matmul(new_hidden_states, lm_head.t())
-    new_logits = new_logits[:, :-1, :] # exclude the last logit: it corresponds to the next token pred
-    old_logits = torch.matmul(old_hidden_states, lm_head.t())
-    old_logits = old_logits[:, :-1, :] # exclude the last logit: it corresponds to the next token pred
-    loss, completion_length, mean_kl = grpo_compute_loss(
-        old_logits,
-        new_logits,
-        completion_input_ids,
-        completion_mask,
-        trainer.beta,
-        advantages,
-    )
-    return loss, completion_length, mean_kl
-    pass
 pass
 RL_REPLACEMENTS["grpo_accumulated_loss"] = grpo_accumulated_loss
 

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -23,7 +23,6 @@ import inspect
 import os
 import math
 import logging
-from contextlib import nullcontext
 from typing import Union, Callable, Optional, List, Dict
 from .device_type import DEVICE_TYPE, device_synchronize
 from unsloth_zoo.temporary_patches.common import (
@@ -1115,6 +1114,12 @@ def grpo_accumulated_loss(
         mm_token_type_ids_chunks,
         completion_ids_chunks
     )
+
+    # Bound in the body, not at module scope, for the reason spelled out just below: this
+    # function's source is copied into the generated UnslothGRPOTrainer cache without
+    # unsloth_zoo's module imports, so a module-level import reaches the import path and
+    # not the one that actually runs in production.
+    from contextlib import nullcontext
 
     if trainer._autocast_dtype is None:
         autocaster = nullcontext()

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -162,7 +162,8 @@ def patch_merge_quantization_configs():
     except Exception as e:
         return raise_error("", e)
 
-    patch_function(transformers.quantizers.auto.AutoHfQuantizer, "merge_quantization_configs", merge_quantization_configs)
+    # Defined by the exec(source, globals()) in the try above.
+    patch_function(transformers.quantizers.auto.AutoHfQuantizer, "merge_quantization_configs", merge_quantization_configs)  # noqa: F821
 pass
 TEMPORARY_PATCHES.append(patch_merge_quantization_configs)
 

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -327,7 +327,8 @@ def patch_bnb4bit_quantizer_param_needs_quantization():
     if getattr(original_param_needs_quantization, "_unsloth_moe_patched", False):
         return
 
-    def patched_param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
+    # PreTrainedModel is a string annotation, never imported or evaluated here.
+    def patched_param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:  # noqa: F821
         if original_param_needs_quantization(self, model, param_name, **kwargs):
             return True
 


### PR DESCRIPTION
## Why

`Source lint` has run

```
ruff check --select E9,F63,F7,F82 unsloth_zoo tests scripts
```

under `continue-on-error: true` since it was added. The step's own comment says why: 13 findings predated it, and "the rest still need clearing before this can gate."

Leaving it muted was not free. It still emits a failure annotation on every single run, on `main` and on every PR, so a real lint failure has to be picked out of standing noise. That is exactly what made triaging #1191 ambiguous: two annotations on one check run, only one of them a gate.

Clearing the 13 turned up two genuine bugs that have been sitting in that muted step.

## The two real ones

**1. GRPO in forced float32 raises `NameError`.**

`rl_replacements.grpo_accumulated_loss` sets `trainer._autocast_dtype = None` when `UNSLOTH_FORCE_FLOAT32=1`:

```python
if os.environ.get('UNSLOTH_FORCE_FLOAT32', '0') == '1': trainer._autocast_dtype = None
```

and then, ~170 lines later, takes the branch that needs it:

```python
if trainer._autocast_dtype is None:
    autocaster = nullcontext()
```

`contextlib` was never imported in that module, so instead of running unautocast the branch dies with `NameError: name 'nullcontext' is not defined`. Confirmed directly: `'nullcontext' in vars(unsloth_zoo.rl_replacements)` is `False`.

**2. `from unsloth_zoo.peft_utils import *` raises.**

`peft_utils.__all__` still lists `merge_and_overwrite_lora` and `merge_and_dequantize_lora`. Both moved to `saving_utils` and neither exists in `peft_utils`, so a star import raises `AttributeError` and imports nothing at all. Nothing in the repo imports them from there, so the stale entries just go.

## The other eleven

Names an `exec(source, globals())` defines a line earlier, which ruff cannot see. For example:

```python
exec(inner_training_loop, globals())
Trainer._inner_training_loop = _fast_inner_training_loop
```

Each gets an inline `# noqa: F821` and a comment naming the `exec` above it, rather than a per-file ignore that would also hide the next real one.

One was neither. Ten lines sit after a `return` in `grpo_accumulated_loss`, marked `# Old non-efficient code path (dead).` by the author, referencing `new_hidden_states` and `old_hidden_states`, which do not exist. It could never have run. Deleted.

With those cleared, the step drops `continue-on-error` and gates.

## Also: an unbounded mlx-vlm on the Linux lane

`pyproject.toml` caps `mlx-vlm>=0.4.4,<0.7.0`, but the marker scopes that to `darwin` + `arm64`, so it constrains nothing on the MLX suites lane, which installs a bare `"mlx-vlm>=0.4.4"`. The moment the transformers cap moves, the lane resolves mlx-vlm 0.7.0 and gates a combination `pyproject` forbids. Bounded in the workflow, with the reason recorded there since the pyproject copy cannot be relied on.

## Verification

`tests/test_undefined_name_gate.py` pins both bugs as behaviour rather than leaving them to the linter, including the star import in a subprocess because it needs module scope. All four tests fail against `main` and pass here:

```
with the fixes reverted:  4 failed
with the fixes:           4 passed
```

The narrow gate itself is clean locally (`All checks passed!`), which is the precondition for dropping `continue-on-error`.

## Not in this PR

Per-PR failures on the open MLX PRs are theirs, and I have commented on each. The one shared cause is the transformers 5.17 / trl 1.13 drift that #1187 already fixed on `main`: #1186 and #964 need a rebase, not a code change.
