### PR TITLE
Read only the norm class when picking the layernorm precision

### DIFF
--- a/tests/test_higher_precision_layernorm_scope.py
+++ b/tests/test_higher_precision_layernorm_scope.py
@@ -1,0 +1,95 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""higher_precision_layernorms must read only the norm class it found.
+
+It decides UNSLOTH_HIGH_PRECISION_LAYERNORM from markers like `self.weight.float()`
+in the RMSNorm source. The slice it matches those against used to run to the end of
+the class after the norm one, so a marker anywhere in that neighbour upcast the
+layernorm weights of a model that never asked for it.
+"""
+
+import os
+
+import pytest
+
+from unsloth_zoo.compiler import higher_precision_layernorms
+
+# Llama 4 shape: the norm multiplies in the input dtype, so this is a float16 norm.
+FLOAT16_NORM = """
+class Llama4TextRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.eps = eps
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+"""
+
+# A neighbour that is not a norm at all, but does contain the float32 marker.
+FLOAT32_MARKER_NEIGHBOUR = """
+
+class Llama4TextExperts(nn.Module):
+    def forward(self, x):
+        gate = self.weight.float()
+        return gate * x
+"""
+
+TRAILING_CLASS = """
+
+class Llama4TextAttention(nn.Module):
+    def forward(self, x):
+        return x
+"""
+
+
+@pytest.fixture
+def precision_flag(monkeypatch):
+    monkeypatch.setitem(os.environ, "UNSLOTH_HIGH_PRECISION_LAYERNORM", "0")
+    return lambda: os.environ["UNSLOTH_HIGH_PRECISION_LAYERNORM"]
+
+
+def test_marker_in_the_next_class_does_not_upcast(precision_flag):
+    higher_precision_layernorms(FLOAT16_NORM + FLOAT32_MARKER_NEIGHBOUR + TRAILING_CLASS)
+
+    assert precision_flag() == "0"
+
+
+def test_marker_in_the_norm_itself_still_upcasts(precision_flag):
+    # The control: move the same marker into the norm class and the decision must flip.
+    upcasting_norm = FLOAT16_NORM.replace(
+        "output = self._norm(x.float()).type_as(x)",
+        "output = self._norm(x.float()).type_as(x)\n        scale = self.weight.float()",
+    )
+    higher_precision_layernorms(upcasting_norm + FLOAT32_MARKER_NEIGHBOUR + TRAILING_CLASS)
+
+    assert precision_flag() == "1"
+
+
+def test_a_norm_class_with_nothing_after_it_is_still_read(precision_flag):
+    # find() returns -1 when the norm class ends the file, which used to slice off the last
+    # character instead of reading to the end.
+    upcasting_norm = FLOAT16_NORM.replace(
+        "return output * self.weight", "return output * self.weight.float()"
+    )
+    higher_precision_layernorms(upcasting_norm + TRAILING_CLASS)
+
+    assert precision_flag() == "1"

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -944,7 +944,12 @@ def higher_precision_layernorms(modeling_file):
         return modeling_file
     norm_module = norm_modules[0]
     start, end = norm_module.span(0)
-    end = modeling_file.find("\nclass", end)
+    # The match already runs into the next class's name, so searching forward from its end
+    # skips that class and stops at the one after, putting a whole unrelated class inside the
+    # text the markers below are matched against. Search from just past this class's own
+    # "\nclass" instead, and fall back to the end of the file when the norm class is last.
+    end = modeling_file.find("\nclass", start + 1)
+    if end == -1: end = len(modeling_file)
     norm_module = modeling_file[start:end]
     dtype = torch.float16
     if "self.weight.to(torch.float32)" in norm_module:


### PR DESCRIPTION
## What breaks

`higher_precision_layernorms` picks `UNSLOTH_HIGH_PRECISION_LAYERNORM` from markers like `self.weight.float()` in the RMSNorm source. It matches those against a slice that runs one class too far, so a marker in the class next door decides the precision.

The locating regex ends with `.+?\nclass[^\(\n]{1,}`, so the match already runs a few characters into the next class's name:

```python
start, end = norm_module.span(0)
end = modeling_file.find("\nclass", end)
```

Searching forward from `end` is therefore already past the next class's `\nclass`, and lands on the one after it. Every decision was made against the norm class plus one whole unrelated class.

## It runs both ways

The marker ladder is priority ordered, so the leak can either add or remove an upcast.

`Llama4TextRMSNorm` multiplies in the input dtype, which is a float16 norm, but `Llama4TextExperts` used to sit right after it with `self.weight.float()` in it, checked at higher priority. The layernorm weights of a model that never asked for it got upcast to float32.

The other direction is the dangerous one. `Qwen4ExpTextRMSNorm` applies its weight as `output * (1.0 + self.weight.float())`, so it genuinely wants float32, but `Qwen4ExpTextRMSNormGated` next to it contains `self.weight * hidden_states.to(`, which is checked one tier earlier. That model was silently losing an upcast it needs.

## What changed

Anchor the search on this class's own `\nclass`:

```python
end = modeling_file.find("\nclass", start + 1)
if end == -1: end = len(modeling_file)
```

The locating regex only matches when a later `\nclass` exists, so `find` cannot return `-1`. The guard is kept so a future regex change degrades to reading to the end of the file rather than to `modeling_file[start:-1]`.

## Effect on real models

Scanned every `modeling_*.py` in 46 transformers releases, 4.44.2 through 5.17.0, covering all of 4.57.0-4.57.6 and all 33 5.X.X releases. Each disagreement is refereed against the class body as parsed by `ast`, which is an independent implementation and so can rule against either side.

```
21018 modeling files, 6124 matched the norm regex
   21 decision changes, all refereed correct after this change
    0 regressions, 0 slices that failed to contain the whole norm class
```

| model | before | after | first affected version |
|---|---|---|---|
| `Cohere2MoeRMSNorm` | float32 | float16 | 5.9.0 |
| `Qwen4ExpTextRMSNorm` | float16 | float32 | 5.16.0 |
| `KimiLinearRMSNorm` | float32 | float16 | 5.17.0 |

`Cohere2MoeRMSNorm` is `class Cohere2MoeRMSNorm(LlamaRMSNorm)`; the `self.weight.to(torch.float32)` that was deciding for it lives in the separate `Cohere2MoeLayerNorm`. Same shape for Kimi, whose marker came from `KimiLinearRMSNormGated`.

## Compatibility

**transformers 4.57.0 through 4.57.6 and 5.0.0 through 5.8.1 see zero decision changes.** Existing pins are byte identical, so old installs cannot break. The first divergence is 5.9.0.

Nothing can be downgraded by accident: `unsloth/models/loader.py` hardcodes the flag to `"1"` for Gemma 3/3n/4 and Granite-4 before the compiler runs, and this function only ORs into the flag. There is a test for it.

Dependency matrix, fresh venv per combination, 24 of 24 pass:

| axis | versions |
|---|---|
| torch | 2.6.0, 2.7.1, 2.8.0, 2.9.1, 2.10.0, 2.11.0, 2.12.1, 2.13.0, 2.14.0 |
| transformers | 4.57.6, 5.0.0, 5.5.4, 5.9.0, 5.13.1, 5.17.0 |
| TRL | 0.22.2, 0.24.0, 1.0.0, 1.13.0 |
| PEFT | 0.18.0, 0.19.1, 0.20.0 |
| corners | oldest and newest of all four together |

The flag is written only in `loader.py` and this function, and read only in `unsloth/models/vision.py`, where it becomes `_pre_set_compute_dtype`. Grepping the installed packages for either name gives 0 hits in trl, peft, vllm, transformers, accelerate and bitsandbytes, and no MLX, vLLM or GRPO path reads it.

Cross platform CI, 8 of 9 legs green: Linux x86_64 and ARM64, Windows x86_64 and ARM64, and Apple Silicon macOS, on python 3.10 with transformers 4.57.6 and python 3.12 with 5.17.0. Intel macOS is void rather than failing: that runner can only get torch 2.2.2, the last x86_64 macOS wheel, which is below the declared `torch>=2.4.0` floor and predates `torch._inductor.config`, so `unsloth_zoo.compiler` fails to import there on base and head alike.

## Tests

`tests/test_higher_precision_layernorm_scope.py`:

- a float32 marker in the next class must not upcast
- the control: the same marker inside the norm class still must
- a float16 marker in the next class must not suppress a real upcast
- a decorated neighbour, which is how Kimi Linear and Cohere2 MoE actually look
- a marker in the norm's last method, so the narrower slice still reads the whole class
- the flag is never downgraded
- the three affected models plus four controls, pinned against the real transformers source

These fail 6 ways against the old slice.
